### PR TITLE
Fix flaky IT: ITPerfectRollupParallelBatchIndexTest

### DIFF
--- a/integration-tests/docker/environment-configs/indexer
+++ b/integration-tests/docker/environment-configs/indexer
@@ -36,3 +36,4 @@ druid_auth_basic_common_cacheDirectory=/tmp/authCache/indexer
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
 druid_worker_capacity=10
+druid_worker_intermediaryPartitionTimeout=PT30M

--- a/integration-tests/docker/environment-configs/indexer
+++ b/integration-tests/docker/environment-configs/indexer
@@ -36,4 +36,4 @@ druid_auth_basic_common_cacheDirectory=/tmp/authCache/indexer
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
 druid_worker_capacity=10
-druid_worker_intermediaryPartitionTimeout=PT30M
+druid_worker_intermediaryPartitionTimeout=PT60M

--- a/integration-tests/docker/environment-configs/indexer
+++ b/integration-tests/docker/environment-configs/indexer
@@ -36,4 +36,3 @@ druid_auth_basic_common_cacheDirectory=/tmp/authCache/indexer
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
 druid_worker_capacity=10
-druid_worker_intermediaryPartitionTimeout=PT60M

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -38,3 +38,4 @@ druid_auth_basic_common_cacheDirectory=/tmp/authCache/middleManager
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
 druid_worker_capacity=10
+druid_worker_intermediaryPartitionTimeout=PT30M

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -38,4 +38,4 @@ druid_auth_basic_common_cacheDirectory=/tmp/authCache/middleManager
 druid_startup_logging_logProperties=true
 druid_server_https_crlPath=/tls/revocations.crl
 druid_worker_capacity=10
-druid_worker_intermediaryPartitionTimeout=PT30M
+druid_worker_intermediaryPartitionTimeout=PT60M


### PR DESCRIPTION
Partially fixes #12692

### Description
Due to the race conditions described in [this comment](https://github.com/apache/druid/issues/12692#issuecomment-1166225796),
the ITPerfectRollupParallelBatchIndexTest and possibly other ITs can exhibit flaky behaviour.
This typically happens when the middle manager/indexer cleans up the partitions of a
supervisor task while a different peon is trying to list those partitions (to account for remaining
space in a storage location).

This PR tries to eliminate this behaviour by increasing the partition timeout, so that partitions are
effectively not cleaned up during the course of the test, but only after.

This is not a permanent fix and a better fix would be improving the way the cleanup is handled
between the peons and the middle manager.

### Changes
 * Add `druid_worker_intermediaryPartitionTimeout = PT30M` in integration-test env configs

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
