### PR TITLE
Suppress CVE-2022-33915

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -296,6 +296,13 @@
     <cve>CVE-2022-23302</cve>
   </suppress>
   <suppress>
+    <notes><![CDATA[
+    file name: log4j-core-2.17.1.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org.apache.logging.log4j/log4j-core@2.17.1$</packageUrl>
+    <cve>CVE-2022-33915</cve>
+  </suppress>
+  <suppress>
     <!--
       - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
       -->


### PR DESCRIPTION
The CVE https://nvd.nist.gov/vuln/detail/CVE-2022-33915 seems unrelated to the version `2.17.1` druid is using for logging
