### PR TITLE
Pushdown join filter with right side referencing columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
@@ -261,7 +261,9 @@ public class JoinableFactoryWrapper
    * - the right-hand columns referenced by the condition must not have any duplicate values. If there are duplicates
    *   values in the column, then the join is tried to be converted to a filter while maintaining the join clause on top
    *   as well for correct results.
-   * - no columns from the right-hand side can appear in "requiredColumns"
+   * - no columns from the right-hand side can appear in "requiredColumns". If the columns from right side are required
+   *   (ie they are directly or indirectly projected in the join output), then the join is tried to be converted to a
+   *   filter while maintaining the join clause on top as well for correct results.
    *
    * @return {@link JoinClauseToFilterConversion} object which contains the converted filter for the clause and a boolean
    * to represent whether the converted filter encapsulates the whole clause or not. More semantics of the object are
@@ -275,12 +277,12 @@ public class JoinableFactoryWrapper
   )
   {
     if (clause.getJoinType() == JoinType.INNER
-        && requiredColumns.stream().noneMatch(clause::includesColumn)
         && clause.getCondition().getNonEquiConditions().isEmpty()
         && clause.getCondition().getEquiConditions().size() > 0) {
       final List<Filter> filters = new ArrayList<>();
       int numValues = maxNumFilterValues;
-      boolean joinClauseFullyConverted = true;
+      // if the right side columns are required, the clause cannot be fully converted
+      boolean joinClauseFullyConverted = requiredColumns.stream().noneMatch(clause::includesColumn);
 
       for (final Equality condition : clause.getCondition().getEquiConditions()) {
         final String leftColumn = condition.getLeftExpr().getBindingIfIdentifier();

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -674,7 +674,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
   }
 
   @Test
-  public void test_convertJoinsToFilters_dontConvertWhenColumnIsUsed()
+  public void test_convertJoinsToFilters_partialConvertWhenColumnIsUsed()
   {
     final JoinableClause clause = new JoinableClause(
         "j.",
@@ -691,7 +691,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
 
     Assert.assertEquals(
         Pair.of(
-            ImmutableList.of(),
+            ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             ImmutableList.of(clause)
         ),
         conversion
@@ -799,7 +799,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
   }
 
   @Test
-  public void test_convertJoinsToFilters_dontConvertJoinsDependedOnByLaterJoins()
+  public void test_convertJoinsToFilters_partialConvertJoinsDependedOnByLaterJoins()
   {
     final ImmutableList<JoinableClause> clauses = ImmutableList.of(
         new JoinableClause(
@@ -830,7 +830,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
 
     Assert.assertEquals(
         Pair.of(
-            ImmutableList.of(),
+            ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             clauses
         ),
         conversion
@@ -838,7 +838,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
   }
 
   @Test
-  public void test_convertJoinsToFilters_dontConvertJoinsDependedOnByLaterJoins2()
+  public void test_convertJoinsToFilters_partialConvertJoinsDependedOnByLaterJoins2()
   {
     final ImmutableList<JoinableClause> clauses = ImmutableList.of(
         new JoinableClause(
@@ -869,7 +869,7 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
 
     Assert.assertEquals(
         Pair.of(
-            ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
+            ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS), new InDimFilter("x", TEST_LOOKUP_KEYS)),
             clauses.subList(1, clauses.size())
         ),
         conversion


### PR DESCRIPTION
Recently, support for partially conversion of join to a filter was added where if a join's right side contains duplicate values we convert the join as a filter to be pushed to left side while maintaing the join itself to support join multiplicity #12225 

With that support, this change also performs a pushdown of join filter incase any of the columns from right side is referenced in the query computing join. Since, the right side columns are needed for the final output computation the join is retained as is.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
