### PR TITLE
Throughput by volume from #10407

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -46,7 +46,7 @@
     <option name="myDefaultNotNull" value="javax.annotation.Nonnull" />
     <option name="myNullables">
       <value>
-        <list size="12">
+        <list size="13">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -59,12 +59,13 @@
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="10" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
           <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="13">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
@@ -76,6 +77,8 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="lombok.NonNull" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
         </list>
       </value>
     </option>
@@ -84,7 +87,10 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+  <component name="SuppressKotlinCodeStyleNotification">
+    <option name="disableForAll" value="true" />
   </component>
 </project>

--- a/core/src/main/java/org/apache/druid/data/input/AbstractInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/AbstractInputSource.java
@@ -35,30 +35,37 @@ public abstract class AbstractInputSource implements InputSource
   public InputSourceReader reader(
       InputRowSchema inputRowSchema,
       @Nullable InputFormat inputFormat,
-      File temporaryDirectory
+      File temporaryDirectory,
+      InputStats inputStats
   )
   {
     if (needsFormat()) {
       return formattableReader(
           inputRowSchema,
           Preconditions.checkNotNull(inputFormat, "inputFormat"),
-          temporaryDirectory
+          temporaryDirectory,
+          inputStats
       );
     } else {
-      return fixedFormatReader(inputRowSchema, temporaryDirectory);
+      return fixedFormatReader(inputRowSchema, temporaryDirectory, inputStats);
     }
   }
 
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      File temporaryDirectory
+      File temporaryDirectory,
+      InputStats inputStats
   )
   {
     throw new UnsupportedOperationException("Implement this method properly if needsFormat() = true");
   }
 
-  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, File temporaryDirectory)
+  protected InputSourceReader fixedFormatReader(
+      InputRowSchema inputRowSchema,
+      File temporaryDirectory,
+      InputStats inputStats
+  )
   {
     throw new UnsupportedOperationException("Implement this method properly if needsFormat() = false");
   }

--- a/core/src/main/java/org/apache/druid/data/input/CountableInputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/CountableInputEntity.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import com.google.common.base.Predicate;
+import com.google.common.io.CountingInputStream;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * Can be used to count number of bytes read from the base InputEntity
+ */
+public class CountableInputEntity implements InputEntity
+{
+  private final InputStats inputStats;
+  private final InputEntity baseInputEntity;
+
+  public CountableInputEntity(InputEntity baseInputEntity, InputStats inputStats)
+  {
+    this.baseInputEntity = baseInputEntity;
+    this.inputStats = inputStats;
+  }
+
+  @Nullable
+  @Override
+  public URI getUri()
+  {
+    return baseInputEntity.getUri();
+  }
+
+  @Override
+  public InputStream open() throws IOException
+  {
+    return new BytesCountingInputStream(baseInputEntity.open(), inputStats);
+  }
+
+  @Override
+  public CleanableFile fetch(File temporaryDirectory, byte[] fetchBuffer) throws IOException
+  {
+    final CleanableFile cleanableFile = baseInputEntity.fetch(temporaryDirectory, fetchBuffer);
+    inputStats.incrementProcessedBytes(cleanableFile.file().length());
+    return cleanableFile;
+  }
+
+  @Override
+  public Predicate<Throwable> getRetryCondition()
+  {
+    return baseInputEntity.getRetryCondition();
+  }
+
+  @Override
+  public InputEntity getBaseInputEntity()
+  {
+    return baseInputEntity;
+  }
+
+  static class BytesCountingInputStream extends FilterInputStream
+  {
+    private final InputStats inputStats;
+
+    /**
+     * Wraps another input stream, counting the number of bytes read.
+     * <p>
+     * Similar to {@link CountingInputStream} but does not reset count on call to
+     * {@link CountingInputStream#reset()}
+     *
+     * @param in the input stream to be wrapped
+     */
+    public BytesCountingInputStream(@Nullable InputStream in, InputStats inputStats)
+    {
+      super(in);
+      this.inputStats = inputStats;
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+      int result = in.read();
+      if (result != -1) {
+        inputStats.incrementProcessedBytes(1);
+      }
+      return result;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException
+    {
+      int result = in.read(b, off, len);
+      if (result != -1) {
+        inputStats.incrementProcessedBytes(result);
+      }
+      return result;
+    }
+
+    @Override
+    public long skip(long n) throws IOException
+    {
+      long result = in.skip(n);
+      inputStats.incrementProcessedBytes(result);
+      return result;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptor.java
+++ b/core/src/main/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptor.java
@@ -97,7 +97,7 @@ public class FirehoseFactoryToInputSourceAdaptor extends AbstractInputSource imp
   }
 
   @Override
-  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory, InputStats inputStats)
   {
     return new FirehoseToInputSourceReaderAdaptor(firehoseFactory, inputRowParser, temporaryDirectory);
   }

--- a/core/src/main/java/org/apache/druid/data/input/InputEntity.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputEntity.java
@@ -137,4 +137,9 @@ public interface InputEntity
     return Predicates.alwaysFalse();
   }
 
+  default InputEntity getBaseInputEntity()
+  {
+    return this;
+  }
+
 }

--- a/core/src/main/java/org/apache/druid/data/input/InputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputSource.java
@@ -81,6 +81,7 @@ public interface InputSource
   InputSourceReader reader(
       InputRowSchema inputRowSchema,
       @Nullable InputFormat inputFormat,
-      File temporaryDirectory
+      File temporaryDirectory,
+      InputStats inputStats
   );
 }

--- a/core/src/main/java/org/apache/druid/data/input/InputStats.java
+++ b/core/src/main/java/org/apache/druid/data/input/InputStats.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class InputStats
+{
+  private final AtomicLong processedBytes = new AtomicLong(0);
+
+  public void incrementProcessedBytes(long incrementByValue)
+  {
+    processedBytes.getAndAdd(incrementByValue);
+  }
+
+  public AtomicLong getProcessedBytes()
+  {
+    return processedBytes;
+  }
+}

--- a/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/CloudObjectInputSource.java
@@ -24,11 +24,13 @@ import com.google.common.primitives.Ints;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.utils.CollectionUtils;
 
@@ -178,13 +180,15 @@ public abstract class CloudObjectInputSource extends AbstractInputSource
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
-        createSplits(inputFormat, null).flatMap(split -> split.get().stream()).map(this::createEntity).iterator(),
+        createSplits(inputFormat, null).flatMap(split -> split.get().stream()).map(
+            cloudObjectLocation -> new CountableInputEntity(createEntity(cloudObjectLocation), inputStats)).iterator(),
         temporaryDirectory
     );
   }

--- a/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/HttpInputSource.java
@@ -24,10 +24,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -122,16 +124,20 @@ public class HttpInputSource extends AbstractInputSource implements SplittableIn
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
-        createSplits(inputFormat, null).map(split -> new HttpEntity(
-            split.get(),
-            httpAuthenticationUsername,
-            httpAuthenticationPasswordProvider
+        createSplits(inputFormat, null).map(split -> new CountableInputEntity(
+            new HttpEntity(
+                split.get(),
+                httpAuthenticationUsername,
+                httpAuthenticationPasswordProvider
+            ),
+            inputStats
         )).iterator(),
         temporaryDirectory
     );

--- a/core/src/main/java/org/apache/druid/data/input/impl/InlineInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/InlineInputSource.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
@@ -66,13 +68,14 @@ public class InlineInputSource extends AbstractInputSource
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
-        Stream.of(new ByteEntity(StringUtils.toUtf8(data))).iterator(),
+        Stream.of(new CountableInputEntity(new ByteEntity(StringUtils.toUtf8(data)), inputStats)).iterator(),
         temporaryDirectory
     );
   }

--- a/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/LocalInputSource.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.impl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import org.apache.commons.io.FileUtils;
@@ -33,11 +34,14 @@ import org.apache.commons.io.filefilter.NotFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
+import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -191,14 +195,21 @@ public class LocalInputSource extends AbstractInputSource implements SplittableI
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     //noinspection ConstantConditions
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
-        Iterators.transform(getFileIterator(), FileEntity::new),
+        Iterators.transform(getFileIterator(), new Function<File, InputEntity>()
+        {
+          @Nullable @Override public InputEntity apply(@Nullable File file)
+          {
+            return new CountableInputEntity(new FileEntity(file), inputStats);
+          }
+        }),
         temporaryDirectory
     );
   }

--- a/core/src/main/java/org/apache/druid/java/util/metrics/InputStatsMonitor.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/InputStatsMonitor.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.InputStats;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+
+import java.util.Map;
+
+public class InputStatsMonitor extends AbstractMonitor
+{
+  private final InputStats inputStats;
+  private long lastReportedValue;
+  private final Map<String, String[]> dimensions;
+
+  public InputStatsMonitor(InputStats inputStats, Map<String, String[]> dimensions)
+  {
+    this.inputStats = inputStats;
+    this.dimensions = ImmutableMap.copyOf(dimensions);
+    this.lastReportedValue = 0;
+  }
+
+  @Override
+  public boolean doMonitor(ServiceEmitter emitter)
+  {
+    final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
+    MonitorUtils.addDimensionsToBuilder(builder, dimensions);
+    final long currentValue = inputStats.getProcessedBytes().get();
+    emitter.emit(builder.build("ingest/events/processedBytes", currentValue - lastReportedValue));
+    lastReportedValue = currentValue;
+    return true;
+  }
+}

--- a/core/src/main/java/org/apache/druid/java/util/metrics/InputStatsMonitor.java
+++ b/core/src/main/java/org/apache/druid/java/util/metrics/InputStatsMonitor.java
@@ -20,9 +20,11 @@
 package org.apache.druid.java.util.metrics;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import org.apache.druid.data.input.InputStats;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+
 
 import java.util.Map;
 
@@ -31,6 +33,12 @@ public class InputStatsMonitor extends AbstractMonitor
   private final InputStats inputStats;
   private long lastReportedValue;
   private final Map<String, String[]> dimensions;
+
+  @Inject
+  public InputStatsMonitor(InputStats inputStats)
+  {
+    this(inputStats, ImmutableMap.of());
+  }
 
   public InputStatsMonitor(InputStats inputStats, Map<String, String[]> dimensions)
   {

--- a/core/src/test/java/org/apache/druid/data/input/CountableInputEntityTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/CountableInputEntityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.FileEntity;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class CountableInputEntityTest
+{
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private CountableInputEntity countableInputEntity;
+  private InputStats inputStats;
+  private byte[] bytes;
+  private final int numBytes = 100;
+
+  @Before
+  public void setUp()
+  {
+    inputStats = new InputStats();
+    bytes = new byte[numBytes];
+  }
+
+  @Test
+  public void testWithFileEntity() throws IOException
+  {
+    final File sourceFile = folder.newFile("testWithFileEntity");
+    final OutputStreamWriter outputStreamWriter = new OutputStreamWriter(
+        new FileOutputStream(sourceFile),
+        StandardCharsets.UTF_8
+    );
+    char[] chars = new char[numBytes];
+    Arrays.fill(chars, ' ');
+    outputStreamWriter.write(chars);
+    outputStreamWriter.flush();
+    outputStreamWriter.close();
+    final FileEntity fileEntity = new FileEntity(sourceFile);
+    countableInputEntity = new CountableInputEntity(fileEntity, inputStats);
+
+    final byte[] intermediateBuffer = new byte[numBytes / 2];
+    countableInputEntity.open().read(intermediateBuffer);
+    Assert.assertEquals(numBytes / 2, inputStats.getProcessedBytes().intValue());
+
+    countableInputEntity.fetch(folder.newFolder(), intermediateBuffer);
+    Assert.assertEquals((numBytes / 2) + numBytes, inputStats.getProcessedBytes().intValue());
+  }
+
+  @Test
+  public void testWithByteEntity() throws IOException
+  {
+    final byte[] intermediateBuffer = new byte[numBytes];
+    final ByteEntity byteEntity = new ByteEntity(bytes);
+    countableInputEntity = new CountableInputEntity(byteEntity, inputStats);
+    countableInputEntity.open().read(intermediateBuffer);
+    Assert.assertEquals(numBytes, inputStats.getProcessedBytes().intValue());
+
+    final byte[] smallIntermediateBuffer = new byte[25];
+    final ByteEntity byteEntity1 = new ByteEntity(bytes);
+    countableInputEntity = new CountableInputEntity(byteEntity1, inputStats);
+    countableInputEntity.fetch(folder.newFolder(), smallIntermediateBuffer);
+    Assert.assertEquals(numBytes + numBytes, inputStats.getProcessedBytes().intValue());
+  }
+}

--- a/core/src/test/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptorTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/FirehoseFactoryToInputSourceAdaptorTest.java
@@ -73,7 +73,8 @@ public class FirehoseFactoryToInputSourceAdaptorTest extends InitializedNullHand
             ColumnsFilter.all()
         ),
         null,
-        null
+        null,
+        new InputStats()
     );
     final List<InputRow> result = new ArrayList<>();
     try (CloseableIterator<InputRow> iterator = reader.read()) {

--- a/core/src/test/java/org/apache/druid/data/input/impl/NoopInputSource.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/NoopInputSource.java
@@ -23,6 +23,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -51,7 +52,8 @@ public class NoopInputSource implements InputSource
   public InputSourceReader reader(
       InputRowSchema inputRowSchema,
       @Nullable InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     throw new UnsupportedOperationException();

--- a/core/src/test/java/org/apache/druid/java/util/metrics/InputStatsMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/InputStatsMonitorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.InputStats;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.core.NoopEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class InputStatsMonitorTest
+{
+  private InputStatsMonitor inputStatsMonitor;
+  private InputStats inputStats;
+  private Map<String, String[]> dimensions;
+  private List<Event> events;
+  private ServiceEmitter emitter;
+
+  @Before
+  public void setUp()
+  {
+    inputStats = new InputStats();
+    dimensions = ImmutableMap.of("k1", new String[] {"v1"});
+    events = new ArrayList<>();
+    inputStatsMonitor = new InputStatsMonitor(inputStats, dimensions);
+    emitter = new ServiceEmitter("", "", new TestEmitter(events));
+  }
+
+  @Test
+  public void testInputStatsMonitor()
+  {
+    inputStats.incrementProcessedBytes(10);
+    inputStatsMonitor.doMonitor(emitter);
+    Assert.assertEquals(10L, events.get(0).toMap().get("value"));
+    Assert.assertEquals("v1", ((List) events.get(0).toMap().get("k1")).get(0));
+    inputStats.incrementProcessedBytes(100);
+    inputStatsMonitor.doMonitor(emitter);
+    Assert.assertEquals(100L, events.get(1).toMap().get("value"));
+  }
+
+  static class TestEmitter extends NoopEmitter
+  {
+    private final List<Event> events;
+
+    public TestEmitter(List<Event> events)
+    {
+      this.events = events;
+    }
+
+    @Override
+    public void emit(Event event)
+    {
+      events.add(event);
+    }
+
+    public List<Event> getEvents()
+    {
+      return events;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/druid/java/util/metrics/InputStatsMonitorTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/metrics/InputStatsMonitorTest.java
@@ -44,7 +44,7 @@ public class InputStatsMonitorTest
   public void setUp()
   {
     inputStats = new InputStats();
-    dimensions = ImmutableMap.of("k1", new String[] {"v1"});
+    dimensions = ImmutableMap.of("k1", new String[]{"v1"});
     events = new ArrayList<>();
     inputStatsMonitor = new InputStatsMonitor(inputStats, dimensions);
     emitter = new ServiceEmitter("", "", new TestEmitter(events));

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.data.input.impl.CsvInputFormat;
@@ -478,7 +479,8 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
@@ -522,7 +524,8 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.data.input.impl.CsvInputFormat;
@@ -292,7 +293,8 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        null
+        null,
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
@@ -336,7 +338,8 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        null
+        null,
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/inputsource/hdfs/HdfsInputSource.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/inputsource/hdfs/HdfsInputSource.java
@@ -27,11 +27,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.InputEntityIteratingReader;
 import org.apache.druid.data.input.impl.SplittableInputSource;
@@ -173,7 +175,8 @@ public class HdfsInputSource extends AbstractInputSource implements SplittableIn
   protected InputSourceReader formattableReader(
       InputRowSchema inputRowSchema,
       InputFormat inputFormat,
-      @Nullable File temporaryDirectory
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
   )
   {
     try {
@@ -185,7 +188,10 @@ public class HdfsInputSource extends AbstractInputSource implements SplittableIn
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
-        Iterators.transform(cachedPaths.iterator(), path -> new HdfsInputEntity(configuration, path)),
+        Iterators.transform(
+            cachedPaths.iterator(),
+            path -> new CountableInputEntity(new HdfsInputEntity(configuration, path), inputStats)
+        ),
         temporaryDirectory
     );
   }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -318,7 +319,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void readsSplitsCorrectly() throws IOException
     {
-      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null);
+      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null, new InputStats());
 
       Map<Long, String> actualTimestampToValue = new HashMap<>();
       try (CloseableIterator<InputRow> iterator = reader.read()) {
@@ -394,7 +395,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void readsSplitsCorrectly() throws IOException
     {
-      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null);
+      InputSourceReader reader = target.formattableReader(INPUT_ROW_SCHEMA, INPUT_FORMAT, null, new InputStats());
 
       try (CloseableIterator<InputRow> iterator = reader.read()) {
         Assert.assertFalse(iterator.hasNext());

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/IncrementalPublishingKafkaIndexTaskRunner.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/IncrementalPublishingKafkaIndexTaskRunner.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.kafka;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.indexing.common.LockGranularity;
@@ -66,14 +67,16 @@ public class IncrementalPublishingKafkaIndexTaskRunner extends SeekableStreamInd
       KafkaIndexTask task,
       @Nullable InputRowParser<ByteBuffer> parser,
       AuthorizerMapper authorizerMapper,
-      LockGranularity lockGranularityToUse
+      LockGranularity lockGranularityToUse,
+      InputStats inputStats
   )
   {
     super(
         task,
         parser,
         authorizerMapper,
-        lockGranularityToUse
+        lockGranularityToUse,
+        inputStats
     );
     this.task = task;
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -84,7 +84,8 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<Integer, Long, Kafka
         this,
         dataSchema.getParser(),
         authorizerMapper,
-        lockGranularityToUse
+        lockGranularityToUse,
+        getInputStats()
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -74,7 +74,8 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, By
         this,
         dataSchema.getParser(),
         authorizerMapper,
-        lockGranularityToUse
+        lockGranularityToUse,
+        getInputStats()
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskRunner.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskRunner.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.kinesis;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.indexing.common.LockGranularity;
@@ -60,14 +61,16 @@ public class KinesisIndexTaskRunner extends SeekableStreamIndexTaskRunner<String
       KinesisIndexTask task,
       @Nullable InputRowParser<ByteBuffer> parser,
       AuthorizerMapper authorizerMapper,
-      LockGranularity lockGranularityToUse
+      LockGranularity lockGranularityToUse,
+      InputStats inputStats
   )
   {
     super(
         task,
         parser,
         authorizerMapper,
-        lockGranularityToUse
+        lockGranularityToUse,
+        inputStats
     );
     this.task = task;
   }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -49,6 +49,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.data.input.impl.CsvInputFormat;
@@ -781,7 +782,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
@@ -825,7 +827,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     final IllegalStateException e = Assert.assertThrows(IllegalStateException.class, reader::read);
@@ -869,7 +872,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0),
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -771,7 +771,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
         inputSource.needsFormat() ? getInputFormat(ingestionSchema) : null,
         rowFilter,
         determinePartitionsMeters,
-        determinePartitionsParseExceptionHandler
+        determinePartitionsParseExceptionHandler,
+        getInputStats()
     )) {
       while (inputRowIterator.hasNext()) {
         final InputRow inputRow = inputRowIterator.next();
@@ -932,7 +933,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           new DefaultIndexTaskInputRowIteratorBuilder(),
           buildSegmentsMeters,
           buildSegmentsParseExceptionHandler,
-          pushTimeout
+          pushTimeout,
+          getInputStats()
       );
 
       // If we use timeChunk lock, then we don't have to specify what segments will be overwritten because

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/InputSourceProcessor.java
@@ -25,6 +25,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.IndexTaskInputRowIteratorBuilder;
@@ -68,7 +69,8 @@ public class InputSourceProcessor
       IndexTaskInputRowIteratorBuilder inputRowIteratorBuilder,
       RowIngestionMeters buildSegmentsMeters,
       ParseExceptionHandler parseExceptionHandler,
-      long pushTimeout
+      long pushTimeout,
+      InputStats inputStats
   ) throws IOException, InterruptedException, ExecutionException, TimeoutException
   {
     @Nullable
@@ -85,7 +87,8 @@ public class InputSourceProcessor
             inputFormat,
             AbstractBatchIndexTask.defaultRowFilter(granularitySpec),
             buildSegmentsMeters,
-            parseExceptionHandler
+            parseExceptionHandler,
+            inputStats
         );
         final HandlingInputRowIterator iterator = inputRowIteratorBuilder
             .delegate(inputRowIterator)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -179,7 +179,8 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
             inputFormat,
             determineIntervals ? Objects::nonNull : AbstractBatchIndexTask.defaultRowFilter(granularitySpec),
             buildSegmentsMeters,
-            parseExceptionHandler
+            parseExceptionHandler,
+            getInputStats()
         );
     ) {
       Map<Interval, byte[]> cardinalities = determineCardinalities(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
@@ -226,7 +226,8 @@ public class PartialDimensionDistributionTask extends PerfectRollupWorkerTask
             inputFormat,
             determineIntervals ? Objects::nonNull : AbstractBatchIndexTask.defaultRowFilter(granularitySpec),
             buildSegmentsMeters,
-            parseExceptionHandler
+            parseExceptionHandler,
+            getInputStats()
         );
         HandlingInputRowIterator iterator =
             new RangePartitionIndexTaskInputRowIteratorBuilder(partitionDimensions, SKIP_NULL)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
@@ -32,6 +33,7 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.DefaultIndexTaskInputRowIteratorBuilder;
 import org.apache.druid.indexing.common.task.batch.partition.HashPartitionAnalysis;
 import org.apache.druid.indexing.worker.shuffle.ShuffleDataSegmentPusher;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.PartialShardSpec;
@@ -199,5 +201,16 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
       intervals.forEach(interval -> partitionAnalysis.updateBucket(interval, numBucketsPerInterval));
     }
     return partitionAnalysis;
+  }
+
+  @Override
+  public Map<String, String[]> getMetricsDimensions()
+  {
+    return ImmutableMap.of(
+        DruidMetrics.TASK_ID, new String[] {getId()},
+        DruidMetrics.TASK_TYPE, new String[] {getType()},
+        DruidMetrics.DATASOURCE, new String[] {getDataSource()},
+        DruidMetrics.SUPERVISOR_ID, new String[] {getSupervisorTaskId()}
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
@@ -35,6 +36,7 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.RangePartitionIndexTaskInputRowIteratorBuilder;
 import org.apache.druid.indexing.common.task.batch.partition.RangePartitionAnalysis;
 import org.apache.druid.indexing.worker.shuffle.ShuffleDataSegmentPusher;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
 import org.joda.time.Interval;
@@ -182,5 +184,16 @@ public class PartialRangeSegmentGenerateTask extends PartialSegmentGenerateTask<
                                                         .map(segment -> toolbox.getIntermediaryDataManager().generatePartitionStat(toolbox, segment))
                                                         .collect(Collectors.toList());
     return new GeneratedPartitionsMetadataReport(getId(), partitionStats, taskReport);
+  }
+
+  @Override
+  public Map<String, String[]> getMetricsDimensions()
+  {
+    return ImmutableMap.of(
+        DruidMetrics.TASK_ID, new String[] {getId()},
+        DruidMetrics.TASK_TYPE, new String[] {getType()},
+        DruidMetrics.DATASOURCE, new String[] {getDataSource()},
+        DruidMetrics.SUPERVISOR_ID, new String[] {getSupervisorTaskId()}
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
@@ -217,7 +217,8 @@ abstract class PartialSegmentGenerateTask<T extends GeneratedPartitionsReport> e
           inputRowIteratorBuilder,
           buildSegmentsMeters,
           parseExceptionHandler,
-          pushTimeout
+          pushTimeout,
+          getInputStats()
       );
       return pushed.getSegments();
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeTask.java
@@ -41,6 +41,7 @@ import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.BaseProgressIndicator;
 import org.apache.druid.segment.IndexIO;
@@ -362,5 +363,16 @@ abstract class PartialSegmentMergeTask<S extends ShardSpec> extends PerfectRollu
           suffix
       );
     }
+  }
+
+  @Override
+  public Map<String, String[]> getMetricsDimensions()
+  {
+    return ImmutableMap.of(
+        DruidMetrics.TASK_ID, new String[] {getId()},
+        DruidMetrics.TASK_TYPE, new String[] {getType()},
+        DruidMetrics.DATASOURCE, new String[] {getDataSource()},
+        DruidMetrics.SUPERVISOR_ID, new String[] {getSupervisorTaskId()}
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -426,7 +426,8 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
               return true;
             },
             rowIngestionMeters,
-            parseExceptionHandler
+            parseExceptionHandler,
+            getInputStats()
         )
     ) {
       driver.startJob();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -31,11 +31,13 @@ import com.google.common.collect.Iterators;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.data.input.AbstractInputSource;
 import org.apache.druid.data.input.ColumnsFilter;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MaxSizeSplitHintSpec;
 import org.apache.druid.data.input.SegmentsSplitHintSpec;
 import org.apache.druid.data.input.SplitHintSpec;
@@ -224,12 +226,12 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
   }
 
   @Override
-  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory, InputStats inputStats)
   {
     final SegmentCacheManager segmentCacheManager = segmentCacheManagerFactory.manufacturate(temporaryDirectory);
 
     final List<TimelineObjectHolder<String, DataSegment>> timeline = createTimeline();
-    final Iterator<DruidSegmentInputEntity> entityIterator = FluentIterable
+    final Iterator<CountableInputEntity> entityIterator = FluentIterable
         .from(timeline)
         .transformAndConcat(holder -> {
           //noinspection ConstantConditions
@@ -237,7 +239,7 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
           //noinspection ConstantConditions
           return FluentIterable
               .from(partitionHolder)
-              .transform(chunk -> new DruidSegmentInputEntity(segmentCacheManager, chunk.getObject(), holder.getInterval()));
+              .transform(chunk -> new CountableInputEntity(new DruidSegmentInputEntity(segmentCacheManager, chunk.getObject(), holder.getInterval()), inputStats));
         }).iterator();
 
     final DruidSegmentInputFormat inputFormat = new DruidSegmentInputFormat(indexIO, dimFilter);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidSegmentReader.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.input;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -88,7 +89,8 @@ public class DruidSegmentReader extends IntermediateRowParsingReader<Map<String,
       final File temporaryDirectory
   )
   {
-    this.source = (DruidSegmentInputEntity) source;
+    Preconditions.checkArgument(source.getBaseInputEntity() instanceof DruidSegmentInputEntity);
+    this.source = (DruidSegmentInputEntity) source.getBaseInputEntity();
     this.indexIO = indexIO;
     this.columnsFilter = columnsFilter;
     this.inputRowSchema = new InputRowSchema(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/GeneratorInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/GeneratorInputSource.java
@@ -30,6 +30,7 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.SplittableInputSource;
@@ -143,7 +144,11 @@ public class GeneratorInputSource extends AbstractInputSource implements Splitta
   }
 
   @Override
-  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+  protected InputSourceReader fixedFormatReader(
+      InputRowSchema inputRowSchema,
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
+  )
   {
     return new InputSourceReader()
     {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/InputSourceSampler.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimedShutoffInputSourceReader;
@@ -216,7 +217,7 @@ public class InputSourceSampler
   {
     final InputRowSchema inputRowSchema = InputRowSchemas.fromDataSchema(dataSchema);
 
-    InputSourceReader reader = inputSource.reader(inputRowSchema, inputFormat, tempDir);
+    InputSourceReader reader = inputSource.reader(inputRowSchema, inputFormat, tempDir, new InputStats());
 
     if (samplerConfig.getTimeoutMs() > 0) {
       reader = new TimedShutoffInputSourceReader(reader, DateTimes.nowUtc().plusMillis(samplerConfig.getTimeoutMs()));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -43,6 +43,7 @@ import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.metrics.InputStatsMonitor;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.NoopQueryRunner;
 import org.apache.druid.query.Query;
@@ -153,6 +154,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   public TaskStatus run(final TaskToolbox toolbox)
   {
     emitMetric(toolbox.getEmitter(), "ingest/count", 1);
+    toolbox.addMonitor(new InputStatsMonitor(inputStats, getMetricsDimensions()));
     return getRunner().run(toolbox);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -24,7 +24,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.appenderator.ActionBasedSegmentAllocator;
@@ -41,6 +43,7 @@ import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.NoopQueryRunner;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
@@ -76,6 +79,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   // See https://github.com/apache/druid/issues/7724 for issues that can cause.
   // By the way, lazily init is synchronized because the runner may be needed in multiple threads.
   private final Supplier<SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOffsetType, ?>> runnerSupplier;
+  private final InputStats inputStats;
 
   @MonotonicNonNull
   protected AuthorizerMapper authorizerMapper;
@@ -107,6 +111,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
                                 ? LockGranularity.TIME_CHUNK
                                 : LockGranularity.SEGMENT;
     this.lockTypeToUse = getContextValue(Tasks.USE_SHARED_LOCK, false) ? TaskLockType.SHARED : TaskLockType.EXCLUSIVE;
+    this.inputStats = new InputStats();
   }
 
   protected static String getFormattedGroupId(String dataSource, String type)
@@ -280,5 +285,19 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   public SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOffsetType, ?> getRunner()
   {
     return runnerSupplier.get();
+  }
+
+  public InputStats getInputStats()
+  {
+    return inputStats;
+  }
+
+  public Map<String, String[]> getMetricsDimensions()
+  {
+    return ImmutableMap.of(
+        DruidMetrics.TASK_ID, new String[] {getId()},
+        DruidMetrics.TASK_TYPE, new String[] {getType()},
+        DruidMetrics.DATASOURCE, new String[] {getDataSource()}
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -40,6 +40,7 @@ import org.apache.druid.data.input.Committer;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.InputRowParser;
 import org.apache.druid.discovery.DiscoveryDruidNode;
@@ -231,6 +232,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
 
   protected volatile boolean pauseRequested = false;
   private volatile long nextCheckpointTime;
+  private final InputStats inputStats;
 
   private volatile CopyOnWriteArrayList<SequenceMetadata<PartitionIdType, SequenceOffsetType>> sequences;
   private volatile Throwable backgroundThreadException;
@@ -239,7 +241,8 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
       final SeekableStreamIndexTask<PartitionIdType, SequenceOffsetType, RecordType> task,
       @Nullable final InputRowParser<ByteBuffer> parser,
       final AuthorizerMapper authorizerMapper,
-      final LockGranularity lockGranularityToUse
+      final LockGranularity lockGranularityToUse,
+      InputStats inputStats
   )
   {
     Preconditions.checkNotNull(task);
@@ -255,7 +258,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
     this.sequences = new CopyOnWriteArrayList<>();
     this.ingestionState = IngestionState.NOT_STARTED;
     this.lockGranularityToUse = lockGranularityToUse;
-
+    this.inputStats = inputStats;
     resetNextCheckpointTime();
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.InputRowParser;
@@ -175,7 +176,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
           createRecordSupplier(),
           ioConfig.isUseEarliestSequenceNumber()
       );
-      this.entityIterator = inputSource.createEntityIterator();
+      this.entityIterator = inputSource.createEntityIterator(new InputStats());
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingWithNullColumnTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingWithNullColumnTest.java
@@ -26,11 +26,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionSchema;
@@ -421,13 +423,14 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
     public InputSourceReader reader(
         InputRowSchema inputRowSchema,
         @Nullable InputFormat inputFormat,
-        File temporaryDirectory
+        File temporaryDirectory,
+        InputStats inputStats
     )
     {
       return new InputEntityIteratingReader(
           inputRowSchema,
           inputFormat,
-          data.stream().map(str -> new ByteEntity(StringUtils.toUtf8(str))).iterator(),
+          data.stream().map(str -> new CountableInputEntity( new ByteEntity(StringUtils.toUtf8(str)), inputStats)).iterator(),
           temporaryDirectory
       );
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/GeneratorInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/GeneratorInputSourceTest.java
@@ -26,6 +26,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
@@ -126,7 +127,7 @@ public class GeneratorInputSourceTest
         timestampIncrement
     );
 
-    InputSourceReader reader = inputSource.fixedFormatReader(null, null);
+    InputSourceReader reader = inputSource.fixedFormatReader(null, null, new InputStats());
     CloseableIterator<InputRow> iterator = reader.read();
 
     InputRow first = iterator.next();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -41,6 +41,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InputRowParser;
@@ -285,7 +286,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
   private static class MockExceptionInputSource extends AbstractInputSource
   {
     @Override
-    protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+    protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory, InputStats inputStats)
     {
       return new InputSourceReader()
       {
@@ -337,7 +338,11 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
   private static class MockInputSource extends AbstractInputSource
   {
     @Override
-    protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+    protected InputSourceReader fixedFormatReader(
+        InputRowSchema inputRowSchema,
+        @Nullable File temporaryDirectory,
+        InputStats inputStats
+    )
     {
       return new InputSourceReader()
       {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DelimitedParseSpec;
@@ -1318,7 +1319,8 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
       public InputSourceReader reader(
           InputRowSchema inputRowSchema,
           @Nullable InputFormat inputFormat,
-          File temporaryDirectory
+          File temporaryDirectory,
+          InputStats inputStats
       )
       {
         throw new RuntimeException();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -83,7 +84,8 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
             ColumnsFilter.all()
         ),
         inputFormat,
-        temporaryFolder.newFolder()
+        temporaryFolder.newFolder(),
+        new InputStats()
     );
 
     int read = 0;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.seekablestream;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -260,7 +261,7 @@ public class SeekableStreamIndexTaskRunnerAuthTest
         AuthorizerMapper authorizerMapper
     )
     {
-      super(task, null, authorizerMapper, LockGranularity.SEGMENT);
+      super(task, null, authorizerMapper, LockGranularity.SEGMENT, new InputStats());
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -35,6 +35,7 @@ public class DruidMetrics
   public static final String TASK_ID = "taskId";
   public static final String STATUS = "status";
   public static final String TASK_INGESTION_MODE = "taskIngestionMode";
+  public static final String SUPERVISOR_ID = "supervisorId";
 
   public static final String PARTITIONING_TYPE = "partitioningType";
 

--- a/server/src/main/java/org/apache/druid/metadata/input/SqlInputSource.java
+++ b/server/src/main/java/org/apache/druid/metadata/input/SqlInputSource.java
@@ -25,10 +25,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.CountableInputEntity;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.InputEntityIteratingReader;
 import org.apache.druid.data.input.impl.SplittableInputSource;
@@ -110,14 +112,20 @@ public class SqlInputSource extends AbstractInputSource implements SplittableInp
   }
 
   @Override
-  protected InputSourceReader fixedFormatReader(InputRowSchema inputRowSchema, @Nullable File temporaryDirectory)
+  protected InputSourceReader fixedFormatReader(
+      InputRowSchema inputRowSchema,
+      @Nullable File temporaryDirectory,
+      InputStats inputStats
+  )
   {
     final SqlInputFormat inputFormat = new SqlInputFormat(objectMapper);
     return new InputEntityIteratingReader(
         inputRowSchema,
         inputFormat,
         createSplits(inputFormat, null)
-            .map(split -> new SqlEntity(split.get(), sqlFirehoseDatabaseConnector, foldCase, objectMapper)).iterator(),
+            .map(split -> new CountableInputEntity(
+                new SqlEntity(split.get(), sqlFirehoseDatabaseConnector, foldCase, objectMapper), inputStats))
+            .iterator(),
         temporaryDirectory
     );
   }

--- a/server/src/main/java/org/apache/druid/metadata/input/SqlReader.java
+++ b/server/src/main/java/org/apache/druid/metadata/input/SqlReader.java
@@ -57,7 +57,7 @@ public class SqlReader extends IntermediateRowParsingReader<Map<String, Object>>
   )
   {
     this.inputRowSchema = inputRowSchema;
-    this.source = (SqlEntity) source;
+    this.source = (SqlEntity) source.getBaseInputEntity();
     this.temporaryDirectory = temporaryDirectory;
     this.objectMapper = objectMapper;
   }

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlInputSourceTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
@@ -155,7 +156,7 @@ public class SqlInputSourceTest
     testUtils.createAndUpdateTable(TABLE_NAME_1, 10);
     final File tempDir = createFirehoseTmpDir("testSingleSplit");
     SqlInputSource sqlInputSource = new SqlInputSource(SQLLIST1, true, testUtils.getDerbyFirehoseConnector(), mapper);
-    InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir);
+    InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir, new InputStats());
     CloseableIterator<InputRow> resultIterator = sqlReader.read();
     final List<Row> rows = new ArrayList<>();
     while (resultIterator.hasNext()) {
@@ -175,7 +176,7 @@ public class SqlInputSourceTest
     testUtils.createAndUpdateTable(TABLE_NAME_2, 10);
     final File tempDir = createFirehoseTmpDir("testMultipleSplit");
     SqlInputSource sqlInputSource = new SqlInputSource(SQLLIST2, true, testUtils.getDerbyFirehoseConnector(), mapper);
-    InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir);
+    InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir, new InputStats());
     CloseableIterator<InputRow> resultIterator = sqlReader.read();
     final List<Row> rows = new ArrayList<>();
     while (resultIterator.hasNext()) {
@@ -207,7 +208,7 @@ public class SqlInputSourceTest
     try {
       final File tempDir = createFirehoseTmpDir("testSingleSplit");
       SqlInputSource sqlInputSource = new SqlInputSource(SQLLIST1, true, testUtils.getDerbyFirehoseConnector(), mapper);
-      InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir);
+      InputSourceReader sqlReader = sqlInputSource.fixedFormatReader(INPUT_ROW_SCHEMA, tempDir, new InputStats());
       CloseableIterator<InputRowListPlusRawValues> resultIterator = sqlReader.sample();
       final List<InputRowListPlusRawValues> rows = new ArrayList<>();
       while (resultIterator.hasNext()) {


### PR DESCRIPTION
Throughput by volume from #10407

Currently there is no way to know how much data is processed by task during ingestion. This PR adds ingest/events/processedBytes metric to emit number of bytes read since last emission time.

This PR adds InputStats class which is present in all task types and acts as holder for task level counts like processed bytes in this case. Thus standardized metrics throughout the task types can be added in future and emitted using InputStatsMonitor which is automatically initialized for all tasks

This PR provides convenient wrapper class named CountableInputEntity which can warp any InputEntity to count number of bytes processed through that InputEntity, thus its easier for new implementations to emit this metric just by wrapping the base input entity in this while creating InputEntityIteratingReader

Since Kafka and Kinesis does not use InputEntity, therefore processed bytes is increment directly in SeekableStreamIndexTaskRunner as it has access to InputStats

With this is place, druid will be able to report throughput by volume

This is a work in progress. 
 have updated the PR to have the monitor emitted correctly now. I am using the following with wikipedia data

```
druid.monitoring.monitors=["org.apache.druid.java.util.metrics.InputStatsMonitor"]
druid.emitter=logging
druid.emitter.logging.logLevel=info
druid.monitoring.emissionPeriod=PT1S
```
There would be an output of the amount of bytes processed per emission period. With the PR, the task report is having outputs such as


```
2022-07-07T17:58:51.547Z","service":"druid/middleManager","host":"localhost:8100","version":"0.24.0-SNAPSHOT","metric":"ingest/events/processedBytes","value":17122640,"dataSource":["wikipedia"],"taskId":["index_parallel_wikipedia_hnpcdnad_2022-07-07T17:58:25.391Z"],"taskType":["index"]}
2022-07-07T17:58:52.550Z","service":"druid/middleManager","host":"localhost:8100","version":"0.24.0-SNAPSHOT","metric":"ingest/events/processedBytes","value":16928464,"dataSource":["wikipedia"],"taskId":["index_parallel_wikipedia_hnpcdnad_2022-07-07T17:58:25.391Z"],"taskType":["index"]}
2022-07-07T17:58:53.555Z","service":"druid/middleManager","host":"localhost:8100","version":"0.24.0-SNAPSHOT","metric":"ingest/events/processedBytes","value":161408,"dataSource":["wikipedia"],"taskId":["index_parallel_wikipedia_hnpcdnad_2022-07-07T17:58:25.391Z"],"taskType":["index"]}
2022-07-07T17:58:54.558Z","service":"druid/middleManager","host":"localhost:8100","version":"0.24.0-SNAPSHOT","metric":"ingest/events/processedBytes","value":0,"dataSource":["wikipedia"],"taskId":["index_parallel_wikipedia_hnpcdnad_2022-07-07T17:58:25.391Z"],"taskType":["index"]}
```
 
 
<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
