### PR TITLE
Mark specific nimbus.lang.tag.version.

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -146,4 +146,19 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <!-- Transitive dependency explicitly added to lock a specific version -->
+            <ignoredUnusedDeclaredDependency>com.nimbusds:lang-tag</ignoredUnusedDeclaredDependency>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -37,6 +37,7 @@
     <pac4j.version>3.8.3</pac4j.version>
 
     <!-- Following must be updated along with any updates to pac4j version -->
+    <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
     <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
     <oauth2.oidc.sdk.version>6.5</oauth2.oidc.sdk.version>
   </properties>
@@ -65,6 +66,11 @@
       <version>${pac4j.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>lang-tag</artifactId>
+      <version>${nimbus.lang.tag.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -803,7 +803,7 @@ name: com.nimbusds lang-tag
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 1.6
+version: 1.7
 libraries:
   - com.nimbusds: lang-tag
 


### PR DESCRIPTION
I'm seeing CI failures during license checking like this:

```
Error: found 1 missing licenses. These licenses are reported, but missing in the registry
druid_module: druid-pac4j, groupId: com.nimbusds, artifactId: lang-tag, version: 1.7, license: Apache License version 2.0
```

Our licenses.yaml has version 1.6 of this artifact. It came in transitively through `com.nimbusds:oauth2-oidc-sdk`, whose pom uses version range `[1.4.3,)`. Version ranges are lame, because they make builds nonreproducible. This patch updates our licenses.yaml, and adds the newer version of `com.nimbusds:lang-tag` to our pom explicitly, to prevent it from changing again.