### PR TITLE
Retain CSP configuration in ServerConfig constructor.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -87,6 +87,7 @@ public class ServerConfig
     this.allowedHttpMethods = allowedHttpMethods;
     this.showDetailedJettyErrors = showDetailedJettyErrors;
     this.errorResponseTransformStrategy = errorResponseTransformStrategy;
+    this.contentSecurityPolicy = contentSecurityPolicy;
   }
 
   public ServerConfig()

--- a/server/src/test/java/org/apache/druid/initialization/ServerConfigTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ServerConfigTest.java
@@ -61,7 +61,7 @@ public class ServerConfigTest
         ImmutableList.of(HttpMethod.OPTIONS),
         true,
         new AllowedRegexErrorResponseTransformStrategy(ImmutableList.of(".*")),
-        defaultConfig.getContentSecurityPolicy()
+        "my-cool-policy"
     );
     String modifiedConfigJson = OBJECT_MAPPER.writeValueAsString(modifiedConfig);
     ServerConfig modifiedConfig2 = OBJECT_MAPPER.readValue(modifiedConfigJson, ServerConfig.class);
@@ -72,6 +72,8 @@ public class ServerConfigTest
     Assert.assertTrue(modifiedConfig2.isEnableForwardedRequestCustomizer());
     Assert.assertEquals(1, modifiedConfig2.getAllowedHttpMethods().size());
     Assert.assertTrue(modifiedConfig2.getAllowedHttpMethods().contains(HttpMethod.OPTIONS));
+    Assert.assertEquals("my-cool-policy", modifiedConfig.getContentSecurityPolicy());
+    Assert.assertEquals("my-cool-policy", modifiedConfig2.getContentSecurityPolicy());
   }
 
   @Test


### PR DESCRIPTION
Without this change, CliIndexer would not apply custom CSP headers and would revert to the default. Other server types respect it just fine, because they use an instance created by JsonConfigProvider, which sets properties directly. Fortunately, the default is a secure choice. Feature originally added in #12609.