### PR TITLE
Document missed simple granularities

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/granularity/GranularityType.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/granularity/GranularityType.java
@@ -28,6 +28,9 @@ import org.joda.time.chrono.ISOChronology;
 /**
  * Only to create a mapping of the granularity and all the supported file patterns
  * namely: default, lowerDefault and hive.
+ *
+ * NOTE:
+ * When a new granularity type is added to following type, DO remember document it here: docs/querying/granularities.md#simple-granularities
  */
 public enum GranularityType
 {

--- a/docs/querying/granularities.md
+++ b/docs/querying/granularities.md
@@ -38,7 +38,7 @@ You can specify a time period as a [simple](#simple-granularities) string, as a 
 
 Simple granularities are specified as a string and bucket timestamps by their UTC time (e.g., days start at 00:00 UTC).
 
-Supported granularity strings are: 
+Druid supports the following granularity strings: 
   - `all`
   - `none`
   - `second`

--- a/docs/querying/granularities.md
+++ b/docs/querying/granularities.md
@@ -38,10 +38,27 @@ You can specify a time period as a [simple](#simple-granularities) string, as a 
 
 Simple granularities are specified as a string and bucket timestamps by their UTC time (e.g., days start at 00:00 UTC).
 
-Supported granularity strings are: `all`, `none`, `second`, `minute`, `fifteen_minute`, `thirty_minute`, `hour`, `day`, `week`, `month`, `quarter` and `year`.
+Supported granularity strings are: 
+  - `all`
+  - `none`
+  - `second`
+  - `minute`
+  - `five_minute`
+  - `ten_minute`
+  - `fifteen_minute`
+  - `thirty_minute`
+  - `hour`
+  - `six_hour`
+  - `eight_hour`
+  - `day`
+  - `week`
+  - `month`
+  - `quarter` 
+  - `year`
 
-* `all` buckets everything into a single bucket
-* `none` does not bucket data (it actually uses the granularity of the index - minimum here is `none` which means millisecond granularity). Using `none` in a [TimeseriesQuery](../querying/timeseriesquery.md) is currently not recommended (the system will try to generate 0 values for all milliseconds that didn’t exist, which is often a lot).
+> NOTE
+> * `all` buckets everything into a single bucket
+> * `none` does not bucket data (it actually uses the granularity of the index - minimum here is `none` which means millisecond granularity). Using `none` in a [TimeseriesQuery](../querying/timeseriesquery.md) is currently not recommended (the system will try to generate 0 values for all milliseconds that didn’t exist, which is often a lot).
 
 #### Example:
 

--- a/docs/querying/granularities.md
+++ b/docs/querying/granularities.md
@@ -56,9 +56,10 @@ Druid supports the following granularity strings:
   - `quarter` 
   - `year`
 
-> NOTE
-> * `all` buckets everything into a single bucket
-> * `none` does not bucket data (it actually uses the granularity of the index - minimum here is `none` which means millisecond granularity). Using `none` in a [TimeseriesQuery](../querying/timeseriesquery.md) is currently not recommended (the system will try to generate 0 values for all milliseconds that didn’t exist, which is often a lot).
+The minimum and maximum granularities are `none` and `all`, described as follows:
+* `all` buckets everything into a single bucket.
+* `none` does not mean zero bucketing. It buckets data to millisecond granularity—the granularity of the internal index. You can think of `none` as equivalent to `millisecond`.
+  > Do not use `none` in a [timeseries query](../querying/timeseriesquery.md); Druid fills empty interior time buckets with zeroes, meaning the output will contain results for every single millisecond in the requested interval.
 
 #### Example:
 


### PR DESCRIPTION
### Description

There're some granularities defined in `GranularityType` but missed in the document. 

And to prevent such missing in future in case of new type is added, a note is also added to the `GranularityType` as as a reminder.

This PR has:
- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
