### PR TITLE
Add druid_service and host_name labels to Prometheus exporter

### DIFF
--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -40,8 +40,8 @@ All the configuration parameters for the Prometheus emitter are under `druid.emi
 |`druid.emitter.prometheus.port`|The port on which to expose the prometheus HTTPServer. Required if using exporter strategy.|no|none|
 |`druid.emitter.prometheus.namespace`|Optional metric namespace. Must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`|no|"druid"|
 |`druid.emitter.prometheus.dimensionMapPath`|JSON file defining the Prometheus metric type, desired dimensions, help text, and conversionFactor for every Druid metric.|no|Default mapping provided. See below.|
-|`druid.emitter.prometheus.hostAsLabel`|Flag to include the hostname as a prometheus label.|no|false|
-|`druid.emitter.prometheus.serviceAsLabel`|If `druid.emitter.prometheus.serviceAsLabel` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`)|no|false|
+|`druid.emitter.prometheus.addHostAsLabel`|Flag to include the hostname as a prometheus label.|no|false|
+|`druid.emitter.prometheus.addServiceAsLabel`|If `druid.emitter.prometheus.addServiceAsLabel` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`)|no|false|
 |`druid.emitter.prometheus.pushGatewayAddress`|Pushgateway address. Required if using Pushgateway strategy|no|none|
 
 

--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -41,7 +41,7 @@ All the configuration parameters for the Prometheus emitter are under `druid.emi
 |`druid.emitter.prometheus.namespace`|Optional metric namespace. Must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`|no|"druid"|
 |`druid.emitter.prometheus.dimensionMapPath`|JSON file defining the Prometheus metric type, desired dimensions, help text, and conversionFactor for every Druid metric.|no|Default mapping provided. See below.|
 |`druid.emitter.prometheus.addHostAsLabel`|Flag to include the hostname as a prometheus label.|no|false|
-|`druid.emitter.prometheus.addServiceAsLabel`|If `druid.emitter.prometheus.addServiceAsLabel` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`)|no|false|
+|`druid.emitter.prometheus.addServiceAsLabel`|Flag to include the druid service name (e.g. `druid/broker`, `druid/coordinator`, etc.) as a prometheus label.|no|false|
 |`druid.emitter.prometheus.pushGatewayAddress`|Pushgateway address. Required if using Pushgateway strategy|no|none|
 
 

--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -40,6 +40,8 @@ All the configuration parameters for the Prometheus emitter are under `druid.emi
 |`druid.emitter.prometheus.port`|The port on which to expose the prometheus HTTPServer. Required if using exporter strategy.|no|none|
 |`druid.emitter.prometheus.namespace`|Optional metric namespace. Must match the regex `[a-zA-Z_:][a-zA-Z0-9_:]*`|no|"druid"|
 |`druid.emitter.prometheus.dimensionMapPath`|JSON file defining the Prometheus metric type, desired dimensions, help text, and conversionFactor for every Druid metric.|no|Default mapping provided. See below.|
+|`druid.emitter.prometheus.hostAsLabel`|Flag to include the hostname as a prometheus label.|no|false|
+|`druid.emitter.prometheus.serviceAsLabel`|If `druid.emitter.prometheus.serviceAsLabel` is true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`)|no|false|
 |`druid.emitter.prometheus.pushGatewayAddress`|Pushgateway address. Required if using Pushgateway strategy|no|none|
 
 

--- a/extensions-contrib/prometheus-emitter/pom.xml
+++ b/extensions-contrib/prometheus-emitter/pom.xml
@@ -43,17 +43,17 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.7.0</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.7.0</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_pushgateway</artifactId>
-      <version>0.7.0</version>
+      <version>0.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
@@ -49,6 +49,9 @@ public class Metrics
   private final ObjectMapper mapper = new ObjectMapper();
   public static final Pattern PATTERN = Pattern.compile("[^a-zA-Z_:][^a-zA-Z0-9_:]*");
 
+  private static final String HOST_LABEL_NAME = "hostName";
+  private static final String SERVICE_LABEL_NAME = "druidService";
+
   public DimensionsAndCollector getByName(String name, String service)
   {
     if (registeredMetrics.containsKey(name)) {
@@ -58,13 +61,22 @@ public class Metrics
     }
   }
 
-  public Metrics(String namespace, String path)
+  public Metrics(String namespace, String path, boolean isIncludeHost, boolean isServiceAsTag)
   {
     Map<String, Metric> metrics = readConfig(path);
     for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
       String name = entry.getKey();
       Metric metric = entry.getValue();
       Metric.Type type = metric.type;
+
+      if (isIncludeHost) {
+        metric.dimensions.add(HOST_LABEL_NAME);
+      }
+
+      if (isServiceAsTag) {
+        metric.dimensions.add(SERVICE_LABEL_NAME);
+      }
+
       String[] dimensions = metric.dimensions.toArray(new String[0]);
       String formattedName = PATTERN.matcher(StringUtils.toLowerCase(name)).replaceAll("_");
       SimpleCollector collector = null;

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
@@ -49,8 +49,8 @@ public class Metrics
   private final ObjectMapper mapper = new ObjectMapper();
   public static final Pattern PATTERN = Pattern.compile("[^a-zA-Z_:][^a-zA-Z0-9_:]*");
 
-  private static final String HOST_LABEL_NAME = "hostName";
-  private static final String SERVICE_LABEL_NAME = "druidService";
+  private static final String TAG_HOSTNAME = "host_name";
+  private static final String TAG_SERVICE = "druid_service";
 
   public DimensionsAndCollector getByName(String name, String service)
   {
@@ -61,7 +61,7 @@ public class Metrics
     }
   }
 
-  public Metrics(String namespace, String path, boolean isIncludeHost, boolean isServiceAsTag)
+  public Metrics(String namespace, String path, boolean isAddHostAsLabel, boolean isAddServiceAsLabel)
   {
     Map<String, Metric> metrics = readConfig(path);
     for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
@@ -69,12 +69,12 @@ public class Metrics
       Metric metric = entry.getValue();
       Metric.Type type = metric.type;
 
-      if (isIncludeHost) {
-        metric.dimensions.add(HOST_LABEL_NAME);
+      if (isAddHostAsLabel) {
+        metric.dimensions.add(TAG_HOSTNAME);
       }
 
-      if (isServiceAsTag) {
-        metric.dimensions.add(SERVICE_LABEL_NAME);
+      if (isAddServiceAsLabel) {
+        metric.dimensions.add(TAG_SERVICE);
       }
 
       String[] dimensions = metric.dimensions.toArray(new String[0]);

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -151,16 +151,17 @@ public class PrometheusEmitter implements Emitter
     if (userDim != null) {
       return formatLabelValue(userDim.toString());
     } else {
-      if (isIncludeHost && lableName.equals(HOST_LABEL_NAME)) {
+      if (isIncludeHost && HOST_LABEL_NAME.equals(lableName)) {
         return hostName;
-      } else if (isServiceAsTag && lableName.equals(SERVICE_LABEL_NAME)) {
+      } else if (isServiceAsTag && SERVICE_LABEL_NAME.equals(lableName)) {
         return serviceName;
       }
     }
     return "unknown";
   }
 
-  private String formatLabelValue(String input) {
+  private String formatLabelValue(String input)
+  {
     return PATTERN.matcher(input).replaceAll("_");
   }
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -54,10 +54,10 @@ public class PrometheusEmitterConfig
   private final String pushGatewayAddress;
 
   @JsonProperty
-  private final boolean hostAsLabel;
+  private final boolean addHostAsLabel;
 
   @JsonProperty
-  private final boolean serviceAsLabel;
+  private final boolean addServiceAsLabel;
 
   @JsonCreator
   public PrometheusEmitterConfig(
@@ -66,8 +66,8 @@ public class PrometheusEmitterConfig
       @JsonProperty("dimensionMapPath") @Nullable String dimensionMapPath,
       @JsonProperty("port") @Nullable Integer port,
       @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress,
-      @JsonProperty("hostAsLabel") boolean hostAsLabel,
-      @JsonProperty("serviceAsLabel") boolean serviceAsLabel
+      @JsonProperty("addHostAsLabel") boolean addHostAsLabel,
+      @JsonProperty("addServiceAsLabel") boolean addServiceAsLabel
   )
   {
 
@@ -80,8 +80,8 @@ public class PrometheusEmitterConfig
       Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
     }
     this.pushGatewayAddress = pushGatewayAddress;
-    this.hostAsLabel = hostAsLabel;
-    this.serviceAsLabel = serviceAsLabel;
+    this.addHostAsLabel = addHostAsLabel;
+    this.addServiceAsLabel = addServiceAsLabel;
   }
 
   public String getNamespace()
@@ -109,14 +109,12 @@ public class PrometheusEmitterConfig
     return strategy;
   }
 
-  public boolean isHostAsLabel()
-  {
-    return hostAsLabel;
+  public boolean isAddHostAsLabel() {
+    return addHostAsLabel;
   }
 
-  public boolean isServiceAsLabel()
-  {
-    return serviceAsLabel;
+  public boolean isAddServiceAsLabel() {
+    return addServiceAsLabel;
   }
 
   public enum Strategy

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -109,11 +109,13 @@ public class PrometheusEmitterConfig
     return strategy;
   }
 
-  public boolean isHostAsLabel() {
+  public boolean isHostAsLabel()
+  {
     return hostAsLabel;
   }
 
-  public boolean isServiceAsLabel() {
+  public boolean isServiceAsLabel()
+  {
     return serviceAsLabel;
   }
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -53,13 +53,21 @@ public class PrometheusEmitterConfig
   @Nullable
   private final String pushGatewayAddress;
 
+  @JsonProperty
+  private final boolean hostAsLabel;
+
+  @JsonProperty
+  private final boolean serviceAsLabel;
+
   @JsonCreator
   public PrometheusEmitterConfig(
       @JsonProperty("strategy") @Nullable Strategy strategy,
       @JsonProperty("namespace") @Nullable String namespace,
       @JsonProperty("dimensionMapPath") @Nullable String dimensionMapPath,
       @JsonProperty("port") @Nullable Integer port,
-      @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress
+      @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress,
+      @JsonProperty("hostAsLabel") boolean hostAsLabel,
+      @JsonProperty("serviceAsLabel") boolean serviceAsLabel
   )
   {
 
@@ -72,6 +80,8 @@ public class PrometheusEmitterConfig
       Preconditions.checkNotNull(pushGatewayAddress, "Invalid pushGateway address");
     }
     this.pushGatewayAddress = pushGatewayAddress;
+    this.hostAsLabel = hostAsLabel;
+    this.serviceAsLabel = serviceAsLabel;
   }
 
   public String getNamespace()
@@ -97,6 +107,14 @@ public class PrometheusEmitterConfig
   public Strategy getStrategy()
   {
     return strategy;
+  }
+
+  public boolean isHostAsLabel() {
+    return hostAsLabel;
+  }
+
+  public boolean isServiceAsLabel() {
+    return serviceAsLabel;
   }
 
   public enum Strategy

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -109,11 +109,13 @@ public class PrometheusEmitterConfig
     return strategy;
   }
 
-  public boolean isAddHostAsLabel() {
+  public boolean isAddHostAsLabel()
+  {
     return addHostAsLabel;
   }
 
-  public boolean isAddServiceAsLabel() {
+  public boolean isAddServiceAsLabel()
+  {
     return addServiceAsLabel;
   }
 

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -28,18 +28,22 @@ public class MetricsTest
   @Test
   public void testMetricsConfiguration()
   {
-    Metrics metrics = new Metrics("test", null);
+    Metrics metrics = new Metrics("test", null, true, true);
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
     Assert.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
     Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("type", dimensions[1]);
+    Assert.assertEquals("druidService", dimensions[1]);
+    Assert.assertEquals("hostName", dimensions[2]);
+    Assert.assertEquals("type", dimensions[3]);
     Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
 
     DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
     Assert.assertNotNull(d);
     String[] dims = d.getDimensions();
-    Assert.assertEquals("server", dims[0]);
+    Assert.assertEquals("druidService", dims[0]);
+    Assert.assertEquals("hostName", dims[1]);
+    Assert.assertEquals("server", dims[2]);
   }
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -33,8 +33,8 @@ public class MetricsTest
     Assert.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
     Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("druidService", dimensions[1]);
-    Assert.assertEquals("hostName", dimensions[2]);
+    Assert.assertEquals("druid_service", dimensions[1]);
+    Assert.assertEquals("host_name", dimensions[2]);
     Assert.assertEquals("type", dimensions[3]);
     Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
@@ -42,8 +42,8 @@ public class MetricsTest
     DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
     Assert.assertNotNull(d);
     String[] dims = d.getDimensions();
-    Assert.assertEquals("druidService", dims[0]);
-    Assert.assertEquals("hostName", dims[1]);
+    Assert.assertEquals("druid_service", dims[0]);
+    Assert.assertEquals("host_name", dims[1]);
     Assert.assertEquals("server", dims[2]);
   }
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -29,9 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
@@ -56,7 +53,7 @@ public class PrometheusEmitterTest
     Assert.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
-        "druid_segment_loadqueue_count", new String[]{"druidService","server"}, new String[]{"historical","druid_data01_vpc_region"}
+        "druid_segment_loadqueue_count", new String[]{"druidService", "server"}, new String[]{"historical", "druid_data01_vpc_region"}
     );
     Assert.assertEquals(10, count.intValue());
   }
@@ -77,7 +74,7 @@ public class PrometheusEmitterTest
     Assert.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
-            "druid_segment_loadqueue_count", new String[]{"druidService","hostName","server"}, new String[]{"historical","druid.test.cn","druid_data01_vpc_region"}
+            "druid_segment_loadqueue_count", new String[]{"druidService", "hostName", "server"}, new String[]{"historical", "druid.test.cn", "druid_data01_vpc_region"}
     );
     Assert.assertEquals(10, count.intValue());
   }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -29,6 +29,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
@@ -38,20 +41,43 @@ import static org.easymock.EasyMock.mock;
 public class PrometheusEmitterTest
 {
   @Test
-  public void testEmitter()
+  public void testEmitterWithServiceLabel()
   {
-    PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null);
+    CollectorRegistry.defaultRegistry.clear();
+    PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null, false, true);
     PrometheusEmitterModule prometheusEmitterModule = new PrometheusEmitterModule();
     Emitter emitter = prometheusEmitterModule.getEmitter(config);
     ServiceMetricEvent build = ServiceMetricEvent.builder()
                                                  .setDimension("server", "druid-data01.vpc.region")
                                                  .build("segment/loadQueue/count", 10)
-                                                 .build(ImmutableMap.of("service", "historical"));
+                                                 .build(ImmutableMap.of("service", "historical", "host", "druid.test.cn"));
     Assert.assertEquals("historical", build.getService());
+    Assert.assertEquals("druid.test.cn", build.getHost());
     Assert.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
-        "druid_segment_loadqueue_count", new String[]{"server"}, new String[]{"druid_data01_vpc_region"}
+        "druid_segment_loadqueue_count", new String[]{"druidService","server"}, new String[]{"historical","druid_data01_vpc_region"}
+    );
+    Assert.assertEquals(10, count.intValue());
+  }
+
+  @Test
+  public void testEmitterWithServiceAndHostLabel()
+  {
+    CollectorRegistry.defaultRegistry.clear();
+    PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null, true, true);
+    PrometheusEmitterModule prometheusEmitterModule = new PrometheusEmitterModule();
+    Emitter emitter = prometheusEmitterModule.getEmitter(config);
+    ServiceMetricEvent build = ServiceMetricEvent.builder()
+            .setDimension("server", "druid-data01.vpc.region")
+            .build("segment/loadQueue/count", 10)
+            .build(ImmutableMap.of("service", "historical", "host", "druid.test.cn"));
+    Assert.assertEquals("historical", build.getService());
+    Assert.assertEquals("druid.test.cn", build.getHost());
+    Assert.assertFalse(build.getUserDims().isEmpty());
+    emitter.emit(build);
+    Double count = CollectorRegistry.defaultRegistry.getSampleValue(
+            "druid_segment_loadqueue_count", new String[]{"druidService","hostName","server"}, new String[]{"historical","druid.test.cn","druid_data01_vpc_region"}
     );
     Assert.assertEquals(10, count.intValue());
   }
@@ -59,33 +85,34 @@ public class PrometheusEmitterTest
   @Test
   public void testEmitterMetric()
   {
-    PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace", null, 0, "pushgateway");
+    CollectorRegistry.defaultRegistry.clear();
+    PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace", null, 0, "pushgateway", true, true);
     PrometheusEmitterModule prometheusEmitterModule = new PrometheusEmitterModule();
     Emitter emitter = prometheusEmitterModule.getEmitter(config);
     ServiceMetricEvent build = ServiceMetricEvent.builder()
             .setDimension("dataSource", "test")
             .setDimension("taskType", "index_parallel")
             .build("task/run/time", 500)
-            .build(ImmutableMap.of("service", "overlord"));
+            .build(ImmutableMap.of("service", "overlord", "host", "druid.test.cn"));
     emitter.emit(build);
     double assertEpsilon = 0.0001;
     Assert.assertEquals(0.0, CollectorRegistry.defaultRegistry.getSampleValue(
-            "namespace_task_run_time_bucket", new String[]{"dataSource", "taskType", "le"}, new String[]{"test", "index_parallel", "0.1"}
+            "namespace_task_run_time_bucket", new String[]{"dataSource", "druidService", "hostName", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.1"}
     ), assertEpsilon);
     Assert.assertEquals(1.0, CollectorRegistry.defaultRegistry.getSampleValue(
-            "namespace_task_run_time_bucket", new String[]{"dataSource", "taskType", "le"}, new String[]{"test", "index_parallel", "0.5"}
+            "namespace_task_run_time_bucket", new String[]{"dataSource", "druidService", "hostName", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.5"}
     ), assertEpsilon);
   }
 
   @Test
   public void testEmitterStart()
   {
-    PrometheusEmitterConfig exportEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, "namespace1", null, 0, null);
+    PrometheusEmitterConfig exportEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, "namespace1", null, 0, null, true, true);
     PrometheusEmitter exportEmitter = new PrometheusEmitter(exportEmitterConfig);
     exportEmitter.start();
     Assert.assertNotNull(exportEmitter.getServer());
 
-    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace2", null, 0, "pushgateway");
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace2", null, 0, "pushgateway", true, true);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
     Assert.assertNotNull(pushEmitter.getPushGateway());
@@ -94,7 +121,7 @@ public class PrometheusEmitterTest
   @Test
   public void testEmitterPush() throws IOException
   {
-    PrometheusEmitterConfig emitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace3", null, 0, "pushgateway");
+    PrometheusEmitterConfig emitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace3", null, 0, "pushgateway", true, true);
 
     PushGateway mockPushGateway = mock(PushGateway.class);
     mockPushGateway.push(anyObject(Collector.class), anyString(), anyObject(ImmutableMap.class));
@@ -105,7 +132,7 @@ public class PrometheusEmitterTest
     ServiceMetricEvent build = ServiceMetricEvent.builder()
             .setDimension("task", "index_parallel")
             .build("task/run/time", 500)
-            .build(ImmutableMap.of("service", "peon"));
+            .build(ImmutableMap.of("service", "peon", "host", "druid.test.cn"));
     emitter.emit(build);
     emitter.flush();
   }
@@ -113,13 +140,13 @@ public class PrometheusEmitterTest
   @Test
   public void testEmitterConfigCreationWithNullAsAddress()
   {
-    Assert.assertThrows(NullPointerException.class, () -> new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, null));
+    Assert.assertThrows(NullPointerException.class, () -> new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, null, true, true));
   }
 
   @Test
   public void testEmitterStartWithHttpUrl()
   {
-    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway");
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway", true, true);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
     Assert.assertNotNull(pushEmitter.getPushGateway());
@@ -128,7 +155,7 @@ public class PrometheusEmitterTest
   @Test
   public void testEmitterStartWithHttpsUrl()
   {
-    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway");
+    PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway", true, true);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
     Assert.assertNotNull(pushEmitter.getPushGateway());

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -53,7 +53,7 @@ public class PrometheusEmitterTest
     Assert.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
-        "druid_segment_loadqueue_count", new String[]{"druidService", "server"}, new String[]{"historical", "druid_data01_vpc_region"}
+        "druid_segment_loadqueue_count", new String[]{"druid_service", "server"}, new String[]{"historical", "druid_data01_vpc_region"}
     );
     Assert.assertEquals(10, count.intValue());
   }
@@ -74,7 +74,7 @@ public class PrometheusEmitterTest
     Assert.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
-            "druid_segment_loadqueue_count", new String[]{"druidService", "hostName", "server"}, new String[]{"historical", "druid.test.cn", "druid_data01_vpc_region"}
+            "druid_segment_loadqueue_count", new String[]{"druid_service", "host_name", "server"}, new String[]{"historical", "druid.test.cn", "druid_data01_vpc_region"}
     );
     Assert.assertEquals(10, count.intValue());
   }
@@ -94,10 +94,10 @@ public class PrometheusEmitterTest
     emitter.emit(build);
     double assertEpsilon = 0.0001;
     Assert.assertEquals(0.0, CollectorRegistry.defaultRegistry.getSampleValue(
-            "namespace_task_run_time_bucket", new String[]{"dataSource", "druidService", "hostName", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.1"}
+            "namespace_task_run_time_bucket", new String[]{"dataSource", "druid_service", "host_name", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.1"}
     ), assertEpsilon);
     Assert.assertEquals(1.0, CollectorRegistry.defaultRegistry.getSampleValue(
-            "namespace_task_run_time_bucket", new String[]{"dataSource", "druidService", "hostName", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.5"}
+            "namespace_task_run_time_bucket", new String[]{"dataSource", "druid_service", "host_name", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.5"}
     ), assertEpsilon);
   }
 


### PR DESCRIPTION
Fixes #12731 

### Description

Some labels are missing from the Prometheus exporter. They were in the Statsd exporter, such as druid_service and host_name, Which makes the result of Prometheus exporter incompatible with the stated exporter.

In this current implementation, these two labels can be optionally added.

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/11659811/178246252-20c7c48a-f3f0-49f1-b67c-e1d499f9394b.png">

<hr>

##### Key changed/added classes in this PR

* `docs/development/extensions-contrib/prometheus.md`
* `extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java`
* `extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java`
* `extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java`
* `extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java`
* `extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
