### PR TITLE
Fix string first/last aggregator comparator

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/SerializablePairLongStringSerde.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SerializablePairLongStringSerde.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation;
 
+import org.apache.druid.collections.SerializablePair;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.GenericColumnSerializer;
@@ -46,42 +47,12 @@ public class SerializablePairLongStringSerde extends ComplexMetricSerde
 {
 
   private static final String TYPE_NAME = "serializablePairLongString";
-  private static final Comparator<SerializablePairLongString> COMPARATOR = (o1, o2) -> {
-    int comparation;
-
-    // First we check if the objects are null
-    if (o1 == null && o2 == null) {
-      comparation = 0;
-    } else if (o1 == null) {
-      comparation = -1;
-    } else if (o2 == null) {
-      comparation = 1;
-    } else {
-
-      // If the objects are not null, we will try to compare using timestamp
-      comparation = o1.lhs.compareTo(o2.lhs);
-
-      // If both timestamp are the same, we try to compare the Strings
-      if (comparation == 0) {
-
-        // First we check if the strings are null
-        if (o1.rhs == null && o2.rhs == null) {
-          comparation = 0;
-        } else if (o1.rhs == null) {
-          comparation = -1;
-        } else if (o2.rhs == null) {
-          comparation = 1;
-        } else {
-
-          // If the strings are not null, we will compare them
-          // Note: This comparation maybe doesn't make sense to first/last aggregators
-          comparation = o1.rhs.compareTo(o2.rhs);
-        }
-      }
-    }
-
-    return comparation;
-  };
+  // Null SerializablePairLongString values are put first
+  private static final Comparator<SerializablePairLongString> COMPARATOR = Comparator.nullsFirst(
+      // assumes that the LHS of the pair will never be null
+      Comparator.<SerializablePairLongString>comparingLong(SerializablePair::getLhs)
+                .thenComparing(SerializablePair::getRhs, Comparator.nullsFirst(Comparator.naturalOrder()))
+  );
 
   @Override
   public String getTypeName()

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -87,6 +87,8 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
       ((SerializablePairLongString) o2).lhs
   );
 
+  // used in comparing aggregation results amongst distinct groups. hence the comparison is done on the finalized
+  // result which is string/value part of the result pair.
   public static final Comparator<SerializablePairLongString> VALUE_COMPARATOR = (o1, o2) -> {
     int comparation;
 
@@ -98,26 +100,18 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
     } else if (o2 == null) {
       comparation = 1;
     } else {
+      // First we check if the strings are null
+      if (o1.rhs == null && o2.rhs == null) {
+        comparation = 0;
+      } else if (o1.rhs == null) {
+        comparation = -1;
+      } else if (o2.rhs == null) {
+        comparation = 1;
+      } else {
 
-      // If the objects are not null, we will try to compare using timestamp
-      comparation = o1.lhs.compareTo(o2.lhs);
-
-      // If both timestamp are the same, we try to compare the Strings
-      if (comparation == 0) {
-
-        // First we check if the strings are null
-        if (o1.rhs == null && o2.rhs == null) {
-          comparation = 0;
-        } else if (o1.rhs == null) {
-          comparation = -1;
-        } else if (o2.rhs == null) {
-          comparation = 1;
-        } else {
-
-          // If the strings are not null, we will compare them
-          // Note: This comparation maybe doesn't make sense to first/last aggregators
-          comparation = o1.rhs.compareTo(o2.rhs);
-        }
+        // If the strings are not null, we will compare them
+        // Note: This comparation maybe doesn't make sense to first/last aggregators
+        comparation = o1.rhs.compareTo(o2.rhs);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
+import org.apache.druid.collections.SerializablePair;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.AggregateCombiner;
 import org.apache.druid.query.aggregation.Aggregator;
@@ -88,35 +89,10 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
   );
 
   // used in comparing aggregation results amongst distinct groups. hence the comparison is done on the finalized
-  // result which is string/value part of the result pair.
-  public static final Comparator<SerializablePairLongString> VALUE_COMPARATOR = (o1, o2) -> {
-    int comparation;
-
-    // First we check if the objects are null
-    if (o1 == null && o2 == null) {
-      comparation = 0;
-    } else if (o1 == null) {
-      comparation = -1;
-    } else if (o2 == null) {
-      comparation = 1;
-    } else {
-      // First we check if the strings are null
-      if (o1.rhs == null && o2.rhs == null) {
-        comparation = 0;
-      } else if (o1.rhs == null) {
-        comparation = -1;
-      } else if (o2.rhs == null) {
-        comparation = 1;
-      } else {
-
-        // If the strings are not null, we will compare them
-        // Note: This comparation maybe doesn't make sense to first/last aggregators
-        comparation = o1.rhs.compareTo(o2.rhs);
-      }
-    }
-
-    return comparation;
-  };
+  // result which is string/value part of the result pair. Null SerializablePairLongString values are put first.
+  public static final Comparator<SerializablePairLongString> VALUE_COMPARATOR = Comparator.nullsFirst(
+      Comparator.comparing(SerializablePair::getRhs, Comparator.nullsFirst(Comparator.naturalOrder()))
+  );
 
   private final String fieldName;
   private final String name;

--- a/processing/src/test/java/org/apache/druid/query/aggregation/first/StringFirstAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/first/StringFirstAggregationTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 
 public class StringFirstAggregationTest extends InitializedNullHandlingTest
 {
@@ -213,6 +214,32 @@ public class StringFirstAggregationTest extends InitializedNullHandlingTest
     stringFirstAggregateCombiner.reset(columnSelector);
 
     Assert.assertEquals(pairs[1], stringFirstAggregateCombiner.getObject());
+  }
+
+  @Test
+  @SuppressWarnings("EqualsWithItself")
+  public void testStringLastAggregatorComparator()
+  {
+    Comparator<SerializablePairLongString> comparator =
+        (Comparator<SerializablePairLongString>) stringFirstAggFactory.getComparator();
+    SerializablePairLongString pair1 = new SerializablePairLongString(1L, "Z");
+    SerializablePairLongString pair2 = new SerializablePairLongString(2L, "A");
+    SerializablePairLongString pair3 = new SerializablePairLongString(3L, null);
+
+    // check non null values
+    Assert.assertEquals(0, comparator.compare(pair1, pair1));
+    Assert.assertTrue(comparator.compare(pair1, pair2) > 0);
+    Assert.assertTrue(comparator.compare(pair2, pair1) < 0);
+
+    // check non null value with null value (null values first comparator)
+    Assert.assertEquals(0, comparator.compare(pair3, pair3));
+    Assert.assertTrue(comparator.compare(pair1, pair3) > 0);
+    Assert.assertTrue(comparator.compare(pair3, pair1) < 0);
+
+    // check non null pair with null pair (null pairs first comparator)
+    Assert.assertEquals(0, comparator.compare(null, null));
+    Assert.assertTrue(comparator.compare(pair1, null) > 0);
+    Assert.assertTrue(comparator.compare(null, pair1) < 0);
   }
 
   private void aggregate(

--- a/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastAggregationTest.java
@@ -38,6 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 
 public class StringLastAggregationTest
 {
@@ -215,6 +216,32 @@ public class StringLastAggregationTest
     stringFirstAggregateCombiner.reset(columnSelector);
 
     Assert.assertEquals(pairs[1], stringFirstAggregateCombiner.getObject());
+  }
+
+  @Test
+  @SuppressWarnings("EqualsWithItself")
+  public void testStringLastAggregatorComparator()
+  {
+    Comparator<SerializablePairLongString> comparator =
+        (Comparator<SerializablePairLongString>) stringLastAggFactory.getComparator();
+    SerializablePairLongString pair1 = new SerializablePairLongString(1L, "Z");
+    SerializablePairLongString pair2 = new SerializablePairLongString(2L, "A");
+    SerializablePairLongString pair3 = new SerializablePairLongString(3L, null);
+
+    // check non null values
+    Assert.assertEquals(0, comparator.compare(pair1, pair1));
+    Assert.assertTrue(comparator.compare(pair1, pair2) > 0);
+    Assert.assertTrue(comparator.compare(pair2, pair1) < 0);
+
+    // check non null value with null value (null values first comparator)
+    Assert.assertEquals(0, comparator.compare(pair3, pair3));
+    Assert.assertTrue(comparator.compare(pair1, pair3) > 0);
+    Assert.assertTrue(comparator.compare(pair3, pair1) < 0);
+
+    // check non null pair with null pair (null pairs first comparator)
+    Assert.assertEquals(0, comparator.compare(null, null));
+    Assert.assertTrue(comparator.compare(pair1, null) > 0);
+    Assert.assertTrue(comparator.compare(null, pair1) < 0);
   }
 
   private void aggregate(


### PR DESCRIPTION
Currently, the first/last string aggregator's `getComparator` method (used in topN ranking, grouping by ordering, post agg ordering) compares two aggregator values on `__time` first and then on values. This change makes that comparator to compare only on values which is the correct behavior. The numerical first/last aggregators already compare on the values.

The current users who are ordering their results on the string first/last aggregator would need to augment their queries a `max(timeCol)` aggreagtor to achieve the same results.
For instance, a query like `SELECT stringCol2, LATEST(stringCol, 1024) as lat FROM table GROUP BY stringCol2 ORDER BY lat` would need to be rewritten as `SELECT stringCol2, LATEST(stringCol, 1024) as lat FROM table GROUP BY stringCol2 ORDER BY MAX(timeCol)`

The ingestion ordering is kept as is it since it doesn't impact the query results.


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
