### PR TITLE
Web console E2E tests: fix ordering in e2e test

### DIFF
--- a/web-console/e2e-tests/tutorial-batch.spec.ts
+++ b/web-console/e2e-tests/tutorial-batch.spec.ts
@@ -173,14 +173,12 @@ async function validateQuery(page: playwright.Page, datasourceName: string) {
   expect(results.length).toBeGreaterThan(0);
   expect(results[0]).toStrictEqual([
     /* __time */ '2015-09-12T00:46:58.772Z',
-    /* added */ '36',
+    /* time */ '2015-09-12T00:46:58.771Z',
     /* channel */ '#en.wikipedia',
     /* cityName */ 'null',
     /* comment */ 'added project',
     /* countryIsoCode */ 'null',
     /* countryName */ 'null',
-    /* deleted */ '0',
-    /* delta */ '36',
     /* isAnonymous */ 'false',
     /* isMinor */ 'false',
     /* isNew */ 'false',
@@ -191,7 +189,9 @@ async function validateQuery(page: playwright.Page, datasourceName: string) {
     /* page */ 'Talk:Oswald Tilghman',
     /* regionIsoCode */ 'null',
     /* regionName */ 'null',
-    /* time */ '2015-09-12T00:46:58.771Z',
     /* user */ 'GELongstreet',
+    /* added */ '36',
+    /* delta */ '36',
+    /* deleted */ '0',
   ]);
 }


### PR DESCRIPTION
The tests are currently broken, specifically one test in the web console e2e suite. It needed to be updated to account for https://github.com/apache/druid/pull/12754. The only reason that PR passed CI is because we do not run the web console e2e tests in CI if there are no web console changes to save time.