### PR TITLE
Web console: make tick formatting more robust

### DIFF
--- a/web-console/src/components/segment-timeline/segment-timeline.tsx
+++ b/web-console/src/components/segment-timeline/segment-timeline.tsx
@@ -33,6 +33,7 @@ import {
   Capabilities,
   ceilToUtcDay,
   formatBytes,
+  formatInteger,
   queryDruidSql,
   QueryManager,
   uniq,
@@ -422,9 +423,10 @@ ORDER BY "start" DESC`;
   }
 
   private readonly formatTick = (n: number) => {
+    if (isNaN(n)) return '';
     const { activeDataType } = this.state;
     if (activeDataType === 'countData') {
-      return n.toString();
+      return formatInteger(n);
     } else {
       return formatBytes(n);
     }


### PR DESCRIPTION
Fixes: https://github.com/apache/druid/issues/12781

Best to never call `.toString()` on `undefined`

This is just a super quick fix that works by making the function more robust. It does not address the reason it is being called with `undefined` in the first place.
The 'real' fix involves refactoring the code a bit. I will do that in a bit but wanted to get this fix out first.