### PR TITLE
Fix: ParseException swallow cause Exception

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/parsers/ParseException.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/parsers/ParseException.java
@@ -57,23 +57,25 @@ public class ParseException extends RuntimeException
 
   public ParseException(@Nullable String input, String formatText, Object... arguments)
   {
-    super(StringUtils.nonStrictFormat(formatText, arguments));
-    this.input = input;
-    this.fromPartiallyValidRow = false;
-    this.timeOfExceptionMillis = System.currentTimeMillis();
+    this(input, false, formatText, arguments);
   }
 
   public ParseException(@Nullable String input, boolean fromPartiallyValidRow, String formatText, Object... arguments)
   {
-    super(StringUtils.nonStrictFormat(formatText, arguments));
-    this.input = input;
-    this.fromPartiallyValidRow = fromPartiallyValidRow;
-    this.timeOfExceptionMillis = System.currentTimeMillis();
+    this(input, fromPartiallyValidRow, null, formatText, arguments);
   }
 
   public ParseException(@Nullable String input, Throwable cause, String formatText, Object... arguments)
   {
-    this(input, false, StringUtils.nonStrictFormat(formatText, arguments), cause);
+    this(input, false, cause, formatText, arguments);
+  }
+
+  public ParseException(@Nullable String input, boolean fromPartiallyValidRow, Throwable cause, String formatText, Object... arguments)
+  {
+    super(StringUtils.nonStrictFormat(formatText, arguments), cause);
+    this.input = input;
+    this.fromPartiallyValidRow = fromPartiallyValidRow;
+    this.timeOfExceptionMillis = System.currentTimeMillis();
   }
 
   public boolean isFromPartiallyValidRow()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
@@ -31,10 +31,15 @@ import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
+import org.apache.log4j.spi.LoggingEvent;
+import org.hibernate.validator.constraints.Email;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -62,12 +67,12 @@ public class FilteringCloseableInputRowIteratorTest
   public void setup()
   {
     rowIngestionMeters = new SimpleRowIngestionMeters();
-    parseExceptionHandler = new ParseExceptionHandler(
+    parseExceptionHandler = Mockito.spy(new ParseExceptionHandler(
         rowIngestionMeters,
-        false,
+        true,
         Integer.MAX_VALUE,
         1024 // do not use Integer.MAX_VALUE since it will create an object array of this length
-    );
+    ));
   }
 
   @Test
@@ -286,6 +291,67 @@ public class FilteringCloseableInputRowIteratorTest
     rowIterator.close();
     Assert.assertTrue(closed.isTrue());
   }
+
+  @Test
+  public void testParseExceptionSaveExceptionCause()
+  {
+
+    // This iterator throws ParseException every other call to hasNext().
+    final CloseableIterator<InputRow> parseExceptionThrowingIterator = new CloseableIterator<InputRow>()
+    {
+      final int numRowsToIterate = ROWS.size() * 2;
+      int currentIndex = 0;
+      int nextIndex = 0;
+
+      @Override
+      public boolean hasNext()
+      {
+        currentIndex = nextIndex++;
+        if (currentIndex % 2 == 0) {
+          return currentIndex < numRowsToIterate;
+        } else {
+          try {
+            throw new IllegalArgumentException("this is the root cause of the exception!");
+          } catch  (Exception e) {
+            throw new ParseException(null, e, "Parse exception at [%d]", currentIndex);
+
+          }
+        }
+      }
+
+      @Override
+      public InputRow next()
+      {
+        return ROWS.get(currentIndex / 2);
+      }
+
+      @Override
+      public void close()
+      {
+      }
+    };
+
+    final FilteringCloseableInputRowIterator rowIterator = new FilteringCloseableInputRowIterator(
+        parseExceptionThrowingIterator,
+        row -> true,
+        rowIngestionMeters,
+        parseExceptionHandler
+    );
+
+    final List<InputRow> filteredRows = new ArrayList<>();
+    rowIterator.forEachRemaining(filteredRows::add);
+    ArgumentCaptor<Exception> exceptionArgumentCaptor = ArgumentCaptor.forClass(Exception.class);
+    Mockito.verify(parseExceptionHandler, Mockito.times(6)).logParseExceptionHelper(exceptionArgumentCaptor.capture());
+    Exception parseException = exceptionArgumentCaptor.getValue();
+    Assert.assertTrue(parseException.getMessage().contains("Parse exception at"));
+    Assert.assertNotNull(parseException.getCause());
+    Assert.assertTrue(parseException.getCause().getMessage().contains("this is the root cause of the exception!"));
+    Assert.assertEquals(IllegalArgumentException.class, parseException.getCause().getClass());
+
+    Assert.assertEquals(ROWS, filteredRows);
+    Assert.assertEquals(ROWS.size(), rowIngestionMeters.getUnparseable());
+  }
+
 
   private static InputRow newRow(DateTime timestamp, Object dim1Val, Object dim2Val)
   {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/FilteringCloseableInputRowIteratorTest.java
@@ -31,10 +31,7 @@ import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
-import org.apache.log4j.spi.LoggingEvent;
-import org.hibernate.validator.constraints.Email;
 import org.joda.time.DateTime;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -312,9 +309,9 @@ public class FilteringCloseableInputRowIteratorTest
         } else {
           try {
             throw new IllegalArgumentException("this is the root cause of the exception!");
-          } catch  (Exception e) {
+          }
+          catch (Exception e) {
             throw new ParseException(null, e, "Parse exception at [%d]", currentIndex);
-
           }
         }
       }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.incremental;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.RE;
@@ -102,6 +103,7 @@ public class ParseExceptionHandler
     return savedParseExceptionReports;
   }
 
+  @VisibleForTesting
   public void logParseExceptionHelper(Exception e) {
     if (logParseExceptions) {
       LOG.error(e, "Encountered parse exception");

--- a/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
@@ -104,7 +104,8 @@ public class ParseExceptionHandler
   }
 
   @VisibleForTesting
-  public void logParseExceptionHelper(Exception e) {
+  public void logParseExceptionHelper(Exception e)
+  {
     if (logParseExceptions) {
       LOG.error(e, "Encountered parse exception");
     }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/ParseExceptionHandler.java
@@ -77,9 +77,7 @@ public class ParseExceptionHandler
       rowIngestionMeters.incrementUnparseable();
     }
 
-    if (logParseExceptions) {
-      LOG.error(e, "Encountered parse exception");
-    }
+    logParseExceptionHelper(e);
 
     if (savedParseExceptionReports != null) {
       ParseExceptionReport parseExceptionReport = new ParseExceptionReport(
@@ -102,5 +100,11 @@ public class ParseExceptionHandler
   public CircularBuffer<ParseExceptionReport> getSavedParseExceptionReports()
   {
     return savedParseExceptionReports;
+  }
+
+  public void logParseExceptionHelper(Exception e) {
+    if (logParseExceptions) {
+      LOG.error(e, "Encountered parse exception");
+    }
   }
 }


### PR DESCRIPTION
Fix: ParseException swallow cause Exception

### Description

The constructor of ParseException is swallowing the cause Exception argument. We should add the underlying root Exception to the cause of the ParseException so that if logParseExceptions is enabled then the cause Exception gets logged too.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
