### PR TITLE
Fix kinesis IT flakiness

### DIFF
--- a/integration-tests/src/test/resources/stream/data/supervisor_spec_template.json
+++ b/integration-tests/src/test/resources/stream/data/supervisor_spec_template.json
@@ -50,7 +50,7 @@
     "%%STREAM_PROPERTIES_KEY%%": %%STREAM_PROPERTIES_VALUE%%,
     "taskCount": 2,
     "replicas": 1,
-    "taskDuration": "PT30S",
+    "taskDuration": "PT120S",
     "%%USE_EARLIEST_KEY%%": true,
     "inputFormat" : %%INPUT_FORMAT%%
   }

--- a/integration-tests/src/test/resources/stream/data/supervisor_with_autoscaler_spec_template.json
+++ b/integration-tests/src/test/resources/stream/data/supervisor_with_autoscaler_spec_template.json
@@ -66,7 +66,7 @@
     },
     "taskCount": 1,
     "replicas": 1,
-    "taskDuration": "PT30S",
+    "taskDuration": "PT120S",
     "%%USE_EARLIEST_KEY%%": true,
     "inputFormat" : %%INPUT_FORMAT%%
   }


### PR DESCRIPTION
Kinesis ITs run with a task duration <= supervisor period and this may cause flakiness.
This is fixed by reverting task duration in test supervisors to 120 seconds.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
