### PR TITLE
Allow dictionary encoded column to use a more generic index interface

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
@@ -31,6 +31,7 @@ import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.ComplexColumn;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
 import org.apache.druid.segment.column.DictionaryEncodedStringValueIndex;
+import org.apache.druid.segment.column.DictionaryEncodedValueIndex;
 import org.apache.druid.segment.data.BitmapValues;
 import org.apache.druid.segment.data.CloseableIndexed;
 import org.apache.druid.segment.data.ImmutableBitmapValues;
@@ -379,7 +380,7 @@ public class QueryableIndexIndexableAdapter implements IndexableAdapter
     if (indexSupplier == null) {
       return BitmapValues.EMPTY;
     }
-    final DictionaryEncodedStringValueIndex bitmaps = indexSupplier.as(DictionaryEncodedStringValueIndex.class);
+    final DictionaryEncodedValueIndex bitmaps = indexSupplier.as(DictionaryEncodedValueIndex.class);
     if (bitmaps == null) {
       return BitmapValues.EMPTY;
     }

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexIndexableAdapter.java
@@ -30,7 +30,6 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.ComplexColumn;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
-import org.apache.druid.segment.column.DictionaryEncodedStringValueIndex;
 import org.apache.druid.segment.column.DictionaryEncodedValueIndex;
 import org.apache.druid.segment.data.BitmapValues;
 import org.apache.druid.segment.data.CloseableIndexed;

--- a/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedValueIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedValueIndex.java
@@ -19,34 +19,18 @@
 
 package org.apache.druid.segment.column;
 
-import javax.annotation.Nullable;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
 
 /**
- * This exposes a 'raw' view into a bitmap value indexes of a string {@link DictionaryEncodedColumn}, allowing
- * operation via dictionaryIds, as well as access to lower level details of such a column like value lookup and
- * value cardinality.
+ * This exposes a 'raw' view into a bitmap value indexes, allowing operation via dictionaryIds
  *
  * This interface should only be used when it is beneficial to operate in such a manner, most filter implementations
- * should likely be using {@link StringValueSetIndex}, {@link DruidPredicateIndex}, {@link LexicographicalRangeIndex} or
- * some other higher level index instead.
+ * should likely be using higher level index instead.
  */
-public interface DictionaryEncodedStringValueIndex extends DictionaryEncodedValueIndex
+public interface DictionaryEncodedValueIndex
 {
-  boolean hasNulls();
   /**
-   * Get the cardinality of the underlying value dictionary
+   * Get the {@link ImmutableBitmap} for dictionary id of the underlying dictionary
    */
-  int getCardinality();
-
-  /**
-   * Get the value in the underlying value dictionary of the specified dictionary id
-   */
-  @Nullable
-  String getValue(int index);
-
-  /**
-   * Returns the index of "value" in this DictionaryEncodedStringValueIndex, or a negative value, if not present in
-   * the underlying dictionary
-   */
-  int getIndex(@Nullable String value);
+  ImmutableBitmap getBitmap(int idx);
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
@@ -35,6 +35,7 @@ import org.apache.druid.segment.IntListUtils;
 import org.apache.druid.segment.column.BitmapColumnIndex;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.DictionaryEncodedStringValueIndex;
+import org.apache.druid.segment.column.DictionaryEncodedValueIndex;
 import org.apache.druid.segment.column.DruidPredicateIndex;
 import org.apache.druid.segment.column.LexicographicalRangeIndex;
 import org.apache.druid.segment.column.NullValueIndex;
@@ -105,7 +106,7 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
             bitmaps,
             NullHandling.isNullOrEquivalent(dictionary.get(0))
         );
-      } else if (clazz.equals(DictionaryEncodedStringValueIndex.class)) {
+      } else if (clazz.equals(DictionaryEncodedStringValueIndex.class) || clazz.equals(DictionaryEncodedValueIndex.class)) {
         return (T) new GenericIndexedDictionaryEncodedStringValueIndex(bitmapFactory, dictionary, bitmaps);
       }
     }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
@@ -46,6 +46,7 @@ import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.DictionaryEncodedStringValueIndex;
+import org.apache.druid.segment.column.DictionaryEncodedValueIndex;
 import org.apache.druid.segment.column.DruidPredicateIndex;
 import org.apache.druid.segment.column.LexicographicalRangeIndex;
 import org.apache.druid.segment.column.NullValueIndex;
@@ -229,7 +230,7 @@ public class ListFilteredVirtualColumn implements VirtualColumn
           return (T) new ListFilteredDruidPredicateIndex(underlyingIndex, idMapping);
         } else if (clazz.equals(LexicographicalRangeIndex.class)) {
           return (T) new ListFilteredLexicographicalRangeIndex(underlyingIndex, idMapping);
-        } else if (clazz.equals(DictionaryEncodedStringValueIndex.class)) {
+        } else if (clazz.equals(DictionaryEncodedStringValueIndex.class) || clazz.equals(DictionaryEncodedValueIndex.class)) {
           return (T) new ListFilteredDictionaryEncodedStringValueIndex(underlyingIndex, idMapping);
         }
         return null;


### PR DESCRIPTION
Allow dictionary encoded column to use a more generic index interface

### Description

Not all dictionary encoded column index is of a String. This PR refactor the bitmaps class in QueryableIndexIndexableAdapter#getBitmapValues to use a more generic interface that doesn't assume the value is of String. This is to allow QueryableIndexIndexableAdapter to not have to care about what actual type the DictionaryEncodedColumnIndexer/DictionaryEncodedColumnMerger deals with

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
