### PR TITLE
Lazy initialisation of Parquet extensions module

### DIFF
--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetExtensionsModule.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetExtensionsModule.java
@@ -30,9 +30,7 @@ import org.apache.druid.data.input.parquet.simple.ParquetHadoopInputRowParser;
 import org.apache.druid.data.input.parquet.simple.ParquetParseSpec;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -76,20 +74,6 @@ public class ParquetExtensionsModule implements DruidModule
 
     // Set explicit CL. Otherwise it'll try to use thread context CL, which may not have all of our dependencies.
     conf.setClassLoader(getClass().getClassLoader());
-
-    // Ensure that FileSystem class level initialization happens with correct CL
-    // See https://github.com/apache/druid/issues/1714
-    ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
-    try {
-      Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-      FileSystem.get(conf);
-    }
-    catch (IOException ex) {
-      throw new RuntimeException(ex);
-    }
-    finally {
-      Thread.currentThread().setContextClassLoader(currCtxCl);
-    }
 
     if (props != null) {
       for (String propName : props.stringPropertyNames()) {

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -55,8 +55,8 @@ public class ParquetInputFormat extends NestedInputFormat
 
   private void initialize(Configuration conf)
   {
-    //Initializing seperately since during eager initialization, resolving
-    //namenode hostname throws an error if nodes are ephemeral
+    // Initializing seperately since during eager initialization, resolving
+    // namenode hostname throws an error if nodes are ephemeral
 
     // Ensure that FileSystem class level initialization happens with correct CL
     // See https://github.com/apache/druid/issues/1714

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/ParquetInputFormat.java
@@ -29,9 +29,11 @@ import org.apache.druid.data.input.impl.NestedInputFormat;
 import org.apache.druid.data.input.parquet.guice.Parquet;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 
 public class ParquetInputFormat extends NestedInputFormat
@@ -49,6 +51,26 @@ public class ParquetInputFormat extends NestedInputFormat
     super(flattenSpec);
     this.binaryAsString = binaryAsString == null ? false : binaryAsString;
     this.conf = conf;
+  }
+
+  private void initialize(Configuration conf)
+  {
+    //Initializing seperately since during eager initialization, resolving
+    //namenode hostname throws an error if nodes are ephemeral
+
+    // Ensure that FileSystem class level initialization happens with correct CL
+    // See https://github.com/apache/druid/issues/1714
+    ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+      FileSystem.get(conf);
+    }
+    catch (IOException ex) {
+      throw new RuntimeException(ex);
+    }
+    finally {
+      Thread.currentThread().setContextClassLoader(currCtxCl);
+    }
   }
 
   @JsonProperty
@@ -70,6 +92,7 @@ public class ParquetInputFormat extends NestedInputFormat
       File temporaryDirectory
   )
   {
+    initialize(conf);
     return new ParquetReader(conf, inputRowSchema, source, temporaryDirectory, getFlattenSpec(), binaryAsString);
   }
 


### PR DESCRIPTION
Fixes Historicals and MiddleManagers failing with `UnknownHostException` when working with the `druid-parquet-extensions` module and Ephemeral Hadoop cluster.

### Description:

Druid services are failing with the following error during loading and configuring modules of the initialization phase in the case when `fs.defaultFS` URI value is specified while operating with an Ephemeral Hadoop cluster. While configuration HDFS DFS object is getting initialized with `fs.defaultFS` URI if present, which isn't getting resolved in case of Ephemeral cluster. Hence routed the initialization from `ParquetExtensionsModule` to `ParquetInputFormat` just before creating the `ParquetReader` object.

This fix is similar to the one done for `OrcExtensionsModule` --> https://github.com/apache/druid/pull/12663, https://github.com/apache/druid/pull/12738

```
An exception was caught and reported. Message: java.net.UnknownHostException: druid-dataproc-hadoop-cluster-us-east4-m
  at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:198)
Caused by: java.lang.IllegalArgumentException: java.net.UnknownHostException: druid-dataproc-hadoop-cluster-us-east4-m
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:417)
	at org.apache.hadoop.hdfs.NameNodeProxiesClient.createProxyWithClientProtocol(NameNodeProxiesClient.java:132)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:351)
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:285)
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:160)
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2812)
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:100)
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2849)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2831)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:389)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:181)
	at org.apache.druid.data.input.parquet.ParquetExtensionsModule.configure(ParquetExtensionsModule.java:85)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
	at com.google.inject.spi.Elements.getElements(Elements.java:110)
	at com.google.inject.util.Modules$OverrideModule.configure(Modules.java:198)
	at com.google.inject.AbstractModule.configure(AbstractModule.java:62)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
	at com.google.inject.spi.Elements.getElements(Elements.java:110)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.apache.druid.initialization.Initialization.makeInjectorWithModules(Initialization.java:451)
	at org.apache.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:93)
	at org.apache.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:86)
	at org.apache.druid.cli.CliPeon.run(CliPeon.java:302)
	at org.apache.druid.cli.Main.main(Main.java:113)
Caused by: java.net.UnknownHostException: druid-dataproc-hadoop-cluster-us-east4-m
	... 28 more
```

<hr/>

#### Key classes changed:
- `ParquetExtensionsModule`
- `ParquetInputFormat`

<hr/>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
