### PR TITLE
add NumericRangeIndex interface and BoundFilter support

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlNestedDataBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlNestedDataBenchmark.java
@@ -165,7 +165,13 @@ public class SqlNestedDataBenchmark
       "SELECT JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) IN (1, 19, 21, 23, 25, 26, 46)",
       // 24, 25
       "SELECT long2 FROM foo WHERE long2 IN (1, 19, 21, 23, 25, 26, 46) GROUP BY 1",
-      "SELECT JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) IN (1, 19, 21, 23, 25, 26, 46) GROUP BY 1"
+      "SELECT JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) IN (1, 19, 21, 23, 25, 26, 46) GROUP BY 1",
+      // 26, 27
+      "SELECT SUM(long1) FROM foo WHERE double3 < 1005.0 AND double3 > 1000.0",
+      "SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 1005.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0",
+      // 28, 29
+      "SELECT SUM(long1) FROM foo WHERE double3 < 2000.0 AND double3 > 1000.0",
+      "SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 2000.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0"
   );
 
   @Param({"5000000"})
@@ -203,7 +209,11 @@ public class SqlNestedDataBenchmark
       "22",
       "23",
       "24",
-      "25"
+      "25",
+      "26",
+      "27",
+      "28",
+      "29"
   })
   private String query;
 

--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -523,7 +523,7 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     private final Supplier<DruidFloatPredicate> floatPredicateSupplier;
     private final Supplier<DruidDoublePredicate> doublePredicateSupplier;
 
-    InFilterDruidPredicateFactory(
+    public InFilterDruidPredicateFactory(
         final ExtractionFn extractionFn,
         final ValuesSet values
     )

--- a/processing/src/main/java/org/apache/druid/segment/column/NumericRangeIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/NumericRangeIndex.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.column;
+
+import javax.annotation.Nullable;
+
+/**
+ * An optimized column value {@link BitmapColumnIndex} provider for specialized processing of numeric value ranges.
+ * This index does not match null values, union the results of this index with {@link NullValueIndex} if null values
+ * should be considered part of the value range.
+ */
+public interface NumericRangeIndex
+{
+  /**
+   * Get a {@link BitmapColumnIndex} corresponding to the values supplied in the specified range. If supplied starting
+   * value is null, the range will begin at the first non-null value in the underlying value dictionary. If the end
+   * value is null, the range will extend to the last value in the underlying value dictionary.
+   */
+  BitmapColumnIndex forRange(
+      @Nullable Number startValue,
+      boolean startStrict,
+      @Nullable Number endValue,
+      boolean endStrict
+  );
+}

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
@@ -216,7 +216,7 @@ public class NestedFieldLiteralColumnIndexSupplier implements ColumnIndexSupplie
       localEndIndex = localEndFound + 1;
     }
 
-    return new IntIntImmutablePair(localStartIndex, localEndIndex);
+    return new IntIntImmutablePair(localStartIndex, Math.min(dictionary.size(), localEndIndex));
   }
 
   private <T> BitmapColumnIndex makeRangeIndex(

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -521,6 +521,20 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 6, 7, 8, 9);
+
+    forRange = rangeIndex.forRange(1.1, false, 3.3, false);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.9, forRange.estimateSelectivity(10), 0.0);
+
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 1, 2, 3, 4, 6, 7, 8, 9);
+
+    forRange = rangeIndex.forRange(1.1, true, 3.3, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.6, forRange.estimateSelectivity(10), 0.0);
+
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 3, 4, 6, 7, 9);
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -220,12 +220,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 5, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -435,12 +435,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 3, 5, 9);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 3, 4, 5, 6, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 3, 4, 5, 6, 9);
@@ -514,12 +514,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 6, 7, 8);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -612,12 +612,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 6, 7);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 3, 4, 6, 7, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 3, 4, 6, 7, 9);
@@ -705,12 +705,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 2, 3, 4, 6, 7, 9);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(1.0, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -803,12 +803,12 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 4, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, true,null, true);
+    forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 4, 5, 7, 8, 9);
 
-    forRange = rangeIndex.forRange(null, false,null, false);
+    forRange = rangeIndex.forRange(null, false, null, false);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 4, 5, 7, 8, 9);

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -19,80 +19,1280 @@
 
 package org.apache.druid.segment.nested;
 
-import junit.framework.TestCase;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.MutableBitmap;
-import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
+import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.DefaultBitmapResultFactory;
+import org.apache.druid.query.filter.DruidPredicateFactory;
+import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.segment.column.BitmapColumnIndex;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.DruidPredicateIndex;
 import org.apache.druid.segment.column.LexicographicalRangeIndex;
+import org.apache.druid.segment.column.NullValueIndex;
+import org.apache.druid.segment.column.NumericRangeIndex;
+import org.apache.druid.segment.column.StringValueSetIndex;
+import org.apache.druid.segment.column.TypeStrategies;
+import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.FixedIndexed;
+import org.apache.druid.segment.data.FixedIndexedWriter;
 import org.apache.druid.segment.data.GenericIndexed;
-import org.easymock.EasyMock;
+import org.apache.druid.segment.data.GenericIndexedWriter;
+import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.serde.Serializer;
+import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.roaringbitmap.IntIterator;
 
-public class NestedFieldLiteralColumnIndexSupplierTest extends TestCase
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.WritableByteChannel;
+import java.util.TreeSet;
+
+public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHandlingTest
 {
+  BitmapSerdeFactory roaringFactory = new RoaringBitmapSerdeFactory(null);
+  BitmapResultFactory<ImmutableBitmap> bitmapResultFactory = new DefaultBitmapResultFactory(
+      roaringFactory.getBitmapFactory()
+  );
+  GenericIndexed<String> globalStrings;
+  FixedIndexed<Long> globalLongs;
+  FixedIndexed<Double> globalDoubles;
+
+  @Before
+  public void setup() throws IOException
+  {
+    ByteBuffer stringBuffer = ByteBuffer.allocate(1 << 12);
+    ByteBuffer longBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer doubleBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+
+    GenericIndexedWriter<String> stringWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "strings",
+        GenericIndexed.STRING_STRATEGY
+    );
+    stringWriter.open();
+    stringWriter.write(null);
+    stringWriter.write("a");
+    stringWriter.write("b");
+    stringWriter.write("fo");
+    stringWriter.write("foo");
+    stringWriter.write("fooo");
+    stringWriter.write("z");
+    writeToBuffer(stringBuffer, stringWriter);
+
+    FixedIndexedWriter<Long> longWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.LONG,
+        ByteOrder.nativeOrder(),
+        Long.BYTES,
+        true
+    );
+    longWriter.open();
+    longWriter.write(1L);
+    longWriter.write(2L);
+    longWriter.write(3L);
+    longWriter.write(5L);
+    longWriter.write(100L);
+    longWriter.write(300L);
+    longWriter.write(9000L);
+    writeToBuffer(longBuffer, longWriter);
+
+    FixedIndexedWriter<Double> doubleWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.DOUBLE,
+        ByteOrder.nativeOrder(),
+        Double.BYTES,
+        true
+    );
+    doubleWriter.open();
+    doubleWriter.write(1.0);
+    doubleWriter.write(1.1);
+    doubleWriter.write(1.2);
+    doubleWriter.write(2.0);
+    doubleWriter.write(2.5);
+    doubleWriter.write(3.3);
+    doubleWriter.write(6.6);
+    doubleWriter.write(9.9);
+    writeToBuffer(doubleBuffer, doubleWriter);
+
+    globalStrings = GenericIndexed.read(stringBuffer, GenericIndexed.STRING_STRATEGY);
+    globalLongs = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES);
+    globalDoubles = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
+  }
+
 
   @Test
-  public void testRangeValueSkipping()
+  public void testSingleTypeStringColumnValueSetIndex() throws IOException
   {
-    FixedIndexed<Integer> localDictionary = EasyMock.createMock(FixedIndexed.class);
-    GenericIndexed<String> stringDictionary = EasyMock.createMock(GenericIndexed.class);
-    FixedIndexed<Long> longDictionary = EasyMock.createMock(FixedIndexed.class);
-    FixedIndexed<Double> doubleDictionary = EasyMock.createMock(FixedIndexed.class);
-    GenericIndexed<ImmutableBitmap> bitmaps = EasyMock.createMock(GenericIndexed.class);
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringSupplier();
 
-    RoaringBitmapFactory bitmapFactory = new RoaringBitmapFactory();
-    MutableBitmap bitmap = bitmapFactory.makeEmptyMutableBitmap();
-    bitmap.add(1);
-    ImmutableBitmap immutableBitmap = bitmapFactory.makeImmutableBitmap(bitmap);
-    MutableBitmap bitmap2 = bitmapFactory.makeEmptyMutableBitmap();
-    bitmap2.add(2);
-    ImmutableBitmap immutableBitmap2 = bitmapFactory.makeImmutableBitmap(bitmap2);
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
 
-    EasyMock.expect(stringDictionary.size()).andReturn(10).times(3);
-    EasyMock.expect(longDictionary.size()).andReturn(0).times(1);
-    EasyMock.expect(stringDictionary.indexOf("fo")).andReturn(3).times(2);
-    EasyMock.expect(stringDictionary.indexOf("fooo")).andReturn(5).times(2);
-    EasyMock.expect(stringDictionary.get(3)).andReturn("fo").times(1);
-    EasyMock.expect(stringDictionary.get(4)).andReturn("foo").times(1);
-    EasyMock.expect(stringDictionary.get(5)).andReturn("fooo").times(1);
-    EasyMock.expect(localDictionary.indexOf(3)).andReturn(0).times(2);
-    EasyMock.expect(localDictionary.indexOf(4)).andReturn(0).times(2);
-    EasyMock.expect(localDictionary.indexOf(5)).andReturn(1).times(2);
-    EasyMock.expect(localDictionary.indexOf(6)).andReturn(-2).times(2);
-    EasyMock.expect(bitmaps.get(0)).andReturn(immutableBitmap).times(1);
-    EasyMock.expect(bitmaps.get(1)).andReturn(immutableBitmap2).times(2);
+    // 10 rows
+    // local: [b, foo, fooo, z]
+    // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
-    EasyMock.replay(localDictionary, stringDictionary, longDictionary, doubleDictionary, bitmaps);
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.4, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 7, 8);
 
-    NestedFieldLiteralColumnIndexSupplier indexSupplier = new NestedFieldLiteralColumnIndexSupplier(
-        new NestedLiteralTypeInfo.TypeSet(new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.STRING).getByteValue()),
-        bitmapFactory,
-        bitmaps,
-        localDictionary,
-        stringDictionary,
-        longDictionary,
-        doubleDictionary
-    );
+    // non-existent in local column
+    columnIndex = valueSetIndex.forValue("fo");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "fooo", "z")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.8, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 2, 3, 4, 5, 6, 7, 8);
+  }
+
+  @Test
+  public void testSingleTypeStringColumnRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringSupplier();
 
     LexicographicalRangeIndex rangeIndex = indexSupplier.as(LexicographicalRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
 
-    BitmapColumnIndex columnIndex = rangeIndex.forRange("fo", false, "fooo", false);
-    DefaultBitmapResultFactory defaultBitmapResultFactory = new DefaultBitmapResultFactory(bitmapFactory);
-    ImmutableBitmap result = columnIndex.computeBitmapResult(defaultBitmapResultFactory);
-    Assert.assertEquals(2, result.size());
-    Assert.assertTrue(result.get(1));
-    Assert.assertTrue(result.get(2));
+    // 10 rows
+    // local: [b, foo, fooo, z]
+    // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
-    // predicate skips first index
-    columnIndex = rangeIndex.forRange("fo", false, "fooo", false, "fooo"::equals);
-    result = columnIndex.computeBitmapResult(defaultBitmapResultFactory);
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.get(2));
-    EasyMock.verify(localDictionary, stringDictionary, longDictionary, doubleDictionary, bitmaps);
+    BitmapColumnIndex forRange = rangeIndex.forRange("f", true, "g", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.4, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 2, 5, 9);
+
+    forRange = rangeIndex.forRange(
+        "f",
+        true,
+        "g",
+        true,
+        s -> !"fooo".equals(s)
+    );
+    Assert.assertEquals(0.2, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 9);
+  }
+
+  @Test
+  public void testSingleTypeStringColumnPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringSupplier();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("b", "z"))
+    );
+
+    // 10 rows
+    // local: [b, foo, fooo, z]
+    // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.6, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 6, 7, 8);
+  }
+
+  @Test
+  public void testSingleTypeStringColumnWithNullValueIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringWithNullsSupplier();
+
+    NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
+    Assert.assertNotNull(nullIndex);
+
+    // 10 rows
+    // local: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    BitmapColumnIndex columnIndex = nullIndex.forNull();
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 7, 8);
+  }
+
+  @Test
+  public void testSingleTypeStringColumnWithNullValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringWithNullsSupplier();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.1, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 3);
+
+    // non-existent in local column
+    columnIndex = valueSetIndex.forValue("fo");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "fooo", "z")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.5, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 3, 4, 5, 6);
+  }
+
+  @Test
+  public void testSingleValueStringWithNullRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringWithNullsSupplier();
+
+    LexicographicalRangeIndex rangeIndex = indexSupplier.as(LexicographicalRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
+
+    // 10 rows
+    // local: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    BitmapColumnIndex forRange = rangeIndex.forRange("f", true, "g", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.4, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 2, 5, 9);
+
+    forRange = rangeIndex.forRange(
+        "f",
+        true,
+        "g",
+        true,
+        s -> !"fooo".equals(s)
+    );
+    Assert.assertEquals(0.2, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 9);
+  }
+
+  @Test
+  public void testSingleValueStringWithNullPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringWithNullsSupplier();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("b", "z"))
+    );
+
+    // 10 rows
+    // local: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 3, 4, 6);
+  }
+
+  @Test
+  public void testSingleTypeLongColumnValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplier();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [1, 3, 100, 300]
+    // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("1");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 9);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1", "300", "700")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.6, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 2, 3, 7, 8, 9);
+  }
+
+  @Test
+  public void testSingleTypeLongColumnRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplier();
+
+    NumericRangeIndex rangeIndex = indexSupplier.as(NumericRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
+
+    // 10 rows
+    // local: [1, 3, 100, 300]
+    // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
+
+    BitmapColumnIndex forRange = rangeIndex.forRange(10L, true, 400L, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.5, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 2, 6, 7, 8);
+  }
+
+  @Test
+  public void testSingleTypeLongColumnPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplier();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("1", "3"))
+    );
+
+    // 10 rows
+    // local: [1, 3, 100, 300]
+    // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.5, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 5, 9);
+  }
+
+  @Test
+  public void testSingleTypeLongColumnWithNullValueIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplierWithNull();
+
+    NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
+    Assert.assertNotNull(nullIndex);
+
+    // 10 rows
+    // local: [null, 1, 3, 100, 300]
+    // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
+
+    BitmapColumnIndex columnIndex = nullIndex.forNull();
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 5, 8);
+  }
+
+  @Test
+  public void testSingleTypeLongColumnWithNullValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplierWithNull();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [null, 1, 3, 100, 300]
+    // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("3");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.1, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 4);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1", "3", "300")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.5, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 7, 9);
+  }
+
+  @Test
+  public void testSingleValueLongWithNullRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplierWithNull();
+
+    NumericRangeIndex rangeIndex = indexSupplier.as(NumericRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
+
+    // 10 rows
+    // local: [null, 1, 3, 100, 300]
+    // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
+
+    BitmapColumnIndex forRange = rangeIndex.forRange(100, false, 700, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.3, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 6, 7);
+  }
+
+  @Test
+  public void testSingleValueLongWithNullPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeLongSupplierWithNull();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("3", "100"))
+    );
+
+    // 10 rows
+    // local: [null, 1, 3, 100, 300]
+    // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 4, 6);
+  }
+
+  @Test
+  public void testSingleTypeDoubleColumnValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplier();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("1.2");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 4, 7);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1.2", "3.3", "6.6")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.7, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 3, 4, 5, 6, 7, 9);
+  }
+
+  @Test
+  public void testSingleTypeDoubleColumnRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplier();
+
+    NumericRangeIndex rangeIndex = indexSupplier.as(NumericRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
+
+    // 10 rows
+    // local: [1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex forRange = rangeIndex.forRange(1.0, true, 5.0, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.9, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 1, 2, 3, 4, 6, 7, 8, 9);
+  }
+
+  @Test
+  public void testSingleTypeDoubleColumnPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplier();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("1.2", "3.3", "5.0"))
+    );
+
+    // 10 rows
+    // local: [1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.6, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 3, 4, 6, 7, 9);
+  }
+
+  @Test
+  public void testSingleTypeDoubleColumnWithNullValueIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplierWithNull();
+
+    NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
+    Assert.assertNotNull(nullIndex);
+
+    // 10 rows
+    // local: [null, 1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex columnIndex = nullIndex.forNull();
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 6);
+  }
+
+  @Test
+  public void testSingleTypeDoubleColumnWithNullValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplierWithNull();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [null, 1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("6.6");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.1, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 5);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1.2", "3.3", "7.7")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.4, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 4, 7, 9);
+  }
+
+  @Test
+  public void testSingleValueDoubleWithNullRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplierWithNull();
+
+    NumericRangeIndex rangeIndex = indexSupplier.as(NumericRangeIndex.class);
+    Assert.assertNotNull(rangeIndex);
+
+    // 10 rows
+    // local: [null, 1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex forRange = rangeIndex.forRange(1.1, false, 5.0, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.6, forRange.estimateSelectivity(10), 0.0);
+
+    ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 2, 4, 7, 8, 9);
+  }
+
+  @Test
+  public void testSingleValueDoubleWithNullPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeDoubleSupplierWithNull();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("1.2", "3.3"))
+    );
+
+    // 10 rows
+    // local: [null, 1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.4, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 4, 7, 9);
+  }
+
+  @Test
+  public void testVariantNullValueIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeVariantSupplierWithNull();
+
+    NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
+    Assert.assertNotNull(nullIndex);
+
+    // 10 rows
+    // local: [null, b, z, 1, 300, 1.1, 9.9]
+    // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
+
+    BitmapColumnIndex columnIndex = nullIndex.forNull();
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.2, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 7);
+  }
+
+  @Test
+  public void testVariantValueSetIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeVariantSupplierWithNull();
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // local: [null, b, z, 1, 300, 1.1, 9.9]
+    // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.2, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 9);
+
+    columnIndex = valueSetIndex.forValue("1");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.2, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 5);
+
+    columnIndex = valueSetIndex.forValue("1.1");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.1, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 8);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "300", "9.9", "1.6")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.4, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 9);
+  }
+
+  @Test
+  public void testVariantRangeIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeVariantSupplierWithNull();
+
+    LexicographicalRangeIndex rangeIndex = indexSupplier.as(LexicographicalRangeIndex.class);
+    Assert.assertNull(rangeIndex);
+
+    NumericRangeIndex numericRangeIndex = indexSupplier.as(NumericRangeIndex.class);
+    Assert.assertNull(numericRangeIndex);
+  }
+
+  @Test
+  public void testVariantPredicateIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeVariantSupplierWithNull();
+
+    DruidPredicateIndex predicateIndex = indexSupplier.as(DruidPredicateIndex.class);
+    Assert.assertNotNull(predicateIndex);
+    DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
+        null,
+        new InDimFilter.ValuesSet(ImmutableSet.of("b", "z", "9.9", "300"))
+    );
+
+    // 10 rows
+    // local: [null, b, z, 1, 300, 1.1, 9.9]
+    // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
+
+    BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.5, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 6, 9);
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeStringSupplier() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [b, foo, fooo, z]
+    // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
+
+    // b
+    localDictionaryWriter.write(2);
+    bitmapWriter.write(fillBitmap(1, 3, 7, 8));
+
+    // foo
+    localDictionaryWriter.write(4);
+    bitmapWriter.write(fillBitmap(0, 9));
+
+    // fooo
+    localDictionaryWriter.write(5);
+    bitmapWriter.write(fillBitmap(2, 5));
+
+    // z
+    localDictionaryWriter.write(6);
+    bitmapWriter.write(fillBitmap(4, 6));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.STRING).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeStringWithNullsSupplier() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    // null
+    localDictionaryWriter.write(0);
+    bitmapWriter.write(fillBitmap(1, 7, 8));
+
+    // b
+    localDictionaryWriter.write(2);
+    bitmapWriter.write(fillBitmap(3));
+
+    // foo
+    localDictionaryWriter.write(4);
+    bitmapWriter.write(fillBitmap(0, 9));
+
+    // fooo
+    localDictionaryWriter.write(5);
+    bitmapWriter.write(fillBitmap(2, 5));
+
+    // z
+    localDictionaryWriter.write(6);
+    bitmapWriter.write(fillBitmap(4, 6));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.STRING).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeLongSupplier() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [1, 3, 100, 300]
+    // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
+
+    // 1
+    localDictionaryWriter.write(7);
+    bitmapWriter.write(fillBitmap(1, 3, 9));
+
+    // 3
+    localDictionaryWriter.write(9);
+    bitmapWriter.write(fillBitmap(4, 5));
+
+    // 100
+    localDictionaryWriter.write(11);
+    bitmapWriter.write(fillBitmap(0, 6));
+
+    // 300
+    localDictionaryWriter.write(12);
+    bitmapWriter.write(fillBitmap(2, 7, 8));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.LONG).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeLongSupplierWithNull() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [null, 1, 3, 100, 300]
+    // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
+
+    // null
+    localDictionaryWriter.write(0);
+    bitmapWriter.write(fillBitmap(2, 5, 8));
+
+    // 1
+    localDictionaryWriter.write(7);
+    bitmapWriter.write(fillBitmap(1, 3, 9));
+
+    // 3
+    localDictionaryWriter.write(9);
+    bitmapWriter.write(fillBitmap(4));
+
+    // 100
+    localDictionaryWriter.write(11);
+    bitmapWriter.write(fillBitmap(0, 6));
+
+    // 300
+    localDictionaryWriter.write(12);
+    bitmapWriter.write(fillBitmap(7));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.LONG).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeDoubleSupplier() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
+
+    // 1.1
+    localDictionaryWriter.write(15);
+    bitmapWriter.write(fillBitmap(0, 1, 8));
+
+    // 1.2
+    localDictionaryWriter.write(16);
+    bitmapWriter.write(fillBitmap(2, 4, 7));
+
+    // 3.3
+    localDictionaryWriter.write(19);
+    bitmapWriter.write(fillBitmap(3, 6, 9));
+
+    // 6.6
+    localDictionaryWriter.write(20);
+    bitmapWriter.write(fillBitmap(5));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.DOUBLE).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeSingleTypeDoubleSupplierWithNull() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [null, 1.1, 1.2, 3.3, 6.6]
+    // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
+
+    // null
+    localDictionaryWriter.write(0);
+    bitmapWriter.write(fillBitmap(1, 3, 6));
+
+    // 1.1
+    localDictionaryWriter.write(15);
+    bitmapWriter.write(fillBitmap(0, 8));
+
+    // 1.2
+    localDictionaryWriter.write(16);
+    bitmapWriter.write(fillBitmap(2, 4, 7));
+
+    // 3.3
+    localDictionaryWriter.write(19);
+    bitmapWriter.write(fillBitmap(9));
+
+    // 6.6
+    localDictionaryWriter.write(20);
+    bitmapWriter.write(fillBitmap(5));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.DOUBLE).getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private NestedFieldLiteralColumnIndexSupplier makeVariantSupplierWithNull() throws IOException
+  {
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, a, b, fo, foo, fooo, z],
+    //    [1, 2, 3, 5, 100, 300, 9000],
+    //    [1.0, 1.1, 1.2, 2.0, 2.5, 3.3, 6.6, 9.9]
+    // ]
+    // local: [null, b, z, 1, 300, 1.1, 9.9]
+    // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
+
+    // null
+    localDictionaryWriter.write(0);
+    bitmapWriter.write(fillBitmap(2, 7));
+
+    // b
+    localDictionaryWriter.write(2);
+    bitmapWriter.write(fillBitmap(1, 9));
+
+    // z
+    localDictionaryWriter.write(6);
+    bitmapWriter.write(fillBitmap(6));
+
+    // 1
+    localDictionaryWriter.write(7);
+    bitmapWriter.write(fillBitmap(0, 5));
+
+    // 300
+    localDictionaryWriter.write(12);
+    bitmapWriter.write(fillBitmap(4));
+
+    // 1.1
+    localDictionaryWriter.write(15);
+    bitmapWriter.write(fillBitmap(8));
+
+    // 9.9
+    localDictionaryWriter.write(21);
+    bitmapWriter.write(fillBitmap(3));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    return new NestedFieldLiteralColumnIndexSupplier(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.STRING)
+                                                      .add(ColumnType.LONG)
+                                                      .add(ColumnType.DOUBLE)
+                                                      .getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionary,
+        globalStrings,
+        globalLongs,
+        globalDoubles
+    );
+  }
+
+  private ImmutableBitmap fillBitmap(int... rows)
+  {
+    MutableBitmap bitmap = roaringFactory.getBitmapFactory().makeEmptyMutableBitmap();
+    for (int i : rows) {
+      bitmap.add(i);
+    }
+    return roaringFactory.getBitmapFactory().makeImmutableBitmap(bitmap);
+  }
+
+  void checkBitmap(ImmutableBitmap bitmap, int... expectedRows)
+  {
+    IntIterator iterator = bitmap.iterator();
+    for (int i : expectedRows) {
+      Assert.assertTrue(iterator.hasNext());
+      Assert.assertEquals(i, iterator.next());
+    }
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  static void writeToBuffer(ByteBuffer buffer, Serializer serializer) throws IOException
+  {
+    WritableByteChannel channel = new WritableByteChannel()
+    {
+      @Override
+      public int write(ByteBuffer src)
+      {
+        int size = src.remaining();
+        buffer.put(src);
+        return size;
+      }
+
+      @Override
+      public boolean isOpen()
+      {
+        return true;
+      }
+
+      @Override
+      public void close()
+      {
+      }
+    };
+
+    serializer.writeTo(channel, null);
+    buffer.position(0);
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -852,7 +852,6 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L}
         )
     );
@@ -954,6 +953,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
+            new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L}
         )
     );
@@ -1052,7 +1052,6 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"2.02", 2L}
         )
     );
@@ -1154,6 +1153,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
+            new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"2.02", 2L}
         )
     );


### PR DESCRIPTION
### Description
This PR adds a `NumericRangeIndex` interface, which is like `LexicographicalRangeIndex` but for numbers. `BoundFilter` now uses `NumericRangeIndex` if comparator is numeric and there is no `extractionFn` defined, allowing number columns with indexes to take the same shortcut we use for string columns.

I have wired this up to `COMPLEX<json>` columns since the nested numeric columns have bitmap indexes, which has a pretty decent performance boost compared to using the predicate based index for numeric ranges. Note that regular numeric columns do not yet have indexes yet, which I plan to add in a future PR.

no index (regular numeric columns):
```
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score   Error  Units
SqlNestedDataBenchmark.querySql       14           5000000        false  avgt    5   97.164 ± 3.767  ms/op
SqlNestedDataBenchmark.querySql       14           5000000        force  avgt    5   53.835 ± 0.783  ms/op
SqlNestedDataBenchmark.querySql       26           5000000        false  avgt    5   75.090 ± 2.488  ms/op
SqlNestedDataBenchmark.querySql       26           5000000        force  avgt    5   48.634 ± 1.097  ms/op
SqlNestedDataBenchmark.querySql       28           5000000        false  avgt    5   86.636 ± 3.613  ms/op
SqlNestedDataBenchmark.querySql       28           5000000        force  avgt    5   52.267 ± 0.978  ms/op
```

predicate index (equivalent nested numeric columns with identical data):
```
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score   Error  Units
SqlNestedDataBenchmark.querySql       15           5000000        false  avgt    5  552.875 ± 6.711  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        force  avgt    5  543.700 ± 6.557  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        false  avgt    5   83.298 ± 1.470  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        force  avgt    5   83.296 ± 1.646  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        false  avgt    5  129.794 ± 2.851  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        force  avgt    5  108.845 ± 2.076  ms/op
```

range index (equivalent nested numeric columns with identical data):
```
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       15           5000000        false  avgt    5  386.536 ± 14.620  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        force  avgt    5  219.167 ±  4.013  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        false  avgt    5   13.366 ±  0.596  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        force  avgt    5   13.465 ±  0.623  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        false  avgt    5   42.618 ±  0.971  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        force  avgt    5   41.069 ±  0.896  ms/op
```

Revisiting the initial benchmarks I ran for nested columns, https://github.com/apache/druid/pull/12753#issuecomment-1183571908, query '15' was significantly slower than '14' which had no indexes, and this is still true though to a lesser degree than before. Digging a bit deeper, the reason for this is that 2.6 million values match which means merging that many bitmaps. Query 27 has ~1500 matches, while query 29 has 270k matching values.

This indicates that there is some threshold of "too many bitmaps" at which we should skip using indexes and fall back to a full scan and value matchers. I plan to introduce a mechanism for this in a future PR.

I also added some direct testing for `NestedFieldLiteralColumnIndexSupplier`, which was previously only indirectly tested via queries. This was a bit tedious, but also fixed a couple of minor bugs.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
