### PR TITLE
fix bugs with nested column jsonpath parser

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedPathFinder.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedPathFinder.java
@@ -33,21 +33,20 @@ public class NestedPathFinder
   public static String toNormalizedJsonPath(List<NestedPathPart> paths)
   {
     if (paths.isEmpty()) {
-      return "$.";
+      return "$";
     }
     StringBuilder bob = new StringBuilder();
     boolean first = true;
     for (NestedPathPart partFinder : paths) {
       if (partFinder instanceof NestedPathField) {
         if (first) {
-          bob.append("$.");
-        } else {
-          bob.append(".");
+          bob.append("$");
         }
         final String id = partFinder.getPartIdentifier();
         if (id.contains(".") || id.contains("'") || id.contains("\"") || id.contains("[") || id.contains("]")) {
           bob.append("['").append(id).append("']");
         } else {
+          bob.append(".");
           bob.append(id);
         }
       } else if (partFinder instanceof NestedPathArrayElement) {
@@ -124,15 +123,19 @@ public class NestedPathFinder
         quoteMark = i;
         partMark = i + 1;
       } else if (current == '\'' && quoteMark >= 0 && path.charAt(i - 1) != '\\') {
+        if (path.charAt(i + 1) != ']') {
+          if (arrayMark >= 0) {
+            continue;
+          }
+          badFormatJsonPath(path, "closing ' must immediately precede ']'");
+        }
+
         parts.add(new NestedPathField(getPathSubstring(path, partMark, i)));
         dotMark = -1;
         quoteMark = -1;
         // chomp to next char to eat closing array
         if (++i == path.length()) {
           break;
-        }
-        if (path.charAt(i) != ']') {
-          badFormatJsonPath(path, "closing ' must immediately precede ']'");
         }
         partMark = i + 1;
         arrayMark = -1;

--- a/processing/src/test/java/org/apache/druid/frame/segment/FrameStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/segment/FrameStorageAdapterTest.java
@@ -100,6 +100,7 @@ public class FrameStorageAdapterTest
     @Before
     public void setUp()
     {
+
       queryableAdapter = new QueryableIndexStorageAdapter(TestIndex.getMMappedTestIndex());
       frameSegment = FrameTestUtil.adapterToFrameSegment(queryableAdapter, frameType);
       frameAdapter = frameSegment.asStorageAdapter();

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
@@ -309,9 +309,14 @@ public class NestedPathFinderTest
         NestedPathFinder.toNormalizedJqPath(pathParts)
     );
     Assert.assertEquals(
-        "$.['x.y.z][\\']][]'].['13234.12[]][23'].['fo.o'].['.b.a.r.']",
+        "$['x.y.z][\\']][]']['13234.12[]][23']['fo.o']['.b.a.r.']",
         NestedPathFinder.toNormalizedJsonPath(pathParts)
     );
+
+    pathParts = NestedPathFinder.parseJsonPath("$['hell'o']");
+    Assert.assertEquals(1, pathParts.size());
+    Assert.assertEquals("hell'o", pathParts.get(0).getPartIdentifier());
+    Assert.assertEquals("$['hell'o']", NestedPathFinder.toNormalizedJsonPath(pathParts));
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -1955,7 +1955,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{"[\"$.\"]", 5L},
+            new Object[]{"[\"$\"]", 5L},
             new Object[]{"[\"$.n.x\",\"$.array[0]\",\"$.array[1]\"]", 2L}
         )
     );


### PR DESCRIPTION
### Description
Fixes some bugs with the custom jsonpath parser used by nested columns. It was overly restrictive in where `'` could appear, which prevented extracting properties from json that contain single quotes, as well as fixes some issues with the 'normalized' jsonpath generated from parsed path parts.

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
