### PR TITLE
Introduce defaultOnDiskStorage config for Group By

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/GroupByTypeInterfaceBenchmark.java
@@ -32,6 +32,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -362,9 +363,9 @@ public class GroupByTypeInterfaceBenchmark
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/GroupByBenchmark.java
@@ -34,6 +34,7 @@ import org.apache.druid.collections.StupidPool;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -477,9 +478,9 @@ public class GroupByBenchmark
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2079,6 +2079,7 @@ Supported runtime properties:
 |`druid.query.groupBy.maxSelectorDictionarySize`|Maximum amount of heap space (approximately) to use for per-segment string dictionaries. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|100000000|
 |`druid.query.groupBy.maxMergingDictionarySize`|Maximum amount of heap space (approximately) to use for per-query string dictionaries. When the dictionary exceeds this size, a spill to disk will be triggered. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|100000000|
 |`druid.query.groupBy.maxOnDiskStorage`|Maximum amount of disk space to use, per-query, for spilling result sets to disk when either the merging buffer or the dictionary fills up. Queries that exceed this limit will fail. Set to zero to disable disk spilling.|0 (disabled)|
+|`druid.query.groupBy.defaultOnDiskStorage`|Default amount of disk space to use, per-query, for spilling the result sets to disk when either the merging buffer or the dictionary fills up. Set to zero to disable disk spilling for queries who don't override `maxOnDiskStorage` in their context.|`druid.query.groupBy.maxOnDiskStorage`|
 
 Supported query contexts:
 
@@ -2086,7 +2087,7 @@ Supported query contexts:
 |---|-----------|
 |`maxSelectorDictionarySize`|Can be used to lower the value of `druid.query.groupBy.maxMergingDictionarySize` for this query.|
 |`maxMergingDictionarySize`|Can be used to lower the value of `druid.query.groupBy.maxMergingDictionarySize` for this query.|
-|`maxOnDiskStorage`|Can be used to lower the value of `druid.query.groupBy.maxOnDiskStorage` for this query.|
+|`maxOnDiskStorage`|Can be used to set `maxOnDiskStorage` to a value between 0 and `druid.query.groupBy.maxOnDiskStorage` for this query. If this query context override exceeds `druid.query.groupBy.maxOnDiskStorage`, the query will use `druid.query.groupBy.maxOnDiskStorage`. Omitting this from the query context will cause the query to use `druid.query.groupBy.defaultOnDiskStorage` for `maxOnDiskStorage`|
 
 
 ### Advanced configurations

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2079,7 +2079,7 @@ Supported runtime properties:
 |`druid.query.groupBy.maxSelectorDictionarySize`|Maximum amount of heap space (approximately) to use for per-segment string dictionaries. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|100000000|
 |`druid.query.groupBy.maxMergingDictionarySize`|Maximum amount of heap space (approximately) to use for per-query string dictionaries. When the dictionary exceeds this size, a spill to disk will be triggered. See [groupBy memory tuning and resource limits](../querying/groupbyquery.md#memory-tuning-and-resource-limits) for details.|100000000|
 |`druid.query.groupBy.maxOnDiskStorage`|Maximum amount of disk space to use, per-query, for spilling result sets to disk when either the merging buffer or the dictionary fills up. Queries that exceed this limit will fail. Set to zero to disable disk spilling.|0 (disabled)|
-|`druid.query.groupBy.defaultOnDiskStorage`|Default amount of disk space to use, per-query, for spilling the result sets to disk when either the merging buffer or the dictionary fills up. Set to zero to disable disk spilling for queries who don't override `maxOnDiskStorage` in their context.|`druid.query.groupBy.maxOnDiskStorage`|
+|`druid.query.groupBy.defaultOnDiskStorage`|Default amount of disk space to use, per-query, for spilling the result sets to disk when either the merging buffer or the dictionary fills up. Set to zero to disable disk spilling for queries which don't override `maxOnDiskStorage` in their context.|`druid.query.groupBy.maxOnDiskStorage`|
 
 Supported query contexts:
 

--- a/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/MaterializedViewQuery.java
+++ b/extensions-contrib/materialized-view-selection/src/main/java/org/apache/druid/query/materializedview/MaterializedViewQuery.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.DataSource;
@@ -168,6 +169,12 @@ public class MaterializedViewQuery<T> implements Query<T>
   public boolean getContextBoolean(String key, boolean defaultValue) 
   {
     return query.getContextBoolean(key, defaultValue);
+  }
+
+  @Override
+  public HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue)
+  {
+    return query.getContextHumanReadableBytes(key, defaultValue);
   }
 
   @Override

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryTest.java
@@ -22,8 +22,10 @@ package org.apache.druid.query.materializedview;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunnerTestHelper;
@@ -88,5 +90,38 @@ public class MaterializedViewQueryTest
     Assert.assertEquals(new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE), query.getDataSource());
     Assert.assertEquals(QueryRunnerTestHelper.ALL_GRAN, query.getGranularity());
     Assert.assertEquals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC.getIntervals(), query.getIntervals());
+  }
+
+  @Test
+  public void testGetContextHumanReadableBytes()
+  {
+    TopNQuery topNQuery = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .granularity(QueryRunnerTestHelper.ALL_GRAN)
+        .dimension(QueryRunnerTestHelper.MARKET_DIMENSION)
+        .metric(QueryRunnerTestHelper.INDEX_METRIC)
+        .threshold(4)
+        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+        .aggregators(
+            Lists.newArrayList(
+                Iterables.concat(
+                    QueryRunnerTestHelper.COMMON_DOUBLE_AGGREGATORS,
+                    Lists.newArrayList(
+                        new DoubleMaxAggregatorFactory("maxIndex", "index"),
+                        new DoubleMinAggregatorFactory("minIndex", "index")
+                    )
+                )
+            )
+        )
+        .context(
+            ImmutableMap.of(
+                "maxOnDiskStorage", "20M"
+            )
+        )
+        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+        .build();
+    MaterializedViewQuery query = new MaterializedViewQuery(topNQuery, optimizer);
+    Assert.assertEquals(20_000_000, query.getContextHumanReadableBytes("maxOnDiskStorage", HumanReadableBytes.ZERO).getBytes());
+
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/BaseQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/BaseQuery.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
@@ -197,6 +198,12 @@ public abstract class BaseQuery<T> implements Query<T>
   public boolean getContextBoolean(String key, boolean defaultValue)
   {
     return context.getAsBoolean(key, defaultValue);
+  }
+
+  @Override
+  public HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue)
+  {
+    return context.getAsHumanReadableBytes(key, defaultValue);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.datasourcemetadata.DataSourceMetadataQuery;
 import org.apache.druid.query.filter.DimFilter;
@@ -128,6 +129,8 @@ public interface Query<T>
   <ContextType> ContextType getContextValue(String key, ContextType defaultValue);
 
   boolean getContextBoolean(String key, boolean defaultValue);
+
+  HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue);
 
   boolean isDescending();
 

--- a/processing/src/main/java/org/apache/druid/query/Query.java
+++ b/processing/src/main/java/org/apache/druid/query/Query.java
@@ -130,7 +130,23 @@ public interface Query<T>
 
   boolean getContextBoolean(String key, boolean defaultValue);
 
-  HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue);
+  /**
+   * Returns {@link HumanReadableBytes} for a specified context key. If the context is null or the key doesn't exist
+   * a caller specified default value is returned. A default implementation is provided since Query is an extension
+   * point. Extensions can choose to rely on this default to retain compatibility with core Druid.
+   *
+   * @param key The context key value being looked up
+   * @param defaultValue The default to return if the key value doesn't exist or the context is null.
+   * @return {@link HumanReadableBytes}
+   */
+  default HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue)
+  {
+    if (null != getQueryContext()) {
+      return getQueryContext().getAsHumanReadableBytes(key, defaultValue);
+    } else {
+      return defaultValue;
+    }
+  }
 
   boolean isDescending();
 

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.query;
 
+import org.apache.druid.java.util.common.HumanReadableBytes;
+
 import javax.annotation.Nullable;
 
 import java.util.Collections;
@@ -174,6 +176,11 @@ public class QueryContext
   public long getAsLong(final String parameter, final long defaultValue)
   {
     return QueryContexts.getAsLong(parameter, get(parameter), defaultValue);
+  }
+
+  public HumanReadableBytes getAsHumanReadableBytes(final String parameter, final HumanReadableBytes defaultValue)
+  {
+    return QueryContexts.getAsHumanReadableBytes(parameter, get(parameter), defaultValue);
   }
 
   public Map<String, Object> getMergedParams()

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.guice.annotations.PublicApi;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Numbers;
@@ -565,6 +566,23 @@ public class QueryContexts
       return ((Number) value).longValue();
     } else {
       throw new IAE("Expected parameter [%s] to be a long", parameter);
+    }
+  }
+
+  public static HumanReadableBytes getAsHumanReadableBytes(
+      final String parameter,
+      final Object value,
+      final HumanReadableBytes defaultValue
+  )
+  {
+    if (null == value) {
+      return defaultValue;
+    } else if (value instanceof Number) {
+      return HumanReadableBytes.valueOf(Numbers.parseLong(value));
+    } else if (value instanceof String) {
+      return new HumanReadableBytes((String) value);
+    } else {
+      throw new IAE("Expected parameter [%s] to be in human readable format", parameter);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -106,7 +106,7 @@ public class GroupByQueryConfig
   private long maxOnDiskStorage = 0L;
 
   @JsonProperty
-  private long defaultOnDiskStorage = Integer.MAX_VALUE;
+  private long defaultOnDiskStorage = -1L;
 
   @JsonProperty
   private boolean forcePushDownLimit = false;
@@ -279,7 +279,7 @@ public class GroupByQueryConfig
    */
   public long getDefaultOnDiskStorage()
   {
-    return defaultOnDiskStorage == Integer.MAX_VALUE ? getMaxOnDiskStorage() : defaultOnDiskStorage;
+    return defaultOnDiskStorage < 0L ? getMaxOnDiskStorage() : defaultOnDiskStorage;
   }
 
   public boolean isForcePushDownLimit()

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -103,10 +103,10 @@ public class GroupByQueryConfig
 
   @JsonProperty
   // Max on-disk temporary storage, per-query; when exceeded, the query fails
-  private long maxOnDiskStorage = 0L;
+  private HumanReadableBytes maxOnDiskStorage = HumanReadableBytes.valueOf(0);
 
   @JsonProperty
-  private long defaultOnDiskStorage = -1L;
+  private HumanReadableBytes defaultOnDiskStorage = HumanReadableBytes.valueOf(-1);
 
   @JsonProperty
   private boolean forcePushDownLimit = false;
@@ -264,7 +264,7 @@ public class GroupByQueryConfig
     );
   }
 
-  public long getMaxOnDiskStorage()
+  public HumanReadableBytes getMaxOnDiskStorage()
   {
     return maxOnDiskStorage;
   }
@@ -277,9 +277,9 @@ public class GroupByQueryConfig
    *
    * @return The working value for defaultOnDiskStorage
    */
-  public long getDefaultOnDiskStorage()
+  public HumanReadableBytes getDefaultOnDiskStorage()
   {
-    return defaultOnDiskStorage < 0L ? getMaxOnDiskStorage() : defaultOnDiskStorage;
+    return defaultOnDiskStorage.getBytes() < 0L ? getMaxOnDiskStorage() : defaultOnDiskStorage;
   }
 
   public boolean isForcePushDownLimit()
@@ -360,9 +360,11 @@ public class GroupByQueryConfig
     // If the client overrides do not provide "maxOnDiskStorage" context key, the server side "defaultOnDiskStorage"
     // value is used in the calculation of the newConfig value of maxOnDiskStorage. This allows the operator to
     // choose a default value lower than the max allowed when the context key is missing in the client query.
-    newConfig.maxOnDiskStorage = Math.min(
-        ((Number) query.getContextValue(CTX_KEY_MAX_ON_DISK_STORAGE, getDefaultOnDiskStorage())).longValue(),
-        getMaxOnDiskStorage()
+    newConfig.maxOnDiskStorage = HumanReadableBytes.valueOf(
+        Math.min(
+            query.getContextHumanReadableBytes(CTX_KEY_MAX_ON_DISK_STORAGE, getDefaultOnDiskStorage()).getBytes(),
+            getMaxOnDiskStorage().getBytes()
+        )
     );
     newConfig.maxSelectorDictionarySize = maxSelectorDictionarySize; // No overrides
     newConfig.maxMergingDictionarySize = maxMergingDictionarySize; // No overrides
@@ -407,8 +409,8 @@ public class GroupByQueryConfig
            ", bufferGrouperMaxLoadFactor=" + bufferGrouperMaxLoadFactor +
            ", bufferGrouperInitialBuckets=" + bufferGrouperInitialBuckets +
            ", maxMergingDictionarySize=" + maxMergingDictionarySize +
-           ", maxOnDiskStorage=" + maxOnDiskStorage +
-           ", defaultOnDiskStorage=" + getDefaultOnDiskStorage() + // use the getter because of special behavior for mirroring maxOnDiskStorage if defaultOnDiskStorage not explicitly set.
+           ", maxOnDiskStorage=" + maxOnDiskStorage.getBytes() +
+           ", defaultOnDiskStorage=" + getDefaultOnDiskStorage().getBytes() + // use the getter because of special behavior for mirroring maxOnDiskStorage if defaultOnDiskStorage not explicitly set.
            ", forcePushDownLimit=" + forcePushDownLimit +
            ", forceHashAggregation=" + forceHashAggregation +
            ", intermediateCombineDegree=" + intermediateCombineDegree +

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -70,8 +70,6 @@ public class GroupByQueryConfig
   private static final long MIN_AUTOMATIC_DICTIONARY_SIZE = 1;
   private static final long MAX_AUTOMATIC_DICTIONARY_SIZE = 1_000_000_000;
 
-
-
   @JsonProperty
   private String defaultStrategy = GroupByStrategySelector.STRATEGY_V2;
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.groupby;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.HumanReadableBytes;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.groupby.strategy.GroupByStrategySelector;
@@ -31,6 +32,8 @@ import org.apache.druid.utils.JvmUtils;
  */
 public class GroupByQueryConfig
 {
+  private static final Logger logger = new Logger(GroupByQueryConfig.class);
+
   public static final long AUTOMATIC = 0;
 
   public static final String CTX_KEY_STRATEGY = "groupByStrategy";
@@ -389,6 +392,8 @@ public class GroupByQueryConfig
         CTX_KEY_ENABLE_MULTI_VALUE_UNNESTING,
         isMultiValueUnnestingEnabled()
     );
+
+    logger.debug(newConfig.toString());
     return newConfig;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -391,7 +391,7 @@ public class GroupByQueryConfig
         isMultiValueUnnestingEnabled()
     );
 
-    logger.debug(newConfig.toString());
+    logger.debug("Override config for GroupBy query %s - %s", query.getId(), newConfig.toString());
     return newConfig;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByMergingQueryRunnerV2.java
@@ -175,7 +175,7 @@ public class GroupByMergingQueryRunnerV2 implements QueryRunner<ResultRow>
             try {
               final LimitedTemporaryStorage temporaryStorage = new LimitedTemporaryStorage(
                   temporaryStorageDirectory,
-                  querySpecificConfig.getMaxOnDiskStorage()
+                  querySpecificConfig.getMaxOnDiskStorage().getBytes()
               );
               final ReferenceCountingResourceHolder<LimitedTemporaryStorage> temporaryStorageHolder =
                   ReferenceCountingResourceHolder.fromCloseable(temporaryStorage);

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
@@ -106,7 +106,7 @@ public class GroupByRowProcessor
 
     final LimitedTemporaryStorage temporaryStorage = new LimitedTemporaryStorage(
         temporaryStorageDirectory,
-        querySpecificConfig.getMaxOnDiskStorage()
+        querySpecificConfig.getMaxOnDiskStorage().getBytes()
     );
 
     closeOnExit.register(temporaryStorage);

--- a/processing/src/main/java/org/apache/druid/query/select/SelectQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/select/SelectQuery.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.select;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.common.collect.Ordering;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Query;
@@ -130,6 +131,12 @@ public class SelectQuery implements Query<Object>
 
   @Override
   public boolean getContextBoolean(String key, boolean defaultValue)
+  {
+    throw new RuntimeException(REMOVED_ERROR_MESSAGE);
+  }
+
+  @Override
+  public HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue)
   {
     throw new RuntimeException(REMOVED_ERROR_MESSAGE);
   }

--- a/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
@@ -134,6 +134,17 @@ public class QueryContextTest
   }
 
   @Test
+  public void testGetHumanReadableBytes()
+  {
+    final QueryContext context = new QueryContext(
+        ImmutableMap.of(
+            "maxOnDiskStorage", "500M"
+        )
+    );
+    Assert.assertEquals(500_000_000, context.getAsHumanReadableBytes("maxOnDiskStorage", HumanReadableBytes.ZERO).getBytes());
+  }
+
+  @Test
   public void testAddSystemParamOverrideUserParam()
   {
     final QueryContext context = new QueryContext(

--- a/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
@@ -23,7 +23,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+import org.apache.druid.java.util.common.HumanReadableBytes;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Numbers;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
@@ -344,6 +347,22 @@ public class QueryContextTest
         return defaultValue;
       }
       return (boolean) context.get(key);
+    }
+
+    @Override
+    public HumanReadableBytes getContextHumanReadableBytes(String key, HumanReadableBytes defaultValue)
+    {
+      if (null == context || !context.containsKey(key)) {
+        return defaultValue;
+      }
+      Object value = context.get(key);
+      if (value instanceof Number) {
+        return HumanReadableBytes.valueOf(Numbers.parseLong(value));
+      } else if (value instanceof String) {
+        return new HumanReadableBytes((String) value);
+      } else {
+        throw new IAE("Expected parameter [%s] to be in human readable format", key);
+      }
     }
 
     @Override

--- a/processing/src/test/java/org/apache/druid/query/QueryContextsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryContextsTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
@@ -273,5 +274,13 @@ public class QueryContextsTest
     catch (IAE e) {
       // Expected
     }
+  }
+
+  @Test
+  public void testGetAsHumanReadableBytes()
+  {
+    Assert.assertEquals(new HumanReadableBytes("500M").getBytes(), QueryContexts.getAsHumanReadableBytes("maxOnDiskStorage", 500_000_000, HumanReadableBytes.ZERO).getBytes());
+    Assert.assertEquals(new HumanReadableBytes("500M").getBytes(), QueryContexts.getAsHumanReadableBytes("maxOnDiskStorage", "500000000", HumanReadableBytes.ZERO).getBytes());
+    Assert.assertEquals(new HumanReadableBytes("500M").getBytes(), QueryContexts.getAsHumanReadableBytes("maxOnDiskStorage", "500M", HumanReadableBytes.ZERO).getBytes());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByLimitPushDownInsufficientBufferTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -291,9 +292,9 @@ public class GroupByLimitPushDownInsufficientBufferTest extends InitializedNullH
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByLimitPushDownMultiNodeMergeTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -562,9 +563,9 @@ public class GroupByLimitPushDownMultiNodeMergeTest
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByMultiSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByMultiSegmentTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -227,9 +228,9 @@ public class GroupByMultiSegmentTest
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryConfigTest.java
@@ -38,7 +38,8 @@ public class GroupByQueryConfigTest
       .put("bufferGrouperInitialBuckets", "1")
       .put("maxIntermediateRows", "2")
       .put("maxResults", "3")
-      .put("maxOnDiskStorage", "4")
+      .put("defaultOnDiskStorage", "1M")
+      .put("maxOnDiskStorage", "4M")
       .put("maxSelectorDictionarySize", "5")
       .put("maxMergingDictionarySize", "6M")
       .put("bufferGrouperMaxLoadFactor", "7")
@@ -54,8 +55,8 @@ public class GroupByQueryConfigTest
     Assert.assertEquals(1, config.getBufferGrouperInitialBuckets());
     Assert.assertEquals(2, config.getMaxIntermediateRows());
     Assert.assertEquals(3, config.getMaxResults());
-    Assert.assertEquals(4, config.getMaxOnDiskStorage());
-    Assert.assertEquals(4, config.getDefaultOnDiskStorage());
+    Assert.assertEquals(4_000_000, config.getMaxOnDiskStorage().getBytes());
+    Assert.assertEquals(1_000_000, config.getDefaultOnDiskStorage().getBytes());
     Assert.assertEquals(5, config.getConfiguredMaxSelectorDictionarySize());
     Assert.assertEquals(6_000_000, config.getConfiguredMaxMergingDictionarySize());
     Assert.assertEquals(7.0, config.getBufferGrouperMaxLoadFactor(), 0.0);
@@ -79,7 +80,7 @@ public class GroupByQueryConfigTest
     Assert.assertEquals(1, config2.getBufferGrouperInitialBuckets());
     Assert.assertEquals(2, config2.getMaxIntermediateRows());
     Assert.assertEquals(3, config2.getMaxResults());
-    Assert.assertEquals(4, config2.getMaxOnDiskStorage());
+    Assert.assertEquals(1_000_000, config2.getMaxOnDiskStorage().getBytes());
     Assert.assertEquals(5, config2.getConfiguredMaxSelectorDictionarySize());
     Assert.assertEquals(6_000_000, config2.getConfiguredMaxMergingDictionarySize());
     Assert.assertEquals(7.0, config2.getBufferGrouperMaxLoadFactor(), 0.0);
@@ -98,7 +99,7 @@ public class GroupByQueryConfigTest
                     .setContext(
                         ImmutableMap.<String, Object>builder()
                                     .put("groupByStrategy", "v1")
-                                    .put("maxOnDiskStorage", 0)
+                                    .put("maxOnDiskStorage", "3M")
                                     .put("maxResults", 2)
                                     .put("maxSelectorDictionarySize", 3)
                                     .put("maxMergingDictionarySize", 4)
@@ -113,7 +114,7 @@ public class GroupByQueryConfigTest
     Assert.assertEquals(1, config2.getBufferGrouperInitialBuckets());
     Assert.assertEquals(2, config2.getMaxIntermediateRows());
     Assert.assertEquals(2, config2.getMaxResults());
-    Assert.assertEquals(0, config2.getMaxOnDiskStorage());
+    Assert.assertEquals(3_000_000, config2.getMaxOnDiskStorage().getBytes());
     Assert.assertEquals(5 /* Can't override */, config2.getConfiguredMaxSelectorDictionarySize());
     Assert.assertEquals(6_000_000 /* Can't override */, config2.getConfiguredMaxMergingDictionarySize());
     Assert.assertEquals(7.0, config2.getBufferGrouperMaxLoadFactor(), 0.0);
@@ -176,8 +177,8 @@ public class GroupByQueryConfigTest
   {
     final GroupByQueryConfig config = MAPPER.convertValue(
         ImmutableMap.of(
-            "maxOnDiskStorage", "10",
-            "defaultOnDiskStorage", "5"
+            "maxOnDiskStorage", "10G",
+            "defaultOnDiskStorage", "5G"
         ),
         GroupByQueryConfig.class
     );
@@ -189,14 +190,14 @@ public class GroupByQueryConfigTest
                     .setContext(ImmutableMap.<String, Object>builder().build())
                     .build()
     );
-    Assert.assertEquals(5L, config2.getMaxOnDiskStorage());
+    Assert.assertEquals(5_000_000_000L, config2.getMaxOnDiskStorage().getBytes());
   }
 
   @Test
   public void testUseMaxOnDiskStorageWhenClientOverrideIsTooLarge()
   {
     final GroupByQueryConfig config = MAPPER.convertValue(
-        ImmutableMap.of("maxOnDiskStorage", "10"),
+        ImmutableMap.of("maxOnDiskStorage", "500M"),
         GroupByQueryConfig.class
     );
     final GroupByQueryConfig config2 = config.withOverrides(
@@ -206,11 +207,11 @@ public class GroupByQueryConfigTest
                     .setGranularity(Granularities.ALL)
                     .setContext(
                         ImmutableMap.<String, Object>builder()
-                            .put("maxOnDiskStorage", 500)
+                            .put("maxOnDiskStorage", "1G")
                             .build()
                     )
                     .build()
     );
-    Assert.assertEquals(10L, config2.getMaxOnDiskStorage());
+    Assert.assertEquals(500_000_000, config2.getMaxOnDiskStorage().getBytes());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryConfigTest.java
@@ -214,4 +214,20 @@ public class GroupByQueryConfigTest
     );
     Assert.assertEquals(500_000_000, config2.getMaxOnDiskStorage().getBytes());
   }
+
+  @Test
+  public void testGetDefaultOnDiskStorageReturnsCorrectValue()
+  {
+    final GroupByQueryConfig config = MAPPER.convertValue(
+        ImmutableMap.of("maxOnDiskStorage", "500M"),
+        GroupByQueryConfig.class
+    );
+    final GroupByQueryConfig config2 = MAPPER.convertValue(
+        ImmutableMap.of("maxOnDiskStorage", "500M",
+                        "defaultOnDiskStorage", "100M"),
+        GroupByQueryConfig.class
+    );
+    Assert.assertEquals(500_000_000, config.getDefaultOnDiskStorage().getBytes());
+    Assert.assertEquals(100_000_000, config2.getDefaultOnDiskStorage().getBytes());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.Rows;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
@@ -283,9 +284,9 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 10L * 1024 * 1024;
+        return HumanReadableBytes.valueOf(10L * 1024 * 1024);
       }
 
       @Override
@@ -315,9 +316,9 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 10L * 1024 * 1024;
+        return HumanReadableBytes.valueOf(10L * 1024 * 1024);
       }
 
       @Override
@@ -3018,7 +3019,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
     List<ResultRow> expectedResults = null;
     if (config.getDefaultStrategy().equals(GroupByStrategySelector.STRATEGY_V2)) {
       expectedException.expect(ResourceLimitExceededException.class);
-      if (config.getMaxOnDiskStorage() > 0) {
+      if (config.getMaxOnDiskStorage().getBytes() > 0) {
         // The error message always mentions disk if you have spilling enabled (maxOnDiskStorage > 0)
         expectedException.expectMessage("Not enough disk space to execute this query");
       } else {

--- a/processing/src/test/java/org/apache/druid/query/groupby/NestedQueryPushDownTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/NestedQueryPushDownTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -272,9 +273,9 @@ public class NestedQueryPushDownTest extends InitializedNullHandlingTest
       }
 
       @Override
-      public long getMaxOnDiskStorage()
+      public HumanReadableBytes getMaxOnDiskStorage()
       {
-        return 1_000_000_000L;
+        return HumanReadableBytes.valueOf(1_000_000_000L);
       }
     };
     config.setSingleThreaded(false);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

This config allows us the cluster operator to set an allowable maxOnDiskStorage value while also providing a default to prevent all queries from using that maximum by default if they don't override to a lower value on the client side via context. This makes sense because an operator may want to allow clients to opt in to a value between 0 and maxOnDiskStorage for their query, while not wanting all queries to use on disk storage by default.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * GroupByQueryConfig

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
