### PR TITLE
add DictionaryEncodedStringValueIndex implementation to NestedFieldLiteralColumnIndexSupplier

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedStringValueIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedStringValueIndex.java
@@ -22,17 +22,15 @@ package org.apache.druid.segment.column;
 import javax.annotation.Nullable;
 
 /**
- * This exposes a 'raw' view into a bitmap value indexes of a string {@link DictionaryEncodedColumn}, allowing
- * operation via dictionaryIds, as well as access to lower level details of such a column like value lookup and
- * value cardinality.
+ * This exposes a 'raw' view into bitmap value indexes of a string {@link DictionaryEncodedColumn}. This allows callers
+ * to directly retrieve bitmaps via dictionary ids, as well as access to lower level details of such a column like
+ * value lookup and value cardinality.
  *
- * This interface should only be used when it is beneficial to operate in such a manner, most filter implementations
- * should likely be using {@link StringValueSetIndex}, {@link DruidPredicateIndex}, {@link LexicographicalRangeIndex} or
- * some other higher level index instead.
+ * Most filter implementations should likely be using higher level index instead, such as {@link StringValueSetIndex},
+ * {@link LexicographicalRangeIndex}, {@link NumericRangeIndex}, or {@link DruidPredicateIndex}
  */
 public interface DictionaryEncodedStringValueIndex extends DictionaryEncodedValueIndex
 {
-  boolean hasNulls();
   /**
    * Get the cardinality of the underlying value dictionary
    */
@@ -43,10 +41,4 @@ public interface DictionaryEncodedStringValueIndex extends DictionaryEncodedValu
    */
   @Nullable
   String getValue(int index);
-
-  /**
-   * Returns the index of "value" in this DictionaryEncodedStringValueIndex, or a negative value, if not present in
-   * the underlying dictionary
-   */
-  int getIndex(@Nullable String value);
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedValueIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/DictionaryEncodedValueIndex.java
@@ -22,10 +22,15 @@ package org.apache.druid.segment.column;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 
 /**
- * This exposes a 'raw' view into a bitmap value indexes, allowing operation via dictionaryIds
+ * This exposes a 'raw' view into bitmap value indexes for {@link DictionaryEncodedColumn}. This allows callers
+ * to directly retrieve bitmaps via dictionary ids.
  *
- * This interface should only be used when it is beneficial to operate in such a manner, most filter implementations
- * should likely be using higher level index instead.
+ * This interface should only be used when it is beneficial to operate in such a manner; callers of this class must
+ * either already know what value the dictionary id represents, not care at all, or have some other means to know
+ * exactly which bitmaps to retrieve.
+ *
+ * Most filter implementations should likely be using higher level index instead, such as {@link StringValueSetIndex},
+ * {@link LexicographicalRangeIndex}, {@link NumericRangeIndex}, or {@link DruidPredicateIndex}.
  */
 public interface DictionaryEncodedValueIndex
 {

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
@@ -157,12 +157,6 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
     }
 
     @Override
-    public boolean hasNulls()
-    {
-      return dictionary.indexOf(null) >= 0;
-    }
-
-    @Override
     public int getCardinality()
     {
       return dictionary.size();
@@ -175,11 +169,6 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
       return dictionary.get(index);
     }
 
-    @Override
-    public int getIndex(@Nullable String value)
-    {
-      return dictionary.indexOf(value);
-    }
   }
 
   public static final class GenericIndexedDictionaryEncodedStringValueSetIndex

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
@@ -608,12 +608,6 @@ public class ListFilteredVirtualColumn implements VirtualColumn
     }
 
     @Override
-    public boolean hasNulls()
-    {
-      return delegate.hasNulls();
-    }
-
-    @Override
     public int getCardinality()
     {
       return idMapping.getValueCardinality();
@@ -624,12 +618,6 @@ public class ListFilteredVirtualColumn implements VirtualColumn
     public String getValue(int index)
     {
       return delegate.getValue(idMapping.getReverseId(index));
-    }
-
-    @Override
-    public int getIndex(@Nullable String value)
-    {
-      return getReverseIndex(value);
     }
 
     @Override

--- a/processing/src/test/java/org/apache/druid/segment/ColumnSelectorColumnIndexSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/ColumnSelectorColumnIndexSelectorTest.java
@@ -79,7 +79,6 @@ public class ColumnSelectorColumnIndexSelectorTest
     EasyMock.expect(indexSupplier.as(DictionaryEncodedStringValueIndex.class)).andReturn(valueIndex).anyTimes();
     BitmapColumnIndex columnIndex = EasyMock.createMock(BitmapColumnIndex.class);
     ImmutableBitmap someBitmap = EasyMock.createMock(ImmutableBitmap.class);
-    EasyMock.expect(valueIndex.getIndex("foo")).andReturn(0).anyTimes();
     EasyMock.expect(valueIndex.getBitmap(0)).andReturn(someBitmap).anyTimes();
 
     EasyMock.expect(someIndex.forValue("foo")).andReturn(columnIndex).anyTimes();

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerNullHandlingTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerNullHandlingTest.java
@@ -198,11 +198,8 @@ public class IndexMergerNullHandlingTest
               }
             }
 
-            Assert.assertEquals(subsetList.toString(), expectedNullRows.size() > 0, valueIndex.hasNulls());
 
             if (expectedNullRows.size() > 0) {
-              Assert.assertEquals(subsetList.toString(), 0, valueIndex.getIndex(null));
-
               final ImmutableBitmap nullBitmap = valueSetIndex.forValue(null)
                                                               .computeBitmapResult(
                                                                   new DefaultBitmapResultFactory(
@@ -217,8 +214,6 @@ public class IndexMergerNullHandlingTest
               }
 
               Assert.assertEquals(subsetList.toString(), expectedNullRows, actualNullRows);
-            } else {
-              Assert.assertEquals(-1, valueIndex.getIndex(null));
             }
           }
         }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnSelectorTest.java
@@ -196,7 +196,6 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
     EasyMock.expect(index.getValue(2)).andReturn("c").atLeastOnce();
 
     EasyMock.expect(index.getBitmap(2)).andReturn(bitmap).once();
-    EasyMock.expect(index.hasNulls()).andReturn(true).once();
 
     EasyMock.replay(selector, holder, timeHolder, indexSupplier, index, bitmap, bitmapFactory);
 
@@ -211,14 +210,10 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
 
     DictionaryEncodedStringValueIndex listFilteredIndex =
         bitmapIndexSelector.getIndexSupplier(ALLOW_VIRTUAL_NAME).as(DictionaryEncodedStringValueIndex.class);
-    Assert.assertEquals(-1, listFilteredIndex.getIndex("a"));
-    Assert.assertEquals(0, listFilteredIndex.getIndex("b"));
-    Assert.assertEquals(1, listFilteredIndex.getIndex("c"));
     Assert.assertEquals(2, listFilteredIndex.getCardinality());
     Assert.assertEquals("b", listFilteredIndex.getValue(0));
     Assert.assertEquals("c", listFilteredIndex.getValue(1));
     Assert.assertEquals(bitmap, listFilteredIndex.getBitmap(1));
-    Assert.assertTrue(listFilteredIndex.hasNulls());
 
     EasyMock.verify(selector, holder, timeHolder, indexSupplier, index, bitmap, bitmapFactory);
   }
@@ -260,7 +255,6 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
     EasyMock.expect(index.getValue(2)).andReturn("c").atLeastOnce();
 
     EasyMock.expect(index.getBitmap(0)).andReturn(bitmap).once();
-    EasyMock.expect(index.hasNulls()).andReturn(true).once();
 
     EasyMock.replay(selector, holder, timeHolder, indexSupplier, index, bitmap, bitmapFactory);
 
@@ -275,12 +269,8 @@ public class ListFilteredVirtualColumnSelectorTest extends InitializedNullHandli
 
     DictionaryEncodedStringValueIndex listFilteredIndex =
         bitmapIndexSelector.getIndexSupplier(DENY_VIRTUAL_NAME).as(DictionaryEncodedStringValueIndex.class);
-    Assert.assertEquals(-1, listFilteredIndex.getIndex("a"));
-    Assert.assertEquals(-1, listFilteredIndex.getIndex("b"));
-    Assert.assertEquals(0, listFilteredIndex.getIndex("c"));
     Assert.assertEquals(1, listFilteredIndex.getCardinality());
     Assert.assertEquals(bitmap, listFilteredIndex.getBitmap(1));
-    Assert.assertTrue(listFilteredIndex.hasNulls());
 
     EasyMock.verify(selector, holder, timeHolder, indexSupplier, index, bitmap, bitmapFactory);
   }


### PR DESCRIPTION
### Description
This PR adds an implementation to `DictionaryEncodedStringValueIndex` to `NestedFieldLiteralColumnIndexSupplier`, which is used in a handful of places for doing stuff with dictionary encoded columns, such as native search and segment metadata queries, fixing some bugs.

I also removed `getIndex` and `hasNulls` from `DictionaryEncodedStringValueIndex`, which were only used by tests.

There is another issue not addressed in this PR, which is that these things rely on `ColumnCapabilities.hasBitmapIndexes` to check if they can use indexes, which is really no longer adequate to know if something will have the type of indexes that they are going to ask for after #12388. I think in the future we might want to either update column capabilities to include all of the classes the `ColumnIndexSupplier` can supply, or make these callers check the `ColumnIndexSupplier` themselves.

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
