### PR TITLE
Docs - README.md community channels removal + link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
   ~ under the License.
   -->
 
-[![Slack](https://img.shields.io/badge/slack-%23druid-72eff8?logo=slack)](https://druid.apache.org/community/join-slack)
 [![Build Status](https://api.travis-ci.com/apache/druid.svg?branch=master)](https://app.travis-ci.com/github/apache/druid)
 [![Language grade: Java](https://img.shields.io/lgtm/grade/java/g/apache/druid.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/apache/druid/context:java)
 [![Coverage Status](https://img.shields.io/codecov/c/gh/apache/druid)](https://codecov.io/gh/apache/druid)
@@ -29,12 +28,14 @@
 ---
 
 [Website](https://druid.apache.org/) |
-[Documentation](https://druid.apache.org/docs/latest/design/) |
-[Developer Mailing List](https://lists.apache.org/list.html?dev@druid.apache.org) |
-[User Mailing List](https://groups.google.com/forum/#!forum/druid-user) |
-[Slack](https://druid.apache.org/community/join-slack) |
 [Twitter](https://twitter.com/druidio) |
-[Download](https://druid.apache.org/downloads.html)
+[Download](https://druid.apache.org/downloads.html) |
+[Get Started](#getting-started) |
+[Documentation](https://druid.apache.org/docs/latest/design/) |
+[Community](https://druid.apache.org/community/) |
+[Build](#building-from-source) |
+[Contribute](#contributing) |
+[License](#license)
 
 ---
 
@@ -76,17 +77,6 @@ the [project website](https://druid.apache.org).
 
 If you would like to contribute documentation, please do so under
 `/docs` in this repository and submit a pull request.
-
-### Community
-
-Community support is available on the
-[druid-user mailing list](https://groups.google.com/forum/#!forum/druid-user), which
-is hosted at Google Groups.
-
-Development discussions occur on [dev@druid.apache.org](https://lists.apache.org/list.html?dev@druid.apache.org), which
-you can subscribe to by emailing [dev-subscribe@druid.apache.org](mailto:dev-subscribe@druid.apache.org).
-
-Chat with Druid committers and users in real-time on the Apache Druid Slack channel. Please use [this invitation link to join and invite others](https://druid.apache.org/community/join-slack).
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 [Download](https://druid.apache.org/downloads.html) |
 [Get Started](#getting-started) |
 [Documentation](https://druid.apache.org/docs/latest/design/) |
-[Community](https://druid.apache.org/community/) |
+[Community](#community) |
 [Build](#building-from-source) |
 [Contribute](#contributing) |
 [License](#license)
@@ -77,6 +77,17 @@ the [project website](https://druid.apache.org).
 
 If you would like to contribute documentation, please do so under
 `/docs` in this repository and submit a pull request.
+
+### Community
+
+Visit the official project [community](https://druid.apache.org/community/) page to read about getting involved in contributing to Apache Druid, and how we help one another use and operate Druid.
+
+* Druid users can find help in the [`druid-user`](https://groups.google.com/forum/#!forum/druid-user) mailing list on Google Groups, and have more technical conversations in `#troubleshooting` on Slack.
+* Druid development discussions take place in the [`druid-dev`](https://lists.apache.org/list.html?dev@druid.apache.org) mailing list ([dev@druid.apache.org](https://lists.apache.org/list.html?dev@druid.apache.org)).  Subscribe by emailing [dev-subscribe@druid.apache.org](mailto:dev-subscribe@druid.apache.org).  For live conversations, join the `#dev` channel on Slack.
+
+Check out the official [community](https://druid.apache.org/community/) page for details of how to join the community Slack channels.
+
+Find articles written by community members and a calendar of upcoming events on the [project site](https://druid.apache.org/) - contribute your own events and articles by submitting a PR in the [`apache/druid-website-src`](https://github.com/apache/druid-website-src/tree/master/_data) repository.
 
 ### Building from source
 


### PR DESCRIPTION
I spotted that the Slack registration links here didn't have the [?v=1 trick](https://github.com/apache/druid-website-src/pull/298) - but thought it might just be better to propose a leaner approach: link directly to the community page itself (which contains the necessary links to lots of stuff) instead of the separate heading here.

* Removed explicit links to project channels in favour of a link direct to the Community page on druid.apache.org.
* Updated nav to match remaining headings in the README.

---

This PR has:
- [X] been self-reviewed.
