### PR TITLE
Add check for eternity time segment to SqlSegmentsMetadataQuery

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -239,6 +239,12 @@ public class SqlSegmentsMetadataQuery
           sb.append(" OR ");
         }
       }
+
+      // Add a special case for a single partition with eternity. Since we are using string comparison, a partition with
+      // this start and end will be incorrectly not returned.
+      if (matchMode.equals(IntervalMode.OVERLAPS)) {
+        sb.append(" OR (start = '-146136543-09-08T08:23:32.096Z' AND \"end\" = '146140482-04-24T15:36:27.903Z')");
+      }
     }
 
     final Query<Map<String, Object>> sql = handle

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -247,6 +247,7 @@ public class SqlSegmentsMetadataQuery
 
       // Add a special check for a single segment with eternity. Since we are using string comparison, a segment with
       // this start and end will not be returned otherwise.
+      // Known Issue: https://github.com/apache/druid/issues/12860
       if (matchMode.equals(IntervalMode.OVERLAPS)) {
         sb.append(StringUtils.format(" OR (start = '%s' AND \"end\" = '%s')", Intervals.ETERNITY.getStart(), Intervals.ETERNITY.getEnd()));
       }

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -109,6 +109,30 @@ public class IndexerSQLMetadataStorageCoordinatorTest
       100
   );
 
+
+  private final DataSegment firstHalfEternityRangeSegment = new DataSegment(
+      "halfEternity",
+      new Interval(DateTimes.MIN, DateTimes.of("3000")),
+      "version",
+      ImmutableMap.of(),
+      ImmutableList.of("dim1"),
+      ImmutableList.of("m1"),
+      new LinearShardSpec(0),
+      9,
+      100
+  );
+
+  private final DataSegment secondHalfEternityRangeSegment = new DataSegment(
+      "halfEternity",
+      new Interval(DateTimes.of("1970"), DateTimes.MAX),
+      "version",
+      ImmutableMap.of(),
+      ImmutableList.of("dim1"),
+      ImmutableList.of("m1"),
+      new LinearShardSpec(0),
+      9,
+      100
+  );
   private final DataSegment defaultSegment2 = new DataSegment(
       "fooDataSource",
       Intervals.of("2015-01-01T00Z/2015-01-02T00Z"),
@@ -1228,7 +1252,49 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         ImmutableSet.of(eternitySegment),
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
-                hugeTimeRangeSegment1.getDataSource(),
+                eternitySegment.getDataSource(),
+                Intervals.of("2020/2021"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  @Test
+  public void testFirstHalfEternitySegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            firstHalfEternityRangeSegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(firstHalfEternityRangeSegment),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                firstHalfEternityRangeSegment.getDataSource(),
+                Intervals.of("2020/2021"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  @Test
+  public void testSecondHalfSegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            secondHalfEternityRangeSegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(secondHalfEternityRangeSegment),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                secondHalfEternityRangeSegment.getDataSource(),
                 Intervals.of("2020/2021"),
                 Segments.ONLY_VISIBLE
             )

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -97,6 +97,18 @@ public class IndexerSQLMetadataStorageCoordinatorTest
       100
   );
 
+  private final DataSegment eternitySegment = new DataSegment(
+      "eternity",
+      Intervals.ETERNITY,
+      "version",
+      ImmutableMap.of(),
+      ImmutableList.of("dim1"),
+      ImmutableList.of("m1"),
+      new LinearShardSpec(0),
+      9,
+      100
+  );
+
   private final DataSegment defaultSegment2 = new DataSegment(
       "fooDataSource",
       Intervals.of("2015-01-01T00Z/2015-01-02T00Z"),
@@ -1196,6 +1208,28 @@ public class IndexerSQLMetadataStorageCoordinatorTest
             coordinator.retrieveUsedSegmentsForInterval(
                 hugeTimeRangeSegment1.getDataSource(),
                 Intervals.of("2993/2995"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+
+  @Test
+  public void testEternitySegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            eternitySegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(eternitySegment),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                hugeTimeRangeSegment1.getDataSource(),
+                Intervals.of("2020/2021"),
                 Segments.ONLY_VISIBLE
             )
         )

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -98,7 +98,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   );
 
   private final DataSegment eternitySegment = new DataSegment(
-      "eternity",
+      "fooDataSource",
       Intervals.ETERNITY,
       "version",
       ImmutableMap.of(),
@@ -111,7 +111,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
 
 
   private final DataSegment firstHalfEternityRangeSegment = new DataSegment(
-      "halfEternity",
+      "fooDataSource",
       new Interval(DateTimes.MIN, DateTimes.of("3000")),
       "version",
       ImmutableMap.of(),
@@ -123,7 +123,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   );
 
   private final DataSegment secondHalfEternityRangeSegment = new DataSegment(
-      "halfEternity",
+      "fooDataSource",
       new Interval(DateTimes.of("1970"), DateTimes.MAX),
       "version",
       ImmutableMap.of(),
@@ -1261,6 +1261,28 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   }
 
   @Test
+  public void testEternityMultipleSegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            numberedSegment0of0,
+            eternitySegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(eternitySegment, numberedSegment0of0),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                eternitySegment.getDataSource(),
+                Intervals.of("2015/2016"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  @Test
   public void testFirstHalfEternitySegmentWithStringComparison() throws IOException
   {
     coordinator.announceHistoricalSegments(
@@ -1282,7 +1304,29 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   }
 
   @Test
-  public void testSecondHalfSegmentWithStringComparison() throws IOException
+  public void testFirstHalfEternityMultipleSegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            numberedSegment0of0,
+            firstHalfEternityRangeSegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(numberedSegment0of0, firstHalfEternityRangeSegment),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                firstHalfEternityRangeSegment.getDataSource(),
+                Intervals.of("2015/2016"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  @Test
+  public void testSecondHalfEternitySegmentWithStringComparison() throws IOException
   {
     coordinator.announceHistoricalSegments(
         ImmutableSet.of(
@@ -1296,6 +1340,28 @@ public class IndexerSQLMetadataStorageCoordinatorTest
             coordinator.retrieveUsedSegmentsForInterval(
                 secondHalfEternityRangeSegment.getDataSource(),
                 Intervals.of("2020/2021"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  @Test
+  public void testSecondHalfEternityMultipleSegmentWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            numberedSegment0of0,
+            secondHalfEternityRangeSegment
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(numberedSegment0of0, secondHalfEternityRangeSegment),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                secondHalfEternityRangeSegment.getDataSource(),
+                Intervals.of("2015/2016"),
                 Segments.ONLY_VISIBLE
             )
         )

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -53,6 +53,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -281,6 +282,18 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   private final DataSegment hugeTimeRangeSegment3 = new DataSegment(
       "hugeTimeRangeDataSource",
       Intervals.of("29940-01-02T00Z/29940-01-03T00Z"),
+      "zversion",
+      ImmutableMap.of(),
+      ImmutableList.of("dim1"),
+      ImmutableList.of("m1"),
+      new NumberedShardSpec(0, 1),
+      9,
+      100
+  );
+
+  private final DataSegment hugeTimeRangeSegment4 = new DataSegment(
+      "hugeTimeRangeDataSource",
+      Intervals.of("1990-01-01T00Z/19940-01-01T00Z"),
       "zversion",
       ImmutableMap.of(),
       ImmutableList.of("dim1"),
@@ -1339,6 +1352,29 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         ImmutableSet.copyOf(
             coordinator.retrieveUsedSegmentsForInterval(
                 secondHalfEternityRangeSegment.getDataSource(),
+                Intervals.of("2020/2021"),
+                Segments.ONLY_VISIBLE
+            )
+        )
+    );
+  }
+
+  // Known Issue: https://github.com/apache/druid/issues/12860
+  @Ignore
+  @Test
+  public void testLargeIntervalWithStringComparison() throws IOException
+  {
+    coordinator.announceHistoricalSegments(
+        ImmutableSet.of(
+            hugeTimeRangeSegment4
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(hugeTimeRangeSegment4),
+        ImmutableSet.copyOf(
+            coordinator.retrieveUsedSegmentsForInterval(
+                hugeTimeRangeSegment4.getDataSource(),
                 Intervals.of("2020/2021"),
                 Segments.ONLY_VISIBLE
             )


### PR DESCRIPTION
There is a problem with org.apache.druid.metadata.SqlSegmentsMetadataQuery#retrieveSegments. If stringComparison is being used to fetch overlapping segments while there is a segment with start and end as Eternity, this segment gets overlooked (since the 'end' field for most years > '146140482-04-24T15:36:27.903Z' if we compare it lexicographically). To find overlapping segments, eternity should always be included.

The earlier SQL to get segments which overlap with a segment [start0, end0] would look like:

```
SELECT payload 
FROM datasource 
WHERE used = :used
    AND dataSource = :dataSource
    AND ((start < :end0 AND \"end\" > :start0))
```

while it now would look like 

```
SELECT payload 
FROM datasource 
WHERE used = :used 
    AND dataSource = :dataSource 
    AND ((start < :end0 AND \"end\" > :start0)
         OR (start = '-146136543-09-08T08:23:32.096Z' AND "end" != '146140482-04-24T15:36:27.903Z' AND "end" > :start0)
         OR (start != '-146136543-09-08T08:23:32.096Z' AND "end" = '146140482-04-24T15:36:27.903Z' AND start < :end0) 
         OR (start = '-146136543-09-08T08:23:32.096Z' AND "end" = '146140482-04-24T15:36:27.903Z'))
```

Changes
- Add a condition for an eternity segment while comparing as string. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
