### PR TITLE
specialized FixedIndexed implementations for java value types

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedDoubles.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedDoubles.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleComparator;
+import it.unimi.dsi.fastutil.doubles.DoubleComparators;
+import it.unimi.dsi.fastutil.doubles.DoubleIterator;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Iterator;
+
+/**
+ * Specialized implementation for {@link FixedIndexed<Double>} which does not contain any null values, allowing it to
+ * deal in java double value types instead of {@link Double} objects, and utilize specialized {@link ByteBuffer} methods
+ * to more efficiently read data.
+ */
+public final class FixedIndexedDoubles implements Indexed<Double>, HotLoopCallee
+{
+  public static FixedIndexedDoubles read(ByteBuffer bb, ByteOrder byteOrder)
+  {
+    final ByteBuffer buffer = bb.asReadOnlyBuffer().order(byteOrder);
+    final byte version = buffer.get();
+    Preconditions.checkState(version == 0, "Unknown version [%s]", version);
+    final byte flags = buffer.get();
+    final boolean hasNull = (flags & NullHandling.IS_NULL_BYTE) == NullHandling.IS_NULL_BYTE ? true : false;
+    final boolean isSorted = (flags & FixedIndexed.IS_SORTED_MASK) == FixedIndexed.IS_SORTED_MASK ? true : false;
+    Preconditions.checkState(!hasNull, "Cannot use FixedIndexedInts for FixedIndex with null values");
+    Preconditions.checkState(!(hasNull && !isSorted), "cannot have null values if not sorted");
+    final int size = buffer.getInt() + (hasNull ? 1 : 0);
+    final int valuesOffset = buffer.position();
+    final FixedIndexedDoubles fixedIndexed = new FixedIndexedDoubles(
+        buffer,
+        isSorted,
+        size,
+        valuesOffset
+    );
+    bb.position(buffer.position() + (Double.BYTES * size));
+    return fixedIndexed;
+  }
+
+  private final ByteBuffer buffer;
+  private final int size;
+  private final int valuesOffset;
+  private final boolean isSorted;
+  private final DoubleComparator comparator;
+
+  private FixedIndexedDoubles(
+      ByteBuffer buffer,
+      boolean isSorted,
+      int size,
+      int valuesOffset
+  )
+  {
+    this.buffer = buffer;
+    this.size = size;
+    this.valuesOffset = valuesOffset;
+    this.isSorted = isSorted;
+    this.comparator = DoubleComparators.NATURAL_COMPARATOR;
+  }
+
+  @Override
+  public int size()
+  {
+    return size;
+  }
+
+  @Nullable
+  @Override
+  public Double get(int index)
+  {
+    return getDouble(index);
+  }
+
+  @Override
+  public int indexOf(@Nullable Double value)
+  {
+    if (value == null) {
+      return -1;
+    }
+    return indexOf(value.doubleValue());
+  }
+
+  public double getDouble(int index)
+  {
+    return buffer.getDouble(valuesOffset + (index * Double.BYTES));
+  }
+
+  public int indexOf(double value)
+  {
+    if (!isSorted) {
+      throw new UnsupportedOperationException("Reverse lookup not allowed.");
+    }
+    int minIndex = 0;
+    int maxIndex = size - 1;
+    while (minIndex <= maxIndex) {
+      int currIndex = (minIndex + maxIndex) >>> 1;
+
+      double currValue = getDouble(currIndex);
+      int comparison = comparator.compare(currValue, value);
+      if (comparison == 0) {
+        return currIndex;
+      }
+
+      if (comparison < 0) {
+        minIndex = currIndex + 1;
+      } else {
+        maxIndex = currIndex - 1;
+      }
+    }
+
+    return -(minIndex + 1);
+  }
+
+  public DoubleIterator doubleIterator()
+  {
+    final ByteBuffer copy = buffer.asReadOnlyBuffer().order(buffer.order());
+    copy.position(valuesOffset);
+    copy.limit(valuesOffset + (size * Double.BYTES));
+    return new DoubleIterator()
+    {
+      @Override
+      public double nextDouble()
+      {
+        return copy.getDouble();
+      }
+
+      @Override
+      public boolean hasNext()
+      {
+        return copy.hasRemaining();
+      }
+    };
+  }
+
+  @Override
+  public Iterator<Double> iterator()
+  {
+    final DoubleIterator doubleIterator = doubleIterator();
+    return new Iterator<Double>()
+    {
+      @Override
+      public boolean hasNext()
+      {
+        return doubleIterator.hasNext();
+      }
+
+      @Override
+      public Double next()
+      {
+        return doubleIterator.nextDouble();
+      }
+    };
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+    inspector.visit("buffer", buffer);
+    inspector.visit("comparator", comparator);
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder("FixedIndexedDoubles[");
+    if (size() > 0) {
+      for (int i = 0; i < size(); i++) {
+        double value = getDouble(i);
+        sb.append(value).append(',').append(' ');
+      }
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedInts.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedInts.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntComparator;
+import it.unimi.dsi.fastutil.ints.IntComparators;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Iterator;
+
+/**
+ * Specialized implementation for {@link FixedIndexed<Integer>} which does not contain any null values, allowing it to
+ * deal in java int value types instead of {@link Integer} objects, and utilize specialized {@link ByteBuffer} methods
+ * to more efficiently read data.
+ */
+public final class FixedIndexedInts implements Indexed<Integer>, HotLoopCallee
+{
+  public static FixedIndexedInts read(ByteBuffer bb, ByteOrder byteOrder)
+  {
+    final ByteBuffer buffer = bb.asReadOnlyBuffer().order(byteOrder);
+    final byte version = buffer.get();
+    Preconditions.checkState(version == 0, "Unknown version [%s]", version);
+    final byte flags = buffer.get();
+    final boolean hasNull = (flags & NullHandling.IS_NULL_BYTE) == NullHandling.IS_NULL_BYTE ? true : false;
+    final boolean isSorted = (flags & FixedIndexed.IS_SORTED_MASK) == FixedIndexed.IS_SORTED_MASK ? true : false;
+    Preconditions.checkState(!hasNull, "Cannot use FixedIndexedInts for FixedIndex with null values");
+    Preconditions.checkState(!(hasNull && !isSorted), "cannot have null values if not sorted");
+    final int size = buffer.getInt() + (hasNull ? 1 : 0);
+    final int valuesOffset = buffer.position();
+    final FixedIndexedInts fixedIndexed = new FixedIndexedInts(
+        buffer,
+        isSorted,
+        size,
+        valuesOffset
+    );
+    bb.position(buffer.position() + (Integer.BYTES * size));
+    return fixedIndexed;
+  }
+
+  private final ByteBuffer buffer;
+  private final int size;
+  private final int valuesOffset;
+  private final boolean isSorted;
+  private final IntComparator comparator;
+
+  private FixedIndexedInts(
+      ByteBuffer buffer,
+      boolean isSorted,
+      int size,
+      int valuesOffset
+  )
+  {
+    this.buffer = buffer;
+    this.size = size;
+    this.valuesOffset = valuesOffset;
+    this.isSorted = isSorted;
+    this.comparator = IntComparators.NATURAL_COMPARATOR;
+  }
+
+  @Override
+  public int size()
+  {
+    return size;
+  }
+
+  @Nullable
+  @Override
+  public Integer get(int index)
+  {
+    return getInt(index);
+  }
+
+  @Override
+  public int indexOf(@Nullable Integer value)
+  {
+    if (value == null) {
+      return -1;
+    }
+    return indexOf(value.intValue());
+  }
+
+  public int getInt(int index)
+  {
+    return buffer.getInt(valuesOffset + (index * Integer.BYTES));
+  }
+
+  public int indexOf(int value)
+  {
+    if (!isSorted) {
+      throw new UnsupportedOperationException("Reverse lookup not allowed.");
+    }
+    int minIndex = 0;
+    int maxIndex = size - 1;
+    while (minIndex <= maxIndex) {
+      int currIndex = (minIndex + maxIndex) >>> 1;
+
+      int currValue = getInt(currIndex);
+      int comparison = comparator.compare(currValue, value);
+      if (comparison == 0) {
+        return currIndex;
+      }
+
+      if (comparison < 0) {
+        minIndex = currIndex + 1;
+      } else {
+        maxIndex = currIndex - 1;
+      }
+    }
+
+    return -(minIndex + 1);
+  }
+
+  public IntIterator intIterator()
+  {
+    final ByteBuffer copy = buffer.asReadOnlyBuffer().order(buffer.order());
+    copy.position(valuesOffset);
+    copy.limit(valuesOffset + (size * Integer.BYTES));
+    return new IntIterator()
+    {
+      @Override
+      public int nextInt()
+      {
+        return copy.getInt();
+      }
+
+      @Override
+      public boolean hasNext()
+      {
+        return copy.hasRemaining();
+      }
+    };
+  }
+
+  @Override
+  public Iterator<Integer> iterator()
+  {
+    final IntIterator iterator = intIterator();
+    return new Iterator<Integer>()
+    {
+      @Override
+      public boolean hasNext()
+      {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public Integer next()
+      {
+        return iterator.nextInt();
+      }
+    };
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+    inspector.visit("buffer", buffer);
+    inspector.visit("comparator", comparator);
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder("FixedIndexedInts[");
+    if (size() > 0) {
+      for (int i = 0; i < size(); i++) {
+        int value = getInt(i);
+        sb.append(value).append(',').append(' ');
+      }
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedLongWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedLongWriter.java
@@ -19,7 +19,7 @@
 
 package org.apache.druid.segment.data;
 
-import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
 import org.apache.druid.segment.serde.Serializer;
@@ -33,14 +33,14 @@ import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
 
 /**
- * Specialized version of {@link FixedIndexedWriter} for writing int value types, with no support for null values,
+ * Specialized version of {@link FixedIndexedWriter} for writing long value types, with no support for null values,
  * and no verification that data is actually sorted. The resulting data can be read into either
- * {@link FixedIndexedInts} or a {@link FixedIndexed<Integer>}, since the format is identical.
+ * {@link FixedIndexedLongs} or a {@link FixedIndexed<Long>}, since the format is identical.
  *
  * Callers should be certain that the data written is in fact sorted if specifying it as such. If null values need
  * to be stored then the generic {@link FixedIndexedWriter} should be used instead.
  */
-public final class FixedIndexedIntWriter implements Serializer
+public class FixedIndexedLongWriter implements Serializer
 {
   private static final int PAGE_SIZE = 4096;
   private final SegmentWriteOutMedium segmentWriteOutMedium;
@@ -51,12 +51,12 @@ public final class FixedIndexedIntWriter implements Serializer
 
   private final boolean isSorted;
 
-  public FixedIndexedIntWriter(SegmentWriteOutMedium segmentWriteOutMedium, boolean sorted)
+  public FixedIndexedLongWriter(SegmentWriteOutMedium segmentWriteOutMedium, boolean sorted)
   {
     this.segmentWriteOutMedium = segmentWriteOutMedium;
     // this is a matter of faith, nothing checks
     this.isSorted = sorted;
-    this.scratch = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.nativeOrder());
+    this.scratch = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.nativeOrder());
   }
 
   public void open() throws IOException
@@ -70,10 +70,10 @@ public final class FixedIndexedIntWriter implements Serializer
     return Byte.BYTES + Byte.BYTES + Integer.BYTES + valuesOut.size();
   }
 
-  public void write(int objectToWrite) throws IOException
+  public void write(long objectToWrite) throws IOException
   {
     scratch.clear();
-    scratch.putInt(objectToWrite);
+    scratch.putLong(objectToWrite);
     scratch.flip();
     Channels.writeFully(valuesOut, scratch);
     numWritten++;
@@ -103,24 +103,25 @@ public final class FixedIndexedIntWriter implements Serializer
     valuesOut.writeTo(channel);
   }
 
-  public IntIterator getIterator()
+  public LongIterator getIterator()
   {
-    final ByteBuffer iteratorBuffer = ByteBuffer.allocate(Integer.BYTES * PAGE_SIZE).order(ByteOrder.nativeOrder());
+    final ByteBuffer iteratorBuffer = ByteBuffer.allocate(Long.BYTES * PAGE_SIZE).order(ByteOrder.nativeOrder());
 
-    return new IntIterator()
+    return new LongIterator()
     {
       @Override
-      public int nextInt()
+      public long nextLong()
       {
         if (pos == 0 || iteratorBuffer.position() >= iteratorBuffer.limit()) {
           readPage();
         }
-        final int value = iteratorBuffer.getInt();
+        final long value = iteratorBuffer.getLong();
         pos++;
         return value;
       }
 
       int pos = 0;
+
       @Override
       public boolean hasNext()
       {
@@ -132,11 +133,11 @@ public final class FixedIndexedIntWriter implements Serializer
         iteratorBuffer.clear();
         try {
           if (numWritten - pos < PAGE_SIZE) {
-            int size = (numWritten - pos) * Integer.BYTES;
+            int size = (numWritten - pos) * Long.BYTES;
             iteratorBuffer.limit(size);
-            valuesOut.readFully((long) pos * Integer.BYTES, iteratorBuffer);
+            valuesOut.readFully((long) pos * Long.BYTES, iteratorBuffer);
           } else {
-            valuesOut.readFully((long) pos * Integer.BYTES, iteratorBuffer);
+            valuesOut.readFully((long) pos * Long.BYTES, iteratorBuffer);
           }
           iteratorBuffer.flip();
         }

--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedLongs.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedLongs.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.data;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.longs.LongComparator;
+import it.unimi.dsi.fastutil.longs.LongComparators;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Iterator;
+
+/**
+ * Specialized implementation for {@link FixedIndexed<Long>} which does not contain any null values, allowing it to
+ * deal in java long value types instead of {@link Long} objects, and utilize specialized {@link ByteBuffer} methods
+ * to more efficiently read data.
+ */
+public final class FixedIndexedLongs implements Indexed<Long>, HotLoopCallee
+{
+  public static FixedIndexedLongs read(ByteBuffer bb, ByteOrder byteOrder)
+  {
+    final ByteBuffer buffer = bb.asReadOnlyBuffer().order(byteOrder);
+    final byte version = buffer.get();
+    Preconditions.checkState(version == 0, "Unknown version [%s]", version);
+    final byte flags = buffer.get();
+    final boolean hasNull = (flags & NullHandling.IS_NULL_BYTE) == NullHandling.IS_NULL_BYTE ? true : false;
+    final boolean isSorted = (flags & FixedIndexed.IS_SORTED_MASK) == FixedIndexed.IS_SORTED_MASK ? true : false;
+    Preconditions.checkState(!hasNull, "Cannot use FixedIndexedInts for FixedIndex with null values");
+    Preconditions.checkState(!(hasNull && !isSorted), "cannot have null values if not sorted");
+    final int size = buffer.getInt() + (hasNull ? 1 : 0);
+    final int valuesOffset = buffer.position();
+    final FixedIndexedLongs fixedIndexed = new FixedIndexedLongs(
+        buffer,
+        isSorted,
+        size,
+        valuesOffset
+    );
+    bb.position(buffer.position() + (Double.BYTES * size));
+    return fixedIndexed;
+  }
+
+  private final ByteBuffer buffer;
+  private final int size;
+  private final int valuesOffset;
+  private final boolean isSorted;
+  private final LongComparator comparator;
+
+  private FixedIndexedLongs(
+      ByteBuffer buffer,
+      boolean isSorted,
+      int size,
+      int valuesOffset
+  )
+  {
+    this.buffer = buffer;
+    this.size = size;
+    this.valuesOffset = valuesOffset;
+    this.isSorted = isSorted;
+    this.comparator = LongComparators.NATURAL_COMPARATOR;
+  }
+
+  @Override
+  public int size()
+  {
+    return size;
+  }
+
+  @Nullable
+  @Override
+  public Long get(int index)
+  {
+    return getLong(index);
+  }
+
+  @Override
+  public int indexOf(@Nullable Long value)
+  {
+    if (value == null) {
+      return -1;
+    }
+    return indexOf(value.longValue());
+  }
+
+  public long getLong(int index)
+  {
+    return buffer.getLong(valuesOffset + (index * Long.BYTES));
+  }
+
+  public int indexOf(long value)
+  {
+    if (!isSorted) {
+      throw new UnsupportedOperationException("Reverse lookup not allowed.");
+    }
+    int minIndex = 0;
+    int maxIndex = size - 1;
+    while (minIndex <= maxIndex) {
+      int currIndex = (minIndex + maxIndex) >>> 1;
+
+      long currValue = getLong(currIndex);
+      int comparison = comparator.compare(currValue, value);
+      if (comparison == 0) {
+        return currIndex;
+      }
+
+      if (comparison < 0) {
+        minIndex = currIndex + 1;
+      } else {
+        maxIndex = currIndex - 1;
+      }
+    }
+
+    return -(minIndex + 1);
+  }
+
+
+  public LongIterator longIterator()
+  {
+    final ByteBuffer copy = buffer.asReadOnlyBuffer().order(buffer.order());
+    copy.position(valuesOffset);
+    copy.limit(valuesOffset + (size * Long.BYTES));
+    return new LongIterator()
+    {
+      @Override
+      public long nextLong()
+      {
+        return copy.getLong();
+      }
+
+      @Override
+      public boolean hasNext()
+      {
+        return copy.hasRemaining();
+      }
+    };
+  }
+
+  @Override
+  public Iterator<Long> iterator()
+  {
+    final LongIterator iterator = longIterator();
+    return new Iterator<Long>()
+    {
+      @Override
+      public boolean hasNext()
+      {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public Long next()
+      {
+        return iterator.nextLong();
+      }
+    };
+  }
+
+  @Override
+  public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+  {
+    inspector.visit("buffer", buffer);
+    inspector.visit("comparator", comparator);
+  }
+
+  @Override
+  public String toString()
+  {
+    StringBuilder sb = new StringBuilder("FixedIndexedLongs[");
+    if (size() > 0) {
+      for (int i = 0; i < size(); i++) {
+        long value = getLong(i);
+        sb.append(value).append(',').append(' ');
+      }
+      sb.setLength(sb.length() - 2);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexedWriter.java
@@ -183,12 +183,13 @@ public class FixedIndexedWriter<T> implements Serializer
       {
         iteratorBuffer.clear();
         try {
-          if (totalCount - pos < PAGE_SIZE) {
-            int size = (totalCount - pos) * width;
+          final int adjustedPos = pos - startPos;
+          if (totalCount - adjustedPos < PAGE_SIZE) {
+            int size = (totalCount - adjustedPos) * width;
             iteratorBuffer.limit(size);
-            valuesOut.readFully((long) pos * width, iteratorBuffer);
+            valuesOut.readFully((long) adjustedPos * width, iteratorBuffer);
           } else {
-            valuesOut.readFully((long) pos * width, iteratorBuffer);
+            valuesOut.readFully((long) adjustedPos * width, iteratorBuffer);
           }
           iteratorBuffer.flip();
         }

--- a/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
@@ -49,7 +49,9 @@ import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
 import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSupplier;
 import org.apache.druid.segment.data.CompressedVariableSizedBlobColumn;
 import org.apache.druid.segment.data.CompressedVariableSizedBlobColumnSupplier;
-import org.apache.druid.segment.data.FixedIndexed;
+import org.apache.druid.segment.data.FixedIndexedDoubles;
+import org.apache.druid.segment.data.FixedIndexedInts;
+import org.apache.druid.segment.data.FixedIndexedLongs;
 import org.apache.druid.segment.data.GenericIndexed;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.data.ReadableOffset;
@@ -86,8 +88,8 @@ public final class CompressedNestedDataComplexColumn extends NestedDataComplexCo
   private final NestedLiteralTypeInfo fieldInfo;
 
   private final GenericIndexed<String> stringDictionary;
-  private final FixedIndexed<Long> longDictionary;
-  private final FixedIndexed<Double> doubleDictionary;
+  private final FixedIndexedLongs longDictionary;
+  private final FixedIndexedDoubles doubleDictionary;
   private final SmooshedFileMapper fileMapper;
 
   private final ConcurrentHashMap<String, ColumnHolder> columns = new ConcurrentHashMap<>();
@@ -102,8 +104,8 @@ public final class CompressedNestedDataComplexColumn extends NestedDataComplexCo
       GenericIndexed<String> fields,
       NestedLiteralTypeInfo fieldInfo,
       GenericIndexed<String> stringDictionary,
-      FixedIndexed<Long> longDictionary,
-      FixedIndexed<Double> doubleDictionary,
+      FixedIndexedLongs longDictionary,
+      FixedIndexedDoubles doubleDictionary,
       SmooshedFileMapper fileMapper
   )
   {
@@ -134,12 +136,12 @@ public final class CompressedNestedDataComplexColumn extends NestedDataComplexCo
     return stringDictionary;
   }
 
-  public FixedIndexed<Long> getLongDictionary()
+  public FixedIndexedLongs getLongDictionary()
   {
     return longDictionary;
   }
 
-  public FixedIndexed<Double> getDoubleDictionary()
+  public FixedIndexedDoubles getDoubleDictionary()
   {
     return doubleDictionary;
   }
@@ -404,11 +406,9 @@ public final class CompressedNestedDataComplexColumn extends NestedDataComplexCo
           )
       );
 
-      final FixedIndexed<Integer> localDictionary = FixedIndexed.read(
+      final FixedIndexedInts localDictionary = FixedIndexedInts.read(
           dataBuffer,
-          NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-          metadata.getByteOrder(),
-          Integer.BYTES
+          metadata.getByteOrder()
       );
       ByteBuffer bb = dataBuffer.asReadOnlyBuffer().order(metadata.getByteOrder());
       int longsLength = bb.getInt();
@@ -444,7 +444,7 @@ public final class CompressedNestedDataComplexColumn extends NestedDataComplexCo
               longDictionary,
               doubleDictionary,
               localDictionary,
-              localDictionary.get(0) == 0
+              localDictionary.getInt(0) == 0
               ? rBitmaps.get(0)
               : metadata.getBitmapSerdeFactory().getBitmapFactory().makeEmptyImmutableBitmap()
           ));

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
@@ -52,8 +52,9 @@ import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSerializer;
 import org.apache.druid.segment.data.CompressedVariableSizedBlobColumnSerializer;
 import org.apache.druid.segment.data.CompressionFactory;
 import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.FixedIndexedDoubleWriter;
 import org.apache.druid.segment.data.FixedIndexedIntWriter;
-import org.apache.druid.segment.data.FixedIndexedWriter;
+import org.apache.druid.segment.data.FixedIndexedLongWriter;
 import org.apache.druid.segment.data.GenericIndexed;
 import org.apache.druid.segment.data.GenericIndexedWriter;
 import org.apache.druid.segment.data.ObjectStrategy;
@@ -115,8 +116,8 @@ public class NestedDataColumnSerializer implements GenericColumnSerializer<Struc
   private GenericIndexedWriter<String> fieldsWriter;
   private NestedLiteralTypeInfo.Writer fieldsInfoWriter;
   private GenericIndexedWriter<String> dictionaryWriter;
-  private FixedIndexedWriter<Long> longDictionaryWriter;
-  private FixedIndexedWriter<Double> doubleDictionaryWriter;
+  private FixedIndexedLongWriter longDictionaryWriter;
+  private FixedIndexedDoubleWriter doubleDictionaryWriter;
   private CompressedVariableSizedBlobColumnSerializer rawWriter;
   private ByteBufferWriter<ImmutableBitmap> nullBitmapWriter;
   private MutableBitmap nullRowsBitmap;
@@ -146,19 +147,13 @@ public class NestedDataColumnSerializer implements GenericColumnSerializer<Struc
     fieldsInfoWriter = new NestedLiteralTypeInfo.Writer(segmentWriteOutMedium);
     fieldsInfoWriter.open();
     dictionaryWriter = createGenericIndexedWriter(GenericIndexed.STRING_STRATEGY, segmentWriteOutMedium);
-    longDictionaryWriter = new FixedIndexedWriter<>(
+    longDictionaryWriter = new FixedIndexedLongWriter(
         segmentWriteOutMedium,
-        ColumnType.LONG.getStrategy(),
-        ByteOrder.nativeOrder(),
-        Long.BYTES,
         true
     );
     longDictionaryWriter.open();
-    doubleDictionaryWriter = new FixedIndexedWriter<>(
+    doubleDictionaryWriter = new FixedIndexedDoubleWriter(
         segmentWriteOutMedium,
-        ColumnType.DOUBLE.getStrategy(),
-        ByteOrder.nativeOrder(),
-        Double.BYTES,
         true
     );
     doubleDictionaryWriter.open();

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplier.java
@@ -32,6 +32,8 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ComplexColumn;
 import org.apache.druid.segment.data.CompressedVariableSizedBlobColumnSupplier;
 import org.apache.druid.segment.data.FixedIndexed;
+import org.apache.druid.segment.data.FixedIndexedDoubles;
+import org.apache.druid.segment.data.FixedIndexedLongs;
 import org.apache.druid.segment.data.GenericIndexed;
 
 import java.io.IOException;
@@ -45,8 +47,8 @@ public class NestedDataColumnSupplier implements Supplier<ComplexColumn>
   private final GenericIndexed<String> fields;
   private final NestedLiteralTypeInfo fieldInfo;
   private final GenericIndexed<String> dictionary;
-  private final FixedIndexed<Long> longDictionary;
-  private final FixedIndexed<Double> doubleDictionary;
+  private final FixedIndexedLongs longDictionary;
+  private final FixedIndexedDoubles doubleDictionary;
   private final ColumnConfig columnConfig;
   private final SmooshedFileMapper fileMapper;
 
@@ -79,21 +81,17 @@ public class NestedDataColumnSupplier implements Supplier<ComplexColumn>
             mapper,
             NestedDataColumnSerializer.LONG_DICTIONARY_FILE_NAME
         );
-        longDictionary = FixedIndexed.read(
+        longDictionary = FixedIndexedLongs.read(
             longDictionaryBuffer,
-            ColumnType.LONG.getStrategy(),
-            metadata.getByteOrder(),
-            Long.BYTES
+            metadata.getByteOrder()
         );
         final ByteBuffer doubleDictionaryBuffer = loadInternalFile(
             mapper,
             NestedDataColumnSerializer.DOUBLE_DICTIONARY_FILE_NAME
         );
-        doubleDictionary = FixedIndexed.read(
+        doubleDictionary = FixedIndexedDoubles.read(
             doubleDictionaryBuffer,
-            ColumnType.DOUBLE.getStrategy(),
-            metadata.getByteOrder(),
-            Double.BYTES
+            metadata.getByteOrder()
         );
         final ByteBuffer rawBuffer = loadInternalFile(mapper, NestedDataColumnSerializer.RAW_FILE_NAME).asReadOnlyBuffer();
         compressedRawColumnSupplier = CompressedVariableSizedBlobColumnSupplier.fromByteBuffer(

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -20,7 +20,13 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.doubles.DoubleIterator;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.TypeStrategies;
+import org.apache.druid.segment.nested.NestedDataColumnSerializer;
+import org.apache.druid.segment.serde.Serializer;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
@@ -29,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -40,7 +47,9 @@ import java.util.Iterator;
 @RunWith(Parameterized.class)
 public class FixedIndexedTest extends InitializedNullHandlingTest
 {
-  private static final Long[] LONGS = new Long[64];
+  private static final long[] LONGS = new long[1 << 16];
+  private static final int[] INTS = new int[1 << 16];
+  private static final double[] DOUBLES = new double[1 << 16];
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> constructorFeeder()
@@ -52,7 +61,9 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
   public static void setup()
   {
     for (int i = 0; i < LONGS.length; i++) {
-      LONGS[i] = i * 10L;
+      LONGS[i] = i * 2L;
+      INTS[i] = i + 1;
+      DOUBLES[i] = i * 1.3;
     }
   }
 
@@ -66,12 +77,12 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
   @Test
   public void testGet() throws IOException
   {
-    ByteBuffer buffer = ByteBuffer.allocate(1 << 14);
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
     fillBuffer(buffer, order, false);
     FixedIndexed<Long> fixedIndexed = FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES);
-    Assert.assertEquals(64, fixedIndexed.size());
+    Assert.assertEquals(LONGS.length, fixedIndexed.size());
     for (int i = 0; i < LONGS.length; i++) {
-      Assert.assertEquals(LONGS[i], fixedIndexed.get(i));
+      Assert.assertEquals(LONGS[i], (long) fixedIndexed.get(i));
       Assert.assertEquals(i, fixedIndexed.indexOf(LONGS[i]));
     }
   }
@@ -79,26 +90,26 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
   @Test
   public void testIterator() throws IOException
   {
-    ByteBuffer buffer = ByteBuffer.allocate(1 << 14);
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
     fillBuffer(buffer, order, false);
     FixedIndexed<Long> fixedIndexed = FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES);
     Iterator<Long> iterator = fixedIndexed.iterator();
     int i = 0;
     while (iterator.hasNext()) {
-      Assert.assertEquals(LONGS[i++], iterator.next());
+      Assert.assertEquals(LONGS[i++], (long) iterator.next());
     }
   }
 
   @Test
   public void testGetWithNull() throws IOException
   {
-    ByteBuffer buffer = ByteBuffer.allocate(1 << 14);
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
     fillBuffer(buffer, order, true);
     FixedIndexed<Long> fixedIndexed = FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES);
-    Assert.assertEquals(65, fixedIndexed.size());
+    Assert.assertEquals(LONGS.length + 1, fixedIndexed.size());
     Assert.assertNull(fixedIndexed.get(0));
     for (int i = 0; i < LONGS.length; i++) {
-      Assert.assertEquals(LONGS[i], fixedIndexed.get(i + 1));
+      Assert.assertEquals(LONGS[i], (long) fixedIndexed.get(i + 1));
       Assert.assertEquals(i + 1, fixedIndexed.indexOf(LONGS[i]));
     }
   }
@@ -106,15 +117,93 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
   @Test
   public void testIteratorWithNull() throws IOException
   {
-    ByteBuffer buffer = ByteBuffer.allocate(1 << 14);
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
     fillBuffer(buffer, order, true);
     FixedIndexed<Long> fixedIndexed = FixedIndexed.read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES);
     Iterator<Long> iterator = fixedIndexed.iterator();
     Assert.assertNull(iterator.next());
     int i = 0;
     while (iterator.hasNext()) {
-      Assert.assertEquals(LONGS[i++], iterator.next());
+      Assert.assertEquals(LONGS[i++], (long) iterator.next());
     }
+  }
+
+  @Test
+  public void testSpecializedInts() throws IOException
+  {
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
+    ByteBuffer buffer2 = ByteBuffer.allocate(1 << 20);
+    fillIntBuffers(buffer, buffer2, order);
+    FixedIndexed<Integer> fixedIndexed = FixedIndexed.read(buffer, NestedDataColumnSerializer.INT_TYPE_STRATEGY, order, Integer.BYTES);
+    FixedIndexedInts specializedIndexed = FixedIndexedInts.read(buffer2, order);
+    Iterator<Integer> iterator = fixedIndexed.iterator();
+    IntIterator intIterator = specializedIndexed.intIterator();
+    int i = 0;
+    while (iterator.hasNext()) {
+      int next = iterator.next();
+      int nextInt = intIterator.nextInt();
+      final String msg = "row : " + i;
+      Assert.assertEquals(msg, INTS[i], next);
+      Assert.assertEquals(msg, INTS[i], nextInt);
+      Assert.assertEquals(msg, next, (int) fixedIndexed.get(i));
+      Assert.assertEquals(msg, nextInt, specializedIndexed.getInt(i));
+      Assert.assertEquals(msg, i, fixedIndexed.indexOf(next));
+      Assert.assertEquals(msg, i, specializedIndexed.indexOf(nextInt));
+      i++;
+    }
+    Assert.assertFalse(intIterator.hasNext());
+  }
+
+  @Test
+  public void testSpecializedLongs() throws IOException
+  {
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
+    ByteBuffer buffer2 = ByteBuffer.allocate(1 << 20);
+    fillLongBuffers(buffer, buffer2, order);
+    FixedIndexed<Long> fixedIndexed = FixedIndexed.read(buffer, TypeStrategies.LONG, order, Long.BYTES);
+    FixedIndexedLongs specializedIndexed = FixedIndexedLongs.read(buffer2, order);
+    Iterator<Long> iterator = fixedIndexed.iterator();
+    LongIterator intIterator = specializedIndexed.longIterator();
+    int i = 0;
+    while (iterator.hasNext()) {
+      long next = iterator.next();
+      long nextLong = intIterator.nextLong();
+      final String msg = "row : " + i;
+      Assert.assertEquals(msg, LONGS[i], next);
+      Assert.assertEquals(msg, LONGS[i], nextLong);
+      Assert.assertEquals(msg, next, (long) fixedIndexed.get(i));
+      Assert.assertEquals(msg, nextLong, specializedIndexed.getLong(i));
+      Assert.assertEquals(msg, i, fixedIndexed.indexOf(next));
+      Assert.assertEquals(msg, i, specializedIndexed.indexOf(nextLong));
+      i++;
+    }
+    Assert.assertFalse(intIterator.hasNext());
+  }
+
+  @Test
+  public void testSpecializedDoubles() throws IOException
+  {
+    ByteBuffer buffer = ByteBuffer.allocate(1 << 20);
+    ByteBuffer buffer2 = ByteBuffer.allocate(1 << 20);
+    fillDoubleBuffers(buffer, buffer2, order);
+    FixedIndexed<Double> fixedIndexed = FixedIndexed.read(buffer, TypeStrategies.DOUBLE, order, Double.BYTES);
+    FixedIndexedDoubles specializedIndexed = FixedIndexedDoubles.read(buffer2, order);
+    Iterator<Double> iterator = fixedIndexed.iterator();
+    DoubleIterator intIterator = specializedIndexed.doubleIterator();
+    int i = 0;
+    while (iterator.hasNext()) {
+      double next = iterator.next();
+      double nextDouble = intIterator.nextDouble();
+      final String msg = "row : " + i;
+      Assert.assertEquals(msg, DOUBLES[i], next, 0.0);
+      Assert.assertEquals(msg, DOUBLES[i], nextDouble, 0.0);
+      Assert.assertEquals(msg, next, fixedIndexed.get(i), 0.0);
+      Assert.assertEquals(msg, nextDouble, specializedIndexed.getDouble(i), 0.0);
+      Assert.assertEquals(msg, i, fixedIndexed.indexOf(next));
+      Assert.assertEquals(msg, i, specializedIndexed.indexOf(nextDouble));
+      i++;
+    }
+    Assert.assertFalse(intIterator.hasNext());
   }
 
   private static void fillBuffer(ByteBuffer buffer, ByteOrder order, boolean withNull) throws IOException
@@ -134,6 +223,212 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     for (Long aLong : LONGS) {
       writer.write(aLong);
     }
+    WritableByteChannel channel = makeChannelForBuffer(buffer);
+    long size = writer.getSerializedSize();
+    Iterator<Long> validationIterator = writer.getIterator();
+    int i = 0;
+    boolean processFirstNull = withNull;
+    while (validationIterator.hasNext()) {
+      if (processFirstNull) {
+        Assert.assertNull(validationIterator.next());
+        processFirstNull = false;
+      } else {
+        Assert.assertEquals(LONGS[i++], (long) validationIterator.next());
+      }
+    }
+    buffer.position(0);
+    writer.writeTo(channel, null);
+    Assert.assertEquals(size, buffer.position());
+    buffer.position(0);
+  }
+
+  private static void fillIntBuffers(ByteBuffer buffer, ByteBuffer specialized, ByteOrder order) throws IOException
+  {
+    buffer.position(0);
+    Serializer genericWriter, specializedWriter;
+    FixedIndexedWriter<Integer> writer = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        order,
+        Integer.BYTES,
+        true
+    );
+    writer.open();
+    genericWriter = writer;
+
+    if (order == ByteOrder.nativeOrder()) {
+      FixedIndexedIntWriter intWriter = new FixedIndexedIntWriter(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          true
+      );
+      specializedWriter = intWriter;
+      intWriter.open();
+      for (Integer val : INTS) {
+        writer.write(val);
+        intWriter.write(val);
+      }
+
+      IntIterator validationIterator = intWriter.getIterator();
+      int i = 0;
+      while (validationIterator.hasNext()) {
+        Assert.assertEquals("row : " + i, INTS[i++], validationIterator.nextInt());
+      }
+    } else {
+      FixedIndexedWriter<Integer> fallbackWriter = new FixedIndexedWriter<>(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+          order,
+          Integer.BYTES,
+          true
+      );
+      fallbackWriter.open();
+      specializedWriter = fallbackWriter;
+      for (Integer val : INTS) {
+        writer.write(val);
+        fallbackWriter.write(val);
+      }
+    }
+    WritableByteChannel channel = makeChannelForBuffer(buffer);
+    long size = genericWriter.getSerializedSize();
+    buffer.position(0);
+    writer.writeTo(channel, null);
+    Assert.assertEquals(size, buffer.position());
+    buffer.position(0);
+
+    WritableByteChannel specializedChannel = makeChannelForBuffer(specialized);
+    long sizeSpecialized = specializedWriter.getSerializedSize();
+    Assert.assertEquals(size, sizeSpecialized);
+    specialized.position(0);
+    specializedWriter.writeTo(specializedChannel, null);
+    Assert.assertEquals(sizeSpecialized, specialized.position());
+    specialized.position(0);
+  }
+
+  private static void fillLongBuffers(ByteBuffer buffer, ByteBuffer specialized, ByteOrder order) throws IOException
+  {
+    buffer.position(0);
+    Serializer genericWriter, specializedWriter;
+    FixedIndexedWriter<Long> writer = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.LONG,
+        order,
+        Long.BYTES,
+        true
+    );
+    writer.open();
+    genericWriter = writer;
+
+    if (order == ByteOrder.nativeOrder()) {
+      FixedIndexedLongWriter longWriter = new FixedIndexedLongWriter(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          true
+      );
+      specializedWriter = longWriter;
+      longWriter.open();
+      for (Long val : LONGS) {
+        writer.write(val);
+        longWriter.write(val);
+      }
+      LongIterator validationIterator = longWriter.getIterator();
+      int i = 0;
+      while (validationIterator.hasNext()) {
+        Assert.assertEquals("row : " + i, LONGS[i++], validationIterator.nextLong());
+      }
+    } else {
+      FixedIndexedWriter<Long> fallbackWriter = new FixedIndexedWriter<>(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          TypeStrategies.LONG,
+          order,
+          Long.BYTES,
+          true
+      );
+      fallbackWriter.open();
+      specializedWriter = fallbackWriter;
+      for (Long val : LONGS) {
+        writer.write(val);
+        fallbackWriter.write(val);
+      }
+    }
+    WritableByteChannel channel = makeChannelForBuffer(buffer);
+    long size = genericWriter.getSerializedSize();
+    buffer.position(0);
+    writer.writeTo(channel, null);
+    Assert.assertEquals(size, buffer.position());
+    buffer.position(0);
+
+    WritableByteChannel specializedChannel = makeChannelForBuffer(specialized);
+    long sizeSpecialized = specializedWriter.getSerializedSize();
+    Assert.assertEquals(size, sizeSpecialized);
+    specialized.position(0);
+    specializedWriter.writeTo(specializedChannel, null);
+    Assert.assertEquals(sizeSpecialized, specialized.position());
+    specialized.position(0);
+  }
+
+  private static void fillDoubleBuffers(ByteBuffer buffer, ByteBuffer specialized, ByteOrder order) throws IOException
+  {
+    buffer.position(0);
+    Serializer genericWriter, specializedWriter;
+    FixedIndexedWriter<Double> writer = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.DOUBLE,
+        order,
+        Double.BYTES,
+        true
+    );
+    writer.open();
+    genericWriter = writer;
+
+    if (order == ByteOrder.nativeOrder()) {
+      FixedIndexedDoubleWriter doubleWriter = new FixedIndexedDoubleWriter(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          true
+      );
+      specializedWriter = doubleWriter;
+      doubleWriter.open();
+      for (Double val : DOUBLES) {
+        writer.write(val);
+        doubleWriter.write(val);
+      }
+      DoubleIterator validationIterator = doubleWriter.getIterator();
+      int i = 0;
+      while (validationIterator.hasNext()) {
+        Assert.assertEquals("row : " + i, DOUBLES[i++], validationIterator.nextDouble(), 0.0);
+      }
+    } else {
+      FixedIndexedWriter<Double> fallbackWriter = new FixedIndexedWriter<>(
+          new OnHeapMemorySegmentWriteOutMedium(),
+          TypeStrategies.DOUBLE,
+          order,
+          Double.BYTES,
+          true
+      );
+      fallbackWriter.open();
+      specializedWriter = fallbackWriter;
+      for (Double val : DOUBLES) {
+        writer.write(val);
+        fallbackWriter.write(val);
+      }
+    }
+    WritableByteChannel channel = makeChannelForBuffer(buffer);
+    long size = genericWriter.getSerializedSize();
+    buffer.position(0);
+    writer.writeTo(channel, null);
+    Assert.assertEquals(size, buffer.position());
+    buffer.position(0);
+
+    WritableByteChannel specializedChannel = makeChannelForBuffer(specialized);
+    long sizeSpecialized = specializedWriter.getSerializedSize();
+    Assert.assertEquals(size, sizeSpecialized);
+    specialized.position(0);
+    specializedWriter.writeTo(specializedChannel, null);
+    Assert.assertEquals(sizeSpecialized, specialized.position());
+    specialized.position(0);
+  }
+
+  @Nonnull
+  private static WritableByteChannel makeChannelForBuffer(ByteBuffer buffer)
+  {
     WritableByteChannel channel = new WritableByteChannel()
     {
       @Override
@@ -155,10 +450,6 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
       {
       }
     };
-    long size = writer.getSerializedSize();
-    buffer.position(0);
-    writer.writeTo(channel, null);
-    Assert.assertEquals(size, buffer.position());
-    buffer.position(0);
+    return channel;
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -33,10 +33,13 @@ import org.apache.druid.segment.column.LexicographicalRangeIndex;
 import org.apache.druid.segment.column.NullValueIndex;
 import org.apache.druid.segment.column.NumericRangeIndex;
 import org.apache.druid.segment.column.StringValueSetIndex;
-import org.apache.druid.segment.column.TypeStrategies;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
-import org.apache.druid.segment.data.FixedIndexed;
-import org.apache.druid.segment.data.FixedIndexedWriter;
+import org.apache.druid.segment.data.FixedIndexedDoubleWriter;
+import org.apache.druid.segment.data.FixedIndexedDoubles;
+import org.apache.druid.segment.data.FixedIndexedIntWriter;
+import org.apache.druid.segment.data.FixedIndexedInts;
+import org.apache.druid.segment.data.FixedIndexedLongWriter;
+import org.apache.druid.segment.data.FixedIndexedLongs;
 import org.apache.druid.segment.data.GenericIndexed;
 import org.apache.druid.segment.data.GenericIndexedWriter;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
@@ -61,8 +64,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
       roaringFactory.getBitmapFactory()
   );
   GenericIndexed<String> globalStrings;
-  FixedIndexed<Long> globalLongs;
-  FixedIndexed<Double> globalDoubles;
+  FixedIndexedLongs globalLongs;
+  FixedIndexedDoubles globalDoubles;
 
   @Before
   public void setup() throws IOException
@@ -86,11 +89,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     stringWriter.write("z");
     writeToBuffer(stringBuffer, stringWriter);
 
-    FixedIndexedWriter<Long> longWriter = new FixedIndexedWriter<>(
+    FixedIndexedLongWriter longWriter = new FixedIndexedLongWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        TypeStrategies.LONG,
-        ByteOrder.nativeOrder(),
-        Long.BYTES,
         true
     );
     longWriter.open();
@@ -103,11 +103,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     longWriter.write(9000L);
     writeToBuffer(longBuffer, longWriter);
 
-    FixedIndexedWriter<Double> doubleWriter = new FixedIndexedWriter<>(
+    FixedIndexedDoubleWriter doubleWriter = new FixedIndexedDoubleWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        TypeStrategies.DOUBLE,
-        ByteOrder.nativeOrder(),
-        Double.BYTES,
         true
     );
     doubleWriter.open();
@@ -122,8 +119,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(doubleBuffer, doubleWriter);
 
     globalStrings = GenericIndexed.read(stringBuffer, GenericIndexed.STRING_STRATEGY);
-    globalLongs = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES);
-    globalDoubles = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
+    globalLongs = FixedIndexedLongs.read(longBuffer, ByteOrder.nativeOrder());
+    globalDoubles = FixedIndexedDoubles.read(doubleBuffer, ByteOrder.nativeOrder());
   }
 
 
@@ -934,11 +931,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -978,11 +972,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1005,11 +997,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1052,11 +1041,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1079,11 +1066,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1123,11 +1107,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1150,11 +1132,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1198,11 +1177,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1225,11 +1202,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1269,11 +1243,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1296,11 +1268,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1344,11 +1313,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
@@ -1371,11 +1338,8 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());
     ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
 
-    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+    FixedIndexedIntWriter localDictionaryWriter = new FixedIndexedIntWriter(
         new OnHeapMemorySegmentWriteOutMedium(),
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES,
         true
     );
     localDictionaryWriter.open();
@@ -1427,11 +1391,9 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    FixedIndexed<Integer> dictionary = FixedIndexed.read(
+    FixedIndexedInts dictionary = FixedIndexedInts.read(
         localDictionaryBuffer,
-        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
-        ByteOrder.nativeOrder(),
-        Integer.BYTES
+        ByteOrder.nativeOrder()
     );
 
     GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());


### PR DESCRIPTION
### Description
Adds specialized implementations for java long, double, and int value type implementations of `FixedIndexed`, which is used by the nested data columns added in #12753.

While not entirely attributable to this PR (the range filtering tests owe that to #12830), repeating the benchmarks done in show
improvement:

```
SELECT SUM(long1) FROM foo
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        0           5000000        false  avgt    5   36.711 ±  0.917  ms/op
SqlNestedDataBenchmark.querySql        0           5000000        force  avgt    5   15.587 ±  0.276  ms/op
SqlNestedDataBenchmark.querySql        1           5000000        false  avgt    5   39.224 ±  0.870  ms/op
SqlNestedDataBenchmark.querySql        1           5000000        force  avgt    5   15.877 ±  0.440  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        0           5000000        false  avgt    5   37.672 ±  1.136  ms/op
SqlNestedDataBenchmark.querySql        0           5000000        force  avgt    5   15.687 ±  0.497  ms/op
SqlNestedDataBenchmark.querySql        1           5000000        false  avgt    5   39.437 ±  0.690  ms/op
SqlNestedDataBenchmark.querySql        1           5000000        force  avgt    5   15.978 ±  0.587  ms/op


SELECT SUM(long1), SUM(long2) FROM foo
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)), SUM(JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT)) FROM foo
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        2           5000000        false  avgt    5   63.805 ±  1.036  ms/op
SqlNestedDataBenchmark.querySql        2           5000000        force  avgt    5   30.381 ±  1.201  ms/op
SqlNestedDataBenchmark.querySql        3           5000000        false  avgt    5   66.660 ±  0.806  ms/op
SqlNestedDataBenchmark.querySql        3           5000000        force  avgt    5   30.341 ±  1.124  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        2           5000000        false  avgt    5   63.825 ±  1.228  ms/op
SqlNestedDataBenchmark.querySql        2           5000000        force  avgt    5   30.955 ±  0.769  ms/op
SqlNestedDataBenchmark.querySql        3           5000000        false  avgt    5   67.277 ±  0.928  ms/op
SqlNestedDataBenchmark.querySql        3           5000000        force  avgt    5   30.860 ±  1.023  ms/op



SELECT SUM(long1), SUM(long2), SUM(double3) FROM foo
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)), SUM(JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT)), SUM(JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE)) FROM foo
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        4           5000000        false  avgt    5   78.570 ±  1.657  ms/op
SqlNestedDataBenchmark.querySql        4           5000000        force  avgt    5   37.777 ±  1.295  ms/op
SqlNestedDataBenchmark.querySql        5           5000000        false  avgt    5   82.672 ±  1.010  ms/op
SqlNestedDataBenchmark.querySql        5           5000000        force  avgt    5   37.887 ±  0.802  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        4           5000000        false  avgt    5   80.173 ±  1.342  ms/op
SqlNestedDataBenchmark.querySql        4           5000000        force  avgt    5   38.272 ±  0.589  ms/op
SqlNestedDataBenchmark.querySql        5           5000000        false  avgt    5   84.370 ±  1.275  ms/op
SqlNestedDataBenchmark.querySql        5           5000000        force  avgt    5   38.541 ±  1.137  ms/op



SELECT string1, SUM(long1) FROM foo GROUP BY 1 ORDER BY 2,
SELECT JSON_VALUE(nested, '$.nesteder.string1'), SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo GROUP BY 1 ORDER BY 2,
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        6           5000000        false  avgt    5  269.560 ±  1.454  ms/op
SqlNestedDataBenchmark.querySql        6           5000000        force  avgt    5  157.090 ±  4.058  ms/op
SqlNestedDataBenchmark.querySql        7           5000000        false  avgt    5  373.162 ±  2.871  ms/op
SqlNestedDataBenchmark.querySql        7           5000000        force  avgt    5  195.213 ±  1.993  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        6           5000000        false  avgt    5  234.328 ±  5.505  ms/op
SqlNestedDataBenchmark.querySql        6           5000000        force  avgt    5  155.711 ±  5.286  ms/op
SqlNestedDataBenchmark.querySql        7           5000000        false  avgt    5  383.741 ±  4.796  ms/op
SqlNestedDataBenchmark.querySql        7           5000000        force  avgt    5  195.051 ±  6.225  ms/op



SELECT string1, SUM(long1), SUM(double3) FROM foo GROUP BY 1 ORDER BY 2
SELECT JSON_VALUE(nested, '$.nesteder.string1'), SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)), SUM(JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE)) FROM foo GROUP BY 1 ORDER BY 2
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        8           5000000        false  avgt    5  251.743 ±  6.438  ms/op
SqlNestedDataBenchmark.querySql        8           5000000        force  avgt    5  172.322 ± 14.814  ms/op
SqlNestedDataBenchmark.querySql        9           5000000        false  avgt    5  417.454 ± 21.276  ms/op
SqlNestedDataBenchmark.querySql        9           5000000        force  avgt    5  215.228 ±  9.304  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql        8           5000000        false  avgt    5  302.745 ±  6.738  ms/op
SqlNestedDataBenchmark.querySql        8           5000000        force  avgt    5  168.410 ±  1.750  ms/op
SqlNestedDataBenchmark.querySql        9           5000000        false  avgt    5  459.633 ±  5.099  ms/op
SqlNestedDataBenchmark.querySql        9           5000000        force  avgt    5  208.978 ±  1.130  ms/op


SELECT SUM(long1) FROM foo WHERE string1 = '10000' OR string1 = '1000'
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.string1') = '10000' OR JSON_VALUE(nested, '$.nesteder.string1') = '1000'
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       10           5000000        false  avgt    5   11.482 ±  0.495  ms/op
SqlNestedDataBenchmark.querySql       10           5000000        force  avgt    5   11.549 ±  0.303  ms/op
SqlNestedDataBenchmark.querySql       11           5000000        false  avgt    5   11.695 ±  0.293  ms/op
SqlNestedDataBenchmark.querySql       11           5000000        force  avgt    5   11.931 ±  0.338  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       10           5000000        false  avgt    5   11.427 ±  0.480  ms/op
SqlNestedDataBenchmark.querySql       10           5000000        force  avgt    5   11.545 ±  0.431  ms/op
SqlNestedDataBenchmark.querySql       11           5000000        false  avgt    5   11.650 ±  0.520  ms/op
SqlNestedDataBenchmark.querySql       11           5000000        force  avgt    5   11.732 ±  0.406  ms/op



SELECT SUM(long1) FROM foo WHERE long2 = 10000 OR long2 = 1000
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) = 10000 OR JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) = 1000
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       12           5000000        false  avgt    5   78.895 ±  2.158  ms/op
SqlNestedDataBenchmark.querySql       12           5000000        force  avgt    5   48.814 ±  0.874  ms/op
SqlNestedDataBenchmark.querySql       13           5000000        false  avgt    5    1.297 ±  0.008  ms/op
SqlNestedDataBenchmark.querySql       13           5000000        force  avgt    5    1.277 ±  0.011  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       12           5000000        false  avgt    5   77.838 ±  3.391  ms/op
SqlNestedDataBenchmark.querySql       12           5000000        force  avgt    5   50.000 ±  1.199  ms/op
SqlNestedDataBenchmark.querySql       13           5000000        false  avgt    5    1.096 ±  0.017  ms/op
SqlNestedDataBenchmark.querySql       13           5000000        force  avgt    5    1.105 ±  0.023  ms/op



SELECT SUM(long1) FROM foo WHERE double3 < 10000.0 AND double3 > 1000.0
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 10000.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       14           5000000        false  avgt    5   92.982 ±  1.473  ms/op
SqlNestedDataBenchmark.querySql       14           5000000        force  avgt    5   54.729 ±  0.429  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        false  avgt    5  580.472 ± 28.064  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        force  avgt    5  561.494 ± 54.096  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       14           5000000        false  avgt    5   93.883 ±  4.995  ms/op
SqlNestedDataBenchmark.querySql       14           5000000        force  avgt    5   52.985 ±  1.123  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        false  avgt    5  228.775 ±  3.131  ms/op
SqlNestedDataBenchmark.querySql       15           5000000        force  avgt    5  216.295 ±  2.309  ms/op



SELECT long1, SUM(double3) FROM foo WHERE string1 = '10000' OR string1 = '1000' GROUP BY 1 ORDER BY 2
SELECT JSON_VALUE(nested, '$.long1' RETURNING BIGINT), SUM(JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.string1') = '10000' OR JSON_VALUE(nested, '$.nesteder.string1') = '1000' GROUP BY 1 ORDER BY 2
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       16           5000000        false  avgt    5  129.760 ±  9.953  ms/op
SqlNestedDataBenchmark.querySql       16           5000000        force  avgt    5  133.015 ± 20.961  ms/op
SqlNestedDataBenchmark.querySql       17           5000000        false  avgt    5  142.197 ±  8.773  ms/op
SqlNestedDataBenchmark.querySql       17           5000000        force  avgt    5  132.048 ± 15.546  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       16           5000000        false  avgt    5  125.571 ±  3.131  ms/op
SqlNestedDataBenchmark.querySql       16           5000000        force  avgt    5  125.625 ±  4.528  ms/op
SqlNestedDataBenchmark.querySql       17           5000000        false  avgt    5  125.689 ±  2.543  ms/op
SqlNestedDataBenchmark.querySql       17           5000000        force  avgt    5  126.233 ±  4.543  ms/op



SELECT string1, SUM(double3) FROM foo WHERE long2 < 10000 AND long2 > 1000 GROUP BY 1 ORDER BY 2
SELECT JSON_VALUE(nested, '$.nesteder.string1'), SUM(JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) < 10000 AND JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) > 1000 GROUP BY 1 ORDER BY 2
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       18           5000000        false  avgt    5  161.445 ±  7.024  ms/op
SqlNestedDataBenchmark.querySql       18           5000000        force  avgt    5  138.212 ± 19.673  ms/op
SqlNestedDataBenchmark.querySql       19           5000000        false  avgt    5  123.486 ±  5.029  ms/op
SqlNestedDataBenchmark.querySql       19           5000000        force  avgt    5  120.079 ±  6.822  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       18           5000000        false  avgt    5  149.483 ±  4.772  ms/op
SqlNestedDataBenchmark.querySql       18           5000000        force  avgt    5  128.978 ±  4.393  ms/op
SqlNestedDataBenchmark.querySql       19           5000000        false  avgt    5  114.389 ±  4.373  ms/op
SqlNestedDataBenchmark.querySql       19           5000000        force  avgt    5  114.224 ±  3.520  ms/op


SELECT string1, SUM(double3) FROM foo WHERE double3 < 10000.0 AND double3 > 1000.0 GROUP BY 1 ORDER BY 2
SELECT JSON_VALUE(nested, '$.nesteder.string1'), SUM(JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 10000.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0 GROUP BY 1 ORDER BY 2
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       20           5000000        false  avgt    5  280.393 ± 15.369  ms/op
SqlNestedDataBenchmark.querySql       20           5000000        force  avgt    5  174.545 ±  2.702  ms/op
SqlNestedDataBenchmark.querySql       21           5000000        false  avgt    5  802.647 ± 32.078  ms/op
SqlNestedDataBenchmark.querySql       21           5000000        force  avgt    5  591.274 ± 16.460  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       20           5000000        false  avgt    5  264.055 ±  4.947  ms/op
SqlNestedDataBenchmark.querySql       20           5000000        force  avgt    5  172.410 ±  3.586  ms/op
SqlNestedDataBenchmark.querySql       21           5000000        false  avgt    5  454.973 ±  5.799  ms/op
SqlNestedDataBenchmark.querySql       21           5000000        force  avgt    5  359.288 ±  5.179  ms/op



SELECT long2 FROM foo WHERE long2 IN (1, 19, 21, 23, 25, 26, 46),
SELECT JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) IN (1, 19, 21, 23, 25, 26, 46),
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       22           5000000        false  avgt    5  273.464 ± 15.731  ms/op
SqlNestedDataBenchmark.querySql       22           5000000        force  avgt    5  272.270 ± 20.511  ms/op
SqlNestedDataBenchmark.querySql       23           5000000        false  avgt    5  174.960 ±  1.923  ms/op
SqlNestedDataBenchmark.querySql       23           5000000        force  avgt    5  177.920 ±  4.095  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       22           5000000        false  avgt    5  283.230 ±  6.222  ms/op
SqlNestedDataBenchmark.querySql       22           5000000        force  avgt    5  282.467 ±  5.709  ms/op
SqlNestedDataBenchmark.querySql       23           5000000        false  avgt    5  177.047 ±  4.990  ms/op
SqlNestedDataBenchmark.querySql       23           5000000        force  avgt    5  172.208 ±  1.031  ms/op



SELECT long2 FROM foo WHERE long2 IN (1, 19, 21, 23, 25, 26, 46) GROUP BY 1",
SELECT JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.long2' RETURNING BIGINT) IN (1, 19, 21, 23, 25, 26, 46) GROUP BY 1
old:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       24           5000000        false  avgt    5  318.280 ±  7.544  ms/op
SqlNestedDataBenchmark.querySql       24           5000000        force  avgt    5  210.866 ± 14.684  ms/op
SqlNestedDataBenchmark.querySql       25           5000000        false  avgt    5  215.200 ±  2.366  ms/op
SqlNestedDataBenchmark.querySql       25           5000000        force  avgt    5  152.399 ± 22.695  ms/op

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       24           5000000        false  avgt    5  308.668 ±  7.274  ms/op
SqlNestedDataBenchmark.querySql       24           5000000        force  avgt    5  199.587 ±  3.162  ms/op
SqlNestedDataBenchmark.querySql       25           5000000        false  avgt    5  212.399 ±  4.406  ms/op
SqlNestedDataBenchmark.querySql       25           5000000        force  avgt    5  149.650 ±  3.489  ms/op


SELECT SUM(long1) FROM foo WHERE double3 < 1005.0 AND double3 > 1000.0
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 1005.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0
old:
(not previously measured)

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       26           5000000        false  avgt    5   74.495 ±  1.506  ms/op
SqlNestedDataBenchmark.querySql       26           5000000        force  avgt    5   48.270 ±  0.806  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        false  avgt    5   12.997 ±  0.509  ms/op
SqlNestedDataBenchmark.querySql       27           5000000        force  avgt    5   13.094 ±  0.553  ms/op


SELECT SUM(long1) FROM foo WHERE double3 < 2000.0 AND double3 > 1000.0
SELECT SUM(JSON_VALUE(nested, '$.long1' RETURNING BIGINT)) FROM foo WHERE JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) < 2000.0 AND JSON_VALUE(nested, '$.nesteder.double3' RETURNING DOUBLE) > 1000.0
old:
(not previously measured)

new:
Benchmark                        (query)  (rowsPerSegment)  (vectorize)  Mode  Cnt    Score    Error  Units
SqlNestedDataBenchmark.querySql       28           5000000        false  avgt    5   79.335 ±  2.919  ms/op
SqlNestedDataBenchmark.querySql       28           5000000        force  avgt    5   51.953 ±  1.056  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        false  avgt    5   40.987 ±  0.710  ms/op
SqlNestedDataBenchmark.querySql       29           5000000        force  avgt    5   40.654 ±  0.713  ms/op

```

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
