### PR TITLE
Log4j bump to 2.18 due to [LOG4J2-3419]

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1837,7 +1837,7 @@ name: Apache Log4j
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.17.1
+version: 2.18.0
 libraries:
   - org.apache.logging.log4j: log4j-1.2-api
   - org.apache.logging.log4j: log4j-api

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.10.5.20201202</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Symptom:
Mappers/Reducers spawned by the 'hadoop_index` tasks on EMR cluster 6.3.xx were running in debug mode. 
They were not respecting the args passed via job properties. 

### Solution: 
As Hadoop is still on the old log4j 1.xx jars, there is some incompatibility when both log4j 1.xx and log4j 2.xx jars are present.
log4j 2.17.1 does not support log4j1.x custom levels. Hence it was defaulting to DEBUG. 
This PR: https://github.com/apache/logging-log4j2/pull/789​  adds the support for log4j 1.x levels. 
Post upgrading the jar to log4j 2.18, the mapper/reducer are picking the correct logger level ie : INFO

```
DEBUG StatusLogger PluginManager 'Lookup' found xx plugins
DEBUG StatusLogger PluginManager 'Log4j Builder' found xx plugins
DEBUG StatusLogger Parsing for [root] with value=[INFO,CLA,EventCounter].
DEBUG StatusLogger Level token is [INFO].
DEBUG StatusLogger Logger root level set to INFO
DEBUG StatusLogger Parsing appender named "CLA".
```

### How to check if your cluster is affected by this

Add the following properties in your ingestion spec:

```json
{
  "type": "index_hadoop",
  "spec": {
    "dataSchema": "xx",
    "ioConfig": "xx",
    "tuningConfig": {
       "xx": "xx",
       "jobProperties": {
       "mapreduce.map.java.opts": "-server -Dlog4j.debug=true -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=TRACE",,
        "mapreduce.reduce.java.opts": "-server  -Dlog4j.debug=true -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=TRACE"
        }
      }
  }
}
```
Grab the application id from the peon task logs. 

Go to yarn main nodes and do 
 `yarn logs --applicationId xxx`

If you see output like : 
```
DEBUG StatusLogger PluginManager 'Log4j Builder' found xx plugins
DEBUG StatusLogger Parsing for [root] with value=[DEBUG,CLA,EventCounter].
DEBUG StatusLogger Level token is [DEBUG].
DEBUG StatusLogger Logger root level set to DEBUG
```

then your mappers and reducers are running in debug mode. 

Another way is to take the flame graph of the mappers/reducers and see if any code path is hitting debug sections. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `pom.xml`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
