### PR TITLE
Frame processing and channels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ README
 .java-version
 integration-tests/gen-scripts/
 bin/
+*.hprof

--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -64,6 +64,13 @@
             <Class name="org.apache.druid.sql.calcite.planner.CapturedState" />
         </And>
     </Match>
+    <Match>
+        <!-- Spotbugs doesn't like the MAGIC array -->
+        <And>
+            <Bug pattern="MS_MUTABLE_ARRAY" />
+            <Class name="org.apache.druid.frame.file.FrameFileWriter" />
+        </And>
+    </Match>
 
     <Bug pattern="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION"/>
     <Bug pattern="BC_UNCONFIRMED_CAST"/>

--- a/core/src/test/resources/log4j2.xml
+++ b/core/src/test/resources/log4j2.xml
@@ -28,7 +28,7 @@
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
-    <Logger level="debug" name="org.apache.druid" additivity="false">
+    <Logger level="info" name="org.apache.druid" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
   </Loggers>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -173,6 +173,10 @@
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/processing/src/main/java/org/apache/druid/frame/Frame.java
+++ b/processing/src/main/java/org/apache/druid/frame/Frame.java
@@ -86,14 +86,15 @@ public class Frame
       Integer.BYTES /* number of columns */ +
       Byte.BYTES /* permuted flag */;
 
+  // Compression type, compressed length, uncompressed length
+  public static final int COMPRESSED_FRAME_HEADER_SIZE = Byte.BYTES + Long.BYTES * 2;
+  public static final int COMPRESSED_FRAME_TRAILER_SIZE = Long.BYTES; // Checksum
+  public static final int COMPRESSED_FRAME_ENVELOPE_SIZE = COMPRESSED_FRAME_HEADER_SIZE
+                                                           + COMPRESSED_FRAME_TRAILER_SIZE;
+
   private static final LZ4Compressor LZ4_COMPRESSOR = LZ4Factory.fastestInstance().fastCompressor();
   private static final LZ4SafeDecompressor LZ4_DECOMPRESSOR = LZ4Factory.fastestInstance().safeDecompressor();
 
-  // Compression type, compressed length, uncompressed length
-  private static final int COMPRESSED_FRAME_HEADER_SIZE = Byte.BYTES + Long.BYTES * 2;
-  private static final int COMPRESSED_FRAME_TRAILER_SIZE = Long.BYTES; // Checksum
-  private static final int COMPRESSED_FRAME_ENVELOPE_SIZE = COMPRESSED_FRAME_HEADER_SIZE
-                                                            + COMPRESSED_FRAME_TRAILER_SIZE;
   private static final int CHECKSUM_SEED = 0;
 
   private final Memory memory;

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -35,9 +35,11 @@ import java.util.Optional;
 /**
  * In-memory channel backed by a limited-capacity {@link java.util.Deque}.
  *
- * This channel is used by a single writer and single reader. The writer and reader may run concurrently.
+ * Instances of this class provide a {@link ReadableFrameChannel} through {@link #readable()}, and a
+ * {@link WritableFrameChannel} through {@link #writable()}. Instances of this class are used by a single writer
+ * and single reader. The writer and reader may run concurrently.
  */
-public class BlockingQueueFrameChannel implements WritableFrameChannel, ReadableFrameChannel
+public class BlockingQueueFrameChannel
 {
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private static final Optional<Either<Throwable, FrameWithPartition>> END_MARKER = Optional.empty();
@@ -45,15 +47,15 @@ public class BlockingQueueFrameChannel implements WritableFrameChannel, Readable
   private final int maxQueuedFrames;
   private final Object lock = new Object();
 
+  private final Writable writable;
+  private final Readable readable;
+
   @GuardedBy("lock")
   private final ArrayDeque<Optional<Either<Throwable, FrameWithPartition>>> queue;
 
-  @GuardedBy("lock")
-  private SettableFuture<?> readyForWritingFuture = null;
-
-  @GuardedBy("lock")
-  private SettableFuture<?> readyForReadingFuture = null;
-
+  /**
+   * Create a channel with a particular buffer size (expressed in number of frames).
+   */
   public BlockingQueueFrameChannel(final int maxQueuedFrames)
   {
     if (maxQueuedFrames < 1 || maxQueuedFrames == Integer.MAX_VALUE) {
@@ -61,160 +63,196 @@ public class BlockingQueueFrameChannel implements WritableFrameChannel, Readable
     }
 
     this.maxQueuedFrames = maxQueuedFrames;
-
-    // Plus one to leave space for END_MARKER.
-    this.queue = new ArrayDeque<>(maxQueuedFrames + 1);
+    this.queue = new ArrayDeque<>(maxQueuedFrames + 1); // Plus one to leave space for END_MARKER.
+    this.writable = new Writable();
+    this.readable = new Readable();
   }
 
+  /**
+   * Returns the writable side of this channel.
+   */
+  public WritableFrameChannel writable()
+  {
+    return writable;
+  }
+
+  /**
+   * Returns the readable side of this channel.
+   */
+  public ReadableFrameChannel readable()
+  {
+    return readable;
+  }
+
+  /**
+   * Create a channel that buffers one frame. This is the smallest possible queue size.
+   */
   public static BlockingQueueFrameChannel minimal()
   {
     return new BlockingQueueFrameChannel(1);
   }
 
-  @Override
-  public void write(FrameWithPartition frame)
-  {
-    synchronized (lock) {
-      if (isFinished()) {
-        throw new ISE("Channel cannot accept new frames");
-      } else if (queue.size() >= maxQueuedFrames) {
-        // Caller should have checked if this channel was ready for writing.
-        throw new ISE("Channel has no capacity");
-      } else {
-        if (!queue.offer(Optional.of(Either.value(frame)))) {
-          // If this happens, it's a bug in this class's capacity-counting.
-          throw new ISE("Channel had capacity, but could not add frame");
-        }
-      }
-
-      notifyReader();
-    }
-  }
-
-  @Override
-  public ListenableFuture<?> writabilityFuture()
-  {
-    synchronized (lock) {
-      if (queue.size() < maxQueuedFrames) {
-        return Futures.immediateFuture(null);
-      } else if (readyForWritingFuture != null) {
-        return readyForWritingFuture;
-      } else {
-        return (readyForWritingFuture = SettableFuture.create());
-      }
-    }
-  }
-
-  @Override
-  public ListenableFuture<?> readabilityFuture()
-  {
-    synchronized (lock) {
-      if (!queue.isEmpty()) {
-        return Futures.immediateFuture(null);
-      } else if (readyForReadingFuture != null) {
-        return readyForReadingFuture;
-      } else {
-        return (readyForReadingFuture = SettableFuture.create());
-      }
-    }
-  }
-
-  @Override
-  public void fail()
-  {
-    synchronized (lock) {
-      queue.clear();
-
-      if (!queue.offer(Optional.of(Either.error(new ISE("Aborted"))))) {
-        // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
-        throw new ISE("Could not write error to channel");
-      }
-
-      doneWriting();
-    }
-  }
-
-  @Override
-  public void doneWriting()
-  {
-    synchronized (lock) {
-      if (isFinished()) {
-        throw new ISE("Already done");
-      }
-
-      if (!queue.offer(END_MARKER)) {
-        // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
-        throw new ISE("Channel had capacity, but could not add end marker");
-      }
-
-      notifyReader();
-    }
-  }
-
-  @Override
-  public boolean isFinished()
+  private boolean isFinished()
   {
     synchronized (lock) {
       return END_MARKER.equals(queue.peek());
     }
   }
 
-  @Override
-  public boolean canRead()
+  private class Writable implements WritableFrameChannel
   {
-    synchronized (lock) {
-      return !queue.isEmpty() && !isFinished();
+    @GuardedBy("lock")
+    private SettableFuture<?> readyForWritingFuture = null;
+
+    @Override
+    public void write(FrameWithPartition frame)
+    {
+      synchronized (lock) {
+        if (isFinished()) {
+          throw new ISE("Channel cannot accept new frames");
+        } else if (queue.size() >= maxQueuedFrames) {
+          // Caller should have checked if this channel was ready for writing.
+          throw new ISE("Channel has no capacity");
+        } else {
+          if (!queue.offer(Optional.of(Either.value(frame)))) {
+            // If this happens, it's a bug in this class's capacity-counting.
+            throw new ISE("Channel had capacity, but could not add frame");
+          }
+        }
+
+        readable.notifyReader();
+      }
+    }
+
+    @Override
+    public ListenableFuture<?> writabilityFuture()
+    {
+      synchronized (lock) {
+        if (queue.size() < maxQueuedFrames) {
+          return Futures.immediateFuture(null);
+        } else if (readyForWritingFuture != null) {
+          return readyForWritingFuture;
+        } else {
+          return (readyForWritingFuture = SettableFuture.create());
+        }
+      }
+    }
+
+    @Override
+    public void fail()
+    {
+      synchronized (lock) {
+        queue.clear();
+
+        if (!queue.offer(Optional.of(Either.error(new ISE("Aborted"))))) {
+          // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
+          throw new ISE("Could not write error to channel");
+        }
+
+        close();
+      }
+    }
+
+    @Override
+    public void close()
+    {
+      synchronized (lock) {
+        if (isFinished()) {
+          throw new ISE("Already done");
+        }
+
+        if (!queue.offer(END_MARKER)) {
+          // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
+          throw new ISE("Channel had capacity, but could not add end marker");
+        }
+
+        readable.notifyReader();
+      }
+    }
+
+    @GuardedBy("lock")
+    private void notifyWriter()
+    {
+      if (readyForWritingFuture != null) {
+        final SettableFuture<?> tmp = readyForWritingFuture;
+        this.readyForWritingFuture = null;
+        tmp.set(null);
+      }
     }
   }
 
-  @Override
-  public Frame read()
+  private class Readable implements ReadableFrameChannel
   {
-    final Optional<Either<Throwable, FrameWithPartition>> next;
+    @GuardedBy("lock")
+    private SettableFuture<?> readyForReadingFuture = null;
 
-    synchronized (lock) {
-      if (isFinished()) {
-        throw new NoSuchElementException();
+    @Override
+    public boolean isFinished()
+    {
+      return BlockingQueueFrameChannel.this.isFinished();
+    }
+
+    @Override
+    public boolean canRead()
+    {
+      synchronized (lock) {
+        return !queue.isEmpty() && !isFinished();
+      }
+    }
+
+    @Override
+    public Frame read()
+    {
+      final Optional<Either<Throwable, FrameWithPartition>> next;
+
+      synchronized (lock) {
+        if (isFinished()) {
+          throw new NoSuchElementException();
+        }
+
+        next = queue.poll();
+
+        if (next == null || !next.isPresent()) {
+          throw new NoSuchElementException();
+        }
+
+        writable.notifyWriter();
       }
 
-      next = queue.poll();
+      return next.get().valueOrThrow().frame();
+    }
 
-      if (next == null || !next.isPresent()) {
-        throw new NoSuchElementException();
+    @Override
+    public ListenableFuture<?> readabilityFuture()
+    {
+      synchronized (lock) {
+        if (!queue.isEmpty()) {
+          return Futures.immediateFuture(null);
+        } else if (readyForReadingFuture != null) {
+          return readyForReadingFuture;
+        } else {
+          return (readyForReadingFuture = SettableFuture.create());
+        }
       }
-
-      notifyWriter();
     }
 
-    return next.get().valueOrThrow().frame();
-  }
-
-  @Override
-  public void doneReading()
-  {
-    synchronized (lock) {
-      queue.clear();
-      notifyWriter();
+    @Override
+    public void close()
+    {
+      synchronized (lock) {
+        queue.clear();
+        writable.notifyWriter();
+      }
     }
-  }
 
-  @GuardedBy("lock")
-  private void notifyReader()
-  {
-    if (readyForReadingFuture != null) {
-      final SettableFuture<?> tmp = readyForReadingFuture;
-      this.readyForReadingFuture = null;
-      tmp.set(null);
-    }
-  }
-
-  @GuardedBy("lock")
-  private void notifyWriter()
-  {
-    if (readyForWritingFuture != null) {
-      final SettableFuture<?> tmp = readyForWritingFuture;
-      this.readyForWritingFuture = null;
-      tmp.set(null);
+    @GuardedBy("lock")
+    private void notifyReader()
+    {
+      if (readyForReadingFuture != null) {
+        final SettableFuture<?> tmp = readyForReadingFuture;
+        this.readyForReadingFuture = null;
+        tmp.set(null);
+      }
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -118,7 +118,7 @@ public class BlockingQueueFrameChannel implements WritableFrameChannel, Readable
   }
 
   @Override
-  public void abort()
+  public void fail()
   {
     synchronized (lock) {
       queue.clear();

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 
 /**
  * In-memory channel backed by a limited-capacity {@link java.util.Deque}.
+ *
+ * This channel is used by a single writer and single reader. The writer and reader may run concurrently.
  */
 public class BlockingQueueFrameChannel implements WritableFrameChannel, ReadableFrameChannel
 {

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.ArrayDeque;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * In-memory channel backed by a limited-capacity {@link java.util.Deque}.
+ */
+public class BlockingQueueFrameChannel implements WritableFrameChannel, ReadableFrameChannel
+{
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private static final Optional<Either<Throwable, FrameWithPartition>> END_MARKER = Optional.empty();
+
+  private final int maxQueuedFrames;
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private final ArrayDeque<Optional<Either<Throwable, FrameWithPartition>>> queue;
+
+  @GuardedBy("lock")
+  private SettableFuture<?> readyForWritingFuture = null;
+
+  @GuardedBy("lock")
+  private SettableFuture<?> readyForReadingFuture = null;
+
+  public BlockingQueueFrameChannel(final int maxQueuedFrames)
+  {
+    if (maxQueuedFrames < 1 || maxQueuedFrames == Integer.MAX_VALUE) {
+      throw new IAE("Cannot handle capacity of [%d]", maxQueuedFrames);
+    }
+
+    this.maxQueuedFrames = maxQueuedFrames;
+
+    // Plus one to leave space for END_MARKER.
+    this.queue = new ArrayDeque<>(maxQueuedFrames + 1);
+  }
+
+  public static BlockingQueueFrameChannel minimal()
+  {
+    return new BlockingQueueFrameChannel(1);
+  }
+
+  @Override
+  public void write(FrameWithPartition frame)
+  {
+    synchronized (lock) {
+      if (isFinished()) {
+        throw new ISE("Channel cannot accept new frames");
+      } else if (queue.size() >= maxQueuedFrames) {
+        // Caller should have checked if this channel was ready for writing.
+        throw new ISE("Channel has no capacity");
+      } else {
+        if (!queue.offer(Optional.of(Either.value(frame)))) {
+          // If this happens, it's a bug in this class's capacity-counting.
+          throw new ISE("Channel had capacity, but could not add frame");
+        }
+      }
+
+      notifyReader();
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> writabilityFuture()
+  {
+    synchronized (lock) {
+      if (queue.size() < maxQueuedFrames) {
+        return Futures.immediateFuture(null);
+      } else if (readyForWritingFuture != null) {
+        return readyForWritingFuture;
+      } else {
+        return (readyForWritingFuture = SettableFuture.create());
+      }
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    synchronized (lock) {
+      if (!queue.isEmpty()) {
+        return Futures.immediateFuture(null);
+      } else if (readyForReadingFuture != null) {
+        return readyForReadingFuture;
+      } else {
+        return (readyForReadingFuture = SettableFuture.create());
+      }
+    }
+  }
+
+  @Override
+  public void abort()
+  {
+    synchronized (lock) {
+      queue.clear();
+
+      if (!queue.offer(Optional.of(Either.error(new ISE("Aborted"))))) {
+        // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
+        throw new ISE("Could not write error to channel");
+      }
+
+      doneWriting();
+    }
+  }
+
+  @Override
+  public void doneWriting()
+  {
+    synchronized (lock) {
+      if (isFinished()) {
+        throw new ISE("Already done");
+      }
+
+      if (!queue.offer(END_MARKER)) {
+        // If this happens, it's a bug, potentially due to incorrectly using this class with multiple writers.
+        throw new ISE("Channel had capacity, but could not add end marker");
+      }
+
+      notifyReader();
+    }
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    synchronized (lock) {
+      return END_MARKER.equals(queue.peek());
+    }
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    synchronized (lock) {
+      return !queue.isEmpty() && !isFinished();
+    }
+  }
+
+  @Override
+  public Frame read()
+  {
+    final Optional<Either<Throwable, FrameWithPartition>> next;
+
+    synchronized (lock) {
+      if (isFinished()) {
+        throw new NoSuchElementException();
+      }
+
+      next = queue.poll();
+
+      if (next == null || !next.isPresent()) {
+        throw new NoSuchElementException();
+      }
+
+      notifyWriter();
+    }
+
+    return next.get().valueOrThrow().frame();
+  }
+
+  @Override
+  public void doneReading()
+  {
+    synchronized (lock) {
+      queue.clear();
+      notifyWriter();
+    }
+  }
+
+  @GuardedBy("lock")
+  private void notifyReader()
+  {
+    if (readyForReadingFuture != null) {
+      final SettableFuture<?> tmp = readyForReadingFuture;
+      this.readyForReadingFuture = null;
+      tmp.set(null);
+    }
+  }
+
+  @GuardedBy("lock")
+  private void notifyWriter()
+  {
+    if (readyForWritingFuture != null) {
+      final SettableFuture<?> tmp = readyForWritingFuture;
+      this.readyForWritingFuture = null;
+      tmp.set(null);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/FrameChannelSequence.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/FrameChannelSequence.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import org.apache.druid.frame.Frame;
+import org.apache.druid.java.util.common.guava.BaseSequence;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Adapter that converts a {@link ReadableFrameChannel} into a {@link org.apache.druid.java.util.common.guava.Sequence}
+ * of {@link Frame}.
+ *
+ * This class does blocking reads on the channel, rather than nonblocking reads. Therefore, it is preferable to use
+ * {@link ReadableFrameChannel} directly whenever nonblocking reads are desired.
+ */
+public class FrameChannelSequence extends BaseSequence<Frame, FrameChannelSequence.FrameChannelIterator>
+{
+  public FrameChannelSequence(final ReadableFrameChannel channel)
+  {
+    super(
+        new IteratorMaker<Frame, FrameChannelIterator>()
+        {
+          @Override
+          public FrameChannelIterator make()
+          {
+            return new FrameChannelIterator(channel);
+          }
+
+          @Override
+          public void cleanup(FrameChannelIterator iterFromMake)
+          {
+            iterFromMake.close();
+          }
+        }
+    );
+  }
+
+  public static class FrameChannelIterator implements Iterator<Frame>, Closeable
+  {
+    private final ReadableFrameChannel channel;
+
+    private FrameChannelIterator(final ReadableFrameChannel channel)
+    {
+      this.channel = channel;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+      // Blocking read.
+      await();
+      return channel.canRead();
+    }
+
+    @Override
+    public Frame next()
+    {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      return channel.read();
+    }
+
+    @Override
+    public void close()
+    {
+      channel.doneReading();
+    }
+
+    private void await()
+    {
+      try {
+        channel.readabilityFuture().get();
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/FrameChannelSequence.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/FrameChannelSequence.java
@@ -87,7 +87,7 @@ public class FrameChannelSequence extends BaseSequence<Frame, FrameChannelSequen
     @Override
     public void close()
     {
-      channel.doneReading();
+      channel.close();
     }
 
     private void await()

--- a/processing/src/main/java/org/apache/druid/frame/channel/FrameWithPartition.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/FrameWithPartition.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import org.apache.druid.frame.Frame;
+
+/**
+ * Frame plus partition number.
+ *
+ * If there is no meaningful partition number to associate with the frame, use {@link #NO_PARTITION}.
+ */
+public class FrameWithPartition
+{
+  public static final int NO_PARTITION = -1;
+
+  private final Frame frame;
+  private final int partition;
+
+  public FrameWithPartition(Frame frame, int partition)
+  {
+    this.frame = frame;
+    this.partition = partition;
+  }
+
+  public Frame frame()
+  {
+    return frame;
+  }
+
+  public int partition()
+  {
+    return partition;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
@@ -114,6 +114,8 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
    */
   public static ReadableByteChunksFrameChannel create(final String id)
   {
+    // Set byte limit to 1, so backpressure will be exerted as soon as we have a full frame buffered.
+    // (The bytesLimit is soft: it will be exceeded if needed to store a complete frame.)
     return new ReadableByteChunksFrameChannel(id, 1);
   }
 

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
@@ -203,7 +203,7 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
   public boolean isFinished()
   {
     synchronized (lock) {
-      return chunks.isEmpty() && noMoreWrites;
+      return chunks.isEmpty() && noMoreWrites && !canRead();
     }
   }
 
@@ -288,7 +288,7 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
   public boolean isErrorOrFinished()
   {
     synchronized (lock) {
-      return isFinished() || canReadError();
+      return isFinished() || (canRead() && !canReadFrame());
     }
   }
 
@@ -442,7 +442,7 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
         positionInFirstChunk = 0;
         chunks.remove(0);
       } else {
-        positionInFirstChunk += toDelete;
+        positionInFirstChunk = Ints.checkedCast(positionInFirstChunk + toDelete);
         toDelete = 0;
       }
     }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
@@ -263,7 +263,7 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
   }
 
   @Override
-  public void doneReading()
+  public void close()
   {
     synchronized (lock) {
       chunks.clear();

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.datasketches.memory.Memory;
+import org.apache.datasketches.memory.WritableMemory;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.file.FrameFileWriter;
+import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Channel backed by a byte stream that is continuously streamed in using {@link #addChunk}. The byte stream
+ * must be in the format of a {@link org.apache.druid.frame.file.FrameFile}.
+ *
+ * This class is used by {@link org.apache.druid.frame.file.FrameFileHttpResponseHandler} to provide nonblocking
+ * reads from a remote http server.
+ */
+public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
+{
+  private static final Logger log = new Logger(ReadableByteChunksFrameChannel.class);
+
+  /**
+   * Largest supported frame. Limit exists as a safeguard against streams with huge frame sizes. It is not expected
+   * that any legitimate frame will be this large: typical usage involves frames an order of magnitude smaller.
+   */
+  private static final long MAX_FRAME_SIZE = 100_000_000;
+
+  private static final int UNKNOWN_LENGTH = -1;
+  private static final int FRAME_MARKER_BYTES = Byte.BYTES;
+  private static final int FRAME_MARKER_AND_COMPRESSED_ENVELOPE_BYTES =
+      Byte.BYTES + Frame.COMPRESSED_FRAME_ENVELOPE_SIZE;
+
+  private enum StreamPart
+  {
+    MAGIC,
+    FRAMES,
+    FOOTER
+  }
+
+  private final Object lock = new Object();
+  private final String id;
+  private final long bytesLimit;
+
+  @GuardedBy("lock")
+  private final List<Either<Throwable, byte[]>> chunks = new ArrayList<>();
+
+  @GuardedBy("lock")
+  private SettableFuture<?> addChunkBackpressureFuture = null;
+
+  @GuardedBy("lock")
+  private SettableFuture<?> readyForReadingFuture = null;
+
+  @GuardedBy("lock")
+  private boolean noMoreWrites = false;
+
+  @GuardedBy("lock")
+  private int positionInFirstChunk = 0;
+
+  @GuardedBy("lock")
+  private long bytesBuffered = 0;
+
+  @GuardedBy("lock")
+  private long bytesAdded = 0;
+
+  @GuardedBy("lock")
+  private long nextCompressedFrameLength = UNKNOWN_LENGTH;
+
+  @GuardedBy("lock")
+  private StreamPart streamPart = StreamPart.MAGIC;
+
+  private ReadableByteChunksFrameChannel(String id, long bytesLimit)
+  {
+    this.id = Preconditions.checkNotNull(id, "id");
+    this.bytesLimit = bytesLimit;
+  }
+
+  /**
+   * Create a channel that aims to limit its memory footprint to one frame. The channel exerts backpressure
+   * from {@link #addChunk} immediately once a full frame has been buffered.
+   */
+  public static ReadableByteChunksFrameChannel create(final String id)
+  {
+    return new ReadableByteChunksFrameChannel(id, 1);
+  }
+
+  /**
+   * Adds a chunk of bytes. If this chunk forms a full frame, it will immediately become available for reading.
+   * Otherwise, the bytes will be buffered until a full frame is encountered.
+   *
+   * Returns an Optional that is absent if the amount of queued bytes is below this channel's limit accept, or present
+   * if the amount of queued bytes is at or above this channel's limit. If the Optional is present, you are politely
+   * requested to wait for the future to resolve before adding additional chunks. (This is not enforced; addChunk will
+   * continue to accept new chunks even if the channel is over its limit.)
+   *
+   * When done adding chunks call {@code doneWriting}.
+   */
+  public Optional<ListenableFuture<?>> addChunk(final byte[] chunk)
+  {
+    synchronized (lock) {
+      if (noMoreWrites) {
+        throw new ISE("Channel is no longer accepting writes");
+      }
+
+      try {
+        if (chunk.length > 0) {
+          if (streamPart != StreamPart.FOOTER) {
+            // Footer is discarded: it isn't useful when reading frame files as streams. (It contains pointers
+            // for random access of frames.)
+            chunks.add(Either.value(chunk));
+            bytesBuffered += chunk.length;
+            bytesAdded += chunk.length;
+          }
+
+          updateStreamState();
+
+          if (readyForReadingFuture != null && canReadFrame()) {
+            readyForReadingFuture.set(null);
+            readyForReadingFuture = null;
+          }
+        }
+
+        if (addChunkBackpressureFuture == null && bytesBuffered >= bytesLimit && canReadFrame()) {
+          addChunkBackpressureFuture = SettableFuture.create();
+        }
+
+        return Optional.ofNullable(addChunkBackpressureFuture);
+      }
+      catch (Throwable e) {
+        // The channel is in an inconsistent state if any of this logic throws an error. Shut it down.
+        setError(e);
+        return Optional.empty();
+      }
+    }
+  }
+
+  /**
+   * Clears the channel and replaces it with the given error. After calling this method, no additional chunks will be accepted.
+   */
+  public void setError(final Throwable t)
+  {
+    synchronized (lock) {
+      if (noMoreWrites) {
+        log.noStackTrace().warn(t, "Channel is no longer accepting writes, cannot propagate exception");
+      } else {
+        chunks.clear();
+        chunks.add(Either.error(t));
+        nextCompressedFrameLength = UNKNOWN_LENGTH;
+        doneWriting();
+      }
+    }
+  }
+
+  /**
+   * Call method when caller is done adding chunks.
+   */
+  public void doneWriting()
+  {
+    synchronized (lock) {
+      noMoreWrites = true;
+
+      if (readyForReadingFuture != null) {
+        readyForReadingFuture.set(null);
+        readyForReadingFuture = null;
+      }
+    }
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    synchronized (lock) {
+      return chunks.isEmpty() && noMoreWrites;
+    }
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    synchronized (lock) {
+      // The noMoreWrites check is here so read() can throw an error if the last few chunks are an incomplete frame.
+      return canReadError() || canReadFrame() || (streamPart != StreamPart.FOOTER && noMoreWrites);
+    }
+  }
+
+  @Override
+  public Frame read()
+  {
+    synchronized (lock) {
+      if (canReadError()) {
+        // This map will be a no-op since we're guaranteed that the next chunk is an error.
+        final Throwable t = chunks.remove(0).map(bytes -> null).error();
+        Throwables.propagateIfPossible(t);
+        throw new RuntimeException(t);
+      } else if (canReadFrame()) {
+        return nextFrame();
+      } else if (noMoreWrites) {
+        // The last few chunks are an incomplete or missing frame.
+        chunks.clear();
+        nextCompressedFrameLength = UNKNOWN_LENGTH;
+
+        throw new ISE(
+            "Incomplete or missing frame at end of stream (id = %s, position = %d)",
+            id,
+            bytesAdded - bytesBuffered
+        );
+      } else {
+        assert !canRead();
+
+        // This method should not have been called at this time.
+        throw new NoSuchElementException();
+      }
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    synchronized (lock) {
+      if (canRead() || isFinished()) {
+        return Futures.immediateFuture(null);
+      } else if (readyForReadingFuture != null) {
+        return readyForReadingFuture;
+      } else {
+        return (readyForReadingFuture = SettableFuture.create());
+      }
+    }
+  }
+
+  @Override
+  public void doneReading()
+  {
+    synchronized (lock) {
+      chunks.clear();
+      nextCompressedFrameLength = UNKNOWN_LENGTH;
+
+      // Setting "noMoreWrites" causes the upstream entity to realize this channel has closed the next time
+      // it calls "addChunk".
+      noMoreWrites = true;
+    }
+  }
+
+  public String getId()
+  {
+    return id;
+  }
+
+  public long getBytesAdded()
+  {
+    synchronized (lock) {
+      return bytesAdded;
+    }
+  }
+
+  public boolean isErrorOrFinished()
+  {
+    synchronized (lock) {
+      return isFinished() || canReadError();
+    }
+  }
+
+  @VisibleForTesting
+  long getBytesBuffered()
+  {
+    synchronized (lock) {
+      return bytesBuffered;
+    }
+  }
+
+  private Frame nextFrame()
+  {
+    final Memory frameMemory;
+
+    synchronized (lock) {
+      if (!canReadFrame()) {
+        throw new ISE("Frame of size [%,d] not yet ready to read", nextCompressedFrameLength);
+      }
+
+      if (nextCompressedFrameLength > Integer.MAX_VALUE - FRAME_MARKER_BYTES - Frame.COMPRESSED_FRAME_ENVELOPE_SIZE) {
+        throw new ISE("Cannot read frame of size [%,d] bytes", nextCompressedFrameLength);
+      }
+
+      final int numBytes = Ints.checkedCast(FRAME_MARKER_AND_COMPRESSED_ENVELOPE_BYTES + nextCompressedFrameLength);
+      frameMemory = copyFromQueuedChunks(numBytes).region(
+          FRAME_MARKER_BYTES,
+          FRAME_MARKER_AND_COMPRESSED_ENVELOPE_BYTES + nextCompressedFrameLength - FRAME_MARKER_BYTES
+      );
+      deleteFromQueuedChunks(numBytes);
+      updateStreamState();
+    }
+
+    final Frame frame = Frame.decompress(frameMemory, 0, frameMemory.getCapacity());
+    log.debug("Read frame with [%,d] rows and [%,d] bytes.", frame.numRows(), frame.numBytes());
+    return frame;
+  }
+
+  @GuardedBy("lock")
+  private void updateStreamState()
+  {
+    if (streamPart == StreamPart.MAGIC) {
+      if (bytesBuffered >= FrameFileWriter.MAGIC.length) {
+        final Memory memory = copyFromQueuedChunks(FrameFileWriter.MAGIC.length);
+
+        if (memory.equalTo(0, Memory.wrap(FrameFileWriter.MAGIC), 0, FrameFileWriter.MAGIC.length)) {
+          streamPart = StreamPart.FRAMES;
+          deleteFromQueuedChunks(FrameFileWriter.MAGIC.length);
+        } else {
+          throw new ISE("Invalid stream header (id = %s, position = %d)", id, bytesAdded - bytesBuffered);
+        }
+      }
+    }
+
+    if (streamPart == StreamPart.FRAMES) {
+      if (bytesBuffered >= Byte.BYTES) {
+        final Memory memory = copyFromQueuedChunks(1);
+
+        if (memory.getByte(0) == FrameFileWriter.MARKER_FRAME) {
+          // Read nextFrameLength if needed; otherwise do nothing.
+          final int bytesRequiredToReadLength = FRAME_MARKER_BYTES + Frame.COMPRESSED_FRAME_HEADER_SIZE;
+
+          if (nextCompressedFrameLength == UNKNOWN_LENGTH && bytesBuffered >= bytesRequiredToReadLength) {
+            nextCompressedFrameLength = copyFromQueuedChunks(bytesRequiredToReadLength)
+                .getLong(FRAME_MARKER_BYTES + Byte.BYTES /* Compression strategy byte */);
+
+            if (nextCompressedFrameLength <= 0 || nextCompressedFrameLength >= MAX_FRAME_SIZE) {
+              throw new ISE("Invalid frame size (size = %,d B)", nextCompressedFrameLength);
+            }
+          }
+        } else if (memory.getByte(0) == FrameFileWriter.MARKER_NO_MORE_FRAMES) {
+          streamPart = StreamPart.FOOTER;
+          nextCompressedFrameLength = UNKNOWN_LENGTH;
+        } else {
+          throw new ISE("Invalid midstream marker (id = %s, position = %d)", id, bytesAdded - bytesBuffered);
+        }
+      }
+    }
+
+    if (streamPart == StreamPart.FOOTER) {
+      if (bytesBuffered > 0) {
+        // Footer is discarded: it isn't useful when reading frame files as streams. (It contains pointers
+        // for random access of frames.)
+        deleteFromQueuedChunks(bytesBuffered);
+      }
+
+      assert bytesBuffered == 0 && chunks.isEmpty() && nextCompressedFrameLength == UNKNOWN_LENGTH;
+    }
+
+    if (addChunkBackpressureFuture != null && (bytesBuffered < bytesLimit || !canReadFrame())) {
+      // Release backpressure.
+      addChunkBackpressureFuture.set(null);
+      addChunkBackpressureFuture = null;
+    }
+  }
+
+  @GuardedBy("lock")
+  private boolean canReadError()
+  {
+    return chunks.size() > 0 && chunks.get(0).isError();
+  }
+
+  @GuardedBy("lock")
+  private boolean canReadFrame()
+  {
+    return nextCompressedFrameLength != UNKNOWN_LENGTH
+           && bytesBuffered >= FRAME_MARKER_AND_COMPRESSED_ENVELOPE_BYTES + nextCompressedFrameLength;
+  }
+
+  @GuardedBy("lock")
+  private Memory copyFromQueuedChunks(final int numBytes)
+  {
+    if (bytesBuffered < numBytes) {
+      throw new IAE("Cannot copy [%,d] bytes, only have [%,d] buffered", numBytes, bytesBuffered);
+    }
+
+    final WritableMemory buf = WritableMemory.allocate(numBytes, ByteOrder.LITTLE_ENDIAN);
+
+    int bufPos = 0;
+    for (int chunkNumber = 0; chunkNumber < chunks.size(); chunkNumber++) {
+      final byte[] chunk = chunks.get(chunkNumber).valueOrThrow();
+      final int chunkPosition = chunkNumber == 0 ? positionInFirstChunk : 0;
+      final int len = Math.min(chunk.length - chunkPosition, numBytes - bufPos);
+
+      buf.putByteArray(bufPos, chunk, chunkPosition, len);
+      bufPos += len;
+
+      if (bufPos == numBytes) {
+        break;
+      }
+    }
+
+    return buf;
+  }
+
+  @GuardedBy("lock")
+  private void deleteFromQueuedChunks(final long numBytes)
+  {
+    if (bytesBuffered < numBytes) {
+      throw new IAE("Cannot delete [%,d] bytes, only have [%,d] buffered", numBytes, bytesBuffered);
+    }
+
+    long toDelete = numBytes;
+
+    while (toDelete > 0) {
+      final byte[] chunk = chunks.get(0).valueOrThrow();
+      final int bytesRemainingInChunk = chunk.length - positionInFirstChunk;
+
+      if (toDelete >= bytesRemainingInChunk) {
+        toDelete -= bytesRemainingInChunk;
+        positionInFirstChunk = 0;
+        chunks.remove(0);
+      } else {
+        positionInFirstChunk += toDelete;
+        toDelete = 0;
+      }
+    }
+
+    bytesBuffered -= numBytes;
+
+    // Clear nextFrameLength; it won't be accurate anymore after deleting bytes.
+    nextCompressedFrameLength = UNKNOWN_LENGTH;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.Frame;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Channel that concatenates a sequence of other channels that are provided by an iterator. The iterator is
+ * walked just-in-time, meaning that {@link Iterator#next()} is not called until the channel is actually ready
+ * to be used.
+ *
+ * The first channel is pulled from the iterator immediately upon construction.
+ */
+public class ReadableConcatFrameChannel implements ReadableFrameChannel
+{
+  private final Iterator<ReadableFrameChannel> channelIterator;
+
+  // Null means there were never any channels to begin with.
+  @Nullable
+  private ReadableFrameChannel currentChannel;
+
+  private ReadableConcatFrameChannel(Iterator<ReadableFrameChannel> channelIterator)
+  {
+    this.channelIterator = channelIterator;
+    this.currentChannel = channelIterator.hasNext() ? channelIterator.next() : null;
+  }
+
+  /**
+   * Creates a new concatenated channel. The first channel is pulled from the provided iterator immediately.
+   * Other channels are pulled on-demand, when they are ready to be used.
+   */
+  public static ReadableConcatFrameChannel open(final Iterator<ReadableFrameChannel> channelIterator)
+  {
+    return new ReadableConcatFrameChannel(channelIterator);
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    advanceCurrentChannelIfFinished();
+    return currentChannel == null || currentChannel.isFinished();
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    advanceCurrentChannelIfFinished();
+    return currentChannel != null && currentChannel.canRead();
+  }
+
+  @Override
+  public Frame read()
+  {
+    if (!canRead() || currentChannel == null) {
+      throw new NoSuchElementException();
+    }
+
+    return currentChannel.read();
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    advanceCurrentChannelIfFinished();
+
+    if (currentChannel == null) {
+      return Futures.immediateFuture(null);
+    } else {
+      return currentChannel.readabilityFuture();
+    }
+  }
+
+  @Override
+  public void doneReading()
+  {
+    if (currentChannel != null) {
+      currentChannel.doneReading();
+    }
+  }
+
+  private void advanceCurrentChannelIfFinished()
+  {
+    while (currentChannel != null && currentChannel.isFinished() && channelIterator.hasNext()) {
+      currentChannel = channelIterator.next();
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
@@ -95,10 +95,10 @@ public class ReadableConcatFrameChannel implements ReadableFrameChannel
   }
 
   @Override
-  public void doneReading()
+  public void close()
   {
     if (currentChannel != null) {
-      currentChannel.doneReading();
+      currentChannel.close();
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableConcatFrameChannel.java
@@ -74,10 +74,11 @@ public class ReadableConcatFrameChannel implements ReadableFrameChannel
   @Override
   public Frame read()
   {
-    if (!canRead() || currentChannel == null) {
+    if (!canRead()) {
       throw new NoSuchElementException();
     }
 
+    assert currentChannel != null; // True because canRead() was true.
     return currentChannel.read();
   }
 

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
@@ -94,7 +94,7 @@ public class ReadableFileFrameChannel implements ReadableFrameChannel
   }
 
   @Override
-  public void doneReading()
+  public void close()
   {
     try {
       frameFile.close();

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
@@ -108,7 +108,7 @@ public class ReadableFileFrameChannel implements ReadableFrameChannel
    * Returns a new reference to the {@link FrameFile} that this channel is reading from. Callers should close this
    * reference when done reading.
    */
-  public FrameFile getFrameFileReference()
+  public FrameFile newFrameFileReference()
   {
     return frameFile.newReference();
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFileFrameChannel.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.file.FrameFile;
+import org.apache.druid.java.util.common.IAE;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+/**
+ * Channel backed by a {@link FrameFile}.
+ *
+ * This class is backed by an actual file that is on disk and memory-mapped. For situations where a stream in frame
+ * file format is being read over the network, use {@link ReadableByteChunksFrameChannel} or
+ * {@link org.apache.druid.frame.file.FrameFileHttpResponseHandler} instead.
+ */
+public class ReadableFileFrameChannel implements ReadableFrameChannel
+{
+  private final FrameFile frameFile;
+  private final int endFrame;
+  private int currentFrame;
+
+  public ReadableFileFrameChannel(final FrameFile frameFile, final int startFrame, final int endFrame)
+  {
+    this.frameFile = frameFile;
+    this.currentFrame = startFrame;
+    this.endFrame = endFrame;
+
+    if (startFrame < 0) {
+      throw new IAE("startFrame[%,d] < 0", startFrame);
+    }
+
+    if (startFrame > endFrame) {
+      throw new IAE("startFrame[%,d] > endFrame[%,d]", startFrame, endFrame);
+    }
+
+    if (endFrame > frameFile.numFrames()) {
+      throw new IAE("endFrame[%,d] > numFrames[%,d]", endFrame, frameFile.numFrames());
+    }
+  }
+
+  public ReadableFileFrameChannel(final FrameFile frameFile)
+  {
+    this(frameFile, 0, frameFile.numFrames());
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    return currentFrame == endFrame;
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    return !isFinished();
+  }
+
+  @Override
+  public Frame read()
+  {
+    if (isFinished()) {
+      throw new NoSuchElementException();
+    }
+
+    return frameFile.frame(currentFrame++);
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    return Futures.immediateFuture(true);
+  }
+
+  @Override
+  public void doneReading()
+  {
+    try {
+      frameFile.close();
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Returns a new reference to the {@link FrameFile} that this channel is reading from. Callers should close this
+   * reference when done reading.
+   */
+  public FrameFile getFrameFileReference()
+  {
+    return frameFile.newReference();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
@@ -27,6 +27,8 @@ import org.apache.druid.frame.Frame;
  * {@link #readabilityFuture()} methods.
  *
  * May be implemented using an in-memory queue, disk file, stream, etc.
+ *
+ * Channels implementing this interface are used by a single reader; they do not support concurrent reads.
  */
 public interface ReadableFrameChannel
 {

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.Frame;
+
+/**
+ * Interface for reading a sequence of frames. Supports nonblocking reads through the {@link #canRead()} and
+ * {@link #readabilityFuture()} methods.
+ *
+ * May be implemented using an in-memory queue, disk file, stream, etc.
+ */
+public interface ReadableFrameChannel
+{
+  /**
+   * Returns whether this channel is finished. Finished channels will not generate any further frames or errors.
+   *
+   * Generally, once you discover that a channel is finished, you should call {@link #doneReading()} and then
+   * discard it.
+   *
+   * Note that it is possible for a channel to be unfinished and also have no available frames or errors. This happens
+   * when it is not in a ready-for-reading state. See {@link #readabilityFuture()} for details.
+   */
+  boolean isFinished();
+
+  /**
+   * Returns whether this channel has a frame or error condition currently available. If this method returns true, then
+   * you can call {@link #read()} to retrieve the frame or error.
+   *
+   * Note that it is possible for a channel to be unfinished and also have no available frames or errors. This happens
+   * when it is not in a ready-for-reading state. See {@link #readabilityFuture()} for details.
+   */
+  boolean canRead();
+
+  /**
+   * Returns the next available frame from this channel.
+   *
+   * Before calling this method, you should check {@link #canRead()} to ensure there is a frame or
+   * error available.
+   *
+   * @throws java.util.NoSuchElementException if there is no frame currently available
+   */
+  Frame read();
+
+  /**
+   * Returns a future that will resolve when either {@link #isFinished()} or {@link #canRead()} would
+   * return true. The future will never resolve to an exception. If something exceptional has happened, the exception
+   * can be retrieved from {@link #read()}.
+   */
+  ListenableFuture<?> readabilityFuture();
+
+  /**
+   * Releases any resources associated with this readable channel. After calling this, you should not call any other
+   * methods on the channel.
+   */
+  void doneReading();
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java
@@ -22,6 +22,8 @@ package org.apache.druid.frame.channel;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.frame.Frame;
 
+import java.io.Closeable;
+
 /**
  * Interface for reading a sequence of frames. Supports nonblocking reads through the {@link #canRead()} and
  * {@link #readabilityFuture()} methods.
@@ -30,12 +32,12 @@ import org.apache.druid.frame.Frame;
  *
  * Channels implementing this interface are used by a single reader; they do not support concurrent reads.
  */
-public interface ReadableFrameChannel
+public interface ReadableFrameChannel extends Closeable
 {
   /**
    * Returns whether this channel is finished. Finished channels will not generate any further frames or errors.
    *
-   * Generally, once you discover that a channel is finished, you should call {@link #doneReading()} and then
+   * Generally, once you discover that a channel is finished, you should call {@link #close()} and then
    * discard it.
    *
    * Note that it is possible for a channel to be unfinished and also have no available frames or errors. This happens
@@ -73,5 +75,6 @@ public interface ReadableFrameChannel
    * Releases any resources associated with this readable channel. After calling this, you should not call any other
    * methods on the channel.
    */
-  void doneReading();
+  @Override
+  void close();
 }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.utils.CloseableUtils;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Channel backed by an {@link InputStream}.
+ *
+ * Frame channels are expected to be nonblocking, but InputStreams cannot be read in nonblocking fashion.
+ * This implementation deals with that by using an {@link ExecutorService} to read from the stream in a
+ * separate thread.
+ */
+public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
+{
+  private final InputStream inputStream;
+  private final ReadableByteChunksFrameChannel delegate;
+  private final ExecutorService executorService;
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private final byte[] buffer = new byte[8 * 1024];
+
+  @GuardedBy("lock")
+  private long totalInputStreamBytesRead = 0;
+
+  @GuardedBy("lock")
+  private boolean inputStreamFinished = false;
+
+  @GuardedBy("lock")
+  private boolean inputStreamError = false;
+
+  private volatile boolean readingStarted = false;
+  private volatile boolean keepReading = true;
+
+  public ReadableInputStreamFrameChannel(InputStream inputStream, String id, ExecutorService executorService)
+  {
+    this.inputStream = inputStream;
+    this.delegate = ReadableByteChunksFrameChannel.create(id);
+    this.executorService = executorService;
+  }
+
+  /**
+   * Method needs to be called for reading of input streams into ByteChunksFrameChannel
+   */
+  public void startReading()
+  {
+    // submit the reading task to the executor service only once
+    if (readingStarted) {
+      return;
+    } else {
+      synchronized (lock) {
+        if (readingStarted) {
+          return;
+        }
+        readingStarted = true;
+      }
+      executorService.submit(() -> {
+        while (true) {
+          if (!keepReading) {
+            try {
+              // Ideally, this would use exponential backoff.
+              Thread.sleep(100);
+              synchronized (lock) {
+                if (inputStreamFinished || inputStreamError || delegate.isErrorOrFinished()) {
+                  return;
+                }
+              }
+            }
+            catch (InterruptedException e) {
+              // close inputstream anyway if the thread interrupts
+              throw CloseableUtils.closeAndWrapInCatch(e, inputStream);
+            }
+          } else {
+            synchronized (lock) {
+              // if done reading method is called we should not read input stream further
+              if (inputStreamFinished) {
+                delegate.doneWriting();
+                break;
+              }
+              try {
+                int bytesRead = inputStream.read(buffer);
+                if (bytesRead == -1) {
+                  inputStreamFinished = true;
+                  delegate.doneWriting();
+                  break;
+                } else {
+                  Optional<ListenableFuture<?>> futureOptional =
+                      delegate.addChunk(Arrays.copyOfRange(buffer, 0, bytesRead));
+                  totalInputStreamBytesRead += bytesRead;
+
+                  if (futureOptional.isPresent()) {
+                    // backpressure handling
+                    keepReading = false;
+                    futureOptional.get().addListener(() -> keepReading = true, Execs.directExecutor());
+                  } else {
+                    keepReading = true;
+                    // continue adding data to delegate
+                    // give up lock so that other threads have a change to do some work
+                  }
+                }
+              }
+              catch (Exception e) {
+                //handle exception
+                long currentStreamOffset = totalInputStreamBytesRead;
+                delegate.setError(new ISE(e, "Found error while reading input stream at %d", currentStreamOffset));
+                inputStreamError = true;
+                // close the stream in case done reading is not called.
+                CloseableUtils.closeAndSuppressExceptions(inputStream, e2 -> {});
+                break;
+              }
+            }
+          }
+        }
+      });
+    }
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    synchronized (lock) {
+      return delegate.isFinished();
+    }
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    synchronized (lock) {
+      if (!readingStarted) {
+        throw new ISE("Please call startReading method before calling canRead()");
+      }
+      return delegate.canRead();
+    }
+  }
+
+  @Override
+  public Frame read()
+  {
+    synchronized (lock) {
+      if (!readingStarted) {
+        throw new ISE("Please call startReading method before calling read");
+      }
+      return delegate.read();
+    }
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    synchronized (lock) {
+      if (!readingStarted) {
+        throw new ISE("Please call startReading method before calling readabilityFuture()");
+      }
+      return delegate.readabilityFuture();
+    }
+  }
+
+
+  @Override
+  public void doneReading()
+  {
+    synchronized (lock) {
+      inputStreamFinished = true;
+      delegate.doneReading();
+      CloseableUtils.closeAndSuppressExceptions(inputStream, e -> {});
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
@@ -202,11 +202,11 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
 
 
   @Override
-  public void doneReading()
+  public void close()
   {
     synchronized (lock) {
       inputStreamFinished = true;
-      delegate.doneReading();
+      delegate.close();
       IOUtils.closeQuietly(inputStream);
     }
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableNilFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableNilFrameChannel.java
@@ -61,7 +61,7 @@ public class ReadableNilFrameChannel implements ReadableFrameChannel
   }
 
   @Override
-  public void doneReading()
+  public void close()
   {
     // Nothing to do.
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableNilFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableNilFrameChannel.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.Frame;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Empty channel.
+ */
+public class ReadableNilFrameChannel implements ReadableFrameChannel
+{
+  public static final ReadableNilFrameChannel INSTANCE = new ReadableNilFrameChannel();
+
+  private ReadableNilFrameChannel()
+  {
+  }
+
+  @Override
+  public boolean isFinished()
+  {
+    return true;
+  }
+
+  @Override
+  public boolean canRead()
+  {
+    return false;
+  }
+
+  @Override
+  public Frame read()
+  {
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public ListenableFuture<?> readabilityFuture()
+  {
+    return Futures.immediateFuture(null);
+  }
+
+  @Override
+  public void doneReading()
+  {
+    // Nothing to do.
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
@@ -22,6 +22,7 @@ package org.apache.druid.frame.channel;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.frame.Frame;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /**
@@ -32,7 +33,7 @@ import java.io.IOException;
  *
  * Channels implementing this interface are used by a single writer; they do not support concurrent writes.
  */
-public interface WritableFrameChannel
+public interface WritableFrameChannel extends Closeable
 {
   /**
    * Writes a frame with an attached partition number.
@@ -52,16 +53,20 @@ public interface WritableFrameChannel
   }
 
   /**
-   * Finish writing to this channel, unsuccessfully. Must be followed by a call to {@link #doneWriting()}.
+   * Called prior to {@link #close()} if the writer has failed. Must be followed by a call to {@link #close()}.
    */
   void fail() throws IOException;
 
   /**
    * Finish writing to this channel.
    *
+   * When this method is called without {@link #fail()} having previously been called, the writer is understood to have
+   * completed successfully.
+   *
    * After calling this method, no additional calls to {@link #write}, {@link #fail()}, or this method are permitted.
    */
-  void doneWriting() throws IOException;
+  @Override
+  void close() throws IOException;
 
   /**
    * Returns a future that resolves when {@link #write} is able to receive a new frame without blocking or throwing

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
@@ -29,6 +29,8 @@ import java.io.IOException;
  * method.
  *
  * May be implemented using an in-memory queue, disk file, stream, etc.
+ *
+ * Channels implementing this interface are used by a single writer; they do not support concurrent writes.
  */
 public interface WritableFrameChannel
 {

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.Frame;
+
+import java.io.IOException;
+
+/**
+ * Interface for writing a sequence of frames. Supports nonblocking writes through the {@link #writabilityFuture()}
+ * method.
+ *
+ * May be implemented using an in-memory queue, disk file, stream, etc.
+ */
+public interface WritableFrameChannel
+{
+  /**
+   * Writes a frame with an attached partition number.
+   *
+   * May throw an exception if {@link #writabilityFuture()} is unresolved.
+   */
+  void write(FrameWithPartition frameWithPartition) throws IOException;
+
+  /**
+   * Writes a frame without an attached partition number.
+   *
+   * May throw an exception if {@link #writabilityFuture()} is unresolved.
+   */
+  default void write(Frame frame) throws IOException
+  {
+    write(new FrameWithPartition(frame, FrameWithPartition.NO_PARTITION));
+  }
+
+  /**
+   * Finish writing to this channel, unsuccessfully. Must be followed by a call to {@link #doneWriting()}.
+   */
+  void abort() throws IOException;
+
+  /**
+   * Finish writing to this channel.
+   *
+   * After calling this method, no additional calls to {@link #write}, {@link #abort()}, or this method are permitted.
+   */
+  void doneWriting() throws IOException;
+
+  /**
+   * Returns a future that resolves when {@link #write} is able to receive a new frame without blocking or throwing
+   * an exception. The future never resolves to an exception.
+   */
+  ListenableFuture<?> writabilityFuture();
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java
@@ -52,12 +52,12 @@ public interface WritableFrameChannel
   /**
    * Finish writing to this channel, unsuccessfully. Must be followed by a call to {@link #doneWriting()}.
    */
-  void abort() throws IOException;
+  void fail() throws IOException;
 
   /**
    * Finish writing to this channel.
    *
-   * After calling this method, no additional calls to {@link #write}, {@link #abort()}, or this method are permitted.
+   * After calling this method, no additional calls to {@link #write}, {@link #fail()}, or this method are permitted.
    */
   void doneWriting() throws IOException;
 

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameFileChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameFileChannel.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 /**
  * Frame channel backed by a {@link FrameFileWriter}.
  */
-public class WritableStreamFrameChannel implements WritableFrameChannel
+public class WritableFrameFileChannel implements WritableFrameChannel
 {
   private final FrameFileWriter writer;
 
-  public WritableStreamFrameChannel(final FrameFileWriter writer)
+  public WritableFrameFileChannel(final FrameFileWriter writer)
   {
     this.writer = writer;
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.file.FrameFileWriter;
+
+import java.io.IOException;
+
+/**
+ * Frame channel backed by a {@link FrameFileWriter}.
+ */
+public class WritableStreamFrameChannel implements WritableFrameChannel
+{
+  private final FrameFileWriter writer;
+
+  public WritableStreamFrameChannel(final FrameFileWriter writer)
+  {
+    this.writer = writer;
+  }
+
+  @Override
+  public void write(FrameWithPartition frame) throws IOException
+  {
+    writer.writeFrame(frame.frame(), frame.partition());
+  }
+
+  @Override
+  public void abort() throws IOException
+  {
+    writer.abort();
+  }
+
+  @Override
+  public void doneWriting() throws IOException
+  {
+    writer.close();
+  }
+
+  @Override
+  public ListenableFuture<?> writabilityFuture()
+  {
+    return Futures.immediateFuture(true);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
@@ -44,7 +44,7 @@ public class WritableStreamFrameChannel implements WritableFrameChannel
   }
 
   @Override
-  public void abort() throws IOException
+  public void fail() throws IOException
   {
     writer.abort();
   }

--- a/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/WritableStreamFrameChannel.java
@@ -50,7 +50,7 @@ public class WritableStreamFrameChannel implements WritableFrameChannel
   }
 
   @Override
-  public void doneWriting() throws IOException
+  public void close() throws IOException
   {
     writer.close();
   }

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.file;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.channel.ReadableByteChunksFrameChannel;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.http.client.response.ClientResponse;
+import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.http.HttpChunk;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Optional;
+
+/**
+ * An {@link HttpResponseHandler} that streams data into a {@link ReadableByteChunksFrameChannel}.
+ *
+ * It is not required that the request actually fetches an entire frame file. The return object for this handler,
+ * {@link FrameFilePartialFetch}, allows callers to tell how much of the file was read in a particular request.
+ *
+ * This handler implements backpressure through {@link FrameFilePartialFetch#backpressureFuture()}. This allows callers
+ * to back off from issuing the next request, if appropriate. However: the handler does not implement backpressure
+ * through the {@link HttpResponseHandler.TrafficCop} mechanism. Therefore, it is important that each request retrieve
+ * a modest amount of data.
+ */
+public class FrameFileHttpResponseHandler implements HttpResponseHandler<FrameFilePartialFetch, FrameFilePartialFetch>
+{
+  private final ReadableByteChunksFrameChannel channel;
+
+  public FrameFileHttpResponseHandler(final ReadableByteChunksFrameChannel channel)
+  {
+    this.channel = Preconditions.checkNotNull(channel, "channel");
+  }
+
+  @Override
+  public ClientResponse<FrameFilePartialFetch> handleResponse(final HttpResponse response, final TrafficCop trafficCop)
+  {
+    final ClientResponse<FrameFilePartialFetch> clientResponse = ClientResponse.unfinished(new FrameFilePartialFetch());
+
+    if (response.getStatus().getCode() != HttpResponseStatus.OK.getCode()) {
+      // Note: if the error body is chunked, we will discard all future chunks due to setting exceptionCaught here.
+      // This is OK because we don't need the body; just the HTTP status code.
+      exceptionCaught(clientResponse, new ISE("Server for [%s] returned [%s]", channel.getId(), response.getStatus()));
+      return clientResponse;
+    } else {
+      return response(clientResponse, response.getContent());
+    }
+  }
+
+  @Override
+  public ClientResponse<FrameFilePartialFetch> handleChunk(
+      final ClientResponse<FrameFilePartialFetch> clientResponse,
+      final HttpChunk chunk,
+      final long chunkNum
+  )
+  {
+    return response(clientResponse, chunk.getContent());
+  }
+
+  @Override
+  public ClientResponse<FrameFilePartialFetch> done(final ClientResponse<FrameFilePartialFetch> clientResponse)
+  {
+    return ClientResponse.finished(clientResponse.getObj());
+  }
+
+  @Override
+  public void exceptionCaught(
+      final ClientResponse<FrameFilePartialFetch> clientResponse,
+      final Throwable e
+  )
+  {
+    clientResponse.getObj().exceptionCaught(e);
+  }
+
+  private ClientResponse<FrameFilePartialFetch> response(
+      final ClientResponse<FrameFilePartialFetch> clientResponse,
+      final ChannelBuffer content
+  )
+  {
+    final FrameFilePartialFetch clientResponseObj = clientResponse.getObj();
+
+    if (clientResponseObj.isExceptionCaught()) {
+      // If there was an exception, exit early without updating "channel". Important because "handleChunk" can be
+      // called after "handleException" in two cases: it can be called after an error "response", if the error body
+      // is chunked; and it can be called when "handleChunk" is called after "exceptionCaught". In neither case do
+      // we want to add that extra chunk to the channel.
+      return ClientResponse.finished(clientResponseObj);
+    }
+
+    final byte[] chunk = new byte[content.readableBytes()];
+    content.getBytes(content.readerIndex(), chunk);
+
+    try {
+      final Optional<ListenableFuture<?>> backpressureFuture = channel.addChunk(chunk);
+      backpressureFuture.ifPresent(clientResponseObj::setBackpressureFuture);
+      clientResponseObj.addBytesRead(chunk.length);
+    }
+    catch (Exception e) {
+      clientResponseObj.exceptionCaught(e);
+    }
+
+    return ClientResponse.unfinished(clientResponseObj);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
@@ -30,8 +30,6 @@ import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.Optional;
-
 /**
  * An {@link HttpResponseHandler} that streams data into a {@link ReadableByteChunksFrameChannel}.
  *
@@ -111,8 +109,12 @@ public class FrameFileHttpResponseHandler implements HttpResponseHandler<FrameFi
     content.getBytes(content.readerIndex(), chunk);
 
     try {
-      final Optional<ListenableFuture<?>> backpressureFuture = channel.addChunk(chunk);
-      backpressureFuture.ifPresent(clientResponseObj::setBackpressureFuture);
+      final ListenableFuture<?> backpressureFuture = channel.addChunk(chunk);
+
+      if (backpressureFuture != null) {
+        clientResponseObj.setBackpressureFuture(backpressureFuture);
+      }
+
       clientResponseObj.addBytesRead(chunk.length);
     }
     catch (Exception e) {

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
@@ -68,6 +68,8 @@ public class FrameFilePartialFetch
 
   /**
    * Future that resolves when it is a good time to request the next chunk of the frame file.
+   *
+   * Must only be called once, because the future is cleared once it is returned.
    */
   public ListenableFuture<?> backpressureFuture()
   {

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
@@ -28,6 +28,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Response object for {@link FrameFileHttpResponseHandler}.
+ *
+ * The handler mutates this object on each chunk of a chunked response. When the response is done, this object
+ * is returned to the caller.
  */
 public class FrameFilePartialFetch
 {

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.file;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Response object for {@link FrameFileHttpResponseHandler}.
+ */
+public class FrameFilePartialFetch
+{
+  private final AtomicLong bytesRead = new AtomicLong(0L);
+  private final AtomicReference<Throwable> exceptionCaught = new AtomicReference<>();
+  private final AtomicReference<ListenableFuture<?>> backpressureFuture = new AtomicReference<>();
+
+  FrameFilePartialFetch()
+  {
+  }
+
+  public boolean isEmptyFetch()
+  {
+    return exceptionCaught.get() == null && bytesRead.get() == 0L;
+  }
+
+  /**
+   * The exception that was encountered, if {@link #isExceptionCaught()} is true.
+   *
+   * @throws IllegalStateException if no exception was caught
+   */
+  public Throwable getExceptionCaught()
+  {
+    if (!isExceptionCaught()) {
+      throw new ISE("No exception caught");
+    }
+
+    return exceptionCaught.get();
+  }
+
+  /**
+   * Whether an exception was encountered during response processing.
+   */
+  public boolean isExceptionCaught()
+  {
+    return exceptionCaught.get() != null;
+  }
+
+  /**
+   * Future that resolves when it is a good time to request the next chunk of the frame file.
+   */
+  public ListenableFuture<?> backpressureFuture()
+  {
+    final ListenableFuture<?> future = backpressureFuture.getAndSet(null);
+    if (future != null) {
+      return future;
+    } else {
+      return Futures.immediateFuture(null);
+    }
+  }
+
+  void setBackpressureFuture(final ListenableFuture<?> future)
+  {
+    backpressureFuture.compareAndSet(null, future);
+  }
+
+  void exceptionCaught(final Throwable t)
+  {
+    exceptionCaught.compareAndSet(null, t);
+  }
+
+  void addBytesRead(final long n)
+  {
+    bytesRead.addAndGet(n);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFileWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFileWriter.java
@@ -171,7 +171,7 @@ public class FrameFileWriter implements Closeable
   public void close() throws IOException
   {
     if (closed) {
-      // Already closed things in abort().
+      // Already closed in abort() or a prior call to close().
       return;
     }
 

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
@@ -82,9 +82,11 @@ public class ClusterBy
    * rows in a given partition will have the exact same bucket key. It is most commonly used to implement
    * segment granularity during ingestion.
    *
+   * The bucket key is a prefix of the complete key.
+   *
    * Will always be less than, or equal to, the size of {@link #getColumns()}.
    *
-   * Not relevant when a ClusterBy instance is used as an ordering key.
+   * Not relevant when a ClusterBy instance is used as an ordering key rather than a partitioning key.
    */
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.segment.ColumnInspector;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes a key used for sorting or partitioning.
+ *
+ * Keys have columns, and some of those columns may comprise a "bucket key". See {@link #getBucketByCount()} for
+ * details about bucket keys.
+ */
+public class ClusterBy
+{
+  private final List<SortColumn> columns;
+  private final int bucketByCount;
+
+  @JsonCreator
+  public ClusterBy(
+      @JsonProperty("columns") List<SortColumn> columns,
+      @JsonProperty("bucketByCount") int bucketByCount
+  )
+  {
+    this.columns = Preconditions.checkNotNull(columns, "columns");
+    this.bucketByCount = bucketByCount;
+
+    if (bucketByCount < 0 || bucketByCount > columns.size()) {
+      throw new IAE("Invalid bucketByCount [%d]", bucketByCount);
+    }
+  }
+
+  /**
+   * Create an empty key.
+   */
+  public static ClusterBy none()
+  {
+    return new ClusterBy(Collections.emptyList(), 0);
+  }
+
+  /**
+   * The columns that comprise this key, in order.
+   */
+  @JsonProperty
+  public List<SortColumn> getColumns()
+  {
+    return columns;
+  }
+
+  /**
+   * How many fields from {@link #getColumns()} comprise the "bucket key". Bucketing is like strict partitioning: all
+   * rows in a given partition will have the exact same bucket key. It is most commonly used to implement
+   * segment granularity during ingestion.
+   *
+   * Will always be less than, or equal to, the size of {@link #getColumns()}.
+   *
+   * Not relevant when a ClusterBy instance is used as an ordering key.
+   */
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public int getBucketByCount()
+  {
+    return bucketByCount;
+  }
+
+  /**
+   * Create a reader for keys for this instance.
+   *
+   * The provided {@link ColumnInspector} is used to determine the types of fields in the keys. The provided signature
+   * does not have to exactly match the sortColumns: it merely has to contain them all.
+   */
+  public RowKeyReader keyReader(final ColumnInspector inspector)
+  {
+    final RowSignature.Builder newSignature = RowSignature.builder();
+
+    for (final SortColumn sortColumn : columns) {
+      final String columnName = sortColumn.columnName();
+      final ColumnCapabilities capabilities = inspector.getColumnCapabilities(columnName);
+      final ColumnType columnType =
+          Preconditions.checkNotNull(capabilities, "Type for column [%s]", columnName).toColumnType();
+
+      newSignature.add(columnName, columnType);
+    }
+
+    return RowKeyReader.create(newSignature.build());
+  }
+
+  /**
+   * Comparator that compares keys for this instance using the given signature.
+   */
+  public Comparator<RowKey> keyComparator()
+  {
+    return RowKeyComparator.create(columns);
+  }
+
+  /**
+   * Comparator that compares bucket keys for this instance. Bucket keys are retrieved by calling
+   * {@link RowKeyReader#trim(RowKey, int)} with {@link #getBucketByCount()}.
+   */
+  public Comparator<RowKey> bucketComparator()
+  {
+    if (bucketByCount == 0) {
+      return Comparators.alwaysEqual();
+    } else {
+      return RowKeyComparator.create(columns.subList(0, bucketByCount));
+    }
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClusterBy clusterBy = (ClusterBy) o;
+    return bucketByCount == clusterBy.bucketByCount && Objects.equals(columns, clusterBy.columns);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(columns, bucketByCount);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ClusterBy{" +
+           "columns=" + columns +
+           ", bucketByCount=" + bucketByCount +
+           '}';
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Boundaries of a partition marked by start and end keys. The keys are generally described by a
+ * {@link ClusterBy} instance that is not referenced here. (It is generally provided contextually.)
+ *
+ * Often, this object is part of a full partition set represented by {@link ClusterByPartitions}.
+ */
+public class ClusterByPartition
+{
+  @Nullable
+  private final RowKey start;
+  @Nullable
+  private final RowKey end;
+
+  @JsonCreator
+  public ClusterByPartition(
+      @JsonProperty("start") @Nullable RowKey start,
+      @JsonProperty("end") @Nullable RowKey end
+  )
+  {
+    this.start = start;
+    this.end = end;
+  }
+
+  /**
+   * Get the starting key for this range. It is inclusive (the range *does* contain this key).
+   *
+   * Null means the range is unbounded at the start.
+   */
+  @JsonProperty
+  @Nullable
+  public RowKey getStart()
+  {
+    return start;
+  }
+
+  /**
+   * Get the ending key for this range. It is exclusive (the range *does not* contain this key).
+   *
+   * Null means the range is unbounded at the end.
+   */
+  @JsonProperty
+  @Nullable
+  public RowKey getEnd()
+  {
+    return end;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClusterByPartition that = (ClusterByPartition) o;
+    return Objects.equals(start, that.start) && Objects.equals(end, that.end);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(start, end);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "{" + start + " -> " + end + "}";
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
@@ -91,6 +91,7 @@ public class ClusterByPartition
     return Objects.hash(start, end);
   }
 
+  @Override
   public String toString()
   {
     return "[" + start + ", " + end + ")";

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartition.java
@@ -91,9 +91,8 @@ public class ClusterByPartition
     return Objects.hash(start, end);
   }
 
-  @Override
   public String toString()
   {
-    return "{" + start + " -> " + end + "}";
+    return "[" + start + ", " + end + ")";
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartitions.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartitions.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.common.IAE;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Holder object for a set of {@link ClusterByPartition}. There are no preconditions put upon the partitions, except
+ * that there is at least one of them.
+ *
+ * In particular, they are not required to abut each other. See {@link #allAbutting()} to check if this particular list
+ * of partitions is in fact all abutting.
+ */
+public class ClusterByPartitions implements Iterable<ClusterByPartition>
+{
+  private static final ClusterByPartitions ONE_UNIVERSAL_PARTITION =
+      new ClusterByPartitions(Collections.singletonList(new ClusterByPartition(null, null)));
+
+  private final List<ClusterByPartition> ranges;
+
+  @JsonCreator
+  public ClusterByPartitions(final List<ClusterByPartition> ranges)
+  {
+    if (ranges.isEmpty()) {
+      throw new IAE("Must provide at least one range");
+    }
+
+    this.ranges = ranges;
+  }
+
+  public static ClusterByPartitions oneUniversalPartition()
+  {
+    return ONE_UNIVERSAL_PARTITION;
+  }
+
+  /**
+   * Whether this list of partitions is all abutting, meaning: each partition's start is equal to the previous
+   * partition's end.
+   *
+   * Note that the start of the first partition, and the end of the last partition, may or may not be unbounded.
+   * So this list of partitions may not cover the entire space even if they are all abutting.
+   */
+  public boolean allAbutting()
+  {
+    if (ranges.isEmpty()) {
+      return true;
+    }
+
+    // Walk through all ranges and make sure they're adjacent.
+    RowKey current = ranges.get(0).getEnd();
+
+    for (int i = 1; i < ranges.size(); i++) {
+      if (current == null || !current.equals(ranges.get(i).getStart())) {
+        return false;
+      }
+
+      current = ranges.get(i).getEnd();
+    }
+
+    return true;
+  }
+
+  public ClusterByPartition get(final int i)
+  {
+    return ranges.get(i);
+  }
+
+  public int size()
+  {
+    return ranges.size();
+  }
+
+  @JsonValue
+  public List<ClusterByPartition> ranges()
+  {
+    return ranges;
+  }
+
+  @Override
+  public Iterator<ClusterByPartition> iterator()
+  {
+    return ranges.iterator();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ClusterByPartitions that = (ClusterByPartitions) o;
+    return Objects.equals(ranges, that.ranges);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(ranges);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ClusterByPartitions{" +
+           "ranges=" + ranges +
+           '}';
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartitions.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterByPartitions.java
@@ -32,8 +32,8 @@ import java.util.Objects;
  * Holder object for a set of {@link ClusterByPartition}. There are no preconditions put upon the partitions, except
  * that there is at least one of them.
  *
- * In particular, they are not required to abut each other. See {@link #allAbutting()} to check if this particular list
- * of partitions is in fact all abutting.
+ * In particular, they are not required to abut each other or to be non-overlapping. Use {@link #allAbutting()} to
+ * check if this particular list of partitions is in fact all abutting (and, therefore, also non-overlapping).
  */
 public class ClusterByPartitions implements Iterable<ClusterByPartition>
 {

--- a/processing/src/main/java/org/apache/druid/frame/key/RowKeyComparator.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/RowKeyComparator.java
@@ -24,8 +24,10 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.druid.frame.read.FrameReaderUtils;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Comparator for {@link RowKey} instances.
@@ -140,5 +142,36 @@ public class RowKeyComparator implements Comparator<RowKey>
     }
 
     return 0;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RowKeyComparator that = (RowKeyComparator) o;
+    return firstFieldPosition == that.firstFieldPosition
+           && Arrays.equals(ascDescRunLengths, that.ascDescRunLengths);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    int result = Objects.hash(firstFieldPosition);
+    result = 31 * result + Arrays.hashCode(ascDescRunLengths);
+    return result;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RowKeyComparator{" +
+           "firstFieldPosition=" + firstFieldPosition +
+           ", ascDescRunLengths=" + Arrays.toString(ascDescRunLengths) +
+           '}';
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/processor/AwaitAnyWidget.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/AwaitAnyWidget.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.java.util.common.concurrent.Execs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper used by {@link FrameProcessorExecutor#runFully} when workers return {@link ReturnOrAwait#awaitAny}.
+ *
+ * The main idea is to reuse listeners from previous calls to {@link #awaitAny(IntSet)} in cases where a particular
+ * channel has not receieved any input since the last call. (Otherwise, listeners would pile up.)
+ */
+public class AwaitAnyWidget
+{
+  private final List<ReadableFrameChannel> channels;
+
+  @GuardedBy("listeners")
+  private final List<Listener> listeners;
+
+  public AwaitAnyWidget(final List<ReadableFrameChannel> channels)
+  {
+    this.channels = channels;
+    this.listeners = new ArrayList<>(channels.size());
+
+    for (int i = 0; i < channels.size(); i++) {
+      listeners.add(null);
+    }
+  }
+
+  public ListenableFuture<?> awaitAny(final IntSet awaitSet)
+  {
+    synchronized (listeners) {
+      final SettableFuture<?> retVal = SettableFuture.create();
+
+      final IntIterator awaitSetIterator = awaitSet.iterator();
+      while (awaitSetIterator.hasNext()) {
+        final int channelNumber = awaitSetIterator.nextInt();
+        final ReadableFrameChannel channel = channels.get(channelNumber);
+
+        if (channel.canRead() || channel.isFinished()) {
+          retVal.set(null);
+          return retVal;
+        } else {
+          final Listener priorListener = listeners.get(channelNumber);
+          if (priorListener == null || !priorListener.replaceFuture(retVal)) {
+            final Listener newListener = new Listener(retVal);
+            channel.readabilityFuture().addListener(newListener, Execs.directExecutor());
+            listeners.set(channelNumber, newListener);
+          }
+        }
+      }
+
+      return retVal;
+    }
+  }
+
+  private static class Listener implements Runnable
+  {
+    @GuardedBy("this")
+    private SettableFuture<?> future;
+
+    public Listener(SettableFuture<?> future)
+    {
+      this.future = future;
+    }
+
+    @Override
+    public void run()
+    {
+      synchronized (this) {
+        try {
+          future.set(null);
+        }
+        finally {
+          future = null;
+        }
+      }
+    }
+
+    /**
+     * Replaces our future if the listener has not fired yet.
+     *
+     * Returns true if the future was replaced, false if the listener has already fired.
+     */
+    public boolean replaceFuture(final SettableFuture<?> newFuture)
+    {
+      synchronized (this) {
+        if (future == null) {
+          return false;
+        } else {
+          future = newFuture;
+          return true;
+        }
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
@@ -38,7 +38,12 @@ public class BlockingQueueOutputChannelFactory implements OutputChannelFactory
   public OutputChannel openChannel(final int partitionNumber)
   {
     final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
-    return OutputChannel.pair(channel, ArenaMemoryAllocator.createOnHeap(frameSize), () -> channel, partitionNumber);
+    return OutputChannel.pair(
+        channel.writable(),
+        ArenaMemoryAllocator.createOnHeap(frameSize),
+        channel::readable,
+        partitionNumber
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
@@ -22,6 +22,9 @@ package org.apache.druid.frame.processor;
 import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 
+/**
+ * An {@link OutputChannelFactory} that generates {@link BlockingQueueFrameChannel}.
+ */
 public class BlockingQueueOutputChannelFactory implements OutputChannelFactory
 {
   private final int frameSize;

--- a/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+
+public class BlockingQueueOutputChannelFactory implements OutputChannelFactory
+{
+  private final int frameSize;
+
+  public BlockingQueueOutputChannelFactory(final int frameSize)
+  {
+    this.frameSize = frameSize;
+  }
+
+  @Override
+  public OutputChannel openChannel(final int partitionNumber)
+  {
+    final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+    return OutputChannel.pair(channel, ArenaMemoryAllocator.createOnHeap(frameSize), () -> channel, partitionNumber);
+  }
+
+  @Override
+  public OutputChannel openNilChannel(final int partitionNumber)
+  {
+    return OutputChannel.nil(partitionNumber);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
@@ -61,6 +61,11 @@ public class Bouncer
     return new Bouncer(Integer.MAX_VALUE);
   }
 
+  public int getMaxCount()
+  {
+    return maxCount;
+  }
+
   public ListenableFuture<Ticket> ticket()
   {
     synchronized (lock) {

--- a/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Limiter for access to some resource.
+ *
+ * Used by {@link FrameProcessorExecutor#runAllFully} to limit the number of outstanding processors.
+ */
+public class Bouncer
+{
+  private final int maxCount;
+
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private int currentCount = 0;
+
+  @GuardedBy("lock")
+  private final Queue<SettableFuture<Ticket>> waiters = new ArrayDeque<>();
+
+  public Bouncer(final int maxCount)
+  {
+    this.maxCount = maxCount;
+
+    if (maxCount <= 0) {
+      throw new ISE("maxConcurrentWorkers must be greater than zero");
+    }
+  }
+
+  public static Bouncer unlimited()
+  {
+    return new Bouncer(Integer.MAX_VALUE);
+  }
+
+  public ListenableFuture<Ticket> ticket()
+  {
+    synchronized (lock) {
+      if (currentCount < maxCount) {
+        currentCount++;
+        //noinspection UnstableApiUsage
+        return Futures.immediateFuture(new Ticket());
+      } else {
+        final SettableFuture<Ticket> future = SettableFuture.create();
+        waiters.add(future);
+        return future;
+      }
+    }
+  }
+
+  @VisibleForTesting
+  int getCurrentCount()
+  {
+    synchronized (lock) {
+      return currentCount;
+    }
+  }
+
+  public class Ticket
+  {
+    private final AtomicBoolean givenBack = new AtomicBoolean();
+
+    public void giveBack()
+    {
+      if (!givenBack.compareAndSet(false, true)) {
+        return;
+      }
+
+      // Loop to find a new home for this ticket that isn't canceled.
+
+      while (true) {
+        final SettableFuture<Ticket> nextFuture;
+
+        synchronized (lock) {
+          nextFuture = waiters.poll();
+
+          if (nextFuture == null) {
+            // Nobody was waiting.
+            currentCount--;
+            return;
+          }
+        }
+
+        if (nextFuture.set(new Ticket())) {
+          return;
+        }
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
- * Output channel factory implementation backed by a local file.
+ * An {@link OutputChannelFactory} that generates {@link WritableStreamFrameChannel} backed by {@link FrameFileWriter}.
  */
 public class FileOutputChannelFactory implements OutputChannelFactory
 {

--- a/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
@@ -24,7 +24,7 @@ import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
 import org.apache.druid.frame.channel.ReadableFileFrameChannel;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
-import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameFileChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.frame.file.FrameFileWriter;
 import org.apache.druid.java.util.common.FileUtils;
@@ -39,7 +39,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
- * An {@link OutputChannelFactory} that generates {@link WritableStreamFrameChannel} backed by {@link FrameFileWriter}.
+ * An {@link OutputChannelFactory} that generates {@link WritableFrameFileChannel} backed by {@link FrameFileWriter}.
  */
 public class FileOutputChannelFactory implements OutputChannelFactory
 {
@@ -60,8 +60,8 @@ public class FileOutputChannelFactory implements OutputChannelFactory
     final String fileName = StringUtils.format("part_%06d_%s", partitionNumber, UUID.randomUUID().toString());
     final File file = new File(fileChannelsDirectory, fileName);
 
-    final WritableStreamFrameChannel writableChannel =
-        new WritableStreamFrameChannel(
+    final WritableFrameFileChannel writableChannel =
+        new WritableFrameFileChannel(
             FrameFileWriter.open(
                 Files.newByteChannel(
                     file.toPath(),

--- a/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FileOutputChannelFactory.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.base.Suppliers;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.channel.ReadableFileFrameChannel;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.file.FrameFile;
+import org.apache.druid.frame.file.FrameFileWriter;
+import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * Output channel factory implementation backed by a local file.
+ */
+public class FileOutputChannelFactory implements OutputChannelFactory
+{
+  private final File fileChannelsDirectory;
+  private final int frameSize;
+
+  public FileOutputChannelFactory(final File fileChannelsDirectory, final int frameSize)
+  {
+    this.fileChannelsDirectory = fileChannelsDirectory;
+    this.frameSize = frameSize;
+  }
+
+  @Override
+  public OutputChannel openChannel(int partitionNumber) throws IOException
+  {
+    FileUtils.mkdirp(fileChannelsDirectory);
+
+    final String fileName = StringUtils.format("part_%06d_%s", partitionNumber, UUID.randomUUID().toString());
+    final File file = new File(fileChannelsDirectory, fileName);
+
+    final WritableStreamFrameChannel writableChannel =
+        new WritableStreamFrameChannel(
+            FrameFileWriter.open(
+                Files.newByteChannel(
+                    file.toPath(),
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE
+                ),
+                ByteBuffer.allocate(Frame.compressionBufferSize(frameSize))
+            )
+        );
+
+    final Supplier<ReadableFrameChannel> readableChannelSupplier = Suppliers.memoize(
+        () -> {
+          try {
+            final FrameFile frameFile = FrameFile.open(file, FrameFile.Flag.DELETE_ON_CLOSE);
+            return new ReadableFileFrameChannel(frameFile);
+          }
+          catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        }
+    )::get;
+
+    return OutputChannel.pair(
+        writableChannel,
+        ArenaMemoryAllocator.createOnHeap(frameSize),
+        readableChannelSupplier,
+        partitionNumber
+    );
+  }
+
+  @Override
+  public OutputChannel openNilChannel(final int partitionNumber)
+  {
+    return OutputChannel.nil(partitionNumber);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelBatcher.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelBatcher.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.java.util.common.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Processor that reads up to "maxFrames" frames from some input channels and combines them into a batch. There may be
+ * frames left over in the channels when the worker is done.
+ *
+ * Returns the batch and the set of channels that have more left to read.
+ *
+ * This processor does not close its input channels. The caller should do that after all input channels are finished.
+ */
+public class FrameChannelBatcher implements FrameProcessor<Pair<List<Frame>, IntSet>>
+{
+  private final List<ReadableFrameChannel> channels;
+  private final int maxFrames;
+
+  private final IntSet channelsToRead;
+  private List<Frame> out = new ArrayList<>();
+
+  public FrameChannelBatcher(
+      final List<ReadableFrameChannel> channels,
+      final int maxFrames
+  )
+  {
+    this.channels = channels;
+    this.maxFrames = maxFrames;
+    this.channelsToRead = new IntOpenHashSet();
+
+    for (int i = 0; i < channels.size(); i++) {
+      if (!channels.get(i).isFinished()) {
+        channelsToRead.add(i);
+      }
+    }
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return channels;
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ReturnOrAwait<Pair<List<Frame>, IntSet>> runIncrementally(final IntSet readableInputs)
+  {
+    if (channelsToRead.isEmpty()) {
+      return ReturnOrAwait.returnObject(Pair.of(flush(), IntSets.emptySet()));
+    }
+
+    if (readableInputs.isEmpty()) {
+      return ReturnOrAwait.awaitAny(channelsToRead);
+    }
+
+    // Random first channel to avoid biasing towards low-numbered channels.
+    final int firstChannel = ThreadLocalRandom.current().nextInt(channels.size());
+
+    // Modular iteration.
+    for (int i = 0; i < channels.size() && out.size() < maxFrames; i++) {
+      final int channelNumber = (firstChannel + i) % channels.size();
+
+      if (readableInputs.contains(channelNumber) && channelsToRead.contains(channelNumber)) {
+        final ReadableFrameChannel channel = channels.get(channelNumber);
+        if (channel.canRead()) {
+          out.add(channel.read());
+        } else if (channel.isFinished()) {
+          channelsToRead.remove(channelNumber);
+        }
+      }
+    }
+
+    if (out.size() >= maxFrames) {
+      return ReturnOrAwait.returnObject(Pair.of(flush(), channelsToRead));
+    } else {
+      return ReturnOrAwait.awaitAny(channelsToRead);
+    }
+  }
+
+  @Override
+  public void cleanup()
+  {
+    // Don't close the input channels, because this worker will not necessarily read through the entire channels.
+    // The channels should be closed by the caller.
+  }
+
+  private List<Frame> flush()
+  {
+    final List<Frame> tmp = out;
+    out = null;
+    return tmp;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
@@ -61,7 +61,7 @@ import java.util.function.Supplier;
  */
 public class FrameChannelMerger implements FrameProcessor<Long>
 {
-  static final long UNLIMITED = -1;
+  private static final long UNLIMITED = -1;
 
   private final List<ReadableFrameChannel> inputChannels;
   private final WritableFrameChannel outputChannel;

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntHeapPriorityQueue;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntPriorityQueue;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.FrameWithPartition;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.key.ClusterBy;
+import org.apache.druid.frame.key.ClusterByPartitions;
+import org.apache.druid.frame.key.FrameComparisonWidget;
+import org.apache.druid.frame.key.RowKey;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.segment.row.FrameColumnSelectorFactory;
+import org.apache.druid.frame.write.FrameWriter;
+import org.apache.druid.frame.write.FrameWriterFactory;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.Cursor;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+/**
+ * Processor that merges already-sorted inputChannels and writes a fully-sorted stream to a single outputChannel.
+ *
+ * Frames from input channels must be {@link org.apache.druid.frame.FrameType#ROW_BASED}. Output frames will
+ * be row-based as well.
+ *
+ * For unsorted output, use {@link FrameChannelMuxer} instead.
+ */
+public class FrameChannelMerger implements FrameProcessor<Long>
+{
+  static final long UNLIMITED = -1;
+
+  private final List<ReadableFrameChannel> inputChannels;
+  private final WritableFrameChannel outputChannel;
+  private final FrameReader frameReader;
+  private final ClusterBy clusterBy;
+  private final ClusterByPartitions partitions;
+  private final IntPriorityQueue priorityQueue;
+  private final FrameWriterFactory frameWriterFactory;
+  private final FramePlus[] currentFrames;
+  private final long rowLimit;
+  private long rowsOutput = 0;
+  private int currentPartition = 0;
+
+  // ColumnSelectorFactory that always reads from the current row in the merged sequence.
+  final MultiColumnSelectorFactory mergedColumnSelectorFactory;
+
+  public FrameChannelMerger(
+      final List<ReadableFrameChannel> inputChannels,
+      final FrameReader frameReader,
+      final WritableFrameChannel outputChannel,
+      final FrameWriterFactory frameWriterFactory,
+      final ClusterBy clusterBy,
+      @Nullable final ClusterByPartitions partitions,
+      final long rowLimit
+  )
+  {
+    if (inputChannels.isEmpty()) {
+      throw new IAE("Must have at least one input channel");
+    }
+
+    final ClusterByPartitions partitionsToUse =
+        partitions == null ? ClusterByPartitions.oneUniversalPartition() : partitions;
+
+    if (!partitionsToUse.allAbutting()) {
+      // Sanity check: we lack logic in FrameMergeIterator for not returning every row in the provided frames, so make
+      // sure there are no holes in partitionsToUse. Note that this check isn't perfect, because rows outside the
+      // min / max value of partitionsToUse can still appear. But it's a cheap check, and it doesn't hurt to do it.
+      throw new IAE("Partitions must all abut each other");
+    }
+
+    this.inputChannels = inputChannels;
+    this.outputChannel = outputChannel;
+    this.frameReader = frameReader;
+    this.frameWriterFactory = frameWriterFactory;
+    this.clusterBy = clusterBy;
+    this.partitions = partitionsToUse;
+    this.rowLimit = rowLimit;
+    this.currentFrames = new FramePlus[inputChannels.size()];
+    this.priorityQueue = new IntHeapPriorityQueue(
+        inputChannels.size(),
+        (k1, k2) -> currentFrames[k1].comparisonWidget.compare(
+            currentFrames[k1].rowNumber,
+            currentFrames[k2].comparisonWidget,
+            currentFrames[k2].rowNumber
+        )
+    );
+
+    final List<Supplier<ColumnSelectorFactory>> frameColumnSelectorFactorySuppliers =
+        new ArrayList<>(inputChannels.size());
+
+    for (int i = 0; i < inputChannels.size(); i++) {
+      final int frameNumber = i;
+      frameColumnSelectorFactorySuppliers.add(() -> currentFrames[frameNumber].cursor.getColumnSelectorFactory());
+    }
+
+    this.mergedColumnSelectorFactory =
+        new MultiColumnSelectorFactory(
+            frameColumnSelectorFactorySuppliers,
+
+            // Include ROW_SIGNATURE_COLUMN, ROW_MEMORY_COLUMN to potentially enable direct row memory copying.
+            // If these columns don't actually exist in the underlying column selector factories, they'll be ignored.
+            RowSignature.builder()
+                        .addAll(frameReader.signature())
+                        .add(FrameColumnSelectorFactory.ROW_SIGNATURE_COLUMN, ColumnType.UNKNOWN_COMPLEX)
+                        .add(FrameColumnSelectorFactory.ROW_MEMORY_COLUMN, ColumnType.UNKNOWN_COMPLEX)
+                        .build()
+        );
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return inputChannels;
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.singletonList(outputChannel);
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(final IntSet readableInputs) throws IOException
+  {
+    final IntSet awaitSet = populateCurrentFramesAndPriorityQueue();
+
+    if (!awaitSet.isEmpty()) {
+      return ReturnOrAwait.awaitAll(awaitSet);
+    }
+
+    if (priorityQueue.isEmpty()) {
+      // Done!
+      return ReturnOrAwait.returnObject(rowsOutput);
+    }
+
+    // Generate one output frame and stop for now.
+    outputChannel.write(nextFrame());
+    return ReturnOrAwait.runAgain();
+  }
+
+  private FrameWithPartition nextFrame()
+  {
+    if (priorityQueue.isEmpty()) {
+      throw new NoSuchElementException();
+    }
+
+    try (final FrameWriter mergedFrameWriter = frameWriterFactory.newFrameWriter(mergedColumnSelectorFactory)) {
+      int mergedFramePartition = currentPartition;
+      RowKey currentPartitionEnd = partitions.get(currentPartition).getEnd();
+
+      while (!priorityQueue.isEmpty()) {
+        final int currentChannel = priorityQueue.firstInt();
+        mergedColumnSelectorFactory.setCurrentFactory(currentChannel);
+
+        if (currentPartitionEnd != null) {
+          final FramePlus currentFrame = currentFrames[currentChannel];
+          if (currentFrame.comparisonWidget.compare(currentFrame.rowNumber, currentPartitionEnd) >= 0) {
+            // Current key is past the end of the partition. Advance currentPartition til it matches the current key.
+            do {
+              currentPartition++;
+              currentPartitionEnd = partitions.get(currentPartition).getEnd();
+            } while (currentPartitionEnd != null
+                     && currentFrame.comparisonWidget.compare(currentFrame.rowNumber, currentPartitionEnd) >= 0);
+
+            if (mergedFrameWriter.getNumRows() == 0) {
+              // Fall through: keep reading into the new partition.
+              mergedFramePartition = currentPartition;
+            } else {
+              // Return current frame.
+              break;
+            }
+          }
+        }
+
+        if (mergedFrameWriter.addSelection()) {
+          rowsOutput++;
+        } else {
+          if (mergedFrameWriter.getNumRows() == 0) {
+            throw new FrameRowTooLargeException(frameWriterFactory.allocatorCapacity());
+          }
+
+          // Frame is full. Don't touch the priority queue; instead, return the current frame.
+          break;
+        }
+
+        if (rowLimit != UNLIMITED && rowsOutput >= rowLimit) {
+          // Limit reached; we're done.
+          priorityQueue.clear();
+          Arrays.fill(currentFrames, null);
+        } else {
+          // Continue populating the priority queue.
+          if (currentChannel != priorityQueue.dequeueInt()) {
+            // There's a bug in this function. Nothing sensible we can really include in this error message.
+            throw new ISE("Unexpected channel");
+          }
+
+          final FramePlus channelFramePlus = currentFrames[currentChannel];
+          channelFramePlus.advance();
+
+          if (!channelFramePlus.cursor.isDone()) {
+            // Add this channel back to the priority queue, so it pops back out at the right time.
+            priorityQueue.enqueue(currentChannel);
+          } else {
+            // Done reading current frame from "channel".
+            // Clear it and see if there is another one available for immediate loading.
+            currentFrames[currentChannel] = null;
+
+            final ReadableFrameChannel channel = inputChannels.get(currentChannel);
+
+            if (channel.canRead()) {
+              // Read next frame from this channel.
+              final Frame frame = channel.read();
+              currentFrames[currentChannel] = new FramePlus(frame, frameReader, clusterBy);
+              priorityQueue.enqueue(currentChannel);
+            } else if (channel.isFinished()) {
+              // Done reading this channel. Fall through and continue with other channels.
+            } else {
+              // Nothing available, not finished; we can't continue. Finish up the current frame and return it.
+              break;
+            }
+          }
+        }
+      }
+
+      final Frame nextFrame = Frame.wrap(mergedFrameWriter.toByteArray());
+      return new FrameWithPartition(nextFrame, mergedFramePartition);
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+  }
+
+  /**
+   * Populates {@link #currentFrames}, wherever necessary, from any readable input channels. Returns the set of
+   * channels that are required for population but are not readable.
+   */
+  private IntSet populateCurrentFramesAndPriorityQueue()
+  {
+    final IntSet await = new IntOpenHashSet();
+
+    for (int i = 0; i < inputChannels.size(); i++) {
+      if (currentFrames[i] == null) {
+        final ReadableFrameChannel channel = inputChannels.get(i);
+
+        if (channel.canRead()) {
+          final Frame frame = channel.read();
+          currentFrames[i] = new FramePlus(frame, frameReader, clusterBy);
+          priorityQueue.enqueue(i);
+        } else if (!channel.isFinished()) {
+          await.add(i);
+        }
+      }
+    }
+
+    return await;
+  }
+
+  /**
+   * Class that encapsulates the apparatus necessary for reading a {@link Frame}.
+   */
+  private static class FramePlus
+  {
+    private final Cursor cursor;
+    private final FrameComparisonWidget comparisonWidget;
+    private int rowNumber;
+
+    private FramePlus(Frame frame, FrameReader frameReader, ClusterBy clusterBy)
+    {
+      this.cursor = FrameProcessors.makeCursor(frame, frameReader);
+      this.comparisonWidget = frameReader.makeComparisonWidget(frame, clusterBy.getColumns());
+      this.rowNumber = 0;
+    }
+
+    private void advance()
+    {
+      cursor.advance();
+      rowNumber++;
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMuxer.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMuxer.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Processor that merges frames from inputChannels into a single outputChannel. No sorting is done: input frames are
+ * simply written to the output channel as they come in.
+ *
+ * For sorted output, use {@link FrameChannelMerger} instead.
+ */
+public class FrameChannelMuxer implements FrameProcessor<Long>
+{
+  private final List<ReadableFrameChannel> inputChannels;
+  private final WritableFrameChannel outputChannel;
+
+  private final IntSet remainingChannels = new IntOpenHashSet();
+  private long rowsRead = 0L;
+
+  public FrameChannelMuxer(
+      final List<ReadableFrameChannel> inputChannels,
+      final WritableFrameChannel outputChannel
+  )
+  {
+    this.inputChannels = inputChannels;
+    this.outputChannel = outputChannel;
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return inputChannels;
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.singletonList(outputChannel);
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(final IntSet readableInputs) throws IOException
+  {
+    if (remainingChannels.isEmpty()) {
+      // First run.
+      for (int i = 0; i < inputChannels.size(); i++) {
+        final ReadableFrameChannel channel = inputChannels.get(i);
+        if (!channel.isFinished()) {
+          remainingChannels.add(i);
+        }
+      }
+    }
+
+    if (!readableInputs.isEmpty()) {
+      // Avoid biasing towards lower-numbered channels.
+      final int channelIdx = ThreadLocalRandom.current().nextInt(readableInputs.size());
+
+      int i = 0;
+      for (IntIterator iterator = readableInputs.iterator(); iterator.hasNext(); i++) {
+        final int channelNumber = iterator.nextInt();
+        final ReadableFrameChannel channel = inputChannels.get(channelNumber);
+
+        if (channel.isFinished()) {
+          remainingChannels.remove(channelNumber);
+        } else if (i == channelIdx) {
+          final Frame frame = channel.read();
+          outputChannel.write(frame);
+          rowsRead += frame.numRows();
+        }
+      }
+    }
+
+    if (remainingChannels.isEmpty()) {
+      return ReturnOrAwait.returnObject(rowsRead);
+    } else {
+      return ReturnOrAwait.awaitAny(remainingChannels);
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
@@ -62,8 +62,8 @@ public interface FrameProcessor<T>
 
   /**
    * Cleans up resources used by this worker, including signalling to input and output channels that we are
-   * done reading and writing, via {@link ReadableFrameChannel#doneReading()} and
-   * {@link WritableFrameChannel#doneWriting()}.
+   * done reading and writing, via {@link ReadableFrameChannel#close()} and
+   * {@link WritableFrameChannel#close()}.
    *
    * This method may be called before the worker reports completion via {@link #runIncrementally}, especially in
    * cases of cancellation.

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
@@ -63,12 +63,18 @@ public interface FrameProcessor<T>
   ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws InterruptedException, IOException;
 
   /**
-   * Cleans up resources used by this worker, including signalling to input and output channels that we are
-   * done reading and writing, via {@link ReadableFrameChannel#close()} and
-   * {@link WritableFrameChannel#close()}.
+   * Closes resources used by this worker.
    *
-   * This method may be called before the worker reports completion via {@link #runIncrementally}, especially in
-   * cases of cancellation.
+   * Exact same concept as {@link java.io.Closeable#close()}. This interface does not extend Closeable, in order to
+   * make it easier to find all places where cleanup happens. (Static analysis tools can lose the thread when Closeables
+   * are closed in generic ways.)
+   *
+   * Implementations typically call {@link ReadableFrameChannel#close()} and
+   * {@link WritableFrameChannel#close()} on all input and output channels, as well as releasing any additional
+   * resources that may be held.
+   *
+   * In cases of cancellation, this method may be called even if {@link #runIncrementally} has not yet returned a
+   * result via {@link ReturnOrAwait#returnObject}.
    */
   void cleanup() throws IOException;
 }

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
@@ -58,7 +58,7 @@ public interface FrameProcessor<T>
    *
    * @return either a final return value or a set of input channels to wait for. Must be nonnull.
    */
-  ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException;
+  ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws InterruptedException, IOException;
 
   /**
    * Cleans up resources used by this worker, including signalling to input and output channels that we are

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A FrameProcessor is like an incremental version of Runnable that operates on {@link ReadableFrameChannel} and
+ * {@link WritableFrameChannel}.
+ *
+ * It is designed to enable interleaved non-blocking work on a fixed-size thread pool. Typically, this is done using
+ * an instance of {@link FrameProcessorExecutor}.
+ */
+public interface FrameProcessor<T>
+{
+  /**
+   * List of input channels. The positions of channels in this list are used to build the {@code readableInputs} set
+   * provided to {@link #runIncrementally}.
+   */
+  List<ReadableFrameChannel> inputChannels();
+
+  /**
+   * List of output channels.
+   */
+  List<WritableFrameChannel> outputChannels();
+
+  /**
+   * Runs some of the algorithm, without blocking, and either returns a value or a set of input channels
+   * to wait for. This method is called by {@link FrameProcessorExecutor#runFully} when all output channels are
+   * writable. Therefore, it is guaranteed that each output channel can accept at least one frame.
+   *
+   * This method must not read more than one frame from each readable input channel, and must not write more than one
+   * frame to each output channel.
+   *
+   * @param readableInputs channels from {@link #inputChannels()} that are either finished or ready to read.
+   *
+   * @return either a final return value or a set of input channels to wait for. Must be nonnull.
+   */
+  ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException;
+
+  /**
+   * Cleans up resources used by this worker, including signalling to input and output channels that we are
+   * done reading and writing, via {@link ReadableFrameChannel#doneReading()} and
+   * {@link WritableFrameChannel#doneWriting()}.
+   *
+   * This method may be called before the worker reports completion via {@link #runIncrementally}, especially in
+   * cases of cancellation.
+   */
+  void cleanup() throws IOException;
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java
@@ -55,6 +55,8 @@ public interface FrameProcessor<T>
    * frame to each output channel.
    *
    * @param readableInputs channels from {@link #inputChannels()} that are either finished or ready to read.
+   *                       That is: either {@link ReadableFrameChannel#isFinished()} or
+   *                       {@link ReadableFrameChannel#canRead()} are true.
    *
    * @return either a final return value or a set of input channels to wait for. Must be nonnull.
    */

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
@@ -228,6 +228,7 @@ public class FrameProcessorExecutor
           retVal = Either.value(processor.runIncrementally(readableInputs));
         }
         catch (Throwable e) {
+          // Catch InterruptedException too: interrupt was meant for the processor, not us.
           retVal = Either.error(e);
         }
         finally {

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
@@ -146,6 +146,7 @@ public class FrameProcessorExecutor
           if (result.isReturn()) {
             succeed(result.value());
           } else {
+            // Don't retain a reference to this set: it may be mutated the next time the processor runs.
             final IntSet await = result.awaitSet();
 
             if (await.isEmpty()) {

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
@@ -1,0 +1,602 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+/**
+ * Manages execution of {@link FrameProcessor} in an {@link ExecutorService}.
+ *
+ * If you want single threaded execution, use {@code Execs.singleThreaded()}. It is not a good idea to use this with a
+ * same-thread executor like {@code Execs.directExecutor()}, because it will lead to deep call stacks.
+ */
+public class FrameProcessorExecutor
+{
+  private static final Logger log = new Logger(FrameProcessorExecutor.class);
+
+  private final ListeningExecutorService exec;
+
+  private final Object lock = new Object();
+
+  // Futures that are active and therefore cancelable.
+  // Does not include return futures: those are in cancelableReturnFutures.
+  @GuardedBy("lock")
+  private final SetMultimap<String, ListenableFuture<?>> cancelableFutures =
+      Multimaps.newSetMultimap(new HashMap<>(), Sets::newIdentityHashSet);
+
+  // Return futures that are active and therefore cancelable.
+  @GuardedBy("lock")
+  private final SetMultimap<String, ListenableFuture<?>> cancelableReturnFutures =
+      Multimaps.newSetMultimap(new HashMap<>(), Sets::newIdentityHashSet);
+
+  // Processors that are active and therefore cancelable. They may not currently be running on an actual thread.
+  @GuardedBy("lock")
+  private final SetMultimap<String, FrameProcessor<?>> cancelableProcessors =
+      Multimaps.newSetMultimap(new HashMap<>(), Sets::newIdentityHashSet);
+
+  // Processors that are currently running on a thread.
+  // The "lock" is notified when processors are removed from runningProcessors.
+  @GuardedBy("lock")
+  private final Map<FrameProcessor<?>, Thread> runningProcessors = new IdentityHashMap<>();
+
+  public FrameProcessorExecutor(final ListeningExecutorService exec)
+  {
+    this.exec = exec;
+  }
+
+  /**
+   * Returns the underlying executor service used by this executor.
+   */
+  public ListeningExecutorService getExecutorService()
+  {
+    return exec;
+  }
+
+  /**
+   * Runs a processor until it is done, and returns a future that resolves when execution is complete.
+   *
+   * If "cancellationId" is provided, it can be used with the {@link #cancel(String)} method to cancel all processors
+   * currently running with the same cancellationId.
+   */
+  public <T> ListenableFuture<T> runFully(final FrameProcessor<T> processor, @Nullable final String cancellationId)
+  {
+    final List<ReadableFrameChannel> inputChannels = processor.inputChannels();
+    final List<WritableFrameChannel> outputChannels = processor.outputChannels();
+    final SettableFuture<T> finished = registerCancelableFuture(SettableFuture.create(), true, cancellationId);
+
+    class ExecutorRunnable implements Runnable
+    {
+      private final AwaitAnyWidget awaitAnyWidget = new AwaitAnyWidget(inputChannels);
+
+      @Override
+      public void run()
+      {
+        try {
+          final List<ListenableFuture<?>> allWritabilityFutures = gatherWritabilityFutures();
+          final List<ListenableFuture<?>> writabilityFuturesToWaitFor =
+              allWritabilityFutures.stream().filter(f -> !f.isDone()).collect(Collectors.toList());
+
+          logProcessorStatusString(processor, finished, allWritabilityFutures);
+
+          if (!writabilityFuturesToWaitFor.isEmpty()) {
+            runProcessorAfterFutureResolves(Futures.allAsList(writabilityFuturesToWaitFor));
+            return;
+          }
+
+          final Optional<ReturnOrAwait<T>> maybeResult = runProcessorNow();
+
+          if (!maybeResult.isPresent()) {
+            // Processor exited abnormally. Just exit; cleanup would have been handled elsewhere.
+            return;
+          }
+
+          final ReturnOrAwait<T> result = maybeResult.get();
+          logProcessorStatusString(processor, finished, null);
+
+          if (result.isReturn()) {
+            succeed(result.value());
+          } else {
+            final IntSet await = result.awaitSet();
+
+            if (await.isEmpty()) {
+              exec.submit(ExecutorRunnable.this);
+            } else if (result.isAwaitAll() || await.size() == 1) {
+              final List<ListenableFuture<?>> readabilityFutures = new ArrayList<>();
+
+              for (final int channelNumber : await) {
+                final ReadableFrameChannel channel = inputChannels.get(channelNumber);
+                if (!channel.isFinished() && !channel.canRead()) {
+                  readabilityFutures.add(channel.readabilityFuture());
+                }
+              }
+
+              if (readabilityFutures.isEmpty()) {
+                exec.submit(ExecutorRunnable.this);
+              } else {
+                runProcessorAfterFutureResolves(Futures.allAsList(readabilityFutures));
+              }
+            } else {
+              // Await any.
+              runProcessorAfterFutureResolves(awaitAnyWidget.awaitAny(await));
+            }
+          }
+        }
+        catch (Throwable e) {
+          fail(e);
+        }
+      }
+
+      private List<ListenableFuture<?>> gatherWritabilityFutures()
+      {
+        final List<ListenableFuture<?>> futures = new ArrayList<>();
+
+        for (final WritableFrameChannel channel : outputChannels) {
+          futures.add(channel.writabilityFuture());
+        }
+
+        return futures;
+      }
+
+      /**
+       * Executes {@link FrameProcessor#runIncrementally} on the currently-readable inputs, while respecting
+       * cancellation. Returns an empty Optional if the processor exited abnormally (canceled or failed). Returns a
+       * present Optional if the processor ran successfully. Throws an exception if the processor does.
+       */
+      private Optional<ReturnOrAwait<T>> runProcessorNow()
+      {
+        final IntSet readableInputs = new IntOpenHashSet(inputChannels.size());
+
+        for (int i = 0; i < inputChannels.size(); i++) {
+          final ReadableFrameChannel channel = inputChannels.get(i);
+          if (channel.isFinished() || channel.canRead()) {
+            readableInputs.add(i);
+          }
+        }
+
+        if (cancellationId != null) {
+          // After this synchronized block, our thread may be interrupted by cancellations, because "cancel"
+          // checks "runningProcessors".
+          synchronized (lock) {
+            if (cancelableProcessors.containsEntry(cancellationId, processor)) {
+              runningProcessors.put(processor, Thread.currentThread());
+            } else {
+              // Processor has been canceled. We don't need to handle cleanup, because someone else did it.
+              return Optional.empty();
+            }
+          }
+        }
+
+        boolean canceled = false;
+        Either<Throwable, ReturnOrAwait<T>> retVal;
+
+        try {
+          if (Thread.interrupted()) {
+            throw new InterruptedException();
+          }
+
+          retVal = Either.value(processor.runIncrementally(readableInputs));
+        }
+        catch (Throwable e) {
+          retVal = Either.error(e);
+        }
+        finally {
+          if (cancellationId != null) {
+            // After this synchronized block, our thread will no longer be interrupted by cancellations,
+            // because "cancel" checks "runningProcessors".
+            synchronized (lock) {
+              if (Thread.interrupted()) {
+                // ignore: interrupt was meant for the processor, but came after the processor already exited.
+              }
+
+              runningProcessors.remove(processor);
+              lock.notifyAll();
+
+              if (!cancelableProcessors.containsEntry(cancellationId, processor)) {
+                // Processor has been canceled by one of the "cancel" methods. They will handle cleanup.
+                canceled = true;
+              }
+            }
+          }
+        }
+
+        if (canceled) {
+          return Optional.empty();
+        } else {
+          return Optional.of(retVal.valueOrThrow());
+        }
+      }
+
+      private <V> void runProcessorAfterFutureResolves(final ListenableFuture<V> future)
+      {
+        final ListenableFuture<V> cancelableFuture = registerCancelableFuture(future, false, cancellationId);
+
+        Futures.addCallback(
+            cancelableFuture,
+            new FutureCallback<V>()
+            {
+              @Override
+              public void onSuccess(final V ignored)
+              {
+                try {
+                  exec.submit(ExecutorRunnable.this);
+                }
+                catch (Throwable e) {
+                  fail(e);
+                }
+              }
+
+              @Override
+              public void onFailure(Throwable t)
+              {
+                // Ignore cancellation.
+                if (!cancelableFuture.isCancelled()) {
+                  fail(t);
+                }
+              }
+            }
+        );
+      }
+
+      /**
+       * Called when a processor succeeds.
+       *
+       * Runs the cleanup routine and sets the finished future to a particular value. If cleanup fails, sets the
+       * finished future to an error.
+       */
+      private void succeed(T value)
+      {
+        try {
+          doProcessorCleanup();
+        }
+        catch (Throwable e) {
+          finished.setException(e);
+          return;
+        }
+
+        finished.set(value);
+      }
+
+      /**
+       * Called when a processor fails.
+       *
+       * Cancels output channels, runs the cleanup routine, and sets the finished future to an error.
+       */
+      private void fail(Throwable e)
+      {
+        for (final WritableFrameChannel outputChannel : outputChannels) {
+          try {
+            outputChannel.abort();
+          }
+          catch (Throwable e1) {
+            e.addSuppressed(e1);
+          }
+        }
+
+        try {
+          doProcessorCleanup();
+        }
+        catch (Throwable e1) {
+          e.addSuppressed(e1);
+        }
+
+        finished.setException(e);
+      }
+
+      /**
+       * Called when a processor exits via {@link #succeed} or {@link #fail}. Not called when a processor
+       * is canceled.
+       */
+      void doProcessorCleanup() throws IOException
+      {
+        final boolean doCleanup;
+
+        if (cancellationId != null) {
+          synchronized (lock) {
+            // Skip cleanup if the processor is no longer in cancelableProcessors. This means one of the "cancel"
+            // methods is going to do the cleanup.
+            doCleanup = cancelableProcessors.remove(cancellationId, processor);
+          }
+        } else {
+          doCleanup = true;
+        }
+
+        if (doCleanup) {
+          processor.cleanup();
+        }
+      }
+    }
+
+    final ExecutorRunnable runnable = new ExecutorRunnable();
+
+    finished.addListener(
+        () -> {
+          logProcessorStatusString(processor, finished, null);
+
+          // If the future was canceled, and the processor is cancelable, then cancel the processor too.
+          if (finished.isCancelled() && cancellationId != null) {
+            boolean didRemoveFromCancelableProcessors;
+
+            synchronized (lock) {
+              didRemoveFromCancelableProcessors = cancelableProcessors.remove(cancellationId, processor);
+            }
+
+            if (didRemoveFromCancelableProcessors) {
+              try {
+                cancel(Collections.singleton(processor));
+              }
+              catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              catch (Throwable e) {
+                // No point throwing. Exceptions thrown in listeners don't go anywhere.
+                log.noStackTrace().warn(e, "Exception encountered while canceling processor [%s]", processor);
+              }
+            }
+          }
+        },
+        Execs.directExecutor()
+    );
+
+    logProcessorStatusString(processor, finished, null);
+    registerCancelableProcessor(processor, cancellationId);
+    exec.submit(runnable);
+    return finished;
+  }
+
+  /**
+   * Runs a sequence of processors and returns a future that resolves when execution is complete. Returns a value
+   * accumulated using the provided {@code accumulateFn}.
+   *
+   * @param processors               sequence of processors to run
+   * @param initialResult            initial value for result accumulation. If there are no processors at all, this
+   *                                 is returned.
+   * @param accumulateFn             result accumulator. Applied in a critical section, so it should be something
+   *                                 that executes quickly. It gets {@code initialResult} for the initial accumulation.
+   * @param maxOutstandingProcessors maximum number of processors to run at once
+   * @param bouncer                  additional limiter on outstanding processors, beyond maxOutstandingProcessors.
+   *                                 Useful when there is some finite resource being shared against multiple different
+   *                                 calls to this method.
+   * @param cancellationId           optional cancellation id for {@link #runFully}.
+   */
+  public <T, ResultType> ListenableFuture<ResultType> runAllFully(
+      final Sequence<? extends FrameProcessor<T>> processors,
+      final ResultType initialResult,
+      final BiFunction<ResultType, T, ResultType> accumulateFn,
+      final int maxOutstandingProcessors,
+      final Bouncer bouncer,
+      @Nullable final String cancellationId
+  )
+  {
+    // Logic resides in a separate class in order to keep this one simpler.
+    return new RunAllFullyWidget<>(
+        processors,
+        this,
+        initialResult,
+        accumulateFn,
+        maxOutstandingProcessors,
+        bouncer,
+        cancellationId
+    ).run();
+  }
+
+  /**
+   * Cancels all processors associated with a given cancellationId. Waits for the processors to exit before
+   * returning.
+   */
+  public void cancel(final String cancellationId) throws InterruptedException
+  {
+    Preconditions.checkNotNull(cancellationId, "cancellationId");
+
+    final Set<ListenableFuture<?>> futuresToCancel;
+    final Set<FrameProcessor<?>> processorsToCancel;
+    final Set<ListenableFuture<?>> returnFuturesToCancel;
+
+    synchronized (lock) {
+      futuresToCancel = cancelableFutures.removeAll(cancellationId);
+      processorsToCancel = cancelableProcessors.removeAll(cancellationId);
+      returnFuturesToCancel = cancelableReturnFutures.removeAll(cancellationId);
+    }
+
+    // Cancel all associated non-return futures. Do this first, because it prevents new processors from being
+    // scheduled by runAllFully.
+    for (final ListenableFuture<?> future : futuresToCancel) {
+      future.cancel(true);
+    }
+
+    // Cancel all processors. Do this before return futures, because this allows the processors to be canceled
+    // all at once, cleanly. Once we start canceling futuresToCancel, we cancel the processor continuation and return
+    // futures one-by-one, which if done first would lead to a noisier cancellation.
+    cancel(processorsToCancel);
+
+    // Cancel all associated return futures.
+    for (final ListenableFuture<?> future : returnFuturesToCancel) {
+      future.cancel(true);
+    }
+  }
+
+  /**
+   * Register a future that will be canceled when the provided {@code cancellationId} is canceled.
+   *
+   * @param future         cancelable future
+   * @param isReturn       if this is a return future for a processor; these are canceled last
+   * @param cancellationId cancellation id
+   */
+  <T, FutureType extends ListenableFuture<T>> FutureType registerCancelableFuture(
+      final FutureType future,
+      final boolean isReturn,
+      @Nullable final String cancellationId
+  )
+  {
+    if (cancellationId != null) {
+      synchronized (lock) {
+        final SetMultimap<String, ListenableFuture<?>> map = isReturn ? cancelableReturnFutures : cancelableFutures;
+        map.put(cancellationId, future);
+        future.addListener(
+            () -> {
+              synchronized (lock) {
+                map.remove(cancellationId, future);
+              }
+            },
+            Execs.directExecutor()
+        );
+      }
+    }
+
+    return future;
+  }
+
+  @VisibleForTesting
+  int cancelableProcessorCount()
+  {
+    synchronized (lock) {
+      return cancelableProcessors.size();
+    }
+  }
+
+  /**
+   * Cancels a given set of processors. Waits for the processors to exit before returning.
+   * Calls {@link FrameProcessor#cleanup()} on all processors.
+   *
+   * Callers must remove processors from {@link #cancelableProcessors} before calling this method.
+   */
+  private void cancel(final Set<FrameProcessor<?>> processorsToCancel)
+      throws InterruptedException
+  {
+    synchronized (lock) {
+      for (final FrameProcessor<?> processor : processorsToCancel) {
+        final Thread processorThread = runningProcessors.get(processor);
+        if (processorThread != null) {
+          // Interrupt the thread running the processor. Do this under lock, because we want to make sure we don't
+          // interrupt the thread shortly *before* or *after* it runs the processor.
+          processorThread.interrupt();
+        }
+      }
+
+      // Wait for all running processors to stop running. Then clean them up outside the critical section.
+      while (processorsToCancel.stream().anyMatch(runningProcessors::containsKey)) {
+        lock.wait();
+      }
+    }
+
+    // Now processorsToCancel are not running, also won't run again, because the caller removed them
+    // from cancelableProcessors. (runProcessorNow checks cancelableProcessors.) Run their cleanup routines
+    // outside the critical section.
+    try (final Closer closer = Closer.create()) {
+      for (final FrameProcessor<?> processor : processorsToCancel) {
+        for (final WritableFrameChannel outputChannel : processor.outputChannels()) {
+          closer.register(outputChannel::abort);
+        }
+
+        closer.register(processor::cleanup);
+      }
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private <T> void registerCancelableProcessor(final FrameProcessor<T> processor, @Nullable final String cancellationId)
+  {
+    if (cancellationId != null) {
+      synchronized (lock) {
+        cancelableProcessors.put(cancellationId, processor);
+      }
+    }
+  }
+
+  private static <T> void logProcessorStatusString(
+      final FrameProcessor<T> processor,
+      final ListenableFuture<?> finishedFuture,
+      @Nullable final List<ListenableFuture<?>> writabilityFutures
+  )
+  {
+    if (log.isDebugEnabled()) {
+      final StringBuilder sb = new StringBuilder()
+          .append("Processor [")
+          .append(processor)
+          .append("]; in=[");
+
+      for (ReadableFrameChannel channel : processor.inputChannels()) {
+        if (channel.canRead()) {
+          sb.append("R"); // R for readable
+        } else if (channel.isFinished()) {
+          sb.append("D"); // D for done
+        } else {
+          sb.append("~"); // ~ for waiting
+        }
+      }
+
+      sb.append("]");
+
+      if (writabilityFutures != null) {
+        sb.append("; out=[");
+
+        for (final ListenableFuture<?> future : writabilityFutures) {
+          if (future.isDone()) {
+            sb.append("W"); // W for writable
+          } else {
+            sb.append("~"); // ~ for waiting
+          }
+        }
+
+        sb.append("]");
+      }
+
+      sb.append("; cancel=").append(finishedFuture.isCancelled() ? "y" : "n");
+      sb.append("; done=").append(finishedFuture.isDone() ? "y" : "n");
+
+      log.debug(StringUtils.encodeForFormat(sb.toString()));
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.segment.FrameStorageAdapter;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.guava.Yielders;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.Cursor;
+import org.apache.druid.segment.VirtualColumns;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class FrameProcessors
+{
+  private FrameProcessors()
+  {
+    // No instantiation.
+  }
+
+  public static <T> FrameProcessor<T> withBaggage(final FrameProcessor<T> processor, final Closeable baggage)
+  {
+    class FrameProcessorWithBaggage implements FrameProcessor<T>
+    {
+      final AtomicBoolean cleanedUp = new AtomicBoolean();
+
+      @Override
+      public List<ReadableFrameChannel> inputChannels()
+      {
+        return processor.inputChannels();
+      }
+
+      @Override
+      public List<WritableFrameChannel> outputChannels()
+      {
+        return processor.outputChannels();
+      }
+
+      @Override
+      public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException
+      {
+        return processor.runIncrementally(readableInputs);
+      }
+
+      @Override
+      public void cleanup() throws IOException
+      {
+        if (cleanedUp.compareAndSet(false, true)) {
+          //noinspection EmptyTryBlock
+          try (Closeable ignore1 = baggage;
+               Closeable ignore2 = processor::cleanup) {
+            // piggy-back try-with-resources semantics
+          }
+        }
+      }
+
+      @Override
+      public String toString()
+      {
+        return processor + " (with baggage)";
+      }
+    }
+
+    return new FrameProcessorWithBaggage();
+  }
+
+  public static Cursor makeCursor(final Frame frame, final FrameReader frameReader)
+  {
+    // Safe to never close the Sequence that the Cursor comes from, because it does not do anything when it is closed.
+    // Refer to FrameStorageAdapter#makeCursors.
+
+    return Yielders.each(
+        new FrameStorageAdapter(frame, frameReader, Intervals.ETERNITY)
+            .makeCursors(null, Intervals.ETERNITY, VirtualColumns.EMPTY, Granularities.ALL, false, null)
+    ).get();
+  }
+
+  /**
+   * Helper method for implementing {@link FrameProcessor#cleanup()}.
+   *
+   * The objects are closed in the order provided.
+   */
+  public static void closeAll(
+      final List<ReadableFrameChannel> readableFrameChannels,
+      final List<WritableFrameChannel> writableFrameChannels,
+      final Closeable... otherCloseables
+  ) throws IOException
+  {
+    final Closer closer = Closer.create();
+
+    // Add everything to the Closer in reverse order, because the Closer closes in reverse order.
+
+    for (Closeable closeable : Lists.reverse(Arrays.asList(otherCloseables))) {
+      if (closeable != null) {
+        closer.register(closeable);
+      }
+    }
+
+    for (WritableFrameChannel channel : Lists.reverse(writableFrameChannels)) {
+      closer.register(channel::doneWriting);
+    }
+
+    for (ReadableFrameChannel channel : Lists.reverse(readableFrameChannels)) {
+      closer.register(channel::doneReading);
+    }
+
+    closer.close();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
@@ -65,7 +65,7 @@ public class FrameProcessors
       }
 
       @Override
-      public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException
+      public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws InterruptedException, IOException
       {
         return processor.runIncrementally(readableInputs);
       }

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessors.java
@@ -125,11 +125,11 @@ public class FrameProcessors
     }
 
     for (WritableFrameChannel channel : Lists.reverse(writableFrameChannels)) {
-      closer.register(channel::doneWriting);
+      closer.register(channel::close);
     }
 
     for (ReadableFrameChannel channel : Lists.reverse(readableFrameChannels)) {
-      closer.register(channel::doneReading);
+      closer.register(channel::close);
     }
 
     closer.close();

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameRowTooLargeException.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameRowTooLargeException.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.apache.druid.frame.write.FrameWriter;
+import org.apache.druid.java.util.common.StringUtils;
+
+/**
+ * Exception that is conventionally thrown by workers when they call
+ * {@link FrameWriter#addSelection} and it returns false on an empty frame, or in
+ * a situation where allocating a new frame is impractical.
+ */
+public class FrameRowTooLargeException extends RuntimeException
+{
+  private final long maxFrameSize;
+
+  public FrameRowTooLargeException(final long maxFrameSize)
+  {
+    super(StringUtils.format("Row too large to add to frame (max frame size = %,d)", maxFrameSize));
+    this.maxFrameSize = maxFrameSize;
+  }
+
+  public long getMaxFrameSize()
+  {
+    return maxFrameSize;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/MultiColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/MultiColumnSelectorFactory.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.base.Predicate;
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.query.filter.ValueMatcher;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.segment.ColumnInspector;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.DimensionSelectorUtils;
+import org.apache.druid.segment.IdLookup;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.data.IndexedInts;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class MultiColumnSelectorFactory implements ColumnSelectorFactory
+{
+  private final List<Supplier<ColumnSelectorFactory>> factorySuppliers;
+  private final ColumnInspector columnInspector;
+
+  private int currentFactory = 0;
+
+  public MultiColumnSelectorFactory(
+      final List<Supplier<ColumnSelectorFactory>> factorySuppliers,
+      final ColumnInspector columnInspector
+  )
+  {
+    this.factorySuppliers = factorySuppliers;
+    this.columnInspector = columnInspector;
+  }
+
+  public void setCurrentFactory(final int currentFactory)
+  {
+    this.currentFactory = currentFactory;
+  }
+
+  @Override
+  public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec)
+  {
+    return new DimensionSelector()
+    {
+      private final ColumnSelectorFactory[] delegateFactories = new ColumnSelectorFactory[factorySuppliers.size()];
+      private final DimensionSelector[] delegateSelectors = new DimensionSelector[factorySuppliers.size()];
+
+      @Override
+      public IndexedInts getRow()
+      {
+        return populateDelegate().getRow();
+      }
+
+      @Override
+      public ValueMatcher makeValueMatcher(@Nullable String value)
+      {
+        return DimensionSelectorUtils.makeValueMatcherGeneric(this, value);
+      }
+
+      @Override
+      public ValueMatcher makeValueMatcher(Predicate<String> predicate)
+      {
+        return DimensionSelectorUtils.makeValueMatcherGeneric(this, predicate);
+      }
+
+      @Nullable
+      @Override
+      public Object getObject()
+      {
+        return populateDelegate().getObject();
+      }
+
+      @Override
+      public Class<?> classOfObject()
+      {
+        return populateDelegate().classOfObject();
+      }
+
+      @Override
+      public int getValueCardinality()
+      {
+        return CARDINALITY_UNKNOWN;
+      }
+
+      @Nullable
+      @Override
+      public String lookupName(int id)
+      {
+        return populateDelegate().lookupName(id);
+      }
+
+      @Nullable
+      @Override
+      public ByteBuffer lookupNameUtf8(int id)
+      {
+        return populateDelegate().lookupNameUtf8(id);
+      }
+
+      @Override
+      public boolean supportsLookupNameUtf8()
+      {
+        return populateDelegate().supportsLookupNameUtf8();
+      }
+
+      @Override
+      public boolean nameLookupPossibleInAdvance()
+      {
+        return false;
+      }
+
+      @Nullable
+      @Override
+      public IdLookup idLookup()
+      {
+        return null;
+      }
+
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+        // Do nothing.
+      }
+
+      private DimensionSelector populateDelegate()
+      {
+        final ColumnSelectorFactory factory = factorySuppliers.get(currentFactory).get();
+
+        //noinspection ObjectEquality: checking reference equality intentionally
+        if (factory != delegateFactories[currentFactory]) {
+          delegateSelectors[currentFactory] = factory.makeDimensionSelector(dimensionSpec);
+          delegateFactories[currentFactory] = factory;
+        }
+
+        return delegateSelectors[currentFactory];
+      }
+    };
+  }
+
+  @Override
+  public ColumnValueSelector makeColumnValueSelector(final String columnName)
+  {
+
+    return new ColumnValueSelector()
+    {
+      private final ColumnSelectorFactory[] delegateFactories = new ColumnSelectorFactory[factorySuppliers.size()];
+
+      @SuppressWarnings("rawtypes")
+      private final ColumnValueSelector[] delegateSelectors = new ColumnValueSelector[factorySuppliers.size()];
+
+      @Override
+      public double getDouble()
+      {
+        return populateDelegate().getDouble();
+      }
+
+      @Override
+      public float getFloat()
+      {
+        return populateDelegate().getFloat();
+      }
+
+      @Override
+      public long getLong()
+      {
+        return populateDelegate().getLong();
+      }
+
+      @Override
+      public boolean isNull()
+      {
+        return populateDelegate().isNull();
+      }
+
+      @Nullable
+      @Override
+      public Object getObject()
+      {
+        return populateDelegate().getObject();
+      }
+
+      @Override
+      public Class classOfObject()
+      {
+        // Assumes all delegate factories have the same class of object.
+        return populateDelegate().classOfObject();
+      }
+
+      private ColumnValueSelector<?> populateDelegate()
+      {
+        final ColumnSelectorFactory factory = factorySuppliers.get(currentFactory).get();
+
+        //noinspection ObjectEquality: checking reference equality intentionally
+        if (factory != delegateFactories[currentFactory]) {
+          delegateSelectors[currentFactory] = factory.makeColumnValueSelector(columnName);
+          delegateFactories[currentFactory] = factory;
+        }
+
+        return delegateSelectors[currentFactory];
+      }
+
+      @Override
+      public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+      {
+        // Do nothing.
+      }
+    };
+  }
+
+  @Nullable
+  @Override
+  public ColumnCapabilities getColumnCapabilities(String column)
+  {
+    return columnInspector.getColumnCapabilities(column);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/MultiColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/MultiColumnSelectorFactory.java
@@ -37,6 +37,10 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.function.Supplier;
 
+/**
+ * A {@link ColumnSelectorFactory} that wraps multiple {@link ColumnSelectorFactory} and delegates to one of
+ * them at any given time. The identity of the delegated-to factory is changed by calling {@link #setCurrentFactory}.
+ */
 public class MultiColumnSelectorFactory implements ColumnSelectorFactory
 {
   private final List<Supplier<ColumnSelectorFactory>> factorySuppliers;

--- a/processing/src/main/java/org/apache/druid/frame/processor/OutputChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/OutputChannel.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Suppliers;
+import org.apache.druid.frame.allocation.MemoryAllocator;
+import org.apache.druid.frame.channel.FrameWithPartition;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.ReadableNilFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Represents an output channel for some frame processor. Composed of a pair of {@link WritableFrameChannel}, which the
+ * processor writes to, along with a supplier of a {@link ReadableFrameChannel}, which readers can read from.
+ *
+ * At the time an instance of this class is created, the writable channel is already open, but the readable channel
+ * has not yet been created. It is created upon the first call to {@link #getReadableChannel()}.
+ */
+public class OutputChannel
+{
+  @Nullable
+  private final WritableFrameChannel writableChannel;
+  @Nullable
+  private final MemoryAllocator frameMemoryAllocator;
+  private final Supplier<ReadableFrameChannel> readableChannelSupplier;
+  private final int partitionNumber;
+
+  private OutputChannel(
+      @Nullable final WritableFrameChannel writableChannel,
+      @Nullable final MemoryAllocator frameMemoryAllocator,
+      final Supplier<ReadableFrameChannel> readableChannelSupplier,
+      final int partitionNumber
+  )
+  {
+    this.writableChannel = writableChannel;
+    this.frameMemoryAllocator = frameMemoryAllocator;
+    this.readableChannelSupplier = readableChannelSupplier;
+    this.partitionNumber = partitionNumber;
+
+    if (partitionNumber < 0 && partitionNumber != FrameWithPartition.NO_PARTITION) {
+      throw new IAE("Invalid partition number [%d]", partitionNumber);
+    }
+  }
+
+  /**
+   * Creates an output channel pair.
+   *
+   * @param writableChannel         writable channel for producer
+   * @param frameMemoryAllocator    memory allocator for producer to use while writing frames to the channel
+   * @param readableChannelSupplier readable channel for consumer. May be called multiple times, so you should wrap this
+   *                                in {@link Suppliers#memoize} if needed.
+   * @param partitionNumber         partition number, if any; may be {@link FrameWithPartition#NO_PARTITION} if unknown
+   */
+  public static OutputChannel pair(
+      final WritableFrameChannel writableChannel,
+      final MemoryAllocator frameMemoryAllocator,
+      final Supplier<ReadableFrameChannel> readableChannelSupplier,
+      final int partitionNumber
+  )
+  {
+    return new OutputChannel(
+        Preconditions.checkNotNull(writableChannel, "writableChannel"),
+        Preconditions.checkNotNull(frameMemoryAllocator, "frameMemoryAllocator"),
+        readableChannelSupplier,
+        partitionNumber
+    );
+  }
+
+  /**
+   * Create a nil output channel, representing a processor that writes nothing. It is not actually writable, but
+   * provides a way for downstream processors to read nothing.
+   */
+  public static OutputChannel nil(final int partitionNumber)
+  {
+    return new OutputChannel(null, null, () -> ReadableNilFrameChannel.INSTANCE, partitionNumber);
+  }
+
+  /**
+   * Returns the writable channel of this pair. The producer writes to this channel.
+   */
+  public WritableFrameChannel getWritableChannel()
+  {
+    if (writableChannel == null) {
+      throw new ISE("Writable channel is not available");
+    } else {
+      return writableChannel;
+    }
+  }
+
+  /**
+   * Returns the memory allocator for the writable channel. The producer uses this to generate frames for the channel.
+   */
+  public MemoryAllocator getFrameMemoryAllocator()
+  {
+    if (frameMemoryAllocator == null) {
+      throw new ISE("Writable channel is not available");
+    } else {
+      return frameMemoryAllocator;
+    }
+  }
+
+  /**
+   * Returns the readable channel of this pair. This readable channel may, or may not, be usable before the
+   * writable channel is closed. It depends on whether the channel pair was created in a stream-capable manner or not.
+   */
+  public ReadableFrameChannel getReadableChannel()
+  {
+    return readableChannelSupplier.get();
+  }
+
+  public int getPartitionNumber()
+  {
+    return partitionNumber;
+  }
+
+  public OutputChannel mapWritableChannel(final Function<WritableFrameChannel, WritableFrameChannel> mapFn)
+  {
+    if (writableChannel == null) {
+      return this;
+    } else {
+      return new OutputChannel(
+          mapFn.apply(writableChannel),
+          frameMemoryAllocator,
+          readableChannelSupplier,
+          partitionNumber
+      );
+    }
+  }
+
+  /**
+   * Returns a read-only version of this instance. Read-only versions have neither {@link #getWritableChannel()} nor
+   * {@link #getFrameMemoryAllocator()}, and therefore require substantially less memory.
+   */
+  public OutputChannel readOnly()
+  {
+    return new OutputChannel(null, null, readableChannelSupplier, partitionNumber);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/OutputChannelFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/OutputChannelFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import java.io.IOException;
+
+/**
+ * Factory for generating channel pairs for output data from processors.
+ */
+public interface OutputChannelFactory
+{
+  /**
+   * Create a channel pair tagged with a particular partition number.
+   */
+  OutputChannel openChannel(int partitionNumber) throws IOException;
+
+  /**
+   * Create a non-writable, always-empty channel pair tagged with a particular partition number.
+   *
+   * Calling {@link OutputChannel#getWritableChannel()} on this nil channel pair will result in an error. Calling
+   * {@link OutputChannel#getReadableChannel()} will return an empty channel.
+   */
+  OutputChannel openNilChannel(int partitionNumber);
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class OutputChannels
+{
+  private final List<OutputChannel> outputChannels;
+  private final Int2ObjectSortedMap<List<OutputChannel>> partitionToChannelMap;
+
+  private OutputChannels(final List<OutputChannel> outputChannels)
+  {
+    this.outputChannels = outputChannels;
+
+    this.partitionToChannelMap = new Int2ObjectRBTreeMap<>();
+
+    for (final OutputChannel outputChannel : outputChannels) {
+      partitionToChannelMap.computeIfAbsent(outputChannel.getPartitionNumber(), ignored -> new ArrayList<>())
+                           .add(outputChannel);
+    }
+  }
+
+  public static OutputChannels none()
+  {
+    return wrap(Collections.emptyList());
+  }
+
+  /**
+   * Creates an instance wrapping all the provided channels.
+   */
+  public static OutputChannels wrap(final List<OutputChannel> outputChannels)
+  {
+    return new OutputChannels(outputChannels);
+  }
+
+  /**
+   * Creates an instance wrapping read-only versions (see {@link OutputChannel#readOnly()}) of all the
+   * provided channels.
+   */
+  public static OutputChannels wrapReadOnly(final List<OutputChannel> outputChannels)
+  {
+    return new OutputChannels(outputChannels.stream().map(OutputChannel::readOnly).collect(Collectors.toList()));
+  }
+
+  /**
+   * Returns the set of partition numbers that appear across all channels.
+   */
+  public IntSortedSet getPartitionNumbers()
+  {
+    return partitionToChannelMap.keySet();
+  }
+
+  /**
+   * Returns all channels.
+   */
+  public List<OutputChannel> getAllChannels()
+  {
+    return outputChannels;
+  }
+
+  /**
+   * Returns channels for which {@link OutputChannel#getPartitionNumber()} returns {@code partitionNumber}.
+   */
+  public List<OutputChannel> getChannelsForPartition(final int partitionNumber)
+  {
+    final List<OutputChannel> retVal = partitionToChannelMap.get(partitionNumber);
+
+    if (retVal != null) {
+      return retVal;
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   * Returns a read-only version of this instance. Each individual output channel is replaced with its
+   * read-only version ({@link OutputChannel#readOnly()}, which reduces memory usage.
+   */
+  public OutputChannels readOnly()
+  {
+    return wrapReadOnly(outputChannels);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
@@ -29,7 +29,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
+ * A list of {@link OutputChannel}.
  *
+ * The advantage of this class over {@code List<OutputChannel>} is that it has extra convenience methods
+ * like {@link #getChannelsForPartition} and {@link #readOnly()}.
  */
 public class OutputChannels
 {

--- a/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
@@ -28,6 +28,9 @@ import org.apache.druid.java.util.common.ISE;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+/**
+ * Return value from {@link FrameProcessor#runIncrementally}.
+ */
 public class ReturnOrAwait<T>
 {
   private static final IntSet RANGE_SET_ONE = IntSets.singleton(0);

--- a/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class ReturnOrAwait<T>
+{
+  private static final IntSet RANGE_SET_ONE = IntSets.singleton(0);
+
+  @Nullable
+  private final T retVal;
+
+  @Nullable
+  private final IntSet await;
+
+  private final boolean awaitAll;
+
+  private ReturnOrAwait(@Nullable T retVal, @Nullable IntSet await, final boolean awaitAll)
+  {
+    this.retVal = retVal;
+    this.await = await;
+    this.awaitAll = awaitAll;
+
+    if (retVal != null && await != null) {
+      throw new IAE("Cannot have a value when await != null");
+    }
+  }
+
+  public static <T> ReturnOrAwait<T> runAgain()
+  {
+    return new ReturnOrAwait<>(null, IntSets.emptySet(), true);
+  }
+
+  /**
+   * Wait for all of the provided channels to become readable. It is OK to pass in a mutable set.
+   */
+  public static <T> ReturnOrAwait<T> awaitAll(final IntSet await)
+  {
+    return new ReturnOrAwait<>(null, await, true);
+  }
+
+  public static <T> ReturnOrAwait<T> awaitAll(final int count)
+  {
+    return new ReturnOrAwait<>(null, rangeSet(count), true);
+  }
+
+  /**
+   * Wait for any of the provided channels to become readable. It is OK to pass in a mutable set.
+   */
+  public static <T> ReturnOrAwait<T> awaitAny(final IntSet await)
+  {
+    return new ReturnOrAwait<>(null, await, false);
+  }
+
+  public static <T> ReturnOrAwait<T> returnObject(final T o)
+  {
+    return new ReturnOrAwait<>(o, null, false);
+  }
+
+  @Nullable
+  public T value()
+  {
+    if (isContinue()) {
+      throw new ISE("No value yet");
+    }
+
+    return retVal;
+  }
+
+  public IntSet awaitSet()
+  {
+    if (isReturn()) {
+      throw new ISE("No await set");
+    }
+
+    return await;
+  }
+
+  public boolean isAwaitAll()
+  {
+    return awaitAll;
+  }
+
+  public boolean isReturn()
+  {
+    return await == null;
+  }
+
+  public boolean isContinue()
+  {
+    return await != null;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ReturnOrAwait<?> that = (ReturnOrAwait<?>) o;
+    return awaitAll == that.awaitAll && Objects.equals(retVal, that.retVal) && Objects.equals(
+        await,
+        that.await
+    );
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(retVal, await, awaitAll);
+  }
+
+  @Override
+  public String toString()
+  {
+    if (isContinue()) {
+      return "await=" + (awaitAll ? "all" : "any") + await;
+    } else {
+      return "return=" + retVal;
+    }
+  }
+
+  private static IntSet rangeSet(final int count)
+  {
+    if (count == 0) {
+      return IntSets.emptySet();
+    } else if (count == 1) {
+      return RANGE_SET_ONE;
+    } else {
+      final IntSet retVal = new IntOpenHashSet();
+
+      for (int i = 0; i < count; i++) {
+        retVal.add(i);
+      }
+
+      return retVal;
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/ReturnOrAwait.java
@@ -29,7 +29,15 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
- * Return value from {@link FrameProcessor#runIncrementally}.
+ * Instances of this class are returned by {@link FrameProcessor#runIncrementally}, and are used by
+ * {@link FrameProcessorExecutor} to manage execution.
+ *
+ * An instance can be a "return" with a result, which means that the {@link FrameProcessor} is done working.
+ * In this case {@link #isReturn()} is true and {@link #value()} contains the result.
+ *
+ * An instance can also be an "await", which means that the {@link FrameProcessor} wants to be scheduled again
+ * in the future. In this case {@link #isAwait()} is true, {@link #awaitSet()} contains the set of input channels to
+ * wait for, and {@link #isAwaitAll()} is whether the processor wants to wait for all channels, or any channel.
  */
 public class ReturnOrAwait<T>
 {
@@ -54,47 +62,74 @@ public class ReturnOrAwait<T>
     }
   }
 
+  /**
+   * Wait for nothing; that is: run again as soon as possible.
+   */
   public static <T> ReturnOrAwait<T> runAgain()
   {
     return new ReturnOrAwait<>(null, IntSets.emptySet(), true);
   }
 
   /**
-   * Wait for all of the provided channels to become readable. It is OK to pass in a mutable set.
+   * Wait for all provided channels to become readable (or finished).
+   *
+   * Numbers in this set correspond to positions in the {@link FrameProcessor#inputChannels()} list.
+   *
+   * It is OK to pass in a mutable set, because this method does not modify the set or retain a reference to it.
    */
   public static <T> ReturnOrAwait<T> awaitAll(final IntSet await)
   {
     return new ReturnOrAwait<>(null, await, true);
   }
 
+  /**
+   * Wait for all of a certain number of channels.
+   */
   public static <T> ReturnOrAwait<T> awaitAll(final int count)
   {
     return new ReturnOrAwait<>(null, rangeSet(count), true);
   }
 
   /**
-   * Wait for any of the provided channels to become readable. It is OK to pass in a mutable set.
+   * Wait for any of the provided channels to become readable (or finished). When using this, callers should consider
+   * removing any fully-processed and finished channels from the await-set, because if any channels in the await-set
+   * are finished, the processor will run again immediately.
+   *
+   * Numbers in this set correspond to positions in the {@link FrameProcessor#inputChannels()} list.
+   *
+   * It is OK to pass in a mutable set, because this method does not modify the set or retain a reference to it.
    */
   public static <T> ReturnOrAwait<T> awaitAny(final IntSet await)
   {
     return new ReturnOrAwait<>(null, await, false);
   }
 
+  /**
+   * Return a result.
+   */
   public static <T> ReturnOrAwait<T> returnObject(final T o)
   {
     return new ReturnOrAwait<>(o, null, false);
   }
 
+  /**
+   * The returned result. Valid if {@link #isReturn()} is true.
+   */
   @Nullable
   public T value()
   {
-    if (isContinue()) {
+    if (isAwait()) {
       throw new ISE("No value yet");
     }
 
     return retVal;
   }
 
+  /**
+   * The set of channels the processors wants to wait for. Valid if {@link #isAwait()} is true.
+   *
+   * Numbers in this set correspond to positions in the {@link FrameProcessor#inputChannels()} list.
+   */
   public IntSet awaitSet()
   {
     if (isReturn()) {
@@ -104,19 +139,32 @@ public class ReturnOrAwait<T>
     return await;
   }
 
-  public boolean isAwaitAll()
-  {
-    return awaitAll;
-  }
-
+  /**
+   * Whether the processor has returned a value.
+   *
+   * This is the opposite of {@link #isAwait()}.
+   */
   public boolean isReturn()
   {
     return await == null;
   }
 
-  public boolean isContinue()
+  /**
+   * Whether the processor wants to be scheduled again.
+   *
+   * This is the opposite of {@link #isReturn()}.
+   */
+  public boolean isAwait()
   {
     return await != null;
+  }
+
+  /**
+   * Whether the processor wants to wait for all channels in {@link #awaitSet()} (true), or any channel (false)
+   */
+  public boolean isAwaitAll()
+  {
+    return awaitAll;
   }
 
   @Override
@@ -129,10 +177,7 @@ public class ReturnOrAwait<T>
       return false;
     }
     ReturnOrAwait<?> that = (ReturnOrAwait<?>) o;
-    return awaitAll == that.awaitAll && Objects.equals(retVal, that.retVal) && Objects.equals(
-        await,
-        that.await
-    );
+    return awaitAll == that.awaitAll && Objects.equals(retVal, that.retVal) && Objects.equals(await, that.await);
   }
 
   @Override
@@ -144,7 +189,7 @@ public class ReturnOrAwait<T>
   @Override
   public String toString()
   {
-    if (isContinue()) {
+    if (isAwait()) {
       return "await=" + (awaitAll ? "all" : "any") + await;
     } else {
       return "return=" + retVal;

--- a/processing/src/main/java/org/apache/druid/frame/processor/RunAllFullyWidget.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/RunAllFullyWidget.java
@@ -43,7 +43,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 /**
- * Helper for {@link FrameProcessorExecutor#runAllFully}.
+ * Helper for {@link FrameProcessorExecutor#runAllFully}. See the javadoc for that method for details about the
+ * expected behavior of this class.
+ *
+ * One instance of this class is created for each call to {@link FrameProcessorExecutor#runAllFully}. It gradually
+ * executes all processors from the provided sequence using the {@link FrameProcessorExecutor#runFully} method.
+ * The {@code bouncer} and {@code maxOutstandingProcessors} parameters are used to control how many processors are
+ * executed on the {@link FrameProcessorExecutor} concurrently.
  */
 public class RunAllFullyWidget<T, ResultType>
 {

--- a/processing/src/main/java/org/apache/druid/frame/processor/RunAllFullyWidget.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/RunAllFullyWidget.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.Yielder;
+import org.apache.druid.java.util.common.guava.Yielders;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+
+/**
+ * Helper for {@link FrameProcessorExecutor#runAllFully}.
+ */
+public class RunAllFullyWidget<T, ResultType>
+{
+  private static final Logger log = new Logger(RunAllFullyWidget.class);
+
+  private final Sequence<? extends FrameProcessor<T>> processors;
+  private final FrameProcessorExecutor exec;
+  private final ResultType initialResult;
+  private final BiFunction<ResultType, T, ResultType> accumulateFn;
+  private final int maxOutstandingProcessors;
+  private final Bouncer bouncer;
+  @Nullable
+  private final String cancellationId;
+
+  RunAllFullyWidget(
+      Sequence<? extends FrameProcessor<T>> processors,
+      FrameProcessorExecutor exec,
+      ResultType initialResult,
+      BiFunction<ResultType, T, ResultType> accumulateFn,
+      int maxOutstandingProcessors,
+      Bouncer bouncer,
+      @Nullable String cancellationId
+  )
+  {
+    this.processors = processors;
+    this.exec = exec;
+    this.initialResult = initialResult;
+    this.accumulateFn = accumulateFn;
+    this.maxOutstandingProcessors = maxOutstandingProcessors;
+    this.bouncer = bouncer;
+    this.cancellationId = cancellationId;
+  }
+
+  ListenableFuture<ResultType> run()
+  {
+    final Yielder<? extends FrameProcessor<T>> processorYielder;
+
+    try {
+      processorYielder = Yielders.each(processors);
+    }
+    catch (Throwable e) {
+      return Futures.immediateFailedFuture(e);
+    }
+
+    if (processorYielder.isDone()) {
+      return Futures.immediateFuture(initialResult);
+    }
+
+    // This single RunAllFullyRunnable will be submitted to the executor "maxOutstandingProcessors" times.
+    final RunAllFullyRunnable runnable = new RunAllFullyRunnable(processorYielder);
+
+    for (int i = 0; i < maxOutstandingProcessors; i++) {
+      exec.getExecutorService().submit(runnable);
+    }
+
+    return runnable.finishedFuture;
+  }
+
+  private class RunAllFullyRunnable implements Runnable
+  {
+    private final AtomicReference<Either<Throwable, ResultType>> finished = new AtomicReference<>();
+    private final SettableFuture<ResultType> finishedFuture;
+    private final Object runAllFullyLock = new Object();
+
+    @GuardedBy("runAllFullyLock")
+    Yielder<? extends FrameProcessor<T>> processorYielder;
+
+    @GuardedBy("runAllFullyLock")
+    ResultType currentResult = null;
+
+    @GuardedBy("runAllFullyLock")
+    boolean seenFirstResult = false;
+
+    @GuardedBy("runAllFullyLock")
+    int outstandingProcessors = 0;
+
+    @GuardedBy("runAllFullyLock")
+    Set<ListenableFuture<?>> outstandingFutures = Collections.newSetFromMap(new IdentityHashMap<>());
+
+    @Nullable // nulled out by cleanup()
+    @GuardedBy("runAllFullyLock")
+    Queue<Bouncer.Ticket> bouncerQueue = new ArrayDeque<>();
+
+    private RunAllFullyRunnable(final Yielder<? extends FrameProcessor<T>> processorYielder)
+    {
+      this.processorYielder = processorYielder;
+      this.finishedFuture = exec.registerCancelableFuture(SettableFuture.create(), false, cancellationId);
+      this.finishedFuture.addListener(
+          () -> {
+            if (finishedFuture.isCancelled()) {
+              try {
+                synchronized (runAllFullyLock) {
+                  // Cancel any outstanding processors.
+                  ImmutableList.copyOf(outstandingFutures).forEach(f -> f.cancel(true));
+
+                  // Cleanup if there were no outstanding processors. (If there were some outstanding ones, future
+                  // cancellation above would trigger cleanup.)
+                  cleanupIfNoMoreProcessors();
+                }
+              }
+              catch (Throwable e) {
+                // No point throwing. Exceptions thrown in listeners don't go anywhere.
+                log.warn(e, "Exception encountered while cleaning up canceled runAllFully execution");
+              }
+            }
+          },
+          Execs.directExecutor()
+      );
+    }
+
+    @Override
+    public void run()
+    {
+      final FrameProcessor<T> nextProcessor;
+      Bouncer.Ticket nextTicket = null;
+
+      synchronized (runAllFullyLock) {
+        if (finished.get() != null) {
+          cleanupIfNoMoreProcessors();
+          return;
+        } else if (!processorYielder.isDone()) {
+          assert bouncerQueue != null;
+
+          try {
+            final Bouncer.Ticket ticketFromQueue = bouncerQueue.poll();
+
+            if (ticketFromQueue != null) {
+              nextTicket = ticketFromQueue;
+            } else {
+              final ListenableFuture<Bouncer.Ticket> ticketFuture =
+                  exec.registerCancelableFuture(bouncer.ticket(), false, cancellationId);
+
+              if (ticketFuture.isDone() && !ticketFuture.isCancelled()) {
+                nextTicket = FutureUtils.getUncheckedImmediately(ticketFuture);
+              } else {
+                ticketFuture.addListener(
+                    () -> {
+                      if (!ticketFuture.isCancelled()) {
+                        // No need to check for exception; bouncer tickets cannot have exceptions.
+                        final Bouncer.Ticket ticket = FutureUtils.getUncheckedImmediately(ticketFuture);
+
+                        synchronized (runAllFullyLock) {
+                          if (finished.get() != null) {
+                            ticket.giveBack();
+                            return;
+                          } else {
+                            bouncerQueue.add(ticket);
+                          }
+                        }
+                        exec.getExecutorService().submit(RunAllFullyRunnable.this);
+                      }
+                    },
+                    Execs.directExecutor()
+                );
+
+                return;
+              }
+            }
+
+            assert outstandingProcessors < maxOutstandingProcessors;
+            nextProcessor = processorYielder.get();
+            processorYielder = processorYielder.next(null);
+            outstandingProcessors++;
+          }
+          catch (Throwable e) {
+            if (nextTicket != null) {
+              nextTicket.giveBack();
+            }
+            finished.compareAndSet(null, Either.error(e));
+            cleanupIfNoMoreProcessors();
+            return;
+          }
+        } else {
+          return;
+        }
+
+        assert nextTicket != null;
+        final ListenableFuture<T> future = exec.runFully(
+            FrameProcessors.withBaggage(nextProcessor, nextTicket::giveBack),
+            cancellationId
+        );
+
+        outstandingFutures.add(future);
+
+        Futures.addCallback(
+            future,
+            new FutureCallback<T>()
+            {
+              @Override
+              public void onSuccess(T result)
+              {
+                final boolean isDone;
+                ResultType retVal = null;
+
+                try {
+                  synchronized (runAllFullyLock) {
+                    outstandingProcessors--;
+                    outstandingFutures.remove(future);
+
+                    if (!seenFirstResult) {
+                      currentResult = accumulateFn.apply(initialResult, result);
+                      seenFirstResult = true;
+                    } else {
+                      currentResult = accumulateFn.apply(currentResult, result);
+                    }
+
+                    isDone = outstandingProcessors == 0 && processorYielder.isDone();
+
+                    if (isDone) {
+                      retVal = currentResult;
+                    }
+                  }
+                }
+                catch (Throwable e) {
+                  finished.compareAndSet(null, Either.error(e));
+
+                  synchronized (runAllFullyLock) {
+                    cleanupIfNoMoreProcessors();
+                  }
+
+                  return;
+                }
+
+                if (isDone) {
+                  finished.compareAndSet(null, Either.value(retVal));
+
+                  synchronized (runAllFullyLock) {
+                    cleanupIfNoMoreProcessors();
+                  }
+                } else {
+                  // Not finished; run again.
+                  exec.getExecutorService().submit(RunAllFullyRunnable.this);
+                }
+              }
+
+              @Override
+              public void onFailure(Throwable t)
+              {
+                finished.compareAndSet(null, Either.error(t));
+
+                synchronized (runAllFullyLock) {
+                  outstandingProcessors--;
+                  outstandingFutures.remove(future);
+                  cleanupIfNoMoreProcessors();
+                }
+              }
+            }
+        );
+      }
+    }
+
+    /**
+     * Run {@link #cleanup()} if no more processors will be launched.
+     */
+    @GuardedBy("runAllFullyLock")
+    private void cleanupIfNoMoreProcessors()
+    {
+      if (outstandingProcessors == 0 && finished.get() != null) {
+        cleanup();
+      }
+    }
+
+    /**
+     * Cleanup work that must happen after everything has calmed down.
+     */
+    @GuardedBy("runAllFullyLock")
+    private void cleanup()
+    {
+      assert finished.get() != null;
+      assert outstandingProcessors == 0;
+
+      try {
+        if (bouncerQueue != null) {
+          // Drain ticket queue, return everything.
+
+          Bouncer.Ticket ticket;
+          while ((ticket = bouncerQueue.poll()) != null) {
+            ticket.giveBack();
+          }
+
+          bouncerQueue = null;
+        }
+
+        if (processorYielder != null) {
+          processorYielder.close();
+          processorYielder = null;
+        }
+      }
+      catch (Throwable e) {
+        // No point throwing, since our caller is just a future callback.
+        log.noStackTrace().warn(e, "Exception encountered while cleaning up from runAllFully");
+      }
+      finally {
+        // Set finishedFuture after all cleanup is done.
+        if (finished.get().isValue()) {
+          finishedFuture.set(finished.get().valueOrThrow());
+        } else {
+          finishedFuture.setException(finished.get().error());
+        }
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -1,0 +1,867 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.math.LongMath;
+import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongRBTreeSet;
+import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.allocation.MemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.FrameWithPartition;
+import org.apache.druid.frame.channel.ReadableFileFrameChannel;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.file.FrameFile;
+import org.apache.druid.frame.file.FrameFileWriter;
+import org.apache.druid.frame.key.ClusterBy;
+import org.apache.druid.frame.key.ClusterByPartitions;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.write.FrameWriters;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.utils.CloseableUtils;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+/**
+ * Sorts and partitions a dataset using parallel external merge sort.
+ *
+ * Input is provided as a set of {@link ReadableFrameChannel} and output is provided as {@link OutputChannels}.
+ * Work is performed on a provided {@link FrameProcessorExecutor}.
+ *
+ * The most central point for SuperSorter logic is the {@link #runWorkersIfPossible} method, which determines what
+ * needs to be done next based on the current state of the SuperSorter. The logic is:
+ *
+ * 1) Read input channels into {@link #inputBuffer} using {@link FrameChannelBatcher}, launched via
+ * {@link #runNextBatcher()}, up to a limit of {@link #maxChannelsPerProcessor} per batcher.
+ *
+ * 2) Merge and write frames from {@link #inputBuffer} into {@link FrameFile} scratch files using
+ * {@link FrameChannelMerger} launched via {@link #runNextLevelZeroMerger()}.
+ *
+ * 3a) Merge level 0 scratch files into level 1 scratch files using {@link FrameChannelMerger} launched from
+ * {@link #runNextMiddleMerger()}, processing up to {@link #maxChannelsPerProcessor} files per merger.
+ * Continue this process through increasing level numbers, with the size of scratch files increasing by a factor
+ * of {@link #maxChannelsPerProcessor} each level.
+ *
+ * 3b) For the penultimate level, the {@link FrameChannelMerger} launched by {@link #runNextMiddleMerger()} writes
+ * partitioned {@link FrameFile} scratch files. The penultimate level cannot be written until
+ * {@link #outputPartitionsFuture} resolves, so if it has not resolved yet by this point, the SuperSorter pauses.
+ * The SuperSorter resumes and writes the penultimate level's files when the future resolves.
+ *
+ * 4) Write the final level using {@link FrameChannelMerger} launched from {@link #runNextUltimateMerger()}.
+ * Outputs for this level are written to channels provided by {@link #outputChannelFactory}, rather than scratch files.
+ *
+ * At all points, higher level processing is preferred over lower-level processing. Writing to final output files
+ * is preferred over intermediate, and writing to intermediate files is preferred over reading inputs. These
+ * preferences ensure that the amount of data buffered up in memory does not grow too large.
+ *
+ * Potential future work (things we could optimize if necessary):
+ *
+ * - Collapse merging to a single level if level zero has one merger, and we want to write one output partition.
+ * - Skip batching, and inject directly into level 0, if input channels are already individually fully-sorted.
+ * - Combine (for example: aggregate) while merging.
+ */
+public class SuperSorter
+{
+  private static final Logger log = new Logger(SuperSorter.class);
+
+  public static final int UNKNOWN_LEVEL = -1;
+  public static final long UNKNOWN_TOTAL = -1;
+
+  private final List<ReadableFrameChannel> inputChannels;
+  private final FrameReader frameReader;
+  private final ClusterBy clusterBy;
+  private final ListenableFuture<ClusterByPartitions> outputPartitionsFuture;
+  private final FrameProcessorExecutor exec;
+  private final File directory;
+  private final OutputChannelFactory outputChannelFactory;
+  private final Supplier<MemoryAllocator> innerFrameAllocatorMaker;
+  private final int maxChannelsPerProcessor;
+  private final int maxActiveProcessors;
+  private final long rowLimit;
+  private final String cancellationId;
+
+  private final Object runWorkersLock = new Object();
+
+  @GuardedBy("runWorkersLock")
+  private boolean batcherIsRunning = false;
+
+  @GuardedBy("runWorkersLock")
+  private IntSet inputChannelsToRead = new IntOpenHashSet();
+
+  @GuardedBy("runWorkersLock")
+  private final Int2ObjectMap<LongSortedSet> outputsReadyByLevel = new Int2ObjectArrayMap<>();
+
+  @GuardedBy("runWorkersLock")
+  private List<OutputChannel> outputChannels = null;
+
+  @GuardedBy("runWorkersLock")
+  private int activeProcessors = 0;
+
+  @GuardedBy("runWorkersLock")
+  private long totalInputFrames = UNKNOWN_TOTAL;
+
+  @GuardedBy("runWorkersLock")
+  private int totalMergingLevels = UNKNOWN_LEVEL;
+
+  @GuardedBy("runWorkersLock")
+  private final Queue<Frame> inputBuffer = new ArrayDeque<>();
+
+  @GuardedBy("runWorkersLock")
+  private long inputFramesReadSoFar = 0;
+
+  @GuardedBy("runWorkersLock")
+  private long levelZeroMergersRunSoFar = 0;
+
+  @GuardedBy("runWorkersLock")
+  private int ultimateMergersRunSoFar = 0;
+
+  @GuardedBy("runWorkersLock")
+  private final Map<File, FrameFile> penultimateFrameFileCache = new HashMap<>();
+
+  @GuardedBy("runWorkersLock")
+  private SettableFuture<OutputChannels> allDone = null;
+
+  @GuardedBy("runWorkersLock")
+  SuperSorterProgressTracker superSorterProgressTracker;
+
+  /**
+   * See {@link #setNoWorkRunnable}.
+   */
+  @GuardedBy("runWorkersLock")
+  private Runnable noWorkRunnable = null;
+
+  /**
+   * Initializes a SuperSorter.
+   *
+   * @param inputChannels              input channels. All frames in these channels must be sorted according to the
+   *                                   {@link ClusterBy#getColumns()}, or else sorting will not produce correct
+   *                                   output.
+   * @param frameReader                frame reader for the input channels
+   * @param clusterBy                  desired sorting order
+   * @param outputPartitionsFuture     a future that resolves to the desired output partitions. Sorting will block
+   *                                   prior to writing out final outputs until this future resolves. However, the
+   *                                   sorter will be able to read all inputs even if this future is unresolved.
+   *                                   If output need not be partitioned, use
+   *                                   {@link ClusterByPartitions#oneUniversalPartition()}. In this case a single
+   *                                   sorted channel is generated.
+   * @param exec                       executor to perform work in
+   * @param temporaryDirectory         directory to use for scratch files. This must have enough space to store at
+   *                                   least two copies of the dataset in {@link FrameFile} format.
+   * @param outputChannelFactory       factory for partitioned, sorted output channels
+   * @param innerFrameAllocatorMaker   supplier for allocators that are used to make merged frames for intermediate
+   *                                   levels of merging, prior to the final output. Final output frame allocation is
+   *                                   controlled by outputChannelFactory. One allocator is created per intermediate
+   *                                   scratch file.
+   * @param maxActiveProcessors        maximum number of merging processors to execute at once in the provided
+   *                                   {@link FrameProcessorExecutor}
+   * @param maxChannelsPerProcessor    maximum number of channels to merge at once per merging processor
+   * @param rowLimit                   limit to apply during sorting. The limit is merely advisory: the actual number
+   *                                   of rows returned may be larger than the limit.
+   * @param cancellationId             cancellation id to use when running processors in the provided
+   *                                   {@link FrameProcessorExecutor}.
+   * @param superSorterProgressTracker progress tracker
+   */
+  public SuperSorter(
+      final List<ReadableFrameChannel> inputChannels,
+      final FrameReader frameReader,
+      final ClusterBy clusterBy,
+      final ListenableFuture<ClusterByPartitions> outputPartitionsFuture,
+      final FrameProcessorExecutor exec,
+      final File temporaryDirectory,
+      final OutputChannelFactory outputChannelFactory,
+      final Supplier<MemoryAllocator> innerFrameAllocatorMaker,
+      final int maxActiveProcessors,
+      final int maxChannelsPerProcessor,
+      final long rowLimit,
+      @Nullable final String cancellationId,
+      final SuperSorterProgressTracker superSorterProgressTracker
+  )
+  {
+    this.inputChannels = inputChannels;
+    this.frameReader = frameReader;
+    this.clusterBy = clusterBy;
+    this.outputPartitionsFuture = outputPartitionsFuture;
+    this.exec = exec;
+    this.directory = temporaryDirectory;
+    this.outputChannelFactory = outputChannelFactory;
+    this.innerFrameAllocatorMaker = innerFrameAllocatorMaker;
+    this.maxChannelsPerProcessor = maxChannelsPerProcessor;
+    this.maxActiveProcessors = maxActiveProcessors;
+    this.rowLimit = rowLimit;
+    this.cancellationId = cancellationId;
+    this.superSorterProgressTracker = superSorterProgressTracker;
+
+    for (int i = 0; i < inputChannels.size(); i++) {
+      inputChannelsToRead.add(i);
+    }
+
+    if (maxActiveProcessors < 1) {
+      throw new IAE("maxActiveProcessors[%d] < 1", maxActiveProcessors);
+    }
+
+    if (maxChannelsPerProcessor < 2) {
+      throw new IAE("maxChannelsPerProcessor[%d] < 2", maxChannelsPerProcessor);
+    }
+  }
+
+  /**
+   * Starts sorting. Can only be called once. Work is performed in the {@link FrameProcessorExecutor} that was
+   * passed to the constructor.
+   *
+   * Returns a future containing partitioned sorted output channels.
+   */
+  public ListenableFuture<OutputChannels> run()
+  {
+    synchronized (runWorkersLock) {
+      if (allDone != null) {
+        throw new ISE("Cannot run() more than once.");
+      }
+
+      allDone = SettableFuture.create();
+      runWorkersIfPossible();
+
+      // When output partitions become known, that may unblock some additional layers of merging.
+      outputPartitionsFuture.addListener(
+          () -> {
+            synchronized (runWorkersLock) {
+              if (outputPartitionsFuture.isDone()) { // Update the progress tracker
+                superSorterProgressTracker.setTotalMergersForUltimateLevel(getOutputPartitions().size());
+              }
+              runWorkersIfPossible();
+              setAllDoneIfPossible();
+            }
+          },
+          exec.getExecutorService()
+      );
+
+      return FutureUtils.futureWithBaggage(
+          allDone,
+          () -> {
+            synchronized (runWorkersLock) {
+              if (activeProcessors == 0) {
+                cleanUp();
+              }
+            }
+          }
+      );
+    }
+  }
+
+  /**
+   * Sets a callback that enables tests to see when this SuperSorter cannot do any work. Only used for testing.
+   */
+  @VisibleForTesting
+  void setNoWorkRunnable(final Runnable runnable)
+  {
+    synchronized (runWorkersLock) {
+      this.noWorkRunnable = runnable;
+    }
+  }
+
+  /**
+   * Called when a worker finishes.
+   */
+  @GuardedBy("runWorkersLock")
+  private void workerFinished()
+  {
+    activeProcessors -= 1;
+
+    if (log.isDebugEnabled()) {
+      log.debug(stateString());
+    }
+
+    runWorkersIfPossible();
+    setAllDoneIfPossible();
+
+    if (isAllDone() && activeProcessors == 0) {
+      cleanUp();
+    }
+  }
+
+  /**
+   * Tries to launch a new worker, and returns whether it was doable.
+   *
+   * Later workers have priority, i.e., those responsible for merging higher levels of the merge tree. Workers that
+   * read the original input channels have the lowest priority. This priority order ensures that we don't build up
+   * too much unmerged data.
+   */
+  @GuardedBy("runWorkersLock")
+  private void runWorkersIfPossible()
+  {
+    if (isAllDone()) {
+      // Do nothing if the instance is all done. This can happen in case of error or cancellation.
+      return;
+    }
+
+    try {
+      while (activeProcessors < maxActiveProcessors &&
+             (runNextUltimateMerger() || runNextMiddleMerger() || runNextLevelZeroMerger() || runNextBatcher())) {
+        activeProcessors += 1;
+
+        if (log.isDebugEnabled()) {
+          log.debug(stateString());
+        }
+      }
+
+      if (activeProcessors == 0 && noWorkRunnable != null) {
+        log.debug("No active workers and no work left to start.");
+
+        // Only called in tests. No need to bother with try/catch and such.
+        noWorkRunnable.run();
+      }
+    }
+    catch (Throwable e) {
+      allDone.setException(e);
+    }
+  }
+
+  @GuardedBy("runWorkersLock")
+  private void setAllDoneIfPossible()
+  {
+    if (totalInputFrames == 0 && outputPartitionsFuture.isDone()) {
+      // No input data -- generate empty output channels.
+      final ClusterByPartitions partitions = getOutputPartitions();
+      final List<OutputChannel> channels = new ArrayList<>(partitions.size());
+
+      for (int partitionNum = 0; partitionNum < partitions.size(); partitionNum++) {
+        channels.add(outputChannelFactory.openNilChannel(partitionNum));
+      }
+
+      // OK to use wrap, not wrapReadOnly, because nil channels are already read-only.
+      allDone.set(OutputChannels.wrap(channels));
+    } else if (totalMergingLevels != UNKNOWN_LEVEL
+               && outputsReadyByLevel.containsKey(totalMergingLevels - 1)
+               && outputsReadyByLevel.get(totalMergingLevels - 1).size() == getOutputPartitions().size()) {
+      // We're done!!
+      try {
+        // OK to use wrap, not wrapReadOnly, because all channels in this list are already read-only.
+        allDone.set(OutputChannels.wrap(outputChannels));
+      }
+      catch (Throwable e) {
+        allDone.setException(e);
+      }
+    }
+  }
+
+  @GuardedBy("runWorkersLock")
+  private boolean runNextBatcher()
+  {
+    if (batcherIsRunning || inputChannelsToRead.isEmpty()) {
+      return false;
+    } else {
+      batcherIsRunning = true;
+
+      runWorker(
+          new FrameChannelBatcher(inputChannels, maxChannelsPerProcessor),
+          result -> {
+            final List<Frame> batch = result.lhs;
+            final IntSet keepReading = result.rhs;
+
+            synchronized (runWorkersLock) {
+              inputBuffer.addAll(batch);
+              inputFramesReadSoFar += batch.size();
+              inputChannelsToRead = keepReading;
+
+              if (inputChannelsToRead.isEmpty()) {
+                inputChannels.forEach(ReadableFrameChannel::doneReading);
+                setTotalInputFrames(inputFramesReadSoFar);
+                runWorkersIfPossible();
+              } else if (inputBuffer.size() >= maxChannelsPerProcessor) {
+                runWorkersIfPossible();
+              }
+
+              batcherIsRunning = false;
+            }
+          }
+      );
+
+      return true;
+    }
+  }
+
+  /**
+   * Level zero mergers read batches of frames from the "inputBuffer". These frames are individually sorted, but there
+   * is no ordering between the frames. Their output is a sorted sequence of frames.
+   */
+  @GuardedBy("runWorkersLock")
+  private boolean runNextLevelZeroMerger()
+  {
+    if (inputBuffer.isEmpty() || (inputBuffer.size() < maxChannelsPerProcessor && !allInputRead())) {
+      return false;
+    }
+
+    final List<ReadableFrameChannel> in = new ArrayList<>();
+
+    while (in.size() < maxChannelsPerProcessor) {
+      final Frame frame = inputBuffer.poll();
+
+      if (frame == null) {
+        break;
+      }
+
+      in.add(singleReadableFrameChannel(new FrameWithPartition(frame, FrameWithPartition.NO_PARTITION)));
+    }
+
+    runMerger(0, levelZeroMergersRunSoFar++, in, null);
+    return true;
+  }
+
+  @GuardedBy("runWorkersLock")
+  private boolean runNextMiddleMerger()
+  {
+    for (int inLevel = outputsReadyByLevel.size() - 1; inLevel >= 0; inLevel--) {
+      final int outLevel = inLevel + 1;
+      final long totalInputs = getTotalMergersInLevel(inLevel);
+      final LongSortedSet inputsReady = outputsReadyByLevel.get(inLevel);
+
+      if (totalMergingLevels != UNKNOWN_LEVEL && outLevel >= totalMergingLevels - 1) {
+        // This is the ultimate level. Skip it, since it will be launched by runNextUltimateMerger.
+        continue;
+      }
+
+      if (totalMergingLevels == UNKNOWN_LEVEL
+          && LongMath.divide(inputsReady.size(), maxChannelsPerProcessor, RoundingMode.CEILING)
+             <= maxChannelsPerProcessor) {
+        // This *might* be the penultimate level. Skip until we know for sure. (i.e., until all input frames have
+        // been read.)
+        continue;
+      }
+
+      final ClusterByPartitions outPartitions;
+
+      if (totalMergingLevels != UNKNOWN_LEVEL && outLevel == totalMergingLevels - 2) {
+        // This is the penultimate level.
+        if (!outputPartitionsFuture.isDone()) {
+          // Can't launch penultimate level until output partitions are known.
+          continue;
+        }
+
+        outPartitions = getOutputPartitions();
+      } else {
+        outPartitions = null;
+      }
+
+      // See if there's work to do.
+
+      final LongIterator iter = inputsReady.iterator();
+
+      long currentSetStart = -1, currentSetIndex = -1;
+      while (iter.hasNext()) {
+        final long w = iter.nextLong();
+        if (w % maxChannelsPerProcessor == 0) {
+          // w is the start of a set
+          currentSetStart = w;
+          currentSetIndex = -1;
+        }
+
+        if (currentSetStart >= 0) {
+          // We're currently exploring a potential set.
+          long pos = w - currentSetStart;
+
+          if (pos == currentSetIndex + 1 &&
+              (pos == maxChannelsPerProcessor - 1 || (totalInputs != UNKNOWN_TOTAL && w == totalInputs - 1))) {
+            // We found a set to merge. Let's collect the input channels and launch the merger.
+            final List<ReadableFrameChannel> in = new ArrayList<>();
+            for (long i = currentSetStart; i < currentSetStart + maxChannelsPerProcessor; i++) {
+              if (inputsReady.remove(i)) {
+                try {
+                  final FrameFile handle = FrameFile.open(mergerOutputFile(inLevel, i), FrameFile.Flag.DELETE_ON_CLOSE);
+                  in.add(new ReadableFileFrameChannel(handle));
+                }
+                catch (IOException e) {
+                  throw new RuntimeException(e);
+                }
+              }
+            }
+
+            runMerger(outLevel, currentSetStart / maxChannelsPerProcessor, in, outPartitions);
+            return true;
+          } else if (w == currentSetStart + currentSetIndex + 1) {
+            currentSetIndex++;
+          } else {
+            currentSetStart = -1;
+            currentSetIndex = -1;
+          }
+        }
+      }
+    }
+
+    // Nothing to merge (yet?).
+    return false;
+  }
+
+  @GuardedBy("runWorkersLock")
+  private boolean runNextUltimateMerger()
+  {
+    if (totalMergingLevels == UNKNOWN_LEVEL
+        || !outputPartitionsFuture.isDone()
+        || ultimateMergersRunSoFar >= getOutputPartitions().size()) {
+      return false;
+    }
+
+    final int inLevel = totalMergingLevels - 2;
+    final int outLevel = inLevel + 1;
+    final LongSortedSet inputsReady = outputsReadyByLevel.get(inLevel);
+
+    if (inputsReady == null) {
+      return false;
+    }
+
+    final int numInputs = inputsReady.size();
+
+    if (numInputs != getTotalMergersInLevel(inLevel)) {
+      return false;
+    }
+
+    final List<ReadableFrameChannel> in = new ArrayList<>(numInputs);
+
+    for (long i = 0; i < numInputs; i++) {
+      final FrameFile fileHandle = penultimateFrameFileCache.computeIfAbsent(
+          mergerOutputFile(inLevel, i),
+          file -> {
+            try {
+              return FrameFile.open(file, FrameFile.Flag.DELETE_ON_CLOSE);
+            }
+            catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          }
+      ).newReference();
+
+      in.add(
+          new ReadableFileFrameChannel(
+              fileHandle,
+              fileHandle.getPartitionStartFrame(ultimateMergersRunSoFar),
+              fileHandle.getPartitionStartFrame(ultimateMergersRunSoFar + 1)
+          )
+      );
+    }
+
+    if (outputChannels == null) {
+      outputChannels = Arrays.asList(new OutputChannel[getOutputPartitions().size()]);
+    }
+
+    runMerger(outLevel, ultimateMergersRunSoFar, in, null);
+    ultimateMergersRunSoFar++;
+    return true;
+  }
+
+  @GuardedBy("runWorkersLock")
+  private void runMerger(
+      final int level,
+      final long rank,
+      final List<ReadableFrameChannel> in,
+      @Nullable final ClusterByPartitions partitions
+  )
+  {
+    try {
+      final WritableFrameChannel writableChannel;
+      final MemoryAllocator frameAllocator;
+
+      if (totalMergingLevels != UNKNOWN_LEVEL && level == totalMergingLevels - 1) {
+        final int intRank = Ints.checkedCast(rank);
+        final OutputChannel outputChannel = outputChannelFactory.openChannel(intRank);
+        outputChannels.set(intRank, outputChannel.readOnly());
+        writableChannel = outputChannel.getWritableChannel();
+        frameAllocator = outputChannel.getFrameMemoryAllocator();
+      } else {
+        frameAllocator = innerFrameAllocatorMaker.get();
+        writableChannel = new WritableStreamFrameChannel(
+            FrameFileWriter.open(
+                Files.newByteChannel(
+                    mergerOutputFile(level, rank).toPath(),
+                    StandardOpenOption.CREATE_NEW,
+                    StandardOpenOption.WRITE
+                ),
+                ByteBuffer.allocate(Frame.compressionBufferSize(frameAllocator.capacity()))
+            )
+        );
+      }
+
+      final FrameChannelMerger worker =
+          new FrameChannelMerger(
+              in,
+              frameReader,
+              writableChannel,
+              FrameWriters.makeFrameWriterFactory(
+                  FrameType.ROW_BASED, // Row-based frames are generally preferred as inputs to mergers
+                  frameAllocator,
+                  frameReader.signature(),
+
+                  // No sortColumns, because FrameChannelMerger generates frames that are sorted all on its own
+                  Collections.emptyList()
+              ),
+              clusterBy,
+              partitions,
+              rowLimit
+          );
+
+      runWorker(worker, ignored1 -> {
+        synchronized (runWorkersLock) {
+          outputsReadyByLevel.computeIfAbsent(level, ignored2 -> new LongRBTreeSet())
+                             .add(rank);
+          superSorterProgressTracker.addMergedBatchesForLevel(level, 1);
+        }
+      });
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private <T> void runWorker(final FrameProcessor<T> worker, final Consumer<T> outConsumer)
+  {
+    Futures.addCallback(
+        exec.runFully(worker, cancellationId),
+        new FutureCallback<T>()
+        {
+          @Override
+          public void onSuccess(T result)
+          {
+            try {
+              outConsumer.accept(result);
+
+              synchronized (runWorkersLock) {
+                workerFinished();
+              }
+            }
+            catch (Throwable e) {
+              synchronized (runWorkersLock) {
+                allDone.setException(e);
+              }
+            }
+          }
+
+          @Override
+          public void onFailure(Throwable t)
+          {
+            synchronized (runWorkersLock) {
+              allDone.setException(t);
+            }
+          }
+        },
+        // Must run in exec, instead of in the same thread, to avoid running callback immediately if the
+        // worker happens to finish super-quickly.
+        exec.getExecutorService()
+    );
+  }
+
+  // This also updates the progressTracker's number of total levels, and total mergers for levels. Therefore, if the
+  // progressTracker is present, calling this multiple times will throw an error.
+  @GuardedBy("runWorkersLock")
+  private void setTotalInputFrames(final long totalInputFrames)
+  {
+    this.totalInputFrames = totalInputFrames;
+
+    // Mark the progress tracker as trivially complete, if there is nothing to sort.
+    if (totalInputFrames == 0) {
+      superSorterProgressTracker.markTriviallyComplete();
+    }
+
+    // Set totalMergingLevels too
+    long totalMergersInLevel = totalInputFrames;
+    int level = 0;
+
+    while (totalMergersInLevel > maxChannelsPerProcessor) {
+      totalMergersInLevel = LongMath.divide(totalMergersInLevel, maxChannelsPerProcessor, RoundingMode.CEILING);
+      superSorterProgressTracker.setTotalMergersForLevel(level, totalMergersInLevel);
+      level++;
+    }
+
+    // Must have at least three levels. (Zero, penultimate, ultimate.)
+    totalMergingLevels = Math.max(level + 1, 3);
+
+    // Add remaining levels to the tracker, if required
+    IntStream.range(level, totalMergingLevels)
+             .forEach(curLevel -> {
+               synchronized (runWorkersLock) {
+                 superSorterProgressTracker.setTotalMergersForLevel(curLevel, 1);
+               }
+             });
+
+    superSorterProgressTracker.setTotalMergingLevels(totalMergingLevels);
+  }
+
+  private ClusterByPartitions getOutputPartitions()
+  {
+    if (!outputPartitionsFuture.isDone()) {
+      throw new ISE("Output partitions are not ready yet");
+    }
+
+    try {
+      return outputPartitionsFuture.get();
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+    catch (ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @GuardedBy("runWorkersLock")
+  private long getTotalMergersInLevel(final int level)
+  {
+    if (totalInputFrames == UNKNOWN_TOTAL || totalMergingLevels == UNKNOWN_LEVEL) {
+      return UNKNOWN_TOTAL;
+    } else if (level >= totalMergingLevels) {
+      throw new ISE("Invalid level %d", level);
+    } else if (level == totalMergingLevels - 1) {
+      return outputPartitionsFuture.isDone() ? getOutputPartitions().size() : UNKNOWN_TOTAL;
+    } else {
+      long totalMergersInLevel = totalInputFrames;
+
+      for (int i = 0; i <= level; i++) {
+        totalMergersInLevel = LongMath.divide(totalMergersInLevel, maxChannelsPerProcessor, RoundingMode.CEILING);
+      }
+
+      return totalMergersInLevel;
+    }
+  }
+
+  @GuardedBy("runWorkersLock")
+  private boolean allInputRead()
+  {
+    return totalInputFrames != UNKNOWN_TOTAL;
+  }
+
+  /**
+   * Whether this instance has finished its processing. This may be due to successful completion, or it may be due
+   * to cancellation or error.
+   *
+   * Note: it is possible for this method to return true even when {@link #activeProcessors} is nonzero. Processors
+   * take some time to exit after the instance becomes "done".
+   */
+  @GuardedBy("runWorkersLock")
+  private boolean isAllDone()
+  {
+    return allDone.isDone() || allDone.isCancelled();
+  }
+
+  /**
+   * Cleanup that must happen regardless of success or failure.
+   */
+  @GuardedBy("runWorkersLock")
+  private void cleanUp()
+  {
+    if (!isAllDone() || activeProcessors != 0) {
+      // This condition indicates a logic bug.
+      throw new ISE("Improper cleanup");
+    }
+
+    if (log.isDebugEnabled()) {
+      log.debug(stateString());
+    }
+
+    outputsReadyByLevel.clear();
+    inputBuffer.clear();
+
+    for (FrameFile frameFile : penultimateFrameFileCache.values()) {
+      CloseableUtils.closeAndSuppressExceptions(
+          frameFile,
+          e -> log.warn(e, "Could not close intermediate file [%s]", frameFile.file())
+      );
+    }
+
+    penultimateFrameFileCache.clear();
+
+    if (!inputChannelsToRead.isEmpty()) {
+      for (final ReadableFrameChannel inputChannel : inputChannels) {
+        CloseableUtils.closeAndSuppressExceptions(
+            inputChannel::doneReading,
+            e -> log.warn(e, "Could not close input channel")
+        );
+      }
+
+      inputChannels.forEach(ReadableFrameChannel::doneReading);
+    }
+
+    inputChannelsToRead.clear();
+  }
+
+  private File mergerOutputFile(final int level, final long rank)
+  {
+    return new File(directory, StringUtils.format("merged.%d.%d", level, rank));
+  }
+
+  /**
+   * Returns a string encapsulating the current state of this object.
+   */
+  public String stateString()
+  {
+    synchronized (runWorkersLock) {
+      return "frames-in=" + inputFramesReadSoFar + "/" + totalInputFrames
+             + " frames-buffered=" + inputBuffer.size()
+             + " lvls=" + totalMergingLevels
+             + " parts=" +
+             (outputPartitionsFuture.isDone() ? FutureUtils.getUncheckedImmediately(outputPartitionsFuture).size() : -1)
+             + " p=" + activeProcessors + "/" + maxActiveProcessors
+             + " ch-pending=" + inputChannelsToRead
+             + " to-merge=" + outputsReadyByLevel
+             + " done=" + (isAllDone() ? "y" : "n");
+    }
+  }
+
+  private static ReadableFrameChannel singleReadableFrameChannel(final FrameWithPartition frame)
+  {
+    final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+    channel.write(frame);
+    channel.doneWriting();
+    return channel;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -43,7 +43,7 @@ import org.apache.druid.frame.channel.FrameWithPartition;
 import org.apache.druid.frame.channel.ReadableFileFrameChannel;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
 import org.apache.druid.frame.channel.WritableFrameChannel;
-import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameFileChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.frame.file.FrameFileWriter;
 import org.apache.druid.frame.key.ClusterBy;
@@ -621,7 +621,7 @@ public class SuperSorter
         frameAllocator = outputChannel.getFrameMemoryAllocator();
       } else {
         frameAllocator = innerFrameAllocatorMaker.get();
-        writableChannel = new WritableStreamFrameChannel(
+        writableChannel = new WritableFrameFileChannel(
             FrameFileWriter.open(
                 Files.newByteChannel(
                     mergerOutputFile(level, rank).toPath(),

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -210,7 +210,8 @@ public class SuperSorter
    *                                   {@link FrameProcessorExecutor}
    * @param maxChannelsPerProcessor    maximum number of channels to merge at once per merging processor
    * @param rowLimit                   limit to apply during sorting. The limit is merely advisory: the actual number
-   *                                   of rows returned may be larger than the limit.
+   *                                   of rows returned may be larger than the limit. The limit is applied across
+   *                                   all partitions, not to each partition individually.
    * @param cancellationId             cancellation id to use when running processors in the provided
    *                                   {@link FrameProcessorExecutor}.
    * @param superSorterProgressTracker progress tracker

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshot.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshot.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Like {@link SuperSorterProgressTracker}, but immutable.
+ */
+public class SuperSorterProgressSnapshot
+{
+  private final int totalMergingLevels;
+  private final Map<Integer, Long> levelToTotalBatches;
+  private final Map<Integer, Long> levelToMergedBatches;
+  private final long totalMergersForUltimateLevel;
+  private final boolean isTriviallyComplete;
+
+  @JsonCreator
+  public SuperSorterProgressSnapshot(
+      @JsonProperty("totalMergingLevels") final int totalMergingLevels,
+      @JsonProperty("levelToTotalBatches") final Map<Integer, Long> levelToTotalBatches,
+      @JsonProperty("levelToMergedBatches") final Map<Integer, Long> levelToMergedBatches,
+      @JsonProperty("totalMergersForUltimateLevel") final long totalMergersForUltimateLevel,
+      @JsonProperty("triviallyComplete") final boolean isTriviallyComplete
+  )
+  {
+    this.totalMergingLevels = totalMergingLevels;
+    this.levelToTotalBatches = levelToTotalBatches;
+    this.levelToMergedBatches = levelToMergedBatches;
+    this.totalMergersForUltimateLevel = totalMergersForUltimateLevel;
+    this.isTriviallyComplete = isTriviallyComplete;
+  }
+
+  @JsonProperty(value = "totalMergingLevels")
+  public int getTotalMergingLevels()
+  {
+    return totalMergingLevels;
+  }
+
+  @JsonProperty(value = "levelToTotalBatches")
+  public Map<Integer, Long> getLevelToTotalBatches()
+  {
+    return levelToTotalBatches;
+  }
+
+  @JsonProperty(value = "levelToMergedBatches")
+  public Map<Integer, Long> getLevelToMergedBatches()
+  {
+    return levelToMergedBatches;
+  }
+
+  @JsonProperty("totalMergersForUltimateLevel")
+  public long getTotalMergersForUltimateLevel()
+  {
+    return totalMergersForUltimateLevel;
+  }
+
+  @JsonProperty("triviallyComplete")
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public boolean isTriviallyComplete()
+  {
+    return isTriviallyComplete;
+  }
+
+  @Nullable
+  @JsonProperty(value = "progressDigest")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Double getProgressDigest()
+  {
+    // Progress is complete if the inputs are sorted trivially without doing any work
+    if (isTriviallyComplete) {
+      return 1.0;
+    }
+
+    if (totalMergingLevels == SuperSorter.UNKNOWN_LEVEL) {
+      return null;
+    }
+
+    double progress = 0.0;
+
+    for (int level = 0; level < totalMergingLevels; ++level) {
+      final Long mergedBatches = levelToMergedBatches.getOrDefault(level, 0L);
+      final Long totalBatches = levelToTotalBatches.getOrDefault(level, SuperSorter.UNKNOWN_TOTAL);
+      if (mergedBatches != null && totalBatches != null && totalBatches > 0) {
+        final double levelProgress = mergedBatches.doubleValue() / totalBatches.doubleValue();
+        progress += levelProgress / totalMergingLevels;
+      }
+    }
+
+    // We use a delta of 0.000001 to round up in case the progress is 1.
+    // The following operation maps the results from range of [0.999999, +inf] to 1 (+inf is not possible, but that is
+    // the behaviour of the following statement)
+    return ((progress + 1e-6) > 1.0) ? 1.0 : progress;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SuperSorterProgressSnapshot that = (SuperSorterProgressSnapshot) o;
+    return totalMergingLevels == that.totalMergingLevels
+           && totalMergersForUltimateLevel == that.totalMergersForUltimateLevel
+           && isTriviallyComplete == that.isTriviallyComplete
+           && Objects.equals(levelToTotalBatches, that.levelToTotalBatches)
+           && Objects.equals(levelToMergedBatches, that.levelToMergedBatches);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(
+        totalMergingLevels,
+        levelToTotalBatches,
+        levelToMergedBatches,
+        totalMergersForUltimateLevel,
+        isTriviallyComplete
+    );
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorterProgressTracker.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorterProgressTracker.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.Ordering;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A thread-safe class that keeps track of the progress of an n-way, multilevel merge sort. The logic for this
+ * class is coupled to the implementation of {@link SuperSorter}, which it is designed to track.
+ *
+ * It keeps a track of the following things:
+ * 1. Total levels to merge (Cannnot be modified once set)
+ * 2. Total mergers to merge in each level
+ * 3. Total merged batches in each level
+ *
+ * There are a few states in which this progress tracker can be in (depending on the SuperSorter's progres):
+ * 1. Unknown everything                                   | totalMergingLevels = -1, mergersForUltimateLevel = UNKNOWN_TOTAL
+ * 2. Known total levels, but unknown output partitions    | totalMergingLevels = set, mergersForUltimateLevelSet = UNKNOWN_TOTAL
+ * 3. Unknown total levels, but known output partitions    | totalMergingLevels = -1, mergersForUltimateLevelSet != UNKNOWN_TOTAL
+ * 4. Known everything                                     | totalMergingLevels = set, mergersForUltimateLevelSet != UNKNOWN_TOTAL
+ *
+ * Progress can only be quantified if the total levels are known
+ *
+ * snapshot function does the housekeeping to hide this operational complexity away from classes other than {@link SuperSorter}
+ * and {@link SuperSorterProgressTracker}
+ */
+public class SuperSorterProgressTracker
+{
+  private int totalMergingLevels = SuperSorter.UNKNOWN_LEVEL;
+
+  // the value of total batches in levelToTotalBatches for the ultimate level get overridden by this member. This is
+  // because the ultimate level is blocked on getting the output partitions, which may happen during the progress of the
+  // SuperSorter
+  private long totalMergersForUltimateLevel = SuperSorter.UNKNOWN_TOTAL;
+
+  // level -> number of mergers in that level, might have some value for the ultimate level, but that is to be ignored
+  private final Map<Integer, Long> levelToTotalBatches;
+
+  // level -> number of mergers completed in that level
+  private final Map<Integer, Long> levelToMergedBatches;
+
+  // This is set to true if the SuperSorter doesn't need to do any work. For example, if there is no input to sort
+  private boolean isTriviallyComplete = false;
+
+  /**
+   * Snapshot of a SuperSorter that is trivially sorted. All the maps have been cleared up. While this is not required
+   * since isTriviallyComplete=true ensures that progressDigest=1.0, it produces a better output
+   */
+  private static final SuperSorterProgressSnapshot TRIVIALLY_COMPLETE_SNAPSHOT = new SuperSorterProgressSnapshot(
+      SuperSorter.UNKNOWN_LEVEL,
+      Collections.emptyMap(),
+      Collections.emptyMap(),
+      SuperSorter.UNKNOWN_TOTAL,
+      true
+  );
+
+  public SuperSorterProgressTracker()
+  {
+    this.levelToMergedBatches = new HashMap<>();
+    this.levelToTotalBatches = new HashMap<>();
+  }
+
+  /**
+   * Set total merging levels for the SuperSorter it is tracking. Can be set only once
+   */
+  public synchronized void setTotalMergingLevels(final int totalMergingLevels)
+  {
+    if (this.totalMergingLevels != SuperSorter.UNKNOWN_LEVEL) {
+      throw new ISE("Total merging levels already defined for the merge sort.");
+    }
+    levelToMergedBatches.keySet().stream().max(Ordering.natural()).ifPresent(max -> {
+      if (max >= totalMergingLevels) {
+        throw new ISE(
+            "Max level found in levelToMergedBatches is %d (0-indexed). Cannot set totalMergingLevels to %d",
+            max,
+            totalMergingLevels
+        );
+      }
+    });
+    levelToTotalBatches.keySet().stream().max(Ordering.natural()).ifPresent(max -> {
+      if (max >= totalMergingLevels) {
+        throw new ISE(
+            "Max level found in levelToTotalBatches is %d (0-indexed). Cannot set totalMergingLevels to %d",
+            max,
+            totalMergingLevels
+        );
+      }
+    });
+
+    this.totalMergingLevels = totalMergingLevels;
+  }
+
+  /**
+   * Sets the total mergers for a level. Can be set only once, except for the ultimate level (if total levels are known)
+   * because they get overridden by totalMergersForUltimateLevel
+   */
+  public synchronized void setTotalMergersForLevel(final int level, final long totalMergers)
+  {
+    if (level < 0) {
+      throw new ISE("Unable to set %d total mergers for level %d. Level must be non-negative", totalMergers, level);
+    }
+    if (totalMergingLevels != SuperSorter.UNKNOWN_LEVEL && level >= totalMergingLevels) {
+      throw new ISE(
+          "Cannot set total mergers for level %d. Valid levels range from 0 to %d",
+          level,
+          totalMergingLevels - 1
+      );
+    }
+    if (totalMergingLevels != SuperSorter.UNKNOWN_LEVEL
+        && level < totalMergingLevels - 1 // This condition is only present for levels excluding the ultimate level
+        && levelToTotalBatches.containsKey(level)) {
+      throw new ISE("Total mergers are already present for the level %d", level);
+    }
+    levelToTotalBatches.put(level, totalMergers);
+  }
+
+  /**
+   * Sets the number of mergers in the ultimate level (number of mergers = number of output partitions).
+   * Can only be set once
+   */
+  public synchronized void setTotalMergersForUltimateLevel(final long totalMergersForUltimateLevel)
+  {
+    if (this.totalMergersForUltimateLevel != SuperSorter.UNKNOWN_TOTAL) {
+      throw new ISE("Cannot set mergers for final level more than once");
+    }
+    this.totalMergersForUltimateLevel = totalMergersForUltimateLevel;
+  }
+
+  /**
+   * This method is designed to be called during the course of the sorting. The batches once merged for a particular
+   * level can be marked as such through this.
+   */
+  public synchronized void addMergedBatchesForLevel(final int level, final long additionalMergedBatches)
+  {
+    if (totalMergingLevels != SuperSorter.UNKNOWN_LEVEL && level >= totalMergingLevels) {
+      throw new ISE(
+          "Cannot add merged batches for level %d. Valid levels range from 0 to %d",
+          level,
+          totalMergingLevels - 1
+      );
+    }
+    levelToMergedBatches.compute(level, (l, mergedBatchesSoFar) -> mergedBatchesSoFar == null
+                                                                   ? additionalMergedBatches
+                                                                   : additionalMergedBatches + mergedBatchesSoFar);
+  }
+
+  /**
+   * If the SuperSorter is trivially done without doing any work (for eg - empty input), the tracker can be marked as
+   * trivially complete. Once a tracker is marked as complete, the snapshots will always report back the progress
+   * digest as 1. Any modification to the state of the tracker (eg: calling setTotalMergersForLevel()) would proceed
+   * as regular, but
+   */
+  public synchronized void markTriviallyComplete()
+  {
+    this.isTriviallyComplete = true;
+  }
+
+  /**
+   * @return Aggregates the information present in the tracker object and returns a
+   * {@link SuperSorterProgressSnapshot} representing the same information
+   */
+  public synchronized SuperSorterProgressSnapshot snapshot()
+  {
+    if (isTriviallyComplete) {
+      return TRIVIALLY_COMPLETE_SNAPSHOT; // Return a cleaned up snapshot
+    }
+    final Map<Integer, Long> levelToTotalBatchesCopy = new HashMap<>(this.levelToTotalBatches);
+    final Map<Integer, Long> levelToMergedBatchesCopy = new HashMap<>(this.levelToMergedBatches);
+
+    if (this.totalMergingLevels != SuperSorter.UNKNOWN_LEVEL
+        && totalMergersForUltimateLevel != SuperSorter.UNKNOWN_TOTAL) {
+      levelToTotalBatchesCopy.put(this.totalMergingLevels - 1, totalMergersForUltimateLevel);
+    } else if (this.totalMergingLevels
+               != SuperSorter.UNKNOWN_LEVEL) { // Override whatever was written in the original map
+      levelToTotalBatchesCopy.put(this.totalMergingLevels - 1, SuperSorter.UNKNOWN_TOTAL);
+    }
+    return new SuperSorterProgressSnapshot(
+        this.totalMergingLevels,
+        levelToTotalBatchesCopy,
+        levelToMergedBatchesCopy,
+        totalMergersForUltimateLevel,
+        isTriviallyComplete
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
@@ -74,6 +74,8 @@ public class ReadableByteChunksFrameChannelTest
       channel.doneWriting();
 
       Assert.assertTrue(channel.canRead());
+      Assert.assertFalse(channel.isFinished());
+      Assert.assertTrue(channel.isErrorOrFinished());
 
       expectedException.expect(IllegalStateException.class);
       expectedException.expectMessage("Incomplete or missing frame at end of stream (id = test, position = 0)");
@@ -89,6 +91,8 @@ public class ReadableByteChunksFrameChannelTest
       channel.doneWriting();
 
       Assert.assertTrue(channel.canRead());
+      Assert.assertFalse(channel.isFinished());
+      Assert.assertTrue(channel.isErrorOrFinished());
 
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage("test error");
@@ -99,6 +103,7 @@ public class ReadableByteChunksFrameChannelTest
     @Test
     public void testEmptyFrameFile() throws IOException
     {
+      // File with no frames (but still well-formed).
       final File file = FrameTestUtil.writeFrameFile(Sequences.empty(), temporaryFolder.newFile());
 
       final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
@@ -106,6 +111,8 @@ public class ReadableByteChunksFrameChannelTest
       channel.doneWriting();
 
       while (channel.canRead()) {
+        Assert.assertFalse(channel.isFinished());
+        Assert.assertFalse(channel.isErrorOrFinished());
         channel.read();
       }
 
@@ -141,12 +148,18 @@ public class ReadableByteChunksFrameChannelTest
       channel.doneWriting();
 
       Assert.assertTrue(channel.canRead());
+      Assert.assertFalse(channel.isFinished());
+      Assert.assertFalse(channel.isErrorOrFinished());
       channel.read(); // Throw away value.
 
       Assert.assertTrue(channel.canRead());
+      Assert.assertFalse(channel.isFinished());
+      Assert.assertFalse(channel.isErrorOrFinished());
       channel.read(); // Throw away value.
 
       Assert.assertTrue(channel.canRead());
+      Assert.assertFalse(channel.isFinished());
+      Assert.assertTrue(channel.isErrorOrFinished());
 
       expectedException.expect(IllegalStateException.class);
       expectedException.expectMessage(CoreMatchers.startsWith("Incomplete or missing frame at end of stream"));

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
@@ -116,7 +116,7 @@ public class ReadableByteChunksFrameChannelTest
       }
 
       Assert.assertTrue(channel.isFinished());
-      channel.doneReading();
+      channel.close();
     }
 
     @Test
@@ -311,14 +311,14 @@ public class ReadableByteChunksFrameChannelTest
           // Read one frame every 3 iterations. Read everything every 11 iterations. Otherwise, read nothing.
           if (iteration % 3 == 0) {
             while (channel.canRead()) {
-              outChannel.write(channel.read());
+              outChannel.writable().write(channel.read());
             }
 
             // After reading everything, backpressure should be off.
             Assert.assertTrue(backpressureFuture == null || backpressureFuture.isDone());
           } else if (iteration % 11 == 0) {
             if (channel.canRead()) {
-              outChannel.write(channel.read());
+              outChannel.writable().write(channel.read());
             }
           }
 
@@ -347,15 +347,15 @@ public class ReadableByteChunksFrameChannelTest
 
         // Get all the remaining frames.
         while (channel.canRead()) {
-          outChannel.write(channel.read());
+          outChannel.writable().write(channel.read());
         }
 
-        outChannel.doneWriting();
+        outChannel.writable().close();
       }
 
       FrameTestUtil.assertRowsEqual(
           FrameTestUtil.readRowsFromAdapter(adapter, null, false),
-          FrameTestUtil.readRowsFromFrameChannel(outChannel, FrameReader.create(adapter.getRowSignature()))
+          FrameTestUtil.readRowsFromFrameChannel(outChannel.readable(), FrameReader.create(adapter.getRowSignature()))
       );
     }
 

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@RunWith(Enclosed.class)
+public class ReadableByteChunksFrameChannelTest
+{
+  /**
+   * Non-parameterized test cases. Each one is special.
+   */
+  public static class NonParameterizedTests extends InitializedNullHandlingTest
+  {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testZeroBytes()
+    {
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      channel.doneWriting();
+
+      Assert.assertTrue(channel.canRead());
+
+      expectedException.expect(IllegalStateException.class);
+      expectedException.expectMessage("Incomplete or missing frame at end of stream (id = test, position = 0)");
+
+      channel.read();
+    }
+
+    @Test
+    public void testZeroBytesWithSpecialError()
+    {
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      channel.setError(new IllegalArgumentException("test error"));
+      channel.doneWriting();
+
+      Assert.assertTrue(channel.canRead());
+
+      expectedException.expect(IllegalArgumentException.class);
+      expectedException.expectMessage("test error");
+
+      channel.read();
+    }
+
+    @Test
+    public void testEmptyFrameFile() throws IOException
+    {
+      final File file = FrameTestUtil.writeFrameFile(Sequences.empty(), temporaryFolder.newFile());
+
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      channel.addChunk(Files.toByteArray(file));
+      channel.doneWriting();
+
+      while (channel.canRead()) {
+        channel.read();
+      }
+
+      Assert.assertTrue(channel.isFinished());
+      channel.doneReading();
+    }
+
+    @Test
+    public void testTruncatedFrameFile() throws IOException
+    {
+      final int allocatorSize = 64000;
+      final int truncatedSize = 30000; // Holds two full columnar frames + one partial frame, after compression.
+
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+      final File file = FrameTestUtil.writeFrameFile(
+          FrameSequenceBuilder.fromAdapter(adapter)
+                              .allocator(ArenaMemoryAllocator.create(ByteBuffer.allocate(allocatorSize)))
+                              .frameType(FrameType.COLUMNAR) // No particular reason to test with both frame types
+                              .frames(),
+          temporaryFolder.newFile()
+      );
+
+      final byte[] truncatedFile = new byte[truncatedSize];
+
+      try (final FileInputStream in = new FileInputStream(file)) {
+        ByteStreams.readFully(in, truncatedFile);
+      }
+
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      channel.addChunk(truncatedFile);
+      channel.doneWriting();
+
+      Assert.assertTrue(channel.canRead());
+      channel.read(); // Throw away value.
+
+      Assert.assertTrue(channel.canRead());
+      channel.read(); // Throw away value.
+
+      Assert.assertTrue(channel.canRead());
+
+      expectedException.expect(IllegalStateException.class);
+      expectedException.expectMessage(CoreMatchers.startsWith("Incomplete or missing frame at end of stream"));
+      channel.read();
+    }
+
+    @Test
+    public void testSetError() throws IOException
+    {
+      final int allocatorSize = 64000;
+      final int errorAtBytePosition = 30000; // Holds two full frames + one partial frame, after compression.
+
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+      final File file = FrameTestUtil.writeFrameFile(
+          FrameSequenceBuilder.fromAdapter(adapter)
+                              .allocator(ArenaMemoryAllocator.create(ByteBuffer.allocate(allocatorSize)))
+                              .frameType(FrameType.COLUMNAR) // No particular reason to test with both frame types
+                              .frames(),
+          temporaryFolder.newFile()
+      );
+
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      final byte[] fileBytes = Files.toByteArray(file);
+      final byte[] chunk1 = new byte[errorAtBytePosition];
+      System.arraycopy(fileBytes, 0, chunk1, 0, chunk1.length);
+      channel.addChunk(chunk1);
+      channel.setError(new ISE("Test error!"));
+      channel.doneWriting();
+
+      expectedException.expect(IllegalStateException.class);
+      expectedException.expectMessage("Test error!");
+      channel.read();
+    }
+  }
+
+  /**
+   * Parameterized test cases that use various FrameFiles built from {@link TestIndex#getIncrementalTestIndex()}.
+   */
+  @RunWith(Parameterized.class)
+  public static class ParameterizedWithTestIndexTests extends InitializedNullHandlingTest
+  {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final FrameType frameType;
+    private final int maxRowsPerFrame;
+    private final int chunkSize;
+
+    public ParameterizedWithTestIndexTests(final FrameType frameType, final int maxRowsPerFrame, final int chunkSize)
+    {
+      this.frameType = frameType;
+      this.maxRowsPerFrame = maxRowsPerFrame;
+      this.chunkSize = chunkSize;
+    }
+
+    @Parameterized.Parameters(name = "frameType = {0}, maxRowsPerFrame = {1}, chunkSize = {2}")
+    public static Iterable<Object[]> constructorFeeder()
+    {
+      final List<Object[]> constructors = new ArrayList<>();
+
+      for (FrameType frameType : FrameType.values()) {
+        for (int maxRowsPerFrame : new int[]{1, 50, Integer.MAX_VALUE}) {
+          for (int chunkSize : new int[]{1, 10, 1_000, 5_000, 50_000, 1_000_000}) {
+            constructors.add(new Object[]{frameType, maxRowsPerFrame, chunkSize});
+          }
+        }
+      }
+
+      return constructors;
+    }
+
+    @Test
+    public void testWriteFullyThenRead() throws IOException
+    {
+      // Create a frame file.
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+      final File file = FrameTestUtil.writeFrameFile(
+          FrameSequenceBuilder.fromAdapter(adapter)
+                              .maxRowsPerFrame(maxRowsPerFrame)
+                              .frameType(frameType)
+                              .frames(),
+          temporaryFolder.newFile()
+      );
+
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      ListenableFuture<?> backpressureFuture = null;
+
+      Assert.assertEquals(0, channel.getBytesBuffered());
+
+      try (final Chunker chunker = new Chunker(new FileInputStream(file), chunkSize)) {
+        byte[] chunk;
+
+        while ((chunk = chunker.nextChunk()) != null) {
+          final Optional<ListenableFuture<?>> addVal = channel.addChunk(chunk);
+
+          // Minimally-sized channel means backpressure is exerted as soon as a single frame is available.
+          Assert.assertEquals(channel.canRead(), addVal.isPresent());
+
+          if (addVal.isPresent()) {
+            if (backpressureFuture == null) {
+              backpressureFuture = addVal.get();
+            } else {
+              Assert.assertSame(backpressureFuture, addVal.get());
+            }
+          }
+        }
+
+        // Backpressure should be exerted right now, since this is a minimal channel with at least one full frame in it.
+        Assert.assertNotNull(backpressureFuture);
+        Assert.assertFalse(backpressureFuture.isDone());
+
+        channel.doneWriting();
+      }
+
+      FrameTestUtil.assertRowsEqual(
+          FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+          FrameTestUtil.readRowsFromFrameChannel(channel, FrameReader.create(adapter.getRowSignature()))
+      );
+    }
+
+    @Test
+    public void testWriteReadInterleaved() throws IOException
+    {
+      // Create a frame file.
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+      final File file = FrameTestUtil.writeFrameFile(
+          FrameSequenceBuilder.fromAdapter(adapter)
+                              .maxRowsPerFrame(maxRowsPerFrame)
+                              .frameType(frameType)
+                              .frames(),
+          temporaryFolder.newFile()
+      );
+
+      final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test");
+      final BlockingQueueFrameChannel outChannel = new BlockingQueueFrameChannel(10_000); // Enough to hold all frames
+      ListenableFuture<?> backpressureFuture = null;
+
+      int iteration = 0;
+
+      try (final Chunker chunker = new Chunker(new FileInputStream(file), chunkSize)) {
+        byte[] chunk;
+
+        while ((chunk = chunker.nextChunk()) != null) {
+          // Read one frame every 3 iterations. Read everything every 11 iterations. Otherwise, read nothing.
+          if (iteration % 3 == 0) {
+            while (channel.canRead()) {
+              outChannel.write(channel.read());
+            }
+
+            // After reading everything, backpressure should be off.
+            Assert.assertTrue(backpressureFuture == null || backpressureFuture.isDone());
+          } else if (iteration % 11 == 0) {
+            if (channel.canRead()) {
+              outChannel.write(channel.read());
+            }
+          }
+
+          if (backpressureFuture != null && backpressureFuture.isDone()) {
+            backpressureFuture = null;
+          }
+
+          iteration++;
+
+          // Write next chunk.
+          final Optional<ListenableFuture<?>> addVal = channel.addChunk(chunk);
+
+          // Minimally-sized channel means backpressure is exerted as soon as a single frame is available.
+          Assert.assertEquals(channel.canRead(), addVal.isPresent());
+
+          if (addVal.isPresent()) {
+            if (backpressureFuture == null) {
+              backpressureFuture = addVal.get();
+            } else {
+              Assert.assertSame(backpressureFuture, addVal.get());
+            }
+          }
+        }
+
+        channel.doneWriting();
+
+        // Get all the remaining frames.
+        while (channel.canRead()) {
+          outChannel.write(channel.read());
+        }
+
+        outChannel.doneWriting();
+      }
+
+      FrameTestUtil.assertRowsEqual(
+          FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+          FrameTestUtil.readRowsFromFrameChannel(outChannel, FrameReader.create(adapter.getRowSignature()))
+      );
+    }
+
+    private static class Chunker implements Closeable
+    {
+      private final FileInputStream in;
+      private final int chunkSize;
+      private final byte[] buf;
+      private boolean eof = false;
+
+      public Chunker(final FileInputStream in, final int chunkSize)
+      {
+        this.in = in;
+        this.chunkSize = chunkSize;
+        this.buf = new byte[chunkSize];
+      }
+
+      @Nullable
+      public byte[] nextChunk() throws IOException
+      {
+        if (eof) {
+          return null;
+        }
+
+        int p = 0;
+        while (p < chunkSize) {
+          final int r = in.read(buf, p, chunkSize - p);
+
+          if (r < 0) {
+            eof = true;
+            break;
+          } else {
+            p += r;
+          }
+        }
+
+        if (p > 0) {
+          return Arrays.copyOf(buf, p);
+        } else {
+          return null;
+        }
+      }
+
+      @Override
+      public void close() throws IOException
+      {
+        in.close();
+      }
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
@@ -51,6 +51,9 @@ public class ReadableConcatFrameChannelTest extends InitializedNullHandlingTest
       channel.write(frame);
       channel.doneWriting();
       channels.add(channel);
+
+      // Sprinkle in some empty channels too, to make sure they work.
+      channels.add(ReadableNilFrameChannel.INSTANCE);
     }
 
     final ReadableConcatFrameChannel concatChannel = ReadableConcatFrameChannel.open(channels.iterator());

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ReadableConcatFrameChannelTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testChannel() throws Exception
+  {
+    final QueryableIndexStorageAdapter adapter = new QueryableIndexStorageAdapter(TestIndex.getMMappedTestIndex());
+    final List<Frame> frames =
+        FrameSequenceBuilder.fromAdapter(adapter)
+                            .frameType(FrameType.ROW_BASED)
+                            .maxRowsPerFrame(11)
+                            .frames()
+                            .toList();
+
+    final List<ReadableFrameChannel> channels = new ArrayList<>();
+    for (final Frame frame : frames) {
+      final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+      channel.write(frame);
+      channel.doneWriting();
+      channels.add(channel);
+    }
+
+    final ReadableConcatFrameChannel concatChannel = ReadableConcatFrameChannel.open(channels.iterator());
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(concatChannel, FrameReader.create(adapter.getRowSignature()))
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableConcatFrameChannelTest.java
@@ -48,9 +48,9 @@ public class ReadableConcatFrameChannelTest extends InitializedNullHandlingTest
     final List<ReadableFrameChannel> channels = new ArrayList<>();
     for (final Frame frame : frames) {
       final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
-      channel.write(frame);
-      channel.doneWriting();
-      channels.add(channel);
+      channel.writable().write(frame);
+      channel.writable().close();
+      channels.add(channel.readable());
 
       // Sprinkle in some empty channels too, to make sure they work.
       channels.add(ReadableNilFrameChannel.INSTANCE);

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.channel;
+
+import com.google.common.io.ByteStreams;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.concurrent.ExecutorService;
+
+public class ReadableInputStreamFrameChannelTest extends InitializedNullHandlingTest
+{
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  final IncrementalIndexStorageAdapter adapter =
+      new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+  ExecutorService executorService = Execs.singleThreaded("input-stream-fetcher-test");
+
+  @Test
+  public void testSimpleFrameFile()
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "readSimpleFrameFile",
+        executorService
+    );
+
+    readableInputStreamFrameChannel.startReading();
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(
+            readableInputStreamFrameChannel,
+            FrameReader.create(adapter.getRowSignature())
+        )
+    );
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+
+  }
+
+
+  @Test
+  public void testEmptyFrameFile() throws IOException
+  {
+    final File file = FrameTestUtil.writeFrameFile(Sequences.empty(), temporaryFolder.newFile());
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        Files.newInputStream(file.toPath()),
+        "readEmptyFrameFile",
+        executorService
+    );
+
+    readableInputStreamFrameChannel.startReading();
+
+    Assert.assertEquals(FrameTestUtil.readRowsFromFrameChannel(
+        readableInputStreamFrameChannel,
+        FrameReader.create(adapter.getRowSignature())
+    ).toList().size(), 0);
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+  @Test
+  public void testZeroBytesFrameFile() throws IOException
+  {
+    final File file = temporaryFolder.newFile();
+    FileOutputStream outputStream = new FileOutputStream(file);
+    outputStream.write(new byte[0]);
+    outputStream.close();
+
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        Files.newInputStream(file.toPath()),
+        "testZeroBytesFrameFile",
+        executorService
+    );
+
+    readableInputStreamFrameChannel.startReading();
+
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Incomplete or missing frame at end of stream");
+
+    FrameTestUtil.readRowsFromFrameChannel(
+        readableInputStreamFrameChannel,
+        FrameReader.create(adapter.getRowSignature())
+    ).toList();
+  }
+
+  @Test
+  public void testTruncatedFrameFile() throws IOException
+  {
+    final int allocatorSize = 64000;
+    final int truncatedSize = 30000; // Holds two full frames + one partial frame, after compression.
+
+    final IncrementalIndexStorageAdapter adapter =
+        new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+
+    final File file = FrameTestUtil.writeFrameFile(
+        FrameSequenceBuilder.fromAdapter(adapter)
+                            .allocator(ArenaMemoryAllocator.create(ByteBuffer.allocate(allocatorSize)))
+                            .frameType(FrameType.ROW_BASED)
+                            .frames(),
+        temporaryFolder.newFile()
+    );
+
+    final byte[] truncatedFile = new byte[truncatedSize];
+
+    try (final FileInputStream in = new FileInputStream(file)) {
+      ByteStreams.readFully(in, truncatedFile);
+    }
+
+
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        new ByteArrayInputStream(truncatedFile),
+        "readTruncatedFrameFile",
+        executorService
+    );
+
+    readableInputStreamFrameChannel.startReading();
+
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Incomplete or missing frame at end of stream");
+
+    Assert.assertEquals(FrameTestUtil.readRowsFromFrameChannel(
+        readableInputStreamFrameChannel,
+        FrameReader.create(adapter.getRowSignature())
+    ).toList().size(), 0);
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+  @Test
+  public void testIncorrectFrameFile() throws IOException
+  {
+    final File file = temporaryFolder.newFile();
+    FileOutputStream outputStream = new FileOutputStream(file);
+    outputStream.write(10);
+    outputStream.close();
+
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        Files.newInputStream(file.toPath()),
+        "readIncorrectFrameFile",
+        executorService
+    );
+
+    readableInputStreamFrameChannel.startReading();
+
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Incomplete or missing frame at end of stream");
+
+    Assert.assertEquals(FrameTestUtil.readRowsFromFrameChannel(
+        readableInputStreamFrameChannel,
+        FrameReader.create(adapter.getRowSignature())
+    ).toList().size(), 0);
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+
+  }
+
+
+  @Test
+  public void closeInputStreamWhileReading() throws IOException
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "closeInputStreamWhileReading",
+        executorService
+    );
+    inputStream.close();
+    readableInputStreamFrameChannel.startReading();
+
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Found error while reading input stream");
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(
+            readableInputStreamFrameChannel,
+            FrameReader.create(adapter.getRowSignature())
+        )
+    );
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+
+  @Test
+  public void closeInputStreamWhileReadingCheckError() throws IOException, InterruptedException
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "closeInputStreamWhileReadingCheckError",
+        executorService
+    );
+
+    inputStream.close();
+    readableInputStreamFrameChannel.startReading();
+
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Found error while reading input stream");
+
+    while (!readableInputStreamFrameChannel.canRead()) {
+      Thread.sleep(10);
+    }
+    readableInputStreamFrameChannel.read();
+    Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+  @Test
+  public void testInvalidStateCanRead()
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "testInvalidStateCanRead",
+        executorService
+    );
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Please call startReading method");
+    readableInputStreamFrameChannel.canRead();
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+
+  @Test
+  public void testInvalidStateRead()
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "testInvalidStateRead",
+        executorService
+    );
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Please call startReading method");
+    readableInputStreamFrameChannel.read();
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+
+  @Test
+  public void testInvalidStateReadabilityFuture()
+  {
+    InputStream inputStream = getInputStream();
+    ReadableInputStreamFrameChannel readableInputStreamFrameChannel = new ReadableInputStreamFrameChannel(
+        inputStream,
+        "testInvalidStateReadabilityFuture",
+        executorService
+    );
+    expectedException.expect(ISE.class);
+    expectedException.expectMessage("Please call startReading method");
+    readableInputStreamFrameChannel.readabilityFuture();
+    readableInputStreamFrameChannel.doneReading();
+  }
+
+  private InputStream getInputStream()
+  {
+    try {
+      final File file = FrameTestUtil.writeFrameFile(
+          FrameSequenceBuilder.fromAdapter(adapter).maxRowsPerFrame(10).frameType(FrameType.ROW_BASED).frames(),
+          temporaryFolder.newFile()
+      );
+      return new FileInputStream(file);
+    }
+    catch (IOException e) {
+      throw new ISE(e, "Unable to create file input stream");
+    }
+  }
+
+}

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
@@ -83,7 +83,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
         )
     );
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
 
   }
 
@@ -105,7 +105,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
         FrameReader.create(adapter.getRowSignature())
     ).toList().size(), 0);
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
   @Test
@@ -179,7 +179,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
         FrameReader.create(adapter.getRowSignature())
     ).toList().size(), 0);
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
   @Test
@@ -206,7 +206,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
         FrameReader.create(adapter.getRowSignature())
     ).toList().size(), 0);
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
 
   }
 
@@ -233,7 +233,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
         )
     );
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
 
@@ -258,7 +258,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
     }
     readableInputStreamFrameChannel.read();
     Assert.assertTrue(readableInputStreamFrameChannel.isFinished());
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
   @Test
@@ -273,7 +273,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
     expectedException.expect(ISE.class);
     expectedException.expectMessage("Please call startReading method");
     readableInputStreamFrameChannel.canRead();
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
 
@@ -289,7 +289,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
     expectedException.expect(ISE.class);
     expectedException.expectMessage("Please call startReading method");
     readableInputStreamFrameChannel.read();
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
 
@@ -305,7 +305,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
     expectedException.expect(ISE.class);
     expectedException.expectMessage("Please call startReading method");
     readableInputStreamFrameChannel.readabilityFuture();
-    readableInputStreamFrameChannel.doneReading();
+    readableInputStreamFrameChannel.close();
   }
 
   private InputStream getInputStream()

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileHttpResponseHandlerTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileHttpResponseHandlerTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.file;
+
+import com.google.common.math.LongMath;
+import com.google.common.primitives.Ints;
+import it.unimi.dsi.fastutil.bytes.ByteArrays;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.channel.ReadableByteChunksFrameChannel;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.http.client.response.ClientResponse;
+import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.jboss.netty.buffer.ByteBufferBackedChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpChunk;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTest
+{
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private final int maxRowsPerFrame;
+
+  private StorageAdapter adapter;
+  private File file;
+  private ReadableByteChunksFrameChannel channel;
+  private FrameFileHttpResponseHandler handler;
+
+  public FrameFileHttpResponseHandlerTest(final int maxRowsPerFrame)
+  {
+    this.maxRowsPerFrame = maxRowsPerFrame;
+  }
+
+  @Parameterized.Parameters(name = "maxRowsPerFrame = {0}")
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    final List<Object[]> constructors = new ArrayList<>();
+
+    for (int maxRowsPerFrame : new int[]{1, 50, Integer.MAX_VALUE}) {
+      constructors.add(new Object[]{maxRowsPerFrame});
+    }
+
+    return constructors;
+  }
+
+  @Before
+  public void setUp() throws IOException
+  {
+    adapter = new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+    file = FrameTestUtil.writeFrameFile(
+        FrameSequenceBuilder.fromAdapter(adapter)
+                            .maxRowsPerFrame(maxRowsPerFrame)
+                            .frameType(FrameType.ROW_BASED) // No particular reason to test with both frame types
+                            .frames(),
+        temporaryFolder.newFile()
+    );
+
+    channel = ReadableByteChunksFrameChannel.create("test");
+    handler = new FrameFileHttpResponseHandler(channel);
+  }
+
+  @Test
+  public void testNonChunkedResponse() throws Exception
+  {
+    final ClientResponse<FrameFilePartialFetch> response1 = handler.handleResponse(
+        makeResponse(HttpResponseStatus.OK, Files.readAllBytes(file.toPath())),
+        null
+    );
+
+    Assert.assertFalse(response1.isFinished());
+    Assert.assertTrue(response1.isContinueReading());
+    Assert.assertFalse(response1.getObj().isExceptionCaught());
+    Assert.assertFalse(response1.getObj().isEmptyFetch());
+
+    final ClientResponse<FrameFilePartialFetch> response2 = handler.done(response1);
+
+    Assert.assertTrue(response2.isFinished());
+    Assert.assertTrue(response2.isContinueReading());
+    Assert.assertFalse(response2.getObj().isExceptionCaught());
+    Assert.assertFalse(response2.getObj().isEmptyFetch());
+
+    channel.doneWriting();
+
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(channel, FrameReader.create(adapter.getRowSignature()))
+    );
+  }
+
+  @Test
+  public void testEmptyResponse()
+  {
+    final ClientResponse<FrameFilePartialFetch> response1 = handler.handleResponse(
+        makeResponse(HttpResponseStatus.OK, ByteArrays.EMPTY_ARRAY),
+        null
+    );
+
+    Assert.assertFalse(response1.isFinished());
+    Assert.assertTrue(response1.isContinueReading());
+    Assert.assertFalse(response1.getObj().isExceptionCaught());
+    Assert.assertTrue(response1.getObj().isEmptyFetch());
+
+    final ClientResponse<FrameFilePartialFetch> response2 = handler.done(response1);
+
+    Assert.assertTrue(response2.isFinished());
+    Assert.assertTrue(response2.isContinueReading());
+    Assert.assertFalse(response2.getObj().isExceptionCaught());
+    Assert.assertTrue(response2.getObj().isEmptyFetch());
+  }
+
+  @Test
+  public void testChunkedResponse() throws Exception
+  {
+    final int chunkSize = 99;
+    final byte[] allBytes = Files.readAllBytes(file.toPath());
+
+    ClientResponse<FrameFilePartialFetch> response = handler.handleResponse(
+        makeResponse(HttpResponseStatus.OK, byteSlice(allBytes, 0, chunkSize)),
+        null
+    );
+
+    Assert.assertFalse(response.isFinished());
+
+    for (int p = chunkSize; p < allBytes.length; p += chunkSize) {
+      response = handler.handleChunk(
+          response,
+          makeChunk(byteSlice(allBytes, p, chunkSize)),
+          p / chunkSize
+      );
+
+      Assert.assertFalse(response.isFinished());
+      Assert.assertFalse(response.getObj().isExceptionCaught());
+      Assert.assertFalse(response.getObj().isEmptyFetch());
+    }
+
+    final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
+
+    Assert.assertTrue(finalResponse.isFinished());
+    Assert.assertTrue(finalResponse.isContinueReading());
+    Assert.assertFalse(response.getObj().isExceptionCaught());
+    Assert.assertFalse(response.getObj().isEmptyFetch());
+
+    channel.doneWriting();
+
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(channel, FrameReader.create(adapter.getRowSignature()))
+    );
+  }
+
+  @Test
+  public void testServerErrorResponse()
+  {
+    ClientResponse<FrameFilePartialFetch> response = handler.handleResponse(
+        makeResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR, StringUtils.toUtf8("Oh no!")),
+        null
+    );
+
+    final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
+    Assert.assertTrue(finalResponse.isFinished());
+    Assert.assertTrue(finalResponse.isContinueReading());
+
+    // Verify that the exception handler was called.
+    Assert.assertTrue(finalResponse.getObj().isExceptionCaught());
+    final Throwable e = finalResponse.getObj().getExceptionCaught();
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(
+            CoreMatchers.equalTo("Server for [test] returned [500 Internal Server Error]")
+        )
+    );
+
+    // Verify that the channel has not had an error state set. This enables reconnection later.
+    Assert.assertFalse(channel.isErrorOrFinished());
+  }
+
+  @Test
+  public void testChunkedServerErrorResponse()
+  {
+    ClientResponse<FrameFilePartialFetch> response = handler.handleResponse(
+        makeResponse(HttpResponseStatus.INTERNAL_SERVER_ERROR, StringUtils.toUtf8("Oh ")),
+        null
+    );
+
+    response = handler.handleChunk(response, makeChunk(StringUtils.toUtf8("no!")), 1);
+
+    final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
+    Assert.assertTrue(finalResponse.isFinished());
+    Assert.assertTrue(finalResponse.isContinueReading());
+
+    // Verify that the exception handler was called.
+    Assert.assertTrue(finalResponse.getObj().isExceptionCaught());
+    final Throwable e = finalResponse.getObj().getExceptionCaught();
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(
+            CoreMatchers.equalTo("Server for [test] returned [500 Internal Server Error]")
+        )
+    );
+
+    // Verify that the channel has not had an error state set. This enables reconnection later.
+    Assert.assertFalse(channel.isErrorOrFinished());
+  }
+
+  @Test
+  public void testCaughtExceptionDuringChunkedResponse() throws Exception
+  {
+    // Split file into 4 quarters.
+    final int chunkSize = Ints.checkedCast(LongMath.divide(file.length(), 4, RoundingMode.CEILING));
+    final byte[] allBytes = Files.readAllBytes(file.toPath());
+
+    ClientResponse<FrameFilePartialFetch> response = handler.handleResponse(
+        makeResponse(HttpResponseStatus.OK, byteSlice(allBytes, 0, chunkSize)),
+        null
+    );
+
+    Assert.assertFalse(response.isFinished());
+
+    // Add next chunk.
+    response = handler.handleChunk(
+        response,
+        makeChunk(byteSlice(allBytes, chunkSize, chunkSize)),
+        1
+    );
+
+    // Set an exception.
+    handler.exceptionCaught(response, new ISE("Oh no!"));
+
+    // Add another chunk after the exception is caught (this can happen in real life!). We expect it to be ignored.
+    handler.handleChunk(
+        response,
+        makeChunk(byteSlice(allBytes, chunkSize * 2, chunkSize)),
+        2
+    );
+
+    // Verify that the exception handler was called.
+    Assert.assertTrue(response.getObj().isExceptionCaught());
+    final Throwable e = response.getObj().getExceptionCaught();
+    MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Oh no!")));
+
+    // Verify that the channel has not had an error state set.
+    Assert.assertFalse(channel.isErrorOrFinished());
+
+    // Simulate successful reconnection with a different handler: add the rest of the data directly to the channel.
+    channel.addChunk(byteSlice(allBytes, chunkSize * 2, chunkSize));
+    channel.addChunk(byteSlice(allBytes, chunkSize * 3, chunkSize));
+    Assert.assertEquals(allBytes.length, channel.getBytesAdded());
+    channel.doneWriting();
+
+    FrameTestUtil.assertRowsEqual(
+        FrameTestUtil.readRowsFromAdapter(adapter, null, false),
+        FrameTestUtil.readRowsFromFrameChannel(channel, FrameReader.create(adapter.getRowSignature()))
+    );
+  }
+
+  private static HttpResponse makeResponse(final HttpResponseStatus status, final byte[] content)
+  {
+    final ByteBufferBackedChannelBuffer channelBuffer = new ByteBufferBackedChannelBuffer(ByteBuffer.wrap(content));
+
+    return new DefaultHttpResponse(HttpVersion.HTTP_1_1, status)
+    {
+      @Override
+      public ChannelBuffer getContent()
+      {
+        return channelBuffer;
+      }
+    };
+  }
+
+  private static HttpChunk makeChunk(final byte[] content)
+  {
+    final ByteBufferBackedChannelBuffer channelBuffer = new ByteBufferBackedChannelBuffer(ByteBuffer.wrap(content));
+    return new DefaultHttpChunk(channelBuffer);
+  }
+
+  private static byte[] byteSlice(final byte[] bytes, final int start, final int length)
+  {
+    final int actualLength = Math.min(bytes.length - start, length);
+    final byte[] retVal = new byte[actualLength];
+    System.arraycopy(bytes, start, retVal, 0, actualLength);
+    return retVal;
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/key/ClusterByTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/ClusterByTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import com.google.common.collect.ImmutableList;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.java.util.common.guava.Comparators;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClusterByTest
+{
+  @Test
+  public void test_keyComparator()
+  {
+    final ImmutableList<SortColumn> sortColumns = ImmutableList.of(
+        new SortColumn("x", false),
+        new SortColumn("y", false)
+    );
+
+    Assert.assertEquals(
+        RowKeyComparator.create(sortColumns),
+        new ClusterBy(sortColumns, 1).keyComparator()
+    );
+  }
+
+  @Test
+  public void test_bucketComparator_noKey()
+  {
+    Assert.assertSame(Comparators.alwaysEqual(), ClusterBy.none().bucketComparator());
+  }
+
+  @Test
+  public void test_bucketComparator_noBucketKey()
+  {
+    Assert.assertSame(
+        Comparators.alwaysEqual(),
+        new ClusterBy(
+            ImmutableList.of(
+                new SortColumn("x", false),
+                new SortColumn("y", false)
+            ),
+            0
+        ).bucketComparator()
+    );
+  }
+
+  @Test
+  public void test_bucketComparator_withBucketKey()
+  {
+    Assert.assertEquals(
+        RowKeyComparator.create(ImmutableList.of(new SortColumn("x", false))),
+        new ClusterBy(
+            ImmutableList.of(
+                new SortColumn("x", false),
+                new SortColumn("y", false)
+            ),
+            1
+        ).bucketComparator()
+    );
+  }
+
+  @Test
+  public void test_equals()
+  {
+    EqualsVerifier.forClass(ClusterBy.class).usingGetClass().verify();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparatorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparatorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.frame.key;
 
 import com.google.common.collect.ImmutableList;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -132,6 +133,12 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         sortUsingObjectComparator(sortColumns, ALL_KEY_OBJECTS),
         sortUsingKeyComparator(sortColumns, ALL_KEY_OBJECTS)
     );
+  }
+
+  @Test
+  public void test_equals()
+  {
+    EqualsVerifier.forClass(RowKeyComparator.class).usingGetClass().verify();
   }
 
   private List<RowKey> sortUsingKeyComparator(final List<SortColumn> sortColumns, final List<Object[]> objectss)

--- a/processing/src/test/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/BlockingQueueOutputChannelFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BlockingQueueOutputChannelFactoryTest
+{
+  @Test
+  public void test_openChannel()
+  {
+    final int frameSize = 100;
+    final BlockingQueueOutputChannelFactory factory = new BlockingQueueOutputChannelFactory(frameSize);
+    final OutputChannel channel = factory.openChannel(1);
+
+    Assert.assertEquals(1, channel.getPartitionNumber());
+    Assert.assertEquals(frameSize, channel.getFrameMemoryAllocator().capacity());
+  }
+
+  @Test
+  public void test_openNilChannel()
+  {
+    final int frameSize = 100;
+    final BlockingQueueOutputChannelFactory factory = new BlockingQueueOutputChannelFactory(frameSize);
+    final OutputChannel channel = factory.openNilChannel(1);
+
+    Assert.assertEquals(1, channel.getPartitionNumber());
+    Assert.assertTrue(channel.getReadableChannel().isFinished());
+    Assert.assertThrows(IllegalStateException.class, channel::getWritableChannel);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
@@ -30,7 +30,7 @@ import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 import org.apache.druid.frame.channel.ReadableFileFrameChannel;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
-import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameFileChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.frame.file.FrameFileWriter;
 import org.apache.druid.frame.processor.test.ChompingFrameProcessor;
@@ -133,7 +133,7 @@ public class FrameProcessorExecutorTest
 
       final FrameChannelMuxer muxer = new FrameChannelMuxer(
           ImmutableList.of(memoryChannel1.readable(), memoryChannel2.readable()),
-          new WritableStreamFrameChannel(
+          new WritableFrameFileChannel(
               FrameFileWriter.open(
                   Channels.newChannel(Files.newOutputStream(outFile.toPath())),
                   null

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
@@ -1,0 +1,484 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.ReadableFileFrameChannel;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.file.FrameFile;
+import org.apache.druid.frame.file.FrameFileWriter;
+import org.apache.druid.frame.processor.test.ChompingFrameProcessor;
+import org.apache.druid.frame.processor.test.FailingFrameProcessor;
+import org.apache.druid.frame.processor.test.InfiniteFrameProcessor;
+import org.apache.druid.frame.processor.test.SleepyFrameProcessor;
+import org.apache.druid.frame.processor.test.SuperBlasterFrameProcessor;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+@RunWith(Enclosed.class)
+public class FrameProcessorExecutorTest
+{
+  @RunWith(Parameterized.class)
+  public static class SuperBlasterTests extends BaseFrameProcessorExecutorTestSuite
+  {
+    // Tests in this class use SuperBlasterFrameProcessor, which can exercise various kinds of await styles.
+    private final SuperBlasterFrameProcessor.AwaitStyle awaitStyle;
+
+    public SuperBlasterTests(int numThreads, SuperBlasterFrameProcessor.AwaitStyle awaitStyle)
+    {
+      super(numThreads);
+      this.awaitStyle = awaitStyle;
+    }
+
+    @Parameterized.Parameters(name = "numThreads = {0}, awaitStyle = {1}")
+    public static Collection<Object[]> constructorFeeder()
+    {
+      final List<Object[]> constructors = new ArrayList<>();
+
+      for (int numThreads : new int[]{1, 3, 12}) {
+        for (SuperBlasterFrameProcessor.AwaitStyle awaitStyle : SuperBlasterFrameProcessor.AwaitStyle.values()) {
+          constructors.add(new Object[]{numThreads, awaitStyle});
+        }
+      }
+
+      return constructors;
+    }
+
+    @Test
+    public void test_runFully() throws Exception
+    {
+      // 3 input files blasted to 2 outputs (2 copies of the data), then muxed to one file.
+
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+      final List<File> inFiles = writeToNFiles(adapter, 3);
+      final File outFile = temporaryFolder.newFile();
+
+      final BlockingQueueFrameChannel memoryChannel1 = BlockingQueueFrameChannel.minimal();
+      final BlockingQueueFrameChannel memoryChannel2 = BlockingQueueFrameChannel.minimal();
+
+      final SuperBlasterFrameProcessor blaster = new SuperBlasterFrameProcessor(
+          inFiles.stream().map(FrameProcessorExecutorTest::openFileChannel).collect(Collectors.toList()),
+          ImmutableList.of(memoryChannel1, memoryChannel2),
+          awaitStyle
+      );
+
+      final FrameChannelMuxer muxer = new FrameChannelMuxer(
+          ImmutableList.of(memoryChannel1, memoryChannel2),
+          new WritableStreamFrameChannel(
+              FrameFileWriter.open(
+                  Channels.newChannel(Files.newOutputStream(outFile.toPath())),
+                  null
+              )
+          )
+      );
+
+      final ListenableFuture<Long> blasterFuture = exec.runFully(blaster, null);
+      final ListenableFuture<Long> muxerFuture = exec.runFully(muxer, null);
+
+      Assert.assertEquals(adapter.getNumRows(), (long) blasterFuture.get());
+      Assert.assertEquals(adapter.getNumRows() * 2, (long) muxerFuture.get());
+
+      Assert.assertEquals(
+          adapter.getNumRows() * 2,
+          FrameTestUtil.readRowsFromFrameChannel(
+              new ReadableFileFrameChannel(FrameFile.open(outFile)),
+              FrameReader.create(adapter.getRowSignature())
+          ).toList().size()
+      );
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class MiscTests extends BaseFrameProcessorExecutorTestSuite
+  {
+    public MiscTests(int numThreads)
+    {
+      super(numThreads);
+    }
+
+    @Parameterized.Parameters(name = "numThreads = {0}")
+    public static Collection<Object[]> constructorFeeder()
+    {
+      final List<Object[]> constructors = new ArrayList<>();
+
+      for (int numThreads : new int[]{1, 3, 12}) {
+        constructors.add(new Object[]{numThreads});
+      }
+
+      return constructors;
+    }
+
+    @Test
+    public void test_runFully_errors() throws Exception
+    {
+      final IncrementalIndexStorageAdapter adapter =
+          new IncrementalIndexStorageAdapter(TestIndex.getIncrementalTestIndex());
+      final File inFile = Iterables.getOnlyElement(writeToNFiles(adapter, 1));
+      final ReadableFrameChannel inChannel = openFileChannel(inFile);
+      final BlockingQueueFrameChannel outChannel = BlockingQueueFrameChannel.minimal();
+
+      final FailingFrameProcessor failer = new FailingFrameProcessor(inChannel, outChannel, 0);
+      final ListenableFuture<Long> failerFuture = exec.runFully(failer, null);
+
+      final ExecutionException e = Assert.assertThrows(
+          ExecutionException.class,
+          failerFuture::get
+      );
+
+      MatcherAssert.assertThat(
+          e.getCause(),
+          ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("failure!"))
+      );
+
+      Assert.assertTrue(outChannel.canRead());
+
+      Assert.assertThrows(
+          IllegalStateException.class,
+          outChannel::read
+      );
+
+      Assert.assertTrue(outChannel.isFinished()); // Finished now that we read the error
+    }
+
+    @Test
+    public void test_registerCancelableFuture() throws InterruptedException
+    {
+      final SettableFuture<Object> future = SettableFuture.create();
+      final String cancellationId = "xyzzy";
+
+      Assert.assertSame(future, exec.registerCancelableFuture(future, false, cancellationId));
+      exec.cancel(cancellationId);
+
+      // Don't wait for the future to resolve, because exec.cancel should have done that.
+      // If we see an unresolved future here, it's a bug in exec.cancel.
+      Assert.assertTrue(future.isDone());
+      Assert.assertTrue(future.isCancelled());
+    }
+
+    @Test
+    public void test_cancel_sleepy() throws Exception
+    {
+      final SleepyFrameProcessor processor = new SleepyFrameProcessor();
+      final String cancellationId = "xyzzy";
+      final ListenableFuture<Long> future = exec.runFully(processor, cancellationId);
+
+      processor.awaitRun();
+      exec.cancel(cancellationId);
+
+      // Don't wait for the future to resolve, because exec.cancel should have done that.
+      // If we see an unresolved future here, it's a bug in exec.cancel.
+      Assert.assertTrue(future.isDone());
+      Assert.assertTrue(future.isCancelled());
+      Assert.assertTrue(processor.didGetInterrupt());
+      Assert.assertTrue(processor.didCleanup());
+    }
+
+    @Test(timeout = 30_000L)
+    public void test_futureCancel_sleepy() throws Exception
+    {
+      final SleepyFrameProcessor processor = new SleepyFrameProcessor();
+      final String cancellationId = "xyzzy";
+      final ListenableFuture<Long> future = exec.runFully(processor, cancellationId);
+
+      processor.awaitRun();
+      Assert.assertTrue(future.cancel(true));
+      Assert.assertTrue(future.isDone());
+      Assert.assertTrue(future.isCancelled());
+
+      processor.awaitCleanup(); // If this times out, it's a bug that means cancellation didn't happen as expected.
+      Assert.assertTrue(processor.didGetInterrupt());
+      Assert.assertTrue(processor.didCleanup());
+    }
+
+    @Test
+    public void test_cancel_concurrency() throws Exception
+    {
+      final int numSystems = 1000;
+      final int numGeneratorsPerSystem = 8;
+
+      // Doesn't matter what's in this frame.
+      final Frame frame =
+          Iterables.getOnlyElement(
+              FrameSequenceBuilder.fromAdapter(new QueryableIndexStorageAdapter(TestIndex.getMMappedTestIndex()))
+                                  .frameType(FrameType.ROW_BASED)
+                                  .frames()
+                                  .toList()
+          );
+
+      // Set up many generators that all feed into a chomper.
+      final Set<String> systemIds = new HashSet<>();
+      final Map<String, List<InfiniteFrameProcessor>> systemGeneratorsMap = new HashMap<>();
+      final Map<String, ChompingFrameProcessor> systemChomperMap = new HashMap<>();
+      final Map<FrameProcessor<?>, ListenableFuture<Long>> processorFutureMap = new IdentityHashMap<>();
+      final Map<String, Boolean> systemCleanStopMap = new HashMap<>();
+
+      // Cancel half of the systems, stop the other half cleanly.
+      boolean doCleanStop = false;
+
+      for (int systemNumber = 0; systemNumber < numSystems; systemNumber++) {
+        final String systemId = UUID.randomUUID().toString();
+
+        final List<InfiniteFrameProcessor> generators = new ArrayList<>(numGeneratorsPerSystem);
+        final List<ReadableFrameChannel> channels = new ArrayList<>(numGeneratorsPerSystem);
+
+        for (int i = 0; i < numGeneratorsPerSystem; i++) {
+          final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+          generators.add(new InfiniteFrameProcessor(frame, channel));
+          channels.add(channel);
+        }
+
+        final ChompingFrameProcessor chomper = new ChompingFrameProcessor(channels);
+
+        systemIds.add(systemId);
+        systemGeneratorsMap.put(systemId, generators);
+        systemChomperMap.put(systemId, chomper);
+        systemCleanStopMap.put(systemId, doCleanStop);
+        doCleanStop = !doCleanStop;
+      }
+
+      // Start up all systems at once.
+      for (final String systemId : systemGeneratorsMap.keySet()) {
+        for (InfiniteFrameProcessor generator : systemGeneratorsMap.get(systemId)) {
+          processorFutureMap.put(generator, exec.runFully(generator, systemId));
+        }
+
+        final ChompingFrameProcessor chomper = systemChomperMap.get(systemId);
+        processorFutureMap.put(chomper, exec.runFully(chomper, systemId));
+      }
+
+      // Stop the systems (either cleanly or through cancellation).
+      for (Map.Entry<String, ChompingFrameProcessor> entry : systemChomperMap.entrySet()) {
+        final String systemId = entry.getKey();
+
+        // Read at least one frame in the chomper before stopping the system.
+        entry.getValue().awaitRead();
+
+        if (systemCleanStopMap.get(systemId)) {
+          systemGeneratorsMap.get(systemId).forEach(InfiniteFrameProcessor::stop);
+        } else {
+          exec.cancel(systemId);
+        }
+      }
+
+      // Verify results of each system.
+      for (final String systemId : systemIds) {
+        final boolean cleanStop = systemCleanStopMap.get(systemId);
+        final List<InfiniteFrameProcessor> generators = systemGeneratorsMap.get(systemId);
+        final ChompingFrameProcessor chomper = systemChomperMap.get(systemId);
+
+        if (cleanStop) {
+          // Check for clean exit.
+          long systemFrameCount = 0;
+
+          // Verify numFrames on each generator.
+          for (final InfiniteFrameProcessor generator : generators) {
+            final Long retVal = processorFutureMap.get(generator).get();
+            Assert.assertNotNull(retVal);
+            Assert.assertEquals(generator.getNumFrames(), (long) retVal);
+            systemFrameCount += retVal;
+          }
+
+          // Verify return value of the chomper.
+          final Long retVal = processorFutureMap.get(chomper).get();
+          Assert.assertNotNull(retVal);
+          Assert.assertEquals(systemFrameCount, (long) retVal);
+        } else {
+          // Check for cancellation.
+          final List<FrameProcessor<?>> allProcessors =
+              ImmutableList.copyOf(Iterables.concat(generators, Collections.singleton(chomper)));
+
+          for (FrameProcessor<?> processor : allProcessors) {
+            final ListenableFuture<Long> future = processorFutureMap.get(processor);
+
+            // Don't wait for the future to resolve, because exec.cancel should have done that.
+            // If we see an unresolved future here, it's a bug in exec.cancel.
+            Assert.assertTrue(future.isDone());
+            Assert.assertTrue(future.isCancelled());
+
+            final Exception e = Assert.assertThrows(Exception.class, future::get);
+            MatcherAssert.assertThat(e, CoreMatchers.instanceOf(CancellationException.class));
+          }
+        }
+
+        // In both cases, check for cleanup.
+        for (final InfiniteFrameProcessor generator : generators) {
+          Assert.assertTrue(generator.didCleanup());
+        }
+
+        Assert.assertTrue(chomper.didCleanup());
+      }
+    }
+
+    @Test
+    public void test_cancel_nonexistentCancellationId() throws InterruptedException
+    {
+      // Just making sure no error is thrown when we refer to a nonexistent cancellationId.
+      exec.cancel("nonexistent");
+    }
+  }
+
+  public static abstract class BaseFrameProcessorExecutorTestSuite extends InitializedNullHandlingTest
+  {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public final int numThreads;
+
+    FrameProcessorExecutor exec;
+
+    public BaseFrameProcessorExecutorTestSuite(int numThreads)
+    {
+      this.numThreads = numThreads;
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+      exec = new FrameProcessorExecutor(
+          MoreExecutors.listeningDecorator(
+              Execs.multiThreaded(
+                  numThreads,
+                  StringUtils.encodeForFormat(getClass().getName()) + "-%s"
+              )
+          )
+      );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+      exec.getExecutorService().shutdownNow();
+      if (!exec.getExecutorService().awaitTermination(1, TimeUnit.MINUTES)) {
+        throw new ISE("Executor service did not terminate within 1 minute");
+      }
+    }
+
+    List<File> writeToNFiles(final StorageAdapter adapter, final int numFiles) throws IOException
+    {
+      final List<File> files = new ArrayList<>();
+      final List<FrameFileWriter> writers = new ArrayList<>();
+
+      try {
+        // Set up input files.
+        for (int i = 0; i < numFiles; i++) {
+          files.add(temporaryFolder.newFile());
+          writers.add(
+              FrameFileWriter.open(
+                  Channels.newChannel(Files.newOutputStream(files.get(i).toPath())),
+                  null
+              )
+          );
+        }
+
+        // Write to input files.
+        FrameSequenceBuilder.fromAdapter(adapter)
+                            .frameType(FrameType.ROW_BASED)
+                            .allocator(ArenaMemoryAllocator.createOnHeap(1_000_000))
+                            .maxRowsPerFrame(3)
+                            .frames()
+                            .forEach(
+                                new Consumer<Frame>()
+                                {
+                                  private int j = 0;
+
+                                  @Override
+                                  public void accept(Frame frame)
+                                  {
+                                    try {
+                                      writers.get(j % writers.size()).writeFrame(frame, FrameFileWriter.NO_PARTITION);
+                                    }
+                                    catch (IOException e) {
+                                      throw new RuntimeException(e);
+                                    }
+
+                                    j++;
+                                  }
+                                }
+                            );
+      }
+      finally {
+        CloseableUtils.closeAll(writers);
+      }
+
+      return files;
+    }
+  }
+
+  private static ReadableFrameChannel openFileChannel(final File file)
+  {
+    try {
+      return new ReadableFileFrameChannel(FrameFile.open(file));
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
@@ -386,7 +386,7 @@ public class FrameProcessorExecutorTest
     }
   }
 
-  public static abstract class BaseFrameProcessorExecutorTestSuite extends InitializedNullHandlingTest
+  public abstract static class BaseFrameProcessorExecutorTestSuite extends InitializedNullHandlingTest
   {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -439,30 +439,31 @@ public class FrameProcessorExecutorTest
         }
 
         // Write to input files.
-        FrameSequenceBuilder.fromAdapter(adapter)
-                            .frameType(FrameType.ROW_BASED)
-                            .allocator(ArenaMemoryAllocator.createOnHeap(1_000_000))
-                            .maxRowsPerFrame(3)
-                            .frames()
-                            .forEach(
-                                new Consumer<Frame>()
-                                {
-                                  private int j = 0;
+        FrameSequenceBuilder
+            .fromAdapter(adapter)
+            .frameType(FrameType.ROW_BASED)
+            .allocator(ArenaMemoryAllocator.createOnHeap(1_000_000))
+            .maxRowsPerFrame(3)
+            .frames()
+            .forEach(
+                new Consumer<Frame>()
+                {
+                  private int j = 0;
 
-                                  @Override
-                                  public void accept(Frame frame)
-                                  {
-                                    try {
-                                      writers.get(j % writers.size()).writeFrame(frame, FrameFileWriter.NO_PARTITION);
-                                    }
-                                    catch (IOException e) {
-                                      throw new RuntimeException(e);
-                                    }
+                  @Override
+                  public void accept(Frame frame)
+                  {
+                    try {
+                      writers.get(j % writers.size()).writeFrame(frame, FrameFileWriter.NO_PARTITION);
+                    }
+                    catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
 
-                                    j++;
-                                  }
-                                }
-                            );
+                    j++;
+                  }
+                }
+            );
       }
       finally {
         CloseableUtils.closeAll(writers);

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameRowTooLargeExceptionTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameRowTooLargeExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FrameRowTooLargeExceptionTest
+{
+  @Test
+  public void test_getMaxFrameSize()
+  {
+    final long maxFrameSize = 100;
+    Assert.assertEquals(maxFrameSize, new FrameRowTooLargeException(maxFrameSize).getMaxFrameSize());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
@@ -53,7 +53,10 @@ public class OutputChannelTest
     );
 
     // Mapping the writable channel of a nil channel has no effect, because there is no writable channel.
-    Assert.assertSame(channel, channel.mapWritableChannel(c -> BlockingQueueFrameChannel.minimal()));
+    Assert.assertSame(
+        channel,
+        channel.mapWritableChannel(c -> BlockingQueueFrameChannel.minimal().writable())
+    );
   }
 
   @Test
@@ -62,9 +65,9 @@ public class OutputChannelTest
     final BlockingQueueFrameChannel theChannel = BlockingQueueFrameChannel.minimal();
     final HeapMemoryAllocator allocator = HeapMemoryAllocator.unlimited();
     final OutputChannel channel = OutputChannel.pair(
-        theChannel,
+        theChannel.writable(),
         allocator,
-        () -> theChannel,
+        theChannel::readable,
         1
     );
 

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
@@ -72,8 +72,8 @@ public class OutputChannelTest
     );
 
     Assert.assertEquals(1, channel.getPartitionNumber());
-    Assert.assertSame(theChannel, channel.getReadableChannel());
-    Assert.assertSame(theChannel, channel.getWritableChannel());
+    Assert.assertSame(theChannel.readable(), channel.getReadableChannel());
+    Assert.assertSame(theChannel.writable(), channel.getWritableChannel());
     Assert.assertSame(allocator, channel.getFrameMemoryAllocator());
 
     // Use mapWritableChannel to replace the writable channel.
@@ -81,7 +81,7 @@ public class OutputChannelTest
     final OutputChannel mappedChannel = channel.mapWritableChannel(c -> otherWritableChannel);
 
     Assert.assertEquals(1, mappedChannel.getPartitionNumber());
-    Assert.assertSame(theChannel, mappedChannel.getReadableChannel());
+    Assert.assertSame(theChannel.readable(), mappedChannel.getReadableChannel());
     Assert.assertSame(otherWritableChannel, mappedChannel.getWritableChannel());
     Assert.assertSame(allocator, mappedChannel.getFrameMemoryAllocator());
   }

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.apache.druid.frame.allocation.HeapMemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+
+public class OutputChannelTest
+{
+  @Test
+  public void test_nil()
+  {
+    final OutputChannel channel = OutputChannel.nil(1);
+
+    Assert.assertEquals(1, channel.getPartitionNumber());
+    Assert.assertTrue(channel.getReadableChannel().isFinished());
+
+    // No writable channel: cannot call getWritableChannel.
+    final IllegalStateException e1 = Assert.assertThrows(IllegalStateException.class, channel::getWritableChannel);
+    MatcherAssert.assertThat(
+        e1,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Writable channel is not available"))
+    );
+
+    // No writable channel: cannot call getFrameMemoryAllocator.
+    final IllegalStateException e2 = Assert.assertThrows(IllegalStateException.class, channel::getFrameMemoryAllocator);
+    MatcherAssert.assertThat(
+        e2,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Writable channel is not available"))
+    );
+
+    // Mapping the writable channel of a nil channel has no effect, because there is no writable channel.
+    Assert.assertSame(channel, channel.mapWritableChannel(c -> BlockingQueueFrameChannel.minimal()));
+  }
+
+  @Test
+  public void test_pair()
+  {
+    final BlockingQueueFrameChannel theChannel = BlockingQueueFrameChannel.minimal();
+    final HeapMemoryAllocator allocator = HeapMemoryAllocator.unlimited();
+    final OutputChannel channel = OutputChannel.pair(
+        theChannel,
+        allocator,
+        () -> theChannel,
+        1
+    );
+
+    Assert.assertEquals(1, channel.getPartitionNumber());
+    Assert.assertSame(theChannel, channel.getReadableChannel());
+    Assert.assertSame(theChannel, channel.getWritableChannel());
+    Assert.assertSame(allocator, channel.getFrameMemoryAllocator());
+
+    // Use mapWritableChannel to replace the writable channel.
+    final WritableStreamFrameChannel otherWritableChannel = new WritableStreamFrameChannel(null);
+    final OutputChannel mappedChannel = channel.mapWritableChannel(c -> otherWritableChannel);
+
+    Assert.assertEquals(1, mappedChannel.getPartitionNumber());
+    Assert.assertSame(theChannel, mappedChannel.getReadableChannel());
+    Assert.assertSame(otherWritableChannel, mappedChannel.getWritableChannel());
+    Assert.assertSame(allocator, mappedChannel.getFrameMemoryAllocator());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
@@ -21,7 +21,7 @@ package org.apache.druid.frame.processor;
 
 import org.apache.druid.frame.allocation.HeapMemoryAllocator;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
-import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameFileChannel;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -77,7 +77,7 @@ public class OutputChannelTest
     Assert.assertSame(allocator, channel.getFrameMemoryAllocator());
 
     // Use mapWritableChannel to replace the writable channel.
-    final WritableStreamFrameChannel otherWritableChannel = new WritableStreamFrameChannel(null);
+    final WritableFrameFileChannel otherWritableChannel = new WritableFrameFileChannel(null);
     final OutputChannel mappedChannel = channel.mapWritableChannel(c -> otherWritableChannel);
 
     Assert.assertEquals(1, mappedChannel.getPartitionNumber());

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.frame.allocation.HeapMemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+
+import java.util.Collections;
+
+public class OutputChannelsTest
+{
+  @Test
+  public void test_none()
+  {
+    final OutputChannels channels = OutputChannels.none();
+
+    Assert.assertEquals(IntSets.emptySet(), channels.getPartitionNumbers());
+    Assert.assertEquals(Collections.emptyList(), channels.getAllChannels());
+    Assert.assertEquals(Collections.emptyList(), channels.getChannelsForPartition(0));
+  }
+
+  @Test
+  public void test_wrap()
+  {
+    final OutputChannels channels = OutputChannels.wrap(ImmutableList.of(OutputChannel.nil(1)));
+
+    Assert.assertEquals(IntSet.of(1), channels.getPartitionNumbers());
+    Assert.assertEquals(1, channels.getAllChannels().size());
+    Assert.assertEquals(Collections.emptyList(), channels.getChannelsForPartition(0));
+    Assert.assertEquals(1, channels.getChannelsForPartition(1).size());
+  }
+
+  @Test
+  public void test_readOnly()
+  {
+    final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+    final OutputChannels channels = OutputChannels.wrap(
+        ImmutableList.of(
+            OutputChannel.pair(
+                channel,
+                HeapMemoryAllocator.unlimited(),
+                () -> channel,
+                1
+            )
+        )
+    );
+
+    final OutputChannels readOnlyChannels = channels.readOnly();
+    Assert.assertEquals(IntSet.of(1), readOnlyChannels.getPartitionNumbers());
+    Assert.assertEquals(1, readOnlyChannels.getAllChannels().size());
+    Assert.assertEquals(1, channels.getChannelsForPartition(1).size());
+
+    final IllegalStateException e = Assert.assertThrows(
+        IllegalStateException.class,
+        () -> Iterables.getOnlyElement(readOnlyChannels.getAllChannels()).getWritableChannel()
+    );
+
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Writable channel is not available"))
+    );
+
+    final IllegalStateException e2 = Assert.assertThrows(
+        IllegalStateException.class,
+        () -> Iterables.getOnlyElement(readOnlyChannels.getAllChannels()).getFrameMemoryAllocator()
+    );
+
+    MatcherAssert.assertThat(
+        e2,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Writable channel is not available"))
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
@@ -63,9 +63,9 @@ public class OutputChannelsTest
     final OutputChannels channels = OutputChannels.wrap(
         ImmutableList.of(
             OutputChannel.pair(
-                channel,
+                channel.writable(),
                 HeapMemoryAllocator.unlimited(),
-                () -> channel,
+                channel::readable,
                 1
             )
         )

--- a/processing/src/test/java/org/apache/druid/frame/processor/ReturnOrAwaitTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/ReturnOrAwaitTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReturnOrAwaitTest
+{
+  @Test
+  public void testToString()
+  {
+    Assert.assertEquals("await=any{0, 1}", ReturnOrAwait.awaitAny(IntSet.of(0, 1)).toString());
+    Assert.assertEquals("await=all{0, 1}", ReturnOrAwait.awaitAll(2).toString());
+    Assert.assertEquals("return=xyzzy", ReturnOrAwait.returnObject("xyzzy").toString());
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(ReturnOrAwait.class).usingGetClass().verify();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
@@ -389,7 +389,7 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
     }
 
     @Override
-    public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException
+    public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws InterruptedException, IOException
     {
       if (didRun.compareAndSet(false, true)) {
         synchronized (RunAllFullyWidgetTest.this) {

--- a/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
@@ -162,15 +162,15 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
                            final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
 
                            try {
-                             channel.write(frame);
-                             channel.doneWriting();
+                             channel.writable().write(frame);
+                             channel.writable().close();
                            }
                            catch (IOException e) {
                              throw new RuntimeException(e);
                            }
 
                            return new ConcurrencyTrackingFrameProcessor<>(
-                               new ChompingFrameProcessor(Collections.singletonList(channel))
+                               new ChompingFrameProcessor(Collections.singletonList(channel.readable()))
                            );
                          }
                      )
@@ -200,7 +200,7 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
                                    new ConcurrencyTrackingFrameProcessor<>(
                                        new FailingFrameProcessor(
                                            ReadableNilFrameChannel.INSTANCE,
-                                           BlockingQueueFrameChannel.minimal(),
+                                           BlockingQueueFrameChannel.minimal().writable(),
                                            0
                                        )
                                    )

--- a/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.ReadableNilFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.test.ChompingFrameProcessor;
+import org.apache.druid.frame.processor.test.FailingFrameProcessor;
+import org.apache.druid.frame.processor.test.SleepyFrameProcessor;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RunWith(Parameterized.class)
+public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameProcessorExecutorTestSuite
+{
+  private final int bouncerPoolSize;
+  private final int maxOutstandingProcessors;
+
+  private Bouncer bouncer;
+
+  @GuardedBy("this")
+  private int concurrentHighWatermark = 0;
+
+  @GuardedBy("this")
+  private int concurrentNow = 0;
+
+  public RunAllFullyWidgetTest(int numThreads, int bouncerPoolSize, int maxOutstandingProcessors)
+  {
+    super(numThreads);
+    this.bouncerPoolSize = bouncerPoolSize;
+    this.maxOutstandingProcessors = maxOutstandingProcessors;
+  }
+
+  @Parameterized.Parameters(name = "numThreads = {0}, bouncerPoolSize = {1}, maxOutstandingProcessors = {2}")
+  public static Collection<Object[]> constructorFeeder()
+  {
+    final List<Object[]> constructors = new ArrayList<>();
+
+    for (int numThreads : new int[]{1, 3, 12}) {
+      for (int bouncerPoolSize : new int[]{1, 3, 12}) {
+        for (int maxOutstandingProcessors : new int[]{1, 3, 12}) {
+          constructors.add(new Object[]{numThreads, bouncerPoolSize, maxOutstandingProcessors});
+        }
+      }
+    }
+
+    return constructors;
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception
+  {
+    super.setUp();
+    bouncer = new Bouncer(bouncerPoolSize);
+
+    synchronized (this) {
+      concurrentNow = 0;
+      concurrentHighWatermark = 0;
+    }
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception
+  {
+    super.tearDown(); // Stops exec, waits for termination
+
+    synchronized (this) {
+      Assert.assertEquals(0, concurrentNow);
+      MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(bouncerPoolSize));
+      MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(maxOutstandingProcessors));
+    }
+
+    Assert.assertEquals(0, bouncer.getCurrentCount());
+  }
+
+  @Test
+  public void test_runAllFully_emptySequence() throws Exception
+  {
+    final ListenableFuture<String> future = exec.<String, String>runAllFully(
+        Sequences.empty(),
+        "xyzzy",
+        (s1, s2) -> s1 + s2,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    Assert.assertEquals("xyzzy", future.get());
+  }
+
+  @Test
+  public void test_runAllFully_fiftyThousandProcessors() throws Exception
+  {
+    final int numProcessors = 50_000;
+
+    // Doesn't matter what's in this frame.
+    final Frame frame =
+        Iterables.getOnlyElement(
+            FrameSequenceBuilder.fromAdapter(new QueryableIndexStorageAdapter(TestIndex.getMMappedTestIndex()))
+                                .frameType(FrameType.ROW_BASED)
+                                .frames()
+                                .toList()
+        );
+
+    final Sequence<? extends FrameProcessor<Long>> processors = Sequences.simple(
+        () ->
+            IntStream.range(0, numProcessors)
+                     .mapToObj(
+                         i -> {
+                           final BlockingQueueFrameChannel channel = BlockingQueueFrameChannel.minimal();
+
+                           try {
+                             channel.write(frame);
+                             channel.doneWriting();
+                           }
+                           catch (IOException e) {
+                             throw new RuntimeException(e);
+                           }
+
+                           return new ConcurrencyTrackingFrameProcessor<>(
+                               new ChompingFrameProcessor(Collections.singletonList(channel))
+                           );
+                         }
+                     )
+                     .iterator()
+    );
+
+    final ListenableFuture<Long> future = exec.runAllFully(
+        processors,
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    Assert.assertEquals(numProcessors, (long) future.get());
+  }
+
+  @Test
+  public void test_runAllFully_failing()
+  {
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(
+            () -> IntStream.generate(() -> 0) // Infinite stream
+                           .mapToObj(
+                               i ->
+                                   new ConcurrencyTrackingFrameProcessor<>(
+                                       new FailingFrameProcessor(
+                                           ReadableNilFrameChannel.INSTANCE,
+                                           BlockingQueueFrameChannel.minimal(),
+                                           0
+                                       )
+                                   )
+                           )
+                           .iterator()
+        ),
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RuntimeException.class));
+    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("failure!")));
+  }
+
+  @Test
+  public void test_runAllFully_errorAccumulateFn()
+  {
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(
+            () -> IntStream.range(0, 100)
+                           .mapToObj(i -> new ChompingFrameProcessor(Collections.emptyList()))
+                           .iterator()
+        ),
+        0L,
+        (x, y) -> {throw new ISE("error!");},
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+  }
+
+  @Test
+  public void test_runAllFully_errorSequenceFirstElement()
+  {
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(
+            () -> IntStream.generate(() -> 0) // Infinite stream
+                           .<FrameProcessor<Long>>mapToObj(
+                               i -> {
+                                 throw new ISE("error!");
+                               }
+                           )
+                           .iterator()
+        ),
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+  }
+
+  @Test
+  public void test_runAllFully_errorSequenceSecondElement()
+  {
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(
+            () -> IntStream.range(0, 101)
+                           .<FrameProcessor<Long>>mapToObj(
+                               i -> {
+                                 if (i != 2) {
+                                   return new ChompingFrameProcessor(Collections.emptyList());
+                                 } else {
+                                   throw new ISE("error!");
+                                 }
+                               }
+                           )
+                           .iterator()
+        ),
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+  }
+
+  @Test
+  public void test_runAllFully_errorSequenceHundredthElement()
+  {
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(
+            () -> IntStream.range(0, 101)
+                           .mapToObj(
+                               i -> {
+                                 if (i != 100) {
+                                   return new ChompingFrameProcessor(Collections.emptyList());
+                                 } else {
+                                   throw new ISE("error!");
+                                 }
+                               }
+                           )
+                           .iterator()
+        ),
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        null
+    );
+
+    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
+    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+  }
+
+  @Test(timeout = 30_000L)
+  @SuppressWarnings("BusyWait")
+  public void test_runAllFully_futureCancel() throws InterruptedException
+  {
+    final List<SleepyFrameProcessor> processors =
+        IntStream.range(0, bouncerPoolSize * maxOutstandingProcessors * numThreads * 2)
+                 .mapToObj(i -> new SleepyFrameProcessor())
+                 .collect(Collectors.toList());
+
+    final ListenableFuture<Long> future = exec.runAllFully(
+        Sequences.simple(processors).map(ConcurrencyTrackingFrameProcessor::new),
+        0L,
+        Long::sum,
+        maxOutstandingProcessors,
+        bouncer,
+        "xyzzy"
+    );
+
+    final int expectedRunningProcessors = Math.min(Math.min(bouncerPoolSize, maxOutstandingProcessors), numThreads);
+
+    for (int i = 0; i < expectedRunningProcessors; i++) {
+      processors.get(i).awaitRun();
+    }
+
+    Assert.assertTrue(future.cancel(true));
+    Assert.assertTrue(future.isCancelled());
+
+    // We don't have a good way to wait for future cancelation to truly finish. Resort to a waiting-loop.
+    while (exec.cancelableProcessorCount() > 0) {
+      Thread.sleep(10);
+    }
+
+    Assert.assertEquals(0, exec.cancelableProcessorCount());
+  }
+
+  /**
+   * FrameProcessor wrapper that updates {@link #concurrentNow}, {@link #concurrentHighWatermark} to enable
+   * verification of concurrency controls.
+   */
+  private class ConcurrencyTrackingFrameProcessor<T> implements FrameProcessor<T>
+  {
+    // Acquire a pool item to ensure that Bouncer and maxOutstandingProcessors work properly.
+    private final AtomicBoolean didRun = new AtomicBoolean(false);
+    private final AtomicBoolean didCleanup = new AtomicBoolean(false);
+    private final FrameProcessor<T> delegate;
+
+    public ConcurrencyTrackingFrameProcessor(FrameProcessor<T> delegate)
+    {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public List<ReadableFrameChannel> inputChannels()
+    {
+      return delegate.inputChannels();
+    }
+
+    @Override
+    public List<WritableFrameChannel> outputChannels()
+    {
+      return delegate.outputChannels();
+    }
+
+    @Override
+    public ReturnOrAwait<T> runIncrementally(IntSet readableInputs) throws IOException
+    {
+      if (didRun.compareAndSet(false, true)) {
+        synchronized (RunAllFullyWidgetTest.this) {
+          concurrentNow++;
+
+          if (concurrentHighWatermark < concurrentNow) {
+            concurrentHighWatermark = concurrentNow;
+          }
+        }
+      }
+
+      return delegate.runIncrementally(readableInputs);
+    }
+
+    @Override
+    public void cleanup() throws IOException
+    {
+      try {
+        delegate.cleanup();
+      }
+      finally {
+        synchronized (RunAllFullyWidgetTest.this) {
+          if (didRun.get()) {
+            if (didCleanup.compareAndSet(false, true)) {
+              concurrentNow--;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshotTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshotTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SuperSorterProgressSnapshotTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
+    final SuperSorterProgressSnapshot snapshot = new SuperSorterProgressSnapshot(
+        1,
+        ImmutableMap.of(1, 2L),
+        ImmutableMap.of(1, 3L),
+        8,
+        false
+    );
+
+    final String jsonString = jsonMapper.writeValueAsString(snapshot);
+    Assert.assertEquals(snapshot, jsonMapper.readValue(jsonString, SuperSorterProgressSnapshot.class));
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(SuperSorterProgressSnapshot.class).usingGetClass().verify();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshotTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressSnapshotTest.java
@@ -24,10 +24,121 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class SuperSorterProgressSnapshotTest
 {
+  private SuperSorterProgressTracker superSorterProgressTracker;
+
+  private final ImmutableMap<Integer, Long> LEVEL_TO_TOTAL_MERGERS_COMMON_MAP = ImmutableMap.<Integer, Long>builder()
+                                                                                            .put(0, 16L)
+                                                                                            .put(1, 8L)
+                                                                                            .put(2, 4L)
+                                                                                            .put(3, 2L)
+                                                                                            .put(4, 1L)
+                                                                                            .build();
+
+
+  private final ImmutableMap<Integer, Long> LEVEL_TO_MERGED_BATCHES_COMMON_MAP = ImmutableMap.<Integer, Long>builder()
+                                                                                             .put(0, 10L)
+                                                                                             .put(1, 2L)
+                                                                                             .put(2, 3L)
+                                                                                             .put(3, 1L)
+                                                                                             .put(4, 12L)
+                                                                                             .build();
+
+  private final int TOTAL_LEVELS = 5;
+
+  // Initialize a base tracker with total mergers for levels from 0-4 set in advance and some mergers already set
+  @Before
+  public void setup()
+  {
+    superSorterProgressTracker = new SuperSorterProgressTracker();
+
+    superSorterProgressTracker.setTotalMergersForLevel(0, 16);
+    superSorterProgressTracker.setTotalMergersForLevel(1, 8);
+    superSorterProgressTracker.setTotalMergersForLevel(2, 4);
+    superSorterProgressTracker.setTotalMergersForLevel(3, 2);
+    superSorterProgressTracker.setTotalMergersForLevel(4, 1);
+
+    superSorterProgressTracker.addMergedBatchesForLevel(0, 5);
+    superSorterProgressTracker.addMergedBatchesForLevel(0, 5);
+    superSorterProgressTracker.addMergedBatchesForLevel(1, 2);
+    superSorterProgressTracker.addMergedBatchesForLevel(2, 3);
+    superSorterProgressTracker.addMergedBatchesForLevel(3, 1);
+    superSorterProgressTracker.addMergedBatchesForLevel(4, 12);
+  }
+
+  @Test
+  public void testSnapshotWhenTotalMergingLevelsUnset()
+  {
+    SuperSorterProgressSnapshot snapshot = superSorterProgressTracker.snapshot();
+
+    Assert.assertNull(snapshot.getProgressDigest());
+    Assert.assertEquals(-1, snapshot.getTotalMergingLevels());
+    Assert.assertEquals(LEVEL_TO_TOTAL_MERGERS_COMMON_MAP, snapshot.getLevelToTotalBatches());
+    Assert.assertEquals(LEVEL_TO_MERGED_BATCHES_COMMON_MAP, snapshot.getLevelToMergedBatches());
+    Assert.assertEquals(false, snapshot.isTriviallyComplete());
+  }
+
+  @Test
+  public void testSnapshotWhenTotalMergingLevelsSetButOutputPartitionsCountUnknown()
+  {
+    superSorterProgressTracker.setTotalMergingLevels(TOTAL_LEVELS);
+    SuperSorterProgressSnapshot snapshot = superSorterProgressTracker.snapshot();
+
+    Assert.assertNotNull(snapshot.getProgressDigest());
+
+    // 10/16 + 2/8 + 3/4 + 1/2 + 0 (ultimate mergers shouldn't be taken into account if not set explicitly)
+    Assert.assertEquals(0.425D, snapshot.getProgressDigest(), 1e-6);
+    Assert.assertEquals(TOTAL_LEVELS, snapshot.getTotalMergingLevels());
+    Map<Integer, Long> levelToTotalMergersModifiedMap = new HashMap<>(LEVEL_TO_TOTAL_MERGERS_COMMON_MAP);
+
+    // Snapshot should replace the total levels of the ultimate in the Map if it is not set explicitly
+    levelToTotalMergersModifiedMap.put(TOTAL_LEVELS - 1, -1L);
+    Assert.assertEquals(levelToTotalMergersModifiedMap, snapshot.getLevelToTotalBatches());
+    Assert.assertEquals(LEVEL_TO_MERGED_BATCHES_COMMON_MAP, snapshot.getLevelToMergedBatches());
+    Assert.assertEquals(false, snapshot.isTriviallyComplete());
+  }
+
+  @Test
+  public void testSnapshotWhenTotalMergingLevelsAndOutputPartitionsCountKnown()
+  {
+    superSorterProgressTracker.setTotalMergingLevels(TOTAL_LEVELS);
+    superSorterProgressTracker.setTotalMergersForUltimateLevel(25);
+
+    SuperSorterProgressSnapshot snapshot = superSorterProgressTracker.snapshot();
+    Assert.assertNotNull(snapshot.getProgressDigest());
+
+    // 10/16 + 2/8 + 3/4 + 1/2 + 12/25
+    Assert.assertEquals(0.521D, snapshot.getProgressDigest(), 1e-6);
+    Assert.assertEquals(TOTAL_LEVELS, snapshot.getTotalMergingLevels());
+    Map<Integer, Long> levelToTotalMergersModifiedMap = new HashMap<>(LEVEL_TO_TOTAL_MERGERS_COMMON_MAP);
+
+    // Snapshot should replace the total levels of the ultimate in the Map if it is not set explicitly
+    levelToTotalMergersModifiedMap.put(TOTAL_LEVELS - 1, 25L);
+    Assert.assertEquals(levelToTotalMergersModifiedMap, snapshot.getLevelToTotalBatches());
+    Assert.assertEquals(LEVEL_TO_MERGED_BATCHES_COMMON_MAP, snapshot.getLevelToMergedBatches());
+    Assert.assertEquals(false, snapshot.isTriviallyComplete());
+  }
+
+  @Test
+  public void testSnapshotWhenTrackerIsTriviallyComplete()
+  {
+    superSorterProgressTracker.setTotalMergingLevels(TOTAL_LEVELS);
+    superSorterProgressTracker.setTotalMergersForUltimateLevel(25);
+    superSorterProgressTracker.markTriviallyComplete();
+
+    SuperSorterProgressSnapshot snapshot = superSorterProgressTracker.snapshot();
+    Assert.assertNotNull(snapshot.getProgressDigest());
+    Assert.assertEquals(1.0, snapshot.getProgressDigest(), 0.0);
+    Assert.assertEquals(true, snapshot.isTriviallyComplete());
+  }
+
   @Test
   public void testSerde() throws Exception
   {

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressTrackerTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterProgressTrackerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import org.apache.druid.java.util.common.ISE;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This class primarily tests the invalid calls to the methods of {@link SuperSorterProgressTracker}. Tests regarding
+ * the correctness of the tracking is primarily present in {@link SuperSorterProgressSnapshotTest}
+ */
+public class SuperSorterProgressTrackerTest
+{
+  SuperSorterProgressTracker superSorterProgressTracker;
+
+  @Before
+  public void setup()
+  {
+    superSorterProgressTracker = new SuperSorterProgressTracker();
+  }
+
+  @Test
+  public void testSetTotalMergingLevelsMultipleTimes()
+  {
+    ISE exception = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergingLevels(5);
+      superSorterProgressTracker.setTotalMergingLevels(5);
+    });
+    Assert.assertEquals("Total merging levels already defined for the merge sort.", exception.getMessage());
+  }
+
+  @Test
+  public void testSetTotalMergingLevelsWithConflictingDataWithTotalMergers()
+  {
+    superSorterProgressTracker.setTotalMergersForLevel(3, 8);
+    ISE exception = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergingLevels(2);
+    });
+    Assert.assertEquals(
+        "Max level found in levelToTotalBatches is 3 (0-indexed). Cannot set totalMergingLevels to 2",
+        exception.getMessage()
+    );
+  }
+
+  @Test
+  public void testSetTotalMergingLevelsWithConflictingDataWithMergedBatches()
+  {
+    superSorterProgressTracker.addMergedBatchesForLevel(3, 8);
+    ISE exception = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergingLevels(3);
+    });
+    Assert.assertEquals(
+        "Max level found in levelToMergedBatches is 3 (0-indexed). Cannot set totalMergingLevels to 3",
+        exception.getMessage()
+    );
+  }
+
+  @Test
+  public void testSetTotalMergersForLevelIncorrectly()
+  {
+    // Init state
+    superSorterProgressTracker.setTotalMergingLevels(4);
+    superSorterProgressTracker.setTotalMergersForLevel(2, 8);
+    superSorterProgressTracker.setTotalMergersForLevel(3, 8);
+
+    // Test throws exception when level is negative
+    ISE exception1 = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergersForLevel(-1, 4);
+    });
+    Assert.assertEquals(
+        "Unable to set 4 total mergers for level -1. Level must be non-negative",
+        exception1.getMessage()
+    );
+
+    // Test throws when trying to set total mergers for level greater than permitted by the totalMergingLevels
+    ISE exception2 = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergersForLevel(4, 1);
+    });
+    Assert.assertEquals(
+        "Cannot set total mergers for level 4. Valid levels range from 0 to 3",
+        exception2.getMessage()
+    );
+
+    // Test throws when trying to set total mergers for a level multiple times. Only works if the ultimate level is known
+    ISE exception3 = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergersForLevel(2, 16);
+    });
+    Assert.assertEquals(
+        "Total mergers are already present for the level 2",
+        exception3.getMessage()
+    );
+
+    // The above check doesn't work for the ultimate level since that will be overridden later
+    superSorterProgressTracker.setTotalMergersForLevel(3, 16);
+  }
+
+  @Test
+  public void testSetMergersForUltimateLevelMultipleTimes()
+  {
+    ISE exception = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.setTotalMergersForUltimateLevel(5);
+      superSorterProgressTracker.setTotalMergersForUltimateLevel(5);
+    });
+    Assert.assertEquals("Cannot set mergers for final level more than once", exception.getMessage());
+  }
+
+  @Test
+  public void testAddMergedBatchesForLevelIncorrectly()
+  {
+    // Init state
+    superSorterProgressTracker.setTotalMergingLevels(4);
+
+    ISE exception = Assert.assertThrows(ISE.class, () -> {
+      superSorterProgressTracker.addMergedBatchesForLevel(5, 4);
+    });
+    Assert.assertEquals(
+        "Cannot add merged batches for level 5. Valid levels range from 0 to 3",
+        exception.getMessage()
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -1,0 +1,664 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
+import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
+import org.apache.druid.frame.channel.ReadableFileFrameChannel;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.file.FrameFile;
+import org.apache.druid.frame.file.FrameFileWriter;
+import org.apache.druid.frame.key.ClusterBy;
+import org.apache.druid.frame.key.ClusterByPartition;
+import org.apache.druid.frame.key.ClusterByPartitions;
+import org.apache.druid.frame.key.KeyTestUtils;
+import org.apache.druid.frame.key.RowKey;
+import org.apache.druid.frame.key.RowKeyReader;
+import org.apache.druid.frame.key.SortColumn;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.testutil.FrameSequenceBuilder;
+import org.apache.druid.frame.testutil.FrameTestUtil;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.segment.QueryableIndexStorageAdapter;
+import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.segment.column.ColumnHolder;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+@RunWith(Enclosed.class)
+public class SuperSorterTest
+{
+  private static final Logger log = new Logger(SuperSorterTest.class);
+
+  /**
+   * Non-parameterized test cases that
+   */
+  public static class NonParameterizedCasesTest extends InitializedNullHandlingTest
+  {
+    private static final int NUM_THREADS = 1;
+    private static final int FRAME_SIZE = 1_000_000;
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private FrameProcessorExecutor exec;
+
+    @Before
+    public void setUp()
+    {
+      exec = new FrameProcessorExecutor(
+          MoreExecutors.listeningDecorator(Execs.multiThreaded(NUM_THREADS, "super-sorter-test-%d"))
+      );
+    }
+
+    @After
+    public void tearDown()
+    {
+      exec.getExecutorService().shutdownNow();
+    }
+
+    @Test
+    public void testSingleEmptyInputChannel() throws Exception
+    {
+      final BlockingQueueFrameChannel inputChannel = BlockingQueueFrameChannel.minimal();
+      inputChannel.doneWriting();
+
+      final SettableFuture<ClusterByPartitions> outputPartitionsFuture = SettableFuture.create();
+      final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
+
+      final SuperSorter superSorter = new SuperSorter(
+          Collections.singletonList(inputChannel),
+          FrameReader.create(RowSignature.empty()),
+          ClusterBy.none(),
+          outputPartitionsFuture,
+          exec,
+          temporaryFolder.newFolder(),
+          new FileOutputChannelFactory(temporaryFolder.newFolder(), FRAME_SIZE),
+          () -> ArenaMemoryAllocator.createOnHeap(FRAME_SIZE),
+          2,
+          2,
+          -1,
+          null,
+          superSorterProgressTracker
+      );
+
+      superSorter.setNoWorkRunnable(() -> outputPartitionsFuture.set(ClusterByPartitions.oneUniversalPartition()));
+      final OutputChannels channels = superSorter.run().get();
+      Assert.assertEquals(1, channels.getAllChannels().size());
+
+      final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
+      Assert.assertTrue(channel.isFinished());
+      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      channel.doneReading();
+    }
+  }
+
+  /**
+   * Parameterized test cases that use {@link TestIndex#getNoRollupIncrementalTestIndex} with various frame sizes,
+   * numbers of channels, and worker configurations.
+   */
+  @RunWith(Parameterized.class)
+  public static class ParameterizedCasesTest extends InitializedNullHandlingTest
+  {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private final int maxRowsPerFrame;
+    private final int maxBytesPerFrame;
+    private final int numChannels;
+    private final int maxActiveProcessors;
+    private final int maxChannelsPerProcessor;
+    private final int numThreads;
+
+    private StorageAdapter adapter;
+    private RowSignature signature;
+    private FrameProcessorExecutor exec;
+    private List<ReadableFrameChannel> inputChannels;
+    private FrameReader frameReader;
+
+    public ParameterizedCasesTest(
+        int maxRowsPerFrame,
+        int maxBytesPerFrame,
+        int numChannels,
+        int maxActiveProcessors,
+        int maxChannelsPerProcessor,
+        int numThreads
+    )
+    {
+      this.maxRowsPerFrame = maxRowsPerFrame;
+      this.maxBytesPerFrame = maxBytesPerFrame;
+      this.numChannels = numChannels;
+      this.maxActiveProcessors = maxActiveProcessors;
+      this.maxChannelsPerProcessor = maxChannelsPerProcessor;
+      this.numThreads = numThreads;
+    }
+
+    @Parameterized.Parameters(
+        name = "maxRowsPerFrame = {0}, "
+               + "maxBytesPerFrame = {1}, "
+               + "numChannels = {2}, "
+               + "maxActiveProcessors = {3}, "
+               + "maxChannelsPerProcessor = {4}, "
+               + "numThreads = {5}"
+    )
+    public static Iterable<Object[]> constructorFeeder()
+    {
+      final List<Object[]> constructors = new ArrayList<>();
+
+      for (int maxRowsPerFrame : new int[]{Integer.MAX_VALUE, 50, 1}) {
+        for (int maxBytesPerFrame : new int[]{20000, 200000}) {
+          for (int numChannels : new int[]{1, 3}) {
+            for (int maxActiveProcessors : new int[]{1, 2, 4}) {
+              for (int maxChannelsPerProcessor : new int[]{2, 3, 8}) {
+                for (int numThreads : new int[]{1, 3}) {
+                  if (maxActiveProcessors >= maxChannelsPerProcessor) {
+                    constructors.add(
+                        new Object[]{
+                            maxRowsPerFrame,
+                            maxBytesPerFrame,
+                            numChannels,
+                            maxActiveProcessors,
+                            maxChannelsPerProcessor,
+                            numThreads
+                        }
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      return constructors;
+    }
+
+    @Before
+    public void setUp()
+    {
+      exec = new FrameProcessorExecutor(
+          MoreExecutors.listeningDecorator(Execs.multiThreaded(numThreads, getClass().getSimpleName() + "[%d]"))
+      );
+      adapter = new QueryableIndexStorageAdapter(TestIndex.getNoRollupMMappedTestIndex());
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+      if (exec != null) {
+        exec.getExecutorService().shutdownNow();
+        if (!exec.getExecutorService().awaitTermination(5, TimeUnit.SECONDS)) {
+          log.warn("Executor did not terminate after 5 seconds");
+        }
+      }
+    }
+
+    /**
+     * Creates input channels.
+     *
+     * Sets {@link #inputChannels}, {@link #signature}, and {@link #frameReader}.
+     */
+    private void setUpInputChannels(final ClusterBy clusterBy) throws Exception
+    {
+      if (signature != null || inputChannels != null) {
+        throw new ISE("Channels already created for this case");
+      }
+
+      final FrameSequenceBuilder frameSequenceBuilder =
+          FrameSequenceBuilder.fromAdapter(adapter)
+                              .maxRowsPerFrame(maxRowsPerFrame)
+                              .sortBy(clusterBy.getColumns())
+                              .allocator(ArenaMemoryAllocator.create(ByteBuffer.allocate(maxBytesPerFrame)))
+                              .frameType(FrameType.ROW_BASED)
+                              .populateRowNumber();
+
+      inputChannels = makeFileChannels(frameSequenceBuilder.frames(), temporaryFolder.newFolder(), numChannels);
+      signature = frameSequenceBuilder.signature();
+      frameReader = FrameReader.create(signature);
+    }
+
+    private OutputChannels verifySuperSorter(
+        final ClusterBy clusterBy,
+        final ClusterByPartitions clusterByPartitions
+    ) throws Exception
+    {
+      final RowKeyReader keyReader = clusterBy.keyReader(signature);
+      final Comparator<RowKey> keyComparator = clusterBy.keyComparator();
+      final SettableFuture<ClusterByPartitions> clusterByPartitionsFuture = SettableFuture.create();
+      final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
+
+      final SuperSorter superSorter = new SuperSorter(
+          inputChannels,
+          frameReader,
+          clusterBy,
+          clusterByPartitionsFuture,
+          exec,
+          temporaryFolder.newFolder(),
+          new FileOutputChannelFactory(temporaryFolder.newFolder(), maxBytesPerFrame),
+          () -> ArenaMemoryAllocator.createOnHeap(maxBytesPerFrame),
+          maxActiveProcessors,
+          maxChannelsPerProcessor,
+          -1,
+          null,
+          superSorterProgressTracker
+      );
+
+      superSorter.setNoWorkRunnable(() -> clusterByPartitionsFuture.set(clusterByPartitions));
+      final OutputChannels outputChannels = superSorter.run().get();
+      Assert.assertEquals(clusterByPartitions.size(), outputChannels.getAllChannels().size());
+      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+
+      final int[] clusterByPartColumns = clusterBy.getColumns().stream().mapToInt(
+          part -> signature.indexOf(part.columnName())
+      ).toArray();
+
+      final List<Sequence<List<Object>>> outputSequences = new ArrayList<>();
+      for (int partitionNumber : outputChannels.getPartitionNumbers()) {
+        final ClusterByPartition partition = clusterByPartitions.get(partitionNumber);
+        final ReadableFrameChannel outputChannel =
+            Iterables.getOnlyElement(outputChannels.getChannelsForPartition(partitionNumber)).getReadableChannel();
+
+        // Validate that everything in this channel is in the correct key range.
+        FrameTestUtil.readRowsFromFrameChannel(
+            duplicateOutputChannel(outputChannel),
+            frameReader
+        ).forEach(
+            row -> {
+              final Object[] array = new Object[clusterByPartColumns.length];
+
+              for (int i = 0; i < array.length; i++) {
+                array[i] = row.get(clusterByPartColumns[i]);
+              }
+
+              final RowKey key = createKey(clusterBy, array);
+
+              Assert.assertTrue(
+                  StringUtils.format(
+                      "Key %s >= partition %,d start %s",
+                      keyReader.read(key),
+                      partitionNumber,
+                      partition.getStart() == null ? null : keyReader.read(partition.getStart())
+                  ),
+                  partition.getStart() == null || keyComparator.compare(key, partition.getStart()) >= 0
+              );
+
+              Assert.assertTrue(
+                  StringUtils.format(
+                      "Key %s < partition %,d end %s",
+                      keyReader.read(key),
+                      partitionNumber,
+                      partition.getEnd() == null ? null : keyReader.read(partition.getEnd())
+                  ),
+                  partition.getEnd() == null || keyComparator.compare(key, partition.getEnd()) < 0
+              );
+            }
+        );
+
+        outputSequences.add(
+            FrameTestUtil.readRowsFromFrameChannel(
+                duplicateOutputChannel(outputChannel),
+                frameReader
+            )
+        );
+      }
+
+      final Sequence<List<Object>> expectedRows = Sequences.sort(
+          FrameTestUtil.readRowsFromAdapter(adapter, signature, true),
+          Comparator.comparing(
+              row -> {
+                final Object[] array = new Object[clusterByPartColumns.length];
+
+                for (int i = 0; i < array.length; i++) {
+                  array[i] = row.get(clusterByPartColumns[i]);
+                }
+
+                return createKey(clusterBy, array);
+              },
+              keyComparator
+          )
+      );
+
+      FrameTestUtil.assertRowsEqual(expectedRows, Sequences.concat(outputSequences));
+
+      return outputChannels;
+    }
+
+    @Test
+    public void test_clusterByQualityLongAscRowNumberAsc_onePartition() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn("qualityLong", false),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+      verifySuperSorter(clusterBy, ClusterByPartitions.oneUniversalPartition());
+    }
+
+    @Test
+    public void test_clusterByQualityLongAscRowNumberAsc_twoPartitionsOneEmpty() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn("qualityLong", false),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+
+      final RowKey zeroZero = createKey(clusterBy, 0L, 0L);
+      final OutputChannels outputChannels = verifySuperSorter(
+          clusterBy,
+          new ClusterByPartitions(
+              ImmutableList.of(
+                  new ClusterByPartition(null, zeroZero), // empty partition
+                  new ClusterByPartition(zeroZero, null) // all data goes in here
+              )
+          )
+      );
+
+      // Verify that one of the partitions is actually empty.
+      Assert.assertEquals(
+          0,
+          countSequence(
+              FrameTestUtil.readRowsFromFrameChannel(
+                  Iterables.getOnlyElement(outputChannels.getChannelsForPartition(0)).getReadableChannel(),
+                  frameReader
+              )
+          )
+      );
+
+      // Verify that the other partition has all data in it.
+      Assert.assertEquals(
+          adapter.getNumRows(),
+          countSequence(
+              FrameTestUtil.readRowsFromFrameChannel(
+                  Iterables.getOnlyElement(outputChannels.getChannelsForPartition(1)).getReadableChannel(),
+                  frameReader
+              )
+          )
+      );
+    }
+
+    @Test
+    public void test_clusterByQualityDescRowNumberAsc_fourPartitions() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn("quality", true),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+
+      final ClusterByPartitions partitions = new ClusterByPartitions(
+          ImmutableList.of(
+              new ClusterByPartition(
+                  createKey(clusterBy, "travel", 8L),
+                  createKey(clusterBy, "premium", 506L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, "premium", 506L),
+                  createKey(clusterBy, "mezzanine", 204L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, "mezzanine", 204L),
+                  createKey(clusterBy, "health", 900L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, "health", 900L),
+                  null
+              )
+          )
+      );
+
+      Assert.assertEquals(4, partitions.size());
+
+      verifySuperSorter(clusterBy, partitions);
+    }
+
+    @Test
+    public void test_clusterByTimeAscMarketAscRowNumberAsc_fourPartitions() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn(ColumnHolder.TIME_COLUMN_NAME, false),
+              new SortColumn("market", false),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+
+      final ClusterByPartitions partitions = new ClusterByPartitions(
+          ImmutableList.of(
+              new ClusterByPartition(
+                  createKey(clusterBy, 1294790400000L, "spot", 0L),
+                  createKey(clusterBy, 1296864000000L, "spot", 302L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1296864000000L, "spot", 302L),
+                  createKey(clusterBy, 1298851200000L, "spot", 604L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1298851200000L, "spot", 604L),
+                  createKey(clusterBy, 1300838400000L, "total_market", 906L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1300838400000L, "total_market", 906L),
+                  null
+              )
+          )
+      );
+
+      Assert.assertEquals(4, partitions.size());
+
+      verifySuperSorter(clusterBy, partitions);
+    }
+
+    @Test
+    public void test_clusterByPlacementishDescRowNumberAsc_fourPartitions() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn("placementish", true),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+
+      final ClusterByPartitions partitions = new ClusterByPartitions(
+          ImmutableList.of(
+              new ClusterByPartition(
+                  createKey(clusterBy, ImmutableList.of("preferred", "t"), 7L),
+                  createKey(clusterBy, ImmutableList.of("p", "preferred"), 506L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, ImmutableList.of("p", "preferred"), 506L),
+                  createKey(clusterBy, ImmutableList.of("m", "preferred"), 204L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, ImmutableList.of("m", "preferred"), 204L),
+                  createKey(clusterBy, ImmutableList.of("h", "preferred"), 900L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, ImmutableList.of("h", "preferred"), 900L),
+                  null
+              )
+          )
+      );
+
+      Assert.assertEquals(4, partitions.size());
+
+      verifySuperSorter(clusterBy, partitions);
+    }
+
+    @Test
+    public void test_clusterByQualityLongDescRowNumberAsc_fourPartitions() throws Exception
+    {
+      final ClusterBy clusterBy = new ClusterBy(
+          ImmutableList.of(
+              new SortColumn("qualityLong", true),
+              new SortColumn(FrameTestUtil.ROW_NUMBER_COLUMN, false)
+          ),
+          0
+      );
+
+      setUpInputChannels(clusterBy);
+
+      final ClusterByPartitions partitions = new ClusterByPartitions(
+          ImmutableList.of(
+              new ClusterByPartition(
+                  createKey(clusterBy, 1800L, 8L),
+                  createKey(clusterBy, 1600L, 506L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1600L, 506L),
+                  createKey(clusterBy, 1400L, 204L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1400L, 204L),
+                  createKey(clusterBy, 1300L, 900L)
+              ),
+              new ClusterByPartition(
+                  createKey(clusterBy, 1300L, 900L),
+                  null
+              )
+          )
+      );
+
+      Assert.assertEquals(4, partitions.size());
+
+      verifySuperSorter(clusterBy, partitions);
+    }
+
+    private RowKey createKey(final ClusterBy clusterBy, final Object... objects)
+    {
+      final RowSignature keySignature = KeyTestUtils.createKeySignature(clusterBy.getColumns(), signature);
+      return KeyTestUtils.createKey(keySignature, objects);
+    }
+  }
+
+  private static List<ReadableFrameChannel> makeFileChannels(
+      final Sequence<Frame> frames,
+      final File tmpDir,
+      final int numChannels
+  ) throws IOException
+  {
+    final List<File> files = new ArrayList<>();
+    final List<WritableFrameChannel> writableChannels = new ArrayList<>();
+
+    for (int i = 0; i < numChannels; i++) {
+      final File file = new File(tmpDir, StringUtils.format("channel-%d", i));
+      files.add(file);
+      writableChannels.add(
+          new WritableStreamFrameChannel(FrameFileWriter.open(Channels.newChannel(new FileOutputStream(file)), null))
+      );
+    }
+
+    frames.forEach(
+        new Consumer<Frame>()
+        {
+          private int i;
+
+          @Override
+          public void accept(final Frame frame)
+          {
+            try {
+              writableChannels.get(i % writableChannels.size()).write(frame);
+            }
+            catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+
+            i++;
+          }
+        }
+    );
+
+    final List<ReadableFrameChannel> retVal = new ArrayList<>();
+
+    for (int i = 0; i < writableChannels.size(); i++) {
+      WritableFrameChannel writableChannel = writableChannels.get(i);
+      writableChannel.doneWriting();
+      retVal.add(new ReadableFileFrameChannel(FrameFile.open(files.get(i))));
+    }
+
+    return retVal;
+  }
+
+  private static ReadableFrameChannel duplicateOutputChannel(final ReadableFrameChannel channel)
+  {
+    return new ReadableFileFrameChannel(((ReadableFileFrameChannel) channel).getFrameFileReference());
+  }
+
+  private static <T> long countSequence(final Sequence<T> sequence)
+  {
+    return sequence.accumulate(
+        0L,
+        (accumulated, in) -> accumulated + 1
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -651,7 +651,7 @@ public class SuperSorterTest
 
   private static ReadableFrameChannel duplicateOutputChannel(final ReadableFrameChannel channel)
   {
-    return new ReadableFileFrameChannel(((ReadableFileFrameChannel) channel).getFrameFileReference());
+    return new ReadableFileFrameChannel(((ReadableFileFrameChannel) channel).newFrameFileReference());
   }
 
   private static <T> long countSequence(final Sequence<T> sequence)

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -113,13 +113,13 @@ public class SuperSorterTest
     public void testSingleEmptyInputChannel() throws Exception
     {
       final BlockingQueueFrameChannel inputChannel = BlockingQueueFrameChannel.minimal();
-      inputChannel.doneWriting();
+      inputChannel.writable().close();
 
       final SettableFuture<ClusterByPartitions> outputPartitionsFuture = SettableFuture.create();
       final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
 
       final SuperSorter superSorter = new SuperSorter(
-          Collections.singletonList(inputChannel),
+          Collections.singletonList(inputChannel.readable()),
           FrameReader.create(RowSignature.empty()),
           ClusterBy.none(),
           outputPartitionsFuture,
@@ -141,7 +141,7 @@ public class SuperSorterTest
       final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
       Assert.assertTrue(channel.isFinished());
       Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
-      channel.doneReading();
+      channel.close();
     }
   }
 
@@ -642,7 +642,7 @@ public class SuperSorterTest
 
     for (int i = 0; i < writableChannels.size(); i++) {
       WritableFrameChannel writableChannel = writableChannels.get(i);
-      writableChannel.doneWriting();
+      writableChannel.close();
       retVal.add(new ReadableFileFrameChannel(FrameFile.open(files.get(i))));
     }
 

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -30,7 +30,7 @@ import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 import org.apache.druid.frame.channel.ReadableFileFrameChannel;
 import org.apache.druid.frame.channel.ReadableFrameChannel;
 import org.apache.druid.frame.channel.WritableFrameChannel;
-import org.apache.druid.frame.channel.WritableStreamFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameFileChannel;
 import org.apache.druid.frame.file.FrameFile;
 import org.apache.druid.frame.file.FrameFileWriter;
 import org.apache.druid.frame.key.ClusterBy;
@@ -614,7 +614,7 @@ public class SuperSorterTest
       final File file = new File(tmpDir, StringUtils.format("channel-%d", i));
       files.add(file);
       writableChannels.add(
-          new WritableStreamFrameChannel(FrameFileWriter.open(Channels.newChannel(new FileOutputStream(file)), null))
+          new WritableFrameFileChannel(FrameFileWriter.open(Channels.newChannel(new FileOutputStream(file)), null))
       );
     }
 

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/ChompingFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/ChompingFrameProcessor.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor.test;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.FrameProcessor;
+import org.apache.druid.frame.processor.FrameProcessors;
+import org.apache.druid.frame.processor.ReturnOrAwait;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Processor used by {@link org.apache.druid.frame.processor.FrameProcessorExecutorTest}.
+ *
+ * Throws away all input frames; never writes any output.
+ *
+ * Returns the number of frames read.
+ */
+public class ChompingFrameProcessor implements FrameProcessor<Long>
+{
+  private final List<ReadableFrameChannel> channels;
+  private final IntSet awaitSet;
+  private final CountDownLatch didReadFrame = new CountDownLatch(1);
+  private final AtomicBoolean didCleanup = new AtomicBoolean(false);
+  private long numFrames = 0L;
+
+  public ChompingFrameProcessor(List<ReadableFrameChannel> channels)
+  {
+    this.channels = channels;
+    this.awaitSet = new IntOpenHashSet(IntSets.fromTo(0, channels.size()));
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return channels;
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(IntSet readableInputs)
+  {
+    for (final int channelNumber : readableInputs) {
+      final ReadableFrameChannel channel = channels.get(channelNumber);
+
+      if (channel.isFinished()) {
+        awaitSet.remove(channelNumber);
+      } else {
+        // Call valueOrThrow() for side effects: we want to throw any exceptions that come in on the channel.
+        channel.read();
+        didReadFrame.countDown();
+        numFrames++;
+      }
+    }
+
+    if (awaitSet.isEmpty()) {
+      return ReturnOrAwait.returnObject(numFrames);
+    } else {
+      return ReturnOrAwait.awaitAny(awaitSet);
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+    didCleanup.set(true);
+  }
+
+  public void awaitRead() throws InterruptedException
+  {
+    didReadFrame.await();
+  }
+
+  public boolean didCleanup()
+  {
+    return didCleanup.get();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/FailingFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/FailingFrameProcessor.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor.test;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.FrameProcessor;
+import org.apache.druid.frame.processor.FrameProcessors;
+import org.apache.druid.frame.processor.ReturnOrAwait;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Processor used by {@link org.apache.druid.frame.processor.FrameProcessorExecutorTest}.
+ *
+ * Copies some number of frames from input to output, then fails. If the input channel does not have this
+ * many frames, fails when the input channel is finished.
+ */
+public class FailingFrameProcessor implements FrameProcessor<Long>
+{
+  private final ReadableFrameChannel inChannel;
+  private final WritableFrameChannel outChannel;
+  private final int numFramesBeforeFailure;
+
+  private int numFramesSoFar = 0;
+
+  public FailingFrameProcessor(
+      final ReadableFrameChannel inChannel,
+      final WritableFrameChannel outChannel,
+      final int numFramesBeforeFailure
+  )
+  {
+    this.inChannel = inChannel;
+    this.outChannel = outChannel;
+    this.numFramesBeforeFailure = numFramesBeforeFailure;
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return Collections.singletonList(inChannel);
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.singletonList(outChannel);
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(final IntSet readableInputs) throws IOException
+  {
+    if (readableInputs.contains(0)) {
+      if (inChannel.isFinished()) {
+        throw new RuntimeException("failure!");
+      }
+
+      if (numFramesSoFar >= numFramesBeforeFailure) {
+        throw new RuntimeException("failure!");
+      }
+
+      outChannel.write(inChannel.read());
+      numFramesSoFar++;
+
+      if (numFramesSoFar >= numFramesBeforeFailure) {
+        throw new RuntimeException("failure!");
+      }
+    }
+
+    return ReturnOrAwait.awaitAll(inputChannels().size());
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/InfiniteFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/InfiniteFrameProcessor.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor.test;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.FrameProcessor;
+import org.apache.druid.frame.processor.FrameProcessors;
+import org.apache.druid.frame.processor.ReturnOrAwait;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Processor used by {@link org.apache.druid.frame.processor.FrameProcessorExecutorTest}.
+ *
+ * Writes the same frame over and over again to its output channel, without ever exiting.
+ *
+ * Returns the number of frames written.
+ */
+public class InfiniteFrameProcessor implements FrameProcessor<Long>
+{
+  private final Frame frame;
+  private final WritableFrameChannel outChannel;
+  private final AtomicBoolean stop = new AtomicBoolean(false);
+  private final AtomicBoolean didCleanup = new AtomicBoolean(false);
+  private final AtomicLong numFrames = new AtomicLong();
+
+  public InfiniteFrameProcessor(
+      final Frame frame,
+      final WritableFrameChannel outChannel
+  )
+  {
+    this.frame = frame;
+    this.outChannel = outChannel;
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.singletonList(outChannel);
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(final IntSet readableInputs) throws IOException
+  {
+    outChannel.write(frame);
+    numFrames.incrementAndGet();
+
+    if (stop.get()) {
+      return ReturnOrAwait.returnObject(numFrames.get());
+    } else {
+      return ReturnOrAwait.runAgain();
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+    didCleanup.set(true);
+  }
+
+  public long getNumFrames()
+  {
+    return numFrames.get();
+  }
+
+  public void stop()
+  {
+    stop.set(true);
+  }
+
+  public boolean didCleanup()
+  {
+    return didCleanup.get();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/SleepyFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/SleepyFrameProcessor.java
@@ -61,7 +61,7 @@ public class SleepyFrameProcessor implements FrameProcessor<Long>
 
   @Override
   @SuppressWarnings({"InfiniteLoopStatement", "BusyWait"})
-  public ReturnOrAwait<Long> runIncrementally(IntSet readableInputs)
+  public ReturnOrAwait<Long> runIncrementally(IntSet readableInputs) throws InterruptedException
   {
     didRun.countDown();
 
@@ -71,8 +71,7 @@ public class SleepyFrameProcessor implements FrameProcessor<Long>
       }
       catch (InterruptedException e) {
         didGetInterrupt.set(true);
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throw e;
       }
     }
   }

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/SleepyFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/SleepyFrameProcessor.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor.test;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.FrameProcessor;
+import org.apache.druid.frame.processor.FrameProcessors;
+import org.apache.druid.frame.processor.ReturnOrAwait;
+import org.joda.time.Duration;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Processor used by {@link org.apache.druid.frame.processor.FrameProcessorExecutorTest}.
+ *
+ * Sleeps forever in {@link #runIncrementally}.
+ *
+ * Returns the number of frames written.
+ */
+public class SleepyFrameProcessor implements FrameProcessor<Long>
+{
+  private final CountDownLatch didRun = new CountDownLatch(1);
+  private final AtomicBoolean didGetInterrupt = new AtomicBoolean(false);
+  private final CountDownLatch cleanupLatch = new CountDownLatch(1);
+  private final AtomicBoolean didCleanup = new AtomicBoolean(false);
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return Collections.emptyList();
+  }
+
+  @Override
+  @SuppressWarnings({"InfiniteLoopStatement", "BusyWait"})
+  public ReturnOrAwait<Long> runIncrementally(IntSet readableInputs)
+  {
+    didRun.countDown();
+
+    while (true) {
+      try {
+        Thread.sleep(Duration.standardDays(1).getMillis());
+      }
+      catch (InterruptedException e) {
+        didGetInterrupt.set(true);
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inputChannels(), outputChannels());
+    didCleanup.set(true);
+    cleanupLatch.countDown();
+  }
+
+  public void awaitRun() throws InterruptedException
+  {
+    didRun.await();
+  }
+
+  public boolean didGetInterrupt()
+  {
+    return didGetInterrupt.get();
+  }
+
+  public boolean didCleanup()
+  {
+    return didCleanup.get();
+  }
+
+  public void awaitCleanup() throws InterruptedException
+  {
+    cleanupLatch.await();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/SuperBlasterFrameProcessor.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/SuperBlasterFrameProcessor.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.processor.test;
+
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.channel.ReadableFrameChannel;
+import org.apache.druid.frame.channel.WritableFrameChannel;
+import org.apache.druid.frame.processor.FrameProcessor;
+import org.apache.druid.frame.processor.FrameProcessors;
+import org.apache.druid.frame.processor.ReturnOrAwait;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Processor used by {@link org.apache.druid.frame.processor.FrameProcessorExecutorTest}.
+ *
+ * Reads from any number of input channels, and writes each input frame to all output channels.
+ * (Hence the "blaster" name.)
+ */
+public class SuperBlasterFrameProcessor implements FrameProcessor<Long>
+{
+  public enum AwaitStyle
+  {
+    NONE,
+    ALL,
+    ANY,
+    SINGLE_ALL,
+    SINGLE_ANY
+  }
+
+  private final List<ReadableFrameChannel> inChannels;
+  private final List<WritableFrameChannel> outChannels;
+  private final AwaitStyle awaitStyle;
+
+  // Used to pick random channels to wait for.
+  private final Random rand;
+
+  private long rowsRead = 0L;
+
+  public SuperBlasterFrameProcessor(
+      final List<ReadableFrameChannel> inChannels,
+      final List<WritableFrameChannel> outChannels,
+      final AwaitStyle awaitStyle
+  )
+  {
+    this.inChannels = inChannels;
+    this.outChannels = outChannels;
+    this.awaitStyle = awaitStyle;
+    this.rand = new Random(0);
+  }
+
+  @Override
+  public List<ReadableFrameChannel> inputChannels()
+  {
+    return inChannels;
+  }
+
+  @Override
+  public List<WritableFrameChannel> outputChannels()
+  {
+    return outChannels;
+  }
+
+  @Override
+  public ReturnOrAwait<Long> runIncrementally(final IntSet readableInputs) throws IOException
+  {
+    if (readableInputs.size() == inChannels.size() && inChannels.stream().allMatch(ReadableFrameChannel::isFinished)) {
+      return ReturnOrAwait.returnObject(rowsRead);
+    }
+
+    for (int channelNumber : readableInputs) {
+      final ReadableFrameChannel inChannel = inChannels.get(channelNumber);
+
+      if (!inChannel.isFinished()) {
+        final Frame frame = inChannel.read();
+        rowsRead += frame.numRows();
+
+        for (WritableFrameChannel outChannel : outChannels) {
+          outChannel.write(frame);
+        }
+
+        // Only permitted to write one frame to each output channel.
+        break;
+      }
+    }
+
+    switch (awaitStyle) {
+      case ALL:
+        return ReturnOrAwait.awaitAll(inChannels.size());
+      case ANY:
+        return ReturnOrAwait.awaitAny(IntSets.fromTo(0, inChannels.size()));
+      case SINGLE_ALL:
+        return ReturnOrAwait.awaitAll(IntSets.singleton(rand.nextInt(inChannels.size())));
+      case SINGLE_ANY:
+        return ReturnOrAwait.awaitAny(IntSets.singleton(rand.nextInt(inChannels.size())));
+      case NONE:
+        return ReturnOrAwait.runAgain();
+      default:
+        throw new UnsupportedOperationException();
+    }
+  }
+
+  @Override
+  public void cleanup() throws IOException
+  {
+    FrameProcessors.closeAll(inChannels, outChannels);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
@@ -132,30 +132,27 @@ public class FrameWritersTest extends InitializedNullHandlingTest
   @Test
   public void test_rowBased_unsupportedSortColumnType()
   {
+    // Register, but don't unregister, because many other tests out there expect this to exist even though they
+    // don't explicitly register it.
     ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
 
-    try {
-      final IllegalArgumentException e = Assert.assertThrows(
-          IllegalArgumentException.class,
-          () ->
-              FrameWriters.makeFrameWriterFactory(
-                  FrameType.ROW_BASED,
-                  ArenaMemoryAllocator.createOnHeap(ALLOCATOR_CAPACITY),
-                  RowSignature.builder().add("x", HyperUniquesAggregatorFactory.TYPE).build(),
-                  Collections.singletonList(new SortColumn("x", false))
-              )
-      );
+    final IllegalArgumentException e = Assert.assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            FrameWriters.makeFrameWriterFactory(
+                FrameType.ROW_BASED,
+                ArenaMemoryAllocator.createOnHeap(ALLOCATOR_CAPACITY),
+                RowSignature.builder().add("x", HyperUniquesAggregatorFactory.TYPE).build(),
+                Collections.singletonList(new SortColumn("x", false))
+            )
+    );
 
-      MatcherAssert.assertThat(
-          e,
-          ThrowableMessageMatcher.hasMessage(
-              CoreMatchers.containsString("Sort column [x] is not comparable (type = COMPLEX<hyperUnique>)")
-          )
-      );
-    }
-    finally {
-      ComplexMetrics.unregisterSerde("hyperUnique");
-    }
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(
+            CoreMatchers.containsString("Sort column [x] is not comparable (type = COMPLEX<hyperUnique>)")
+        )
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
@@ -132,8 +132,8 @@ public class FrameWritersTest extends InitializedNullHandlingTest
   @Test
   public void test_rowBased_unsupportedSortColumnType()
   {
-    // Register, but don't unregister, because many other tests out there expect this to exist even though they
-    // don't explicitly register it.
+    // Register, but don't unregister at the end of this test, because many other tests out there expect this to exist
+    // even though they don't explicitly register it.
     ComplexMetrics.registerSerde("hyperUnique", new HyperUniquesSerde());
 
     final IllegalArgumentException e = Assert.assertThrows(


### PR DESCRIPTION
Follow-up to #12745. Part of #12262. This patch adds three new concepts:

1) Frame channels are interfaces for doing nonblocking reads and writes
   of frames.

2) Frame processors are interfaces for doing nonblocking processing of
   frames received from input channels and sent to output channels.

3) Cluster-by keys, which can be used for sorting or partitioning.

The patch also adds SuperSorter, a user of these concepts, both to
illustrate how they are used, and also because it is going to be useful
in future work.

Central classes:

- [ReadableFrameChannel](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/channel/ReadableFrameChannel.java), nonblocking source of frames. Implementations include BlockingQueueFrameChannel (in-memory channel that implements both interfaces), ReadableFileFrameChannel (file-based channel), ReadableByteChunksFrameChannel (byte-stream-based channel), and others.

- [WritableFrameChannel](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/channel/WritableFrameChannel.java), nonblocking sink for frames. Implementations include BlockingQueueFrameChannel and WritableStreamFrameChannel (byte-stream-based channel).

- [ClusterBy](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java), a sorting or partitioning key.

- [FrameProcessor](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessor.java), nonblocking processor of frames. Implementations include FrameChannelBatcher, FrameChannelMerger, and FrameChannelMuxer.

- [FrameProcessorExecutor](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java), an executor service that runs FrameProcessors.

- [SuperSorter](https://github.com/gianm/druid/blob/frame-processor/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java), a class that uses frame channels and processors to do parallel external merge sort of any amount of data (as long as there is enough disk space).