### PR TITLE
fix nested column sql operator return type inference

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.StringUtils;
@@ -56,6 +57,12 @@ import java.util.List;
 
 public class NestedDataOperatorConversions
 {
+  public static SqlReturnTypeInference NESTED_RETURN_TYPE_INFERENCE = opBinding -> RowSignatures.makeComplexType(
+      opBinding.getTypeFactory(),
+      NestedDataComplexTypeSerde.TYPE,
+      true
+  );
+
   public static class GetPathOperatorConversion implements SqlOperatorConversion
   {
     private static final String FUNCTION_NAME = StringUtils.toUpperCase("get_path");
@@ -236,13 +243,7 @@ public class NestedDataOperatorConversions
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
         .operatorBuilder(FUNCTION_NAME)
         .operandTypeChecker(OperandTypes.family(new SqlTypeFamily[]{SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY}))
-        .returnTypeCascadeNullable(
-            new RowSignatures.ComplexSqlType(
-                SqlTypeName.OTHER,
-                NestedDataComplexTypeSerde.TYPE,
-                true
-            ).getSqlTypeName()
-        )
+        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
         .functionCategory(SqlFunctionCategory.SYSTEM)
         .build();
 
@@ -429,16 +430,12 @@ public class NestedDataOperatorConversions
               continue;
             }
             operandTypes[i] = typeFactory.createTypeWithNullability(
-                typeFactory.createSqlType(SqlTypeName.ANY), true);
+                typeFactory.createSqlType(SqlTypeName.ANY),
+                true
+            );
           }
         })
-        .returnTypeCascadeNullable(
-            new RowSignatures.ComplexSqlType(
-                SqlTypeName.OTHER,
-                NestedDataComplexTypeSerde.TYPE,
-                true
-            ).getSqlTypeName()
-        )
+        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
         .functionCategory(SqlFunctionCategory.SYSTEM)
         .build();
 
@@ -484,13 +481,7 @@ public class NestedDataOperatorConversions
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
         .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandTypes(SqlTypeFamily.ANY)
-        .returnTypeCascadeNullable(
-            new RowSignatures.ComplexSqlType(
-                SqlTypeName.OTHER,
-                NestedDataComplexTypeSerde.TYPE,
-                true
-            ).getSqlTypeName()
-        )
+        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
         .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
         .build();
 
@@ -566,13 +557,7 @@ public class NestedDataOperatorConversions
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
         .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandTypes(SqlTypeFamily.ANY)
-        .returnTypeCascadeNullable(
-            new RowSignatures.ComplexSqlType(
-                SqlTypeName.OTHER,
-                NestedDataComplexTypeSerde.TYPE,
-                true
-            ).getSqlTypeName()
-        )
+        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
         .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
         .build();
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -57,7 +57,7 @@ import java.util.List;
 
 public class NestedDataOperatorConversions
 {
-  public static SqlReturnTypeInference NESTED_RETURN_TYPE_INFERENCE = opBinding -> RowSignatures.makeComplexType(
+  public static final SqlReturnTypeInference NESTED_RETURN_TYPE_INFERENCE = opBinding -> RowSignatures.makeComplexType(
       opBinding.getTypeFactory(),
       NestedDataComplexTypeSerde.TYPE,
       true

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -409,7 +409,8 @@ public class DruidPlanner implements Closeable
     // because no values were provided. (Values are not required in the PREPARE case
     // but now that we're planning, we require them.)
     RelNode parameterized = possiblyLimitedRoot.rel.accept(
-        new RelParameterizerShuttle(plannerContext));
+        new RelParameterizerShuttle(plannerContext)
+    );
     final DruidRel<?> druidRel = (DruidRel<?>) planner.transform(
         CalciteRulesManager.DRUID_CONVENTION_RULES,
         planner.getEmptyTraitSet()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.Query;
@@ -310,7 +311,7 @@ public class CalciteIngestionDmlTest extends BaseCalciteQueryTest
           analyzeResources(plannerConfig, new AuthConfig(), sql, queryContext, authenticationResult)
       );
 
-      final List<Object[]> results =
+      final Pair<RowSignature, List<Object[]>> results =
           getResults(plannerConfig, queryContext, Collections.emptyList(), sql, authenticationResult);
 
       verifyResults(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -56,6 +56,7 @@ import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.NestedDataDimensionSchema;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 import org.apache.druid.segment.serde.ComplexMetrics;
@@ -230,7 +231,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -263,7 +268,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -296,7 +305,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -329,7 +342,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{NullHandling.defaultStringValue(), 5L},
             new Object[]{"2", 1L},
             new Object[]{"hello", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -371,7 +388,13 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             },
             new Object[]{"100", "100", "100", 2L},
             new Object[]{"200", "200", "200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.STRING)
+                    .add("EXPR$2", ColumnType.STRING)
+                    .add("EXPR$3", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -413,7 +436,13 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             },
             new Object[]{"100", "100", "100", 2L},
             new Object[]{"200", "200", "200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.STRING)
+                    .add("EXPR$2", ColumnType.STRING)
+                    .add("EXPR$3", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -448,7 +477,12 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{NullHandling.defaultStringValue(), NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", "100", 2L},
             new Object[]{"200", "200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.STRING)
+                    .add("EXPR$2", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -483,7 +517,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                 "100",
                 2L
             }
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -519,7 +557,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                 "100",
                 2L
             }
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -555,7 +597,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                 "100",
                 2L
             }
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -591,7 +637,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                 "100",
                 1L
             }
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -622,7 +672,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of(new Object[]{"100", 1L})
+        ImmutableList.of(new Object[]{"100", 1L}),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -656,7 +710,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 1L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -690,7 +748,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -721,7 +783,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
-        ImmutableList.of()
+        ImmutableList.of(),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -755,7 +821,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -788,7 +858,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -821,7 +895,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -853,7 +931,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -887,7 +969,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -921,7 +1007,48 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testGroupByPathNumericBoundFilterLongNoUpperNumeric() throws Exception
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(nest, '$.x' RETURNING BIGINT),"
+        + "SUM(cnt) "
+        + "FROM druid.nested WHERE JSON_VALUE(nest, '$.x' RETURNING BIGINT) >= 100 GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            new NestedFieldVirtualColumn("nest", "$.x", "v0", ColumnType.LONG)
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)
+                            )
+                        )
+                        .setDimFilter(bound("v0", "100", null, false, false, null, StringComparators.NUMERIC))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{100L, 2L},
+            new Object[]{200L, 1L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -955,7 +1082,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -988,7 +1119,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"2.02", 2L},
             new Object[]{"3.03", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1021,7 +1156,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"2.02", 2L},
             new Object[]{"3.03", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1053,7 +1192,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"2.02", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1087,7 +1230,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"2.02", 2L},
             new Object[]{"3.03", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1121,7 +1268,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"2.02", 2L},
             new Object[]{"3.03", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1155,7 +1306,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"2.02", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1188,7 +1343,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1222,7 +1381,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 1L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1256,7 +1419,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{NullHandling.defaultStringValue(), 4L},
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1288,7 +1455,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1321,7 +1492,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1354,7 +1529,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1387,7 +1566,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1421,7 +1604,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1455,7 +1642,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 2L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1489,7 +1680,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"100", 1L},
             new Object[]{"200", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1522,7 +1717,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"100", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1545,7 +1744,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{400.0}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1581,7 +1783,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{200.0}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1615,7 +1820,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{100.0}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1640,7 +1848,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{2.1}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1677,7 +1888,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{2.1}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1710,7 +1924,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{1.1}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
     );
   }
 
@@ -1733,7 +1950,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{400L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1757,7 +1977,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{700L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1780,7 +2003,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{400L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1804,7 +2030,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{700L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1842,7 +2071,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{null, 5L},
             new Object[]{"[\"array\",\"n\"]", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING_ARRAY)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1880,7 +2113,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{null, 5L},
             new Object[]{"[\"array\",\"n\"]", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING_ARRAY)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1919,7 +2156,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{null, 4L},
             new Object[]{"[\"x\",\"y\",\"z\",\"mixed\",\"mixed2\"]", 2L},
             new Object[]{"[\"x\",\"y\",\"z\",\"mixed2\"]", 1L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING_ARRAY)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1957,7 +2198,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{"[\"$.\"]", 5L},
             new Object[]{"[\"$.n.x\",\"$.array[0]\",\"$.array[1]\"]", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING_ARRAY)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -1989,7 +2234,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[]{NullHandling.defaultStringValue(), 5L},
             new Object[]{"b", 2L}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 
@@ -2052,7 +2301,12 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{null, null},
             new Object[]{"{\"x\":1}", "{\"array\":[\"a\",\"b\"],\"n\":{\"x\":1}}"},
             new Object[]{null, "2"}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", NestedDataComplexTypeSerde.TYPE)
+                    .add("EXPR$1", NestedDataComplexTypeSerde.TYPE)
+                    .build()
+
     );
   }
 
@@ -2097,7 +2351,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{"{\"x\":null,\"n\":null}"},
             new Object[]{"{\"x\":\"100\",\"n\":{\"x\":1}}"},
             new Object[]{"{\"x\":null,\"n\":null}"}
-        )
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", NestedDataComplexTypeSerde.TYPE)
+                    .build()
     );
   }
 
@@ -2156,7 +2413,14 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
             new Object[]{"eee", "\"eee\"", "\"eee\"", "{\"foo\":1}", null},
             new Object[]{"aaa", "\"aaa\"", "\"aaa\"", "{\"foo\":1}", "{\"array\":[\"a\",\"b\"],\"n\":{\"x\":1}}"},
             new Object[]{"ddd", "\"ddd\"", "\"ddd\"", "{\"foo\":1}", "2"}
-        )
+        ),
+        RowSignature.builder()
+                    .add("string", ColumnType.STRING)
+                    .add("EXPR$1", NestedDataComplexTypeSerde.TYPE)
+                    .add("EXPR$2", NestedDataComplexTypeSerde.TYPE)
+                    .add("EXPR$3", NestedDataComplexTypeSerde.TYPE)
+                    .add("EXPR$4", NestedDataComplexTypeSerde.TYPE)
+                    .build()
     );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
@@ -34,7 +34,6 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.ArraySqlType;
 import org.apache.calcite.sql.type.BasicSqlType;
-import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -72,8 +71,10 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
       .operandTypes(SqlTypeFamily.ANY)
       .requiredOperands(0)
       .returnTypeInference(
-          ReturnTypes.explicit(
-              new RowSignatures.ComplexSqlType(SqlTypeName.OTHER, ColumnType.ofComplex("hyperUnique"), true)
+          opBinding -> RowSignatures.makeComplexType(
+              opBinding.getTypeFactory(),
+              ColumnType.ofComplex("hyperUnique"),
+              true
           )
       )
       .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)


### PR DESCRIPTION
### Description
Fixes some issues with SQL return type information of nested column functions that return `COMPLEX<json>` types.

Druid native `COMPLEX` types are handled in SQL with `RowSignatures.ComplexSqlType`, which contains the native complex type name, which is a relatively recent addition. This works relatively well so far, but there were a few rough edges with how we were using it and the way that calcite works that were causing the complex type information to be lost, making the query result type header information report the types as `COMPLEX` (the "unknown" complex) instead of `COMPLEX<json>`. The reason for this loss of information was due to the way `ReturnTypes.explicit` type inference works, which makes a new type using the `SqlTypeName`, which would lose the Druid complex type name when it made a standard `SqlTypeName.OTHER` instead of a `RowSignatures.ComplexSqlType`. This can be fixed by implementing the return type directly. However, this made apparent another issue, which is that Calcite uses `!=` to check type equality instead of `equals`, so it is necessary to feed the `RowSignatures.ComplexSqlType` into the `RelDataTypeFactory` to ensure that the type is interned so that all of the signatures are using the same instance.

Ive added a new method 
```
public static RelDataType makeComplexType(RelDataTypeFactory typeFactory, ColumnType columnType, boolean isNullable)
```

which uses the `typeFactory` to ensure that the types are interned. I've also updated the javadocs to mention how to effectively use `RowSignatures.ComplexSqlType` if not using this method to try to prevent other users of this type from
running into the same issues.

I've also added some methods to `BaseCalciteQueryTest` that allow expecting the result `RowSignature` of the query being tested, and switched `CalciteNestedQueryTest` to use them to ensure that the the fixes work correctly. Prior to the changes here, some of these tests would fail with error messages similar to

```
java.lang.AssertionError: 
Expected :{EXPR$0:COMPLEX<json>, EXPR$1:COMPLEX<json>}
Actual   :{EXPR$0:COMPLEX, EXPR$1:COMPLEX}
```

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
