### PR TITLE
Fix race in task reports API.

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -197,9 +197,10 @@ public class CliOverlord extends ServerRunnable
                 }
             )
                   .toProvider(
+                      // Check TaskLogs (deep storage) first, then runner, to avoid races when tasks are shutting down.
                       new ListProvider<TaskLogStreamer>()
-                          .add(TaskRunnerTaskLogStreamer.class)
                           .add(TaskLogs.class)
+                          .add(TaskRunnerTaskLogStreamer.class)
                   )
                   .in(LazySingleton.class);
 


### PR DESCRIPTION
There is a race in the task reports API logic: it checks the running
task first, then deep storage. However, if the API is called when a
task is shutting down (but still technically running), the Overlord
will encounter an error in talking to the task and then return an
error to the client, rather than checking deep storage.

Swapping the order avoids this race, at the cost of increasing load
on deep storage. We need to check the existence of a file.