### PR TITLE
add missing information to topn and groupby cache keys

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/topn/NumericTopNMetricSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/NumericTopNMetricSpec.java
@@ -24,13 +24,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.joda.time.DateTime;
 
-import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
 
@@ -135,12 +133,7 @@ public class NumericTopNMetricSpec implements TopNMetricSpec
   @Override
   public byte[] getCacheKey()
   {
-    byte[] metricBytes = StringUtils.toUtf8(metric);
-
-    return ByteBuffer.allocate(1 + metricBytes.length)
-                     .put(CACHE_TYPE_ID)
-                     .put(metricBytes)
-                     .array();
+    return new byte[] {CACHE_TYPE_ID};
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
@@ -144,6 +144,7 @@ public class NestedFieldVirtualColumn implements VirtualColumn
   {
     final String partsString = NestedPathFinder.toNormalizedJsonPath(parts);
     return new CacheKeyBuilder(VirtualColumnCacheHelper.CACHE_TYPE_ID_USER_DEFINED).appendString("nested-field")
+                                                                                   .appendString(outputName)
                                                                                    .appendString(columnName)
                                                                                    .appendString(partsString)
                                                                                    .appendBoolean(processFromRaw)

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryQueryToolChestTest.java
@@ -301,8 +301,6 @@ public class TopNQueryQueryToolChestTest extends InitializedNullHandlingTest
     ));
   }
 
-
-
   @Test
   public void testMinTopNThreshold()
   {


### PR DESCRIPTION
### Description
Fixes an issue with the cache key information used to encode ordering for top n and group by queries, which just refer to the name. However, since many agg and post-agg implementations do not add the output name to the cache key, constructing the ordering cache key information just by name is insufficient to ensure that the cached data is actually sorted in the same manner. 

This PR fixes this by appending extra cache information for the inputs of the ordering information, basically duplicating the key information of the dimspec, aggregator factory, or postagg as appropriate. Alternatively, we could have added output name to all agg and postagg cache keys, but it seems like that could result in slightly lower cache hit rate so this way seems preferable to me at least.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
