### PR TITLE
fix expression plan type inference to correctly handle complex types

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlan.java
@@ -230,6 +230,10 @@ public class ExpressionPlan
     if (outputType != null) {
       final ColumnType inferredValueType = ExpressionType.toColumnType(outputType);
 
+      if (inferredValueType.is(ValueType.COMPLEX)) {
+        return ColumnCapabilitiesImpl.createDefault().setHasNulls(true).setType(inferredValueType);
+      }
+
       if (inferredValueType.isNumeric()) {
         // if float was explicitly specified preserve it, because it will currently never be the computed output type
         // since there is no float expression type

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
@@ -23,12 +23,14 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Parser;
+import org.apache.druid.query.expression.NestedDataExpressions;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -805,6 +807,36 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, thePlan.getOutputType());
     thePlan = plan("array(long1, double1, scalar_string)");
     Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
+  }
+
+  @Test
+  public void testNestedColumnExpression()
+  {
+    ExpressionPlan thePlan = plan("json_object('long1', long1, 'long2', long2)");
+    Assert.assertFalse(
+        thePlan.is(
+            ExpressionPlan.Trait.NON_SCALAR_OUTPUT,
+            ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
+            ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
+            ExpressionPlan.Trait.UNKNOWN_INPUTS,
+            ExpressionPlan.Trait.INCOMPLETE_INPUTS,
+            ExpressionPlan.Trait.NEEDS_APPLIED,
+            ExpressionPlan.Trait.NON_SCALAR_INPUTS,
+            ExpressionPlan.Trait.VECTORIZABLE
+        )
+    );
+    Assert.assertEquals(NestedDataExpressions.TYPE, thePlan.getOutputType());
+    ColumnCapabilities inferred = thePlan.inferColumnCapabilities(
+        ExpressionType.toColumnType(thePlan.getOutputType())
+    );
+    Assert.assertEquals(
+        NestedDataComplexTypeSerde.TYPE.getType(),
+        inferred.getType()
+    );
+    Assert.assertEquals(
+        NestedDataExpressions.TYPE.getComplexTypeName(),
+        inferred.getComplexTypeName()
+    );
   }
 
   private static ExpressionPlan plan(String expression)


### PR DESCRIPTION
### Description
Fixes `ExpressionPlan.inferColumnCapabilities`, which is used by native `ExpressionVirtualColumn` to infer the output type from the input row signature, and can play a role in determining the output row signature of a query to correctly handle `COMPLEX` typed expressions (added in #11853). This bug could cause incorrect behavior due to this method making default `STRING` typed capabilities, causing incorrect selectors to be chosen, which for json columns whose in process values are things like java `Map` to effectively be calling `toString` on everything, which for something like `JSON_OBJECT(KEY 'a' VALUE 'A', KEY 'b' VALUE 1)` would end up with the values as strings appearing like `'{a=A, b=1}'` instead of actual JSON `{"a":"A", "b":1}`.

The fix is just to add a short circuit for `COMPLEX` types so that the default string capabilities are not used.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
