### PR TITLE
Add export parameters for Java 11

### DIFF
--- a/examples/bin/run-java
+++ b/examples/bin/run-java
@@ -42,8 +42,12 @@ then
     "$@"
 elif [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
 then
+  # Parameters below are required to use datasketches-memory as a library
   exec "$JAVA_BIN" \
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
     --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
     "$@"
 else
   exec "$JAVA_BIN" "$@"

--- a/examples/bin/run-java
+++ b/examples/bin/run-java
@@ -40,6 +40,11 @@ then
     --add-opens=java.base/java.lang=ALL-UNNAMED \
     --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
     "$@"
+elif [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
+then
+  exec "$JAVA_BIN" \
+    --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
+    "$@"
 else
   exec "$JAVA_BIN" "$@"
 fi


### PR DESCRIPTION
`--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED` is required if the Java version used is 11 or higher.  This adds it as a parameter if the Java version is appropriate.

Tested by setting running the script in trace mode.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
