### PR TITLE
Adding withName implementation to AggregatorFactory 

### DIFF
--- a/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
+++ b/extensions-contrib/distinctcount/src/main/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountAggregatorFactory.java
@@ -89,6 +89,12 @@ public class DistinctCountAggregatorFactory extends AggregatorFactory
     }
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DistinctCountAggregatorFactory(newName, getFieldName(), getBitMapFactory());
+  }
+
   private DimensionSelector makeDimensionSelector(final ColumnSelectorFactory columnFactory)
   {
     return columnFactory.makeDimensionSelector(new DefaultDimensionSpec(fieldName, fieldName));

--- a/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountGroupByQueryTest.java
@@ -45,6 +45,7 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -156,5 +157,17 @@ public class DistinctCountGroupByQueryTest extends InitializedNullHandlingTest
         )
     );
     TestHelper.assertExpectedObjects(expectedResults, results, "distinct-count");
+  }
+
+  @Test
+  public void testWithName()
+  {
+    DistinctCountAggregatorFactory aggregatorFactory = new DistinctCountAggregatorFactory(
+        "distinct",
+        "visitor_id",
+        null
+    );
+    Assert.assertEquals(aggregatorFactory, aggregatorFactory.withName("distinct"));
+    Assert.assertEquals("newTest", aggregatorFactory.withName("newTest").getName());
   }
 }

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactory.java
@@ -265,6 +265,12 @@ public class MomentSketchAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new MomentSketchAggregatorFactory(newName, getFieldName(), getK(), getCompress(), cacheTypeId);
+  }
+
+  @Override
   public boolean equals(final Object o)
   {
     if (this == o) {

--- a/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchMergeAggregatorFactory.java
+++ b/extensions-contrib/momentsketch/src/main/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchMergeAggregatorFactory.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.aggregation.momentsketch.aggregator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.momentsketch.MomentSketchWrapper;
@@ -59,4 +60,9 @@ public class MomentSketchMergeAggregatorFactory extends MomentSketchAggregatorFa
     return new MomentSketchMergeBufferAggregator(selector, getK(), getCompress());
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new MomentSketchMergeAggregatorFactory(newName, getK(), getCompress());
+  }
 }

--- a/extensions-contrib/momentsketch/src/test/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactoryTest.java
+++ b/extensions-contrib/momentsketch/src/test/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactoryTest.java
@@ -86,4 +86,21 @@ public class MomentSketchAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    MomentSketchAggregatorFactory sketchAggFactory = new MomentSketchAggregatorFactory(
+        "name", "fieldName", 128, true
+    );
+    Assert.assertEquals(sketchAggFactory, sketchAggFactory.withName("name"));
+    Assert.assertEquals("newTest", sketchAggFactory.withName("newTest").getName());
+
+
+    MomentSketchMergeAggregatorFactory sketchMergeAggregatorFactory = new MomentSketchMergeAggregatorFactory(
+        "name", 128, true
+    );
+    Assert.assertEquals(sketchAggFactory, sketchMergeAggregatorFactory.withName("name"));
+    Assert.assertEquals("newTest", sketchMergeAggregatorFactory.withName("newTest").getName());
+  }
 }

--- a/extensions-contrib/momentsketch/src/test/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactoryTest.java
+++ b/extensions-contrib/momentsketch/src/test/java/org/apache/druid/query/aggregation/momentsketch/aggregator/MomentSketchAggregatorFactoryTest.java
@@ -100,7 +100,7 @@ public class MomentSketchAggregatorFactoryTest
     MomentSketchMergeAggregatorFactory sketchMergeAggregatorFactory = new MomentSketchMergeAggregatorFactory(
         "name", 128, true
     );
-    Assert.assertEquals(sketchAggFactory, sketchMergeAggregatorFactory.withName("name"));
+    Assert.assertEquals(sketchMergeAggregatorFactory, sketchMergeAggregatorFactory.withName("name"));
     Assert.assertEquals("newTest", sketchMergeAggregatorFactory.withName("newTest").getName());
   }
 }

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
@@ -181,4 +181,10 @@ public class AveragerFactoryWrapper<T, R> extends AggregatorFactory
   {
     throw new UnsupportedOperationException("Invalid operation for AveragerFactoryWrapper.");
   }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new AveragerFactoryWrapper(af, newName);
+  }
 }

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/AveragerFactoryWrapper.java
@@ -29,6 +29,7 @@ import org.apache.druid.segment.column.ColumnType;
 import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * A wrapper around averagers that makes them appear to be aggregators.
@@ -186,5 +187,24 @@ public class AveragerFactoryWrapper<T, R> extends AggregatorFactory
   public AggregatorFactory withName(String newName)
   {
     return new AveragerFactoryWrapper(af, newName);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AveragerFactoryWrapper<?, ?> that = (AveragerFactoryWrapper<?, ?>) o;
+    return af.equals(that.af) && prefix.equals(that.prefix);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(af, prefix);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/AveragerFactoryWrapperTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/AveragerFactoryWrapperTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.movingaverage.averagers;
+
+import org.apache.druid.query.movingaverage.AveragerFactoryWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AveragerFactoryWrapperTest
+{
+  @Test
+  public void testWithName()
+  {
+    AveragerFactoryWrapper factoryWrapper = new AveragerFactoryWrapper(
+        new DoubleMaxAveragerFactory("double", 1, 1, "test"),
+        "test"
+    );
+    Assert.assertEquals(factoryWrapper, factoryWrapper.withName("test"));
+    Assert.assertEquals("newTestdouble", factoryWrapper.withName("newTest").getName());
+  }
+}

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactory.java
@@ -234,6 +234,12 @@ public class TDigestSketchAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new TDigestSketchAggregatorFactory(newName, getFieldName(), getCompression(), cacheTypeId);
+  }
+
+  @Override
   public AggregateCombiner makeAggregateCombiner()
   {
     return new ObjectAggregateCombiner<MergingDigest>()

--- a/extensions-contrib/tdigestsketch/src/test/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactoryTest.java
+++ b/extensions-contrib/tdigestsketch/src/test/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorFactoryTest.java
@@ -62,4 +62,12 @@ public class TDigestSketchAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    TDigestSketchAggregatorFactory factory = new TDigestSketchAggregatorFactory("tdigest", "col", null);
+    Assert.assertEquals(factory, factory.withName("tdigest"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMaxAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMaxAggregatorFactory.java
@@ -56,6 +56,12 @@ public class TimestampMaxAggregatorFactory extends TimestampAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new TimestampMaxAggregatorFactory(newName, getFieldName(), getTimeFormat());
+  }
+
+  @Override
   public String toString()
   {
     return "TimestampMaxAggregatorFactory{" +

--- a/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMinAggregatorFactory.java
+++ b/extensions-contrib/time-min-max/src/main/java/org/apache/druid/query/aggregation/TimestampMinAggregatorFactory.java
@@ -55,6 +55,12 @@ public class TimestampMinAggregatorFactory extends TimestampAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new TimestampMinAggregatorFactory(newName, getFieldName(), getTimeFormat());
+  }
+
+  @Override
   public String toString()
   {
     return "TimestampMinAggregatorFactory{" +

--- a/extensions-contrib/time-min-max/src/test/java/org/apache/druid/query/aggregation/TimestampMinMaxAggregatorFactoryTest.java
+++ b/extensions-contrib/time-min-max/src/test/java/org/apache/druid/query/aggregation/TimestampMinMaxAggregatorFactoryTest.java
@@ -119,4 +119,16 @@ public class TimestampMinMaxAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    TimestampMaxAggregatorFactory maxAgg = new TimestampMaxAggregatorFactory("timeMax", "__time", null);
+    Assert.assertEquals(maxAgg, maxAgg.withName("timeMax"));
+    Assert.assertEquals("newTest", maxAgg.withName("newTest").getName());
+
+    TimestampMinAggregatorFactory minAgg = new TimestampMinAggregatorFactory("timeMin", "__time", null);
+    Assert.assertEquals(minAgg, minAgg.withName("timeMin"));
+    Assert.assertEquals("newTest", minAgg.withName("newTest").getName());
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
@@ -25,6 +25,7 @@ import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.VectorAggregator;
@@ -119,6 +120,12 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
   public int getMaxIntermediateSize()
   {
     return HllSketch.getMaxUpdatableSerializationBytes(getLgK(), TgtHllType.valueOf(getTgtHllType()));
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new HllSketchBuildAggregatorFactory(newName, getFieldName(), getLgK(), getTgtHllType(), isRound());
   }
 
   private void validateInputs(@Nullable ColumnCapabilities capabilities)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -131,4 +131,10 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
     return Union.getMaxSerializationBytes(getLgK());
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new HllSketchMergeAggregatorFactory(newName, getFieldName(), getLgK(), getTgtHllType(), isRound());
+  }
+
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactory.java
@@ -304,6 +304,12 @@ public class DoublesSketchAggregatorFactory extends AggregatorFactory
     return DoublesSketch.getUpdatableStorageBytes(k, rows);
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoublesSketchAggregatorFactory(newName, getFieldName(), getK(), getMaxStreamLength(), cacheTypeId);
+  }
+
   // Quantiles sketches never stop growing, but they do so very slowly.
   // This size must suffice for overwhelming majority of sketches,
   // but some sketches may request more memory on heap and move there

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactory.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.datasketches.quantiles.DoublesSketch;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -74,4 +75,9 @@ public class DoublesSketchMergeAggregatorFactory extends DoublesSketchAggregator
     return new DoublesSketchMergeBufferAggregator(selector, getK(), getMaxIntermediateSizeWithNulls());
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoublesSketchMergeAggregatorFactory(newName, getK(), getMaxStreamLength());
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -165,6 +165,19 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new SketchMergeAggregatorFactory(
+        newName,
+        getFieldName(),
+        getSize(),
+        getShouldFinalize(),
+        getIsInputThetaSketch(),
+        getErrorBoundsStdDev()
+    );
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.aggregation.datasketches.theta.oldapi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchMergeAggregatorFactory;
 
 /**
@@ -35,5 +36,11 @@ public class OldSketchBuildAggregatorFactory extends SketchMergeAggregatorFactor
   )
   {
     super(name, fieldName, size, true, false, null);
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new OldSketchBuildAggregatorFactory(newName, getFieldName(), getSize());
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchMergeAggregatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.aggregation.datasketches.theta.oldapi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchMergeAggregatorFactory;
 
 /**
@@ -37,4 +38,11 @@ public class OldSketchMergeAggregatorFactory extends SketchMergeAggregatorFactor
   {
     super(name, fieldName, size, shouldFinalize, true, null);
   }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new OldSketchMergeAggregatorFactory(newName, getFieldName(), getSize(), getShouldFinalize());
+  }
+
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactory.java
@@ -267,16 +267,28 @@ public class ArrayOfDoublesSketchAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new ArrayOfDoublesSketchAggregatorFactory(
+        newName,
+        getFieldName(),
+        getNominalEntries(),
+        getMetricColumns(),
+        getNumberOfValues()
+    );
+  }
+
+  @Override
   public List<AggregatorFactory> getRequiredColumns()
   {
     return Collections.singletonList(
-      new ArrayOfDoublesSketchAggregatorFactory(
-          fieldName,
-          fieldName,
-          nominalEntries,
-          metricColumns,
-          numberOfValues
-      )
+        new ArrayOfDoublesSketchAggregatorFactory(
+            fieldName,
+            fieldName,
+            nominalEntries,
+            metricColumns,
+            numberOfValues
+        )
     );
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -362,5 +362,11 @@ public class HllSketchAggregatorFactoryTest
     {
       return DUMMY_SIZE;
     }
+
+    @Override
+    public AggregatorFactory withName(String newName)
+    {
+      return new TestHllSketchAggregatorFactory(newName, getFieldName(), getLgK(), getTgtHllType(), isRound());
+    }
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -83,6 +83,17 @@ public class HllSketchAggregatorFactoryTest
     Assert.assertEquals(ROUND, aggregatorFactory.isRound());
   }
 
+
+  @Test
+  public void testWithName()
+  {
+    List<AggregatorFactory> aggregatorFactories = target.getRequiredColumns();
+    Assert.assertEquals(1, aggregatorFactories.size());
+    HllSketchAggregatorFactory aggregatorFactory = (HllSketchAggregatorFactory) aggregatorFactories.get(0);
+    Assert.assertEquals(aggregatorFactory, aggregatorFactory.withName(aggregatorFactory.getName()));
+    Assert.assertEquals("newTest", aggregatorFactory.withName("newTest").getName());
+  }
+
   @Test
   public void testFinalizeComputationNull()
   {

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -156,4 +156,12 @@ public class HllSketchMergeAggregatorFactoryTest
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
     Assert.assertTrue(result.isRound());
   }
+
+  @Test
+  public void testWithName() throws Exception
+  {
+    HllSketchAggregatorFactory factory = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
+    Assert.assertEquals(factory, factory.withName(targetRound.getName()));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactoryTest.java
@@ -153,4 +153,17 @@ public class DoublesSketchAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    final DoublesSketchAggregatorFactory factory = new DoublesSketchAggregatorFactory(
+        "myFactory",
+        "myField",
+        1024,
+        1000L
+    );
+    Assert.assertEquals(factory, factory.withName("myFactory"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactoryTest.java
@@ -60,4 +60,16 @@ public class DoublesSketchMergeAggregatorFactoryTest
     );
     Assert.assertEquals(factory, fromJson);
   }
+
+  @Test
+  public void testWithName()
+  {
+    final DoublesSketchMergeAggregatorFactory factory = new DoublesSketchMergeAggregatorFactory(
+        "myFactory",
+        1024,
+        1000L
+    );
+    Assert.assertEquals(factory, factory.withName("myFactory"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
@@ -160,4 +160,11 @@ public class SketchAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    Assert.assertEquals(AGGREGATOR_16384, AGGREGATOR_16384.withName("x"));
+    Assert.assertEquals("newTest", AGGREGATOR_16384.withName("newTest").getName());
+  }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -242,6 +242,23 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     Assert.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
   }
 
+  @Test
+  public void testWithNameMerge()
+  {
+    OldSketchMergeAggregatorFactory factory = new OldSketchMergeAggregatorFactory("name", "fieldName", 16, null);
+    Assert.assertEquals(factory, factory.withName("name"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
+
+
+  @Test
+  public void testWithNameBuild()
+  {
+    OldSketchBuildAggregatorFactory factory = new OldSketchBuildAggregatorFactory("name", "fieldName", 16);
+    Assert.assertEquals(factory, factory.withName("name"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
+
   private void assertPostAggregatorSerde(PostAggregator agg) throws Exception
   {
     Assert.assertEquals(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactoryTest.java
@@ -110,4 +110,12 @@ public class ArrayOfDoublesSketchAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    AggregatorFactory factory = new ArrayOfDoublesSketchAggregatorFactory("name", "", null, null, null);
+    Assert.assertEquals(factory, factory.withName("name"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -208,6 +208,12 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new BloomFilterAggregatorFactory(newName, getField(), getMaxNumEntries());
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return new CacheKeyBuilder(AggregatorUtil.BLOOM_FILTER_CACHE_TYPE_ID)

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterMergeAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterMergeAggregatorFactory.java
@@ -71,6 +71,12 @@ public class BloomFilterMergeAggregatorFactory extends BloomFilterAggregatorFact
         .build();
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new BloomFilterMergeAggregatorFactory(newName, fieldName, getMaxNumEntries());
+  }
+
   private BloomFilterMergeAggregator makeMergeAggregator(ColumnSelectorFactory metricFactory)
   {
     final BaseNullableColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactoryTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactoryTest.java
@@ -69,4 +69,25 @@ public class BloomFilterAggregatorFactoryTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithNameBloomFilterAggFactory()
+  {
+    BloomFilterAggregatorFactory factory = new BloomFilterAggregatorFactory(
+        "bloom",
+        DefaultDimensionSpec.of("col"),
+        1024
+    );
+    Assert.assertEquals(factory, factory.withName("bloom"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
+
+
+  @Test
+  public void testWithNameBloomFilterMergeAggFactory()
+  {
+    BloomFilterMergeAggregatorFactory factory = new BloomFilterMergeAggregatorFactory("bloomMerge", "bloom", 1024);
+    Assert.assertEquals(factory, factory.withName("bloomMerge"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorFactory.java
@@ -348,6 +348,20 @@ public class ApproximateHistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new ApproximateHistogramAggregatorFactory(
+        newName,
+        getFieldName(),
+        getResolution(),
+        getNumBuckets(),
+        getLowerLimit(),
+        getUpperLimit(),
+        finalizeAsBase64Binary
+    );
+  }
+
+  @Override
   public String toString()
   {
     return "ApproximateHistogramAggregatorFactory{" +

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingAggregatorFactory.java
@@ -143,6 +143,20 @@ public class ApproximateHistogramFoldingAggregatorFactory extends ApproximateHis
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new ApproximateHistogramFoldingAggregatorFactory(
+        newName,
+        getFieldName(),
+        getResolution(),
+        getNumBuckets(),
+        getLowerLimit(),
+        getUpperLimit(),
+        finalizeAsBase64Binary
+    );
+  }
+
+  @Override
   public String toString()
   {
     return "ApproximateHistogramFoldingAggregatorFactory{" +

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
@@ -303,6 +303,20 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FixedBucketsHistogramAggregatorFactory(
+        newName,
+        getFieldName(),
+        getNumBuckets(),
+        getLowerLimit(),
+        getUpperLimit(),
+        getOutlierHandlingMode(),
+        isFinalizeAsBase64Binary()
+    );
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     final CacheKeyBuilder builder = new CacheKeyBuilder(AggregatorUtil.FIXED_BUCKET_HIST_CACHE_TYPE_ID)

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -155,4 +155,20 @@ public class ApproximateHistogramAggregatorTest extends InitializedNullHandlingT
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
+        "approxHisto",
+        "col",
+        null,
+        null,
+        null,
+        null,
+        false
+    );
+    Assert.assertEquals(factory, factory.withName("approxHisto"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
@@ -123,6 +123,14 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
 
   }
 
+  @Test
+  public void testWithName()
+  {
+    ApproximateHistogramFoldingAggregatorFactory factory = buildHistogramFactory();
+    Assert.assertEquals(factory, factory.withName("field"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
+
   private ApproximateHistogramFoldingAggregatorFactory buildHistogramFactory()
   {
     return buildHistogramFactory("field");

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
@@ -127,7 +127,7 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
   public void testWithName()
   {
     ApproximateHistogramFoldingAggregatorFactory factory = buildHistogramFactory();
-    Assert.assertEquals(factory, factory.withName("field"));
+    Assert.assertEquals(factory, factory.withName("approximateHistoFold"));
     Assert.assertEquals("newTest", factory.withName("newTest").getName());
   }
 

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
@@ -176,4 +176,20 @@ public class FixedBucketsHistogramBufferAggregatorTest
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
   }
+
+  @Test
+  public void testWithName()
+  {
+    FixedBucketsHistogramAggregatorFactory factory = new FixedBucketsHistogramAggregatorFactory(
+        "billy",
+        "billy",
+        5,
+        0,
+        50,
+        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+        false
+    );
+    Assert.assertEquals(factory, factory.withName("billy"));
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -118,6 +118,12 @@ public class VarianceAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new VarianceAggregatorFactory(newName, getFieldName(), getEstimator(), getInputType());
+  }
+
+  @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     ColumnValueSelector<?> selector = metricFactory.makeColumnValueSelector(fieldName);

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -120,7 +120,7 @@ public class VarianceAggregatorFactory extends AggregatorFactory
   @Override
   public AggregatorFactory withName(String newName)
   {
-    return new VarianceAggregatorFactory(newName, getFieldName(), getEstimator(), getInputType());
+    return new VarianceAggregatorFactory(newName, getFieldName(), getEstimator(), inputType);
   }
 
   @Override

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceFoldingAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceFoldingAggregatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.aggregation.variance;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 
 import javax.annotation.Nullable;
 
@@ -36,5 +37,11 @@ public class VarianceFoldingAggregatorFactory extends VarianceAggregatorFactory
   )
   {
     super(name, fieldName, estimator, "variance");
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new VarianceFoldingAggregatorFactory(newName, getFieldName(), getEstimator());
   }
 }

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactoryTest.java
@@ -85,4 +85,20 @@ public class VarianceAggregatorFactoryTest extends InitializedNullHandlingTest
     VarianceAggregatorFactory target = new VarianceAggregatorFactory("test", "test", null, null);
     Assert.assertEquals(NullHandling.defaultDoubleValue(), target.finalizeComputation(null));
   }
+
+  @Test
+  public void testWithName()
+  {
+    VarianceAggregatorFactory varianceAggregatorFactory = new VarianceAggregatorFactory("variance", "col");
+    Assert.assertEquals(varianceAggregatorFactory, varianceAggregatorFactory.withName("variance"));
+    Assert.assertEquals("newTest", varianceAggregatorFactory.withName("newTest").getName());
+
+    VarianceFoldingAggregatorFactory varianceFoldingAggregatorFactory = new VarianceFoldingAggregatorFactory(
+        "varianceFold",
+        "col",
+        null
+    );
+    Assert.assertEquals(varianceFoldingAggregatorFactory, varianceFoldingAggregatorFactory.withName("varianceFold"));
+    Assert.assertEquals("newTest", varianceFoldingAggregatorFactory.withName("newTest").getName());
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -227,6 +227,9 @@ public abstract class AggregatorFactory implements Cacheable
   @Nullable
   public abstract Object finalizeComputation(@Nullable Object object);
 
+  /**
+   * @return output name of the aggregator column.
+   */
   public abstract String getName();
 
   /**
@@ -345,6 +348,21 @@ public abstract class AggregatorFactory implements Cacheable
   public AggregatorFactory optimizeForSegment(PerSegmentQueryOptimizationContext optimizationContext)
   {
     return this;
+  }
+
+  /**
+   * Used in cases where we want to change the output name of the aggregator to something else. For eg: if we have
+   * a query "select a , sum(b) as total group by table" the aggregator returned from the native group by query is "a0" set in
+   * {@link org.apache.druid.sql.calcite.rel.DruidQuery#computeAggregations}. We can use withName("total") to set the output name
+   * of the aggregator to "total".
+   *
+   * @param newName newName of the output for aggregator factory
+   * @return AggregatorFactory with the output name set as the input param.
+   */
+  @SuppressWarnings("unused")
+  public AggregatorFactory withName(String newName)
+  {
+    throw new UOE("Cannot change output name for AggregatorFactory[%s].", this.getClass().getName());
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -352,7 +352,7 @@ public abstract class AggregatorFactory implements Cacheable
 
   /**
    * Used in cases where we want to change the output name of the aggregator to something else. For eg: if we have
-   * a query "select a , sum(b) as total group by table" the aggregator returned from the native group by query is "a0" set in
+   * a query `select a, sum(b) as total group by a from table` the aggregator returned from the native group by query is "a0" set in
    * {@link org.apache.druid.sql.calcite.rel.DruidQuery#computeAggregations}. We can use withName("total") to set the output name
    * of the aggregator to "total".
    *

--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -355,6 +355,8 @@ public abstract class AggregatorFactory implements Cacheable
    * a query `select a, sum(b) as total group by a from table` the aggregator returned from the native group by query is "a0" set in
    * {@link org.apache.druid.sql.calcite.rel.DruidQuery#computeAggregations}. We can use withName("total") to set the output name
    * of the aggregator to "total".
+   * <p>
+   * As all implementations of this interface method may not exist, callers of this method are advised to handle such a case.
    *
    * @param newName newName of the output for aggregator factory
    * @return AggregatorFactory with the output name set as the input param.

--- a/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/CountAggregatorFactory.java
@@ -109,6 +109,12 @@ public class CountAggregatorFactory extends AggregatorFactory
     return object;
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new CountAggregatorFactory(newName);
+  }
+
   @Nullable
   @Override
   public Object finalizeComputation(@Nullable Object object)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMaxAggregatorFactory.java
@@ -118,6 +118,12 @@ public class DoubleMaxAggregatorFactory extends SimpleDoubleAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleMaxAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleMinAggregatorFactory.java
@@ -118,6 +118,12 @@ public class DoubleMinAggregatorFactory extends SimpleDoubleAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleMinAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/DoubleSumAggregatorFactory.java
@@ -118,6 +118,12 @@ public class DoubleSumAggregatorFactory extends SimpleDoubleAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleSumAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/ExpressionLambdaAggregatorFactory.java
@@ -453,6 +453,27 @@ public class ExpressionLambdaAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new ExpressionLambdaAggregatorFactory(
+        newName,
+        fields,
+        accumulatorId,
+        initialValueExpressionString,
+        initialCombineValueExpressionString,
+        isNullUnlessAggregated,
+        shouldAggregateNullInputs,
+        shouldCombineAggregateNullInputs,
+        foldExpressionString,
+        combineExpressionString,
+        compareExpressionString,
+        finalizeExpressionString,
+        maxSizeBytes,
+        macroTable
+    );
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -166,6 +166,12 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FilteredAggregatorFactory(delegate.withName(newName), dimFilter, newName);
+  }
+
+  @Override
   public List<String> requiredFields()
   {
     return ImmutableList.copyOf(

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMaxAggregatorFactory.java
@@ -118,6 +118,12 @@ public class FloatMaxAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatMaxAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatMinAggregatorFactory.java
@@ -118,6 +118,12 @@ public class FloatMinAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatMinAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
@@ -118,6 +118,12 @@ public class FloatSumAggregatorFactory extends SimpleFloatAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatMaxAggregatorFactory(newName, getFieldName(), getFieldName(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregatorFactory.java
@@ -120,7 +120,7 @@ public class FloatSumAggregatorFactory extends SimpleFloatAggregatorFactory
   @Override
   public AggregatorFactory withName(String newName)
   {
-    return new FloatMaxAggregatorFactory(newName, getFieldName(), getFieldName(), macroTable);
+    return new FloatSumAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/GroupingAggregatorFactory.java
@@ -225,6 +225,12 @@ public class GroupingAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new GroupingAggregatorFactory(newName, groupings, keyDimensions);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     CacheKeyBuilder keyBuilder = new CacheKeyBuilder(AggregatorUtil.GROUPING_CACHE_TYPE_ID)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/HistogramAggregatorFactory.java
@@ -230,6 +230,12 @@ public class HistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new HistogramAggregatorFactory(newName, fieldName, breaksList);
+  }
+
+  @Override
   public String toString()
   {
     return "HistogramAggregatorFactory{" +

--- a/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/JavaScriptAggregatorFactory.java
@@ -286,6 +286,19 @@ public class JavaScriptAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new JavaScriptAggregatorFactory(
+        newName,
+        getFieldNames(),
+        getFnAggregate(),
+        getFnReset(),
+        getFnCombine(),
+        config
+    );
+  }
+
+  @Override
   public String toString()
   {
     return "JavaScriptAggregatorFactory{" +

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMaxAggregatorFactory.java
@@ -118,6 +118,12 @@ public class LongMaxAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongMaxAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongMinAggregatorFactory.java
@@ -118,6 +118,12 @@ public class LongMinAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongMinAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     return cacheKey.get();

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregatorFactory.java
@@ -106,6 +106,12 @@ public class LongSumAggregatorFactory extends SimpleLongAggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongSumAggregatorFactory(newName, getFieldName(), getExpression(), macroTable);
+  }
+
+  @Override
   public AggregatorFactory getCombiningFactory()
   {
     return new LongSumAggregatorFactory(name, name, null, macroTable);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
@@ -170,6 +170,12 @@ public class SuppressedAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return delegate.withName(newName);
+  }
+
+  @Override
   public byte[] getCacheKey()
   {
     CacheKeyBuilder cacheKeyBuilder = new CacheKeyBuilder(AggregatorUtil.SUPPRESSED_AGG_CACHE_TYPE_ID);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/SuppressedAggregatorFactory.java
@@ -172,7 +172,7 @@ public class SuppressedAggregatorFactory extends AggregatorFactory
   @Override
   public AggregatorFactory withName(String newName)
   {
-    return delegate.withName(newName);
+    return new SuppressedAggregatorFactory(delegate.withName(newName));
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
@@ -227,6 +227,12 @@ public class DoubleAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleAnyAggregatorFactory(newName, getFieldName());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
@@ -225,6 +225,12 @@ public class FloatAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatAnyAggregatorFactory(newName, getFieldName());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
@@ -222,6 +222,12 @@ public class LongAnyAggregatorFactory extends AggregatorFactory
     return Long.BYTES + Byte.BYTES;
   }
 
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongAnyAggregatorFactory(newName, getFieldName());
+  }
+
 
   @Override
   public boolean equals(Object o)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/StringAnyAggregatorFactory.java
@@ -197,6 +197,12 @@ public class StringAnyAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new StringAnyAggregatorFactory(newName, getFieldName(), getMaxStringBytes());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/cardinality/CardinalityAggregatorFactory.java
@@ -339,6 +339,12 @@ public class CardinalityAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new CardinalityAggregatorFactory(newName, null, getFields(), byRow, round);
+  }
+
+  @Override
   public boolean equals(final Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/DoubleFirstAggregatorFactory.java
@@ -303,6 +303,12 @@ public class DoubleFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleFirstAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/FloatFirstAggregatorFactory.java
@@ -298,6 +298,12 @@ public class FloatFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatFirstAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/LongFirstAggregatorFactory.java
@@ -296,6 +296,12 @@ public class LongFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongFirstAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -261,6 +261,12 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new StringFirstAggregatorFactory(newName, getFieldName(), getTimeColumn(), getMaxStringBytes());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstFoldingAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstFoldingAggregatorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.aggregation.first;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 
 /**
  * For backwards compatibility; equivalent to a regular StringFirstAggregatorFactory.
@@ -30,5 +31,11 @@ public class StringFirstFoldingAggregatorFactory extends StringFirstAggregatorFa
   public StringFirstFoldingAggregatorFactory(String name, String fieldName, Integer maxStringBytes)
   {
     super(name, fieldName, null, maxStringBytes);
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new StringFirstFoldingAggregatorFactory(newName, getFieldName(), getMaxStringBytes());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -285,6 +285,12 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new HyperUniquesAggregatorFactory(newName, getFieldName(), getIsInputHyperUnique(), isRound());
+  }
+
+  @Override
   public String toString()
   {
     return "HyperUniquesAggregatorFactory{" +

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -331,6 +331,12 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleLastAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
@@ -326,6 +326,12 @@ public class FloatLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new FloatLastAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
@@ -323,6 +323,12 @@ public class LongLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new LongLastAggregatorFactory(newName, getFieldName(), getTimeColumn());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
@@ -276,6 +276,12 @@ public class StringLastAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new StringLastAggregatorFactory(newName, getFieldName(), getTimeColumn(), getMaxStringBytes());
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastFoldingAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastFoldingAggregatorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.aggregation.last;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 
 /**
  * For backwards compatibility; equivalent to a regular StringLastAggregatorFactory.
@@ -30,5 +31,11 @@ public class StringLastFoldingAggregatorFactory extends StringLastAggregatorFact
   public StringLastFoldingAggregatorFactory(String name, String fieldName, Integer maxStringBytes)
   {
     super(name, fieldName, null, maxStringBytes);
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new StringLastFoldingAggregatorFactory(newName, getFieldName(), getMaxStringBytes());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
@@ -101,6 +101,12 @@ public class DoubleMeanAggregatorFactory extends AggregatorFactory
   }
 
   @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new DoubleMeanAggregatorFactory(newName, getFieldName());
+  }
+
+  @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     return new DoubleMeanAggregator(metricFactory.makeColumnValueSelector(fieldName));

--- a/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/mean/DoubleMeanAggregatorFactory.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  */
@@ -201,5 +202,24 @@ public class DoubleMeanAggregatorFactory extends AggregatorFactory
         .appendString(name)
         .appendString(fieldName)
         .build();
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DoubleMeanAggregatorFactory that = (DoubleMeanAggregatorFactory) o;
+    return Objects.equals(name, that.name) && Objects.equals(fieldName, that.fieldName);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(name, fieldName);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
+++ b/processing/src/test/java/org/apache/druid/query/TestBigDecimalSumAggregatorFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query;
 
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 
 import javax.annotation.Nullable;
@@ -43,6 +44,12 @@ public class TestBigDecimalSumAggregatorFactory extends DoubleSumAggregatorFacto
     } else {
       return object;
     }
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new TestBigDecimalSumAggregatorFactory(newName, getFieldName());
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregatorFactoryTest.java
@@ -50,6 +50,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -266,5 +267,65 @@ public class AggregatorFactoryTest extends InitializedNullHandlingTest
                     .build(),
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
+  }
+
+  @Test
+  public void testWithName()
+  {
+    List<AggregatorFactory> aggregatorFactories = Arrays.asList(
+        new CountAggregatorFactory("col"),
+        new JavaScriptAggregatorFactory(
+            "col",
+            ImmutableList.of("col"),
+            "function(a,b) { return a + b; }",
+            "function() { return 0; }",
+            "function(a,b) { return a + b }",
+            new JavaScriptConfig(true)
+        ),
+        // long aggs
+        new LongSumAggregatorFactory("col", "long-col"),
+        new LongMinAggregatorFactory("col", "long-col"),
+        new LongMaxAggregatorFactory("col", "long-col"),
+        new LongFirstAggregatorFactory("col", "long-col", null),
+        new LongLastAggregatorFactory("col", "long-col", null),
+        new LongAnyAggregatorFactory("col", "long-col"),
+        // double aggs
+        new DoubleSumAggregatorFactory("col", "double-col"),
+        new DoubleMinAggregatorFactory("col", "double-col"),
+        new DoubleMaxAggregatorFactory("col", "double-col"),
+        new DoubleFirstAggregatorFactory("col", "double-col", null),
+        new DoubleLastAggregatorFactory("col", "double-col", null),
+        new DoubleAnyAggregatorFactory("col", "double-col"),
+        new DoubleMeanAggregatorFactory("col", "double-col"),
+        // float aggs
+        new FloatSumAggregatorFactory("col", "float-col"),
+        new FloatMinAggregatorFactory("col", "float-col"),
+        new FloatMaxAggregatorFactory("col", "float-col"),
+        new FloatFirstAggregatorFactory("col", "float-col", null),
+        new FloatLastAggregatorFactory("col", "float-col", null),
+        new FloatAnyAggregatorFactory("col", "float-col"),
+        // string aggregators
+        new StringFirstAggregatorFactory("col", "col", null, 1024),
+        new StringLastAggregatorFactory("col", "col", null, 1024),
+        new StringAnyAggregatorFactory("col", "col", 1024),
+        // sketch aggs
+        new CardinalityAggregatorFactory("col", ImmutableList.of(DefaultDimensionSpec.of("some-col")), false),
+        new HyperUniquesAggregatorFactory("col", "hyperunique"),
+        new HistogramAggregatorFactory("col", "histogram", ImmutableList.of(0.25f, 0.5f, 0.75f)),
+        // delegate aggs
+        new FilteredAggregatorFactory(
+            new HyperUniquesAggregatorFactory("col", "hyperunique"),
+            new SelectorDimFilter("col", "hello", null),
+            "col"
+        ),
+        new SuppressedAggregatorFactory(
+            new HyperUniquesAggregatorFactory("col", "hyperunique")
+        )
+    );
+
+    for (AggregatorFactory aggregatorFactory : aggregatorFactories) {
+      Assert.assertEquals(aggregatorFactory, aggregatorFactory.withName("col"));
+      Assert.assertEquals("newTest", aggregatorFactory.withName("newTest").getName());
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/CountAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/CountAggregatorTest.java
@@ -61,4 +61,13 @@ public class CountAggregatorTest
     Assert.assertEquals(0, comp.compare(agg.get(), agg.get()));
     Assert.assertEquals(1, comp.compare(agg.get(), first));
   }
+
+  @Test
+  public void testWithName()
+  {
+    CountAggregatorFactory factory = new CountAggregatorFactory("test");
+    Assert.assertEquals(factory, factory.withName("test"));
+
+    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -477,6 +477,12 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     }
 
     @Override
+    public AggregatorFactory withName(String newName)
+    {
+      return new InvalidAggregatorFactory(newName, fieldName);
+    }
+
+    @Override
     public byte[] getCacheKey()
     {
       return new byte[0];

--- a/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoCounterAggregatorFactory.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoCounterAggregatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.virtual;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.CountVectorAggregator;
@@ -83,12 +84,19 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
             return new AlwaysTwoCounterVectorAggregator(selectorFactory.makeMultiValueDimensionSelector(
                 DefaultDimensionSpec.of(fieldName)));
           }
-          return new AlwaysTwoCounterVectorAggregator(selectorFactory.makeSingleValueDimensionSelector(DefaultDimensionSpec.of(fieldName)));
+          return new AlwaysTwoCounterVectorAggregator(selectorFactory.makeSingleValueDimensionSelector(
+              DefaultDimensionSpec.of(fieldName)));
         }
         return new AlwaysTwoCounterVectorAggregator(selectorFactory.makeObjectSelector(fieldName));
       default:
         throw new IllegalStateException("how did this happen");
     }
+  }
+
+  @Override
+  public AggregatorFactory withName(String newName)
+  {
+    return new AlwaysTwoCounterAggregatorFactory(newName, fieldName);
   }
 
   public static class AlwaysTwoCounterVectorAggregator extends CountVectorAggregator


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

This PR adds a new method withName(String newName) to the AggregatorFactory interface.

As part of the https://github.com/apache/druid/issues/12262 sql based ingestion,
The sql task changes the query to a native query and then generates segments out of it. 
We would need to change the output name of the aggregator to something else. 

For eg: if we have a query
```sql 
select a , sum(b) as total group by a from table
```
the aggregator returned from the native group by query is `a0` set in `org.apache.druid.sql.calcite.rel.DruidQuery#computeAggregations`

With can then use withName("total") to set the output name of the aggregator factory to "total".

Currently, the compaction looks up the segment metadata with the column name 'total' and tries to find the aggFactory for it.  
So while generating the segment the conversion from the native col name to the output col name is required. 
 

 


This would be a non-breaking change as there is a default implementation provided which will not break any custom extensions. 




<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `AggregatorFactory`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
