### PR TITLE
Enable conversion of join to filter by default

### DIFF
--- a/docs/querying/query-context.md
+++ b/docs/querying/query-context.md
@@ -93,7 +93,7 @@ Some query types offer context parameters specific to that query type.
 |enableJoinFilterPushDown | `true` | Controls whether a join query will attempt filter push down, which reduces the number of rows that have to be compared in a join operation.|
 |enableJoinFilterRewrite | `true` | Controls whether filter clauses that reference non-base table columns will be rewritten into filters on base table columns.|
 |enableJoinFilterRewriteValueColumnFilters | `false` | Controls whether Druid rewrites non-base table filters on non-key columns in the non-base table. Requires a scan of the non-base table.|
-|enableRewriteJoinToFilter | `true` | Controls whether a join can be pushed partial or fully to the base table as a filter whenever possible.|
+|enableRewriteJoinToFilter | `true` | Controls whether a join can be pushed partial or fully to the base table as a filter at runtime.|
 |joinFilterRewriteMaxSize | `10000` | The maximum size of the correlated value set used for filter rewrites. Set this limit to prevent excessive memory use.| 
 
 ### GroupBy

--- a/docs/querying/query-context.md
+++ b/docs/querying/query-context.md
@@ -93,6 +93,7 @@ Some query types offer context parameters specific to that query type.
 |enableJoinFilterPushDown | `true` | Controls whether a join query will attempt filter push down, which reduces the number of rows that have to be compared in a join operation.|
 |enableJoinFilterRewrite | `true` | Controls whether filter clauses that reference non-base table columns will be rewritten into filters on base table columns.|
 |enableJoinFilterRewriteValueColumnFilters | `false` | Controls whether Druid rewrites non-base table filters on non-key columns in the non-base table. Requires a scan of the non-base table.|
+|enableRewriteJoinToFilter | `true` | Controls whether a join can be pushed partial or fully to the base table as a filter whenever possible.|
 |joinFilterRewriteMaxSize | `10000` | The maximum size of the correlated value set used for filter rewrites. Set this limit to prevent excessive memory use.| 
 
 ### GroupBy

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -95,7 +95,7 @@ public class QueryContexts
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_PUSH_DOWN = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE = true;
   public static final boolean DEFAULT_ENABLE_JOIN_FILTER_REWRITE_VALUE_COLUMN_FILTERS = false;
-  public static final boolean DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER = false;
+  public static final boolean DEFAULT_ENABLE_REWRITE_JOIN_TO_FILTER = true;
   public static final long DEFAULT_ENABLE_JOIN_FILTER_REWRITE_MAX_SIZE = 10000;
   public static final boolean DEFAULT_ENABLE_SQL_JOIN_LEFT_SCAN_DIRECT = false;
   public static final boolean DEFAULT_USE_FILTER_CNF = false;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -3843,9 +3843,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   @Test
   public void testGroupingWithNullInFilter() throws Exception
   {
-    // HashJoinSegmentStorageAdapter is not vectorizable
-    cannotVectorize();
-
     testQuery(
         "SELECT COUNT(*) FROM foo WHERE dim1 IN (NULL)",
         ImmutableList.of(

--- a/website/.spelling
+++ b/website/.spelling
@@ -1652,6 +1652,7 @@ enableParallelMerge
 enableJoinLeftTableScanDirect
 enableJoinFilterPushDown
 enableJoinFilterRewrite
+enableRewriteJoinToFilter
 enableJoinFilterRewriteValueColumnFilters
 floatSum
 joinFilterRewriteMaxSize


### PR DESCRIPTION
Conversion of joins to filter is a very effective feature due to the fact that filters can use indexes whereas the join requires a materlization of the data rows and then value matching them.
Initially, the feature started with supporting full conversion of joins to filters. Recently, we've also added support for doing a partial conversion of joins to filters thus making the feature even more applicable.