### PR TITLE
Fix NPE when applying a transform that outputs to __time

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/Transformer.java
@@ -24,6 +24,7 @@ import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.Rows;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.segment.RowAdapters;
 import org.apache.druid.segment.RowBasedColumnSelectorFactory;
@@ -114,7 +115,12 @@ public class Transformer
       final List<InputRow> originalRows = row.getInputRows();
       final List<InputRow> transformedRows = new ArrayList<>(originalRows.size());
       for (InputRow originalRow : originalRows) {
-        transformedRows.add(new TransformedInputRow(originalRow, transforms));
+        try {
+          transformedRows.add(new TransformedInputRow(originalRow, transforms));
+        }
+        catch (ParseException pe) {
+          return InputRowListPlusRawValues.of(row.getRawValues(), pe);
+        }
       }
       inputRowListPlusRawValues = InputRowListPlusRawValues.ofList(row.getRawValuesList(), transformedRows);
     }
@@ -170,7 +176,11 @@ public class Transformer
       final long ts;
       if (transform != null) {
         //noinspection ConstantConditions time column is never null
-        ts = Rows.objectToNumber(ColumnHolder.TIME_COLUMN_NAME, transform.eval(row), true).longValue();
+        final Number transformedVal = Rows.objectToNumber(ColumnHolder.TIME_COLUMN_NAME, transform.eval(row), true);
+        if (transformedVal == null) {
+          throw new ParseException(row.toString(), "Could not transform value for __time.");
+        }
+        ts = transformedVal.longValue();
       } else {
         ts = row.getTimestampFromEpoch();
       }


### PR DESCRIPTION
This PR fixes an NPE that can occur when `druid.generic.useDefaultValueForNull=false` is set and an expression in the `transformSpec` that overwrites the `__time` column fails to return a timestamp on an input. 

When this happens, a ParseException will be thrown.

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
