### PR TITLE
changes to run examples when CDPATH environment variable is set where cd command returns current dir…

### DIFF
--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -34,8 +34,8 @@ else
   CONFDIR="$2"
 fi
 
-CONFDIR="$(cd "$CONFDIR" && pwd)"
-WHEREAMI="$(cd "$WHEREAMI" && pwd)"
+CONFDIR="$(cd "$CONFDIR">NUL && pwd)"
+WHEREAMI="$(cd "$WHEREAMI">NUL && pwd)"
 
 LOG_DIR="${DRUID_LOG_DIR:=${WHEREAMI}/../log}"
 # Remove possible ending slash

--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -35,7 +35,7 @@ else
 fi
 
 CONFDIR="$(cd "$CONFDIR">/dev/null && pwd)"
-WHEREAMI="$(cd "$WHEREAMI">NUL && pwd)"
+WHEREAMI="$(cd "$WHEREAMI">/dev/null && pwd)"
 
 LOG_DIR="${DRUID_LOG_DIR:=${WHEREAMI}/../log}"
 # Remove possible ending slash

--- a/examples/bin/run-druid
+++ b/examples/bin/run-druid
@@ -34,7 +34,7 @@ else
   CONFDIR="$2"
 fi
 
-CONFDIR="$(cd "$CONFDIR">NUL && pwd)"
+CONFDIR="$(cd "$CONFDIR">/dev/null && pwd)"
 WHEREAMI="$(cd "$WHEREAMI">NUL && pwd)"
 
 LOG_DIR="${DRUID_LOG_DIR:=${WHEREAMI}/../log}"

--- a/examples/bin/run-zk
+++ b/examples/bin/run-zk
@@ -33,8 +33,8 @@ else
   CONFDIR="$1"
 fi
 
-CONFDIR="$(cd "$CONFDIR" && pwd)/zk"
-WHEREAMI="$(cd "$WHEREAMI" && pwd)"
+CONFDIR="$(cd "$CONFDIR">NUL && pwd)/zk"
+WHEREAMI="$(cd "$WHEREAMI">NUL && pwd)"
 
 LOG_DIR="${DRUID_LOG_DIR:=${WHEREAMI}/../log}"
 # Remove possible ending slash

--- a/examples/bin/run-zk
+++ b/examples/bin/run-zk
@@ -33,8 +33,8 @@ else
   CONFDIR="$1"
 fi
 
-CONFDIR="$(cd "$CONFDIR">NUL && pwd)/zk"
-WHEREAMI="$(cd "$WHEREAMI">NUL && pwd)"
+CONFDIR="$(cd "$CONFDIR">/dev/null && pwd)/zk"
+WHEREAMI="$(cd "$WHEREAMI">/dev/null && pwd)"
 
 LOG_DIR="${DRUID_LOG_DIR:=${WHEREAMI}/../log}"
 # Remove possible ending slash


### PR DESCRIPTION
### Description
fixes issue https://github.com/apache/druid/issues/12878

when CDPATH environment variable is set the example scripts like `/bin/start-micro-quickstart` do not run because  the below lines in run-druid and run-zk script 
 ```
CONFDIR="$(cd "$CONFDIR" && pwd)"
WHEREAMI="$(cd "$WHEREAMI" && pwd)"
```
expects  `cd` command to return no output. however 
when CDPATH environment variable is set the `cd` command returns the current directory path as output. This causes the `CONFDIR` and `WHEREAMI` variables to have the directory path twice  ( the output from cd command gets concatenated to the output from pwd command)

This PR has:
- [x] been self-reviewed.
