### PR TITLE
fix issue with SQL sum aggregator due to bug with DruidTypeSystem and AggregateRemoveRule

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
@@ -44,6 +44,12 @@ import org.apache.druid.sql.calcite.planner.UnsupportedSQLQueryException;
 
 public class SumSqlAggregator extends SimpleSqlAggregator
 {
+  /**
+   * We are using a custom SUM function instead of {@link org.apache.calcite.sql.fun.SqlStdOperatorTable#SUM} to
+   * work around the issue described in https://issues.apache.org/jira/browse/CALCITE-4609. Once we upgrade Calcite
+   * to 1.27.0+ we can return to using the built-in SUM function, and {@link DruidSumAggFunction and
+   * {@link DruidSumSplitter} can be removed.
+   */
   private static final SqlAggFunction DRUID_SUM = new DruidSumAggFunction();
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
@@ -20,8 +20,17 @@
 package org.apache.druid.sql.calcite.aggregation.builtin;
 
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlSplittableAggFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -35,10 +44,12 @@ import org.apache.druid.sql.calcite.planner.UnsupportedSQLQueryException;
 
 public class SumSqlAggregator extends SimpleSqlAggregator
 {
+  private static final SqlAggFunction DRUID_SUM = new DruidSumAggFunction();
+
   @Override
   public SqlAggFunction calciteFunction()
   {
-    return SqlStdOperatorTable.SUM;
+    return DRUID_SUM;
   }
 
   @Override
@@ -72,6 +83,71 @@ public class SumSqlAggregator extends SimpleSqlAggregator
         return new DoubleSumAggregatorFactory(name, fieldName, null, macroTable);
       default:
         throw new UnsupportedSQLQueryException("Sum aggregation is not supported for '%s' type", aggregationType);
+    }
+  }
+
+  /**
+   * Customized verison of {@link org.apache.calcite.sql.fun.SqlSumAggFunction} with a customized
+   * implementation of {@link #unwrap(Class)} to provide a customized {@link SqlSplittableAggFunction} that correctly
+   * honors Druid's type system. The default sum implementation of {@link SqlSplittableAggFunction} assumes that it can
+   * reduce its output to its input in the case of a single row, which means that it doesn't necessarily reflect the
+   * output type as if it were run through the SUM function (e.g. INTEGER -> BIGINT)
+   */
+  private static class DruidSumAggFunction extends SqlAggFunction
+  {
+    public DruidSumAggFunction() {
+      super(
+          "SUM",
+          null,
+          SqlKind.SUM,
+          ReturnTypes.AGG_SUM,
+          null,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC,
+          false,
+          false,
+          Optionality.FORBIDDEN
+      );
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> clazz)
+    {
+      if (clazz == SqlSplittableAggFunction.class) {
+        return clazz.cast(DruidSumSplitter.INSTANCE);
+      }
+      return super.unwrap(clazz);
+    }
+  }
+
+  /**
+   * The default sum implementation of {@link SqlSplittableAggFunction} assumes that it can reduce its output to its
+   * input in the case of a single row for the {@link #singleton(RexBuilder, RelDataType, AggregateCall)} method, which
+   * is fine for the default type system where the output type of SUM is the same numeric type as the inputs, but
+   * Druid SUM always produces DOUBLE or BIGINT, so this is incorrect for
+   * {@link org.apache.druid.sql.calcite.planner.DruidTypeSystem}.
+   */
+  private static class DruidSumSplitter extends SqlSplittableAggFunction.AbstractSumSplitter
+  {
+    public static DruidSumSplitter INSTANCE = new DruidSumSplitter();
+
+    @Override
+    public RexNode singleton(RexBuilder rexBuilder, RelDataType inputRowType, AggregateCall aggregateCall)
+    {
+      final int arg = aggregateCall.getArgList().get(0);
+      final RelDataTypeField field = inputRowType.getFieldList().get(arg);
+      final RexNode inputRef = rexBuilder.makeInputRef(field.getType(), arg);
+      // if input and output do not aggree, we must cast the input to the output type
+      if (!aggregateCall.getType().equals(field.getType())) {
+        return rexBuilder.makeCast(aggregateCall.getType(), inputRef);
+      }
+      return inputRef;
+    }
+
+    @Override
+    protected SqlAggFunction getMergeAggFunctionOfTopSplit()
+    {
+      return DRUID_SUM;
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SumSqlAggregator.java
@@ -95,7 +95,8 @@ public class SumSqlAggregator extends SimpleSqlAggregator
    */
   private static class DruidSumAggFunction extends SqlAggFunction
   {
-    public DruidSumAggFunction() {
+    public DruidSumAggFunction()
+    {
       super(
           "SUM",
           null,


### PR DESCRIPTION
### Description
This PR fixes an issue that occurs when using a `SUM` function in sub-query that is a result of a bug in the version of Calcite that we are using in `SqlSplittableAggFunction.AbstractSumSplitter`. Queries impacted will be of this form and involve INTEGER (or FLOAT) literals:

```
SELECT
  dim1,
  SUM(CASE WHEN sum_l1 = 0 THEN 1 ELSE 0 END) AS outer_l1
from (
  select
    dim1,
    SUM(l1) as sum_l1
  from numfoo
  group by dim1
)
group by 1
```

This issue is described by https://issues.apache.org/jira/browse/CALCITE-4609 and was fixed by https://github.com/apache/calcite/commit/c96d85ccad32cbdc9b52b5e2488887ed14a1b5ec.

The problem arises because `RelDataTypeSystem` implementations are allowed to define the built-in `SUM` function return type inference via [`deriveSumType`](https://github.com/apache/druid/blob/master/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidTypeSystem.java#L102) which we have done, however in our version [`AggregateRemoveRule`](https://github.com/apache/calcite/blob/branch-1.21/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java#L112) attempts to simplify the query using `SqlSplittableAggFunction.singleton`, which "Generates an expression for the value of the aggregate function when applied to a single row." in this case, to compare the subquery signature to the outer signature to see if it can remove the outer aggregate (and eventually collapse the outer and inner query).

The default [implementation of this for `SUM`](https://github.com/apache/calcite/blob/branch-1.21/core/src/main/java/org/apache/calcite/sql/SqlSplittableAggFunction.java#L263) however just passes through the argument as the output, which in this case is an `INTEGER` literal, instead of a `BIGINT` which the Druid type system would have chosen if it was consulted.

This is the part of the bug, and for my fix I have duplicated `SqlSumAggFunction` as `DruidSumAggFunction` and overwritten `unwrap` to use a new `DruidSumSplitter` which checks to see if the type of the `aggregateCall` is the same as the type of the argument, otherwise it will wrap the identifier in a cast expression to ensure it is the correct type.

Without this, the query planning fails with an error like
```
java.lang.AssertionError: Type mismatch:
rowtype of new rel:
RecordType(VARCHAR dim2, BIGINT NOT NULL outer_l2) NOT NULL
rowtype of set:
RecordType(VARCHAR dim2, INTEGER NOT NULL $f1) NOT NULL
```

This is already fixed upstream, where [`AggregateRemoveRule`](https://github.com/apache/calcite/blob/main/core/src/main/java/org/apache/calcite/rel/rules/AggregateRemoveRule.java#L112) now ensures that the output of `singleton` is the correct type or casts it, which is basically what I've done here. We will no longer need this change once we can upgrade to a newer version of Calcite.

<hr>


This PR has:
- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
