### PR TITLE
Kinesis docs and logs improvements

### DIFF
--- a/docs/development/extensions-core/kinesis-ingestion.md
+++ b/docs/development/extensions-core/kinesis-ingestion.md
@@ -649,7 +649,5 @@ Before you deploy the Kinesis extension to production, consider the following kn
 
 - Avoid implementing more than one Kinesis supervisor that read from the same Kinesis stream for ingestion. Kinesis has a per-shard read throughput limit and having multiple supervisors on the same stream can reduce available read throughput for an individual Supervisor's tasks. Additionally, multiple Supervisors ingesting to the same Druid Datasource can cause increased contention for locks on the Datasource.
 - The only way to change the stream reset policy is to submit a new ingestion spec and set up a new supervisor.
-- Timeouts for retrieving earliest sequence number will cause a reset of the supervisor. The job will resume own its own eventually, but it can trigger alerts.
-- The Kinesis supervisor will not make progress if you have empty shards. Make sure you have at least 1 record in the shard.
 - If ingestion tasks get stuck, the supervisor does not automatically recover. You should monitor ingestion tasks and investigate if your ingestion falls behind.
 - A Kinesis supervisor can sometimes compare the checkpoint offset to retention window of the stream to see if it has fallen behind. These checks fetch the earliest sequence number for Kinesis which can result in `IteratorAgeMilliseconds` becoming very high in AWS CloudWatch.

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -229,7 +229,7 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
 
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
               log.warn("OrderedPartitionableRecord buffer full, retrying in [%,dms]. "
-                       + "Kinesis record processing has become slow or recordsPerFetch is too high.",
+                       + "Kinesis records are being processed slower than they are fetched.",
                        recordBufferFullWait);
               scheduleBackgroundFetch(recordBufferFullWait);
             }
@@ -296,7 +296,7 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
               log.warn(
                   "OrderedPartitionableRecord buffer full, storing iterator and retrying in [%,dms]. "
-                  + "Kinesis record processing has become slow or recordsPerFetch is too high.",
+                  + "Kinesis records are being processed slower than they are fetched.",
                   recordBufferFullWait
               );
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -228,7 +228,9 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             recordsResult = null;
 
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
-              log.warn("OrderedPartitionableRecord buffer full, retrying in [%,dms]", recordBufferFullWait);
+              log.warn("OrderedPartitionableRecord buffer full, retrying in [%,dms]. "
+                       + "Kinesis record processing has become slow or recordsPerFetch is too high.",
+                       recordBufferFullWait);
               scheduleBackgroundFetch(recordBufferFullWait);
             }
 
@@ -293,7 +295,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             // from this message and back off for a bit to let the buffer drain before retrying.
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
               log.warn(
-                  "OrderedPartitionableRecord buffer full, storing iterator and retrying in [%,dms]",
+                  "OrderedPartitionableRecord buffer full, storing iterator and retrying in [%,dms]. "
+                  + "Kinesis record processing has become slow or recordsPerFetch is too high.",
                   recordBufferFullWait
               );
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplier.java
@@ -228,8 +228,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             recordsResult = null;
 
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
-              log.warn("OrderedPartitionableRecord buffer full, retrying in [%,dms]. "
-                       + "Kinesis records are being processed slower than they are fetched.",
+              log.warn("Kinesis records are being processed slower than they are fetched. "
+                       + "OrderedPartitionableRecord buffer full, retrying in [%,dms].",
                        recordBufferFullWait);
               scheduleBackgroundFetch(recordBufferFullWait);
             }
@@ -295,8 +295,8 @@ public class KinesisRecordSupplier implements RecordSupplier<String, String, Byt
             // from this message and back off for a bit to let the buffer drain before retrying.
             if (!records.offer(currRecord, recordBufferOfferTimeout, TimeUnit.MILLISECONDS)) {
               log.warn(
-                  "OrderedPartitionableRecord buffer full, storing iterator and retrying in [%,dms]. "
-                  + "Kinesis records are being processed slower than they are fetched.",
+                  "Kinesis records are being processed slower than they are fetched. "
+                  + "OrderedPartitionableRecord buffer full, storing iterator and retrying in [%,dms].",
                   recordBufferFullWait
               );
 


### PR DESCRIPTION
https://github.com/apache/druid/pull/12792 allows kinesis ingestion with empty shards and removes the need for a sequence number fetch timeout. This PR fixes the docs to not mention related limitations.
 
It also improves other kinesis ingestion logs such as `OrderedPartitionableRecord buffer full`

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
