### PR TITLE
fix bug with json_object expression not fully unwrapping inputs

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
+import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,6 +68,7 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   Expr.ObjectBinding inputBindings = InputBindings.withTypedSuppliers(
       new ImmutableMap.Builder<String, Pair<ExpressionType, Supplier<Object>>>()
           .put("nest", new Pair<>(NestedDataExpressions.TYPE, () -> NEST))
+          .put("nestWrapped", new Pair<>(NestedDataExpressions.TYPE, () -> new StructuredData(NEST)))
           .put("nester", new Pair<>(NestedDataExpressions.TYPE, () -> NESTER))
           .put("string", new Pair<>(ExpressionType.STRING, () -> "abcdef"))
           .put("long", new Pair<>(ExpressionType.LONG, () -> 1234L))
@@ -345,5 +347,13 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
     eval = expr.eval(inputBindings);
     Assert.assertEquals(100L, eval.value());
     Assert.assertEquals(ExpressionType.LONG, eval.type());
+
+    expr = Parser.parse("to_json_string(json_object('x', nestWrapped))", MACRO_TABLE);
+    eval = expr.eval(inputBindings);
+    Assert.assertEquals("{\"x\":{\"x\":100,\"y\":200,\"z\":300}}", eval.value());
+
+    expr = Parser.parse("to_json_string(json_object('xs', array(nest, nestWrapped)))", MACRO_TABLE);
+    eval = expr.eval(inputBindings);
+    Assert.assertEquals("{\"xs\":[{\"x\":100,\"y\":200,\"z\":300},{\"x\":100,\"y\":200,\"z\":300}]}", eval.value());
   }
 }


### PR DESCRIPTION
### Description
This PR fixes a bug with `JSON_OBJECT` not unwrapping all value objects, which can result in `StructuredData` appearing in the resulting object. This is problematic if the value is used with `TO_JSON_STRING`, which is currently using a default object mapper which doesn't know how to serialize `StructuredData`, causing a failure.

While it might be a good idea to determine how to use the `@Json` `ObjectMapper` we use everywhere for `to_json_string`, it was also unintentional that `json_object` wasn't "unwrapping" `StructuredData` from the inputs to its value arguments, so I've fixed that part in this PR.

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
