### PR TITLE
Fix hasBuiltInFilters for joins

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -212,8 +212,11 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   @Override
   public boolean hasBuiltInFilters()
   {
-    return clauses.stream()
-                  .anyMatch(clause -> clause.getJoinType() == JoinType.INNER && !clause.getCondition().isAlwaysTrue());
+    // empty clause means that the join has been converted to a filter (captured in baseFilter). So, if the baseFilter
+    // non-null, then the adapter can potentially filter rows.
+    return (clauses.isEmpty() && baseFilter != null) || clauses.stream().anyMatch(
+        clause -> clause.getJoinType() == JoinType.INNER && !clause.getCondition().isAlwaysTrue()
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapter.java
@@ -212,9 +212,9 @@ public class HashJoinSegmentStorageAdapter implements StorageAdapter
   @Override
   public boolean hasBuiltInFilters()
   {
-    // empty clause means that the join has been converted to a filter (captured in baseFilter). So, if the baseFilter
-    // non-null, then the adapter can potentially filter rows.
-    return (clauses.isEmpty() && baseFilter != null) || clauses.stream().anyMatch(
+    // if the baseFilter is not null, then rows from underlying storage adapter can be potentially filtered.
+    // otherwise, a filtering inner join can also filter rows.
+    return baseFilter != null || clauses.stream().anyMatch(
         clause -> clause.getJoinType() == JoinType.INNER && !clause.getCondition().isAlwaysTrue()
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentStorageAdapterTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.join;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
@@ -29,6 +30,7 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.filter.ExpressionDimFilter;
 import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.VirtualColumn;
@@ -2299,6 +2301,19 @@ public class HashJoinSegmentStorageAdapterTest extends BaseHashJoinSegmentStorag
     Assert.assertFalse(
         new HashJoinSegmentStorageAdapter(
             factSegment.asStorageAdapter(),
+            ImmutableList.of(),
+            null
+        ).hasBuiltInFilters()
+    );
+  }
+
+  @Test
+  public void test_hasBuiltInFiltersForConvertedJoin()
+  {
+    Assert.assertTrue(
+        new HashJoinSegmentStorageAdapter(
+            factSegment.asStorageAdapter(),
+            new InDimFilter("dim", ImmutableSet.of("foo", "bar")),
             ImmutableList.of(),
             null
         ).hasBuiltInFilters()


### PR DESCRIPTION
As a part of the fix in #11517, a couple of cases are missing : 
1. where if a join is fully converted into filter
2. where if an independent filter on the base table is carried to the join

In both cases we should convey that the storage adapter might have built-in filters. 
It might be the case that the outer query doesn't have any filters, so to inform the topN query engine that the scan is not on the full segment, we need to convey it via the join's storage adapter. This will help the topN query engine in taking decision whether to short circuit the scan or not.

This was uncovered when the existing test for `CalciteQueryTest#testExactTopNOnInnerJoinWithLimit` started failing as a part of #12868

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
