### PR TITLE
Add EXTERNAL resource type.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/security/ResourceType.java
+++ b/server/src/main/java/org/apache/druid/server/security/ResourceType.java
@@ -34,6 +34,7 @@ public class ResourceType
   public static final String STATE = "STATE";
   public static final String SYSTEM_TABLE = "SYSTEM_TABLE";
   public static final String QUERY_CONTEXT = "QUERY_CONTEXT";
+  public static final String EXTERNAL = "EXTERNAL";
 
   private static final Set<String> KNOWN_TYPES = Sets.newConcurrentHashSet();
 
@@ -45,6 +46,7 @@ public class ResourceType
     registerResourceType(STATE);
     registerResourceType(SYSTEM_TABLE);
     registerResourceType(QUERY_CONTEXT);
+    registerResourceType(EXTERNAL);
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalOperatorConversion.java
@@ -35,6 +35,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
+import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.sql.calcite.expression.AuthorizableOperator;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
@@ -55,11 +56,9 @@ public class ExternalOperatorConversion implements SqlOperatorConversion
 {
   public static final String FUNCTION_NAME = "EXTERN";
 
-  // EXTERNAL is not an "official" resource type (it doesn't appear as a constant in the ResourceType class).
-  // It is here so we can write tests that check that authorization works as expected, like CalciteInsertDmlTest.
-  // This should be rethought before the functionality is exposed to end users.
+  // Resource that allows reading external data via SQL.
   public static final ResourceAction EXTERNAL_RESOURCE_ACTION =
-      new ResourceAction(new Resource("EXTERNAL", "EXTERNAL"), Action.READ);
+      new ResourceAction(new Resource("EXTERNAL", ResourceType.EXTERNAL), Action.READ);
 
   private static final RelDataTypeFactory TYPE_FACTORY = new SqlTypeFactoryImpl(DruidTypeSystem.INSTANCE);
 


### PR DESCRIPTION
This is used to control access to the EXTERN function, which allows
reading external data in SQL. The EXTERN function is not usable in
production as of today, but it is used by the task-based SQL engine
contemplated in #12262.