### PR TITLE
DruidQuery: Return a copy from withScanSignatureIfNeeded, as promised.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -64,10 +64,23 @@ public class QueryContext
 
   public QueryContext(@Nullable Map<String, Object> userParams)
   {
-    this.defaultParams = new TreeMap<>();
-    this.userParams = userParams == null ? new TreeMap<>() : new TreeMap<>(userParams);
-    this.systemParams = new TreeMap<>();
-    invalidateMergedParams();
+    this(
+        new TreeMap<>(),
+        userParams == null ? new TreeMap<>() : new TreeMap<>(userParams),
+        new TreeMap<>()
+    );
+  }
+
+  private QueryContext(
+      final Map<String, Object> defaultParams,
+      final Map<String, Object> userParams,
+      final Map<String, Object> systemParams
+  )
+  {
+    this.defaultParams = defaultParams;
+    this.userParams = userParams;
+    this.systemParams = systemParams;
+    this.mergedParams = null;
   }
 
   private void invalidateMergedParams()
@@ -127,6 +140,7 @@ public class QueryContext
         QueryContexts.DEFAULT_ENABLE_SQL_JOIN_LEFT_SCAN_DIRECT
     );
   }
+
   @SuppressWarnings("unused")
   public boolean containsKey(String key)
   {
@@ -192,6 +206,15 @@ public class QueryContext
       mergedParams = Collections.unmodifiableMap(merged);
     }
     return mergedParams;
+  }
+
+  public QueryContext copy()
+  {
+    return new QueryContext(
+        new TreeMap<>(defaultParams),
+        new TreeMap<>(userParams),
+        new TreeMap<>(systemParams)
+    );
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryContextTest.java
@@ -263,6 +263,35 @@ public class QueryContextTest
   }
 
   @Test
+  public void testCopy()
+  {
+    final QueryContext context = new QueryContext(
+        ImmutableMap.of(
+            "user1", "userVal1",
+            "conflict", "userVal2"
+        )
+    );
+
+    context.addDefaultParams(
+        ImmutableMap.of(
+            "default1", "defaultVal1",
+            "conflict", "defaultVal2"
+        )
+    );
+
+    context.addSystemParam("sys1", "val1");
+
+    final Map<String, Object> merged = ImmutableMap.copyOf(context.getMergedParams());
+
+    final QueryContext context2 = context.copy();
+    context2.removeUserParam("conflict");
+    context2.addSystemParam("sys2", "val2");
+    context2.addDefaultParam("default3", "defaultVal3");
+
+    Assert.assertEquals(merged, context.getMergedParams());
+  }
+
+  @Test
   public void testLegacyReturnsLegacy()
   {
     Query<?> legacy = new LegacyContextQuery(ImmutableMap.of("foo", "bar"));

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1366,11 +1366,12 @@ public class DruidQuery
       final RowSignature signature = scanSignatureBuilder.build();
 
       try {
-        queryContext.addSystemParam(
+        final QueryContext newContext = queryContext.copy();
+        newContext.addSystemParam(
             CTX_SCAN_SIGNATURE,
             plannerContext.getJsonMapper().writeValueAsString(signature)
         );
-        return queryContext;
+        return newContext;
       }
       catch (JsonProcessingException e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
The method wasn't following its contract, leading to pollution of the overall planner context, when really we just want to create a new context for a specific query.