### PR TITLE
Fixing overlord issued too many redirects

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -232,6 +232,19 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
     return overlordLeaderSelector.getCurrentLeader();
   }
 
+  public Optional<String> getRedirectLocation()
+  {
+    String leader = overlordLeaderSelector.getCurrentLeader();
+    // do not redirect when
+    // leader is not elected
+    // leader is the current node
+    if (leader == null || leader.isEmpty() || overlordLeaderSelector.isLeader()) {
+      return Optional.absent();
+    } else {
+      return Optional.of(leader);
+    }
+  }
+
   public Optional<TaskRunner> getTaskRunner()
   {
     if (isLeader()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfo.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.http;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -55,13 +56,12 @@ public class OverlordRedirectInfo implements RedirectInfo
   public URL getRedirectURL(String queryString, String requestURI)
   {
     try {
-      final String leader = taskMaster.getCurrentLeader();
-      if (leader == null || leader.isEmpty()) {
+      final Optional<String> redirectLocation = taskMaster.getRedirectLocation();
+      if (!redirectLocation.isPresent()) {
         return null;
       }
 
-      String location = StringUtils.format("%s%s", leader, requestURI);
-
+      String location = StringUtils.format("%s%s", redirectLocation.get(), requestURI);
       if (queryString != null) {
         location = StringUtils.format("%s?%s", location, queryString);
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfoTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordRedirectInfoTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.http;
 
+import com.google.common.base.Optional;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -66,19 +67,9 @@ public class OverlordRedirectInfoTest
   }
 
   @Test
-  public void testGetRedirectURLNull()
+  public void testGetRedirectURLWithEmptyLocation()
   {
-    EasyMock.expect(taskMaster.getCurrentLeader()).andReturn(null).anyTimes();
-    EasyMock.replay(taskMaster);
-    URL url = redirectInfo.getRedirectURL("query", "/request");
-    Assert.assertNull(url);
-    EasyMock.verify(taskMaster);
-  }
-
-  @Test
-  public void testGetRedirectURLEmpty()
-  {
-    EasyMock.expect(taskMaster.getCurrentLeader()).andReturn("").anyTimes();
+    EasyMock.expect(taskMaster.getRedirectLocation()).andReturn(Optional.absent()).anyTimes();
     EasyMock.replay(taskMaster);
     URL url = redirectInfo.getRedirectURL("query", "/request");
     Assert.assertNull(url);
@@ -91,7 +82,7 @@ public class OverlordRedirectInfoTest
     String host = "http://localhost";
     String query = "foo=bar&x=y";
     String request = "/request";
-    EasyMock.expect(taskMaster.getCurrentLeader()).andReturn(host).anyTimes();
+    EasyMock.expect(taskMaster.getRedirectLocation()).andReturn(Optional.of(host)).anyTimes();
     EasyMock.replay(taskMaster);
     URL url = redirectInfo.getRedirectURL(query, request);
     Assert.assertEquals("http://localhost/request?foo=bar&x=y", url.toString());
@@ -107,7 +98,7 @@ public class OverlordRedirectInfoTest
         "UTF-8"
     ) + "/status";
 
-    EasyMock.expect(taskMaster.getCurrentLeader()).andReturn(host).anyTimes();
+    EasyMock.expect(taskMaster.getRedirectLocation()).andReturn(Optional.of(host)).anyTimes();
     EasyMock.replay(taskMaster);
     URL url = redirectInfo.getRedirectURL(null, request);
     Assert.assertEquals(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -80,7 +80,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -217,6 +216,7 @@ public class OverlordTest
       Thread.sleep(10);
     }
     Assert.assertEquals(taskMaster.getCurrentLeader(), druidNode.getHostAndPort());
+    Assert.assertEquals(Optional.absent(), taskMaster.getRedirectLocation());
 
     final TaskStorageQueryAdapter taskStorageQueryAdapter = new TaskStorageQueryAdapter(taskStorage, taskLockbox);
     final WorkerTaskRunnerQueryAdapter workerTaskRunnerQueryAdapter = new WorkerTaskRunnerQueryAdapter(taskMaster, null);

--- a/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
@@ -200,7 +200,12 @@ public class ServiceClientImpl implements ServiceClient
                         final String newUri = result.error().getResponse().headers().get("Location");
 
                         if (redirectCount >= MAX_REDIRECTS) {
-                          retVal.setException(new RpcException("Service [%s] issued too many redirects", serviceName));
+                          retVal.setException(new RpcException(
+                              "Service [%s] redirected too many times [%d] to invalid url %s",
+                              serviceName,
+                              redirectCount,
+                              newUri
+                          ));
                         } else {
                           // Update preferredLocationNoPath if we got a redirect.
                           final ServiceLocation redirectLocationNoPath = serviceLocationNoPathFromUri(newUri);
@@ -212,7 +217,12 @@ public class ServiceClientImpl implements ServiceClient
                             );
                           } else {
                             retVal.setException(
-                                new RpcException("Service [%s] redirected to invalid URL [%s]", serviceName, newUri)
+                                new RpcException(
+                                    "Service [%s] redirected [%d] times to invalid URL [%s]",
+                                    serviceName,
+                                    redirectCount,
+                                    newUri
+                                )
                             );
                           }
                         }

--- a/server/src/test/java/org/apache/druid/rpc/ServiceClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/ServiceClientImplTest.java
@@ -289,7 +289,7 @@ public class ServiceClientImplTest
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RpcException.class));
     MatcherAssert.assertThat(
         e.getCause(),
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("too many redirects"))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("redirected too many times"))
     );
   }
 
@@ -313,7 +313,8 @@ public class ServiceClientImplTest
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RpcException.class));
     MatcherAssert.assertThat(
         e.getCause(),
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("redirected to invalid URL [invalid-url]"))
+        ThrowableMessageMatcher.hasMessage(
+            CoreMatchers.containsString("redirected [0] times to invalid URL [invalid-url]"))
     );
   }
 
@@ -337,7 +338,7 @@ public class ServiceClientImplTest
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RpcException.class));
     MatcherAssert.assertThat(
         e.getCause(),
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("redirected to invalid URL [null]"))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("redirected [0] times to invalid URL [null]"))
     );
   }
 
@@ -361,7 +362,7 @@ public class ServiceClientImplTest
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RpcException.class));
     MatcherAssert.assertThat(
         e.getCause(),
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("too many redirects"))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("redirected too many times"))
     );
   }
 


### PR DESCRIPTION
### Description

While debugging a cluster, I found that during an overlord switch, the tasks were failing. 

The task log showed 
```
Caused by: org.apache.druid.rpc.RpcException: Service [overlord] issued too many redirects
	at org.apache.druid.rpc.ServiceClientImpl$1.onSuccess(ServiceClientImpl.java:203)
	at org.apache.druid.rpc.ServiceClientImpl$1.onSuccess(ServiceClientImpl.java:168)
	at com.google.common.util.concurrent.Futures$4.run(Futures.java:1181)
```

Which lead me to debug the overlord redirect code. 

The `RedirectFilter` on the overlord checks if the current node is the elected leader and is initialized using `TaskMaster.isLeader()` and if no, redirect it to the elected leader using `overlordLeaderSelector.getCurrentLeader()`. 

Now the `redirectFilter` was redirecting requests to itself resulting in a never-ending loop until the initialized flag is set hence causing `issued too many redirects` for the clients.

Note that the new leader may take some time to set the initialized flag as it has to fetch tasks/locks from the metadatastore. 

Adjusted the code in such a way that the `redirectFilter` will not redirect the requests to itself resulting in a `SC_SERVICE_UNAVAILABLE = 503` which will cause the overlord clients to back off exponentially which IMHO is the correct behaviour. 









<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `TaskMaster`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
