### PR TITLE
Light refactor of the heavily refactored statement classes

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
@@ -30,7 +30,6 @@ import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.sql.calcite.planner.DruidPlanner;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
-import org.apache.druid.sql.calcite.planner.PlannerResult;
 
 import java.io.Closeable;
 import java.util.Set;
@@ -158,20 +157,6 @@ public abstract class AbstractStatement implements Closeable
           resourceActions,
           sqlToolbox.plannerFactory.getAuthorizerMapper()
     );
-  }
-
-  /**
-   * Plan the query, which also produces the sequence that runs
-   * the query.
-   */
-  protected PlannerResult createPlan(DruidPlanner planner)
-  {
-    try {
-      return planner.plan();
-    }
-    catch (ValidationException e) {
-      throw new SqlPlanningException(e);
-    }
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
@@ -164,7 +164,7 @@ public abstract class AbstractStatement implements Closeable
    * Plan the query, which also produces the sequence that runs
    * the query.
    */
-  protected PlannerResult plan(DruidPlanner planner)
+  protected PlannerResult createPlan(DruidPlanner planner)
   {
     try {
       return planner.plan();
@@ -188,7 +188,7 @@ public abstract class AbstractStatement implements Closeable
     return fullResourceActions;
   }
 
-  public SqlQueryPlus sqlRequest()
+  public SqlQueryPlus query()
   {
     return queryPlus;
   }
@@ -219,5 +219,18 @@ public abstract class AbstractStatement implements Closeable
    */
   public void closeQuietly()
   {
+  }
+
+  /**
+   * Convenience method to close the statement and report an error
+   * associated with the statement. Same as calling:{@code
+   * stmt.reporter().failed(e);
+   * stmt.close();
+   * }
+   */
+  public void closeWithError(Throwable e)
+  {
+    reporter.failed(e);
+    close();
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/HttpStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/HttpStatement.java
@@ -68,9 +68,4 @@ public class HttpStatement extends DirectStatement
           sqlToolbox.plannerFactory.getAuthorizerMapper()
     );
   }
-
-  public SqlRowTransformer createRowTransformer()
-  {
-    return new SqlRowTransformer(plannerContext.getTimeZone(), plannerResult.rowType());
-  }
 }

--- a/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.druid.query.BadQueryException;
@@ -63,6 +64,11 @@ public class SqlPlanningException extends BadQueryException
   }
 
   public SqlPlanningException(ValidationException e)
+  {
+    this(PlanningError.VALIDATION_ERROR, e.getMessage());
+  }
+
+  public SqlPlanningException(CalciteContextException e)
   {
     this(PlanningError.VALIDATION_ERROR, e.getMessage());
   }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcPreparedStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcPreparedStatement.java
@@ -65,7 +65,7 @@ public class DruidJdbcPreparedStatement extends AbstractDruidJdbcStatement
       PrepareResult prepareResult = sqlStatement.prepare();
       signature = createSignature(
           prepareResult,
-          sqlStatement.sqlRequest().sql()
+          sqlStatement.query().sql()
       );
       state = State.PREPARED;
     }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -114,7 +114,7 @@ public class DruidJdbcResultSet implements Closeable
       yielder = Yielders.each(retSequence);
       signature = AbstractDruidJdbcStatement.createSignature(
           stmt.prepareResult(),
-          stmt.sqlRequest().sql()
+          stmt.query().sql()
       );
     }
     catch (ExecutionException e) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
@@ -44,6 +44,11 @@ public class PlannerResult
     this.rowType = rowType;
   }
 
+  public boolean runnable()
+  {
+    return !didRun.get();
+  }
+
   /**
    * Run the query
    */

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerResult.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.planner;
 
 import com.google.common.base.Supplier;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.guava.Sequence;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -56,7 +57,7 @@ public class PlannerResult
   {
     if (!didRun.compareAndSet(false, true)) {
       // Safety check.
-      throw new IllegalStateException("Cannot run more than once");
+      throw new ISE("Cannot run more than once");
     }
     return resultsSupplier.get();
   }

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -44,6 +44,7 @@ import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.ResourceAction;
+import org.apache.druid.sql.DirectStatement.ResultSet;
 import org.apache.druid.sql.HttpStatement;
 import org.apache.druid.sql.SqlExecutionReporter;
 import org.apache.druid.sql.SqlLifecycleManager;
@@ -67,6 +68,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
@@ -135,7 +137,7 @@ public class SqlResource
 
     try {
       Thread.currentThread().setName(StringUtils.format("sql[%s]", sqlQueryId));
-      HttpStatement.ResultSet resultSet = stmt.plan();
+      ResultSet resultSet = stmt.plan();
       final Sequence<Object[]> sequence = resultSet.run();
       final SqlRowTransformer rowTransformer = resultSet.createRowTransformer();
       final Yielder<Object[]> yielder0 = Yielders.each(sequence);

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -135,8 +135,9 @@ public class SqlResource
 
     try {
       Thread.currentThread().setName(StringUtils.format("sql[%s]", sqlQueryId));
-      final Sequence<Object[]> sequence = stmt.execute();
-      final SqlRowTransformer rowTransformer = stmt.createRowTransformer();
+      HttpStatement.ResultSet resultSet = stmt.plan();
+      final Sequence<Object[]> sequence = resultSet.run();
+      final SqlRowTransformer rowTransformer = resultSet.createRowTransformer();
       final Yielder<Object[]> yielder0 = Yielders.each(sequence);
 
       try {

--- a/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
@@ -442,7 +442,7 @@ public class SqlStatementTest
         .auth(CalciteTests.REGULAR_USER_AUTH_RESULT)
         .build();
     DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
-    Map<String, Object> context = stmt.sqlRequest().context().getMergedParams();
+    Map<String, Object> context = stmt.query().context().getMergedParams();
     Assert.assertEquals(2, context.size());
     // should contain only query id, not bySegment since it is not valid for SQL
     Assert.assertTrue(context.containsKey(PlannerContext.CTX_SQL_QUERY_ID));
@@ -457,7 +457,7 @@ public class SqlStatementTest
         .auth(CalciteTests.REGULAR_USER_AUTH_RESULT)
         .build();
     DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
-    Map<String, Object> context = stmt.sqlRequest().context().getMergedParams();
+    Map<String, Object> context = stmt.query().context().getMergedParams();
     Assert.assertEquals(2, context.size());
     // Statement should contain default query context values
     for (String defaultContextKey : defaultQueryConfig.getContext().keySet()) {

--- a/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.guava.LazySequence;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -45,6 +46,7 @@ import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.ForbiddenException;
+import org.apache.druid.sql.DirectStatement.ResultSet;
 import org.apache.druid.sql.SqlPlanningException.PlanningError;
 import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
 import org.apache.druid.sql.calcite.planner.DruidOperatorTable;
@@ -68,6 +70,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.servlet.http.HttpServletRequest;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -75,6 +78,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SqlStatementTest
@@ -213,10 +219,53 @@ public class SqlStatementTest
         "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
         CalciteTests.REGULAR_USER_AUTH_RESULT);
     DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
-    List<Object[]> results = stmt.execute().toList();
+    ResultSet resultSet = stmt.plan();
+    assertTrue(resultSet.runnable());
+    List<Object[]> results = resultSet.run().toList();
     assertEquals(1, results.size());
     assertEquals(6L, results.get(0)[0]);
     assertEquals("foo", results.get(0)[1]);
+    assertSame(stmt.reporter(), resultSet.reporter());
+    assertSame(stmt.resources(), resultSet.resources());
+    assertSame(stmt.query(), resultSet.query());
+    assertFalse(resultSet.runnable());
+    resultSet.close();
+    stmt.close();
+  }
+
+  @Test
+  public void testDirectPlanTwice()
+  {
+    SqlQueryPlus sqlReq = queryPlus(
+        "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
+        CalciteTests.REGULAR_USER_AUTH_RESULT);
+    DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
+    stmt.plan();
+    try {
+      stmt.plan();
+      fail();
+    }
+    catch (ISE e) {
+      stmt.closeWithError(e);
+    }
+  }
+
+  @Test
+  public void testDirectExecTwice()
+  {
+    SqlQueryPlus sqlReq = queryPlus(
+        "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
+        CalciteTests.REGULAR_USER_AUTH_RESULT);
+    DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
+    ResultSet resultSet = stmt.plan();
+    resultSet.run();
+    try {
+      resultSet.run();
+      fail();
+    }
+    catch (ISE e) {
+      stmt.closeWithError(e);
+    }
   }
 
   @Test
@@ -352,7 +401,7 @@ public class SqlStatementTest
   // Prepared statements: using a prepare/execute model.
 
   @Test
-  public void testJdbcHappyPath()
+  public void testPreparedHappyPath()
   {
     SqlQueryPlus sqlReq = queryPlus(
         "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
@@ -381,7 +430,7 @@ public class SqlStatementTest
   }
 
   @Test
-  public void testJdbcSyntaxError()
+  public void testPrepareSyntaxError()
   {
     SqlQueryPlus sqlReq = queryPlus(
         "SELECT COUNT(*) AS cnt, 'foo' AS",
@@ -398,7 +447,7 @@ public class SqlStatementTest
   }
 
   @Test
-  public void testJdbcValidationError()
+  public void testPrepareValidationError()
   {
     SqlQueryPlus sqlReq = queryPlus(
         "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.bogus",
@@ -415,7 +464,7 @@ public class SqlStatementTest
   }
 
   @Test
-  public void testJdbcPermissionError()
+  public void testPreparePermissionError()
   {
     SqlQueryPlus sqlReq = queryPlus(
         "select count(*) from forbiddenDatasource",

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
@@ -88,6 +88,9 @@ import java.util.stream.Collectors;
 
 public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
 {
+  // Timeout to allow (rapid) debugging, while not blocking tests with errors.
+  private static final int WAIT_TIMEOUT_SECS = 60;
+
   private SpecificSegmentsQuerySegmentWalker walker;
   private TestServerInventoryView serverView;
   private List<ImmutableDruidServer> druidServers;
@@ -931,11 +934,11 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
     segmentDataSourceNames.add("foo");
     joinableDataSourceNames.add("foo");
     serverView.addSegment(someNewBrokerSegment, ServerType.BROKER);
-    Assert.assertTrue(markDataSourceLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(markDataSourceLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for build twice
-    Assert.assertTrue(buildTableLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(buildTableLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for get again, just to make sure table has been updated (latch counts down just before tables are updated)
-    Assert.assertTrue(getDatasourcesLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(getDatasourcesLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
 
     fooTable = schema.getDatasource("foo");
     Assert.assertNotNull(fooTable);
@@ -952,11 +955,11 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
     segmentDataSourceNames.remove("foo");
     serverView.removeSegment(someNewBrokerSegment, ServerType.BROKER);
 
-    Assert.assertTrue(markDataSourceLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(markDataSourceLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for build
-    Assert.assertTrue(buildTableLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(buildTableLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for get again, just to make sure table has been updated (latch counts down just before tables are updated)
-    Assert.assertTrue(getDatasourcesLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(getDatasourcesLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
 
     fooTable = schema.getDatasource("foo");
     Assert.assertNotNull(fooTable);
@@ -996,10 +999,10 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
     segmentDataSourceNames.add("foo");
     serverView.addSegment(someNewBrokerSegment, ServerType.BROKER);
 
-    Assert.assertTrue(markDataSourceLatch.await(2, TimeUnit.SECONDS));
-    Assert.assertTrue(buildTableLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(markDataSourceLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
+    Assert.assertTrue(buildTableLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for get again, just to make sure table has been updated (latch counts down just before tables are updated)
-    Assert.assertTrue(getDatasourcesLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(getDatasourcesLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
 
     fooTable = schema.getDatasource("foo");
     Assert.assertNotNull(fooTable);
@@ -1017,11 +1020,11 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
     segmentDataSourceNames.remove("foo");
     serverView.removeSegment(someNewBrokerSegment, ServerType.BROKER);
 
-    Assert.assertTrue(markDataSourceLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(markDataSourceLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for build
-    Assert.assertTrue(buildTableLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(buildTableLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
     // wait for get again, just to make sure table has been updated (latch counts down just before tables are updated)
-    Assert.assertTrue(getDatasourcesLatch.await(2, TimeUnit.SECONDS));
+    Assert.assertTrue(getDatasourcesLatch.await(WAIT_TIMEOUT_SECS, TimeUnit.SECONDS));
 
     fooTable = schema.getDatasource("foo");
     Assert.assertNotNull(fooTable);

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -134,7 +134,8 @@ public class SqlResourceTest extends CalciteTestBase
 {
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
   private static final String DUMMY_SQL_QUERY_ID = "dummy";
-  private static final int WAIT_TIMEOUT_SECS = 3;
+  // Timeout to allow (rapid) debugging, while not blocking tests with errors.
+  private static final int WAIT_TIMEOUT_SECS = 60;
   private static final Consumer<DirectStatement> NULL_ACTION = s -> {};
 
   private static final List<String> EXPECTED_COLUMNS_FOR_RESULT_FORMAT_TESTS =

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1917,11 +1917,11 @@ public class SqlResourceTest extends CalciteTestBase
     }
 
     @Override
-    public PlannerResult plan(DruidPlanner planner)
+    public PlannerResult createPlan(DruidPlanner planner)
     {
       if (planLatchSupplier.get() != null) {
         if (planLatchSupplier.get().rhs) {
-          PlannerResult result = super.plan(planner);
+          PlannerResult result = super.createPlan(planner);
           planLatchSupplier.get().lhs.countDown();
           return result;
         } else {
@@ -1933,10 +1933,10 @@ public class SqlResourceTest extends CalciteTestBase
           catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
-          return super.plan(planner);
+          return super.createPlan(planner);
         }
       } else {
-        return super.plan(planner);
+        return super.createPlan(planner);
       }
     }
 
@@ -1944,18 +1944,13 @@ public class SqlResourceTest extends CalciteTestBase
     public Sequence<Object[]> execute()
     {
       onExecute.accept(this);
-      return super.execute();
-    }
-
-    @Override
-    public Sequence<Object[]> doExecute()
-    {
+      ResultSet resultSet = plan();
       final Function<Sequence<Object[]>, Sequence<Object[]>> sequenceMapFn =
           Optional.ofNullable(sequenceMapFnSupplier.get()).orElse(Function.identity());
 
       if (executeLatchSupplier.get() != null) {
         if (executeLatchSupplier.get().rhs) {
-          Sequence<Object[]> sequence = sequenceMapFn.apply(super.doExecute());
+          Sequence<Object[]> sequence = sequenceMapFn.apply(resultSet.run());
           executeLatchSupplier.get().lhs.countDown();
           return sequence;
         } else {
@@ -1967,10 +1962,10 @@ public class SqlResourceTest extends CalciteTestBase
           catch (InterruptedException e) {
             throw new RuntimeException(e);
           }
-          return sequenceMapFn.apply(super.doExecute());
+          return sequenceMapFn.apply(resultSet.run());
         }
       } else {
-        return sequenceMapFn.apply(super.doExecute());
+        return sequenceMapFn.apply(resultSet.run());
       }
     }
   }


### PR DESCRIPTION
PR #12845 converted `SqlLifecycle` into a set of statement classes. The `DirectStatement` class combined planning and execution into a single `execute()` method. However, it turns out that a consumer outside of the Druid code base had need to separate the plan portion of the operation from execution.

This PR provides that separation in the form of a `ResultSet` class that holds onto the "physical plan" (such as it is in Druid) and does the execution step. The previous `execute()` method still exists for the code, within Druid, that uses the all-in-one approach.

<hr>

This PR has:
- [X] been self-reviewed.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] been tested in a test Druid cluster.
