### PR TITLE
Add SQL query planning time metric

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -278,7 +278,7 @@ For native JSON request, the `sql_query` field is empty. Example
 
 For SQL query request, the `native_query` field is empty. Example
 ```
-2019-01-14T10:00:00.000Z        127.0.0.1       {"sqlQuery/time":100,"sqlQuery/bytes":600,"success":true,"identity":"user1"}  {"query":"SELECT page, COUNT(*) AS Edits FROM wikiticker WHERE TIME_IN_INTERVAL(\"__time\", '2015-09-12/2015-09-13') GROUP BY page ORDER BY Edits DESC LIMIT 10","context":{"sqlQueryId":"c9d035a0-5ffd-4a79-a865-3ffdadbb5fdd","nativeQueryIds":"[490978e4-f5c7-4cf6-b174-346e63cf8863]"}}
+2019-01-14T10:00:00.000Z        127.0.0.1       {"sqlQuery/time":100, "sqlQuery/planningTimeMs":10, "sqlQuery/bytes":600, "success":true, "identity":"user1"}  {"query":"SELECT page, COUNT(*) AS Edits FROM wikiticker WHERE TIME_IN_INTERVAL(\"__time\", '2015-09-12/2015-09-13') GROUP BY page ORDER BY Edits DESC LIMIT 10","context":{"sqlQueryId":"c9d035a0-5ffd-4a79-a865-3ffdadbb5fdd","nativeQueryIds":"[490978e4-f5c7-4cf6-b174-346e63cf8863]"}}
 ```
 
 #### Emitter request logging

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -57,6 +57,7 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will re-send the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.|Varies.||
 |`query/priority`|Assigned lane and priority, only if Laning strategy is enabled. Refer to [Laning strategies](../configuration/index.md#laning-strategies)|lane, dataSource, type|0|
 |`sqlQuery/time`|Milliseconds taken to complete a SQL query.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
+|`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 |`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 
 ### Historical
@@ -140,6 +141,7 @@ If SQL is enabled, the Broker will emit the following metrics for SQL.
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|
 |`sqlQuery/time`|Milliseconds taken to complete a SQL.|id, nativeQueryIds, dataSource, remoteAddress, success.|< 1s|
+|`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 |`sqlQuery/bytes`|number of bytes returned in SQL response.|id, nativeQueryIds, dataSource, remoteAddress, success.| |
 
 ## Ingestion metrics

--- a/docs/operations/request-logging.md
+++ b/docs/operations/request-logging.md
@@ -122,6 +122,7 @@ The following shows an example log emitter output:
         "queryStats":
         {
             "sqlQuery/time": 43,
+            "sqlQuery/planningTimeMs": 5,
             "sqlQuery/bytes": 9351,
             "success": true,
             "context":

--- a/server/src/test/java/org/apache/druid/server/log/DefaultRequestLogEventTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/DefaultRequestLogEventTest.java
@@ -130,7 +130,14 @@ public class DefaultRequestLogEventTest
     final String host = "127.0.0.1";
     final String sql = "select * from 1337";
     final QueryStats queryStats = new QueryStats(
-        ImmutableMap.of("sqlQuery/time", 13L, "sqlQuery/bytes", 10L, "success", true, "identity", "allowAll"));
+        ImmutableMap.of(
+            "sqlQuery/time", 13L,
+            "sqlQuery/planningTimeMs", 1L,
+            "sqlQuery/bytes", 10L,
+            "success", true,
+            "identity", "allowAll"
+        )
+    );
 
     RequestLogLine nativeLine = RequestLogLine.forSql(
         sql,

--- a/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
@@ -202,6 +202,7 @@ public class DirectStatement extends AbstractStatement implements Cancelable
     if (state != State.START) {
       throw new ISE("Can plan a query only once.");
     }
+    long planningStartNanos = System.nanoTime();
     try (DruidPlanner planner = sqlToolbox.plannerFactory.createPlanner(
         sqlToolbox.engine,
         queryPlus.sql(),
@@ -218,6 +219,7 @@ public class DirectStatement extends AbstractStatement implements Cancelable
       prepareResult = planner.prepareResult();
       // Double check needed by SqlResourceTest
       transition(State.PREPARED);
+      reporter.planningTimeNanos(System.nanoTime() - planningStartNanos);
       return resultSet;
     }
     catch (RuntimeException e) {

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -54,6 +54,7 @@ public class SqlExecutionReporter
   private final long startNs;
   private Throwable e;
   private long bytesWritten;
+  private long planningTimeNanos;
 
   public SqlExecutionReporter(
       final AbstractStatement stmt,
@@ -74,6 +75,11 @@ public class SqlExecutionReporter
   public void succeeded(final long bytesWritten)
   {
     this.bytesWritten = bytesWritten;
+  }
+
+  public void planningTimeNanos(final long planningTimeNanos)
+  {
+    this.planningTimeNanos = planningTimeNanos;
   }
 
   public void emit()
@@ -105,9 +111,16 @@ public class SqlExecutionReporter
       if (bytesWritten >= 0) {
         emitter.emit(metricBuilder.build("sqlQuery/bytes", bytesWritten));
       }
+      if (planningTimeNanos >= 0) {
+        emitter.emit(metricBuilder.build(
+            "sqlQuery/planningTimeMs",
+            TimeUnit.NANOSECONDS.toMillis(planningTimeNanos)
+        ));
+      }
 
       final Map<String, Object> statsMap = new LinkedHashMap<>();
       statsMap.put("sqlQuery/time", TimeUnit.NANOSECONDS.toMillis(queryTimeNs));
+      statsMap.put("sqlQuery/planningTimeMs", TimeUnit.NANOSECONDS.toMillis(planningTimeNanos));
       statsMap.put("sqlQuery/bytes", bytesWritten);
       statsMap.put("success", success);
       QueryContext queryContext;

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -1097,6 +1097,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
       Assert.assertEquals(true, stats.get("success"));
       Assert.assertEquals("regularUser", stats.get("identity"));
       Assert.assertTrue(stats.containsKey("sqlQuery/time"));
+      Assert.assertTrue(stats.containsKey("sqlQuery/planningTimeMs"));
       Assert.assertTrue(stats.containsKey("sqlQuery/bytes"));
     }
 
@@ -1151,6 +1152,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
       Assert.assertEquals(true, stats.get("success"));
       Assert.assertEquals("regularUser", stats.get("identity"));
       Assert.assertTrue(stats.containsKey("sqlQuery/time"));
+      Assert.assertTrue(stats.containsKey("sqlQuery/planningTimeMs"));
       Assert.assertTrue(stats.containsKey("sqlQuery/bytes"));
     }
 


### PR DESCRIPTION
Adds `sqlQuery/planningTimeMs` metric per SQL query which computes the time it takes to build a native query from the SQL query.
While comparing the perf of native to SQL API for the same query, users tend to check the extra time taken by planning stage of the SQL. Currently, that time is estimated as the difference between running the SQL and then running the native query using EXPLAIN. To find the exact difference, the `query/time` metrics of both SQL and native queries are compared.
Further, for SQL query workloads there is no easy visiblity into the holistic planning time.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
