### PR TITLE
Remove misleading logging on router for JDBC queries

### DIFF
--- a/server/src/main/java/org/apache/druid/server/security/UnsecuredResourceFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/UnsecuredResourceFilter.java
@@ -50,7 +50,9 @@ public class UnsecuredResourceFilter implements Filter
         new AuthenticationResult(
             AuthConfig.ALLOW_ALL_NAME,
             AuthConfig.ALLOW_ALL_NAME,
-            AuthConfig.ALLOW_ALL_NAME,
+            // adding null so that the router doesn't try to decorate the request. It is ok since we're already bypassing
+            // authentication for unsecure paths.
+            null,
             null
         )
     );


### PR DESCRIPTION
On a cluster with non `allow-all` authentication configured, JDBC queries log the following misleading message : `Can not find Authenticator with Name [allowAll]`. It is misleading since we use `allow-all` authentication for JDBC queries to bypass the authentication on router itself. JDBC queries are authenticated on broker.
The log comes because having an `authenticatedBy` field in the bypass auth result leads the query to a codepath where the authenticator object is tried to be fetched. But since we haven't configured `allow-all` auth, the error log comes.
This change removes the `authenticatedBy` field in `AuthenticationResult` for bypass requests to avoid the misleading logging.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
