### PR TITLE
Update ORC to 1.7.6

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -31,7 +31,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.7.5</orc.version>
+        <orc.version>1.7.6</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4567,7 +4567,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.7.5
+version: 1.7.6
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core


### PR DESCRIPTION
### Description

This PR aims to update ORC to 1.7.6. 
This will bring the latest changes and bug fixes. 

https://github.com/apache/orc/releases/tag/v1.7.6

- ORC-1204: ORC MapReduce writer to flush when long arrays
- ORC-1205: `nextVector` should invoke `ensureSize` when reusing vectors
- ORC-1215: Remove a wrong `NotNull` annotation on `value` of `setAttribute`
- ORC-1222: Upgrade `tools.hadoop.version` to 2.10.2
- ORC-1227: Use `Constructor.newInstance` instead of `Class.newInstance`
- ORC-1228: Fix `setAttribute` to handle null value

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)

