### PR TITLE
Correct spelling in messages and variable names.

### DIFF
--- a/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/InputEntityIteratingReader.java
@@ -79,8 +79,8 @@ public class InputEntityIteratingReader implements InputSourceReader
       }
       catch (IOException e) {
         throw new RuntimeException(entity.getUri() != null ?
-                                   "Error occured while trying to read uri: " + entity.getUri() :
-                                   "Error occured while reading input", e);
+                                   "Error occurred while trying to read uri: " + entity.getUri() :
+                                   "Error occurred while reading input", e);
       }
     });
   }

--- a/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
@@ -121,7 +121,7 @@ public class InputEntityIteratingReaderTest
         ).iterator(),
         temporaryFolder.newFolder()
     );
-    String expectedMessage = "Error occured while trying to read uri: testscheme://some/path";
+    String expectedMessage = "Error occurred while trying to read uri: testscheme://some/path";
     Exception exception = Assert.assertThrows(RuntimeException.class, firehose::read);
 
     Assert.assertTrue(exception.getMessage().contains(expectedMessage));

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/CommonCacheNotifier.java
@@ -144,7 +144,7 @@ public class CommonCacheNotifier
               LOG.noStackTrace().info(e, "%s: Interrupted while handling updates for cachedUserMaps.", callerName);
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, callerName + ":Error occured while handling updates for cachedUserMaps.").emit();
+              LOG.makeAlert(t, callerName + ":Error occurred while handling updates for cachedUserMaps.").emit();
             }
           }
         }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/cache/CoordinatorPollingBasicAuthenticatorCacheManager.java
@@ -127,7 +127,7 @@ public class CoordinatorPollingBasicAuthenticatorCacheManager implements BasicAu
               LOG.debug("Scheduled user cache poll is done");
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, "Error occured while polling for cachedUserMaps.").emit();
+              LOG.makeAlert(t, "Error occurred while polling for cachedUserMaps.").emit();
             }
           }
       );

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
@@ -192,7 +192,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
                 LOG.debug("Scheduled db userMap poll is done");
               }
               catch (Throwable t) {
-                LOG.makeAlert(t, "Error occured while polling for cachedUserMaps.").emit();
+                LOG.makeAlert(t, "Error occurred while polling for cachedUserMaps.").emit();
               }
               return ScheduledExecutors.Signal.REPEAT;
             }

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
@@ -136,7 +136,7 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
               LOG.debug("Scheduled userMap cache poll is done");
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, "Error occured while polling for cachedUserMaps.").emit();
+              LOG.makeAlert(t, "Error occurred while polling for cachedUserMaps.").emit();
             }
           }
       );
@@ -162,7 +162,7 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
               LOG.debug("Scheduled groupMappingMap cache poll is done");
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, "Error occured while polling for cachedGroupMappingMaps.").emit();
+              LOG.makeAlert(t, "Error occurred while polling for cachedGroupMappingMaps.").emit();
             }
           }
       );

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/updater/CoordinatorBasicAuthorizerMetadataStorageUpdater.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/updater/CoordinatorBasicAuthorizerMetadataStorageUpdater.java
@@ -235,7 +235,7 @@ public class CoordinatorBasicAuthorizerMetadataStorageUpdater implements BasicAu
               LOG.debug("Scheduled db poll is done");
             }
             catch (Throwable t) {
-              LOG.makeAlert(t, "Error occured while polling for cachedUserMaps, cachedGroupMappingMaps, cachedRoleMaps.").emit();
+              LOG.makeAlert(t, "Error occurred while polling for cachedUserMaps, cachedGroupMappingMaps, cachedRoleMaps.").emit();
             }
             return ScheduledExecutors.Signal.REPEAT;
           }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -1975,7 +1975,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .andReturn(Futures.immediateFailedFuture(new RuntimeException())).times(2);
     taskQueue.shutdown(
         EasyMock.contains("sequenceName-0"),
-        EasyMock.eq("An exception occured while waiting for task [%s] to pause: [%s]"),
+        EasyMock.eq("An exception occurred while waiting for task [%s] to pause: [%s]"),
         EasyMock.contains("sequenceName-0"),
         EasyMock.anyString()
     );

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -2258,7 +2258,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .andReturn(Futures.immediateFailedFuture(new RuntimeException())).times(2);
     taskQueue.shutdown(
         EasyMock.contains("sequenceName-0"),
-        EasyMock.eq("An exception occured while waiting for task [%s] to pause: [%s]"),
+        EasyMock.eq("An exception occurred while waiting for task [%s] to pause: [%s]"),
         EasyMock.contains("sequenceName-0"),
         EasyMock.anyString()
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2967,7 +2967,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
                 killTask(
                     taskId,
-                    "An exception occured while waiting for task [%s] to pause: [%s]",
+                    "An exception occurred while waiting for task [%s] to pause: [%s]",
                     taskId,
                     pauseException
                 );

--- a/processing/src/test/java/org/apache/druid/query/QueriesTest.java
+++ b/processing/src/test/java/org/apache/druid/query/QueriesTest.java
@@ -72,16 +72,16 @@ public class QueriesTest
         )
     );
 
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     try {
       Queries.prepareAggregations(ImmutableList.of(), aggFactories, postAggs);
     }
     catch (IllegalArgumentException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
 
-    Assert.assertFalse(exceptionOccured);
+    Assert.assertFalse(exceptionOccurred);
   }
 
   @Test
@@ -104,16 +104,16 @@ public class QueriesTest
         )
     );
 
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     try {
       Queries.prepareAggregations(ImmutableList.of(), aggFactories, postAggs);
     }
     catch (IllegalArgumentException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
 
-    Assert.assertTrue(exceptionOccured);
+    Assert.assertTrue(exceptionOccurred);
   }
 
   @Test
@@ -158,16 +158,16 @@ public class QueriesTest
         )
     );
 
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     try {
       Queries.prepareAggregations(ImmutableList.of(), aggFactories, postAggs);
     }
     catch (IllegalArgumentException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
 
-    Assert.assertFalse(exceptionOccured);
+    Assert.assertFalse(exceptionOccurred);
   }
 
   @Test
@@ -212,16 +212,16 @@ public class QueriesTest
         )
     );
 
-    boolean exceptionOccured = false;
+    boolean exceptionOccurred = false;
 
     try {
       Queries.prepareAggregations(ImmutableList.of(), aggFactories, postAggs);
     }
     catch (IllegalArgumentException e) {
-      exceptionOccured = true;
+      exceptionOccurred = true;
     }
 
-    Assert.assertTrue(exceptionOccured);
+    Assert.assertTrue(exceptionOccurred);
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
+++ b/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
@@ -108,7 +108,7 @@ public class BaseNodeRoleWatcher
               listener.nodesAdded(currNodes);
               listener.nodeViewInitialized();
             },
-            "Exception occured in nodesAdded([%s]) in listener [%s].", currNodes, listener
+            "Exception occurred in nodesAdded([%s]) in listener [%s].", currNodes, listener
         );
       }
       nodeListeners.add(listener);
@@ -145,7 +145,7 @@ public class BaseNodeRoleWatcher
         for (DruidNodeDiscovery.Listener listener : nodeListeners) {
           safeSchedule(
               () -> listener.nodesAdded(newNode),
-              "Exception occured in nodeAdded(node=[%s]) in listener [%s].",
+              "Exception occurred in nodeAdded(node=[%s]) in listener [%s].",
               druidNode.getDruidNode().getHostAndPortToUse(),
               listener
           );
@@ -200,7 +200,7 @@ public class BaseNodeRoleWatcher
       for (DruidNodeDiscovery.Listener listener : nodeListeners) {
         safeSchedule(
             () -> listener.nodesRemoved(nodeRemoved),
-            "Exception occured in nodeRemoved(node [%s] of role [%s]) in listener [%s].",
+            "Exception occurred in nodeRemoved(node [%s] of role [%s]) in listener [%s].",
             druidNode.getDruidNode().getUriToUse(),
             druidNode.getNodeRole().getJsonName(),
             listener
@@ -233,7 +233,7 @@ public class BaseNodeRoleWatcher
               listener.nodesAdded(currNodes);
               listener.nodeViewInitialized();
             },
-            "Exception occured in nodesAdded([%s]) in listener [%s].",
+            "Exception occurred in nodesAdded([%s]) in listener [%s].",
             currNodes,
             listener
         );
@@ -282,7 +282,7 @@ public class BaseNodeRoleWatcher
                   listener.nodesRemoved(nodesDeleted);
                 }
               },
-              "Exception occured in resetNodes in listener [%s].",
+              "Exception occurred in resetNodes in listener [%s].",
               listener
           );
         }

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -176,7 +176,7 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
                     LockSupport.parkNanos(LookupReferencesManager.this, TimeUnit.MINUTES.toNanos(1));
                   }
                   catch (Throwable t) {
-                    LOG.makeAlert(t, "Error occured while lookup notice handling.").emit();
+                    LOG.makeAlert(t, "Error occurred while lookup notice handling.").emit();
                   }
                 }
               }
@@ -219,8 +219,8 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
         notice.handle(lookupMap);
       }
       catch (Exception ex) {
-        LOG.error(ex, "Exception occured while handling lookup notice [%s].", notice);
-        LOG.makeAlert("Exception occured while handling lookup notice, with message [%s].", ex.getMessage()).emit();
+        LOG.error(ex, "Exception occurred while handling lookup notice [%s].", notice);
+        LOG.makeAlert("Exception occurred while handling lookup notice, with message [%s].", ex.getMessage()).emit();
       }
     }
 


### PR DESCRIPTION
Corrects spelling mistake of occured used as occurred in a few places in variables as well as error messages returned to the user.

<hr>

This PR has:
- [x] been self-reviewed.

