### PR TITLE
Fix serialization in TaskReportFileWriters.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
@@ -20,7 +20,6 @@
 package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.Objects;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/IngestionStatsAndErrorsTaskReport.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.Objects;
 
-@JsonTypeName("ingestionStatsAndErrors")
 public class IngestionStatsAndErrorsTaskReport implements TaskReport
 {
   public static final String REPORT_KEY = "ingestionStatsAndErrors";
@@ -89,14 +88,5 @@ public class IngestionStatsAndErrorsTaskReport implements TaskReport
            "taskId='" + taskId + '\'' +
            ", payload=" + payload +
            '}';
-  }
-
-  // TaskReports are put into a Map and serialized.
-  // Jackson doesn't normally serialize the TaskReports with a "type" field in that situation,
-  // so explictly serialize the "type" field (otherwise, deserialization fails).
-  @JsonProperty("type")
-  private String getType()
-  {
-    return "ingestionStatsAndErrors";
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
@@ -24,6 +24,7 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,7 +50,10 @@ public class MultipleFileTaskReportFileWriter implements TaskReportFileWriter
       if (reportsFileParent != null) {
         FileUtils.mkdirp(reportsFileParent);
       }
-      objectMapper.writeValue(reportsFile, reports);
+
+      try (final FileOutputStream outputStream = new FileOutputStream(reportsFile)) {
+        SingleFileTaskReportFileWriter.writeReportToStream(objectMapper, outputStream, reports);
+      }
     }
     catch (Exception e) {
       log.error(e, "Encountered exception in write().");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriter.java
@@ -21,7 +21,9 @@ package org.apache.druid.indexing.common;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.File;
@@ -71,12 +73,14 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
       final Map<String, TaskReport> reports
   ) throws Exception
   {
+    final SerializerProvider serializers = objectMapper.getSerializerProviderInstance();
+
     try (final JsonGenerator jg = objectMapper.getFactory().createGenerator(outputStream)) {
       jg.writeStartObject();
 
       for (final Map.Entry<String, TaskReport> entry : reports.entrySet()) {
         jg.writeFieldName(entry.getKey());
-        objectMapper.writeValue(jg, entry.getValue());
+        JacksonUtils.writeObjectUsingSerializerProvider(jg, serializers, entry.getValue());
       }
 
       jg.writeEndObject();


### PR DESCRIPTION
For some reason, serializing a Map<String, TaskReport> would omit the "type" field. Explicitly sending each value through the ObjectMapper fixes this, because the type information does not get lost. This eliminates the need for a hack in IngestionStatsAndErrorsTaskReport.