### PR TITLE
Fix misspelling in license.md

### DIFF
--- a/dev/license.md
+++ b/dev/license.md
@@ -40,7 +40,7 @@ The licenses for binary packages are maintained _automatically_.
 All licenses (for both source code and binary releases) should be registered in [the `licenses.yaml` file](https://github.com/apache/druid/blob/master/licenses.yaml).
 [`generate-binary-license.py`](https://github.com/apache/druid/blob/master/distribution/bin/generate-binary-license.py)
 and [`generate-binary-notice.py`](https://github.com/apache/druid/blob/master/distribution/bin/generate-binary-notice.py)
-will generate the `LICENSE` and `NOTICE` files automatially based on the registry.
+will generate the `LICENSE` and `NOTICE` files automatically based on the registry.
 
 
 ### Adding licenses


### PR DESCRIPTION
### Description

Fixes a typo in the license.md file

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.