### PR TITLE
Docs: fix doc footer

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -28,7 +28,7 @@ class Footer extends React.Component {
               <a href="/technology">Technology</a>&ensp;·&ensp;
               <a href="/use-cases">Use Cases</a>&ensp;·&ensp;
               <a href="/druid-powered">Powered by Druid</a>&ensp;·&ensp;
-              <a href="/docs/latest">Docs</a>&ensp;·&ensp;
+              <a href="/docs/">Docs</a>&ensp;·&ensp;
               <a href="/community/">Community</a>&ensp;·&ensp;
               <a href="/downloads.html">Download</a>&ensp;·&ensp;
               <a href="/faq">FAQ</a>

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -28,7 +28,7 @@ class Footer extends React.Component {
               <a href="/technology">Technology</a>&ensp;·&ensp;
               <a href="/use-cases">Use Cases</a>&ensp;·&ensp;
               <a href="/druid-powered">Powered by Druid</a>&ensp;·&ensp;
-              <a href="/docs/">Docs</a>&ensp;·&ensp;
+              <a href="/docs/latest">Docs</a>&ensp;·&ensp;
               <a href="/community/">Community</a>&ensp;·&ensp;
               <a href="/downloads.html">Download</a>&ensp;·&ensp;
               <a href="/faq">FAQ</a>

--- a/website/script/fix-path.js
+++ b/website/script/fix-path.js
@@ -27,6 +27,13 @@ var urlVersion = process.argv[2];
 var druidVersion = process.argv[3];
 
 try {
+  // Change any explict "/docs/latest" links to "/docs/" to be picked up by the next replace
+  replace.sync({
+    files: './build/ApacheDruid/docs/**/*.html',
+    from: /"\/docs\/latest"/g,
+    to: `"/docs/"`,
+  });
+
   // Fix doc paths
   replace.sync({
     files: './build/ApacheDruid/docs/**/*.html',


### PR DESCRIPTION
This PR fixes the `doc` link in the footer template for the docs.

The issue is that as part of the doc build process the version gets inlined in right here: https://github.com/apache/druid/blob/master/website/script/fix-path.js#L33

Since the template already has the version it generates an invalid URL.

This PR will fix this going forwards and https://github.com/apache/druid-website-src/pull/320 fixes it for the already released docs.