### PR TITLE
Disallow timeseries queries with ETERNITY interval and non-ALL granularity

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowBasedStorageAdapterTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -822,6 +823,22 @@ public class RowBasedStorageAdapterTest
     );
 
     Assert.assertEquals(1, numCloses.get());
+  }
+
+  @Test
+  public void test_makeCursors_eternityIntervalWithMonthGranularity()
+  {
+    final RowBasedStorageAdapter<Integer> adapter = createIntAdapter(0, 1);
+    Assert.assertThrows(IAE.class, () -> {
+      adapter.makeCursors(
+          null,
+          Intervals.ETERNITY,
+          VirtualColumns.EMPTY,
+          Granularities.MONTH,
+          false,
+          null
+      );
+    });
   }
 
   private static List<List<Object>> walkCursors(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -28,6 +28,7 @@ import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.HumanReadableBytes;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.StringUtils;
@@ -14117,6 +14118,37 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             new Object[]{"2", 1L},
             new Object[]{"abc", 0L},
             new Object[]{"def", 0L}
+        )
+    );
+  }
+
+  @Test
+  public void testTimeseriesQueryWithEmptyInlineDatasourceAndGranularity()
+  {
+    // the SQL query contains an always FALSE filter ('bar' = 'baz'), which optimizes the query to also remove time
+    // filter. the converted query hence contains ETERNITY interval but still a MONTH granularity due to the grouping.
+    // Such a query should fail since it will create a huge amount of time grains which can lead to OOM or a very very
+    // high query time.
+    Assert.assertThrows(IAE.class, () ->
+        testQuery(
+            "SELECT TIME_FLOOR(__time, 'P1m'), max(m1) from \"foo\"\n"
+            + "WHERE __time > CURRENT_TIMESTAMP - INTERVAL '3' MONTH  AND 'bar'='baz'\n"
+            + "GROUP BY 1\n"
+            + "ORDER BY 1 DESC",
+            ImmutableList.of(
+                Druids.newTimeseriesQueryBuilder()
+                      .dataSource(
+                          InlineDataSource.fromIterable(
+                              ImmutableList.of(),
+                              RowSignature.builder().addTimeColumn().add("m1", ColumnType.STRING).build()
+                          ))
+                      .intervals(ImmutableList.of(Intervals.ETERNITY))
+                      .descending(true)
+                      .granularity(Granularities.MONTH)
+                      .aggregators(new LongMaxAggregatorFactory("a0", "m1"))
+                      .build()
+            ),
+            ImmutableList.of()
         )
     );
   }


### PR DESCRIPTION
A user might construct a timeseries query on inline data by mistake which contains no filters on time intervals (hence the query is on ETERNITY interval) and also specifies a non-ALL granularity. Currently, those queries will start generating a large number of time grains while generating the results which can lead to a very high chance for heap OOM or a very very long query runtime.
This change disallows such queries from execution to avoid the problems mentioned above. Semantically as well, there is less point in running a time granularity query over the ETERNITY interval.

An augmentation to the solution could be to find the time-interval of the inline data by traversing it and then using that interval in the `RowBasedStorageAdapater`. But doing that change today will either require recompuation of inline data or eager materialization of it in the adapater, both of which approaches have their own short-comings. So, for now this change is refrained - it can be considered in future if needed.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
