### PR TITLE
[DRUID-12945] type conversion exception occurs during the variance query

### DIFF
--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceObjectVectorAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceObjectVectorAggregator.java
@@ -46,29 +46,31 @@ public class VarianceObjectVectorAggregator implements VectorAggregator
   @Override
   public void aggregate(ByteBuffer buf, int position, int startRow, int endRow)
   {
-    VarianceAggregatorCollector[] vector = (VarianceAggregatorCollector[]) selector.getObjectVector();
     VarianceAggregatorCollector previous = VarianceBufferAggregator.getVarianceCollector(buf, position);
+    VarianceAggregatorCollector current;
     for (int i = startRow; i < endRow; i++) {
-      previous.fold(vector[i]);
+      current = (VarianceAggregatorCollector) selector.getObjectVector()[i];
+      previous.fold(current);
     }
     VarianceBufferAggregator.writeNVariance(buf, position, previous.count, previous.sum, previous.nvariance);
   }
 
   @Override
   public void aggregate(
-      ByteBuffer buf,
-      int numRows,
-      int[] positions,
-      @Nullable int[] rows,
-      int positionOffset
+          ByteBuffer buf,
+          int numRows,
+          int[] positions,
+          @Nullable int[] rows,
+          int positionOffset
   )
   {
-    VarianceAggregatorCollector[] vector = (VarianceAggregatorCollector[]) selector.getObjectVector();
+    VarianceAggregatorCollector current;
     for (int i = 0; i < numRows; i++) {
       int position = positions[i] + positionOffset;
       int row = rows != null ? rows[i] : i;
+      current = (VarianceAggregatorCollector) selector.getObjectVector()[row];
       VarianceAggregatorCollector previous = VarianceBufferAggregator.getVarianceCollector(buf, position);
-      previous.fold(vector[row]);
+      previous.fold(current);
       VarianceBufferAggregator.writeNVariance(buf, position, previous.count, previous.sum, previous.nvariance);
     }
   }

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceObjectVectorAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceObjectVectorAggregatorTest.java
@@ -47,6 +47,13 @@ public class VarianceObjectVectorAggregatorTest extends InitializedNullHandlingT
       new VarianceAggregatorCollector(2, 183, 1984.5)
   };
   private static final boolean[] NULLS = new boolean[]{false, false, true, true, false};
+  private static final Object[] OBJECTS = new Object[]{
+          new VarianceAggregatorCollector(1, 7.8, 0),
+          new VarianceAggregatorCollector(1, 11, 0),
+          new VarianceAggregatorCollector(1, 23.67, 0),
+          null,
+          new VarianceAggregatorCollector(2, 183, 1984.5)
+  };
 
   @Mock
   private VectorObjectSelector selector;
@@ -86,6 +93,17 @@ public class VarianceObjectVectorAggregatorTest extends InitializedNullHandlingT
   }
 
   @Test
+  public void aggregateCompatibilityTest()
+  {
+    this.resetSelectorObjectVectorWithObjects();
+    target.aggregate(buf, POSITION, START_ROW, VALUES.length);
+    VarianceAggregatorCollector collector = VarianceBufferAggregator.getVarianceCollector(buf, POSITION);
+    Assert.assertEquals(4, collector.count);
+    Assert.assertEquals(217.67, collector.sum, EPSILON);
+    Assert.assertEquals(7565.211675, collector.nvariance, EPSILON);
+  }
+
+  @Test
   public void aggregateBatchWithoutRows()
   {
     int[] positions = new int[]{0, 43, 70};
@@ -96,6 +114,23 @@ public class VarianceObjectVectorAggregatorTest extends InitializedNullHandlingT
       VarianceAggregatorCollector collector = VarianceBufferAggregator.getVarianceCollector(
           buf,
           positions[i] + positionOffset
+      );
+      Assert.assertEquals(VALUES[i], collector);
+    }
+  }
+
+  @Test
+  public void aggregateBatchWithoutRowsCompatibilityTest()
+  {
+    this.resetSelectorObjectVectorWithObjects();
+    int[] positions = new int[]{0, 43, 70};
+    int positionOffset = 2;
+    clearBufferForPositions(positionOffset, positions);
+    target.aggregate(buf, 3, positions, null, positionOffset);
+    for (int i = 0; i < positions.length; i++) {
+      VarianceAggregatorCollector collector = VarianceBufferAggregator.getVarianceCollector(
+              buf,
+              positions[i] + positionOffset
       );
       Assert.assertEquals(VALUES[i], collector);
     }
@@ -120,6 +155,25 @@ public class VarianceObjectVectorAggregatorTest extends InitializedNullHandlingT
   }
 
   @Test
+  public void aggregateBatchWithRowsCompatibilityTest()
+  {
+    this.resetSelectorObjectVectorWithObjects();
+    int[] positions = new int[]{0, 43, 70};
+    int[] rows = new int[]{3, 2, 0};
+    int positionOffset = 2;
+    clearBufferForPositions(positionOffset, positions);
+    target.aggregate(buf, 3, positions, rows, positionOffset);
+    for (int i = 0; i < positions.length; i++) {
+      VarianceAggregatorCollector collector = VarianceBufferAggregator.getVarianceCollector(
+              buf,
+              positions[i] + positionOffset
+      );
+      VarianceAggregatorCollector expectedCollector = VALUES[rows[i]];
+      Assert.assertEquals(expectedCollector == null ? new VarianceAggregatorCollector() : expectedCollector, collector);
+    }
+  }
+
+  @Test
   public void getShouldReturnAllZeros()
   {
     VarianceAggregatorCollector collector = target.get(buf, POSITION);
@@ -133,5 +187,10 @@ public class VarianceObjectVectorAggregatorTest extends InitializedNullHandlingT
     for (int position : positions) {
       VarianceBufferAggregator.doInit(buf, offset + position);
     }
+  }
+
+  private void resetSelectorObjectVectorWithObjects()
+  {
+    Mockito.doReturn(OBJECTS).when(selector).getObjectVector();
   }
 }


### PR DESCRIPTION
Fixes #12945

### Description

Fixed bug: type conversion exception occurs during the variance query

<hr>

##### Key changed/added classes in this PR
 * `VarianceObjectVectorAggregator`
 * `VarianceObjectVectorAggregatorTest`

<hr>

This PR has:
- been self-reviewed
- added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage]
- added integration tests.
- been tested in a test Druid cluster.
