### PR TITLE
Web console: fix pagination, add error delimiters

### DIFF
--- a/web-console/lib/keywords.js
+++ b/web-console/lib/keywords.js
@@ -60,6 +60,7 @@ exports.SQL_KEYWORDS = [
   'INSERT INTO',
   'REPLACE INTO',
   'OVERWRITE',
+  'RETURNING',
 ];
 
 exports.SQL_EXPRESSION_PARTS = [

--- a/web-console/src/react-table/react-table-pagination/react-table-pagination.tsx
+++ b/web-console/src/react-table/react-table-pagination/react-table-pagination.tsx
@@ -101,7 +101,7 @@ export const ReactTablePagination = React.memo(function ReactTablePagination(
   const start = page * pageSize + 1;
   let end = page * pageSize + pageSize;
   if (nonEmptyArray(sortedData)) {
-    end = Math.min(end, sortedData.length);
+    end = Math.min(end, page * pageSize + sortedData.length);
   }
 
   let pageInfo = 'Showing';

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -17,26 +17,24 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
       (Stack trace)
     </a>
   </p>
-  <p>
+  <div>
     Failed task ID: 
     <Memo(ClickToCopy)
       text="query-0cf1a40a-aaef-4d17-bda4-5afa7edf07e7-worker0"
     />
-     /
-     
-    On host: 
+     (on host: 
     <Memo(ClickToCopy)
       text="localhost:8101"
     />
-     /
-     
-    Debug:
-     
+    )
+  </div>
+  <div>
+    Debug: 
     <a
       onClick={[Function]}
     >
-      download query detail archive
+      get query detail archive
     </a>
-  </p>
+  </div>
 </Blueprint4.Callout>
 `;

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -22,12 +22,14 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
     <Memo(ClickToCopy)
       text="query-0cf1a40a-aaef-4d17-bda4-5afa7edf07e7-worker0"
     />
-     
+     /
+     
     On host: 
     <Memo(ClickToCopy)
       text="localhost:8101"
     />
-     
+     /
+     
     Debug:
      
     <a

--- a/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.scss
+++ b/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.scss
@@ -19,6 +19,8 @@
 @import '../../../variables';
 
 .execution-error-pane {
+  overflow: hidden;
+
   .#{$bp-ns}-dark & {
     background: $dark-gray3;
   }

--- a/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
@@ -61,14 +61,12 @@ export const ExecutionErrorPane = React.memo(function ExecutionErrorPane(
       <p>
         {taskId && (
           <>
-            Failed task ID: <ClickToCopy text={taskId} />
-            &nbsp;
+            Failed task ID: <ClickToCopy text={taskId} /> /{' '}
           </>
         )}
         {host && (
           <>
-            On host: <ClickToCopy text={host} />
-            &nbsp;
+            On host: <ClickToCopy text={host} /> /{' '}
           </>
         )}
         Debug:{' '}

--- a/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
@@ -58,26 +58,27 @@ export const ExecutionErrorPane = React.memo(function ExecutionErrorPane(
           </>
         )}
       </p>
-      <p>
-        {taskId && (
-          <>
-            Failed task ID: <ClickToCopy text={taskId} /> /{' '}
-          </>
-        )}
-        {host && (
-          <>
-            On host: <ClickToCopy text={host} /> /{' '}
-          </>
-        )}
-        Debug:{' '}
+      {taskId && (
+        <div>
+          Failed task ID: <ClickToCopy text={taskId} />
+          {host && (
+            <>
+              {' (on host: '}
+              <ClickToCopy text={host} />)
+            </>
+          )}
+        </div>
+      )}
+      <div>
+        {'Debug: '}
         <a
           onClick={() => {
             void downloadQueryDetailArchive(execution.id);
           }}
         >
-          download query detail archive
+          get query detail archive
         </a>
-      </p>
+      </div>
 
       {stackToShow && (
         <ShowValueDialog

--- a/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
+++ b/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
@@ -190,7 +190,7 @@ LIMIT 100`,
                   )}
                 <MenuItem
                   icon={IconNames.ARCHIVE}
-                  text="Download query detail archive"
+                  text="Get query detail archive"
                   onClick={() => downloadQueryDetailArchive(w.taskId)}
                 />
                 {w.taskStatus === 'RUNNING' && (


### PR DESCRIPTION
This PR fixes the pagination control count and adds delimiters (`/`) for the error display:

<img width="853" alt="image" src="https://user-images.githubusercontent.com/177816/186570135-a0c3bb71-29c2-43ba-a6bd-c9048fb8192b.png">
