### PR TITLE
Suppressing CVE-2022-25168 - hadoop-common-2.8.5.jar

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -360,6 +360,7 @@
      <packageUrl regex="true">^pkg:maven/org\.apache\.hadoop/hadoop\-.*@.*$</packageUrl>
      <cve>CVE-2018-11765</cve>
      <cve>CVE-2020-9492</cve>
+     <cve>CVE-2022-25168</cve>
      <cve>CVE-2022-26612</cve>
      <cve>CVE-2018-8009</cve>
   </suppress>


### PR DESCRIPTION
Suppressing CVE-2022-25168 - hadoop-common-2.8.5.jar