### PR TITLE
add json function support for paths with negative array indexes

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedPathArrayElement.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedPathArrayElement.java
@@ -44,7 +44,12 @@ public class NestedPathArrayElement implements NestedPathPart
     // handle lists or arrays because who knows what might end up here, depending on how is created
     if (input instanceof List) {
       List<?> currentList = (List<?>) input;
-      if (currentList.size() > index) {
+      final int currentSize = currentList.size();
+      if (index < 0) {
+        if (currentSize + index >= 0) {
+          return currentList.get(currentSize + index);
+        }
+      } else if (currentList.size() > index) {
         return currentList.get(index);
       }
     } else if (input instanceof Object[]) {

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
@@ -228,6 +228,18 @@ public class NestedPathFinderTest
     Assert.assertEquals(".\"x\"[1]", NestedPathFinder.toNormalizedJqPath(pathParts));
     Assert.assertEquals("$.x[1]", NestedPathFinder.toNormalizedJsonPath(pathParts));
 
+
+    // { "x" : ["a", "b"]}
+    pathParts = NestedPathFinder.parseJsonPath("$.x[-1]");
+    Assert.assertEquals(2, pathParts.size());
+
+    Assert.assertTrue(pathParts.get(0) instanceof NestedPathField);
+    Assert.assertEquals("x", pathParts.get(0).getPartIdentifier());
+    Assert.assertTrue(pathParts.get(1) instanceof NestedPathArrayElement);
+    Assert.assertEquals("-1", pathParts.get(1).getPartIdentifier());
+    Assert.assertEquals(".\"x\"[-1]", NestedPathFinder.toNormalizedJqPath(pathParts));
+    Assert.assertEquals("$.x[-1]", NestedPathFinder.toNormalizedJsonPath(pathParts));
+
     // { "x" : ["a", "b"]}
     pathParts = NestedPathFinder.parseJsonPath("$['x'][1]");
     Assert.assertEquals(2, pathParts.size());
@@ -421,6 +433,18 @@ public class NestedPathFinderTest
     pathParts = NestedPathFinder.parseJqPath(".x[1]");
     Assert.assertEquals("b", NestedPathFinder.find(NESTER, pathParts));
     Assert.assertEquals("b", NestedPathFinder.findStringLiteral(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".x[-1]");
+    Assert.assertEquals("c", NestedPathFinder.find(NESTER, pathParts));
+    Assert.assertEquals("c", NestedPathFinder.findStringLiteral(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".x[-2]");
+    Assert.assertEquals("b", NestedPathFinder.find(NESTER, pathParts));
+    Assert.assertEquals("b", NestedPathFinder.findStringLiteral(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".x[-4]");
+    Assert.assertNull(NestedPathFinder.find(NESTER, pathParts));
+    Assert.assertNull(NestedPathFinder.findStringLiteral(NESTER, pathParts));
 
     // nonexistent
     pathParts = NestedPathFinder.parseJqPath(".x[1].y.z");

--- a/processing/src/test/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumnTest.java
@@ -91,6 +91,7 @@ public class NestedFieldVirtualColumnTest
   {
     EqualsVerifier.forClass(NestedFieldVirtualColumn.class)
                   .withNonnullFields("columnName", "outputName")
+                  .withIgnoredFields("hasNegativeArrayIndex")
                   .usingGetClass()
                   .verify();
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -2415,4 +2415,95 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                     .build()
     );
   }
+
+  @Test
+  public void testGroupByNegativeJsonPathIndex()
+  {
+    // negative array index cannot vectorize
+    cannotVectorize();
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(nester, '$.array[-1]'), "
+        + "SUM(cnt) "
+        + "FROM druid.nested GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            new NestedFieldVirtualColumn("nester", "$.array[-1]", "v0", ColumnType.STRING)
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0")
+                            )
+                        )
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{NullHandling.defaultStringValue(), 5L},
+            new Object[]{"b", 2L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testJsonPathNegativeIndex()
+  {
+    testQuery(
+        "SELECT JSON_VALUE(nester, '$.array[-1]'), JSON_QUERY(nester, '$.array[-1]'), JSON_KEYS(nester, '$.array[-1]') FROM druid.nested",
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(DATA_SOURCE)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .virtualColumns(
+                      new NestedFieldVirtualColumn(
+                          "nester",
+                          "v0",
+                          ColumnType.STRING,
+                          null,
+                          false,
+                          "$.array[-1]",
+                          false
+                      ),
+                      new NestedFieldVirtualColumn(
+                          "nester",
+                          "v1",
+                          NestedDataComplexTypeSerde.TYPE,
+                          null,
+                          true,
+                          "$.array[-1]",
+                          false
+                      ),
+                      expressionVirtualColumn("v2", "json_keys(\"nester\",'$.array[-1]')", ColumnType.STRING_ARRAY)
+                  )
+                  .columns("v0", "v1", "v2")
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .legacy(false)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"b", "\"b\"", null},
+            new Object[]{NullHandling.defaultStringValue(), null, null},
+            new Object[]{NullHandling.defaultStringValue(), null, null},
+            new Object[]{NullHandling.defaultStringValue(), null, null},
+            new Object[]{NullHandling.defaultStringValue(), null, null},
+            new Object[]{"b", "\"b\"", null},
+            new Object[]{NullHandling.defaultStringValue(), null, null}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", NestedDataComplexTypeSerde.TYPE)
+                    .add("EXPR$2", ColumnType.STRING_ARRAY)
+                    .build()
+
+    );
+  }
 }


### PR DESCRIPTION
### Description
This PR adds SQL and native JSON function support for using negative array indexes in jsonpath expressions, e.g. `json_value(nested, '$.x[-2]')` will return the 2nd to last element of the array. This fixes a bug where using negative array indexes would cause an `ArrayIndexOutOfBoundsException` to be thrown, failing the query.

Since the underlying column does not currently provide an optimal way to select the values, using negative array indexes with `JSON_VALUE` will "fall back" to processing the "raw" JSON data, similar to when using `JSON_QUERY`. Additionally, using negative array indexes will make the query not eligible for vectorization. I save both of these optimizations for a future PR or two.

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
