### PR TITLE
Add Java 17 information to documentation.

### DIFF
--- a/docs/operations/java.md
+++ b/docs/operations/java.md
@@ -27,8 +27,8 @@ a Java runtime for Druid.
 
 ## Selecting a Java runtime
 
-Druid fully supports Java 8 and 11. The project team recommends Java 11. The project team does not recommend running
-with Java 17, because certain Druid functionality is not currently compatible with Java 17.
+Druid fully supports Java 8 and 11, and has experimental support for [Java 17](#java-17).
+The project team recommends Java 11.
 
 The project team recommends using an OpenJDK-based Java distribution. There are many free and actively-supported
 distributions available, including
@@ -70,7 +70,6 @@ Druid, because Java 8 does not recognize these parameters and fails to start up 
 To do this, add the following lines to your `jvm.config` files:
 
 ```
---add-exports=java.base/jdk.internal.perf=ALL-UNNAMED
 --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
 --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
 --add-opens=java.base/java.lang=ALL-UNNAMED
@@ -78,7 +77,6 @@ To do this, add the following lines to your `jvm.config` files:
 --add-opens=java.base/java.nio=ALL-UNNAMED
 --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
 --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
---add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED
 ```
 
 Additionally, tasks run by [MiddleManagers](../design/architecture.md) execute in separate JVMs. The command line for
@@ -87,8 +85,29 @@ these JVMs is given by `druid.indexer.runner.javaOptsArray` or `druid.indexer.ru
 a line like the following:
 
 ```
-druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager","--add-exports=java.base/jdk.internal.perf=ALL-UNNAMED","--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED","--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED","--add-opens=java.base/java.lang=ALL-UNNAMED","--add-opens=java.base/java.io=ALL-UNNAMED","--add-opens=java.base/java.nio=ALL-UNNAMED","--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED","--add-opens=java.base/sun.nio.ch=ALL-UNNAMED","--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED"]
+druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager","--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED","--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED","--add-opens=java.base/java.lang=ALL-UNNAMED","--add-opens=java.base/java.io=ALL-UNNAMED","--add-opens=java.base/java.nio=ALL-UNNAMED","--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED","--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]
 ```
 
 The `Xms`, `Xmx`, and `MaxDirectMemorySize` parameters in the line above are merely an example. You may use different
 values in your specific environment.
+
+## Java 17
+
+Druid has experimental support for Java 17.
+
+An important change in Java 17 is that [strong encapsulation](#strong-encapsulation) is enabled by default. The various
+`--add-opens` and `--add-exports` parameters listed in the [strong encapsulation](#strong-encapsulation) section are
+required in all `jvm.config` files and in `druid.indexer.runner.javaOpts` or `druid.indexer.runner.javaOptsArray` on
+MiddleManagers. Failure to include these parameters leads to failure of various operations.
+
+In addition, Druid's launch scripts detect Java 17 and log the following message rather than starting up:
+
+```
+Druid requires Java 8 or 11. Your current version is: 17.X.Y.
+```
+
+You can skip this check with an environment variable:
+
+```
+export DRUID_SKIP_JAVA_CHECK=1
+```

--- a/examples/bin/run-java
+++ b/examples/bin/run-java
@@ -31,14 +31,12 @@ then
   # Must disable strong encapsulation for certain packages on Java 17.
   exec "$JAVA_BIN" \
     --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
-    --add-exports=java.base/jdk.internal.perf=ALL-UNNAMED \
     --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED \
     --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED \
     --add-opens=java.base/java.nio=ALL-UNNAMED \
     --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
     --add-opens=java.base/java.io=ALL-UNNAMED \
     --add-opens=java.base/java.lang=ALL-UNNAMED \
-    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
     "$@"
 elif [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
 then

--- a/pom.xml
+++ b/pom.xml
@@ -1690,10 +1690,6 @@
             </activation>
             <properties>
                 <jdk.surefire.argLine>
-                    <!-- required for JvmMonitor on Java 11+ -->
-                    --add-exports=java.base/jdk.internal.perf=ALL-UNNAMED
-                    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED
-
                     <!-- required for DataSketches Memory on Java 11+ -->
                     --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
                     --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED


### PR DESCRIPTION
Once #12987 is merged, I'm not aware of anything that is nonfunctional
on Java 17, so I thought it would be good to declare the support "officially
experimental" (allowing ourselves to consider that a thing 🙂).

Since #12987 is a legitimate Java 17 incompatibility that cannot be worked
around with `--add-opens` and `--add-exports`, this one should be merged
after that one.

This patch also removes java.base/jdk.internal.perf and
jdk.management/com.sun.management.internal from the list of required
exports and opens, because they were formerly needed for JvmMonitor,
which was rewritten in #12481 to use MXBeans instead.

This work is towards #12838.