### PR TITLE
ScanQuery supports multi column orderBy queries

### DIFF
--- a/core/src/main/java/org/apache/druid/collections/MultiColumnSorter.java
+++ b/core/src/main/java/org/apache/druid/collections/MultiColumnSorter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.collect.Ordering;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class MultiColumnSorter<T>
+{
+
+  private final MinMaxPriorityQueue<MultiColumnSorterElement<T>> queue;
+
+  public MultiColumnSorter(int limit, Comparator<MultiColumnSorterElement<T>> comparator)
+  {
+    this.queue = MinMaxPriorityQueue
+        .orderedBy(Ordering.from(comparator))
+        .maximumSize(limit)
+        .create();
+  }
+
+  /**
+   * Offer an element to the sorter.If there are multiple values of different types in the same column, a CalssCastException will be thrown
+   */
+  public void add(T element, List<Comparable> orderByColumns)
+  {
+    for (Comparable orderByColumn : orderByColumns) {
+      if (Objects.isNull(orderByColumn)) {
+        return;
+      }
+    }
+    try {
+      queue.offer(new MultiColumnSorterElement<>(element, orderByColumns));
+    }
+    catch (ClassCastException e) {
+      throw new ISE("Multiple values of different types scanOrderBy are not allowed in the same column.");
+    }
+  }
+
+  /**
+   * Drain elements in sorted order (least first).
+   */
+  public Iterator<T> drain()
+  {
+    return new Iterator<T>()
+    {
+      @Override
+      public boolean hasNext()
+      {
+        return !queue.isEmpty();
+      }
+
+      @Override
+      public T next()
+      {
+        return queue.poll().getElement();
+      }
+
+      @Override
+      public void remove()
+      {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @VisibleForTesting
+  public static class MultiColumnSorterElement<T>
+  {
+    private final T element;
+    private final List<Comparable> orderByColumValues;
+
+    public MultiColumnSorterElement(T element, List<Comparable> orderByColums)
+    {
+      this.element = element;
+      this.orderByColumValues = orderByColums;
+    }
+
+    public T getElement()
+    {
+      return element;
+    }
+
+    public List<Comparable> getOrderByColumValues()
+    {
+      return orderByColumValues;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      MultiColumnSorterElement<?> that = (MultiColumnSorterElement<?>) o;
+      return orderByColumValues == that.orderByColumValues &&
+             Objects.equals(element, that.element);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(element, orderByColumValues);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
@@ -51,11 +51,11 @@ import java.util.List;
  */
 public class ScanQueryLimitRowIterator implements CloseableIterator<ScanResultValue>
 {
-  private Yielder<ScanResultValue> yielder;
-  private ScanQuery.ResultFormat resultFormat;
-  private long limit;
-  private long count = 0;
-  private ScanQuery query;
+  protected Yielder<ScanResultValue> yielder;
+  protected ScanQuery.ResultFormat resultFormat;
+  protected long limit;
+  protected long count = 0;
+  protected ScanQuery query;
 
   ScanQueryLimitRowIterator(
       QueryRunner<ScanResultValue> baseRunner,

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryOrderByLimitRowIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryOrderByLimitRowIterator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.scan;
+
+import com.google.common.collect.Iterators;
+import org.apache.druid.collections.MultiColumnSorter;
+import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.context.ResponseContext;
+
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ScanQueryOrderByLimitRowIterator extends ScanQueryLimitRowIterator
+{
+
+  public ScanQueryOrderByLimitRowIterator(
+      QueryRunner<ScanResultValue> baseRunner,
+      QueryPlus<ScanResultValue> queryPlus,
+      ResponseContext responseContext
+  )
+  {
+    super(baseRunner, queryPlus, responseContext);
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    return !yielder.isDone();
+  }
+
+  @Override
+  public ScanResultValue next()
+  {
+    if (ScanQuery.ResultFormat.RESULT_FORMAT_VALUE_VECTOR.equals(resultFormat)) {
+      throw new UOE(ScanQuery.ResultFormat.RESULT_FORMAT_VALUE_VECTOR + " is not supported yet");
+    }
+    final int limit = Math.toIntExact(query.getScanRowsLimit());
+    List<String> sortColumns = query.getOrderBys().stream().map(orderBy -> orderBy.getColumnName()).collect(Collectors.toList());
+    List<String> orderByDirection = query.getOrderBys().stream().map(orderBy -> orderBy.getOrder().toString()).collect(Collectors.toList());
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Object>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Object>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Object> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Object> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter<Object> multiColumnSorter = new MultiColumnSorter<Object>(limit, comparator);
+
+    List<String> columns = new ArrayList<>();
+    while (!yielder.isDone()) {
+      ScanResultValue srv = yielder.get();
+      // Only replace once using the columns from the first event
+      columns = columns.isEmpty() ? srv.getColumns() : columns;
+      List<Integer> idxs = sortColumns.stream().map(c -> srv.getColumns().indexOf(c)).collect(Collectors.toList());
+      List events = (List) (srv.getEvents());
+      for (Object event : events) {
+        List<Comparable> sortValues;
+        if (event instanceof LinkedHashMap) {
+          sortValues = sortColumns.stream().map(c -> ((LinkedHashMap<Object, Comparable>) event).get(c)).collect(Collectors.toList());
+        } else {
+          sortValues = idxs.stream().map(idx -> ((List<Comparable>) event).get(idx)).collect(Collectors.toList());
+        }
+
+        multiColumnSorter.add(event, sortValues);
+      }
+
+      yielder = yielder.next(null);
+      count++;
+    }
+    final List<Object> sortedElements = new ArrayList<>(limit);
+    Iterators.addAll(sortedElements, multiColumnSorter.drain());
+    return new ScanResultValue(null, columns, sortedElements);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/collections/MultiColumnSorterTests.java
+++ b/processing/src/test/java/org/apache/druid/collections/MultiColumnSorterTests.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.query.scan.ScanQuery;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+public class MultiColumnSorterTests
+{
+  @Test
+  public void singleColumnAscSort()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(2, ImmutableList.of(2));
+    multiColumnSorter.add(3, ImmutableList.of(3));
+    multiColumnSorter.add(4, ImmutableList.of(4));
+    multiColumnSorter.add(5, ImmutableList.of(5));
+    multiColumnSorter.add(6, ImmutableList.of(7));
+    multiColumnSorter.add(7, ImmutableList.of(8));
+    multiColumnSorter.add(1, ImmutableList.of(9));
+    multiColumnSorter.add(100, ImmutableList.of(0));
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(1, ImmutableList.of(3));
+    multiColumnSorter.add(9, ImmutableList.of(6));
+    multiColumnSorter.add(11, ImmutableList.of(6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(100, 1, 1, 2, 1);
+    int i = 0;
+    while (it.hasNext()) {
+      Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+
+  @Test
+  public void singleColumnAscSortSkipNull()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(2, ImmutableList.of(2));
+    multiColumnSorter.add(3, ImmutableList.of(3));
+    multiColumnSorter.add(4, ImmutableList.of(4));
+    multiColumnSorter.add(5, ImmutableList.of(5));
+    multiColumnSorter.add(6, ImmutableList.of(7));
+    multiColumnSorter.add(7, ImmutableList.of(8));
+    multiColumnSorter.add(1, ImmutableList.of(9));
+    List list = new ArrayList();
+    list.add(null);
+    multiColumnSorter.add(100, list);
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(1, ImmutableList.of(3));
+    multiColumnSorter.add(9, ImmutableList.of(6));
+    multiColumnSorter.add(11, ImmutableList.of(6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(1, 1, 2, 1, 3);
+    int i = 0;
+    while (it.hasNext()) {
+      Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+
+  @Test
+  public void multiColumnSort()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING", "DESCENDING", "DESCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(2, ImmutableList.of(0, 0, 2));
+    multiColumnSorter.add(3, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(4, ImmutableList.of(0, 0, 4));
+    multiColumnSorter.add(5, ImmutableList.of(0, 3, 5));
+    multiColumnSorter.add(6, ImmutableList.of(0, 6, 7));
+    multiColumnSorter.add(7, ImmutableList.of(0, 0, 8));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 9));
+    multiColumnSorter.add(100, ImmutableList.of(1, 0, 0));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(9, ImmutableList.of(0, 0, 6));
+    multiColumnSorter.add(11, ImmutableList.of(0, 0, 6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(6, 5, 1, 7, 11);
+    int i = 0;
+    while (it.hasNext()) {
+      Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+
+
+  @Test
+  public void multiColumnSorSkipNull()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING", "DESCENDING", "DESCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(4, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(2, ImmutableList.of(0, 0, 2));
+    multiColumnSorter.add(3, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(4, ImmutableList.of(0, 0, 4));
+    multiColumnSorter.add(5, ImmutableList.of(0, 3, 5));
+    List list = new ArrayList();
+    list.add(null);
+    list.add(6);
+    list.add(7);
+    multiColumnSorter.add(6, list);
+    multiColumnSorter.add(7, ImmutableList.of(0, 0, 8));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 9));
+    multiColumnSorter.add(100, ImmutableList.of(1, 0, 0));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(9, ImmutableList.of(0, 0, 6));
+    multiColumnSorter.add(11, ImmutableList.of(0, 0, 6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(5, 1, 7, 9);
+    int i = 0;
+    while (it.hasNext()) {
+      Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+
+
+  @Test
+  public void multiColumnSortCalssCastException()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING", "DESCENDING", "DESCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(2, ImmutableList.of(0, 0, 2));
+    ISE ise = null;
+    try {
+      multiColumnSorter.add(3, ImmutableList.of(0, 0, 3L));
+    }
+    catch (ISE e) {
+      ise = e;
+    }
+    Assert.assertEquals("Multiple values of different types scanOrderBy are not allowed in the same column.", ise.getMessage());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.scan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -335,7 +336,7 @@ public class ScanQueryTest
               .intervals(intervalSpec)
               .build();
 
-    Assert.assertThrows("Cannot execute query with orderBy [quality ASC]", ISE.class, scanQuery::getResultOrdering);
+    Assert.assertEquals(Ordering.natural(), scanQuery.getResultOrdering());
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1288,6 +1288,7 @@ public class DruidQuery
       orderByColumns = Collections.emptyList();
     }
 
+    /*
     if (!plannerContext.engineHasFeature(EngineFeature.SCAN_ORDER_BY_NON_TIME) && !orderByColumns.isEmpty()) {
       if (orderByColumns.size() > 1 || !ColumnHolder.TIME_COLUMN_NAME.equals(orderByColumns.get(0).getColumnName())) {
         // Cannot handle this ordering.
@@ -1307,7 +1308,7 @@ public class DruidQuery
         );
         return null;
       }
-    }
+    }*/
 
     // Compute the list of columns to select, sorted and deduped.
     final SortedSet<String> scanColumns = new TreeSet<>(outputRowSignature.getColumnNames());


### PR DESCRIPTION


<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [#12958](https://github.com/apache/druid/issues/12958).

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Scanquery supports multi column orderby queries to meet the requirements of sorting detailed data
#### MultiColumnSorter add more tests and tips

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MultiColumnSorter`
 * `ScanQuery`
 * `ScanQueryEngine`
 * `ScanQueryLimitRowIterator`
 * `ScanQueryOrderByLimitRowIterator`
 * `ScanQueryQueryToolChest`
 * `ScanQueryRunnerFactory`
 * `MultiColumnSorterTests`
 * `ScanQueryResultOrderingTest`
 * `ScanQueryTest`
 * `DruidQuery`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
