### PR TITLE
Fix web-console message in MSQ data loader

### DIFF
--- a/web-console/src/views/sql-data-loader-view/ingestion-progress-dialog/ingestion-progress-dialog.tsx
+++ b/web-console/src/views/sql-data-loader-view/ingestion-progress-dialog/ingestion-progress-dialog.tsx
@@ -68,7 +68,8 @@ export const IngestionProgressDialog = React.memo(function IngestionProgressDial
         {insertResultState.isLoading() && (
           <>
             <p>
-              The data is now being loaded. You can track the task from both the Query and the Ingestion views.
+              The data is now being loaded. You can track the task from both the Query and the
+              Ingestion views.
             </p>
             <ExecutionProgressBarPane
               execution={insertResultState.intermediate}

--- a/web-console/src/views/sql-data-loader-view/ingestion-progress-dialog/ingestion-progress-dialog.tsx
+++ b/web-console/src/views/sql-data-loader-view/ingestion-progress-dialog/ingestion-progress-dialog.tsx
@@ -68,8 +68,7 @@ export const IngestionProgressDialog = React.memo(function IngestionProgressDial
         {insertResultState.isLoading() && (
           <>
             <p>
-              The data is now being loaded. You can say here or do something else. The task can be
-              tracked from both the Query view and the Ingestion views.
+              The data is now being loaded. You can track the task from both the Query and the Ingestion views.
             </p>
             <ExecutionProgressBarPane
               execution={insertResultState.intermediate}


### PR DESCRIPTION
On the batch MSQ "Load data" view, there is nothing to do once the data loading starts.
- There is no way to close the popup
- The progress bar doesn't seem to progress either after the initial increase.
- The only possible action is to "Go to Ingestion view"

![Screenshot 2022-08-30 at 5 15 01 PM](https://user-images.githubusercontent.com/18635897/187429322-d15d987a-ad95-4089-84f7-0f2adfe4b7f0.png)

Changes:
- Remove the sentence "You can stay here" as it might be a little misleading.