### PR TITLE
[Backport] FrameFile: Java 17 compatibility

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/common/ByteBufferUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/ByteBufferUtils.java
@@ -20,7 +20,6 @@
 package org.apache.druid.java.util.common;
 
 import org.apache.druid.collections.ResourceHolder;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.JvmUtils;
 
 import javax.annotation.Nullable;
@@ -39,8 +38,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ByteBufferUtils
 {
-  private static final Logger log = new Logger(ByteBufferUtils.class);
-
   // the following MethodHandle lookup code is adapted from Apache Kafka
   // https://github.com/apache/kafka/blob/e554dc518eaaa0747899e708160275f95c4e525f/clients/src/main/java/org/apache/kafka/common/utils/MappedByteBuffers.java
 

--- a/core/src/main/java/org/apache/druid/java/util/common/MappedByteBufferHandler.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/MappedByteBufferHandler.java
@@ -19,16 +19,16 @@
 
 package org.apache.druid.java.util.common;
 
+import org.apache.druid.collections.ResourceHolder;
+
 import java.nio.MappedByteBuffer;
 
 /**
- * Facilitates using try-with-resources with {@link MappedByteBuffer}s which don't implement {@link AutoCloseable}.
- *
- * <p>This interface is a specialization of {@code org.apache.druid.collections.ResourceHandler}.
+ * Facilitates using try-with-resources with {@link MappedByteBuffer}.
  *
  * @see FileUtils#map
  */
-public final class MappedByteBufferHandler implements AutoCloseable
+public final class MappedByteBufferHandler implements ResourceHolder<MappedByteBuffer>
 {
   private final MappedByteBuffer mappedByteBuffer;
 
@@ -40,6 +40,7 @@ public final class MappedByteBufferHandler implements AutoCloseable
   /**
    * Returns the wrapped buffer.
    */
+  @Override
   public MappedByteBuffer get()
   {
     return mappedByteBuffer;

--- a/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/common/FileUtilsTest.java
@@ -60,6 +60,38 @@ public class FileUtilsTest
   }
 
   @Test
+  public void testMapFileTooLarge() throws IOException
+  {
+    File dataFile = temporaryFolder.newFile("data");
+    try (RandomAccessFile raf = new RandomAccessFile(dataFile, "rw")) {
+      raf.write(42);
+      raf.setLength(1 << 20); // 1 MiB
+    }
+    final IllegalArgumentException e = Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> FileUtils.map(dataFile, 0, (long) Integer.MAX_VALUE + 1)
+    );
+    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("Cannot map region larger than"));
+  }
+
+  @Test
+  public void testMapRandomAccessFileTooLarge() throws IOException
+  {
+    File dataFile = temporaryFolder.newFile("data");
+    try (RandomAccessFile raf = new RandomAccessFile(dataFile, "rw")) {
+      raf.write(42);
+      raf.setLength(1 << 20); // 1 MiB
+    }
+    try (RandomAccessFile raf = new RandomAccessFile(dataFile, "r")) {
+      final IllegalArgumentException e = Assert.assertThrows(
+          IllegalArgumentException.class,
+          () -> FileUtils.map(raf, 0, (long) Integer.MAX_VALUE + 1)
+      );
+      MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("Cannot map region larger than"));
+    }
+  }
+
+  @Test
   public void testWriteAtomically() throws IOException
   {
     final File tmpDir = temporaryFolder.newFolder();

--- a/processing/src/main/java/org/apache/druid/frame/allocation/AppendableMemory.java
+++ b/processing/src/main/java/org/apache/druid/frame/allocation/AppendableMemory.java
@@ -19,20 +19,15 @@
 
 package org.apache.druid.frame.allocation;
 
-import com.google.common.primitives.Ints;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.druid.collections.ResourceHolder;
-import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 
 import java.io.Closeable;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -237,28 +232,6 @@ public class AppendableMemory implements Closeable
     }
 
     return sz;
-  }
-
-  /**
-   * Write current memory to a channel.
-   */
-  public void writeTo(final WritableByteChannel channel) throws IOException
-  {
-    for (int i = 0; i < blockHolders.size(); i++) {
-      final ResourceHolder<WritableMemory> memoryHolder = blockHolders.get(i);
-      final WritableMemory memory = memoryHolder.get();
-      final int limit = limits.getInt(i);
-
-      if (memory.hasByteBuffer()) {
-        final ByteBuffer byteBuffer = memory.getByteBuffer().duplicate();
-        byteBuffer.limit(Ints.checkedCast(memory.getRegionOffset(limit)));
-        byteBuffer.position(Ints.checkedCast(memory.getRegionOffset(0)));
-        Channels.writeFully(channel, byteBuffer);
-      } else {
-        // No implementation currently for Memory without backing ByteBuffer. (It's never needed.)
-        throw new UnsupportedOperationException("Cannot write Memory without backing ByteBuffer");
-      }
-    }
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileTest.java
@@ -41,15 +41,12 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -121,7 +118,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   private final int maxRowsPerFrame;
   private final boolean partitioned;
   private final AdapterType adapterType;
-  private final FrameFile.Flag openMode;
+  private final int maxMmapSize;
 
   private StorageAdapter adapter;
   private File file;
@@ -131,14 +128,14 @@ public class FrameFileTest extends InitializedNullHandlingTest
       final int maxRowsPerFrame,
       final boolean partitioned,
       final AdapterType adapterType,
-      final FrameFile.Flag openMode
+      final int maxMmapSize
   )
   {
     this.frameType = frameType;
     this.maxRowsPerFrame = maxRowsPerFrame;
     this.partitioned = partitioned;
     this.adapterType = adapterType;
-    this.openMode = openMode;
+    this.maxMmapSize = maxMmapSize;
   }
 
   @Parameterized.Parameters(
@@ -146,27 +143,26 @@ public class FrameFileTest extends InitializedNullHandlingTest
              + "maxRowsPerFrame = {1}, "
              + "partitioned = {2}, "
              + "adapter = {3}, "
-             + "openMode = {4}"
+             + "maxMmapSize = {4}"
   )
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
-    final List<FrameFile.Flag> openModes = new ArrayList<>();
-    openModes.add(FrameFile.Flag.BB_MEMORY_MAP);
-
-    if (FrameTestUtil.jdkCanDataSketchesMemoryMap()) {
-      // datasketches-memory mapping only works up through JDK 13. Higher JDK versions are unable to load 2GB+ files.
-      // Skip these tests on higher JDK versions, since we test with JDK 15 in CI even though we don't officially
-      // support it yet.
-      openModes.add(FrameFile.Flag.DS_MEMORY_MAP);
-    }
 
     for (FrameType frameType : FrameType.values()) {
       for (int maxRowsPerFrame : new int[]{1, 17, 50, PARTITION_SIZE, Integer.MAX_VALUE}) {
         for (boolean partitioned : new boolean[]{true, false}) {
           for (AdapterType adapterType : AdapterType.values()) {
-            for (FrameFile.Flag openMode : openModes) {
-              constructors.add(new Object[]{frameType, maxRowsPerFrame, partitioned, adapterType, openMode});
+            final int[] maxMmapSizes;
+
+            if (maxRowsPerFrame == 1) {
+              maxMmapSizes = new int[]{1_000, 10_000, Integer.MAX_VALUE};
+            } else {
+              maxMmapSizes = new int[]{Integer.MAX_VALUE};
+            }
+
+            for (int maxMmapSize : maxMmapSizes) {
+              constructors.add(new Object[]{frameType, maxRowsPerFrame, partitioned, adapterType, maxMmapSize});
             }
           }
         }
@@ -215,7 +211,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_numFrames() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       Assert.assertEquals(computeExpectedNumFrames(), frameFile.numFrames());
     }
   }
@@ -223,7 +219,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_numPartitions() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       Assert.assertEquals(computeExpectedNumPartitions(), frameFile.numPartitions());
     }
   }
@@ -231,7 +227,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_frame_first() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       // Skip test for empty files.
       Assume.assumeThat(frameFile.numFrames(), Matchers.greaterThan(0));
 
@@ -243,7 +239,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_frame_last() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       // Skip test for empty files.
       Assume.assumeThat(frameFile.numFrames(), Matchers.greaterThan(0));
 
@@ -260,7 +256,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_frame_outOfBoundsNegative() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage("Frame [-1] out of bounds");
       frameFile.frame(-1);
@@ -270,7 +266,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_frame_outOfBoundsTooLarge() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       expectedException.expect(IllegalArgumentException.class);
       expectedException.expectMessage(StringUtils.format("Frame [%,d] out of bounds", frameFile.numFrames()));
       frameFile.frame(frameFile.numFrames());
@@ -282,7 +278,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   {
     final FrameReader frameReader = FrameReader.create(adapter.getRowSignature());
 
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       final Sequence<List<Object>> frameFileRows = Sequences.concat(
           () -> IntStream.range(0, frameFile.numFrames())
                          .mapToObj(frameFile::frame)
@@ -299,7 +295,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_getPartitionStartFrame() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       if (partitioned) {
         for (int partitionNum = 0; partitionNum < frameFile.numPartitions(); partitionNum++) {
           Assert.assertEquals(
@@ -324,7 +320,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_file() throws IOException
   {
-    try (final FrameFile frameFile = FrameFile.open(file, openMode)) {
+    try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize)) {
       Assert.assertEquals(file, frameFile.file());
     }
   }
@@ -332,7 +328,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   @Test
   public void test_open_withDeleteOnClose() throws IOException
   {
-    FrameFile.open(file, openMode).close();
+    FrameFile.open(file, maxMmapSize).close();
     Assert.assertTrue(file.exists());
 
     FrameFile.open(file, FrameFile.Flag.DELETE_ON_CLOSE).close();
@@ -373,52 +369,6 @@ public class FrameFileTest extends InitializedNullHandlingTest
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage("Frame file is closed");
     frameFile1.newReference();
-  }
-
-  @Test
-  public void test_handleMemoryMapError_java11()
-  {
-    @SuppressWarnings("ThrowableNotThrown")
-    final RuntimeException e = Assert.assertThrows(
-        RuntimeException.class,
-        () -> FrameFile.handleMemoryMapError(new IllegalAccessError("foo"), 11)
-    );
-
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Could not map frame file"))
-    );
-
-    // Include the original error, since we don't have a better explanation.
-    MatcherAssert.assertThat(
-        e.getCause(),
-        CoreMatchers.instanceOf(IllegalAccessError.class)
-    );
-  }
-
-  @Test
-  public void test_handleMemoryMapError_java17()
-  {
-    @SuppressWarnings("ThrowableNotThrown")
-    final IllegalStateException e = Assert.assertThrows(
-        IllegalStateException.class,
-        () -> FrameFile.handleMemoryMapError(new IllegalAccessError("foo"), 17)
-    );
-
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.containsString(
-                StringUtils.format(
-                    "Cannot read frame files larger than %,d bytes with Java 17.",
-                    Integer.MAX_VALUE
-                )
-            )
-        )
-    );
-
-    // Cause not included; we want to keep logs relatively cleaner and highlight the actual issue.
-    Assert.assertNull(e.getCause());
   }
 
   private int computeExpectedNumFrames()

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
@@ -70,16 +70,11 @@ public class FrameFileWriterTest extends InitializedNullHandlingTest
 
     fileWriter.abort();
 
-    final IOException e = Assert.assertThrows(IOException.class, () -> FrameFile.open(file));
+    final IllegalStateException e = Assert.assertThrows(IllegalStateException.class, () -> FrameFile.open(file));
 
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.anyOf(
-                CoreMatchers.containsString("end marker location out of range"),
-                CoreMatchers.containsString("end marker not in expected location")
-            )
-        )
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Corrupt or truncated file?"))
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
+++ b/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
@@ -50,7 +50,6 @@ import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.timeline.SegmentId;
-import org.apache.druid.utils.JvmUtils;
 import org.junit.Assert;
 
 import javax.annotation.Nullable;
@@ -311,15 +310,6 @@ public class FrameTestUtil
     finally {
       cursor.close();
     }
-  }
-
-  /**
-   * Whether the current JDK supports {@link org.apache.datasketches.memory.Memory#map}. This is needed to read
-   * frame files 2GB+ in size.
-   */
-  public static boolean jdkCanDataSketchesMemoryMap()
-  {
-    return JvmUtils.majorVersion() < 14;
   }
 
   private static Supplier<Object> dimensionSelectorReader(final DimensionSelector selector)


### PR DESCRIPTION
Backport #12987 to 24.0.0.

Main reason: it's not _just_ about Java 17 compatibility; this also eliminates the need for special JVM args on Java 11, which will help people that are upgrading.