### PR TITLE
[Backport] Fix accounting of bytesAdded in ReadableByteChunksFrameChannel.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannel.java
@@ -139,12 +139,13 @@ public class ReadableByteChunksFrameChannel implements ReadableFrameChannel
 
       try {
         if (chunk.length > 0) {
+          bytesAdded += chunk.length;
+
           if (streamPart != StreamPart.FOOTER) {
             // Footer is discarded: it isn't useful when reading frame files as streams. (It contains pointers
             // for random access of frames.)
             chunks.add(Either.value(chunk));
             bytesBuffered += chunk.length;
-            bytesAdded += chunk.length;
           }
 
           updateStreamState();


### PR DESCRIPTION
Backport #12988 to 24.0.0.