### PR TITLE
Web console: don't show transform actions on * queries

### DIFF
--- a/web-console/src/views/query-view/query-output/query-output.tsx
+++ b/web-console/src/views/query-view/query-output/query-output.tsx
@@ -152,22 +152,23 @@ export const QueryOutput = React.memo(function QueryOutput(props: QueryOutputPro
       }
 
       if (!parsedQuery.hasStarInSelect()) {
-        basicActions.push({
-          icon: IconNames.EDIT,
-          title: `Rename column`,
-          onAction: () => {
-            setRenamingColumn(headerIndex);
+        basicActions.push(
+          {
+            icon: IconNames.EDIT,
+            title: 'Rename column',
+            onAction: () => {
+              setRenamingColumn(headerIndex);
+            },
           },
-        });
+          {
+            icon: IconNames.CROSS,
+            title: 'Remove column',
+            onAction: () => {
+              onQueryAction(q => q.removeOutputColumn(header));
+            },
+          },
+        );
       }
-
-      basicActions.push({
-        icon: IconNames.CROSS,
-        title: `Remove column`,
-        onAction: () => {
-          onQueryAction(q => q.removeOutputColumn(header));
-        },
-      });
 
       return basicActionsToMenu(basicActions)!;
     } else {

--- a/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
+++ b/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
@@ -244,7 +244,7 @@ export const ResultTablePane = React.memo(function ResultTablePane(props: Result
       }
 
       // JSON hint
-      if (column.nativeType === 'COMPLEX<json>') {
+      if (selectExpression && column.nativeType === 'COMPLEX<json>') {
         const paths = getJsonPaths(
           filterMap(queryResult.rows, row => {
             const v = row[headerIndex];
@@ -319,7 +319,7 @@ export const ResultTablePane = React.memo(function ResultTablePane(props: Result
         }
       }
 
-      if (!parsedQuery.hasStarInSelect()) {
+      if (noStar) {
         menuItems.push(
           <MenuItem
             key="edit_column"
@@ -487,16 +487,18 @@ export const ResultTablePane = React.memo(function ResultTablePane(props: Result
         }
       }
 
-      menuItems.push(
-        <MenuItem
-          key="remove_column"
-          icon={IconNames.CROSS}
-          text="Remove column"
-          onClick={() => {
-            onQueryAction(q => q.removeOutputColumn(header));
-          }}
-        />,
-      );
+      if (noStar) {
+        menuItems.push(
+          <MenuItem
+            key="remove_column"
+            icon={IconNames.CROSS}
+            text="Remove column"
+            onClick={() => {
+              onQueryAction(q => q.removeOutputColumn(header));
+            }}
+          />,
+        );
+      }
     } else {
       menuItems.push(
         <MenuItem


### PR DESCRIPTION
Don't show the transform/remove actions on `SELECT *` queries. Since they do not work.