### PR TITLE
[Backport] Make console e2e tests run in band so as to not hog task slots (#13004)

### DIFF
--- a/web-console/e2e-tests/component/workbench/overview.ts
+++ b/web-console/e2e-tests/component/workbench/overview.ts
@@ -40,7 +40,7 @@ export class WorkbenchOverview {
     const input = await this.page.waitForSelector('div.flexible-query-input textarea');
     await input.fill(query);
     await clickButton(this.page, 'Run');
-    await this.page.waitForSelector('div.result-table-pane', { timeout: 120000 });
+    await this.page.waitForSelector('div.result-table-pane', { timeout: 5 * 60 * 1000 });
 
     return await extractTable(this.page, 'div.result-table-pane div.rt-tr-group', 'div.rt-td');
   }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -32,7 +32,7 @@
     "test-base": "npm run eslint && npm run sasslint && npm run prettify-check && npm run jest",
     "test": "npm run test-base -- --silent 2>&1",
     "test-ci": "npm run test-base -- --coverage",
-    "test-e2e": "jest --config jest.e2e.config.js e2e-tests",
+    "test-e2e": "jest --runInBand --config jest.e2e.config.js e2e-tests",
     "codecov": "codecov --disable=gcov -p ..",
     "coverage": "jest --coverage src",
     "update-snapshots": "jest -u --config jest.unit.config.js",

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -60,7 +60,8 @@ function _build_distribution() {
     && cd distribution/target \
     && tar xzf "apache-druid-$(_get_druid_version)-bin.tar.gz" \
     && cd apache-druid-$(_get_druid_version) \
-    && bin/run-java -classpath "lib/*" org.apache.druid.cli.Main tools pull-deps -c org.apache.druid.extensions:druid-testing-tools \
+    && mkdir -p extensions/druid-testing-tools \
+    && cp "$(_get_code_root)/extensions-core/testing-tools/target/druid-testing-tools-$(_get_druid_version).jar" extensions/druid-testing-tools/ \
     && echo -e "\n\ndruid.extensions.loadList=[\"druid-hdfs-storage\", \"druid-kafka-indexing-service\", \"druid-datasketches\", \"druid-multi-stage-query\", \"druid-testing-tools\"]" >> conf/druid/single-server/micro-quickstart/_common/common.runtime.properties \
     && echo -e "\n\ndruid.server.http.allowedHttpMethods=[\"HEAD\"]" >> conf/druid/single-server/micro-quickstart/_common/common.runtime.properties \
   )


### PR DESCRIPTION
This makes the tests less flakey so I think it is good to backport.