### PR TITLE
Add CTA and fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ README
 .pmdruleset.xml
 .java-version
 integration-tests/gen-scripts/
-bin/
+/bin/
 *.hprof

--- a/examples/bin/greet
+++ b/examples/bin/greet
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+use strict;
+use warnings;
+use Sys::Hostname qw/hostname/;
+
+my $h = hostname;
+system("host \Q$h\E >/dev/null 2>&1");
+my $h_valid = !$?;
+
+print "Starting Apache Druid.\n";
+print "Open http://localhost:8888/" . 
+        ($h_valid ? " or http://$h:8888/" : "") . 
+        " in your browser to access the web console.\n";
+print "Or, if you have enabled TLS, use https on port 9088.\n"

--- a/examples/bin/supervise
+++ b/examples/bin/supervise
@@ -55,12 +55,13 @@ sub read_config_file
 
   my @commands;
   my @verify;
+  my @notify;
   my $kill_timeout;
   while (my $line = <$config_fh>) {
     chomp $line;
     next if $line =~ /^(\s*\#.*|\s*)$/;
 
-    if ($line =~ /^(:verify|:kill-timeout|(?:\!p[0-9]+\s+)?[^:]\S+)\s+(.+)$/) {
+    if ($line =~ /^(:verify|:notify|:kill-timeout|(?:\!p[0-9]+\s+)?[^:]\S+)\s+(.+)$/) {
       my $name = $1;
       my $order = 50;
       my $command = $2;
@@ -72,6 +73,8 @@ sub read_config_file
 
       if ($name eq ':verify') {
         push @verify, $command;
+      } elsif ($name eq ':notify') {
+        push @notify, $command;
       } elsif ($name eq ':kill-timeout') {
         $kill_timeout = int($command);
       } else {
@@ -92,7 +95,7 @@ sub read_config_file
   }
 
   close $config_fh;
-  return { commands => \@commands, verify => \@verify, 'kill-timeout' => $kill_timeout };
+  return { commands => \@commands, verify => \@verify, notify => \@notify, 'kill-timeout' => $kill_timeout };
 }
 
 sub stringify_exit_status
@@ -236,8 +239,13 @@ $SIG{TERM} = sub { if (!$killed) { $killed = 15; $killkill = time + $opt{'kill-t
 # Build up control fifo command over multiple sysreads, potentially
 my $fifobuffer = '';
 
+# Print notification lines
+for my $notify_line (@{$config->{notify}}) {
+  logit $notify_line;
+}
+
 if (defined $opt{svlogd}) {
-  logit "Staring services with log directory [svdir].";
+  logit "Starting services with log directory [$svdir].";
 } else {
   logit "Starting services with log directory [$logdir].";
 }

--- a/examples/bin/supervise
+++ b/examples/bin/supervise
@@ -139,6 +139,8 @@ sub pretty
       return "\x1b[1m$text\x1b[0m";
     } elsif ($color eq 'red') {
       return "\x1b[31m\x1b[1m$text\x1b[0m";
+    } elsif ($color eq 'green') {
+      return "\x1b[32m\x1b[1m$text\x1b[0m";
     } else {
       return $text;
     }
@@ -239,9 +241,14 @@ $SIG{TERM} = sub { if (!$killed) { $killed = 15; $killkill = time + $opt{'kill-t
 # Build up control fifo command over multiple sysreads, potentially
 my $fifobuffer = '';
 
-# Print notification lines
-for my $notify_line (@{$config->{notify}}) {
-  logit $notify_line;
+# Run notification commands and print their output
+for my $notify_cmd (@{$config->{notify}}) {
+  my $notify_output = qx[$notify_cmd 2>&1];
+  if (!$?) {
+    for my $notify_line (split /\n/, $notify_output) {
+      logit pretty($notify_line, 'green');
+    }
+  }
 }
 
 if (defined $opt{svlogd}) {

--- a/examples/conf/supervise/single-server/large.conf
+++ b/examples/conf/supervise/single-server/large.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/large.conf
+++ b/examples/conf/supervise/single-server/large.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/medium.conf
+++ b/examples/conf/supervise/single-server/medium.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/medium.conf
+++ b/examples/conf/supervise/single-server/medium.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/micro-quickstart.conf
+++ b/examples/conf/supervise/single-server/micro-quickstart.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/micro-quickstart.conf
+++ b/examples/conf/supervise/single-server/micro-quickstart.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/nano-quickstart.conf
+++ b/examples/conf/supervise/single-server/nano-quickstart.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/nano-quickstart.conf
+++ b/examples/conf/supervise/single-server/nano-quickstart.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/small.conf
+++ b/examples/conf/supervise/single-server/small.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/small.conf
+++ b/examples/conf/supervise/single-server/small.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/xlarge.conf
+++ b/examples/conf/supervise/single-server/xlarge.conf
@@ -1,5 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
+:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf

--- a/examples/conf/supervise/single-server/xlarge.conf
+++ b/examples/conf/supervise/single-server/xlarge.conf
@@ -1,6 +1,6 @@
 :verify bin/verify-java
 :verify bin/verify-default-ports
-:notify Starting Apache Druid. Open http://localhost:8888 in your web browser to access the web console.
+:notify bin/greet
 :kill-timeout 10
 
 !p10 zk bin/run-zk conf


### PR DESCRIPTION
This PR adds ability for the supervise script to print notification lines and adds a call to action (CTA) for all the single server configs.

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/177816/187778030-ca3e2a1e-3489-4ad2-9b0e-5cae06e0fd66.png">

This idea came to me from doing user testing on getting Druid running. The user started Druid with `./bin/start-micro-quickstart` and then they were lost as to what to do next (they were not following the quickstart). I think a single log line can go a long way in certain situations 