### PR TITLE
Web console: don't crash if cookies are totally disabled

### DIFF
--- a/web-console/e2e-tests/util/playwright.ts
+++ b/web-console/e2e-tests/util/playwright.ts
@@ -27,7 +27,7 @@ export async function createBrowser(): Promise<playwright.Browser> {
   const headless = process.env['DRUID_E2E_TEST_HEADLESS'] || TRUE;
   const debug = headless !== TRUE;
   const launchOptions: any = {
-    args: [`--window-size=${WIDTH},${HEIGHT + PADDING}`],
+    args: [`--window-size=${WIDTH},${HEIGHT + PADDING}`, `--disable-local-storage`],
   };
   if (debug) {
     launchOptions.headless = false;

--- a/web-console/src/utils/local-storage-keys.tsx
+++ b/web-console/src/utils/local-storage-keys.tsx
@@ -18,6 +18,14 @@
 
 import * as JSONBig from 'json-bigint-native';
 
+function noLocalStorage(): boolean {
+  try {
+    return typeof localStorage === 'undefined';
+  } catch {
+    return true;
+  }
+}
+
 export const LocalStorageKeys = {
   CAPABILITIES_OVERRIDE: 'capabilities-override' as const,
   INGESTION_SPEC: 'ingestion-spec' as const,
@@ -65,7 +73,7 @@ function prependNamespace(key: string): string {
 }
 
 export function localStorageSet(key: LocalStorageKeys, value: string): void {
-  if (typeof localStorage === 'undefined') return;
+  if (noLocalStorage()) return;
   try {
     localStorage.setItem(prependNamespace(key), value);
   } catch (e) {
@@ -78,7 +86,7 @@ export function localStorageSetJson(key: LocalStorageKeys, value: any): void {
 }
 
 export function localStorageGet(key: LocalStorageKeys): string | undefined {
-  if (typeof localStorage === 'undefined') return;
+  if (noLocalStorage()) return;
   try {
     return localStorage.getItem(prependNamespace(key)) || localStorage.getItem(key) || undefined;
   } catch (e) {
@@ -98,7 +106,7 @@ export function localStorageGetJson(key: LocalStorageKeys): any {
 }
 
 export function localStorageRemove(key: LocalStorageKeys): void {
-  if (typeof localStorage === 'undefined') return;
+  if (noLocalStorage()) return;
   try {
     localStorage.removeItem(prependNamespace(key));
   } catch (e) {

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -103,6 +103,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
             </>
           }
           minValue={2}
+          integer
           initValue={maxNumTasks}
           onSubmit={p => {
             changeQueryContext(changeMaxNumTasks(queryContext, p));


### PR DESCRIPTION
So I was reading this blog post: https://blog.tomayac.com/2022/08/30/things-not-available-when-someone-blocks-all-cookies/

And I wondered what would happen to the web console if I disabled the cookies in chrome. Turns out it crashes because even doing `typeof localStorage === 'undefined'` throws an exception.

Also made the numeric input dialog be able to represent not having any state selected.
