### PR TITLE
Improve range partitioning docs.

### DIFF
--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -433,8 +433,8 @@ For example, if you configure the following `range` partitioning during ingestio
 ```json
 "partitionsSpec": {
   "type": "range",
-  "partitionDimensions": ["coutryName", "cityName"],
-  "targetRowsPerSegment": 5000
+  "partitionDimensions": ["countryName", "cityName"],
+  "targetRowsPerSegment": 5000000
 }
 ```
 


### PR DESCRIPTION
Two improvements:

- Use a realistic targetRowsPerSegment, so if people copy and paste
  the example from the docs, it will generate reasonable segments.
- Spell "countryName" correctly.