### PR TITLE
Update ORC to 1.8.0

### DIFF
--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -31,7 +31,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>
-        <orc.version>1.7.6</orc.version>
+        <orc.version>1.8.0</orc.version>
     </properties>
     <dependencies>
         <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4557,7 +4557,7 @@ name: Apache ORC libraries
 license_category: binary
 module: extensions/druid-orc-extensions
 license_name: Apache License version 2.0
-version: 1.7.6
+version: 1.8.0
 libraries:
   - org.apache.orc: orc-mapreduce
   - org.apache.orc: orc-core


### PR DESCRIPTION
### Description

This PR aims to update ORC to 1.8.0.
This will bring the latest changes and bug fixes. 

https://github.com/apache/orc/releases/tag/v1.8.0
https://orc.apache.org/news/2022/09/03/ORC-1.8.0/

This PR has:
- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)