### PR TITLE
fix bug in /status/properties filtering

### DIFF
--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -85,6 +85,9 @@ public class StatusResource
   /**
    * filter out entries from allProperties with key containing elements in hiddenProperties (case insensitive)
    *
+   * for example, if hiddenProperties = ["pwd"] and allProperties = {"foopwd": "secret", "foo": "bar", "my.pwd": "secret"},
+   * this method will return {"foo":"bar"}
+   *
    * @return map of properties that are not filtered out.
    */
   @Nonnull

--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.MediaType;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -92,15 +93,15 @@ public class StatusResource
       Map<String, String> allProperties
   )
   {
-    return Maps.filterEntries(
-        allProperties,
-        (entry) -> hiddenProperties
-            .stream()
-            .anyMatch(
-                hiddenPropertyElement ->
-                    !StringUtils.toLowerCase(entry.getKey()).contains(StringUtils.toLowerCase(hiddenPropertyElement))
-            )
+    Map<String, String> propertyCopy = new HashMap<>(allProperties);
+    allProperties.keySet().forEach(
+        (key) -> {
+          if (hiddenProperties.stream().anyMatch((hiddenProperty) -> StringUtils.toLowerCase(key).contains(StringUtils.toLowerCase(hiddenProperty)))) {
+            propertyCopy.remove(key);
+          }
+        }
     );
+    return propertyCopy;
   }
 
   @GET

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -85,7 +85,11 @@ public class StatusResourceTest
                                                            .map(StringUtils::toLowerCase)
                                                            .collect(Collectors.toSet());
     Set<String> hiddenProperties = new HashSet<>();
-    Splitter.on(",").split(returnedProperties.get("druid.server.hiddenProperties")).forEach(hiddenProperties::add);
+    String hiddenPropertiesString = returnedProperties.get("druid.server.hiddenProperties")
+                                                      .replace("[", "")
+                                                      .replace("]", "")
+                                                      .replace("\"", "");
+    Splitter.on(",").split(hiddenPropertiesString).forEach(hiddenProperties::add);
     hiddenProperties.forEach(
         (property) -> {
           lowerCasePropertyNames.forEach(

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.druid.server;
 
-import com.google.common.base.Splitter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -32,7 +33,6 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,18 +64,18 @@ public class StatusResourceTest
   }
 
   @Test
-  public void testHiddenProperties()
+  public void testHiddenProperties() throws Exception
   {
     testHiddenPropertiesWithPropertyFileName("status.resource.test.runtime.properties");
   }
 
   @Test
-  public void testHiddenPropertiesContain()
+  public void testHiddenPropertiesContain() throws Exception
   {
     testHiddenPropertiesWithPropertyFileName("status.resource.test.runtime.hpc.properties");
   }
 
-  private void testHiddenPropertiesWithPropertyFileName(String fileName)
+  private void testHiddenPropertiesWithPropertyFileName(String fileName) throws Exception
   {
     Injector injector = Guice.createInjector(Collections.singletonList(new PropertiesModule(Collections.singletonList(
         fileName))));
@@ -84,12 +84,8 @@ public class StatusResourceTest
                                                            .stream()
                                                            .map(StringUtils::toLowerCase)
                                                            .collect(Collectors.toSet());
-    Set<String> hiddenProperties = new HashSet<>();
-    String hiddenPropertiesString = returnedProperties.get("druid.server.hiddenProperties")
-                                                      .replace("[", "")
-                                                      .replace("]", "")
-                                                      .replace("\"", "");
-    Splitter.on(",").split(hiddenPropertiesString).forEach(hiddenProperties::add);
+
+    Set<String> hiddenProperties = new ObjectMapper().readValue(returnedProperties.get("druid.server.hiddenProperties"), new TypeReference<Set<String>>() {});
     hiddenProperties.forEach(
         (property) -> {
           lowerCasePropertyNames.forEach(

--- a/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/StatusResourceTest.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -85,7 +86,15 @@ public class StatusResourceTest
                                                            .map(StringUtils::toLowerCase)
                                                            .collect(Collectors.toSet());
 
-    Set<String> hiddenProperties = new ObjectMapper().readValue(returnedProperties.get("druid.server.hiddenProperties"), new TypeReference<Set<String>>() {});
+    Assert.assertTrue(
+        "The list of unfiltered Properties is not > the list of filtered Properties?!?",
+        injector.getInstance(Properties.class).stringPropertyNames().size() > returnedProperties.size()
+    );
+
+    Set<String> hiddenProperties = new ObjectMapper().readValue(
+        returnedProperties.get("druid.server.hiddenProperties"),
+        new TypeReference<Set<String>>() {});
+
     hiddenProperties.forEach(
         (property) -> {
           lowerCasePropertyNames.forEach(


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed a bug in `/status/properties` endpoint

#12950 introduced ~or exposed~ an issue with masking sensitive properties when calling `/status/properties`. 

The unit test for this method was broken before the aforementioned patch was created which lead this patch to silently breaking the actual code

```JAVA
Splitter.on(",").split(returnedProperties.get("druid.server.hiddenProperties")).forEach(hiddenProperties::add);
```

That java is not a valid way to split a string with the format `["item1", ... "itemN"]` ... `[` `]` `"` all need to be stripped out of the string before that line is valid.

Due to that bad splitting of the string, the unit test was passing, but not testing what we wanted it to test. My patch fixes the splitting of that hiddenProperties string. This fix causes the test to fail, alerting me to the fact that the filtering method is not working as intended. I went away from using the filtered map concept in the original patch, and instead removed the sensitive k:v pairs from a copy of the passed map and returned that modified map. This now passes the updated unit tests and has been verified in a cluster.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `StatusResource`
 * `StatusResourceTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [X] been self-reviewed.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [X] been tested in a test Druid cluster.
