### PR TITLE
Fix QueryContext race condition

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -97,7 +97,7 @@ public class DruidConnection
       final DruidJdbcStatement statement = new DruidJdbcStatement(
           connectionId,
           statementId,
-          context,
+          context.copy(),
           sqlStatementFactory
       );
 
@@ -109,7 +109,7 @@ public class DruidConnection
 
   public DruidJdbcPreparedStatement createPreparedStatement(
       SqlStatementFactory sqlStatementFactory,
-      SqlQueryPlus sqlRequest,
+      SqlQueryPlus sqlQueryPlus,
       final long maxRowCount)
   {
     final int statementId = statementCounter.incrementAndGet();
@@ -127,7 +127,7 @@ public class DruidConnection
 
       @SuppressWarnings("GuardedBy")
       final PreparedStatement statement = sqlStatementFactory.preparedStatement(
-          sqlRequest.withContext(context)
+          sqlQueryPlus.withContext(context.copy())
       );
       final DruidJdbcPreparedStatement jdbcStmt = new DruidJdbcPreparedStatement(
           connectionId,


### PR DESCRIPTION
Fixes [#12955](https://github.com/apache/druid/issues/12955), [#12739](https://github.com/apache/druid/issues/12739).

Ensures that JDBC makes a copy of the `QueryContext` stored on a connection when creating statements. Doing so avoids race conditions which produced flaky results in `DruidAvaticaHandlerTest.testConcurrentQueries()`.

An earlier version of this PR first took a hack approach. @gianm correctly pointed out that the problem is really with a flaw in JDBC. A second version explored the alternative of replacing `QueryContext`. That is a good idea, and expands on work that @FrankChen021 started in #13022, but was overkill for the specific problem in question. The refactoring was moved to a new PR, #13071. In the end, the simplest fix was good enough, and is safe, so this PR presents just that minimal fix.

The fix was verified by running `testConcurrentQueries()` many times in a loop until it failed due to an OOM. That OOM is a separate issue to be addressed elsewhere.

<hr>

This PR has:
- [X] been self-reviewed.
- [ ] been tested in a test Druid cluster.
