### PR TITLE
improve nested column serializer

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
@@ -36,7 +36,7 @@ import java.util.function.Supplier;
  * Reader for a virtual contiguous address range backed by compressed blocks of data.
  *
  * Format:
- * | version (byte) | compression (byte) | num blocks (int) | block size (int) | end offsets | compressed data |
+ * | version (byte) | compression (byte) | block size (int) | num blocks (int) | end offsets | compressed data |
  *
  * This mechanism supports two modes of use, the first where callers may ask for a range of data from the underlying
  * blocks, provided by {@link #getRange(long, int)}. The {@link ByteBuffer} provided by this method may or may not
@@ -48,6 +48,8 @@ import java.util.function.Supplier;
  * {@link #seekBlock(int)} to change which block is currently loaded.
  *
  * {@link #getRange(long, int)} uses these same mechanisms internally to supply data.
+ *
+ * @see CompressedBlockSerializer for writer
  */
 public final class CompressedBlockReader implements Closeable
 {

--- a/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryIdLookup.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryIdLookup.java
@@ -22,10 +22,6 @@ package org.apache.druid.segment.nested;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.Double2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.doubles.Double2IntMap;
-import it.unimi.dsi.fastutil.ints.Int2DoubleLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2DoubleMap;
-import it.unimi.dsi.fastutil.ints.Int2LongLinkedOpenHashMap;
-import it.unimi.dsi.fastutil.ints.Int2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
@@ -35,18 +31,15 @@ import javax.annotation.Nullable;
 
 /**
  * Ingestion time dictionary identifier lookup, used by {@link NestedDataColumnSerializer} to build a global dictionary
- * id to value mapping for the 'stacked' global value dictionaries. Also provides reverse lookup for numeric values,
- * since they serialize a value column
+ * id to value mapping for the 'stacked' global value dictionaries.
  */
 public class GlobalDictionaryIdLookup
 {
   private final Object2IntMap<String> stringLookup;
 
   private final Long2IntMap longLookup;
-  private final Int2LongMap reverseLongLookup;
 
   private final Double2IntMap doubleLookup;
-  private final Int2DoubleMap reverseDoubleLookup;
 
   private int dictionarySize;
 
@@ -54,9 +47,7 @@ public class GlobalDictionaryIdLookup
   {
     this.stringLookup = new Object2IntLinkedOpenHashMap<>();
     this.longLookup = new Long2IntLinkedOpenHashMap();
-    this.reverseLongLookup = new Int2LongLinkedOpenHashMap();
     this.doubleLookup = new Double2IntLinkedOpenHashMap();
-    this.reverseDoubleLookup = new Int2DoubleLinkedOpenHashMap();
   }
 
   public void addString(@Nullable String value)
@@ -82,7 +73,6 @@ public class GlobalDictionaryIdLookup
     );
     int id = dictionarySize++;
     longLookup.put(value, id);
-    reverseLongLookup.put(id, value);
   }
 
   public int lookupLong(@Nullable Long value)
@@ -93,20 +83,10 @@ public class GlobalDictionaryIdLookup
     return longLookup.get(value.longValue());
   }
 
-  @Nullable
-  public Long lookupLong(int id)
-  {
-    if (id == 0) {
-      return null;
-    }
-    return reverseLongLookup.get(id);
-  }
-
   public void addDouble(double value)
   {
     int id = dictionarySize++;
     doubleLookup.put(value, id);
-    reverseDoubleLookup.put(id, value);
   }
 
   public int lookupDouble(@Nullable Double value)
@@ -115,14 +95,5 @@ public class GlobalDictionaryIdLookup
       return 0;
     }
     return doubleLookup.get(value.doubleValue());
-  }
-
-  @Nullable
-  public Double lookupDouble(int id)
-  {
-    if (id == 0) {
-      return null;
-    }
-    return reverseDoubleLookup.get(id);
   }
 }


### PR DESCRIPTION
changes:
* long and double value columns are now written directly, at the same time as writing out the 'intermediary' dictionaryid column with unsorted ids
* remove reverse value lookup from GlobalDictionaryIdLookup since it is no longer needed

### Description
This PR improves nested column serializer heap usage and write performance by modifying the serializer to write the long and double value columns for the nested fields on the "first" pass though the data, which is building the local dictionaries for the nested fields while writing out the 'raw' JSON-smile encoded column. This is a change from the current version, which writes out the value columns on the "second" pass, where it sorts the local dictionary for each field and writes out the new dictionaryid int column, builds bitmap indexes, and writes the column itself.

Making this change eliminate the need of the 'reverse' value lookup for long and double values in `GlobalDictionaryIdLookup`, and so they have been removed. Besides eliminating this from memory, it also saves a value lookup per row per column to write the long and double value columns.

I haven't measured this at all yet, but naively I assume it should be a fair bit more chill in practice to do things this way.

<hr>


This PR has:
- [ ] been self-reviewed.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
