### PR TITLE
Web console: quote columns, datasources in auto complete if needed

### DIFF
--- a/web-console/src/views/query-view/query-input/query-input.tsx
+++ b/web-console/src/views/query-view/query-input/query-input.tsx
@@ -20,6 +20,7 @@ import { ResizeEntry } from '@blueprintjs/core';
 import { ResizeSensor2 } from '@blueprintjs/popover2';
 import type { Ace } from 'ace-builds';
 import ace from 'ace-builds';
+import { SqlRef, SqlTableRef } from 'druid-query-toolkit';
 import escape from 'lodash.escape';
 import React from 'react';
 import AceEditor from 'react-ace';
@@ -150,7 +151,7 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
     ) {
       const completions = ([] as any[]).concat(
         uniq(columnMetadata.map(d => d.TABLE_SCHEMA)).map(v => ({
-          value: v,
+          value: SqlTableRef.create(v).toString(),
           score: 10,
           meta: 'schema',
         })),
@@ -159,7 +160,7 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
             .filter(d => (currentSchema ? d.TABLE_SCHEMA === currentSchema : true))
             .map(d => d.TABLE_NAME),
         ).map(v => ({
-          value: v,
+          value: SqlTableRef.create(v).toString(),
           score: 49,
           meta: 'datasource',
         })),
@@ -172,7 +173,7 @@ export class QueryInput extends React.PureComponent<QueryInputProps, QueryInputS
             )
             .map(d => d.COLUMN_NAME),
         ).map(v => ({
-          value: v,
+          value: SqlRef.column(v).toString(),
           score: 50,
           meta: 'column',
         })),

--- a/web-console/src/views/workbench-view/flexible-query-input/flexible-query-input.tsx
+++ b/web-console/src/views/workbench-view/flexible-query-input/flexible-query-input.tsx
@@ -21,6 +21,7 @@ import { ResizeSensor2 } from '@blueprintjs/popover2';
 import type { Ace } from 'ace-builds';
 import ace from 'ace-builds';
 import classNames from 'classnames';
+import { SqlRef, SqlTableRef } from 'druid-query-toolkit';
 import escape from 'lodash.escape';
 import React from 'react';
 import AceEditor from 'react-ace';
@@ -163,7 +164,7 @@ export class FlexibleQueryInput extends React.PureComponent<
     ) {
       const completions = ([] as any[]).concat(
         uniq(columnMetadata.map(d => d.TABLE_SCHEMA)).map(v => ({
-          value: v,
+          value: SqlTableRef.create(v).toString(),
           score: 10,
           meta: 'schema',
         })),
@@ -172,7 +173,7 @@ export class FlexibleQueryInput extends React.PureComponent<
             .filter(d => (currentSchema ? d.TABLE_SCHEMA === currentSchema : true))
             .map(d => d.TABLE_NAME),
         ).map(v => ({
-          value: v,
+          value: SqlTableRef.create(v).toString(),
           score: 49,
           meta: 'datasource',
         })),
@@ -185,7 +186,7 @@ export class FlexibleQueryInput extends React.PureComponent<
             )
             .map(d => d.COLUMN_NAME),
         ).map(v => ({
-          value: v,
+          value: SqlRef.column(v).toString(),
           score: 50,
           meta: 'column',
         })),


### PR DESCRIPTION
Auto complete should add the proper quotes if the column / datasource / schema needs it (like if it is reserved).

<img width="463" alt="image" src="https://user-images.githubusercontent.com/177816/189214161-43f2bc88-07dc-4178-83ce-054070ee1d11.png">
