### PR TITLE
Install bash-static in docker image

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -50,6 +50,8 @@ LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox
 RUN ["/busybox/busybox", "--install", "/bin"]
+RUN wget https://github.com/robxu9/bash-static/releases/download/5.1.016-1.2.3/bash-linux-x86_64 -O /bin/bash \
+ && chmod 755 /bin/bash
 
 RUN addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid


### PR DESCRIPTION
Fixes issue #13057 

This is a partial backport of #13059 

With recent changes (addition of `run-java` script), 
`bash-static` is required to run the docker container. Otherwise, ingestion fails with the following error.

```
middlemanager    | java.io.IOException: Cannot run program "bin/run-java": error=2, No such file or directory
middlemanager    |      at java.lang.ProcessBuilder.start(ProcessBuilder.java:1128) ~[?:?]
middlemanager    |      at java.lang.ProcessBuilder.start(ProcessBuilder.java:1071) ~[?:?]
middlemanager    |      at org.apache.druid.indexing.overlord.ForkingTaskRunner.runTaskProcess(ForkingTaskRunner.java:491) ~[druid-indexing-service-25.0.0-SNAPSHOT.jar:25.0.0-SNAPSHOT]
middlemanager    |      at org.apache.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:390) ~[druid-indexing-service-25.0.0-SNAPSHOT.jar:25.0.0-SNAPSHOT]
middlemanager    |      at org.apache.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:153) ~[druid-indexing-service-25.0.0-SNAPSHOT.jar:25.0.0-SNAPSHOT]
middlemanager    |      at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
middlemanager    |      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
middlemanager    |      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
middlemanager    |      at java.lang.Thread.run(Thread.java:829) ~[?:?]
middlemanager    | Caused by: java.io.IOException: error=2, No such file or directory
middlemanager    |      at java.lang.ProcessImpl.forkAndExec(Native Method) ~[?:?]
middlemanager    |      at java.lang.ProcessImpl.<init>(ProcessImpl.java:340) ~[?:?]
middlemanager    |      at java.lang.ProcessImpl.start(ProcessImpl.java:271) ~[?:?]
middlemanager    |      at java.lang.ProcessBuilder.start(ProcessBuilder.java:1107) ~[?:?]
```

The other changes from PR #13059 are not being backported as they are potential improvements,
not bug-fixes and might pose some risk to the upcoming release.

---

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
