### PR TITLE
Getting extension list from pom

### DIFF
--- a/distribution/bin/generate-license-dependency-reports.py
+++ b/distribution/bin/generate-license-dependency-reports.py
@@ -59,7 +59,8 @@ def generate_reports(druid_path, tmp_path, exclude_ext, num_threads):
 
     if not exclude_ext:
         extensions_core_path = os.path.join(druid_path, "extensions-core")
-        extension_dirs = os.listdir(extensions_core_path)
+        command = "mvn -Dexec.executable='echo' -Dexec.args='${basedir}' exec:exec -q | grep extensions-core | grep -o '[^/]*$'"
+        extension_dirs = subprocess.check_output(command, cwd=druid_path, shell=True).decode().split('\n')[:-1]
         print("Found {} extensions".format(len(extension_dirs)))
         for extension_dir in extension_dirs:
             print("extension dir: {}".format(extension_dir))


### PR DESCRIPTION
Currently we are getting the extensions by getting all the directories present in extensions-core directory.

Going forward, we want to get the list of modules from the pom.xml. For this we will using the following command -
`mvn -Dexec.executable='echo' -Dexec.args='${basedir}' exec:exec -q | grep extensions-core | grep -o '[^/]*$'` .