### PR TITLE
Move JDK11 ITs to cron stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -699,21 +699,25 @@ jobs:
     - <<: *integration_batch_index
       name: "(Compile=openjdk8, Run=openjdk11) batch index integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_input_format
       name: "(Compile=openjdk8, Run=openjdk11) input format integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=input-format' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_input_source
       name: "(Compile=openjdk8, Run=openjdk11) input source integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=input-source' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_perfect_rollup_parallel_batch_index
       name: "(Compile=openjdk8, Run=openjdk11) perfect rollup parallel batch index integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=perfect-rollup-parallel-batch-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_query
@@ -724,11 +728,13 @@ jobs:
     - <<: *integration_query_retry
       name: "(Compile=openjdk8, Run=openjdk11) query retry integration test for missing segments"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=query-retry' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager' OVERRIDE_CONFIG_PATH='./environment-configs/test-groups/prepopulated-data'
 
     - <<: *integration_query_error
       name: "(Compile=openjdk8, Run=openjdk11) query error integration test for missing segments"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=query-error' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager' OVERRIDE_CONFIG_PATH='./environment-configs/test-groups/prepopulated-data'
 
     - <<: *integration_security
@@ -744,21 +750,25 @@ jobs:
     - <<: *integration_realtime_index
       name: "(Compile=openjdk8, Run=openjdk11) realtime index integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=realtime-index' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_append_ingestion
       name: "(Compile=openjdk8, Run=openjdk11) append ingestion integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=append-ingestion' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_compaction_tests
       name: "(Compile=openjdk8, Run=openjdk11) compaction integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-Dgroups=compaction' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_tests
       name: "(Compile=openjdk8, Run=openjdk11) other integration test"
       jdk: openjdk8
+      stage: cron
       env: TESTNG_GROUPS='-DexcludedGroups=batch-index,input-format,input-source,perfect-rollup-parallel-batch-index,kafka-index,query,query-retry,query-error,realtime-index,security,ldap-security,s3-deep-storage,gcs-deep-storage,azure-deep-storage,hdfs-deep-storage,s3-ingestion,kinesis-index,kinesis-data-format,kafka-transactional-index,kafka-index-slow,kafka-transactional-index-slow,kafka-data-format,hadoop-s3-to-s3-deep-storage,hadoop-s3-to-hdfs-deep-storage,hadoop-azure-to-azure-deep-storage,hadoop-azure-to-hdfs-deep-storage,hadoop-gcs-to-gcs-deep-storage,hadoop-gcs-to-hdfs-deep-storage,aliyun-oss-deep-storage,append-ingestion,compaction,high-availability,upgrade,shuffle-deep-store,custom-coordinator-duties' JVM_RUNTIME='-Djvm.runtime=11' USE_INDEXER='middleManager'
 
     - <<: *integration_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,11 @@ install: ./check_test_suite.py && travis_terminate 0  || echo 'Running Maven ins
 # 2. Tests - phase 2
 # 3. cron
 #
-# The cron type only runs jobs that are marked with stage cron. The ron stage also runs alongside
+# The cron type only runs jobs that are marked with stage cron. The cron stage also runs alongside
 # phase 1 and phase 2 for commit builds on release branches.
 # The test type is split into 2 stages. This is done so that more PRs can run their validation
 # in parallel. The first phase is meant to include sanity test jobs. The jobs in this phase are
-# meant to be fast. The second phase is meant to run all other tests.
+# meant to be fast. The second phase is meant to run all other tests. Cron stage does not run on pull requests.
 # Jobs with known flaky tests should be put in the second phase since the second phase will not
 # start if there are any failures in the second stage.
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ install: ./check_test_suite.py && travis_terminate 0  || echo 'Running Maven ins
 # 2. Tests - phase 2
 # 3. cron
 #
-# The cron type only runs jobs that are marked with stage cron.
+# The cron type only runs jobs that are marked with stage cron. The ron stage also runs alongside
+# phase 1 and phase 2 for commit builds on release branches.
 # The test type is split into 2 stages. This is done so that more PRs can run their validation
 # in parallel. The first phase is meant to include sanity test jobs. The jobs in this phase are
 # meant to be fast. The second phase is meant to run all other tests.
@@ -65,7 +66,7 @@ stages:
   - name: Tests - phase 2
     if: type != cron
   - name: cron
-    if: type = cron
+    if: type = cron OR (type != pull_request AND branch != master)
 
 jobs:
   include:

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -116,6 +116,9 @@ For docs, please make sure to add any relevant redirects in `website/redirects.j
 The only additions to the release branch after branching should be bug fixes, which should be back-ported from the master branch, via a second PR or a cherry-pick, not with a direct PR to the release branch.  
 
 Release manager must also ensure that CI is passing successfully on the release branch. Since CI on branch can contain additional tests such as ITs for different JVM flavours. (Note that CI is sometimes flaky for older branches).
+To check the CI status on a release branch, you can to the commits page e.g. https://github.com/apache/druid/commits/24.0.0. On this page, latest commmit should show
+a green &#10004; in the commit description. If commit has a failed build, please click on red &#10005; icon in the commit description to go to travis build job and investigate. 
+You can restart a failed build via travis if it is flaky. 
 
 Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone and CI on branch is green, the next step is to put together a release candidate.
 

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -116,8 +116,8 @@ For docs, please make sure to add any relevant redirects in `website/redirects.j
 The only additions to the release branch after branching should be bug fixes, which should be back-ported from the master branch, via a second PR or a cherry-pick, not with a direct PR to the release branch.  
 
 Release manager must also ensure that CI is passing successfully on the release branch. Since CI on branch can contain additional tests such as ITs for different JVM flavours. (Note that CI is sometimes flaky for older branches).
-To check the CI status on a release branch, you can to the commits page e.g. https://github.com/apache/druid/commits/24.0.0. On this page, latest commmit should show
-a green &#10004; in the commit description. If commit has a failed build, please click on red &#10005; icon in the commit description to go to travis build job and investigate. 
+To check the CI status on a release branch, you can go to the commits page e.g. https://github.com/apache/druid/commits/24.0.0. On this page, latest commmit should show
+a green &#10004; in the commit description. If the commit has a failed build, please click on red &#10005; icon in the commit description to go to travis build job and investigate. 
 You can restart a failed build via travis if it is flaky. 
 
 Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone and CI on branch is green, the next step is to put together a release candidate.

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -113,9 +113,11 @@ For docs, please make sure to add any relevant redirects in `website/redirects.j
 
 ### Release branch hygiene
 
-The only additions to the release branch after branching should be bug fixes, which should be back-ported from the master branch, via a second PR, not with a direct PR to the release branch. Bug fix release branches may be initially populated via cherry-picking, but it is recommended to leave at least 1 commit to do as a backport PR in order to run through CI. (Note that CI is sometimes flaky for older branches).
+The only additions to the release branch after branching should be bug fixes, which should be back-ported from the master branch, via a second PR or a cherry-pick, not with a direct PR to the release branch.  
 
-Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone, the next step is to put together a release candidate.
+Release manager must also ensure that CI is passing successfully on the release branch. Since CI on branch can contain additional tests such as ITs for different JVM flavours. (Note that CI is sometimes flaky for older branches).
+
+Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone and CI on branch is green, the next step is to put together a release candidate.
 
 ## Initial setup to create a release candidate
 


### PR DESCRIPTION
This PR moves some of the ITs for JRE 11 runtime to the cron stage. The reason is simple - we have a lot of tests and our PR checks take too long to finish. This would improve the situation slightly. I have kept the following ITs around
 - query integration test (so we at least check the whole ingestion and querying end-to-end on runtime 11)
 - security integration test, leadership integration test, query integration test (mariaDB) - I kept these around since they involve another service like a zookeeper. There are no unit tests with the MariaDB driver. The same goes for TLSCertificateChecker.

This PR has:
- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.
