### PR TITLE
Update Snappy to 1.1.8.4.

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3798,7 +3798,7 @@ name: snappy-java
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
-version: 1.1.2.6
+version: 1.1.8.4
 libraries:
   - org.xerial.snappy: snappy-java
 
@@ -4979,7 +4979,7 @@ libraries:
 
 name: snappy-java
 license_category: binary
-version: 1.1.7.1
+version: 1.1.8.4
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/pom.xml
+++ b/pom.xml
@@ -730,6 +730,11 @@
                 <version>1.8.0</version>
             </dependency>
             <dependency>
+                <groupId>org.xerial.snappy</groupId>
+                <artifactId>snappy-java</artifactId>
+                <version>1.1.8.4</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
                 <version>${protobuf.version}</version>


### PR DESCRIPTION
Prior to this, because snappy-java wasn't included in dependencyManagement, we actually shipped multiple different versions for different extensions, ranging from 1.1.7.1 to 1.1.8.4. Now, we standardize on 1.1.8.4.

Among other things, this enables the tests to pass on M1 Macs.