### PR TITLE
Web console: link to error code docs

### DIFF
--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -576,13 +576,6 @@ export class WorkbenchQuery {
       apiQuery.query = queryPrepend + apiQuery.query + queryAppend;
     }
 
-    const m = /(--:context\s.+)(?:\n|$)/.exec(apiQuery.query);
-    if (m) {
-      throw new Error(
-        `This query contains a context comment '${m[1]}'. Context comments have been deprecated. Please rewrite the context comment as a context parameter. The context parameter editor is located in the "Engine" dropdown.`,
-      );
-    }
-
     const ingestQuery = this.isIngestQuery();
     if (!unlimited && !ingestQuery) {
       apiQuery.context ||= {};

--- a/web-console/src/links.ts
+++ b/web-console/src/links.ts
@@ -63,6 +63,7 @@ export type LinkNames =
   | 'DOCS_SQL'
   | 'DOCS_RUNE'
   | 'DOCS_API'
+  | 'DOCS_MSQ_ERROR'
   | 'COMMUNITY'
   | 'SLACK'
   | 'USER_GROUP'
@@ -82,6 +83,8 @@ export function getLink(linkName: LinkNames): string {
       return `${links.docsHref}/querying/querying.html`;
     case 'DOCS_API':
       return `${links.docsHref}/operations/api-reference.html`;
+    case 'DOCS_MSQ_ERROR':
+      return `${links.docsHref}/multi-stage-query/concepts.html#error-codes`;
     case 'COMMUNITY':
       return links.communityHref;
     case 'SLACK':

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -8,7 +8,12 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
   <p
     className="error-message-text"
   >
-    TooManyWarnings: 
+    <Memo(ExternalLink)
+      href="https://druid.apache.org/docs/latest/multi-stage-query/concepts.html#error-codes"
+    >
+      TooManyWarnings
+    </Memo(ExternalLink)>
+    : 
     Too many warnings of type CannotParseExternalData generated (max = 10)
   </p>
   <div>

--- a/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-error-pane/execution-error-pane.tsx
@@ -20,9 +20,10 @@ import { Callout } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React, { useState } from 'react';
 
-import { ClickToCopy } from '../../../components';
+import { ClickToCopy, ExternalLink } from '../../../components';
 import { ShowValueDialog } from '../../../dialogs/show-value-dialog/show-value-dialog';
 import { Execution } from '../../../druid-models';
+import { getLink } from '../../../links';
 import { downloadQueryDetailArchive } from '../../../utils';
 
 import './execution-error-pane.scss';
@@ -43,7 +44,12 @@ export const ExecutionErrorPane = React.memo(function ExecutionErrorPane(
   return (
     <Callout className="execution-error-pane" icon={IconNames.ERROR}>
       <p className="error-message-text">
-        {error.errorCode && <>{`${error.errorCode}: `}</>}
+        {error.errorCode && (
+          <>
+            <ExternalLink href={getLink('DOCS_MSQ_ERROR')}>{error.errorCode}</ExternalLink>
+            {': '}
+          </>
+        )}
         {error.errorMessage || (exceptionStackTrace || '').split('\n')[0]}
         {exceptionStackTrace && (
           <>


### PR DESCRIPTION
Make the error codes clickable links:

<img width="921" alt="image" src="https://user-images.githubusercontent.com/177816/190454388-b7555425-d5a9-4b85-8065-25ad6107b7ea.png">
