### PR TITLE
Web console: support Kafka lookups

### DIFF
--- a/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
@@ -74,6 +74,7 @@ exports[`LookupEditDialog matches snapshot 1`] = `
             "suggestions": Array [
               "map",
               "cachedNamespace",
+              "kafka",
             ],
             "type": "string",
           },
@@ -396,6 +397,35 @@ exports[`LookupEditDialog matches snapshot 1`] = `
             "defined": [Function],
             "info": "If the underlying map is injective (keys and values are unique) then optimizations can occur internally by setting this to true",
             "name": "injective",
+            "type": "boolean",
+          },
+          Object {
+            "defined": [Function],
+            "info": "The Kafka topic to read the data from",
+            "name": "kafkaTopic",
+            "required": true,
+            "type": "string",
+          },
+          Object {
+            "defined": [Function],
+            "height": "100px",
+            "issueWithValue": [Function],
+            "name": "kafkaProperties",
+            "required": true,
+            "type": "json",
+          },
+          Object {
+            "defaultValue": 0,
+            "defined": [Function],
+            "info": "How long to wait for an initial connection",
+            "name": "connectTimeout",
+            "type": "number",
+          },
+          Object {
+            "defaultValue": false,
+            "defined": [Function],
+            "info": "If the underlying map is one-to-one (keys and values are unique) then optimizations can occur internally by setting this to true",
+            "name": "isOneToOne",
             "type": "boolean",
           },
         ]

--- a/web-console/src/views/lookups-view/lookups-view.tsx
+++ b/web-console/src/views/lookups-view/lookups-view.tsx
@@ -419,7 +419,9 @@ export class LookupsView extends React.PureComponent<LookupsViewProps, LookupsVi
             className: 'padded',
             accessor: row => deepGet(row, 'spec.extractionNamespace.pollPeriod'),
             Cell: ({ original }) => {
-              if (original.spec.type === 'map') return 'Static map';
+              const { type } = original.spec;
+              if (type === 'map') return 'Static map';
+              if (type === 'kafka') return 'Kafka based';
               const pollPeriod = deepGet(original, 'spec.extractionNamespace.pollPeriod');
               if (!pollPeriod) {
                 return (


### PR DESCRIPTION
Add support for [Kafka based lookups](https://druid.apache.org/docs/latest/development/extensions-core/kafka-extraction-namespace.html) rendering and input in the console.

Input:

<img width="625" alt="image" src="https://user-images.githubusercontent.com/177816/190553222-7c89ebee-e6b3-4924-ac5f-e9008f420711.png">

Rendering:

<img width="1650" alt="image" src="https://user-images.githubusercontent.com/177816/190553362-eb42bd5e-d943-4c94-b452-d685ee5246b8.png">
