### PR TITLE
Web console: correctly escape path based flatten specs

### DIFF
--- a/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
@@ -22,7 +22,7 @@ describe('flatten-spec', () => {
   describe('computeFlattenExprsForData', () => {
     const data = [
       {
-        context: { host: 'cla', topic: 'moon', bonus: { foo: 'bar' } },
+        context: { host: 'cla', topic: 'moon', bonus: { 'fo.o': 'bar' } },
         tags: ['a', 'b', 'c'],
         messages: [
           { metric: 'request/time', value: 122 },
@@ -32,7 +32,7 @@ describe('flatten-spec', () => {
         value: 5,
       },
       {
-        context: { host: 'piv', popic: 'sun' },
+        context: { 'host': 'piv', '1pic': 'sun' },
         tags: ['a', 'd'],
         messages: [
           { metric: 'request/time', value: 44 },
@@ -41,7 +41,7 @@ describe('flatten-spec', () => {
         value: 4,
       },
       {
-        context: { host: 'imp', dopik: 'fun' },
+        context: { 'host': 'imp', 'do\npic': 'fun' },
         tags: ['x', 'y'],
         messages: [
           { metric: 'request/time', value: 4 },
@@ -53,22 +53,12 @@ describe('flatten-spec', () => {
     ];
 
     it('works for path, ignore-arrays', () => {
-      expect(computeFlattenExprsForData(data, 'path', 'ignore-arrays')).toEqual([
-        '$.context.bonus.foo',
-        '$.context.dopik',
+      expect(computeFlattenExprsForData(data, 'ignore-arrays')).toEqual([
+        "$.context.bonus['fo.o']",
         '$.context.host',
-        '$.context.popic',
         '$.context.topic',
-      ]);
-    });
-
-    it('works for jq, ignore-arrays', () => {
-      expect(computeFlattenExprsForData(data, 'jq', 'ignore-arrays')).toEqual([
-        '.context.bonus.foo',
-        '.context.dopik',
-        '.context.host',
-        '.context.popic',
-        '.context.topic',
+        "$.context['1pic']",
+        "$.context['do\npic']",
       ]);
     });
   });

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
@@ -41,7 +41,7 @@ describe('flatten-spec', () => {
         value: 4,
       },
       {
-        context: { 'host': 'imp', 'do\npic': 'fun' },
+        context: { 'host': 'imp', "do\npi'c": 'fun' },
         tags: ['x', 'y'],
         messages: [
           { metric: 'request/time', value: 4 },
@@ -58,7 +58,7 @@ describe('flatten-spec', () => {
         '$.context.host',
         '$.context.topic',
         "$.context['1pic']",
-        "$.context['do\npic']",
+        "$.context['do\npi\\'c']",
       ]);
     });
   });

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
@@ -41,7 +41,7 @@ describe('flatten-spec', () => {
         value: 4,
       },
       {
-        context: { 'host': 'imp', "do\npi'c'": 'fun' },
+        context: { 'host': 'imp', "d\\o\npi'c'": 'fun' },
         tags: ['x', 'y'],
         messages: [
           { metric: 'request/time', value: 4 },
@@ -58,7 +58,7 @@ describe('flatten-spec', () => {
         '$.context.host',
         '$.context.topic',
         "$.context['1pic']",
-        "$.context['do\npi\\'c\\'']",
+        "$.context['d\\\\o\npi\\'c\\'']",
       ]);
     });
   });

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.spec.ts
@@ -41,7 +41,7 @@ describe('flatten-spec', () => {
         value: 4,
       },
       {
-        context: { 'host': 'imp', "do\npi'c": 'fun' },
+        context: { 'host': 'imp', "do\npi'c'": 'fun' },
         tags: ['x', 'y'],
         messages: [
           { metric: 'request/time', value: 4 },
@@ -58,7 +58,7 @@ describe('flatten-spec', () => {
         '$.context.host',
         '$.context.topic',
         "$.context['1pic']",
-        "$.context['do\npi\\'c']",
+        "$.context['do\npi\\'c\\'']",
       ]);
     });
   });

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
@@ -64,7 +64,7 @@ export const FLATTEN_FIELD_FIELDS: Field<FlattenField>[] = [
 export type ArrayHandling = 'ignore-arrays' | 'include-arrays';
 
 function escapePathKey(pathKey: string): string {
-  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey.replace(/'/, "\\'")}']`;
+  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey.replace(/'/g, "\\'")}']`;
 }
 
 export function computeFlattenPathsForData(

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
@@ -61,18 +61,20 @@ export const FLATTEN_FIELD_FIELDS: Field<FlattenField>[] = [
   },
 ];
 
-export type ExprType = 'path' | 'jq';
 export type ArrayHandling = 'ignore-arrays' | 'include-arrays';
+
+function escapePathKey(pathKey: string): string {
+  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey}']`;
+}
 
 export function computeFlattenPathsForData(
   data: Record<string, any>[],
-  exprType: ExprType,
   arrayHandling: ArrayHandling,
 ): FlattenField[] {
-  return computeFlattenExprsForData(data, exprType, arrayHandling).map(expr => {
+  return computeFlattenExprsForData(data, arrayHandling).map(expr => {
     return {
-      name: expr.replace(/^\$?\./, ''),
-      type: exprType,
+      name: expr.replace(/^\$\./, '').replace(/['\]]/g, '').replace(/\[/g, '.'),
+      type: 'path',
       expr,
     };
   });
@@ -80,7 +82,6 @@ export function computeFlattenPathsForData(
 
 export function computeFlattenExprsForData(
   data: Record<string, any>[],
-  exprType: ExprType,
   arrayHandling: ArrayHandling,
   includeTopLevel = false,
 ): string[] {
@@ -91,12 +92,7 @@ export function computeFlattenExprsForData(
     for (const datumKey of datumKeys) {
       const datumValue = datum[datumKey];
       if (includeTopLevel || isNested(datumValue)) {
-        addPath(
-          seenPaths,
-          exprType === 'path' ? `$.${datumKey}` : `.${datumKey}`,
-          datumValue,
-          arrayHandling,
-        );
+        addPath(seenPaths, `$${escapePathKey(datumKey)}`, datumValue, arrayHandling);
       }
     }
   }
@@ -114,7 +110,7 @@ function addPath(
     if (!Array.isArray(value)) {
       const valueKeys = Object.keys(value);
       for (const valueKey of valueKeys) {
-        addPath(paths, `${path}.${valueKey}`, value[valueKey], arrayHandling);
+        addPath(paths, `${path}${escapePathKey(valueKey)}`, value[valueKey], arrayHandling);
       }
     } else if (arrayHandling === 'include-arrays') {
       for (let i = 0; i < value.length; i++) {

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
@@ -64,7 +64,7 @@ export const FLATTEN_FIELD_FIELDS: Field<FlattenField>[] = [
 export type ArrayHandling = 'ignore-arrays' | 'include-arrays';
 
 function escapePathKey(pathKey: string): string {
-  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey}']`;
+  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey.replace(/'/, "\\'")}']`;
 }
 
 export function computeFlattenPathsForData(

--- a/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
+++ b/web-console/src/druid-models/flatten-spec/flatten-spec.tsx
@@ -64,7 +64,9 @@ export const FLATTEN_FIELD_FIELDS: Field<FlattenField>[] = [
 export type ArrayHandling = 'ignore-arrays' | 'include-arrays';
 
 function escapePathKey(pathKey: string): string {
-  return /^[a-z]\w*$/i.test(pathKey) ? `.${pathKey}` : `['${pathKey.replace(/'/g, "\\'")}']`;
+  return /^[a-z]\w*$/i.test(pathKey)
+    ? `.${pathKey}`
+    : `['${pathKey.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}']`;
 }
 
 export function computeFlattenPathsForData(

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1490,7 +1490,6 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     if (canFlatten && !flattenFields.length && parserQueryState.data) {
       suggestedFlattenFields = computeFlattenPathsForData(
         filterMap(parserQueryState.data.rows, r => r.input),
-        'path',
         'ignore-arrays',
       );
     }

--- a/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
+++ b/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
@@ -82,7 +82,7 @@ function jsonValue(ex: SqlExpression, path: string): SqlExpression {
 }
 
 function getJsonPaths(jsons: Record<string, any>[]): string[] {
-  return ['$.'].concat(computeFlattenExprsForData(jsons, 'path', 'include-arrays', true));
+  return ['$.'].concat(computeFlattenExprsForData(jsons, 'include-arrays', true));
 }
 
 function isComparable(x: unknown): boolean {


### PR DESCRIPTION
Also ret rid of the ability to generate `jq` flatten specs because we never use it in the first place.

Try it with this record:

```
{"hello.world":{"a\nb":{"x'y\"z":"hi there"}}}
```

It now generates a correct flatten spec that works:

<img width="398" alt="image" src="https://user-images.githubusercontent.com/177816/190835509-d49e88ca-9d81-4ad7-8640-c68d74541ead.png">

