### PR TITLE
Docs: Clarify the situation with SELECT.

### DIFF
--- a/docs/multi-stage-query/concepts.md
+++ b/docs/multi-stage-query/concepts.md
@@ -29,14 +29,15 @@ sidebar_label: "Key concepts"
 
 ## SQL task engine
 
-The `druid-multi-stage-query` extension adds a multi-stage query (MSQ) task engine that executes SQL SELECT,
-[INSERT](reference.md#insert), and [REPLACE](reference.md#replace) statements as batch tasks in the indexing service,
-which execute on [Middle Managers](../design/architecture.md#druid-services). INSERT and REPLACE tasks publish
+The `druid-multi-stage-query` extension adds a multi-stage query (MSQ) task engine that executes SQL statements as batch
+tasks in the indexing service, which execute on [Middle Managers](../design/architecture.md#druid-services).
+[INSERT](reference.md#insert) and [REPLACE](reference.md#replace) tasks publish
 [segments](../design/architecture.md#datasources-and-segments) just like [all other forms of batch
 ingestion](../ingestion/index.md#batch). Each query occupies at least two task slots while running: one controller task,
-and at least one worker task.
+and at least one worker task. As an experimental feature, the MSQ task engine also supports running SELECT queries as
+batch tasks. The behavior and result format of plain SELECT (without INSERT or REPLACE) is subject to change.
 
-You can execute queries using the MSQ task engine through the **Query** view in the [web
+You can execute SQL statements using the MSQ task engine through the **Query** view in the [web
 console](../operations/web-console.md) or through the [`/druid/v2/sql/task` API](api.md).
 
 For more details on how SQL queries are executed using the MSQ task engine, see [multi-stage query

--- a/docs/multi-stage-query/index.md
+++ b/docs/multi-stage-query/index.md
@@ -30,11 +30,12 @@ description: Introduces multi-stage query architecture and its task engine
 
 Apache Druid supports SQL-based ingestion using the bundled [`druid-multi-stage-query` extension](#load-the-extension).
 This extension adds a [multi-stage query task engine for SQL](concepts.md#sql-task-engine) that allows running SQL
-[INSERT](concepts.md#insert) and [REPLACE](concepts.md#replace) statements as batch tasks.
+[INSERT](concepts.md#insert) and [REPLACE](concepts.md#replace) statements as batch tasks. As an experimental feature,
+the task engine also supports running SELECT queries as batch tasks.
 
-Nearly all SELECT capabilities are available for `INSERT ... SELECT` and `REPLACE ... SELECT` queries, with certain
-exceptions listed on the [Known issues](./known-issues.md#select) page. This allows great flexibility to apply
-transformations, filters, JOINs, aggregations, and so on while ingesting data. This also allows in-database
+Nearly all SELECT capabilities are available in the SQL task engine, with certain exceptions listed on the [Known
+issues](./known-issues.md#select) page. This allows great flexibility to apply transformations, filters, JOINs,
+aggregations, and so on as part of `INSERT ... SELECT` and `REPLACE ... SELECT` statements. This also allows in-database
 transformation: creating new tables based on queries of other tables.
 
 ## Vocabulary


### PR DESCRIPTION
SELECT (without INSERT or REPLACE) is an experimental feature for the SQL task endpoint. The changes in #13107 made this less clear, so fixing that in this patch.