### PR TITLE
be consistent about referring to the web console by its name

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -19,4 +19,4 @@ queries:
 extraction:
   java:
     index:
-      build_command: mvn clean package -f "pom.xml" -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Ddruid.console.skip=true
+      build_command: mvn clean package -f "pom.xml" -B -V -e -Dfindbugs.skip -Dcheckstyle.skip -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec -Dlicense.skip=true -Dweb.console.skip=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - DOCKER_IP=127.0.0.1  # for integration tests
     - MVN="mvn -B"
     - > # Various options to make execution of maven goals faster (e.g., mvn install)
-      MAVEN_SKIP="-P skip-static-checks -Ddruid.console.skip=true -Dmaven.javadoc.skip=true"
+      MAVEN_SKIP="-P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true"
     - MAVEN_SKIP_TESTS="-P skip-tests"
 
 addons:
@@ -43,7 +43,7 @@ addons:
       - maven
       - python3
 
-# Add various options to make 'mvn install' fast and skip javascript compile (-Ddruid.console.skip=true) since it is not
+# Add various options to make 'mvn install' fast and skip javascript compile (-Dweb.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
 # output.  To compensate, use travis_wait to extend the timeout.
 install: ./check_test_suite.py && travis_terminate 0  || echo 'Running Maven install...' && MAVEN_OPTS='-Xmx3000m' travis_wait 15 ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C && ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
@@ -179,7 +179,7 @@ jobs:
       before_script: *setup_generate_license
       script: >
         MAVEN_OPTS='-Xmx3000m' ${MVN} clean install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end
-        -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Ddruid.console.skip=false -T1C
+        -pl '!benchmarks' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
 
     - <<: *package
       name: "(openjdk11) packaging check"
@@ -419,7 +419,7 @@ jobs:
       jdk: openjdk11
       env:
         - MAVEN_PROJECTS='core,indexing-hadoop,indexing-service,processing'
-      script: ${MVN} test -B -pl ${MAVEN_PROJECTS} -Ddruid.console.skip=true -DargLine=-Xmx3000m
+      script: ${MVN} test -B -pl ${MAVEN_PROJECTS} -Dweb.console.skip=true -DargLine=-Xmx3000m
 
     - name: "Build and test on ARM64 CPU architecture (2)"
       stage: Tests - phase 2
@@ -430,7 +430,7 @@ jobs:
       jdk: openjdk11
       env:
         - MAVEN_PROJECTS='core,sql,server,services'
-      script: ${MVN} test -B -pl ${MAVEN_PROJECTS} -Ddruid.console.skip=true -DargLine=-Xmx3000m
+      script: ${MVN} test -B -pl ${MAVEN_PROJECTS} -Dweb.console.skip=true -DargLine=-Xmx3000m
 
 
     # Integration tests Java Compile version is set by the machine environment jdk (set by the jdk key)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Druid is designed for workflows where fast queries and ingest really matter. Dru
 You can get started with Druid with our [local](https://druid.apache.org/docs/latest/tutorials/quickstart.html) or [Docker](http://druid.apache.org/docs/latest/tutorials/docker.html) quickstart.
 
 Druid provides a rich set of APIs (via HTTP and [JDBC](https://druid.apache.org/docs/latest/querying/sql.html#jdbc)) for loading, managing, and querying your data.
-You can also interact with Druid via the [built-in console](https://druid.apache.org/docs/latest/operations/druid-console.html) (shown below).
+You can also interact with Druid via the built-in [web console](https://druid.apache.org/docs/latest/operations/web-console.html) (shown below).
 
 #### Load data
 

--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -67,7 +67,7 @@ Before running or debugging the apps, you should do a `mvn clean install -Pdist 
 
 `-Pdist` is required because it puts all core extensions under `distribution\target\extensions` directory, where `runConfigurations` below could load extensions from.
 
-You may also add `-Ddruid.console.skip=true` to the command if you're focusing on backend servers instead of frontend project. This option saves great building time.
+You may also add `-Dweb.console.skip=true` to the command if you're focusing on backend servers instead of frontend project. This option saves great building time.
 
 ## Debug a running Druid cluster using Intellij
 Intellij IDEA debugger can attach to a local or remote Java process (Druid process). 

--- a/distribution/bin/web-console-dep-lister.py
+++ b/distribution/bin/web-console-dep-lister.py
@@ -18,7 +18,7 @@
 import re
 import sys
 
-# Helper program for listing the deps in the compiled web-console-<VERSION>.js file in druid-console.jar
+# Helper program for listing the deps in the compiled web-console-<VERSION>.js file in web-console.jar
 
 if len(sys.argv) != 2:
   sys.stderr.write('usage: program <web-console js path>\n')

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <!-- This is needed to bundle the web console -->
             <groupId>org.apache.druid</groupId>
-            <artifactId>druid-console</artifactId>
+            <artifactId>web-console</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -63,7 +63,7 @@ In addition to the basic stages, you may also want to add the following profiles
 - **-Papache-release** - Apache release profile: Generates GPG signature and checksums, and builds the source distribution tarball as `distribution/target/apache-druid-x.x.x-src.tar.gz`
 - **-Prat** - Apache Rat profile: Runs the Apache Rat license audit tool
 - **-DskipTests** - Skips unit tests (which reduces build time)
-- **-Ddruid.console.skip=true** - Skip front end project
+- **-Dweb.console.skip=true** - Skip front end project
 
 Putting these together, if you wish to build the source and binary distributions with signatures and checksums, audit licenses, and skip the unit tests, you would run:
 

--- a/integration-tests-ex/docs/conversion.md
+++ b/integration-tests-ex/docs/conversion.md
@@ -123,7 +123,7 @@ Use the following to verify the `pom.xml`:
 
 ```bash
 mvn dependency:analyze -DoutputXML=true -DignoreNonCompile=true \
-    -P skip-static-checks -Ddruid.console.skip=true -Dmaven.javadoc.skip=true \
+    -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true \
     -P skip-tests
 ```
 

--- a/integration-tests/script/copy_resources_template.sh
+++ b/integration-tests/script/copy_resources_template.sh
@@ -30,7 +30,7 @@ cp -R docker $SHARED_DIR/docker
 
 pushd ../
 rm -rf distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin
-mvn -P skip-static-checks,skip-tests -T1C -Danimal.sniffer.skip=true -Dcheckstyle.skip=true -Ddruid.console.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true install -Pintegration-test
+mvn -P skip-static-checks,skip-tests -T1C -Danimal.sniffer.skip=true -Dcheckstyle.skip=true -Dweb.console.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true install -Pintegration-test
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions
 popd

--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -21,9 +21,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>druid-console</artifactId>
-  <name>druid-console</name>
-  <description>Unified web console for a Druid cluster</description>
+  <artifactId>web-console</artifactId>
+  <name>web-console</name>
+  <description>Web console for Druid</description>
 
   <parent>
     <groupId>org.apache.druid</groupId>
@@ -33,7 +33,7 @@
 
   <properties>
     <resources.directory>${project.build.directory}/resources</resources.directory>
-    <druid.console.skip>false</druid.console.skip>  <!-- this property is overidden in Travis CI to skip the javascript-related work -->
+    <web.console.skip>false</web.console.skip>  <!-- this property is overidden in Travis CI to skip the javascript-related work -->
     <node.version>v16.17.0</node.version>
     <npm.version>8.15.0</npm.version>
   </properties>
@@ -44,7 +44,7 @@
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <configuration>
-          <skip>${druid.console.skip}</skip>
+          <skip>${web.console.skip}</skip>
           <skipTests>${skipUTs}</skipTests>
         </configuration>
         <executions>
@@ -108,7 +108,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <configuration>
-          <skip>${druid.console.skip}</skip>
+          <skip>${web.console.skip}</skip>
         </configuration>
         <executions>
           <execution>
@@ -152,7 +152,7 @@
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <outputDirectory>${project.build.outputDirectory}/org/apache/druid/console</outputDirectory>
-          <skip>${druid.console.skip}</skip>
+          <skip>${web.console.skip}</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -191,8 +191,8 @@ const RestrictedMode = React.memo(function RestrictedMode(props: RestrictedModeP
           {message}
           <p>
             For more info check out the{' '}
-            <ExternalLink href={`${getLink('DOCS')}/operations/management-uis.html#druid-console`}>
-              console documentation
+            <ExternalLink href={`${getLink('DOCS')}/operations/web-console.html`}>
+              web console documentation
             </ExternalLink>
             .
           </p>

--- a/web-console/unified-console.html
+++ b/web-console/unified-console.html
@@ -55,7 +55,7 @@
   <body class="bp4-dark mouse-mode">
     <div class="app-container"></div>
     <div id="browser-update" style="display: none">
-      You are using an unsupported browser. The console will not work properly.
+      You are using an unsupported browser. The web console will not work properly.
       <a href="https://browser-update.org/update.html">Update to a supported browser.</a>
     </div>
     <script>

--- a/website/.spelling
+++ b/website/.spelling
@@ -752,7 +752,7 @@ v9
 DskipTests
 Papache-release
 Pdist
-Ddruid.console.skip
+Dweb.console.skip
 yaml
 Phadoop3
 dist-hadoop3


### PR DESCRIPTION
Standardize on calling the "web-console" by its name instead of "druid-console" in the build system.

I hope I did not break all CI.