### PR TITLE
Add LoadDropByPeriod to improve retention rules

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -144,10 +144,9 @@ public class RunRules implements CoordinatorDuty
           }
           stats.accumulate(rule.run(coordinator, paramsWithReplicationManager, segment));
           foundMatchingRule = true;
-          break;
-        } else {
-          //Clear the inapplicable replicant from the corresponding tier
-          rule.cleanExpireReplicant(paramsWithReplicationManager, segment);
+          if (rule.isBreak()) {
+            break;
+          }
         }
       }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -133,7 +133,7 @@ public class RunRules implements CoordinatorDuty
           if (
               stats.getGlobalStat(
                   "totalNonPrimaryReplicantsLoaded") >= paramsWithReplicationManager.getCoordinatorDynamicConfig()
-                                                                                   .getMaxNonPrimaryReplicantsToLoad()
+                                                                                    .getMaxNonPrimaryReplicantsToLoad()
               && !paramsWithReplicationManager.getReplicationManager().isLoadPrimaryReplicantsOnly()
           ) {
             log.info(
@@ -145,6 +145,9 @@ public class RunRules implements CoordinatorDuty
           stats.accumulate(rule.run(coordinator, paramsWithReplicationManager, segment));
           foundMatchingRule = true;
           break;
+        } else {
+          //Clear the inapplicable replicant from the corresponding tier
+          rule.cleanExpireReplicant(paramsWithReplicationManager, segment);
         }
       }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -133,7 +133,7 @@ public class RunRules implements CoordinatorDuty
           if (
               stats.getGlobalStat(
                   "totalNonPrimaryReplicantsLoaded") >= paramsWithReplicationManager.getCoordinatorDynamicConfig()
-                                                                                    .getMaxNonPrimaryReplicantsToLoad()
+                                                                                   .getMaxNonPrimaryReplicantsToLoad()
               && !paramsWithReplicationManager.getReplicationManager().isLoadPrimaryReplicantsOnly()
           ) {
             log.info(
@@ -145,9 +145,6 @@ public class RunRules implements CoordinatorDuty
           stats.accumulate(rule.run(coordinator, paramsWithReplicationManager, segment));
           foundMatchingRule = true;
           break;
-        } else {
-          //Clear the inapplicable replicant from the corresponding tier
-          rule.cleanExpireReplicant(paramsWithReplicationManager, segment);
         }
       }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
@@ -24,12 +24,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordinator.CoordinatorStats;
 import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import java.util.NavigableSet;
@@ -78,15 +82,31 @@ public class LoadDropByPeriod extends PeriodLoadRule
   }
 
   @Override
-  public void cleanExpireReplicant(
+  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
+  {
+    return true;
+  }
+
+  @Override
+  public CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment)
+  {
+    if (super.appliesTo(segment, DateTimes.nowUtc())) {
+      return super.run(coordinator, params, segment);
+    } else {
+      return cleanExpireReplicant(params, segment);
+    }
+
+  }
+
+  public CoordinatorStats cleanExpireReplicant(
       final DruidCoordinatorRuntimeParams params,
       final DataSegment segment
   )
   {
+    final CoordinatorStats stats = new CoordinatorStats();
     try {
       targetReplicants.putAll(getTieredReplicants());
       currentReplicants.putAll(params.getSegmentReplicantLookup().getClusterTiers(segment.getId()));
-      final CoordinatorStats stats = new CoordinatorStats();
 
       final DruidCluster druidCluster = params.getDruidCluster();
       final boolean isLoading = loadingInProgress(druidCluster);
@@ -133,5 +153,6 @@ public class LoadDropByPeriod extends PeriodLoadRule
       targetReplicants.clear();
       currentReplicants.clear();
     }
+    return stats;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.rules;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.server.coordinator.CoordinatorStats;
+import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.timeline.DataSegment;
+import org.joda.time.Period;
+
+import java.util.NavigableSet;
+
+/**
+ * Segments not in the loading range will be cleared.
+ * One LoadDropByPeriod can only correspond to one tier.
+ */
+public class LoadDropByPeriod extends PeriodLoadRule
+{
+  private static final EmittingLogger log = new EmittingLogger(LoadDropByPeriod.class);
+  static final String TYPE = "loadDropByPeriod";
+  private final String tier;
+  private final int replicants;
+
+  @JsonCreator
+  public LoadDropByPeriod(
+      @JsonProperty("period") Period period,
+      @JsonProperty("includeFuture") Boolean includeFuture,
+      @JsonProperty("tier") String tier,
+      @JsonProperty("replicants") int replicants
+  )
+  {
+    super(period, includeFuture, tier == null ? ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS) : ImmutableMap.of(tier, replicants));
+    this.tier = tier == null ? DruidServer.DEFAULT_TIER : tier;
+    this.replicants = tier == null ? DruidServer.DEFAULT_NUM_REPLICANTS : replicants;
+  }
+
+  @Override
+  @JsonProperty
+  public String getType()
+  {
+    return TYPE;
+  }
+
+  @JsonProperty
+  public String getTier()
+  {
+    return tier;
+  }
+
+  @JsonProperty
+  public int getReplicants()
+  {
+    return replicants;
+  }
+
+  @Override
+  public void cleanExpireReplicant(
+      final DruidCoordinatorRuntimeParams params,
+      final DataSegment segment
+  )
+  {
+    try {
+      targetReplicants.putAll(getTieredReplicants());
+      currentReplicants.putAll(params.getSegmentReplicantLookup().getClusterTiers(segment.getId()));
+      final CoordinatorStats stats = new CoordinatorStats();
+
+      final DruidCluster druidCluster = params.getDruidCluster();
+      final boolean isLoading = loadingInProgress(druidCluster);
+
+      for (final Object2IntMap.Entry<String> entry : currentReplicants.object2IntEntrySet()) {
+        final String tier = entry.getKey();
+
+        final NavigableSet<ServerHolder> holders = druidCluster.getHistoricalsByTier(tier);
+
+        final int numDropped;
+        if (holders == null) {
+          log.makeAlert("No holders found for tier[%s]", tier).emit();
+          numDropped = 0;
+        } else {
+          final int currentReplicantsInTier = entry.getIntValue();
+          if (currentReplicantsInTier > 0) {
+            // This enforces that loading is completed before we attempt to drop stuffs as a safety measure.
+            if (isLoading) {
+              log.info(
+                  "Loading in progress for segment [%s], skipping drop from tier [%s] until loading is complete! %s",
+                  segment.getId(),
+                  tier,
+                  getReplicationLogString()
+              );
+              break;
+            }
+            numDropped = dropForTier(
+                currentReplicantsInTier,
+                holders,
+                segment,
+                params.getBalancerStrategy(),
+                getReplicationLogString()
+            );
+          } else {
+            numDropped = 0;
+          }
+        }
+
+        stats.addToTieredStat(DROPPED_COUNT, tier, numDropped);
+      }
+
+    }
+    finally {
+      targetReplicants.clear();
+      currentReplicants.clear();
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadDropByPeriod.java
@@ -24,16 +24,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import org.apache.druid.client.DruidServer;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordinator.CoordinatorStats;
 import org.apache.druid.server.coordinator.DruidCluster;
-import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
-import org.joda.time.DateTime;
-import org.joda.time.Interval;
 import org.joda.time.Period;
 
 import java.util.NavigableSet;
@@ -82,31 +78,15 @@ public class LoadDropByPeriod extends PeriodLoadRule
   }
 
   @Override
-  public boolean appliesTo(Interval interval, DateTime referenceTimestamp)
-  {
-    return true;
-  }
-
-  @Override
-  public CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment)
-  {
-    if (super.appliesTo(segment, DateTimes.nowUtc())) {
-      return super.run(coordinator, params, segment);
-    } else {
-      return cleanExpireReplicant(params, segment);
-    }
-
-  }
-
-  public CoordinatorStats cleanExpireReplicant(
+  public void cleanExpireReplicant(
       final DruidCoordinatorRuntimeParams params,
       final DataSegment segment
   )
   {
-    final CoordinatorStats stats = new CoordinatorStats();
     try {
       targetReplicants.putAll(getTieredReplicants());
       currentReplicants.putAll(params.getSegmentReplicantLookup().getClusterTiers(segment.getId()));
+      final CoordinatorStats stats = new CoordinatorStats();
 
       final DruidCluster druidCluster = params.getDruidCluster();
       final boolean isLoading = loadingInProgress(druidCluster);
@@ -153,6 +133,5 @@ public class LoadDropByPeriod extends PeriodLoadRule
       targetReplicants.clear();
       currentReplicants.clear();
     }
-    return stats;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/LoadRule.java
@@ -60,8 +60,8 @@ public abstract class LoadRule implements Rule
   public final String NON_PRIMARY_ASSIGNED_COUNT = "totalNonPrimaryReplicantsLoaded";
   public static final String REQUIRED_CAPACITY = "requiredCapacity";
 
-  private final Object2IntMap<String> targetReplicants = new Object2IntOpenHashMap<>();
-  private final Object2IntMap<String> currentReplicants = new Object2IntOpenHashMap<>();
+  protected final Object2IntMap<String> targetReplicants = new Object2IntOpenHashMap<>();
+  protected final Object2IntMap<String> currentReplicants = new Object2IntOpenHashMap<>();
 
   // Cache to hold unused results from strategy call in assignPrimary
   private final Map<String, ServerHolder> strategyCache = new HashMap<>();
@@ -439,7 +439,7 @@ public abstract class LoadRule implements Rule
   /**
    * Returns true if at least one tier in target replica assignment exists in cluster but does not have enough replicas.
    */
-  private boolean loadingInProgress(final DruidCluster druidCluster)
+  protected boolean loadingInProgress(final DruidCluster druidCluster)
   {
     for (final Object2IntMap.Entry<String> entry : targetReplicants.object2IntEntrySet()) {
       final String tier = entry.getKey();
@@ -452,7 +452,7 @@ public abstract class LoadRule implements Rule
     return false;
   }
 
-  private static int dropForTier(
+  protected static int dropForTier(
       final int numToDrop,
       final NavigableSet<ServerHolder> holdersInTier,
       final DataSegment segment,

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -108,11 +108,4 @@ public interface Rule
    * See https://github.com/apache/druid/issues/7228
    */
   CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment);
-
-  default void cleanExpireReplicant(
-      final DruidCoordinatorRuntimeParams params,
-      final DataSegment segment
-  )
-  {
-  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -108,4 +108,11 @@ public interface Rule
    * See https://github.com/apache/druid/issues/7228
    */
   CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment);
+
+  default void cleanExpireReplicant(
+      final DruidCoordinatorRuntimeParams params,
+      final DataSegment segment
+  )
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -39,6 +39,7 @@ import java.util.Map;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "loadByPeriod", value = PeriodLoadRule.class),
+    @JsonSubTypes.Type(name = LoadDropByPeriod.TYPE, value = LoadDropByPeriod.class),
     @JsonSubTypes.Type(name = "loadByInterval", value = IntervalLoadRule.class),
     @JsonSubTypes.Type(name = "loadForever", value = ForeverLoadRule.class),
     @JsonSubTypes.Type(name = "dropByPeriod", value = PeriodDropRule.class),
@@ -107,4 +108,11 @@ public interface Rule
    * See https://github.com/apache/druid/issues/7228
    */
   CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment);
+
+  default void cleanExpireReplicant(
+      final DruidCoordinatorRuntimeParams params,
+      final DataSegment segment
+  )
+  {
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -109,10 +109,12 @@ public interface Rule
    */
   CoordinatorStats run(DruidCoordinator coordinator, DruidCoordinatorRuntimeParams params, DataSegment segment);
 
-  default void cleanExpireReplicant(
-      final DruidCoordinatorRuntimeParams params,
-      final DataSegment segment
-  )
+  /**
+   * By default, when a segment matches multiple rules, as long as one of the rules matches, it will immediately break, and the remaining rules will have no effect.
+   * In some cases, even if some rules are matched, the remaining rules are expected to work.
+   */
+  default boolean isBreak()
   {
+    return true;
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [#13080](https://github.com/apache/druid/issues/13080).

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->



The existing retention rules cannot handle the following cases well:

Data upto 3 days old lives on  default tiers
Data more than 3 days old and upto 7 days old lives only on cold tier
older data is dropped

This case can be handled by the following retention rules:
```
loadByPeriod P3D _defaultTier
loadByPeriod P7D cold
dropForever
```

This retention rule can improve the tier query at the router level, but default tier stores the data of the last 7 days, which will waste the storage of default tier.

 By configuring the following retention rules, you can perfectly solve the problem of _defaultTier resource waste, without affecting the existing retention rules

```
loadDropByPeriod P3D _defaultTier
loadDropByPeriod P7D cold
dropForever
```


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `RunRules`
 * `LoadDropByPeriod`
 * `PeriodLoadRule`
 * `Rule`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
