### PR TITLE
fix: follow naming convention for msq task engine

### DIFF
--- a/docs/multi-stage-query/api.md
+++ b/docs/multi-stage-query/api.md
@@ -48,7 +48,7 @@ The SQL task endpoint accepts [SQL requests in the JSON-over-HTTP form](../query
 
 This endpoint accepts [INSERT](reference.md#insert) and [REPLACE](reference.md#replace) statements.
 
-This endpoint also accepts SELECT queries. SELECT query results are collected from workers
+As an experimental feature, this endpoint also accepts SELECT queries. SELECT query results are collected from workers
 by the controller, and written into the [task report](#get-the-report-for-a-query-task) as an array of arrays. The
 behavior and result format of plain SELECT queries (without INSERT or REPLACE) is subject to change.
 
@@ -202,7 +202,7 @@ Keep the following in mind when using the task API to view reports:
 - The task report for an entire job is associated with the `query_controller` task. The `query_worker` tasks do not have
   their own reports; their information is incorporated into the controller report.
 - The task report API may report `404 Not Found` temporarily while the task is in the process of starting up.
-- The MSQ task engine supports running SELECT queries. SELECT query results are written into
+- As an experimental feature, the MSQ task engine supports running SELECT queries. SELECT query results are written into
 the `multiStageQuery.payload.results.results` task report key as an array of arrays. The behavior and result format of plain
 SELECT queries (without INSERT or REPLACE) is subject to change.
 

--- a/docs/multi-stage-query/api.md
+++ b/docs/multi-stage-query/api.md
@@ -48,7 +48,7 @@ The SQL task endpoint accepts [SQL requests in the JSON-over-HTTP form](../query
 
 This endpoint accepts [INSERT](reference.md#insert) and [REPLACE](reference.md#replace) statements.
 
-As an experimental feature, this endpoint also accepts SELECT queries. SELECT query results are collected from workers
+This endpoint also accepts SELECT queries. SELECT query results are collected from workers
 by the controller, and written into the [task report](#get-the-report-for-a-query-task) as an array of arrays. The
 behavior and result format of plain SELECT queries (without INSERT or REPLACE) is subject to change.
 
@@ -202,7 +202,7 @@ Keep the following in mind when using the task API to view reports:
 - The task report for an entire job is associated with the `query_controller` task. The `query_worker` tasks do not have
   their own reports; their information is incorporated into the controller report.
 - The task report API may report `404 Not Found` temporarily while the task is in the process of starting up.
-- As an experimental feature, the SQL task engine supports running SELECT queries. SELECT query results are written into
+- The MSQ task engine supports running SELECT queries. SELECT query results are written into
 the `multiStageQuery.payload.results.results` task report key as an array of arrays. The behavior and result format of plain
 SELECT queries (without INSERT or REPLACE) is subject to change.
 

--- a/docs/multi-stage-query/concepts.md
+++ b/docs/multi-stage-query/concepts.md
@@ -27,7 +27,7 @@ sidebar_label: "Key concepts"
 > extension, new in Druid 24.0. Refer to the [ingestion methods](../ingestion/index.md#batch) table to determine which
 > ingestion method is right for you.
 
-## SQL task engine
+## Multi-stage query task engine
 
 The `druid-multi-stage-query` extension adds a multi-stage query (MSQ) task engine that executes SQL statements as batch
 tasks in the indexing service, which execute on [Middle Managers](../design/architecture.md#druid-services).

--- a/docs/multi-stage-query/index.md
+++ b/docs/multi-stage-query/index.md
@@ -29,7 +29,7 @@ description: Introduces multi-stage query architecture and its task engine
 > ingestion method is right for you.
 
 Apache Druid supports SQL-based ingestion using the bundled [`druid-multi-stage-query` extension](#load-the-extension).
-This extension adds a [multi-stage query task engine for SQL](concepts.md#sql-task-engine) that allows running SQL
+This extension adds a [multi-stage query task engine for SQL](concepts.md#multi-stage-query-task-engine) that allows running SQL
 [INSERT](concepts.md#insert) and [REPLACE](concepts.md#replace) statements as batch tasks. As an experimental feature,
 the task engine also supports running SELECT queries as batch tasks.
 

--- a/docs/multi-stage-query/index.md
+++ b/docs/multi-stage-query/index.md
@@ -33,7 +33,7 @@ This extension adds a [multi-stage query task engine for SQL](concepts.md#sql-ta
 [INSERT](concepts.md#insert) and [REPLACE](concepts.md#replace) statements as batch tasks. As an experimental feature,
 the task engine also supports running SELECT queries as batch tasks.
 
-Nearly all SELECT capabilities are available in the SQL task engine, with certain exceptions listed on the [Known
+Nearly all SELECT capabilities are available in the multi-stage query (MSQ) task engine, with certain exceptions listed on the [Known
 issues](./known-issues.md#select) page. This allows great flexibility to apply transformations, filters, JOINs,
 aggregations, and so on as part of `INSERT ... SELECT` and `REPLACE ... SELECT` statements. This also allows in-database
 transformation: creating new tables based on queries of other tables.


### PR DESCRIPTION
This PR has:
- [x] been self-reviewed.
