### PR TITLE
Composite approach for checking in-filter values set in column dictionary

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/DictionaryEncodedStringIndexSupplierBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/DictionaryEncodedStringIndexSupplierBenchmark.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.FluentIterable;
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.collections.bitmap.MutableBitmap;
+import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.BitmapColumnIndex;
+import org.apache.druid.segment.column.StringValueSetIndex;
+import org.apache.druid.segment.data.BitmapSerdeFactory;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.serde.DictionaryEncodedStringIndexSupplier;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class DictionaryEncodedStringIndexSupplierBenchmark
+{
+  static {
+    NullHandling.initializeForTests();
+  }
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState
+  {
+    @Nullable
+    private DictionaryEncodedStringIndexSupplier.GenericIndexedDictionaryEncodedStringValueSetIndex stringValueSetIndex;
+    private final TreeSet<ByteBuffer> values = new TreeSet<>();
+    private static final int START_INT = 10_000_000;
+
+    // cardinality of the dictionary. it will contain this many ints (as strings, of course), starting at START_INT,
+    // even numbers only.
+    @Param({"1000000"})
+    int dictionarySize;
+
+    @Param({"1", "2", "5", "10", "15", "20", "30", "50", "100"})
+    int filterToDictionaryPercentage;
+
+    @Param({"10", "100"})
+    int selectivityPercentage;
+
+    @Setup(Level.Trial)
+    public void setup()
+    {
+      final BitmapFactory bitmapFactory = new RoaringBitmapFactory();
+      final BitmapSerdeFactory serdeFactory = new RoaringBitmapSerdeFactory(null);
+      final Iterable<Integer> ints = intGenerator();
+      final GenericIndexed<String> dictionary = GenericIndexed.fromIterable(
+          FluentIterable.from(ints)
+                        .transform(Object::toString),
+          GenericIndexed.STRING_STRATEGY
+      );
+      final GenericIndexed<ByteBuffer> dictionaryUtf8 = GenericIndexed.fromIterable(
+          FluentIterable.from(ints)
+                        .transform(i -> ByteBuffer.wrap(StringUtils.toUtf8(String.valueOf(i)))),
+          GenericIndexed.BYTE_BUFFER_STRATEGY
+      );
+      final GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.fromIterable(
+          () -> IntStream.range(0, dictionarySize)
+                         .mapToObj(
+                             i -> {
+                               final MutableBitmap mutableBitmap = bitmapFactory.makeEmptyMutableBitmap();
+                               mutableBitmap.add(i);
+                               return bitmapFactory.makeImmutableBitmap(mutableBitmap);
+                             }
+                         )
+                         .iterator(),
+          serdeFactory.getObjectStrategy()
+      );
+      DictionaryEncodedStringIndexSupplier dictionaryEncodedStringIndexSupplier =
+          new DictionaryEncodedStringIndexSupplier(bitmapFactory, dictionary, dictionaryUtf8, bitmaps, null);
+      stringValueSetIndex =
+          (DictionaryEncodedStringIndexSupplier.GenericIndexedDictionaryEncodedStringValueSetIndex)
+              dictionaryEncodedStringIndexSupplier.as(StringValueSetIndex.class);
+      List<Integer> filterValues = new ArrayList<>();
+      List<Integer> nonFilterValues = new ArrayList<>();
+      for (int i = 0; i < dictionarySize; i++) {
+        filterValues.add(START_INT + i * 2);
+        nonFilterValues.add(START_INT + i * 2 + 1);
+      }
+      Random r = new Random(9001);
+      Collections.shuffle(filterValues);
+      Collections.shuffle(nonFilterValues);
+      values.clear();
+      for (int i = 0; i < filterToDictionaryPercentage * dictionarySize / 100; i++) {
+        if (r.nextInt(100) < selectivityPercentage) {
+          values.add(ByteBuffer.wrap((filterValues.get(i).toString()).getBytes(StandardCharsets.UTF_8)));
+        } else {
+          values.add(ByteBuffer.wrap((nonFilterValues.get(i).toString()).getBytes(StandardCharsets.UTF_8)));
+        }
+      }
+    }
+
+    private Iterable<Integer> intGenerator()
+    {
+      // i * 2 => half of these values will be present in the inFilter, half won't.
+      return () -> IntStream.range(0, dictionarySize).map(i -> START_INT + i * 2).boxed().iterator();
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void doValueSetCheck(Blackhole blackhole, BenchmarkState state)
+  {
+    BitmapColumnIndex bitmapIndex = state.stringValueSetIndex.forSortedValuesUtf8(state.values);
+    bitmapIndex.estimateSelectivity(10_000_000);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -373,11 +373,6 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
     return -(minIndex + 1);
   }
 
-  public int compare(@Nullable T b1, @Nullable T b2)
-  {
-    return strategy.compare(b1, b2);
-  }
-
   @Override
   public Iterator<T> iterator()
   {

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -45,7 +45,6 @@ import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.NoSuchElementException;
 
 /**
  * A generic, flat storage mechanism.  Use static methods fromArray() or fromIterable() to construct.  If input
@@ -383,36 +382,6 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
   public Iterator<T> iterator()
   {
     return IndexedIterable.create(this).iterator();
-  }
-
-  public Iterator<ValueWithIndex> iteratorWithIndexId()
-  {
-    return new Iterator<ValueWithIndex>()
-    {
-      private int currIndex = 0;
-
-      @Override
-      public boolean hasNext()
-      {
-        return currIndex < size();
-      }
-
-      @Override
-      public ValueWithIndex next()
-      {
-        if (!hasNext()) {
-          throw new NoSuchElementException();
-        }
-        int idx = currIndex++;
-        return new ValueWithIndex(get(idx), idx);
-      }
-
-      @Override
-      public void remove()
-      {
-        throw new UnsupportedOperationException();
-      }
-    };
   }
 
   @Override
@@ -861,29 +830,5 @@ public class GenericIndexed<T> implements CloseableIndexed<T>, Serializer
         inspector.visit("strategy", strategy);
       }
     };
-  }
-
-  public class ValueWithIndex
-  {
-    @Nullable
-    private final T value;
-    private final int idx;
-
-    public ValueWithIndex(@Nullable T value, int idx)
-    {
-      this.value = value;
-      this.idx = idx;
-    }
-
-    @Nullable
-    public T getValue()
-    {
-      return value;
-    }
-
-    public int getIdx()
-    {
-      return idx;
-    }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
@@ -297,7 +297,7 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
                 while (next < 0 && valuesIterator.hasNext() && dictionaryIterator.hasNext()) {
                   ByteBuffer nextValue = valuesIterator.peek();
                   ByteBuffer nextDictionaryKey = dictionaryIterator.peek();
-                  int comparison = genericIndexedDictionary.compare(nextValue, nextDictionaryKey);
+                  int comparison = GenericIndexed.BYTE_BUFFER_STRATEGY.compare(nextValue, nextDictionaryKey);
                   if (comparison == 0) {
                     next = idx;
                     valuesIterator.next();

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplier.java
@@ -315,6 +315,8 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
         };
       }
 
+      // if the size of in-filter values is less than the threshold percentage of dictionary size, then use binary search
+      // based lookup per value. The algorithm works well for smaller number of values.
       return new SimpleImmutableBitmapIterableIndex()
       {
         @Override
@@ -351,8 +353,6 @@ public class DictionaryEncodedStringIndexSupplier implements ColumnIndexSupplier
 
             private void findNext()
             {
-              // if the size of in-filter values is less than the threshold percentage of dictionary size, then use binary search
-              // based lookup per value. The algorithm works well for smaller number of values.
               while (next < 0 && valuesIterator.hasNext()) {
                 ByteBuffer nextValue = valuesIterator.next();
                 next = dictionary.indexOf(nextValue);

--- a/processing/src/test/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplierTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.serde;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.collections.bitmap.MutableBitmap;
+import org.apache.druid.query.BitmapResultFactory;
+import org.apache.druid.query.DefaultBitmapResultFactory;
+import org.apache.druid.segment.column.BitmapColumnIndex;
+import org.apache.druid.segment.column.StringValueSetIndex;
+import org.apache.druid.segment.data.BitmapSerdeFactory;
+import org.apache.druid.segment.data.GenericIndexed;
+import org.apache.druid.segment.data.GenericIndexedWriter;
+import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.roaringbitmap.IntIterator;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.TreeSet;
+
+public class DictionaryEncodedStringIndexSupplierTest extends InitializedNullHandlingTest
+{
+  BitmapSerdeFactory roaringFactory = new RoaringBitmapSerdeFactory(null);
+  BitmapResultFactory<ImmutableBitmap> bitmapResultFactory = new DefaultBitmapResultFactory(
+      roaringFactory.getBitmapFactory()
+  );
+
+  @Test
+  public void testStringColumnWithNullValueSetIndex() throws IOException
+  {
+    DictionaryEncodedStringIndexSupplier indexSupplier = makeStringWithNullsSupplier();
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 10 rows
+    // dictionary: [null, b, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.1, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 3);
+
+    // non-existent in local column
+    columnIndex = valueSetIndex.forValue("fo");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    // set index
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "fooo", "z")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.5, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 3, 4, 5, 6);
+
+    // set index with single value in middle
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("foo")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.2, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 9);
+
+    // set index with no element in column and all elements less than lowest non-null value
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("a", "aa", "aaa")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    // set index with no element in column and all elements greater than highest non-null value
+    columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("zz", "zzz", "zzzz")));
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+  }
+
+  private DictionaryEncodedStringIndexSupplier makeStringWithNullsSupplier() throws IOException
+  {
+    ByteBuffer stringBuffer = ByteBuffer.allocate(1 << 12);
+    ByteBuffer byteBuffer = ByteBuffer.allocate(1 << 12);
+
+    GenericIndexedWriter<String> stringWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "strings",
+        GenericIndexed.STRING_STRATEGY
+    );
+    GenericIndexedWriter<ByteBuffer> byteBufferWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "byteBuffers",
+        GenericIndexed.BYTE_BUFFER_STRATEGY
+    );
+
+    stringWriter.open();
+    byteBufferWriter.open();
+
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 12);
+
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+    // 10 rows
+    // dictionary: [null, b, fo, foo, fooo, z]
+    // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
+
+    // null
+    stringWriter.write(null);
+    byteBufferWriter.write(null);
+    bitmapWriter.write(fillBitmap(1, 7, 8));
+
+    // b
+    stringWriter.write("b");
+    byteBufferWriter.write(ByteBuffer.wrap("b".getBytes(StandardCharsets.UTF_8)));
+    bitmapWriter.write(fillBitmap(3));
+
+    // fo
+    stringWriter.write("foo");
+    byteBufferWriter.write(ByteBuffer.wrap("foo".getBytes(StandardCharsets.UTF_8)));
+    bitmapWriter.write(fillBitmap(0, 9));
+
+    // fooo
+    stringWriter.write("fooo");
+    byteBufferWriter.write(ByteBuffer.wrap("fooo".getBytes(StandardCharsets.UTF_8)));
+    bitmapWriter.write(fillBitmap(2, 5));
+
+    // z
+    stringWriter.write("z");
+    byteBufferWriter.write(ByteBuffer.wrap("z".getBytes(StandardCharsets.UTF_8)));
+    bitmapWriter.write(fillBitmap(4, 6));
+
+    writeToBuffer(stringBuffer, stringWriter);
+    writeToBuffer(byteBuffer, stringWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    return new DictionaryEncodedStringIndexSupplier(
+        roaringFactory.getBitmapFactory(),
+        GenericIndexed.read(stringBuffer, GenericIndexed.STRING_STRATEGY),
+        GenericIndexed.read(byteBuffer, GenericIndexed.BYTE_BUFFER_STRATEGY),
+        bitmaps,
+        null
+    );
+  }
+
+  static void writeToBuffer(ByteBuffer buffer, Serializer serializer) throws IOException
+  {
+    WritableByteChannel channel = new WritableByteChannel()
+    {
+      @Override
+      public int write(ByteBuffer src)
+      {
+        int size = src.remaining();
+        buffer.put(src);
+        return size;
+      }
+
+      @Override
+      public boolean isOpen()
+      {
+        return true;
+      }
+
+      @Override
+      public void close()
+      {
+      }
+    };
+
+    serializer.writeTo(channel, null);
+    buffer.position(0);
+  }
+
+  private ImmutableBitmap fillBitmap(int... rows)
+  {
+    MutableBitmap bitmap = roaringFactory.getBitmapFactory().makeEmptyMutableBitmap();
+    for (int i : rows) {
+      bitmap.add(i);
+    }
+    return roaringFactory.getBitmapFactory().makeImmutableBitmap(bitmap);
+  }
+
+  private void checkBitmap(ImmutableBitmap bitmap, int... expectedRows)
+  {
+    IntIterator iterator = bitmap.iterator();
+    for (int i : expectedRows) {
+      Assert.assertTrue(iterator.hasNext());
+      Assert.assertEquals(i, iterator.next());
+    }
+    Assert.assertFalse(iterator.hasNext());
+  }
+}


### PR DESCRIPTION
Currently, for checking the in-filter values in a column dictionary we use a binary search per value in the set. That works well for smaller value-sets but starts slowing down as the number of values in the set increase. To accommodate for large value-sets arising from large in-filters or from joins being pushed down as in-filters, we use sorted merge algorithm for merging the set and dictionary for larger values.

The following benchmark was run to find the cutoff point :

```
Benchmark     (dictionarySize)  (filterToDictionaryPercentage)  (selectivityPercentage)  Mode  Cnt        Score       Error  Units
binarySearch           1000000                               1                       10  avgt   10    11271.575 ±   621.620  us/op
binarySearch           1000000                               1                      100  avgt   10    16751.127 ±   580.550  us/op
binarySearch           1000000                               2                       10  avgt   10    25387.245 ±  1795.582  us/op
binarySearch           1000000                               2                      100  avgt   10    19707.334 ±   973.384  us/op
binarySearch           1000000                               5                       10  avgt   10    37256.779 ±  2287.203  us/op
binarySearch           1000000                               5                      100  avgt   10    47391.511 ±  1689.971  us/op
binarySearch           1000000                              10                       10  avgt   10    76204.615 ±  6515.056  us/op
binarySearch           1000000                              10                      100  avgt   10    71483.416 ±  7197.376  us/op
binarySearch           1000000                              12                       10  avgt   10  139481.091 ± 15513.357  us/op
binarySearch           1000000                              12                      100  avgt   10  142881.846 ±  9511.367  us/op
binarySearch           1000000                              15                       10  avgt   10   113786.273 ±  4123.158  us/op
binarySearch           1000000                              15                      100  avgt   10   165300.278 ± 10555.479  us/op
binarySearch           1000000                              20                       10  avgt   10   138410.942 ± 14330.367  us/op
binarySearch           1000000                              20                      100  avgt   10   137543.621 ±  9273.845  us/op
binarySearch           1000000                              30                       10  avgt   10   206512.608 ± 13497.954  us/op
binarySearch           1000000                              30                      100  avgt   10   305317.908 ± 12452.686  us/op
binarySearch           1000000                              50                       10  avgt   10   328867.893 ± 14594.249  us/op
binarySearch           1000000                              50                      100  avgt   10   332823.291 ± 26349.158  us/op
binarySearch           1000000                             100                       10  avgt   10   668720.906 ± 49193.818  us/op
binarySearch           1000000                             100                      100  avgt   10  1014546.405 ± 30709.670  us/op
sortedMerge            1000000                               1                       10  avgt   10    47220.743 ±  2598.755  us/op
sortedMerge            1000000                               1                      100  avgt   10    53634.485 ±  2886.296  us/op
sortedMerge            1000000                               2                       10  avgt   10    51201.356 ±  2745.801  us/op
sortedMerge            1000000                               2                      100  avgt   10    53046.058 ±  4500.987  us/op
sortedMerge            1000000                               5                       10  avgt   10    58501.742 ±  7320.870  us/op
sortedMerge            1000000                               5                      100  avgt   10    65597.519 ±  7356.548  us/op
sortedMerge            1000000                              10                       10  avgt   10    75347.468 ±  9417.556  us/op
sortedMerge            1000000                              10                      100  avgt   10    74601.584 ±  5251.078  us/op
sortedMerge            1000000                              12                       10  avgt   10   64838.734 ±  2644.738  us/op
sortedMerge            1000000                              12                      100  avgt   10   80342.737 ±  5414.306  us/op
sortedMerge            1000000                              15                       10  avgt   10    83345.836 ±  6034.488  us/op
sortedMerge            1000000                              15                      100  avgt   10    78405.299 ±  1651.375  us/op
sortedMerge            1000000                              20                       10  avgt   10   111307.577 ± 10924.456  us/op
sortedMerge            1000000                              20                      100  avgt   10    89371.173 ± 10347.814  us/op
sortedMerge            1000000                              30                       10  avgt   10   116740.355 ±  6003.945  us/op
sortedMerge            1000000                              30                      100  avgt   10   117312.763 ±  6325.076  us/op
sortedMerge            1000000                              50                       10  avgt   10   132145.411 ± 23121.259  us/op
sortedMerge            1000000                              50                      100  avgt   10   192802.722 ± 39032.876  us/op
sortedMerge            1000000                             100                       10  avgt   10   216079.634 ± 28725.333  us/op
sortedMerge            1000000                             100                      100  avgt   10   236561.476 ± 14369.673  us/op
```

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
