### PR TITLE
fix: fix broken postgres link

### DIFF
--- a/docs/development/extensions-core/postgresql.md
+++ b/docs/development/extensions-core/postgresql.md
@@ -69,7 +69,7 @@ To use this Apache Druid extension, [include](../../development/extensions.md#lo
 
 ## Configuration
 
-In most cases, the configuration options map directly to the [postgres JDBC connection options](https://jdbc.postgresql.org/documentation/head/connect.html).
+In most cases, the configuration options map directly to the [postgres JDBC connection options](https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database).
 
 |Property|Description|Default|Required|
 |--------|-----------|-------|--------|


### PR DESCRIPTION
Based on the archive.org snapshot, this is the page it is now: https://jdbc.postgresql.org/documentation/use/#connecting-to-the-database

Old content https://web.archive.org/web/20220801081313/https://jdbc.postgresql.org/documentation/head/connect.html

This PR has:
- [x] been self-reviewed.