### PR TITLE
Web console: better spec conversion with issues

### DIFF
--- a/web-console/src/ace-modes/dsql.js
+++ b/web-console/src/ace-modes/dsql.js
@@ -64,6 +64,10 @@ ace.define(
       this.$rules = {
         start: [
           {
+            token: 'comment.issue',
+            regex: '--:ISSUE:.*$',
+          },
+          {
             token: 'comment',
             regex: '--.*$',
           },
@@ -73,16 +77,12 @@ ace.define(
             end: '\\*/',
           },
           {
-            token: 'string', // " string
+            token: 'variable.column', // " quoted reference
             regex: '".*?"',
           },
           {
-            token: 'string', // ' string
+            token: 'string', // ' string literal
             regex: "'.*?'",
-          },
-          {
-            token: 'string', // ` string (apache drill)
-            regex: '`.*?`',
           },
           {
             token: 'constant.numeric', // float

--- a/web-console/src/bootstrap/ace.scss
+++ b/web-console/src/bootstrap/ace.scss
@@ -25,6 +25,18 @@
 .ace-solarized-dark {
   background-color: rgba($dark-gray1, 0.5);
 
+  // START: Custom code styles
+  .ace_variable.ace_column {
+    color: #2ceefb;
+  }
+
+  .ace_comment.ace_issue {
+    color: #cb3116;
+    text-decoration: underline;
+    text-decoration-style: wavy;
+  }
+  // END: Custom code styles
+
   &.no-background {
     background-color: transparent;
   }

--- a/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
@@ -423,6 +423,20 @@ describe('WorkbenchQuery', () => {
         sqlPrefixLines: 0,
       });
     });
+
+    it('works with sql with ISSUE comment', () => {
+      const sql = sane`
+        SELECT *
+        --:ISSUE: There is something wrong with this query.
+        FROM wikipedia
+      `;
+
+      const workbenchQuery = WorkbenchQuery.blank().changeQueryString(sql);
+
+      expect(() => workbenchQuery.getApiQuery(makeQueryId)).toThrow(
+        `This query contains an ISSUE comment: There is something wrong with this query. (Please resolve the issue in the comment, delete the ISSUE comment and re-run the query.)`,
+      );
+    });
   });
 
   describe('#getIngestDatasource', () => {

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -576,6 +576,18 @@ export class WorkbenchQuery {
       apiQuery.query = queryPrepend + apiQuery.query + queryAppend;
     }
 
+    const m = /--:ISSUE:(.+)(?:\n|$)/.exec(apiQuery.query);
+    if (m) {
+      throw new Error(
+        `This query contains an ISSUE comment: ${m[1]
+          .trim()
+          .replace(
+            /\.$/,
+            '',
+          )}. (Please resolve the issue in the comment, delete the ISSUE comment and re-run the query.)`,
+      );
+    }
+
     const ingestQuery = this.isIngestQuery();
     if (!unlimited && !ingestQuery) {
       apiQuery.context ||= {};


### PR DESCRIPTION
This PR adds the concept of issue comments: a comment like `--:ISSUE: this is an issue` that can be added in SQL which will be rendered in red and will prevent the SQL from running. These comments are then used by the spec-to-SQL converter to indicate that something could not be converted. The spec converter will also (purposefully) generate invalid SQL to force the user to take action and not just click `Run`.

<img width="996" alt="image" src="https://user-images.githubusercontent.com/177816/191653579-fc975925-c62d-4955-968a-7fb777f929ad.png">
