### PR TITLE
Fix the Injector creation in HadoopTask

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -330,6 +330,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
     try {
       registerResourceCloserOnAbnormalExit(config -> killHadoopJob());
       String hadoopJobIdFile = getHadoopJobIdFileName();
+      logExtensionsConfig();
       final ClassLoader loader = buildClassLoader(toolbox);
       boolean determineIntervals = spec.getDataSchema().getGranularitySpec().inputIntervals().isEmpty();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -64,7 +64,6 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
   {
     super(id, dataSource, context, IngestionMode.HADOOP);
     this.hadoopDependencyCoordinates = hadoopDependencyCoordinates;
-    log.info("HadoopTask started with the following config:\n%s", EXTENSIONS_LOADER.config().toString());
   }
 
   public List<String> getHadoopDependencyCoordinates()
@@ -206,6 +205,15 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
     System.setProperty("druid.hadoop.internal.classpath", hadoopContainerDruidClasspathJars);
 
     return classLoader;
+  }
+
+  /**
+   * This method logs the {@link ExtensionsConfig} that was used to fetch the hadoop dependencies and build the classpath
+   * for the jobs
+   */
+  protected static void logExtensionsConfig()
+  {
+    log.info("HadoopTask started with the following config:\n%s", EXTENSIONS_LOADER.config().toString());
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -64,6 +64,7 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
   {
     super(id, dataSource, context, IngestionMode.HADOOP);
     this.hadoopDependencyCoordinates = hadoopDependencyCoordinates;
+    log.info("HadoopTask started with the following config:\n%s", EXTENSIONS_LOADER.config().toString());
   }
 
   public List<String> getHadoopDependencyCoordinates()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -50,7 +50,7 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
 {
   private static final Logger log = new Logger(HadoopTask.class);
 
-  static final Injector INJECTOR = new StartupInjectorBuilder().withExtensions().build();
+  static final Injector INJECTOR = new StartupInjectorBuilder().forServer().build();
   private static final ExtensionsLoader EXTENSIONS_LOADER = ExtensionsLoader.instance(INJECTOR);
 
   private final List<String> hadoopDependencyCoordinates;


### PR DESCRIPTION
### Description

As a part of the Guice refactoring, the injectors are built differently, having the ability to have or not have modules required for a class. HadoopTask uses the injector to create an instance of `ExtensionsLoader` which contains the `ExtensionsConfig` class. However, the modules in the injector are insufficient to supply the properties passed to the druid server to the `ExtensionsConfig` (POJO), due to which irrespective of the Druid's config, it will get instantiated with the default properties.
This PR fixes the injector so that the `ExtensionsConfig` is instantiated properly.

#### Testing
To be added


<hr>

##### Key changed/added classes in this PR
 * `HadoopTask`

<hr>

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
