### PR TITLE
Grab the thread name in a poisoned pool

### DIFF
--- a/core/src/main/java/org/apache/druid/collections/StupidPool.java
+++ b/core/src/main/java/org/apache/druid/collections/StupidPool.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.Cleaners;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import java.lang.ref.WeakReference;
@@ -156,7 +157,7 @@ public class StupidPool<T> implements NonBlockingPool<T>
       if (POISONED.get()) {
         final RuntimeException exception = capturedException.get();
         if (exception == null) {
-          resourceHolder.notifier.except = new RuntimeException("leaky leak!");
+          resourceHolder.notifier.except = new RE("Thread[%s]: leaky leak!", Thread.currentThread().getName());
         } else {
           throw exception;
         }
@@ -316,7 +317,7 @@ public class StupidPool<T> implements NonBlockingPool<T>
       poolReference = new WeakReference<>(pool);
       leakedObjectsCounter = pool.leakedObjectsCounter;
 
-      except = poisoned ? new RuntimeException("drip drip") : null;
+      except = poisoned ? new RE("Thread[%s]: drip drip", Thread.currentThread().getName()) : null;
     }
 
     @Override


### PR DESCRIPTION
Sometimes resources are checked out from other threads.  In those cases, the stack trace for the leak doesn't actually have the name of the test in it, we attempt to grab the thread name as well in the hopes of figuring out where the leak came from.