### PR TITLE
Lazy initialization of segment killers, movers and archivers

### DIFF
--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssStorageDruidModuleTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssStorageDruidModuleTest.java
@@ -42,8 +42,8 @@ public class OssStorageDruidModuleTest
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
     Assert.assertTrue(killer.getKillers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
     Assert.assertSame(
-        killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP),
-        killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP)
+        killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
+        killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );
   }
 
@@ -54,8 +54,8 @@ public class OssStorageDruidModuleTest
     OmniDataSegmentArchiver archiver = injector.getInstance(OmniDataSegmentArchiver.class);
     Assert.assertTrue(archiver.getArchivers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
     Assert.assertSame(
-        archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP),
-        archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP)
+        archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
+        archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );
   }
 
@@ -66,8 +66,8 @@ public class OssStorageDruidModuleTest
     OmniDataSegmentMover mover = injector.getInstance(OmniDataSegmentMover.class);
     Assert.assertTrue(mover.getMovers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
     Assert.assertSame(
-        mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP),
-        mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP)
+        mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
+        mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );
   }
 

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageDruidModuleTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageDruidModuleTest.java
@@ -278,11 +278,11 @@ public class AzureStorageDruidModuleTest extends EasyMockSupport
     Assert.assertTrue(killer.getKillers().containsKey(AzureStorageDruidModule.SCHEME));
     Assert.assertSame(
         AzureDataSegmentKiller.class,
-        killer.getKillers().get(AzureStorageDruidModule.SCHEME).getClass()
+        killer.getKillers().get(AzureStorageDruidModule.SCHEME).get().getClass()
     );
     Assert.assertSame(
-        killer.getKillers().get(AzureStorageDruidModule.SCHEME),
-        killer.getKillers().get(AzureStorageDruidModule.SCHEME)
+        killer.getKillers().get(AzureStorageDruidModule.SCHEME).get(),
+        killer.getKillers().get(AzureStorageDruidModule.SCHEME).get()
     );
   }
 

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageDruidModuleTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageDruidModuleTest.java
@@ -36,8 +36,8 @@ public class GoogleStorageDruidModuleTest
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
     Assert.assertTrue(killer.getKillers().containsKey(GoogleStorageDruidModule.SCHEME));
     Assert.assertSame(
-        killer.getKillers().get(GoogleStorageDruidModule.SCHEME),
-        killer.getKillers().get(GoogleStorageDruidModule.SCHEME)
+        killer.getKillers().get(GoogleStorageDruidModule.SCHEME).get(),
+        killer.getKillers().get(GoogleStorageDruidModule.SCHEME).get()
     );
   }
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModuleTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModuleTest.java
@@ -70,8 +70,8 @@ public class HdfsStorageDruidModuleTest
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
     Assert.assertTrue(killer.getKillers().containsKey(HdfsStorageDruidModule.SCHEME));
     Assert.assertSame(
-        killer.getKillers().get(HdfsStorageDruidModule.SCHEME),
-        killer.getKillers().get(HdfsStorageDruidModule.SCHEME)
+        killer.getKillers().get(HdfsStorageDruidModule.SCHEME).get(),
+        killer.getKillers().get(HdfsStorageDruidModule.SCHEME).get()
     );
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
@@ -38,8 +38,8 @@ public class S3StorageDruidModuleTest
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
     Assert.assertTrue(killer.getKillers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
     Assert.assertSame(
-        killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP),
-        killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP)
+        killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
+        killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );
   }
 
@@ -50,8 +50,8 @@ public class S3StorageDruidModuleTest
     OmniDataSegmentArchiver archiver = injector.getInstance(OmniDataSegmentArchiver.class);
     Assert.assertTrue(archiver.getArchivers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
     Assert.assertSame(
-        archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP),
-        archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP)
+        archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
+        archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );
   }
 
@@ -62,8 +62,8 @@ public class S3StorageDruidModuleTest
     OmniDataSegmentMover mover = injector.getInstance(OmniDataSegmentMover.class);
     Assert.assertTrue(mover.getMovers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
     Assert.assertSame(
-        mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP),
-        mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP)
+        mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
+        mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );
   }
 

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentArchiver.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentArchiver.java
@@ -40,8 +40,9 @@ public class OmniDataSegmentArchiver implements DataSegmentArchiver
   )
   {
     this.archivers = new HashMap<>();
-    for (String type : archivers.keySet()) {
-      Provider<DataSegmentArchiver> provider = archivers.get(type);
+    for (Map.Entry<String, Provider<DataSegmentArchiver>> entry : archivers.entrySet()) {
+      String type = entry.getKey();
+      Provider<DataSegmentArchiver> provider = entry.getValue();
       this.archivers.put(type, Suppliers.memoize(provider::get));
     }
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentArchiver.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentArchiver.java
@@ -20,22 +20,30 @@
 package org.apache.druid.segment.loading;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.timeline.DataSegment;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class OmniDataSegmentArchiver implements DataSegmentArchiver
 {
-  private final Map<String, DataSegmentArchiver> archivers;
+  private final Map<String, Supplier<DataSegmentArchiver>> archivers;
 
   @Inject
   public OmniDataSegmentArchiver(
-      Map<String, DataSegmentArchiver> archivers
+      Map<String, Provider<DataSegmentArchiver>> archivers
   )
   {
-    this.archivers = archivers;
+    this.archivers = new HashMap<>();
+    for (String type : archivers.keySet()) {
+      Provider<DataSegmentArchiver> provider = archivers.get(type);
+      this.archivers.put(type, Suppliers.memoize(provider::get));
+    }
   }
 
   @Override
@@ -53,17 +61,17 @@ public class OmniDataSegmentArchiver implements DataSegmentArchiver
   private DataSegmentArchiver getArchiver(DataSegment segment) throws SegmentLoadingException
   {
     String type = MapUtils.getString(segment.getLoadSpec(), "type");
-    DataSegmentArchiver archiver = archivers.get(type);
+    Supplier<DataSegmentArchiver> archiver = archivers.get(type);
 
     if (archiver == null) {
       throw new SegmentLoadingException("Unknown loader type[%s].  Known types are %s", type, archivers.keySet());
     }
 
-    return archiver;
+    return archiver.get();
   }
 
   @VisibleForTesting
-  public Map<String, DataSegmentArchiver> getArchivers()
+  public Map<String, Supplier<DataSegmentArchiver>> getArchivers()
   {
     return archivers;
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentKiller.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentKiller.java
@@ -20,25 +20,34 @@
 package org.apache.druid.segment.loading;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
+
+import java.util.HashMap;
 import java.util.Map;
 
 /**
  */
 public class OmniDataSegmentKiller implements DataSegmentKiller
 {
-  private final Map<String, DataSegmentKiller> killers;
+  private final Map<String, Supplier<DataSegmentKiller>> killers;
 
   @Inject
   public OmniDataSegmentKiller(
-      Map<String, DataSegmentKiller> killers
+      Map<String, Provider<DataSegmentKiller>> killers
   )
   {
-    this.killers = killers;
+    this.killers = new HashMap<>();
+    for (String type : killers.keySet()) {
+      Provider<DataSegmentKiller> provider = killers.get(type);
+      this.killers.put(type, Suppliers.memoize(provider::get));
+    }
   }
 
   @Override
@@ -57,13 +66,13 @@ public class OmniDataSegmentKiller implements DataSegmentKiller
       return null;
     }
     String type = MapUtils.getString(segment.getLoadSpec(), "type");
-    DataSegmentKiller loader = killers.get(type);
+    Supplier<DataSegmentKiller> killer = killers.get(type);
 
-    if (loader == null) {
-      throw new SegmentLoadingException("Unknown loader type[%s].  Known types are %s", type, killers.keySet());
+    if (killer == null) {
+      throw new SegmentLoadingException("Unknown segment killer type[%s].  Known types are %s", type, killers.keySet());
     }
 
-    return loader;
+    return killer.get();
   }
 
   @Override
@@ -73,7 +82,7 @@ public class OmniDataSegmentKiller implements DataSegmentKiller
   }
 
   @VisibleForTesting
-  public Map<String, DataSegmentKiller> getKillers()
+  public Map<String, Supplier<DataSegmentKiller>> getKillers()
   {
     return killers;
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentKiller.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentKiller.java
@@ -44,8 +44,9 @@ public class OmniDataSegmentKiller implements DataSegmentKiller
   )
   {
     this.killers = new HashMap<>();
-    for (String type : killers.keySet()) {
-      Provider<DataSegmentKiller> provider = killers.get(type);
+    for (Map.Entry<String, Provider<DataSegmentKiller>> entry : killers.entrySet()) {
+      String type = entry.getKey();
+      Provider<DataSegmentKiller> provider = entry.getValue();
       this.killers.put(type, Suppliers.memoize(provider::get));
     }
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentMover.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentMover.java
@@ -40,8 +40,9 @@ public class OmniDataSegmentMover implements DataSegmentMover
   )
   {
     this.movers = new HashMap<>();
-    for (String type : movers.keySet()) {
-      Provider<DataSegmentMover> provider = movers.get(type);
+    for (Map.Entry<String, Provider<DataSegmentMover>> entry : movers.entrySet()) {
+      String type = entry.getKey();
+      Provider<DataSegmentMover> provider = entry.getValue();
       this.movers.put(type, Suppliers.memoize(provider::get));
     }
   }

--- a/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentMover.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/OmniDataSegmentMover.java
@@ -20,22 +20,30 @@
 package org.apache.druid.segment.loading;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.timeline.DataSegment;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class OmniDataSegmentMover implements DataSegmentMover
 {
-  private final Map<String, DataSegmentMover> movers;
+  private final Map<String, Supplier<DataSegmentMover>> movers;
 
   @Inject
   public OmniDataSegmentMover(
-      Map<String, DataSegmentMover> movers
+      Map<String, Provider<DataSegmentMover>> movers
   )
   {
-    this.movers = movers;
+    this.movers = new HashMap<>();
+    for (String type : movers.keySet()) {
+      Provider<DataSegmentMover> provider = movers.get(type);
+      this.movers.put(type, Suppliers.memoize(provider::get));
+    }
   }
 
   @Override
@@ -47,17 +55,17 @@ public class OmniDataSegmentMover implements DataSegmentMover
   private DataSegmentMover getMover(DataSegment segment) throws SegmentLoadingException
   {
     String type = MapUtils.getString(segment.getLoadSpec(), "type");
-    DataSegmentMover mover = movers.get(type);
+    Supplier<DataSegmentMover> mover = movers.get(type);
 
     if (mover == null) {
       throw new SegmentLoadingException("Unknown loader type[%s].  Known types are %s", type, movers.keySet());
     }
 
-    return mover;
+    return mover.get();
   }
 
   @VisibleForTesting
-  public Map<String, DataSegmentMover> getMovers()
+  public Map<String, Supplier<DataSegmentMover>> getMovers()
   {
     return movers;
   }

--- a/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
+++ b/server/src/test/java/org/apache/druid/guice/LocalDataStorageDruidModuleTest.java
@@ -42,8 +42,8 @@ public class LocalDataStorageDruidModuleTest
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
     Assert.assertTrue(killer.getKillers().containsKey(LocalDataStorageDruidModule.SCHEME));
     Assert.assertSame(
-        killer.getKillers().get(LocalDataStorageDruidModule.SCHEME),
-        killer.getKillers().get(LocalDataStorageDruidModule.SCHEME)
+        killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get(),
+        killer.getKillers().get(LocalDataStorageDruidModule.SCHEME).get()
     );
   }
 

--- a/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentArchiverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentArchiverTest.java
@@ -108,13 +108,13 @@ public class OmniDataSegmentArchiverTest
     }
 
     @Override
-    public DataSegment archive(DataSegment segment) throws SegmentLoadingException
+    public DataSegment archive(DataSegment segment)
     {
       return null;
     }
 
     @Override
-    public DataSegment restore(DataSegment segment) throws SegmentLoadingException
+    public DataSegment restore(DataSegment segment)
     {
       return null;
     }

--- a/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentArchiverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentArchiverTest.java
@@ -21,10 +21,12 @@ package org.apache.druid.segment.loading;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.druid.guice.Binders;
 import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.timeline.DataSegment;
 import org.junit.Assert;
 import org.junit.Test;
@@ -62,6 +64,21 @@ public class OmniDataSegmentArchiverTest
     );
   }
 
+  @Test
+  public void testBadSegmentArchiverAccessException()
+  {
+    final DataSegment segment = Mockito.mock(DataSegment.class);
+    Mockito.when(segment.getLoadSpec()).thenReturn(ImmutableMap.of("type", "bad"));
+
+    final Injector injector = createInjector(null);
+    final OmniDataSegmentArchiver segmentArchiver = injector.getInstance(OmniDataSegmentArchiver.class);
+    Assert.assertThrows(
+        "BadSegmentArchiver must not have been initialized",
+        RuntimeException.class,
+        () -> segmentArchiver.archive(segment)
+    );
+  }
+
   private static Injector createInjector(@Nullable DataSegmentArchiver archiver)
   {
     return GuiceInjectors.makeStartupInjectorWithModules(
@@ -71,8 +88,35 @@ public class OmniDataSegmentArchiverTest
               if (archiver != null) {
                 mapBinder.addBinding("sane").toInstance(archiver);
               }
+            },
+            binder -> {
+              MapBinder<String, DataSegmentArchiver> mapBinder = Binders.dataSegmentArchiverBinder(binder);
+              mapBinder.addBinding("bad").to(BadSegmentArchiver.class);
             }
         )
     );
+  }
+  
+  @LazySingleton
+  private static class BadSegmentArchiver implements DataSegmentArchiver
+  {
+
+    @Inject
+    BadSegmentArchiver()
+    {
+      throw new RuntimeException("BadSegmentArchiver must not have been initialized");
+    }
+
+    @Override
+    public DataSegment archive(DataSegment segment) throws SegmentLoadingException
+    {
+      return null;
+    }
+
+    @Override
+    public DataSegment restore(DataSegment segment) throws SegmentLoadingException
+    {
+      return null;
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentKillerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentKillerTest.java
@@ -21,10 +21,14 @@ package org.apache.druid.segment.loading;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Module;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.druid.guice.Binders;
 import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
@@ -33,6 +37,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
+
+import java.io.IOException;
 
 public class OmniDataSegmentKillerTest
 {
@@ -65,16 +71,32 @@ public class OmniDataSegmentKillerTest
     );
   }
 
+  @Test
+  public void testBadSegmentKillerAccessException()
+  {
+    final DataSegment segment = Mockito.mock(DataSegment.class);
+    Mockito.when(segment.getLoadSpec()).thenReturn(ImmutableMap.of("type", "bad"));
+
+    final Injector injector = createInjector(null);
+    final OmniDataSegmentKiller segmentKiller = injector.getInstance(OmniDataSegmentKiller.class);
+    Assert.assertThrows(
+        "BadSegmentKiller should not have been initialized",
+        RuntimeException.class,
+        () -> segmentKiller.kill(segment)
+    );
+  }
+
   private static Injector createInjector(@Nullable DataSegmentKiller killer)
   {
     return GuiceInjectors.makeStartupInjectorWithModules(
         ImmutableList.of(
-            binder -> {
+            (Module) binder -> {
               MapBinder<String, DataSegmentKiller> mapBinder = Binders.dataSegmentKillerBinder(binder);
               if (killer != null) {
                 mapBinder.addBinding("sane").toInstance(killer);
               }
-            }
+            },
+            new BadSegmentKillerModule()
         )
     );
   }
@@ -96,6 +118,39 @@ public class OmniDataSegmentKillerTest
     final Injector injector = createInjector(null);
     final OmniDataSegmentKiller segmentKiller = injector.getInstance(OmniDataSegmentKiller.class);
     segmentKiller.kill(tombstone);
+  }
+
+  private static class BadSegmentKillerModule extends AbstractModule
+  {
+
+    @Override
+    protected void configure()
+    {
+      MapBinder<String, DataSegmentKiller> mapBinder = Binders.dataSegmentKillerBinder(binder());
+      mapBinder.addBinding("bad").to(BadSegmentKiller.class);
+    }
+  }
+
+  @LazySingleton
+  private static class BadSegmentKiller implements DataSegmentKiller
+  {
+    @Inject
+    BadSegmentKiller()
+    {
+      throw new RuntimeException("BadSegmentKiller should not have been initialized");
+    }
+
+    @Override
+    public void kill(DataSegment segment) throws SegmentLoadingException
+    {
+
+    }
+
+    @Override
+    public void killAll() throws IOException
+    {
+
+    }
   }
 
 

--- a/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentMoverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentMoverTest.java
@@ -21,16 +21,20 @@ package org.apache.druid.segment.loading;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.druid.guice.Binders;
 import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.timeline.DataSegment;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
+
+import java.util.Map;
 
 public class OmniDataSegmentMoverTest
 {
@@ -62,6 +66,21 @@ public class OmniDataSegmentMoverTest
     );
   }
 
+  @Test
+  public void testBadSegmentMoverAccessException()
+  {
+    final DataSegment segment = Mockito.mock(DataSegment.class);
+    Mockito.when(segment.getLoadSpec()).thenReturn(ImmutableMap.of("type", "bad"));
+
+    final Injector injector = createInjector(null);
+    final OmniDataSegmentMover segmentMover = injector.getInstance(OmniDataSegmentMover.class);
+    Assert.assertThrows(
+        "BadSegmentMover must not have been initialized",
+        RuntimeException.class,
+        () -> segmentMover.move(segment, null)
+    );
+  }
+
   private static Injector createInjector(@Nullable DataSegmentMover mover)
   {
     return GuiceInjectors.makeStartupInjectorWithModules(
@@ -71,8 +90,29 @@ public class OmniDataSegmentMoverTest
               if (mover != null) {
                 mapBinder.addBinding("sane").toInstance(mover);
               }
+            },
+            binder -> {
+              MapBinder<String, DataSegmentMover> mapBinder = Binders.dataSegmentMoverBinder(binder);
+              mapBinder.addBinding("bad").to(BadSegmentMover.class);
             }
         )
     );
+  }
+
+  @LazySingleton
+  private static class BadSegmentMover implements DataSegmentMover
+  {
+
+    @Inject
+    BadSegmentMover()
+    {
+      throw new RuntimeException("BadSegmentMover must not have been initialized");
+    }
+
+    @Override
+    public DataSegment move(DataSegment segment, Map<String, Object> targetLoadSpec) throws SegmentLoadingException
+    {
+      return null;
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentMoverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/loading/OmniDataSegmentMoverTest.java
@@ -110,7 +110,7 @@ public class OmniDataSegmentMoverTest
     }
 
     @Override
-    public DataSegment move(DataSegment segment, Map<String, Object> targetLoadSpec) throws SegmentLoadingException
+    public DataSegment move(DataSegment segment, Map<String, Object> targetLoadSpec)
     {
       return null;
     }


### PR DESCRIPTION
This is a follow-up change to https://github.com/apache/druid/pull/12207. Even after this PR, we do see issues when enabling cloud storage extensions. E.g. if google cloud extension is enabled, `org.apache.druid.common.gcp.GcpModule#getHttpRequestInitializer` is invoked during task startup. This method fails if the druid cannot find valid google storage credentials. 

```
Caused by: java.io.IOException: The Application Default Credentials are not available. They are available if running on Google App Engine, Google Compute Engine, or Google Cloud Shell. Otherwise, the environment variable GOOGLE_APPLICATION_CREDENTIALS must be defined pointing to a file defining the credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
	at com.google.api.client.googleapis.auth.oauth2.DefaultCredentialProvider.getDefaultCredential(DefaultCredentialProvider.java:98) ~[google-api-client-1.26.0.jar:1.26.0]
	at com.google.api.client.googleapis.auth.oauth2.GoogleCredential.getApplicationDefault(GoogleCredential.java:213) ~[google-api-client-1.26.0.jar:1.26.0]
	at org.apache.druid.common.gcp.GcpModule.getHttpRequestInitializer(GcpModule.java:60) ~[druid-gcp-common-xxxx]
```

IMO #12207 pushes the burden of solving this problem down to the extension. I was going to do the same initially but instead opted for a different approach. The underlying problem is that maps are materialized in `OmniDataSegmentKiller`, `OmniDataSegmentPusher` and `OmniDataSegmentArchiver` eagerly. I have changed the implementations of these classes to use `Provider` as values in the map. The `provider.get` is further wrapped inside `Suppliers.memoize` so we create just one instance for each provider. 

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
