### PR TITLE
upgrade kubernetes extension k8s client api jar to v16

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>11.0.1</kubernetes.client.version>
+    <kubernetes.client.version>16.0.0</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -134,16 +134,20 @@ public class DefaultK8sApiClient implements K8sApiClient
               if (item != null && item.type != null) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
                 if (item.object != null && item.object.getMetadata() != null) {
-                  result = new DiscoveryDruidNodeAndResourceVersion(
-                    item.object.getMetadata().getResourceVersion(),
-                    getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
-                  );
+                  if (item.object.getMetadata().getAnnotations() != null) {
+                    result = new DiscoveryDruidNodeAndResourceVersion(
+                        item.object.getMetadata().getResourceVersion(),
+                        getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
+                    );
+                  } else {
+                    LOGGER.debug("item of type [%s] had NULL annotations when watching nodeRole [%s]", item.type, nodeRole);
+                  }
                 } else {
                   // The item's object, or the metadata it contains, can be null in some
                   // cases -- likely due to a blip in the k8s watch. Handle that by
                   // passing the null upwards. The caller needs to know that the object
                   // can be null.
-                  LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
+                  LOGGER.debug("item of type [%s] was NULL or had NULL metadata when watching nodeRole [%s]", item.type, nodeRole);
                 }
 
                 obj = new Watch.Response<DiscoveryDruidNodeAndResourceVersion>(

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -139,9 +139,10 @@ public class DefaultK8sApiClient implements K8sApiClient
                     getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
                   );
                 } else {
-                  // The item's object can be null in some cases -- likely due to a blip
-                  // in the k8s watch. Handle that by passing the null upwards. The caller
-                  // needs to know that the object can be null.
+                  // The item's object, or the metadata it contains, can be null in some
+                  // cases -- likely due to a blip in the k8s watch. Handle that by
+                  // passing the null upwards. The caller needs to know that the object
+                  // can be null.
                   LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
                 }
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -133,7 +133,7 @@ public class DefaultK8sApiClient implements K8sApiClient
               Watch.Response<V1Pod> item = watch.next();
               if (item != null && item.type != null) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
-                if (item.object != null) {
+                if (item.object != null && item.object.getMetadata() != null) {
                   result = new DiscoveryDruidNodeAndResourceVersion(
                     item.object.getMetadata().getResourceVersion(),
                     getDiscoveryDruidNodeFromPodDef(nodeRole, item.object)
@@ -142,7 +142,7 @@ public class DefaultK8sApiClient implements K8sApiClient
                   // The item's object can be null in some cases -- likely due to a blip
                   // in the k8s watch. Handle that by passing the null upwards. The caller
                   // needs to know that the object can be null.
-                  LOGGER.debug("item of type " + item.type + " was NULL when watching nodeRole [%s]", nodeRole);
+                  LOGGER.debug("item of type " + item.type + " was NULL or had NULL metadata when watching nodeRole [%s]", nodeRole);
                 }
 
                 obj = new Watch.Response<DiscoveryDruidNodeAndResourceVersion>(

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
@@ -26,11 +26,6 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.List;
-import java.util.TimeZone;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderSelector;
@@ -42,6 +37,12 @@ import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.server.DruidNode;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
 
 public class K8sDiscoveryModule implements DruidModule
 {

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
@@ -26,6 +26,11 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.List;
+import java.util.TimeZone;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
 import org.apache.druid.discovery.DruidLeaderSelector;
@@ -37,10 +42,6 @@ import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.server.DruidNode;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 public class K8sDiscoveryModule implements DruidModule
 {
@@ -63,7 +64,10 @@ public class K8sDiscoveryModule implements DruidModule
                 try {
                   // Note: we can probably improve things here about figuring out how to find the K8S API server,
                   // HTTP client timeouts etc.
-                  return Config.defaultClient();
+                  final SimpleDateFormat dateFormat = new SimpleDateFormat(
+                      "yyyyMMdd'T'HHmmss.SSS'Z'");
+                  dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+                  return Config.defaultClient().setDateFormat(dateFormat);
                 }
                 catch (IOException ex) {
                   throw new RuntimeException("Failed to create K8s ApiClient instance", ex);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Applies to #12904.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
- Upgrade the k8s client API jar to v16.0.0
- Adopt the API changes required in the kubernetes extension

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Kubernetes client API jar v.11.0.0 contains several critical security vulnerabilities.  Adopting v16 requires two small changes to the existing code:
1. a new constructor parameter has been added to the ApiClient
2. the ApiClient config now requires the date formatter used to parse the timestamps in the k8s metadata.
3. pod metadata can be null, which creates an NPE attempting to extract information.  This is treated the same as if the pod itself were null, an existing condition.

The date parsing in particular is necessary to handle the possible date format differences.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
- pom change to bump the k8s client jar version
- constructor change - ApiClient now requires an additional parameter
- APIClient config change - requires a custom data parser to support he data format used by druid.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
