### PR TITLE
Fix null message handling in AllowedRegexErrorResponseTransformStrategy.

### DIFF
--- a/core/src/main/java/org/apache/druid/common/exception/AllowedRegexErrorResponseTransformStrategy.java
+++ b/core/src/main/java/org/apache/druid/common/exception/AllowedRegexErrorResponseTransformStrategy.java
@@ -51,7 +51,8 @@ public class AllowedRegexErrorResponseTransformStrategy implements ErrorResponse
   public Function<String, String> getErrorMessageTransformFunction()
   {
     return (String errorMessage) -> {
-      if (allowedRegexPattern.stream().anyMatch(pattern -> pattern.matcher(errorMessage).matches())) {
+      if (errorMessage == null || allowedRegexPattern.stream()
+                                                     .anyMatch(pattern -> pattern.matcher(errorMessage).matches())) {
         return errorMessage;
       } else {
         return null;

--- a/core/src/test/java/org/apache/druid/common/exception/AllowedRegexErrorResponseTransformStrategyTest.java
+++ b/core/src/test/java/org/apache/druid/common/exception/AllowedRegexErrorResponseTransformStrategyTest.java
@@ -60,6 +60,16 @@ public class AllowedRegexErrorResponseTransformStrategyTest
   }
 
   @Test
+  public void testGetErrorMessageTransformFunctionWithNullMessage()
+  {
+    AllowedRegexErrorResponseTransformStrategy allowedRegex = new AllowedRegexErrorResponseTransformStrategy(
+        ImmutableList.of("acbd", "qwer")
+    );
+    String result = allowedRegex.getErrorMessageTransformFunction().apply(null);
+    Assert.assertNull(result);
+  }
+
+  @Test
   public void testEqualsAndHashCode()
   {
     EqualsVerifier.forClass(AllowedRegexErrorResponseTransformStrategy.class)


### PR DESCRIPTION
Error messages can be null. If the incoming error message is null, then return null.