### PR TITLE
Set useMaxMemoryEstimates=false by default

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -46,15 +46,13 @@ public class Tasks
   public static final long DEFAULT_LOCK_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(5);
   public static final boolean DEFAULT_FORCE_TIME_CHUNK_LOCK = true;
   public static final boolean DEFAULT_STORE_COMPACTION_STATE = false;
-  public static final boolean DEFAULT_USE_MAX_MEMORY_ESTIMATES = true;
+  public static final boolean DEFAULT_USE_MAX_MEMORY_ESTIMATES = false;
 
   public static final String PRIORITY_KEY = "priority";
   public static final String LOCK_TIMEOUT_KEY = "taskLockTimeout";
   public static final String FORCE_TIME_CHUNK_LOCK_KEY = "forceTimeChunkLock";
   public static final String USE_SHARED_LOCK = "useSharedLock";
   public static final String STORE_EMPTY_COLUMNS_KEY = "storeEmptyColumns";
-  public static final String DYNAMIC_CONFIG_PROVIDER_KEY = "dynamicConfigProviderKey";
-
 
   /**
    * Context flag denoting if maximum possible values should be used to estimate

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorsTest.java
@@ -246,7 +246,7 @@ public class AppenderatorsTest
               indexMerger,
               rowIngestionMeters,
               new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-              true
+              false
           );
           break;
         case "CLOSED_SEGMENTS":
@@ -261,7 +261,7 @@ public class AppenderatorsTest
               indexMerger,
               rowIngestionMeters,
               new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-              true
+              false
           );
 
           break;
@@ -277,7 +277,7 @@ public class AppenderatorsTest
               indexMerger,
               rowIngestionMeters,
               new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-              true
+              false
           );
           break;
         default:

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
@@ -258,7 +258,7 @@ public class BatchAppenderatorsTest
                   Integer.MAX_VALUE,
                   0
               ),
-              true
+              false
           );
           break;
         case "CLOSED_SEGMENTS":
@@ -281,7 +281,7 @@ public class BatchAppenderatorsTest
                   Integer.MAX_VALUE,
                   0
               ),
-              true
+              false
           );
 
           break;
@@ -305,7 +305,7 @@ public class BatchAppenderatorsTest
                   Integer.MAX_VALUE,
                   0
               ),
-              true
+              false
           );
           break;
         default:

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
@@ -90,7 +90,7 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         cachePopulatorStats,
         rowIngestionMeters,
         parseExceptionHandler,
-        true
+        useMaxMemoryEstimates
     );
     return realtimeAppenderator;
   }
@@ -121,7 +121,7 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         indexMerger,
         rowIngestionMeters,
         parseExceptionHandler,
-        true
+        useMaxMemoryEstimates
     );
   }
 
@@ -181,7 +181,7 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         indexMerger,
         rowIngestionMeters,
         parseExceptionHandler,
-        true
+        useMaxMemoryEstimates
     );
   }
 


### PR DESCRIPTION
Sets the flag `useMaxMemoryEstimates` added by #12073 to `false` by default.
A value of `false` denotes that the new flow with improved estimates will be used.

Changes:
- Update default value in `Tasks`
- Update default value used in tests.

This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)