### PR TITLE
Add inline descriptor Protobuf bytes decoder

### DIFF
--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -1308,6 +1308,26 @@ Sample spec:
 }
 ```
 
+#### Inline Descriptor Protobuf Bytes Decoder
+
+This Protobuf bytes decoder allows the user to provide the contents of a Protobuf descriptor file inline, encoded as a Base64 string, and then parse it to get schema used to decode the Protobuf record from bytes.
+
+| Field | Type | Description | Required |
+|-------|------|-------------|----------|
+| type | String | Set value to `inline`. | yes |
+| descriptorString | String | A compiled Protobuf descriptor, encoded as a Base64 string. | yes |
+| protoMessageType | String | Protobuf message type in the descriptor.  Both short name and fully qualified name are accepted. The parser uses the first message type found in the descriptor if not specified. | no |
+
+Sample spec:
+
+```json
+"protoBytesDecoder": {
+  "type": "inline",
+  "descriptorString": <Contents of a Protobuf descriptor file encoded as Base64 string>,
+  "protoMessageType": "Metrics"
+}
+```
+
 ##### Confluent Schema Registry-based Protobuf Bytes Decoder
 
 This Protobuf bytes decoder first extracts a unique `id` from input message bytes, and then uses it to look up the schema in the Schema Registry used to decode the Avro record from bytes.

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -164,6 +164,11 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/DescriptorBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/DescriptorBasedProtobufBytesDecoder.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.data.input.protobuf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -10,12 +29,13 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class DescriptorBasedProtobufBytesDecoder implements ProtobufBytesDecoder
 {
-  protected Descriptors.Descriptor descriptor;
-  protected final String protoMessageType;
+  private Descriptors.Descriptor descriptor;
+  private final String protoMessageType;
 
   public DescriptorBasedProtobufBytesDecoder(
       final String protoMessageType
@@ -30,16 +50,21 @@ public abstract class DescriptorBasedProtobufBytesDecoder implements ProtobufByt
     return protoMessageType;
   }
 
+  public Descriptors.Descriptor getDescriptor()
+  {
+    return descriptor;
+  }
+
   @VisibleForTesting
   void initDescriptor()
   {
     if (this.descriptor == null) {
-      final DynamicSchema dynamicSchema = getDynamicSchema();
-      this.descriptor = getDescriptor(dynamicSchema);
+      final DynamicSchema dynamicSchema = generateDynamicSchema();
+      this.descriptor = generateDescriptor(dynamicSchema);
     }
   }
 
-  protected abstract DynamicSchema getDynamicSchema();
+  protected abstract DynamicSchema generateDynamicSchema();
 
   @Override
   public DynamicMessage parse(ByteBuffer bytes)
@@ -53,7 +78,7 @@ public abstract class DescriptorBasedProtobufBytesDecoder implements ProtobufByt
     }
   }
 
-  private Descriptors.Descriptor getDescriptor(DynamicSchema dynamicSchema)
+  private Descriptors.Descriptor generateDescriptor(DynamicSchema dynamicSchema)
   {
     Set<String> messageTypes = dynamicSchema.getMessageTypes();
     if (messageTypes.size() == 0) {
@@ -73,5 +98,24 @@ public abstract class DescriptorBasedProtobufBytesDecoder implements ProtobufByt
       );
     }
     return desc;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DescriptorBasedProtobufBytesDecoder that = (DescriptorBasedProtobufBytesDecoder) o;
+    return Objects.equals(getProtoMessageType(), that.getProtoMessageType());
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(getProtoMessageType());
   }
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/DescriptorBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/DescriptorBasedProtobufBytesDecoder.java
@@ -1,0 +1,77 @@
+package org.apache.druid.data.input.protobuf;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.os72.protobuf.dynamic.DynamicSchema;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.ParseException;
+
+import java.nio.ByteBuffer;
+import java.util.Set;
+
+public abstract class DescriptorBasedProtobufBytesDecoder implements ProtobufBytesDecoder
+{
+  protected Descriptors.Descriptor descriptor;
+  protected final String protoMessageType;
+
+  public DescriptorBasedProtobufBytesDecoder(
+      final String protoMessageType
+  )
+  {
+    this.protoMessageType = protoMessageType;
+  }
+
+  @JsonProperty
+  public String getProtoMessageType()
+  {
+    return protoMessageType;
+  }
+
+  @VisibleForTesting
+  void initDescriptor()
+  {
+    if (this.descriptor == null) {
+      final DynamicSchema dynamicSchema = getDynamicSchema();
+      this.descriptor = getDescriptor(dynamicSchema);
+    }
+  }
+
+  protected abstract DynamicSchema getDynamicSchema();
+
+  @Override
+  public DynamicMessage parse(ByteBuffer bytes)
+  {
+    try {
+      DynamicMessage message = DynamicMessage.parseFrom(descriptor, ByteString.copyFrom(bytes));
+      return message;
+    }
+    catch (Exception e) {
+      throw new ParseException(null, e, "Fail to decode protobuf message!");
+    }
+  }
+
+  private Descriptors.Descriptor getDescriptor(DynamicSchema dynamicSchema)
+  {
+    Set<String> messageTypes = dynamicSchema.getMessageTypes();
+    if (messageTypes.size() == 0) {
+      throw new ParseException(null, "No message types found in the descriptor.");
+    }
+
+    String messageType = protoMessageType == null ? (String) messageTypes.toArray()[0] : protoMessageType;
+    Descriptors.Descriptor desc = dynamicSchema.getMessageDescriptor(messageType);
+    if (desc == null) {
+      throw new ParseException(
+          null,
+          StringUtils.format(
+              "Protobuf message type %s not found in the specified descriptor.  Available messages types are %s",
+              protoMessageType,
+              messageTypes
+          )
+      );
+    }
+    return desc;
+  }
+}

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
@@ -48,14 +48,14 @@ public class FileBasedProtobufBytesDecoder extends DescriptorBasedProtobufBytesD
     initDescriptor();
   }
 
-  @JsonProperty
-  public String getDescriptor()
+  @JsonProperty("descriptor")
+  public String getDescriptorFilePath()
   {
     return descriptorFilePath;
   }
 
   @Override
-  protected DynamicSchema getDynamicSchema()
+  protected DynamicSchema generateDynamicSchema()
   {
     InputStream fin;
 
@@ -100,17 +100,16 @@ public class FileBasedProtobufBytesDecoder extends DescriptorBasedProtobufBytesD
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
+    if (!super.equals(o)) {
+      return false;
+    }
     FileBasedProtobufBytesDecoder that = (FileBasedProtobufBytesDecoder) o;
-
-    return Objects.equals(descriptorFilePath, that.descriptorFilePath) &&
-           Objects.equals(protoMessageType, that.protoMessageType);
+    return Objects.equals(descriptorFilePath, that.descriptorFilePath);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(descriptorFilePath, protoMessageType);
+    return Objects.hash(super.hashCode(), descriptorFilePath);
   }
-
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoder.java
@@ -22,27 +22,19 @@ package org.apache.druid.data.input.protobuf;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.os72.protobuf.dynamic.DynamicSchema;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.ByteString;
+import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.DynamicMessage;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.util.Objects;
-import java.util.Set;
 
-public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
+public class FileBasedProtobufBytesDecoder extends DescriptorBasedProtobufBytesDecoder
 {
   private final String descriptorFilePath;
-  private final String protoMessageType;
-  private Descriptors.Descriptor descriptor;
-
 
   @JsonCreator
   public FileBasedProtobufBytesDecoder(
@@ -50,8 +42,9 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
       @JsonProperty("protoMessageType") String protoMessageType
   )
   {
+    super(protoMessageType);
+    Preconditions.checkNotNull(descriptorFilePath);
     this.descriptorFilePath = descriptorFilePath;
-    this.protoMessageType = protoMessageType;
     initDescriptor();
   }
 
@@ -61,33 +54,8 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     return descriptorFilePath;
   }
 
-  @JsonProperty
-  public String getProtoMessageType()
-  {
-    return protoMessageType;
-  }
-
-  @VisibleForTesting
-  void initDescriptor()
-  {
-    if (this.descriptor == null) {
-      this.descriptor = getDescriptor(descriptorFilePath);
-    }
-  }
-
   @Override
-  public DynamicMessage parse(ByteBuffer bytes)
-  {
-    try {
-      DynamicMessage message = DynamicMessage.parseFrom(descriptor, ByteString.copyFrom(bytes));
-      return message;
-    }
-    catch (Exception e) {
-      throw new ParseException(null, e, "Fail to decode protobuf message!");
-    }
-  }
-
-  private Descriptors.Descriptor getDescriptor(String descriptorFilePath)
+  protected DynamicSchema getDynamicSchema()
   {
     InputStream fin;
 
@@ -111,9 +79,9 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
         throw new ParseException(url.toString(), e, "Cannot read descriptor file: " + url);
       }
     }
-    DynamicSchema dynamicSchema;
+
     try {
-      dynamicSchema = DynamicSchema.parseFrom(fin);
+      return DynamicSchema.parseFrom(fin);
     }
     catch (Descriptors.DescriptorValidationException e) {
       throw new ParseException(null, e, "Invalid descriptor file: " + descriptorFilePath);
@@ -121,25 +89,6 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     catch (IOException e) {
       throw new ParseException(null, e, "Cannot read descriptor file: " + descriptorFilePath);
     }
-
-    Set<String> messageTypes = dynamicSchema.getMessageTypes();
-    if (messageTypes.size() == 0) {
-      throw new ParseException(null, "No message types found in the descriptor: " + descriptorFilePath);
-    }
-
-    String messageType = protoMessageType == null ? (String) messageTypes.toArray()[0] : protoMessageType;
-    Descriptors.Descriptor desc = dynamicSchema.getMessageDescriptor(messageType);
-    if (desc == null) {
-      throw new ParseException(
-          null,
-          StringUtils.format(
-              "Protobuf message type %s not found in the specified descriptor.  Available messages types are %s",
-              protoMessageType,
-              messageTypes
-          )
-      );
-    }
-    return desc;
   }
 
   @Override
@@ -155,7 +104,7 @@ public class FileBasedProtobufBytesDecoder implements ProtobufBytesDecoder
     FileBasedProtobufBytesDecoder that = (FileBasedProtobufBytesDecoder) o;
 
     return Objects.equals(descriptorFilePath, that.descriptorFilePath) &&
-        Objects.equals(protoMessageType, that.protoMessageType);
+           Objects.equals(protoMessageType, that.protoMessageType);
   }
 
   @Override

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.protobuf;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.os72.protobuf.dynamic.DynamicSchema;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.ParseException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.Set;
+
+public class InlineDescriptorProtobufBytesDecoder implements ProtobufBytesDecoder
+{
+  private final String descriptorString;
+  private final String protoMessageType;
+  private Descriptors.Descriptor descriptor;
+
+
+  @JsonCreator
+  public InlineDescriptorProtobufBytesDecoder(
+      @JsonProperty("descriptorString") String descriptorString,
+      @JsonProperty("protoMessageType") String protoMessageType
+  )
+  {
+    this.descriptorString = descriptorString;
+    this.protoMessageType = protoMessageType;
+    initDescriptor();
+  }
+
+  @JsonProperty
+  public String getDescriptorString()
+  {
+    return descriptorString;
+  }
+
+  @JsonProperty
+  public String getProtoMessageType()
+  {
+    return protoMessageType;
+  }
+
+  @VisibleForTesting
+  void initDescriptor()
+  {
+    if (this.descriptor == null) {
+      this.descriptor = getDescriptor(descriptorString);
+    }
+  }
+
+  @Override
+  public DynamicMessage parse(ByteBuffer bytes)
+  {
+    try {
+      DynamicMessage message = DynamicMessage.parseFrom(descriptor, ByteString.copyFrom(bytes));
+      return message;
+    }
+    catch (Exception e) {
+      throw new ParseException(null, e, "Fail to decode protobuf message!");
+    }
+  }
+
+  private Descriptors.Descriptor getDescriptor(String descriptorString)
+  {
+    DynamicSchema dynamicSchema;
+    try {
+      byte[] decodedDesc = StringUtils.decodeBase64String(descriptorString);
+      dynamicSchema = DynamicSchema.parseFrom(decodedDesc);
+    }
+    catch (Descriptors.DescriptorValidationException e) {
+      throw new ParseException(null, e, "Invalid descriptor string: " + descriptorString);
+    }
+    catch (IOException e) {
+      throw new ParseException(null, e, "Cannot read descriptor string: " + descriptorString);
+    }
+
+    Set<String> messageTypes = dynamicSchema.getMessageTypes();
+    if (messageTypes.size() == 0) {
+      throw new ParseException(null, "No message types found in the descriptor: " + descriptorString);
+    }
+
+    String messageType = protoMessageType == null ? (String) messageTypes.toArray()[0] : protoMessageType;
+    Descriptors.Descriptor desc = dynamicSchema.getMessageDescriptor(messageType);
+    if (desc == null) {
+      throw new ParseException(
+          null,
+          StringUtils.format(
+              "Protobuf message type %s not found in the specified descriptor.  Available messages types are %s",
+              protoMessageType,
+              messageTypes
+          )
+      );
+    }
+    return desc;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    InlineDescriptorProtobufBytesDecoder that = (InlineDescriptorProtobufBytesDecoder) o;
+
+    return Objects.equals(descriptorString, that.descriptorString) &&
+           Objects.equals(protoMessageType, that.protoMessageType);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(descriptorString, protoMessageType);
+  }
+
+}

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
@@ -61,7 +61,7 @@ public class InlineDescriptorProtobufBytesDecoder extends DescriptorBasedProtobu
       return DynamicSchema.parseFrom(decodedDesc);
     }
     catch (IllegalArgumentException e) {
-      throw new IAE("Descriptor string was did not have valid Base64 encoding.");
+      throw new IAE("Descriptor string does not have valid Base64 encoding.");
     }
     catch (Descriptors.DescriptorValidationException e) {
       throw new ParseException(null, e, "Invalid descriptor string: " + descriptorString);

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.os72.protobuf.dynamic.DynamicSchema;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.Descriptors;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
@@ -58,6 +59,9 @@ public class InlineDescriptorProtobufBytesDecoder extends DescriptorBasedProtobu
     try {
       byte[] decodedDesc = StringUtils.decodeBase64String(descriptorString);
       return DynamicSchema.parseFrom(decodedDesc);
+    }
+    catch (IllegalArgumentException e) {
+      throw new IAE("Descriptor string was did not have valid Base64 encoding.");
     }
     catch (Descriptors.DescriptorValidationException e) {
       throw new ParseException(null, e, "Invalid descriptor string: " + descriptorString);

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoder.java
@@ -54,7 +54,7 @@ public class InlineDescriptorProtobufBytesDecoder extends DescriptorBasedProtobu
   }
 
   @Override
-  protected DynamicSchema getDynamicSchema()
+  protected DynamicSchema generateDynamicSchema()
   {
     try {
       byte[] decodedDesc = StringUtils.decodeBase64String(descriptorString);
@@ -80,16 +80,16 @@ public class InlineDescriptorProtobufBytesDecoder extends DescriptorBasedProtobu
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
+    if (!super.equals(o)) {
+      return false;
+    }
     InlineDescriptorProtobufBytesDecoder that = (InlineDescriptorProtobufBytesDecoder) o;
-
-    return Objects.equals(descriptorString, that.descriptorString) &&
-           Objects.equals(protoMessageType, that.protoMessageType);
+    return Objects.equals(getDescriptorString(), that.getDescriptorString());
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(descriptorString, protoMessageType);
+    return Objects.hash(super.hashCode(), getDescriptorString());
   }
 }

--- a/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufBytesDecoder.java
+++ b/extensions-core/protobuf-extensions/src/main/java/org/apache/druid/data/input/protobuf/ProtobufBytesDecoder.java
@@ -28,7 +28,8 @@ import java.nio.ByteBuffer;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = SchemaRegistryBasedProtobufBytesDecoder.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "file", value = FileBasedProtobufBytesDecoder.class),
-    @JsonSubTypes.Type(name = "schema_registry", value = SchemaRegistryBasedProtobufBytesDecoder.class)
+    @JsonSubTypes.Type(name = "schema_registry", value = SchemaRegistryBasedProtobufBytesDecoder.class),
+    @JsonSubTypes.Type(name = "inline", value = InlineDescriptorProtobufBytesDecoder.class)
 })
 public interface ProtobufBytesDecoder
 {

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.protobuf;
 
+import com.google.protobuf.Descriptors;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,5 +74,23 @@ public class FileBasedProtobufBytesDecoderTest
     @SuppressWarnings("unused") // expected to create parser without exception
     FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", null);
     decoder.initDescriptor();
+  }
+
+  @Test
+  public void testEquals()
+  {
+    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
+    decoder.initDescriptor();
+    Descriptors.Descriptor descriptorA = decoder.getDescriptor();
+
+    decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent.Foo");
+    decoder.initDescriptor();
+    Descriptors.Descriptor descriptorB = decoder.getDescriptor();
+
+    EqualsVerifier.forClass(FileBasedProtobufBytesDecoder.class)
+                  .usingGetClass()
+                  .withIgnoredFields("descriptor")
+                  .withPrefabValues(Descriptors.Descriptor.class, descriptorA, descriptorB)
+                  .verify();
   }
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
@@ -20,6 +20,8 @@
 package org.apache.druid.data.input.protobuf;
 
 import com.google.common.io.Files;
+import com.google.protobuf.Descriptors;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
@@ -33,7 +35,8 @@ public class InlineDescriptorProtobufBytesDecoderTest
   private String descString;
 
   @Before
-  public void initDescriptorString() throws Exception {
+  public void initDescriptorString() throws Exception
+  {
     File descFile = new File(this.getClass()
                                  .getClassLoader()
                                  .getResource("prototest.desc")
@@ -45,7 +48,10 @@ public class InlineDescriptorProtobufBytesDecoderTest
   public void testShortMessageType()
   {
     @SuppressWarnings("unused") // expected to create parser without exception
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "ProtoTestEvent");
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(
+        descString,
+        "ProtoTestEvent"
+    );
     decoder.initDescriptor();
   }
 
@@ -53,7 +59,10 @@ public class InlineDescriptorProtobufBytesDecoderTest
   public void testLongMessageType()
   {
     @SuppressWarnings("unused") // expected to create parser without exception
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "prototest.ProtoTestEvent");
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(
+        descString,
+        "prototest.ProtoTestEvent"
+    );
     decoder.initDescriptor();
   }
 
@@ -77,7 +86,10 @@ public class InlineDescriptorProtobufBytesDecoderTest
   public void testMalformedDescriptorValidBase64InvalidDescriptor()
   {
     @SuppressWarnings("unused") // expected exception
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder("aGVsbG8gd29ybGQ=", "BadName");
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(
+        "aGVsbG8gd29ybGQ=",
+        "BadName"
+    );
     decoder.initDescriptor();
   }
 
@@ -89,4 +101,23 @@ public class InlineDescriptorProtobufBytesDecoderTest
     InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, null);
     decoder.initDescriptor();
   }
+
+  @Test
+  public void testEquals()
+  {
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "ProtoTestEvent");
+    decoder.initDescriptor();
+    Descriptors.Descriptor descriptorA = decoder.getDescriptor();
+
+    decoder = new InlineDescriptorProtobufBytesDecoder(descString, "ProtoTestEvent.Foo");
+    decoder.initDescriptor();
+    Descriptors.Descriptor descriptorB = decoder.getDescriptor();
+
+    EqualsVerifier.forClass(InlineDescriptorProtobufBytesDecoder.class)
+                  .usingGetClass()
+                  .withIgnoredFields("descriptor")
+                  .withPrefabValues(Descriptors.Descriptor.class, descriptorA, descriptorB)
+                  .verify();
+  }
+
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.protobuf;
+
+import com.google.common.io.Files;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class InlineDescriptorProtobufBytesDecoderTest
+{
+  private String descString;
+
+  @Before
+  public void initDescriptorString() throws Exception {
+    File descFile = new File(this.getClass()
+                                 .getClassLoader()
+                                 .getResource("prototest.desc")
+                                 .toURI());
+    descString = StringUtils.encodeBase64String(Files.toByteArray(descFile));
+  }
+
+  @Test
+  public void testShortMessageType()
+  {
+    @SuppressWarnings("unused") // expected to create parser without exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "ProtoTestEvent");
+    decoder.initDescriptor();
+  }
+
+  @Test
+  public void testLongMessageType()
+  {
+    @SuppressWarnings("unused") // expected to create parser without exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "prototest.ProtoTestEvent");
+    decoder.initDescriptor();
+  }
+
+  @Test(expected = ParseException.class)
+  public void testBadProto()
+  {
+    @SuppressWarnings("unused") // expected exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "BadName");
+    decoder.initDescriptor();
+  }
+
+  @Test(expected = IAE.class)
+  public void testMalformedDescriptorBase64()
+  {
+    @SuppressWarnings("unused") // expected exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder("invalidString", "BadName");
+    decoder.initDescriptor();
+  }
+
+  @Test(expected = ParseException.class)
+  public void testMalformedDescriptorValidBase64InvalidDescriptor()
+  {
+    @SuppressWarnings("unused") // expected exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder("aGVsbG8gd29ybGQ=", "BadName");
+    decoder.initDescriptor();
+  }
+
+  @Test
+  public void testSingleDescriptorNoMessageType()
+  {
+    // For the backward compatibility, protoMessageType allows null when the desc file has only one message type.
+    @SuppressWarnings("unused") // expected to create parser without exception
+    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, null);
+    decoder.initDescriptor();
+  }
+}

--- a/website/.spelling
+++ b/website/.spelling
@@ -1233,6 +1233,7 @@ column_1
 column_n
 com.opencsv
 ctrl
+descriptorString
 headerFormat
 headerLabelPrefix
 jsonLowercase


### PR DESCRIPTION
This PR adds a new ProtobufBytesDecoder implementation that allows the user to pass inline the contents of a Protobuf descriptor file, encoded as a Base64 string. 

This can be useful when the user does not have the ability/convenience of placing files on the filesystems of the Druid cluster nodes.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
