### PR TITLE
Support to read task logs from some S3 compatible cloud storage

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -95,7 +95,7 @@ public class S3TaskLogs implements TaskLogs
         }
 
         final GetObjectRequest request = new GetObjectRequest(config.getS3Bucket(), taskKey)
-            .withMatchingETagConstraint(objectMetadata.getETag())
+            .withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"")
             .withRange(start, end);
 
         return Optional.of(service.getObject(request).getObjectContent());

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -35,6 +35,7 @@ import org.apache.druid.tasklogs.TaskLogs;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Date;
 
 /**
@@ -95,8 +96,14 @@ public class S3TaskLogs implements TaskLogs
         }
 
         final GetObjectRequest request = new GetObjectRequest(config.getS3Bucket(), taskKey)
-            .withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"")
+            .withMatchingETagConstraint(objectMetadata.getETag())
             .withRange(start, end);
+
+        if (objectMetadata.getETag() != null) {
+          if (!objectMetadata.getETag().startsWith("\"") && !objectMetadata.getETag().endsWith("\"")) {
+            request.setMatchingETagConstraints(Collections.singletonList("\"" + objectMetadata.getETag() + "\""));
+          }
+        }
 
         return Optional.of(service.getObject(request).getObjectContent());
       }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -335,7 +335,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(0, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -363,7 +363,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.substring(1).getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(1, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -391,7 +391,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.substring(1).getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(1, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -419,7 +419,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(REPORT_CONTENTS.getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(0, REPORT_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -55,6 +55,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -335,7 +336,12 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(0, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
+    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    if (objectMetadata.getETag() != null) {
+      if (!objectMetadata.getETag().startsWith("\"") && !objectMetadata.getETag().endsWith("\"")) {
+        getObjectRequest.setMatchingETagConstraints(Collections.singletonList("\"" + objectMetadata.getETag() + "\""));
+      }
+    }
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -363,7 +369,12 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.substring(1).getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(1, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
+    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    if (objectMetadata.getETag() != null) {
+      if (!objectMetadata.getETag().startsWith("\"") && !objectMetadata.getETag().endsWith("\"")) {
+        getObjectRequest.setMatchingETagConstraints(Collections.singletonList("\"" + objectMetadata.getETag() + "\""));
+      }
+    }
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -391,7 +402,12 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(LOG_CONTENTS.substring(1).getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(1, LOG_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
+    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    if (objectMetadata.getETag() != null) {
+      if (!objectMetadata.getETag().startsWith("\"") && !objectMetadata.getETag().endsWith("\"")) {
+        getObjectRequest.setMatchingETagConstraints(Collections.singletonList("\"" + objectMetadata.getETag() + "\""));
+      }
+    }
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 
@@ -419,7 +435,12 @@ public class S3TaskLogsTest extends EasyMockSupport
     s3Object.setObjectContent(new ByteArrayInputStream(REPORT_CONTENTS.getBytes(StandardCharsets.UTF_8)));
     GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
     getObjectRequest.setRange(0, REPORT_CONTENTS.length() - 1);
-    getObjectRequest.withMatchingETagConstraint("\"" + objectMetadata.getETag() + "\"");
+    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    if (objectMetadata.getETag() != null) {
+      if (!objectMetadata.getETag().startsWith("\"") && !objectMetadata.getETag().endsWith("\"")) {
+        getObjectRequest.setMatchingETagConstraints(Collections.singletonList("\"" + objectMetadata.getETag() + "\""));
+      }
+    }
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #13166.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Added quotation marks to the beginning and end of withMatchingETagConstraint() Arguments to comply with RFC7232.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
-->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->
<!--
<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>
-->
<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
