### PR TITLE
MSQ: Report the warning directly as an error if none of it is allowed by the user

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -644,11 +644,19 @@ public class ControllerImpl implements Controller
       Long limit = warningsExceeded.get().rhs;
 
       if (limit == 0L) {
-        for (MSQErrorReport errorReport1 : workerWarnings) {
-          if (errorReport1.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
-            workerError(errorReport1);
+        boolean foundWarningReport = false;
+        for (MSQErrorReport warningReport : workerWarnings) {
+          if (warningReport.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
+            foundWarningReport = true;
+            workerError(warningReport);
             break;
           }
+        }
+        if (!foundWarningReport) {
+          throw new ISE(
+              "Warnings of type %s exceed the limit but the controller is unable to find the warning report.",
+              errorCode
+          );
         }
       } else {
         workerError(MSQErrorReport.fromFault(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -637,26 +637,19 @@ public class ControllerImpl implements Controller
     taskCountersForLiveReports.putAll(snapshotsTree);
     Optional<Pair<String, Long>> warningsExceeded =
         faultsExceededChecker.addFaultsAndCheckIfExceeded(taskCountersForLiveReports);
-    log.warn("Executing the new changes");
 
     if (warningsExceeded.isPresent()) {
       // Present means the warning limit was exceeded, and warnings have therefore turned into an error.
       String errorCode = warningsExceeded.get().lhs;
       Long limit = warningsExceeded.get().rhs;
+
       if (limit == 0L) {
-        workerWarnings.forEach(
-            workerWarning -> {
-              if (workerWarning.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
-                workerError(workerWarning);
-              }
-            }
-        );
-//        for (MSQErrorReport errorReport1 : workerWarnings) {
-//          if (errorReport1.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
-//            workerError(errorReport1);
-//            break;
-//          }
-//        }
+        for (MSQErrorReport errorReport1 : workerWarnings) {
+          if (errorReport1.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
+            workerError(errorReport1);
+            break;
+          }
+        }
       } else {
         workerError(MSQErrorReport.fromFault(
             id(),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -637,17 +637,34 @@ public class ControllerImpl implements Controller
     taskCountersForLiveReports.putAll(snapshotsTree);
     Optional<Pair<String, Long>> warningsExceeded =
         faultsExceededChecker.addFaultsAndCheckIfExceeded(taskCountersForLiveReports);
+    log.warn("Executing the new changes");
 
     if (warningsExceeded.isPresent()) {
       // Present means the warning limit was exceeded, and warnings have therefore turned into an error.
       String errorCode = warningsExceeded.get().lhs;
       Long limit = warningsExceeded.get().rhs;
-      workerError(MSQErrorReport.fromFault(
-          id(),
-          selfDruidNode.getHost(),
-          null,
-          new TooManyWarningsFault(limit.intValue(), errorCode)
-      ));
+      if (limit == 0L) {
+        workerWarnings.forEach(
+            workerWarning -> {
+              if (workerWarning.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
+                workerError(workerWarning);
+              }
+            }
+        );
+//        for (MSQErrorReport errorReport1 : workerWarnings) {
+//          if (errorReport1.getFault().getErrorCode().equalsIgnoreCase(errorCode)) {
+//            workerError(errorReport1);
+//            break;
+//          }
+//        }
+      } else {
+        workerError(MSQErrorReport.fromFault(
+            id(),
+            selfDruidNode.getHost(),
+            null,
+            new TooManyWarningsFault(limit.intValue(), errorCode)
+        ));
+      }
       addToKernelManipulationQueue(
           queryKernel ->
               queryKernel.getActiveStages().forEach(queryKernel::failStage)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -276,9 +276,11 @@ public class WorkerImpl implements Worker
       maxVerboseParseExceptions = Math.min(maxAllowedParseExceptions, Limits.MAX_VERBOSE_PARSE_EXCEPTIONS);
     }
 
-    Set<String> disallowedWarningCode = ImmutableSet.of();
+    Set<String> criticalWarningCodes;
     if (maxAllowedParseExceptions == 0) {
-      disallowedWarningCode = ImmutableSet.of(CannotParseExternalDataFault.CODE);
+      criticalWarningCodes = ImmutableSet.of(CannotParseExternalDataFault.CODE);
+    } else {
+      criticalWarningCodes = ImmutableSet.of();
     }
 
     final MSQWarningReportPublisher msqWarningReportPublisher = new MSQWarningReportLimiterPublisher(
@@ -290,7 +292,7 @@ public class WorkerImpl implements Worker
         ),
         Limits.MAX_VERBOSE_WARNINGS,
         ImmutableMap.of(CannotParseExternalDataFault.CODE, maxVerboseParseExceptions),
-        disallowedWarningCode,
+        criticalWarningCodes,
         controllerClient,
         id(),
         MSQTasks.getHostFromSelfNode(selfDruidNode)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -262,19 +262,14 @@ public class WorkerImpl implements Worker
       }
     });
 
-    Long maxVerboseParseExceptions = (Long) task.getContext()
-                                                .getOrDefault(
-                                                    MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED,
-                                                    Long.MAX_VALUE
-                                                );
-    if (maxVerboseParseExceptions != null) {
-      if (maxVerboseParseExceptions == -1) {
-        maxVerboseParseExceptions = Limits.MAX_VERBOSE_PARSE_EXCEPTIONS;
-      } else {
-        maxVerboseParseExceptions = Math.min(maxVerboseParseExceptions, Limits.MAX_VERBOSE_PARSE_EXCEPTIONS);
-      }
-    } else {
+    long maxVerboseParseExceptions = ((Integer) task.getContext().getOrDefault(
+        MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED,
+        Integer.MAX_VALUE
+    )).longValue();
+    if (maxVerboseParseExceptions == -1) {
       maxVerboseParseExceptions = Limits.MAX_VERBOSE_PARSE_EXCEPTIONS;
+    } else {
+      maxVerboseParseExceptions = Math.min(maxVerboseParseExceptions, Limits.MAX_VERBOSE_PARSE_EXCEPTIONS);
     }
 
     final MSQWarningReportPublisher msqWarningReportPublisher = new MSQWarningReportLimiterPublisher(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -37,11 +37,13 @@ import org.apache.druid.msq.exec.ControllerContext;
 import org.apache.druid.msq.exec.ControllerImpl;
 import org.apache.druid.msq.exec.WorkerManagerClient;
 import org.apache.druid.msq.indexing.error.MSQException;
+import org.apache.druid.msq.indexing.error.MSQWarnings;
 import org.apache.druid.msq.indexing.error.TaskStartTimeoutFault;
 import org.apache.druid.msq.indexing.error.UnknownFault;
 import org.apache.druid.msq.indexing.error.WorkerFailedFault;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -83,6 +85,9 @@ public class MSQWorkerTaskLauncher
   private final long maxTaskStartDelayMillis;
   private final boolean durableStageStorageEnabled;
 
+  @Nullable
+  private final Long maxParseExceptions;
+
   // Mutable state meant to be accessible by threads outside the main loop.
   private final SettableFuture<?> stopFuture = SettableFuture.create();
   private final AtomicReference<State> state = new AtomicReference<>(State.NEW);
@@ -111,6 +116,7 @@ public class MSQWorkerTaskLauncher
       final String dataSource,
       final ControllerContext context,
       final boolean durableStageStorageEnabled,
+      @Nullable final Long maxParseExceptions,
       final long maxTaskStartDelayMillis
   )
   {
@@ -121,6 +127,7 @@ public class MSQWorkerTaskLauncher
         "multi-stage-query-task-launcher[" + StringUtils.encodeForFormat(controllerTaskId) + "]-%s"
     );
     this.durableStageStorageEnabled = durableStageStorageEnabled;
+    this.maxParseExceptions = maxParseExceptions;
     this.maxTaskStartDelayMillis = maxTaskStartDelayMillis;
   }
 
@@ -306,6 +313,10 @@ public class MSQWorkerTaskLauncher
 
     if (durableStageStorageEnabled) {
       taskContext.put(MultiStageQueryContext.CTX_ENABLE_DURABLE_SHUFFLE_STORAGE, true);
+    }
+
+    if (maxParseExceptions != null) {
+      taskContext.put(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, maxParseExceptions);
     }
 
     final int firstTask;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQWarningReportLimiterPublisher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQWarningReportLimiterPublisher.java
@@ -20,7 +20,6 @@
 package org.apache.druid.msq.indexing.error;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.exec.ControllerClient;
 import org.apache.druid.msq.exec.Limits;
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQWarningReportLimiterPublisher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQWarningReportLimiterPublisher.java
@@ -91,7 +91,6 @@ public class MSQWarningReportLimiterPublisher implements MSQWarningReportPublish
   @Override
   public void publishException(int stageNumber, Throwable e)
   {
-    new Logger(MSQWarningReportLimiterPublisher.class).warn("LOGG for NEWWWW");
     String errorCode = MSQErrorReport.getFaultFromException(e).getErrorCode();
     synchronized (lock) {
       totalCount = totalCount + 1;

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
@@ -151,6 +151,7 @@ public class MSQTasksTest
         "foo",
         controllerContext,
         false,
+        -1L,
         TimeUnit.SECONDS.toMillis(5)
     );
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQWarningsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/error/MSQWarningsTest.java
@@ -139,7 +139,7 @@ public class MSQWarningsTest extends MSQTestBase
                                 .columnMappings(defaultColumnMappings)
                                 .tuningConfig(MSQTuningConfig.defaultConfig())
                                 .build())
-                     .setExpectedMSQFault(new TooManyWarningsFault(0, CannotParseExternalDataFault.CODE))
+                     .setExpectedMSQFaultClass(CannotParseExternalDataFault.class)
                      .verifyResults();
   }
 
@@ -318,7 +318,7 @@ public class MSQWarningsTest extends MSQTestBase
                                 .columnMappings(defaultColumnMappings)
                                 .tuningConfig(MSQTuningConfig.defaultConfig())
                                 .build())
-                     .setExpectedMSQFault(new TooManyWarningsFault(0, CannotParseExternalDataFault.CODE))
+                     .setExpectedMSQFaultClass(CannotParseExternalDataFault.class)
                      .verifyResults();
   }
 
@@ -340,7 +340,7 @@ public class MSQWarningsTest extends MSQTestBase
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
                      .addExpectedAggregatorFactory(new LongSumAggregatorFactory("cnt", "cnt"))
-                     .setExpectedMSQFault(new TooManyWarningsFault(0, CannotParseExternalDataFault.CODE))
+                     .setExpectedMSQFaultClass(CannotParseExternalDataFault.class)
                      .verifyResults();
   }
 
@@ -359,7 +359,7 @@ public class MSQWarningsTest extends MSQTestBase
                              + ") group by 1  PARTITIONED by day ")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setExpectedMSQFault(new TooManyWarningsFault(0, CannotParseExternalDataFault.CODE))
+                     .setExpectedMSQFaultClass(CannotParseExternalDataFault.class)
                      .verifyResults();
 
     // Temporary directory should not contain any controller-related folders

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -702,6 +702,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
     protected Matcher<Throwable> expectedValidationErrorMatcher = null;
     protected Matcher<Throwable> expectedExecutionErrorMatcher = null;
     protected MSQFault expectedMSQFault = null;
+    protected Class<? extends MSQFault> expectedMSQFaultClass = null;
 
     private boolean hasRun = false;
 
@@ -761,6 +762,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
     public Builder setExpectedMSQFault(MSQFault MSQFault)
     {
       this.expectedMSQFault = MSQFault;
+      return (Builder) this;
+    }
+
+    public Builder setExpectedMSQFaultClass(Class<? extends MSQFault> expectedMSQFaultClass)
+    {
+      this.expectedMSQFaultClass = expectedMSQFaultClass;
       return (Builder) this;
     }
 
@@ -851,19 +858,28 @@ public class MSQTestBase extends BaseCalciteQueryTest
       Preconditions.checkArgument(expectedDataSource != null, "dataSource cannot be null");
       Preconditions.checkArgument(expectedRowSignature != null, "expectedRowSignature cannot be null");
       Preconditions.checkArgument(
-          expectedResultRows != null || expectedMSQFault != null,
-          "atleast one of expectedResultRows or expectedMSQFault should be set to non null"
+          expectedResultRows != null || expectedMSQFault != null || expectedMSQFaultClass != null,
+          "atleast one of expectedResultRows, expectedMSQFault or expectedMSQFaultClass should be set to non null"
       );
       Preconditions.checkArgument(expectedShardSpec != null, "shardSpecClass cannot be null");
       readyToRun();
       try {
         String controllerId = runMultiStageQuery(sql, queryContext);
-        if (expectedMSQFault != null) {
+        if (expectedMSQFault != null || expectedMSQFaultClass != null) {
           MSQErrorReport msqErrorReport = getErrorReportOrThrow(controllerId);
-          Assert.assertEquals(
-              expectedMSQFault.getCodeWithMessage(),
-              msqErrorReport.getFault().getCodeWithMessage()
-          );
+          if (expectedMSQFault != null) {
+            Assert.assertEquals(
+                expectedMSQFault.getCodeWithMessage(),
+                msqErrorReport.getFault().getCodeWithMessage()
+            );
+          }
+          if (expectedMSQFaultClass != null) {
+            Assert.assertEquals(
+                expectedMSQFaultClass,
+                msqErrorReport.getFault().getClass()
+            );
+          }
+
           return;
         }
         getPayloadOrThrow(controllerId);
@@ -1017,12 +1033,20 @@ public class MSQTestBase extends BaseCalciteQueryTest
       try {
         String controllerId = runMultiStageQuery(sql, queryContext);
 
-        if (expectedMSQFault != null) {
+        if (expectedMSQFault != null || expectedMSQFaultClass != null) {
           MSQErrorReport msqErrorReport = getErrorReportOrThrow(controllerId);
-          Assert.assertEquals(
-              expectedMSQFault.getCodeWithMessage(),
-              msqErrorReport.getFault().getCodeWithMessage()
-          );
+          if (expectedMSQFault != null) {
+            Assert.assertEquals(
+                expectedMSQFault.getCodeWithMessage(),
+                msqErrorReport.getFault().getCodeWithMessage()
+            );
+          }
+          if (expectedMSQFaultClass != null) {
+            Assert.assertEquals(
+                expectedMSQFaultClass,
+                msqErrorReport.getFault().getClass()
+            );
+          }
           return null;
         }
 


### PR DESCRIPTION
### Description

In MSQ, there can be an upper limit to the number of worker warnings. For example, for parseExceptions encountered while parsing the external data, the user can specify an upper limit to the number of parse exceptions that can be allowed before it throws an error of type `TooManyWarnings`. 

This PR makes it so that if the user disallows warnings of a certain type i.e. the limit is 0 (or is executing in `strict` mode), instead of throwing an error of type `TooManyWarnings`, we can directly surface the warning as the error, saving the user from the hassle of going throw the warning reports.

<hr>

##### Key changed/added classes in this PR
 * `ControllerImpl`


<hr>


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
