### PR TITLE
Improve direct-memory check on startup.

### DIFF
--- a/core/src/main/java/org/apache/druid/utils/RuntimeInfo.java
+++ b/core/src/main/java/org/apache/druid/utils/RuntimeInfo.java
@@ -48,7 +48,7 @@ public class RuntimeInfo
   public long getDirectMemorySizeBytes()
   {
     try {
-      Class<?> vmClass = Class.forName("sun.misc.VM");
+      Class<?> vmClass = Class.forName(JvmUtils.majorVersion() >= 9 ? "jdk.internal.misc.VM" : "sun.misc.VM");
       Object maxDirectMemoryObj = vmClass.getMethod("maxDirectMemory").invoke(null);
 
       if (maxDirectMemoryObj == null || !(maxDirectMemoryObj instanceof Number)) {

--- a/core/src/test/java/org/apache/druid/utils/JvmUtilsTest.java
+++ b/core/src/test/java/org/apache/druid/utils/JvmUtilsTest.java
@@ -31,18 +31,10 @@ import java.util.List;
 public class JvmUtilsTest
 {
   @Test
-  public void testgetMaxDirectMemory()
+  public void testGetMaxDirectMemory()
   {
-    try {
-      long maxMemory = JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-      Assert.assertTrue((maxMemory > 0));
-    }
-    catch (UnsupportedOperationException expected) {
-      Assert.assertTrue(true);
-    }
-    catch (RuntimeException expected) {
-      Assert.assertTrue(true);
-    }
+    long maxMemory = JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
+    Assert.assertTrue((maxMemory > 0));
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/guice/BrokerProcessingModule.java
+++ b/server/src/main/java/org/apache/druid/guice/BrokerProcessingModule.java
@@ -153,10 +153,11 @@ public class BrokerProcessingModule implements Module
 
   private void verifyDirectMemory(DruidProcessingConfig config)
   {
+    final long memoryNeeded = (long) config.intermediateComputeSizeBytes() *
+                              (config.getNumMergeBuffers() + 1);
+
     try {
       final long maxDirectMemory = JvmUtils.getRuntimeInfo().getDirectMemorySizeBytes();
-      final long memoryNeeded = (long) config.intermediateComputeSizeBytes() *
-                                (config.getNumMergeBuffers() + 1);
 
       if (maxDirectMemory < memoryNeeded) {
         throw new ProvisionException(
@@ -174,10 +175,14 @@ public class BrokerProcessingModule implements Module
     catch (UnsupportedOperationException e) {
       log.debug("Checking for direct memory size is not support on this platform: %s", e);
       log.info(
-          "Unable to determine max direct memory size. If druid.processing.buffer.sizeBytes is explicitly configured, "
-          + "then make sure to set -XX:MaxDirectMemorySize to at least \"druid.processing.buffer.sizeBytes * "
-          + "(druid.processing.numMergeBuffers[%,d] + 1)\", "
-          + "or else set -XX:MaxDirectMemorySize to at least 25%% of maximum jvm heap size.",
+          "Your memory settings require at least %,d bytes of direct memory. "
+          + "Your machine must have at least this much memory available, and your JVM "
+          + "-XX:MaxDirectMemorySize parameter must be at least this high. "
+          + "If it is, you may safely ignore this message. "
+          + "Otherwise, consider adjusting your memory settings. "
+          + "Calculation: druid.processing.buffer.sizeBytes[%,d] * (druid.processing.numMergeBuffers[%,d] + 1).",
+          memoryNeeded,
+          config.intermediateComputeSizeBytes(),
           config.getNumMergeBuffers()
       );
     }


### PR DESCRIPTION
1) Better support for Java 9+ in RuntimeInfo. This means that in many cases,
   an actual validation can be done.

2) Clearer log message in cases where an actual validation cannot be done.