### PR TITLE
fix issue with nested column null value index incorrectly matching non-null values

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
@@ -108,8 +108,14 @@ public class NestedFieldLiteralColumnIndexSupplier implements ColumnIndexSupplie
   public <T> T as(Class<T> clazz)
   {
     if (clazz.equals(NullValueIndex.class)) {
-      // null index is always 0 in the global dictionary, even if there are no null rows in any of the literal columns
-      return (T) (NullValueIndex) () -> new SimpleImmutableBitmapIndex(bitmaps.get(0));
+      final BitmapColumnIndex nullIndex;
+      if (dictionary.get(0) == 0) {
+        // null index is always 0 in the global dictionary, even if there are no null rows in any of the literal columns
+        nullIndex = new SimpleImmutableBitmapIndex(bitmaps.get(0));
+      } else {
+        nullIndex = new SimpleImmutableBitmapIndex(bitmapFactory.makeEmptyImmutableBitmap());
+      }
+      return (T) (NullValueIndex) () -> nullIndex;
     } else if (clazz.equals(DictionaryEncodedStringValueIndex.class) || clazz.equals(DictionaryEncodedValueIndex.class)) {
       return (T) new NestedLiteralDictionaryEncodedStringValueIndex();
     }

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -128,6 +128,24 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     globalDoubles = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
   }
 
+  @Test
+  public void testSingleTypeStringColumnValueIndex() throws IOException
+  {
+    NestedFieldLiteralColumnIndexSupplier indexSupplier = makeSingleTypeStringSupplier();
+
+    NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
+    Assert.assertNotNull(nullIndex);
+
+    // 10 rows
+    // local: [b, foo, fooo, z]
+    // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
+
+    BitmapColumnIndex columnIndex = nullIndex.forNull();
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(10), 0.0);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    Assert.assertEquals(0, bitmap.size());
+  }
 
   @Test
   public void testSingleTypeStringColumnValueSetIndex() throws IOException


### PR DESCRIPTION
### Description
Fixes a mistake in `NestedFieldLiteralColumnIndexSupplier` when creating `NullValueIndex`, where it was incorrectly always returning the bitmap for the first dictionary entry, instead of first confirming that this value is actually `null`. While the global value dictionary entry 0 is always null, within the local dictionary of the nested literal column, dictionary id must point to the global id 0 for the first bitmap entry to be the null value bitmap. If this is not the case, an empty bitmap should be used since the column contains no null values.

This fixes queries using `IS NULL` or `IS NOT NULL` filters on nested columns that do not contain a null value in every segment, which presents as having a single value per segment matched and returned in the results

<img width="446" alt="Screen Shot 2022-10-11 at 12 26 35 AM" src="https://user-images.githubusercontent.com/1577461/195030879-8adc489e-0bf4-400a-8f96-61f97a07533f.png">
<img width="353" alt="Screen Shot 2022-10-11 at 12 26 50 AM" src="https://user-images.githubusercontent.com/1577461/195030897-c89ff40c-d081-4108-865a-86a51a16d8a4.png">

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
