### PR TITLE
fix json_value sql planning with decimal type, fix vectorized expression math null value handling in default mode

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/BinaryMathOperatorExpr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/BinaryMathOperatorExpr.java
@@ -112,7 +112,7 @@ final class BinMinusExpr extends BinaryEvalOpExprBase
   @Override
   public boolean canVectorize(InputBindingInspector inspector)
   {
-    return inspector.areNumeric(left, right) && inspector.canVectorize(left, right);
+    return inspector.areScalar(left, right) && inspector.canVectorize(left, right);
   }
 
   @Override
@@ -151,7 +151,7 @@ final class BinMulExpr extends BinaryEvalOpExprBase
   @Override
   public boolean canVectorize(InputBindingInspector inspector)
   {
-    return inspector.areNumeric(left, right) && inspector.canVectorize(left, right);
+    return inspector.areScalar(left, right) && inspector.canVectorize(left, right);
   }
 
   @Override
@@ -190,7 +190,7 @@ final class BinDivExpr extends BinaryEvalOpExprBase
   @Override
   public boolean canVectorize(InputBindingInspector inspector)
   {
-    return inspector.areNumeric(left, right) && inspector.canVectorize(left, right);
+    return inspector.areScalar(left, right) && inspector.canVectorize(left, right);
   }
 
   @Override
@@ -229,7 +229,7 @@ class BinPowExpr extends BinaryEvalOpExprBase
   @Override
   public boolean canVectorize(InputBindingInspector inspector)
   {
-    return inspector.areNumeric(left, right) && inspector.canVectorize(left, right);
+    return inspector.areScalar(left, right) && inspector.canVectorize(left, right);
   }
 
   @Override
@@ -268,7 +268,7 @@ class BinModuloExpr extends BinaryEvalOpExprBase
   @Override
   public boolean canVectorize(InputBindingInspector inspector)
   {
-    return inspector.areNumeric(left, right) && inspector.canVectorize(left, right);
+    return inspector.areScalar(left, right) && inspector.canVectorize(left, right);
   }
 
   @Override

--- a/core/src/main/java/org/apache/druid/math/expr/vector/BivariateDoubleFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/BivariateDoubleFunctionVectorValueProcessor.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.math.expr.vector;
+
+import org.apache.druid.math.expr.Expr;
+
+/**
+ * common machinery for processing two input operators and functions, which should always treat null inputs as null
+ * output, and are backed by a primitive values instead of an object values (and need to use the null vectors instead of
+ * checking the vector themselves for nulls)
+ *
+ * this one is specialized for producing double[], see {@link BivariateLongFunctionVectorValueProcessor} for
+ * long[] primitives.
+ */
+public abstract class BivariateDoubleFunctionVectorValueProcessor<TLeftInput, TRightInput>
+    implements ExprVectorProcessor<double[]>
+{
+  final ExprVectorProcessor<TLeftInput> left;
+  final ExprVectorProcessor<TRightInput> right;
+  final int maxVectorSize;
+  final boolean[] outNulls;
+  final double[] outValues;
+
+  protected BivariateDoubleFunctionVectorValueProcessor(
+      ExprVectorProcessor<TLeftInput> left,
+      ExprVectorProcessor<TRightInput> right,
+      int maxVectorSize
+  )
+  {
+    this.left = left;
+    this.right = right;
+    this.maxVectorSize = maxVectorSize;
+    this.outValues = new double[maxVectorSize];
+    this.outNulls = new boolean[maxVectorSize];
+  }
+
+  @Override
+  public final ExprEvalVector<double[]> evalVector(Expr.VectorInputBinding bindings)
+  {
+    final ExprEvalVector<TLeftInput> lhs = left.evalVector(bindings);
+    final ExprEvalVector<TRightInput> rhs = right.evalVector(bindings);
+
+    final int currentSize = bindings.getCurrentVectorSize();
+    final boolean[] leftNulls = lhs.getNullVector();
+    final boolean[] rightNulls = rhs.getNullVector();
+    final boolean hasLeftNulls = leftNulls != null;
+    final boolean hasRightNulls = rightNulls != null;
+    final boolean hasNulls = hasLeftNulls || hasRightNulls;
+
+    final TLeftInput leftInput = lhs.values();
+    final TRightInput rightInput = rhs.values();
+
+    if (hasNulls) {
+      for (int i = 0; i < currentSize; i++) {
+        outNulls[i] = (hasLeftNulls && leftNulls[i]) || (hasRightNulls && rightNulls[i]);
+        if (!outNulls[i]) {
+          processIndex(leftInput, rightInput, i);
+        } else {
+          outValues[i] = 0.0;
+        }
+      }
+    } else {
+      for (int i = 0; i < currentSize; i++) {
+        processIndex(leftInput, rightInput, i);
+        outNulls[i] = false;
+      }
+    }
+    return asEval();
+  }
+
+  abstract void processIndex(TLeftInput leftInput, TRightInput rightInput, int i);
+
+  final ExprEvalVector<double[]> asEval()
+  {
+    return new ExprEvalDoubleVector(outValues, outNulls);
+  }
+}

--- a/core/src/main/java/org/apache/druid/math/expr/vector/BivariateFunctionVectorProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/BivariateFunctionVectorProcessor.java
@@ -26,8 +26,9 @@ import javax.annotation.Nullable;
 
 /**
  * Basic vector processor that processes 2 inputs and works for both primitive value vectors and object vectors.
- * Different from {@link BivariateFunctionVectorValueProcessor} and {@link BivariateFunctionVectorObjectProcessor} in
- * that subclasses of this class must check for and directly decide how to handle null values.
+ * Different from {@link BivariateLongFunctionVectorValueProcessor}, {@link BivariateDoubleFunctionVectorValueProcessor}
+ * and {@link BivariateFunctionVectorObjectProcessor} in that subclasses of this class must check for and directly
+ * decide how to handle null values.
  */
 public abstract class BivariateFunctionVectorProcessor<TLeftInput, TRightInput, TOutput>
     implements ExprVectorProcessor<TOutput>

--- a/core/src/main/java/org/apache/druid/math/expr/vector/BivariateFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/BivariateFunctionVectorValueProcessor.java
@@ -70,6 +70,8 @@ public abstract class BivariateFunctionVectorValueProcessor<TLeftInput, TRightIn
         outNulls[i] = (hasLeftNulls && leftNulls[i]) || (hasRightNulls && rightNulls[i]);
         if (!outNulls[i]) {
           processIndex(leftInput, rightInput, i);
+        } else {
+          processNull(i);
         }
       }
     } else {
@@ -82,6 +84,8 @@ public abstract class BivariateFunctionVectorValueProcessor<TLeftInput, TRightIn
   }
 
   abstract void processIndex(TLeftInput leftInput, TRightInput rightInput, int i);
+
+  abstract void processNull(int i);
 
   abstract ExprEvalVector<TOutput> asEval();
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/BivariateLongFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/BivariateLongFunctionVectorValueProcessor.java
@@ -25,32 +25,34 @@ import org.apache.druid.math.expr.Expr;
  * common machinery for processing two input operators and functions, which should always treat null inputs as null
  * output, and are backed by a primitive values instead of an object values (and need to use the null vectors instead of
  * checking the vector themselves for nulls)
+ *
+ * this one is specialized for producing long[], see {@link BivariateDoubleFunctionVectorValueProcessor} for
+ * double[] primitives.
  */
-public abstract class BivariateFunctionVectorValueProcessor<TLeftInput, TRightInput, TOutput>
-    implements ExprVectorProcessor<TOutput>
+public abstract class BivariateLongFunctionVectorValueProcessor<TLeftInput, TRightInput>
+    implements ExprVectorProcessor<long[]>
 {
   final ExprVectorProcessor<TLeftInput> left;
   final ExprVectorProcessor<TRightInput> right;
   final int maxVectorSize;
   final boolean[] outNulls;
-  final TOutput outValues;
+  final long[] outValues;
 
-  protected BivariateFunctionVectorValueProcessor(
+  protected BivariateLongFunctionVectorValueProcessor(
       ExprVectorProcessor<TLeftInput> left,
       ExprVectorProcessor<TRightInput> right,
-      int maxVectorSize,
-      TOutput outValues
+      int maxVectorSize
   )
   {
     this.left = left;
     this.right = right;
     this.maxVectorSize = maxVectorSize;
+    this.outValues = new long[maxVectorSize];
     this.outNulls = new boolean[maxVectorSize];
-    this.outValues = outValues;
   }
 
   @Override
-  public final ExprEvalVector<TOutput> evalVector(Expr.VectorInputBinding bindings)
+  public final ExprEvalVector<long[]> evalVector(Expr.VectorInputBinding bindings)
   {
     final ExprEvalVector<TLeftInput> lhs = left.evalVector(bindings);
     final ExprEvalVector<TRightInput> rhs = right.evalVector(bindings);
@@ -71,7 +73,7 @@ public abstract class BivariateFunctionVectorValueProcessor<TLeftInput, TRightIn
         if (!outNulls[i]) {
           processIndex(leftInput, rightInput, i);
         } else {
-          processNull(i);
+          outValues[i] = 0L;
         }
       }
     } else {
@@ -85,7 +87,8 @@ public abstract class BivariateFunctionVectorValueProcessor<TLeftInput, TRightIn
 
   abstract void processIndex(TLeftInput leftInput, TRightInput rightInput, int i);
 
-  abstract void processNull(int i);
-
-  abstract ExprEvalVector<TOutput> asEval();
+  final ExprEvalVector<long[]> asEval()
+  {
+    return new ExprEvalLongVector(outValues, outNulls);
+  }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleInFunctionVectorValueProcessor.java
@@ -47,6 +47,12 @@ public abstract class DoubleOutDoubleInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleInFunctionVectorValueProcessor.java
@@ -22,14 +22,14 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link UnivariateFunctionVectorValueProcessor} for processing (double[]) -> double[]
+ * specialized {@link UnivariateDoubleFunctionVectorValueProcessor} for processing (double[]) -> double[]
  */
 public abstract class DoubleOutDoubleInFunctionVectorValueProcessor
-    extends UnivariateFunctionVectorValueProcessor<double[], double[]>
+    extends UnivariateDoubleFunctionVectorValueProcessor<double[]>
 {
   public DoubleOutDoubleInFunctionVectorValueProcessor(ExprVectorProcessor<double[]> processor, int maxVectorSize)
   {
-    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.DOUBLE), maxVectorSize, new double[maxVectorSize]);
+    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.DOUBLE), maxVectorSize);
   }
 
   public abstract double apply(double input);
@@ -44,17 +44,5 @@ public abstract class DoubleOutDoubleInFunctionVectorValueProcessor
   final void processIndex(double[] input, int i)
   {
     outValues[i] = apply(input[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleLongInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (double[], long[]) -> double[]
+ * specialized {@link BivariateDoubleFunctionVectorValueProcessor} for processing (double[], long[]) -> double[]
  */
 public abstract class DoubleOutDoubleLongInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<double[], long[], double[]>
+    extends BivariateDoubleFunctionVectorValueProcessor<double[], long[]>
 {
   public DoubleOutDoubleLongInFunctionVectorValueProcessor(
       ExprVectorProcessor<double[]> left,
@@ -36,8 +36,7 @@ public abstract class DoubleOutDoubleLongInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.DOUBLE),
         CastToTypeVectorProcessor.cast(right, ExpressionType.LONG),
-        maxVectorSize,
-        new double[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class DoubleOutDoubleLongInFunctionVectorValueProcessor
   final void processIndex(double[] leftInput, long[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoubleLongInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class DoubleOutDoubleLongInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoublesInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoublesInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class DoubleOutDoublesInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoublesInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutDoublesInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (double[], double[]) -> double[]
+ * specialized {@link BivariateDoubleFunctionVectorValueProcessor} for processing (double[], double[]) -> double[]
  */
 public abstract class DoubleOutDoublesInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<double[], double[], double[]>
+    extends BivariateDoubleFunctionVectorValueProcessor<double[], double[]>
 {
   public DoubleOutDoublesInFunctionVectorValueProcessor(
       ExprVectorProcessor<double[]> left,
@@ -36,8 +36,7 @@ public abstract class DoubleOutDoublesInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.DOUBLE),
         CastToTypeVectorProcessor.cast(right, ExpressionType.DOUBLE),
-        maxVectorSize,
-        new double[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class DoubleOutDoublesInFunctionVectorValueProcessor
   final void processIndex(double[] leftInput, double[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongDoubleInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (long[], double[]) -> double[]
+ * specialized {@link BivariateDoubleFunctionVectorValueProcessor} for processing (long[], double[]) -> double[]
  */
 public abstract class DoubleOutLongDoubleInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<long[], double[], double[]>
+    extends BivariateDoubleFunctionVectorValueProcessor<long[], double[]>
 {
   public DoubleOutLongDoubleInFunctionVectorValueProcessor(
       ExprVectorProcessor<long[]> left,
@@ -36,8 +36,7 @@ public abstract class DoubleOutLongDoubleInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.LONG),
         CastToTypeVectorProcessor.cast(right, ExpressionType.DOUBLE),
-        maxVectorSize,
-        new double[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class DoubleOutLongDoubleInFunctionVectorValueProcessor
   final void processIndex(long[] leftInput, double[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongDoubleInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class DoubleOutLongDoubleInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongInFunctionVectorValueProcessor.java
@@ -47,6 +47,12 @@ public abstract class DoubleOutLongInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongInFunctionVectorValueProcessor.java
@@ -22,14 +22,14 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link UnivariateFunctionVectorValueProcessor} for processing (long[]) -> double[]
+ * specialized {@link UnivariateDoubleFunctionVectorValueProcessor} for processing (long[]) -> double[]
  */
 public abstract class DoubleOutLongInFunctionVectorValueProcessor
-    extends UnivariateFunctionVectorValueProcessor<long[], double[]>
+    extends UnivariateDoubleFunctionVectorValueProcessor<long[]>
 {
   public DoubleOutLongInFunctionVectorValueProcessor(ExprVectorProcessor<long[]> processor, int maxVectorSize)
   {
-    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.LONG), maxVectorSize, new double[maxVectorSize]);
+    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.LONG), maxVectorSize);
   }
 
   public abstract double apply(long input);
@@ -44,17 +44,5 @@ public abstract class DoubleOutLongInFunctionVectorValueProcessor
   final void processIndex(long[] input, int i)
   {
     outValues[i] = apply(input[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (long[], long[]) -> double[]
+ * specialized {@link BivariateDoubleFunctionVectorValueProcessor} for processing (long[], long[]) -> double[]
  */
 public abstract class DoubleOutLongsInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<long[], long[], double[]>
+    extends BivariateDoubleFunctionVectorValueProcessor<long[], long[]>
 {
   public DoubleOutLongsInFunctionVectorValueProcessor(
       ExprVectorProcessor<long[]> left,
@@ -36,8 +36,7 @@ public abstract class DoubleOutLongsInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.LONG),
         CastToTypeVectorProcessor.cast(right, ExpressionType.LONG),
-        maxVectorSize,
-        new double[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class DoubleOutLongsInFunctionVectorValueProcessor
   final void processIndex(long[] leftInput, long[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0.0;
-  }
-
-  @Override
-  final ExprEvalVector<double[]> asEval()
-  {
-    return new ExprEvalDoubleVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class DoubleOutLongsInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0.0;
+  }
+
+  @Override
   final ExprEvalVector<double[]> asEval()
   {
     return new ExprEvalDoubleVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleInFunctionVectorValueProcessor.java
@@ -46,6 +46,12 @@ public abstract class LongOutDoubleInFunctionVectorValueProcessor extends Univar
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleInFunctionVectorValueProcessor.java
@@ -22,13 +22,14 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link UnivariateFunctionVectorValueProcessor} for processing (long[]) -> long[]
+ * specialized {@link UnivariateLongFunctionVectorValueProcessor} for processing (long[]) -> long[]
  */
-public abstract class LongOutDoubleInFunctionVectorValueProcessor extends UnivariateFunctionVectorValueProcessor<double[], long[]>
+public abstract class LongOutDoubleInFunctionVectorValueProcessor
+    extends UnivariateLongFunctionVectorValueProcessor<double[]>
 {
   public LongOutDoubleInFunctionVectorValueProcessor(ExprVectorProcessor<double[]> processor, int maxVectorSize)
   {
-    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.DOUBLE), maxVectorSize, new long[maxVectorSize]);
+    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.DOUBLE), maxVectorSize);
   }
 
   public abstract long apply(double input);
@@ -43,17 +44,5 @@ public abstract class LongOutDoubleInFunctionVectorValueProcessor extends Univar
   final void processIndex(double[] input, int i)
   {
     outValues[i] = apply(input[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleLongInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (double[], long[]) -> long[]
+ * specialized {@link BivariateLongFunctionVectorValueProcessor} for processing (double[], long[]) -> long[]
  */
 public abstract class LongOutDoubleLongInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<double[], long[], long[]>
+    extends BivariateLongFunctionVectorValueProcessor<double[], long[]>
 {
   public LongOutDoubleLongInFunctionVectorValueProcessor(
       ExprVectorProcessor<double[]> left,
@@ -36,8 +36,7 @@ public abstract class LongOutDoubleLongInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.DOUBLE),
         CastToTypeVectorProcessor.cast(right, ExpressionType.LONG),
-        maxVectorSize,
-        new long[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class LongOutDoubleLongInFunctionVectorValueProcessor
   final void processIndex(double[] leftInput, long[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoubleLongInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class LongOutDoubleLongInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoublesInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoublesInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (double[], double[]) -> long[]
+ * specialized {@link BivariateLongFunctionVectorValueProcessor} for processing (double[], double[]) -> long[]
  */
 public abstract class LongOutDoublesInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<double[], double[], long[]>
+    extends BivariateLongFunctionVectorValueProcessor<double[], double[]>
 {
   public LongOutDoublesInFunctionVectorValueProcessor(
       ExprVectorProcessor<double[]> left,
@@ -36,8 +36,7 @@ public abstract class LongOutDoublesInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.DOUBLE),
         CastToTypeVectorProcessor.cast(right, ExpressionType.DOUBLE),
-        maxVectorSize,
-        new long[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class LongOutDoublesInFunctionVectorValueProcessor
   final void processIndex(double[] leftInput, double[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoublesInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutDoublesInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class LongOutDoublesInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongDoubleInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (long[], double[]) -> long[]
+ * specialized {@link BivariateLongFunctionVectorValueProcessor} for processing (long[], double[]) -> long[]
  */
 public abstract class LongOutLongDoubleInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<long[], double[], long[]>
+    extends BivariateLongFunctionVectorValueProcessor<long[], double[]>
 {
   public LongOutLongDoubleInFunctionVectorValueProcessor(
       ExprVectorProcessor<long[]> left,
@@ -36,8 +36,7 @@ public abstract class LongOutLongDoubleInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.LONG),
         CastToTypeVectorProcessor.cast(right, ExpressionType.DOUBLE),
-        maxVectorSize,
-        new long[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class LongOutLongDoubleInFunctionVectorValueProcessor
   final void processIndex(long[] leftInput, double[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongDoubleInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongDoubleInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class LongOutLongDoubleInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongInFunctionVectorValueProcessor.java
@@ -22,13 +22,14 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link UnivariateFunctionVectorValueProcessor} for processing (long[]) -> long[]
+ * specialized {@link UnivariateLongFunctionVectorValueProcessor} for processing (long[]) -> long[]
  */
-public abstract class LongOutLongInFunctionVectorValueProcessor extends UnivariateFunctionVectorValueProcessor<long[], long[]>
+public abstract class LongOutLongInFunctionVectorValueProcessor
+    extends UnivariateLongFunctionVectorValueProcessor<long[]>
 {
   public LongOutLongInFunctionVectorValueProcessor(ExprVectorProcessor<long[]> processor, int maxVectorSize)
   {
-    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.LONG), maxVectorSize, new long[maxVectorSize]);
+    super(CastToTypeVectorProcessor.cast(processor, ExpressionType.LONG), maxVectorSize);
   }
 
   public abstract long apply(long input);
@@ -43,17 +44,5 @@ public abstract class LongOutLongInFunctionVectorValueProcessor extends Univaria
   final void processIndex(long[] input, int i)
   {
     outValues[i] = apply(input[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongInFunctionVectorValueProcessor.java
@@ -46,6 +46,12 @@ public abstract class LongOutLongInFunctionVectorValueProcessor extends Univaria
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongsInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongsInFunctionVectorValueProcessor.java
@@ -22,10 +22,10 @@ package org.apache.druid.math.expr.vector;
 import org.apache.druid.math.expr.ExpressionType;
 
 /**
- * specialized {@link BivariateFunctionVectorValueProcessor} for processing (long[], long[]) -> long[]
+ * specialized {@link BivariateLongFunctionVectorValueProcessor} for processing (long[], long[]) -> long[]
  */
 public abstract class LongOutLongsInFunctionVectorValueProcessor
-    extends BivariateFunctionVectorValueProcessor<long[], long[], long[]>
+    extends BivariateLongFunctionVectorValueProcessor<long[], long[]>
 {
   public LongOutLongsInFunctionVectorValueProcessor(
       ExprVectorProcessor<long[]> left,
@@ -36,8 +36,7 @@ public abstract class LongOutLongsInFunctionVectorValueProcessor
     super(
         CastToTypeVectorProcessor.cast(left, ExpressionType.LONG),
         CastToTypeVectorProcessor.cast(right, ExpressionType.LONG),
-        maxVectorSize,
-        new long[maxVectorSize]
+        maxVectorSize
     );
   }
 
@@ -53,17 +52,5 @@ public abstract class LongOutLongsInFunctionVectorValueProcessor
   final void processIndex(long[] leftInput, long[] rightInput, int i)
   {
     outValues[i] = apply(leftInput[i], rightInput[i]);
-  }
-
-  @Override
-  final void processNull(int i)
-  {
-    outValues[i] = 0L;
-  }
-
-  @Override
-  final ExprEvalVector<long[]> asEval()
-  {
-    return new ExprEvalLongVector(outValues, outNulls);
   }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongsInFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/LongOutLongsInFunctionVectorValueProcessor.java
@@ -56,6 +56,12 @@ public abstract class LongOutLongsInFunctionVectorValueProcessor
   }
 
   @Override
+  final void processNull(int i)
+  {
+    outValues[i] = 0L;
+  }
+
+  @Override
   final ExprEvalVector<long[]> asEval()
   {
     return new ExprEvalLongVector(outValues, outNulls);

--- a/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateDoubleFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateDoubleFunctionVectorValueProcessor.java
@@ -25,28 +25,30 @@ import org.apache.druid.math.expr.Expr;
  * common machinery for processing single input operators and functions, which should always treat null input as null
  * output, and are backed by a primitive value instead of an object value (and need to use the null vector instead of
  * checking the vector itself for nulls)
+ *
+ * this one is specialized for producing double[], see {@link UnivariateLongFunctionVectorValueProcessor} for
+ * long[] primitives.
  */
-public abstract class UnivariateFunctionVectorValueProcessor<TInput, TOutput> implements ExprVectorProcessor<TOutput>
+public abstract class UnivariateDoubleFunctionVectorValueProcessor<TInput> implements ExprVectorProcessor<double[]>
 {
   final ExprVectorProcessor<TInput> processor;
   final int maxVectorSize;
   final boolean[] outNulls;
-  final TOutput outValues;
+  final double[] outValues;
 
-  public UnivariateFunctionVectorValueProcessor(
+  public UnivariateDoubleFunctionVectorValueProcessor(
       ExprVectorProcessor<TInput> processor,
-      int maxVectorSize,
-      TOutput outValues
+      int maxVectorSize
   )
   {
     this.processor = processor;
     this.maxVectorSize = maxVectorSize;
     this.outNulls = new boolean[maxVectorSize];
-    this.outValues = outValues;
+    this.outValues = new double[maxVectorSize];
   }
 
   @Override
-  public final ExprEvalVector<TOutput> evalVector(Expr.VectorInputBinding bindings)
+  public final ExprEvalVector<double[]> evalVector(Expr.VectorInputBinding bindings)
   {
     final ExprEvalVector<TInput> lhs = processor.evalVector(bindings);
 
@@ -62,7 +64,7 @@ public abstract class UnivariateFunctionVectorValueProcessor<TInput, TOutput> im
         if (!outNulls[i]) {
           processIndex(input, i);
         } else {
-          processNull(i);
+          outValues[i] = 0.0;
         }
       }
     } else {
@@ -76,7 +78,8 @@ public abstract class UnivariateFunctionVectorValueProcessor<TInput, TOutput> im
 
   abstract void processIndex(TInput input, int i);
 
-  abstract void processNull(int i);
-
-  abstract ExprEvalVector<TOutput> asEval();
+  final ExprEvalVector<double[]> asEval()
+  {
+    return new ExprEvalDoubleVector(outValues, outNulls);
+  }
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateFunctionVectorValueProcessor.java
@@ -61,6 +61,8 @@ public abstract class UnivariateFunctionVectorValueProcessor<TInput, TOutput> im
         outNulls[i] = inputNulls[i];
         if (!outNulls[i]) {
           processIndex(input, i);
+        } else {
+          processNull(i);
         }
       }
     } else {
@@ -73,6 +75,8 @@ public abstract class UnivariateFunctionVectorValueProcessor<TInput, TOutput> im
   }
 
   abstract void processIndex(TInput input, int i);
+
+  abstract void processNull(int i);
 
   abstract ExprEvalVector<TOutput> asEval();
 }

--- a/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateLongFunctionVectorValueProcessor.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/UnivariateLongFunctionVectorValueProcessor.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.math.expr.vector;
+
+import org.apache.druid.math.expr.Expr;
+
+/**
+ * common machinery for processing single input operators and functions, which should always treat null input as null
+ * output, and are backed by a primitive value instead of an object value (and need to use the null vector instead of
+ * checking the vector itself for nulls)
+ *
+ * this one is specialized for producing long[], see {@link UnivariateDoubleFunctionVectorValueProcessor} for
+ * double[] primitives.
+ */
+public abstract class UnivariateLongFunctionVectorValueProcessor<TInput> implements ExprVectorProcessor<long[]>
+{
+  final ExprVectorProcessor<TInput> processor;
+  final int maxVectorSize;
+  final boolean[] outNulls;
+  final long[] outValues;
+
+  public UnivariateLongFunctionVectorValueProcessor(
+      ExprVectorProcessor<TInput> processor,
+      int maxVectorSize
+  )
+  {
+    this.processor = processor;
+    this.maxVectorSize = maxVectorSize;
+    this.outNulls = new boolean[maxVectorSize];
+    this.outValues = new long[maxVectorSize];
+  }
+
+  @Override
+  public final ExprEvalVector<long[]> evalVector(Expr.VectorInputBinding bindings)
+  {
+    final ExprEvalVector<TInput> lhs = processor.evalVector(bindings);
+
+    final int currentSize = bindings.getCurrentVectorSize();
+    final boolean[] inputNulls = lhs.getNullVector();
+    final boolean hasNulls = inputNulls != null;
+
+    final TInput input = lhs.values();
+
+    if (hasNulls) {
+      for (int i = 0; i < currentSize; i++) {
+        outNulls[i] = inputNulls[i];
+        if (!outNulls[i]) {
+          processIndex(input, i);
+        } else {
+          outValues[i] = 0L;
+        }
+      }
+    } else {
+      for (int i = 0; i < currentSize; i++) {
+        outNulls[i] = false;
+        processIndex(input, i);
+      }
+    }
+    return asEval();
+  }
+
+  abstract void processIndex(TInput input, int i);
+
+  final ExprEvalVector<long[]> asEval()
+  {
+    return new ExprEvalLongVector(outValues, outNulls);
+  }
+}

--- a/core/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
@@ -696,7 +696,7 @@ public class VectorMathProcessors
   {
     final ExpressionType leftType = left.getOutputType(inspector);
     final ExpressionType rightType = right.getOutputType(inspector);
-    BivariateFunctionVectorValueProcessor<?, ?, ?> processor = null;
+    ExprVectorProcessor<?> processor = null;
     if ((Types.is(leftType, ExprType.LONG) && Types.isNullOr(rightType, ExprType.LONG)) ||
         (leftType == null && Types.is(rightType, ExprType.LONG))) {
       processor = new DoubleOutLongsInFunctionVectorValueProcessor(

--- a/core/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
+++ b/core/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
@@ -158,9 +158,9 @@ public class VectorMathProcessors
       }
     } else if (leftType.is(ExprType.STRING)) {
       if (Types.is(rightType, ExprType.LONG)) {
-        processor = longOutLongsInProcessor.get();
+        processor = doubleOutDoubleLongInProcessor.get();
       } else if (Types.is(rightType, ExprType.DOUBLE)) {
-        processor = doubleOutLongDoubleInProcessor.get();
+        processor = doubleOutDoublesInProcessor.get();
       }
     }
     if (processor == null) {

--- a/core/src/test/java/org/apache/druid/math/expr/VectorExprSanityTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/VectorExprSanityTest.java
@@ -88,7 +88,7 @@ public class VectorExprSanityTest extends InitializedNullHandlingTest
   @Test
   public void testBinaryMathOperators()
   {
-    final String[] columns = new String[]{"d1", "d2", "l1", "l2", "1", "1.0", "nonexistent", "null"};
+    final String[] columns = new String[]{"d1", "d2", "l1", "l2", "1", "1.0", "nonexistent", "null", "s1"};
     final String[] columns2 = new String[]{"d1", "d2", "l1", "l2", "1", "1.0"};
     final String[][] templateInputs = makeTemplateArgs(columns, columns2);
     final String[] templates =
@@ -305,7 +305,7 @@ public class VectorExprSanityTest extends InitializedNullHandlingTest
     ExprEvalVector<?> vectorEval = parsed.buildVectorized(bindings.rhs).evalVector(bindings.rhs);
     // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
     if (outputType != null) {
-      Assert.assertEquals(outputType, vectorEval.getType());
+      Assert.assertEquals(expr, outputType, vectorEval.getType());
     }
     for (int i = 0; i < VECTOR_SIZE; i++) {
       ExprEval<?> eval = parsed.eval(bindings.lhs[i]);

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -247,7 +247,7 @@ public class VirtualColumns implements Cacheable
 
   public boolean canVectorize(ColumnInspector columnInspector)
   {
-    return virtualColumns.stream().allMatch(virtualColumn -> virtualColumn.canVectorize(columnInspector));
+    return virtualColumns.stream().allMatch(virtualColumn -> virtualColumn.canVectorize(wrapInspector(columnInspector)));
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -247,7 +247,8 @@ public class VirtualColumns implements Cacheable
 
   public boolean canVectorize(ColumnInspector columnInspector)
   {
-    return virtualColumns.stream().allMatch(virtualColumn -> virtualColumn.canVectorize(wrapInspector(columnInspector)));
+    final ColumnInspector inspector = wrapInspector(columnInspector);
+    return virtualColumns.stream().allMatch(virtualColumn -> virtualColumn.canVectorize(inspector));
   }
 
   /**

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -276,8 +276,8 @@ public class NestedDataOperatorConversions
               call.operand(0),
               call.operand(1)
           );
-        } else if (SqlTypeName.APPROX_TYPES.contains(sqlType.getSqlTypeName()) ||
-                   SqlTypeName.DECIMAL.equals(sqlType.getSqlTypeName())) {
+        } else if (SqlTypeName.DECIMAL.equals(sqlType.getSqlTypeName()) ||
+                   SqlTypeName.APPROX_TYPES.contains(sqlType.getSqlTypeName())) {
           rewrite = JsonValueDoubleOperatorConversion.FUNCTION.createCall(
               SqlParserPos.ZERO,
               call.operand(0),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -276,7 +276,8 @@ public class NestedDataOperatorConversions
               call.operand(0),
               call.operand(1)
           );
-        } else if (SqlTypeName.APPROX_TYPES.contains(sqlType.getSqlTypeName())) {
+        } else if (SqlTypeName.APPROX_TYPES.contains(sqlType.getSqlTypeName()) ||
+                   SqlTypeName.DECIMAL.equals(sqlType.getSqlTypeName())) {
           rewrite = JsonValueDoubleOperatorConversion.FUNCTION.createCall(
               SqlParserPos.ZERO,
               call.operand(0),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -1952,6 +1952,35 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testReturningAndSumPathWithMaths()
+  {
+    testQuery(
+        "SELECT "
+        + "SUM(JSON_VALUE(nest, '$.x' RETURNING BIGINT) / 100) "
+        + "FROM druid.nested",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(DATA_SOURCE)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .virtualColumns(
+                      expressionVirtualColumn("v0", "(\"v1\" / 100)", ColumnType.LONG),
+                      new NestedFieldVirtualColumn("nest", "$.x", "v1", ColumnType.LONG)
+                  )
+                  .aggregators(aggregators(new LongSumAggregatorFactory("a0", "v0")))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{4L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
   public void testReturningAndSumPathDouble()
   {
     testQuery(
@@ -1996,6 +2025,35 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{400.0}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.DOUBLE)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testReturningAndSumPathDecimalWithMaths()
+  {
+    testQuery(
+        "SELECT "
+        + "SUM(JSON_VALUE(nest, '$.x' RETURNING DECIMAL) / 100.0) "
+        + "FROM druid.nested",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(DATA_SOURCE)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(Granularities.ALL)
+                  .virtualColumns(
+                      expressionVirtualColumn("v0", "(\"v1\" / 100.0)", ColumnType.DOUBLE),
+                      new NestedFieldVirtualColumn("nest", "$.x", "v1", ColumnType.DOUBLE)
+                  )
+                  .aggregators(aggregators(new DoubleSumAggregatorFactory("a0", "v0")))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{4.0}
         ),
         RowSignature.builder()
                     .add("EXPR$0", ColumnType.DOUBLE)


### PR DESCRIPTION
### Description
This PR fixes two bugs, the first around the SQL planner for `JSON_VALUE` queries using the "returning" syntax with SQL `DECIMAL` types incorrectly being inferred to have a `STRING` output, which prevents them from working correctly with vectorized math expressions, such as

```JSON_VALUE(x, '$.y' RETURNING DECIMAL) + 100```

They should now correctly be determined to be Druid native `DOUBLE` type which will allow vectorized math expressions (which require numeric inputs) to not violate a check.

This was actually triggering another bug, where the `VirtualColumns.canVectorize` check was using a `ColumnInspector` which did not have access to the column capabilities of the other virtual columns, while `getColumnCapabilities` did, which would sometimes lead to them not agreeing. The inspector missing the virtual columns would result in `null` capabilities, which is treated as a missing column for the purposes of vectorization check, while `getColumnCapabilities` used later during expression planning would have the correct virtual column identifier types.

While writing the test for this issue, I stumbled into yet another bug, this one around the fact that vector math processors were not zeroing out 'null' values in the value vector, which would cause anything downstream that was not checking the null vector to produce incorrect results from stale values in the 'null' positions. Most typically, this would be when `druid.generic.useDefaultValueForNull=true` which is also the default mode, but luckily is fairly unlikely to happen unless expressions were explicitly producing null values before being used in part of sum or some other thing that does not check the null vector in default value mode. Numeric nested literal columns also are impacted by this issue, since they always write out a null value bitmap even in "default" value mode, because they write out bitmap for all values, and rely on downstream selectors to just ignore the null vector in default mode.

Finally, I questioned why the numeric math expressions required all the inputs to be numeric instead of scalar in order to vectorize. Since the vector processors that drive them have implicit casts to ensure the correct type is used, we can allow cases where a string is one of the arguments to provide vectorized versions of the non-vectorized behavior, where if one of the arguments is a `STRING`, the output type is `DOUBLE`. There was a flaw in the `VectorMathProcessors.makeMathProcessor` which didn't match the non-vectorized behavior which has also been fixed (this code path was not able to be hit because of the previous checks to ensure all numeric args so no behavior has been changed).


<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
