### PR TITLE
Add more information to exceptions occurred while writing temporary data

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.writeout;
 import com.google.common.io.ByteStreams;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.IOE;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,7 +60,12 @@ final class FileWriteOutBytes extends WriteOutBytes
   public void flush() throws IOException
   {
     buffer.flip();
-    Channels.writeFully(ch, buffer);
+    try {
+      Channels.writeFully(ch, buffer);
+    }
+    catch (IOException e) {
+      throw new IOE(e, "Failed to write to file: %s. Space needed: %d", file.getAbsolutePath(), writeOutBytes);
+    }
     buffer.clear();
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
+++ b/processing/src/main/java/org/apache/druid/segment/writeout/FileWriteOutBytes.java
@@ -64,7 +64,7 @@ final class FileWriteOutBytes extends WriteOutBytes
       Channels.writeFully(ch, buffer);
     }
     catch (IOException e) {
-      throw new IOE(e, "Failed to write to file: %s. Space needed: %d", file.getAbsolutePath(), writeOutBytes);
+      throw new IOE(e, "Failed to write to file: %s. Current size of file: %d", file.getAbsolutePath(), writeOutBytes);
     }
     buffer.clear();
   }

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -34,12 +34,14 @@ public class FileWriteOutBytesTest
 {
   private FileWriteOutBytes fileWriteOutBytes;
   private FileChannel mockFileChannel;
+  private File mockFile;
 
   @Before
   public void setUp()
   {
     mockFileChannel = EasyMock.mock(FileChannel.class);
-    fileWriteOutBytes = new FileWriteOutBytes(EasyMock.mock(File.class), mockFileChannel);
+    mockFile = EasyMock.mock(File.class);
+    fileWriteOutBytes = new FileWriteOutBytes(mockFile, mockFileChannel);
   }
 
   @Test
@@ -191,5 +193,19 @@ public class FileWriteOutBytesTest
     destination.position(0);
     Assert.assertThrows(IAE.class, () -> fileWriteOutBytes.readFully(5000, destination));
     EasyMock.verify(mockFileChannel);
+  }
+
+  @Test
+  public void testIOExceptionHasFileInfo() throws Exception
+  {
+    IOException cause = new IOException("Too many bytes");
+    EasyMock.expect(mockFileChannel.write(EasyMock.anyObject(ByteBuffer.class))).andThrow(cause);
+    EasyMock.expect(mockFile.getAbsolutePath()).andReturn("/tmp/file");
+    EasyMock.replay(mockFileChannel, mockFile);
+    fileWriteOutBytes.writeInt(10);
+    fileWriteOutBytes.write(new byte[30]);
+    IOException actual = Assert.assertThrows(IOException.class, () -> fileWriteOutBytes.flush());
+    Assert.assertEquals(String.valueOf(actual.getCause()), actual.getCause(), cause);
+    Assert.assertEquals(actual.getMessage(), actual.getMessage(), "Failed to write to file: /tmp/file. Space needed: 34");
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/FileWriteOutBytesTest.java
@@ -206,6 +206,6 @@ public class FileWriteOutBytesTest
     fileWriteOutBytes.write(new byte[30]);
     IOException actual = Assert.assertThrows(IOException.class, () -> fileWriteOutBytes.flush());
     Assert.assertEquals(String.valueOf(actual.getCause()), actual.getCause(), cause);
-    Assert.assertEquals(actual.getMessage(), actual.getMessage(), "Failed to write to file: /tmp/file. Space needed: 34");
+    Assert.assertEquals(actual.getMessage(), actual.getMessage(), "Failed to write to file: /tmp/file. Current size of file: 34");
   }
 }


### PR DESCRIPTION
This typical error is seen when ingestion is writing intermediate data to a temporary file 

```
java.io.IOException: No space left on device
	at sun.nio.ch.FileDispatcherImpl.write0(Native Method) ~[?:?]
	at sun.nio.ch.FileDispatcherImpl.write(FileDispatcherImpl.java:62) ~[?:?]
	at sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:113) ~[?:?]
	at sun.nio.ch.IOUtil.write(IOUtil.java:79) ~[?:?]
	at sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:280) ~[?:?]
	at org.apache.druid.io.Channels.writeFully(Channels.java:32) ~[?:?]
	at org.apache.druid.segment.writeout.FileWriteOutBytes.flush(FileWriteOutBytes.java:62) ~[?:?]
	at org.apache.druid.segment.writeout.FileWriteOutBytes.flushIfNeeded(FileWriteOutBytes.java:54) ~[?:?]
	at org.apache.druid.segment.writeout.FileWriteOutBytes.write(FileWriteOutBytes.java:86) ~[?:?]
	at org.apache.druid.io.Channels.writeFully(Channels.java:32) ~[?:?]
```

From this exception, it's hard to know how much data we were trying to write or what location we were exactly trying to write to. I added a bit of code to intercept this exception and add some more info to the outbound exception. 

This PR has:

- [ ] been self-reviewed.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
