### PR TITLE
Improve global-cached-lookups metric reporting

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -169,5 +169,8 @@
 
   "segment/compacted/bytes" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/compacted/count" : { "dimensions" : ["dataSource"], "type" : "count" },
-  "interval/compacted/count" : { "dimensions" : ["dataSource"], "type" : "count" }
+  "interval/compacted/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+
+  "namespace/cache/numEntries" : { "dimensions" : [], "type" : "gauge" },
+  "namespace/cache/heapSizeInBytes" : { "dimensions" : [], "type" : "gauge" }
 }

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/data/input/MapPopulator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/data/input/MapPopulator.java
@@ -245,7 +245,8 @@ public class MapPopulator<K, V>
   {
     if (null != o) {
       if (o.getClass().getName().equals(STRING_CLASS_NAME)) {
-        return ((String) (o)).length();
+        // Each String object has ~40 bytes of overhead
+        return ((long) ((String) (o)).length() * Character.BYTES) + 40;
       } else if (o.getClass().getName().equals(DOUBLE_CLASS_NAME)) {
         return 8;
       } else if (o.getClass().getName().equals(FLOAT_CLASS_NAME)) {

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -105,7 +105,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
       );
       final long duration = System.nanoTime() - startNs;
       LOG.info(
-          "Finished loading %,d values (%d bytes) for [%s] in %,d ns",
+          "Finished loading %d values (%d bytes) for [%s] in %d ns",
           populateResult.getEntries(),
           populateResult.getBytes(),
           entryId,
@@ -151,7 +151,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
     final String keyColumn = namespace.getKeyColumn();
 
     return handle.createQuery(buildLookupQuery(table, filter, keyColumn, valueColumn))
-            .map((index1, r1, ctx1) -> new Pair<>(r1.getString(keyColumn), r1.getString(valueColumn)))
+            .map((index1, r1, ctx1) -> new Pair<>(r1.getString(1), r1.getString(2)))
             .iterator();
   }
 

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/UriCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/UriCacheGenerator.java
@@ -156,7 +156,7 @@ public final class UriCacheGenerator implements CacheGenerator<UriExtractionName
             );
             final long duration = System.nanoTime() - startNs;
             log.info(
-                "Finished loading %,d values (%d bytes) from %,d lines for [%s] in %,d ns",
+                "Finished loading %d values (%d bytes) from %d lines for [%s] in %d ns",
                 populateResult.getEntries(),
                 populateResult.getBytes(),
                 populateResult.getLines(),

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -150,7 +150,9 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
         size += key.length() + value.length();
       }
     }
+    // Each String object has ~40 bytes of overhead, and x 2 for key and value strings
+    long heapSizeInBytes = (80 * numEntries) + size * Character.BYTES;
     serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/numEntries", numEntries));
-    serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/heapSizeInBytes", size * Character.BYTES));
+    serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/heapSizeInBytes", heapSizeInBytes));
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/data/input/MapPopulatorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/data/input/MapPopulatorTest.java
@@ -39,7 +39,7 @@ public class MapPopulatorTest
   public void test_getByteLengthOfObject_string_stringLength()
   {
     String o = "string";
-    Assert.assertEquals(o.length(), MapPopulator.getByteLengthOfObject(o));
+    Assert.assertEquals((o.length() * Character.BYTES) + 40, MapPopulator.getByteLengthOfObject(o));
   }
 
   @Test
@@ -184,7 +184,7 @@ public class MapPopulatorTest
     Assert.assertEquals(expectedMap, map);
     Assert.assertEquals(4, result.getEntries());
     Assert.assertEquals(0, result.getLines());
-    Assert.assertEquals(16L, result.getBytes());
+    Assert.assertEquals(192L, result.getBytes());
   }
 
   @Test


### PR DESCRIPTION
It was found that the `namespace/cache/heapSizeInBytes` metric that tracks the total heap size in bytes of all lookup caches loaded on a service instance was being under reported. We were not accounting for the memory overhead of the String object, which I've found in testing to be ~40 bytes. While this overhead may be java version dependent, it should not vary much, and accounting for this provides a better estimate. Also fixed some logging, and reading bytes from the JDBI result set a little more efficient by saving hash table lookups. Also added some of the lookup metrics to the default statsD emitter metric whitelist.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
