### PR TITLE
fix(sec): upgrade org.apache.thrift:libthrift to 0.14.0

### DIFF
--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -34,7 +34,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <thrift.version>0.13.0</thrift.version>
+    <thrift.version>0.14.0</thrift.version>
     <elephantbird.version>4.17</elephantbird.version>
     <scrooge.version>19.10.0</scrooge.version>
   </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.thrift:libthrift 0.13.0
- [CVE-2020-13949](https://www.oscs1024.com/hd/CVE-2020-13949)


### What did I do？
Upgrade org.apache.thrift:libthrift from 0.13.0 to 0.14.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS