### PR TITLE
fix(sec): upgrade com.nimbusds:oauth2-oidc-sdk to 8.36.2

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -39,7 +39,7 @@
     <!-- Following must be updated along with any updates to pac4j version -->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
     <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
-    <oauth2.oidc.sdk.version>6.5</oauth2.oidc.sdk.version>
+    <oauth2.oidc.sdk.version>8.36.2</oauth2.oidc.sdk.version>
   </properties>
 
   <dependencies>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -820,7 +820,7 @@ name: com.nimbusds oauth2-oidc-sdk
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 6.5
+version: 8.36.2
 libraries:
   - com.nimbusds: oauth2-oidc-sdk
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.nimbusds:oauth2-oidc-sdk 6.5
- [MPS-2022-12182](https://www.oscs1024.com/hd/MPS-2022-12182)


### What did I do？
Upgrade com.nimbusds:oauth2-oidc-sdk from 6.5 to 8.36.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS