### PR TITLE
Fix race condition in HttpPostEmitter that occurs during shutdown

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -534,11 +534,6 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
         Object batch = concurrentBatch.get();
         if (batch instanceof Batch) {
           ((Batch) batch).sealIfFlushNeeded();
-        } else {
-          // batch == null means that HttpPostEmitter is terminated. Batch object might also be a Long object if some
-          // thread just failed with a serious error in onSealExclusive(). In this case we don't want to shutdown
-          // the emitter thread.
-          needsToShutdown = batch == null;
         }
       }
       return needsToShutdown;


### PR DESCRIPTION
There is a bug (race condition) in HttpPostEmitter where the emitting thread is getting prematurely stopped while there is data to be flushed.

`HttpPostEmitter.close()` does following

```
Object lastBatch = concurrentBatch.getAndSet(null);
if (lastBatch instanceof Batch) {
          flush((Batch) lastBatch);
        }
      
```
 
if the emitting thread is stopped, the `flush` call will hang. In each run, emitting thread checks if `concurrentBatch.get()` returns null.  If null is returned, it will flush the batch and shut itself down. It's possible that `flush(batch)` in `HttpPostEmitter.close()` gets invoked after the emitting thread shuts down. 

This race condition is more likely if flushMillis is set to a lower value. When that happens, the event loop in the emitting thread runs more frequently.  The race condition can easily be reproduced by adding below code to `HttpPostEmitter.close()` and running `EmitterTest.testTimeBasedEmission`

```
       Object lastBatch = concurrentBatch.getAndSet(null);
        Thread.sleep(60000);   // new code that is to be added
        if (lastBatch instanceof Batch) {
          flush((Batch) lastBatch);
        }
```


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
