### PR TITLE
Update data loader parse screen help text

### DIFF
--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -67,8 +67,11 @@ export const ParserMessage = React.memo(function ParserMessage(props: ParserMess
     <FormGroup>
       <Callout>
         <p>
-          Druid requires flat data (non-nested, non-hierarchical). Each row should represent a
-          discrete event.
+          You can{' '}
+          <ExternalLink href={`${getLink('DOCS')}/querying/nested-columns.html`}>
+            directly ingest nested data
+          </ExternalLink>{' '}
+          into COMPLEX&lt;json&gt; columns.
         </p>
         {canFlatten && (
           <p>
@@ -76,11 +79,9 @@ export const ParserMessage = React.memo(function ParserMessage(props: ParserMess
             <ExternalLink href={`${getLink('DOCS')}/ingestion/index.html#flattenspec`}>
               flatten
             </ExternalLink>{' '}
-            it here. If the provided flattening capabilities are not sufficient, please pre-process
-            your data before ingesting it into Druid.
+            it here.
           </p>
         )}
-        <p>Ensure that your data appears correctly in a row/column orientation.</p>
         <LearnMore href={`${getLink('DOCS')}/ingestion/data-formats.html`} />
       </Callout>
     </FormGroup>


### PR DESCRIPTION
### Description

Updates the data loader parse screen help text to reflect the docs. 

if canFlatten: 
<img width="307" alt="Screen Shot 2022-10-17 at 4 32 48 PM" src="https://user-images.githubusercontent.com/37322608/196302878-a0a26913-9b20-4df8-a65a-09586262bc7d.png">

if !canFlatten: 
<img width="306" alt="Screen Shot 2022-10-17 at 4 37 26 PM" src="https://user-images.githubusercontent.com/37322608/196303018-19aa97b0-0fe4-48c7-819e-5c214ac0b209.png">