### PR TITLE
Upgrade jackson-databind to 2.13.4.2 to address CVEs

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
+++ b/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
@@ -58,9 +58,9 @@ public class GuiceAnnotationIntrospector extends NopAnnotationIntrospector
       if (m instanceof AnnotatedMethod) {
         throw new IAE("Annotated methods don't work very well yet...");
       }
-      return Key.get(m.getGenericType());
+      return Key.get(m.getType());
     }
-    return Key.get(m.getGenericType(), guiceAnnotation);
+    return Key.get(m.getType(), guiceAnnotation);
   }
 
   /**

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -278,7 +278,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5.1
+version: 2.13.4.2
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -237,7 +237,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5
+version: 2.13.4
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.48.v20220622</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.13.4.2</jackson.version>
+        <jackson.version>2.13.4.20221013</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.48.v20220622</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.10.5.20201202</jackson.version>
+        <jackson.version>2.13.4.2</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>


### PR DESCRIPTION
CVEs:
[CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004)
[CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)

Changes:
- Upgrade jackson-bom to 2.13.4.20221013
- Remove usage of methods deleted from latest version of jackson-databind

<hr>

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)


