### PR TITLE
Upgrade python version used on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ addons:
   apt:
     packages:
       - maven
-      - python3
+      - python3.6
 
 # Add various options to make 'mvn install' fast and skip javascript compile (-Dweb.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
     - name: "license checks"
       before_script: &setup_generate_license
         - sudo apt-get update && sudo apt-get install python3.6 -y
-        - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
+        - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ jobs:
       before_script: &setup_generate_license
         - sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
+        - pip3 install --upgrade pip==3.6
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3=3.5.2* python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ env:
 
 addons:
   apt:
+    sources:
+      - sourceline: 'ppa:jblgf0/python'
     packages:
       - maven
       - python3.6
@@ -91,7 +93,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo add-apt-repository -y ppa:jblgf0/python && sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,11 +93,10 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3.6 python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
-        - pip3 install --upgrade pip==3.6
-        - pip3 install wheel  # install wheel first explicitly
-        - pip3 install pyyaml==5.4.1
+        - python3.6 -m pip install wheel  # install wheel first explicitly
+        - python3.6 -m pip install pyyaml==5.4.1
       script:
         - >
           ${MVN} apache-rat:check -Prat --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3 python3-pip python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
         - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
-        - pip3 install pyyaml==5.4.1
+        - pip3 install pyyaml==6.0
       script:
         - >
           ${MVN} apache-rat:check -Prat --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,8 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3 python3-pip python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3.6 -y
+        - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,10 +93,11 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3.6 python3-setuptools -y
+        - sudo apt-get update && sudo apt-get install python3.6 -y
+        - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.6
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
-        - python3.6 -m pip install wheel  # install wheel first explicitly
-        - python3.6 -m pip install pyyaml==5.4.1
+        - pip3 install wheel  # install wheel first explicitly
+        - pip3 install pyyaml==5.4.1
       script:
         - >
           ${MVN} apache-rat:check -Prat --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3-distutils -y
+        - sudo apt-get update && sudo apt-get install python3.9-distutils -y
         - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.9
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,11 +93,10 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3.6 -y
-        - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
+        - sudo apt-get update && sudo apt-get install python3 python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
-        - pip3 install -U pyyaml
+        - pip3 install pyyaml==5.4.1
       script:
         - >
           ${MVN} apache-rat:check -Prat --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
+        - sudo apt-get update && sudo apt-get install python3-distutils -y
         - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.9
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
         - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
-        - pip3 install pyyaml==6.0
+        - pip3 install -U pyyaml
       script:
         - >
           ${MVN} apache-rat:check -Prat --fail-at-end

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3=3.5.2* python3-pip python3-setuptools -y
+        - sudo add-apt-repository -y ppa:jblgf0/python && sudo apt-get update && sudo apt-get install python3.6 python3-pip python3-setuptools -y
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
       - sourceline: 'ppa:jblgf0/python'
     packages:
       - maven
-      - python3.6
+      - python3.9
 
 # Add various options to make 'mvn install' fast and skip javascript compile (-Dweb.console.skip=true) since it is not
 # needed. Depending on network speeds, "mvn -q install" may take longer than the default 10 minute timeout to print any
@@ -93,8 +93,7 @@ jobs:
 
     - name: "license checks"
       before_script: &setup_generate_license
-        - sudo apt-get update && sudo apt-get install python3.6 -y
-        - curl https://bootstrap.pypa.io/pip/3.6/get-pip.py | sudo -H python3.6
+        - curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.9
         - ./check_test_suite.py && travis_terminate 0 || echo 'Continuing setup'
         - pip3 install wheel  # install wheel first explicitly
         - pip3 install pyyaml==5.4.1

--- a/check_test_suite.py
+++ b/check_test_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/check_test_suite.py
+++ b/check_test_suite.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
+++ b/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
@@ -58,9 +58,9 @@ public class GuiceAnnotationIntrospector extends NopAnnotationIntrospector
       if (m instanceof AnnotatedMethod) {
         throw new IAE("Annotated methods don't work very well yet...");
       }
-      return Key.get(m.getGenericType());
+      return Key.get(m.getType());
     }
-    return Key.get(m.getGenericType(), guiceAnnotation);
+    return Key.get(m.getType(), guiceAnnotation);
   }
 
   /**

--- a/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
+++ b/core/src/main/java/org/apache/druid/guice/GuiceAnnotationIntrospector.java
@@ -58,9 +58,9 @@ public class GuiceAnnotationIntrospector extends NopAnnotationIntrospector
       if (m instanceof AnnotatedMethod) {
         throw new IAE("Annotated methods don't work very well yet...");
       }
-      return Key.get(m.getType());
+      return Key.get(m.getGenericType());
     }
-    return Key.get(m.getType(), guiceAnnotation);
+    return Key.get(m.getGenericType(), guiceAnnotation);
   }
 
   /**

--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/distribution/bin/generate-binary-license.py
+++ b/distribution/bin/generate-binary-license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/distribution/bin/generate-binary-license.py
+++ b/distribution/bin/generate-binary-license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/distribution/bin/generate-license-dependency-reports.py
+++ b/distribution/bin/generate-license-dependency-reports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/distribution/bin/generate-license-dependency-reports.py
+++ b/distribution/bin/generate-license-dependency-reports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3.9
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
The `license check` step seems to be failing on Travis builds due to a python version mismatch.

[Sample failure logs](https://api.travis-ci.com/v3/job/586315928/log.txt)
[Sample failing job](https://app.travis-ci.com/github/apache/druid/jobs/586315928)

### Fix
- Use python version 3.9
- Add new repository as default repo `deadsnakes` has stopped support for Ubuntu 16.04

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
