### PR TITLE
Fix two sources of SQL statement leaks.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
@@ -210,7 +210,8 @@ public class DirectStatement extends AbstractStatement implements Cancelable
         // Context keys for authorization. Use the user-provided keys,
         // NOT the keys from the query context which, by this point,
         // will have been extended with internally-defined values.
-        queryPlus.context().keySet())) {
+        queryPlus.context().keySet()
+    )) {
       validate(planner);
       authorize(planner, authorizer());
 
@@ -301,6 +302,7 @@ public class DirectStatement extends AbstractStatement implements Cancelable
   public void close()
   {
     if (state != State.START && state != State.CLOSED) {
+      // super.close calls closeQuietly, which removes us from the sqlLifecycleManager.
       super.close();
       state = State.CLOSED;
     }
@@ -310,8 +312,17 @@ public class DirectStatement extends AbstractStatement implements Cancelable
   public void closeWithError(Throwable e)
   {
     if (state != State.START && state != State.CLOSED) {
+      // super.closeWithError does not call closeQuietly; we need to explicitly remove from the sqlLifecycleManager.
+      sqlToolbox.sqlLifecycleManager.remove(sqlQueryId(), this);
       super.closeWithError(e);
       state = State.CLOSED;
     }
+  }
+
+  @Override
+  public void closeQuietly()
+  {
+    sqlToolbox.sqlLifecycleManager.remove(sqlQueryId(), this);
+    super.closeQuietly();
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -411,7 +411,8 @@ public class DruidJdbcResultSet implements Closeable
       throw new RuntimeException(t);
     }
     finally {
-      // Closing the statement cause logs and metrics to be emitted.
+      // Closing the statement causes logs and metrics to be emitted, and causes the statement to be removed
+      // from the SqlLifecycleManager.
       stmt.close();
     }
   }


### PR DESCRIPTION
1) SqlTaskResource and DruidJdbcResultSet leaked statements 100% of the
   time, since they call stmt.plan(), which adds statements to
   SqlLifecycleManager, and they do not explicitly remove them.

2) SqlResource leaked statements if yielder.close() threw an exception.
   (And also would not emit metrics, since in that case it failed to
   call stmt.close as well.)

Item (2) has been around for a while. Item (1) is a regression in 24.0, introduced in #12845. That patch moved SqlLifecycleManager registration from SqlResource to DirectStatement, but kept _de_-registration in SqlResource only.