### PR TITLE
helm: add Kubernetes discovery support

### DIFF
--- a/helm/druid/templates/broker/deployment.yaml
+++ b/helm/druid/templates/broker/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "broker" ]
           env:
+          - name: POD_NAME
+            valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+          - name: POD_NAMESPACE
+            valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
           {{- range $key, $val := .Values.broker.config }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/helm/druid/templates/coordinator/deployment.yaml
+++ b/helm/druid/templates/coordinator/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "coordinator" ]
           env:
+          - name: POD_NAME
+            valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+          - name: POD_NAMESPACE
+            valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
           {{- range $key, $val := .Values.coordinator.config }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/helm/druid/templates/historical/statefulset.yaml
+++ b/helm/druid/templates/historical/statefulset.yaml
@@ -95,6 +95,10 @@ spec:
       - name: druid
         args: [ "historical" ]
         env:
+        - name: POD_NAME
+          valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+        - name: POD_NAMESPACE
+          valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
         {{- range $key, $val := .Values.historical.config }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/helm/druid/templates/middleManager/statefulset.yaml
+++ b/helm/druid/templates/middleManager/statefulset.yaml
@@ -95,6 +95,10 @@ spec:
       - name: druid
         args: [ "middleManager" ]
         env:
+        - name: POD_NAME
+          valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+        - name: POD_NAMESPACE
+          valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
         {{- range $key, $val := .Values.middleManager.config }}
         - name: {{ $key }}
           value: {{ $val | quote }}

--- a/helm/druid/templates/overlord/deployment.yaml
+++ b/helm/druid/templates/overlord/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "overlord" ]
           env:
+          - name: POD_NAME
+            valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+          - name: POD_NAMESPACE
+            valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
           {{- range $key, $val := .Values.overlord.config }}
           - name: {{ $key }}
             value: {{ $val | quote }}

--- a/helm/druid/templates/router/deployment.yaml
+++ b/helm/druid/templates/router/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [ "router" ]
           env:
+          - name: POD_NAME
+            valueFrom:  {fieldRef: {fieldPath: metadata.name}}
+          - name: POD_NAMESPACE
+            valueFrom: {fieldRef: {fieldPath: metadata.namespace}}
           {{- range $key, $val := .Values.router.config }}
           - name: {{ $key }}
             value: {{ $val | quote }}


### PR DESCRIPTION
The K8 discovery mechanism, enabled by the druid-kubernetes-extension, relies on each pod advertising its name and namespace on the env variables POD_NAME and POD_NAMESPACE [1]. Add env variables to all deployments/statefulsets.

[1] https://druid.apache.org/docs/latest/development/extensions-core/kubernetes.html

Signed-off-by: Alejandro del Castillo <alejandro.delcastillo@ni.com>

### Description

Helm deployment is not compatible with the druid-kubernetes-extension since the extension relies on each pod advertising its name and namespace on the env variables POD_NAME and POD_NAMESPACE

Add POD_NAME and POD_NAMESPACE env variables to all deployments/statefulsets.

#### Release note
- Add K8 discovery support to helm charts.

<hr>


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ X] been tested in a test Druid cluster.
