### PR TITLE
Add task start status to worker report

### DIFF
--- a/docs/multi-stage-query/api.md
+++ b/docs/multi-stage-query/api.md
@@ -553,6 +553,8 @@ The following table describes the response fields when you retrieve a report for
 |multiStageQuery.payload.status.status|RUNNING, SUCCESS, or FAILED.|
 |multiStageQuery.payload.status.startTime|Start time of the query in ISO format. Only present if the query has started running.|
 |multiStageQuery.payload.status.durationMs|Milliseconds elapsed after the query has started running. -1 denotes that the query hasn't started running yet.|
+|multiStageQuery.payload.status.pendingTasks|Number of tasks that are not fully started. -1 denotes that the number is currently unknown.|
+|multiStageQuery.payload.status.runningTasks|Number of currently running tasks. Should be at least 1 since the controller is included.|
 |multiStageQuery.payload.status.errorReport|Error object. Only present if there was an error.|
 |multiStageQuery.payload.status.errorReport.taskId|The task that reported the error, if known. May be a controller task or a worker task.|
 |multiStageQuery.payload.status.errorReport.host|The hostname and port of the task that reported the error, if known.|

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -1813,12 +1813,13 @@ public class ControllerImpl implements Controller
       MSQWorkerTaskLauncher taskLauncher
   )
   {
-    int pendingTasks = 0;
+    int pendingTasks = -1;
     int runningTasks = 1;
 
     if (taskLauncher != null) {
-      pendingTasks = taskLauncher.getPendingWorkerTasks();
-      runningTasks = taskLauncher.getRunningWorkerTasks() + 1; // To account for controller.
+      Pair<Integer, Integer> workerTaskStatus = taskLauncher.getWorkerTaskStatus();
+      pendingTasks = workerTaskStatus.lhs;
+      runningTasks = workerTaskStatus.rhs + 1; // To account for controller.
     }
     return new MSQStatusReport(
         taskState,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -346,12 +346,12 @@ public class MSQWorkerTaskLauncher
   }
 
   /**
-   * Returns the number of worker tasks not yet in running state or not assigned a location.
+   * Returns the number of worker tasks that are not yet fully started.
    */
   public int getPendingWorkerTasks()
   {
     synchronized (taskIds) {
-      return desiredTaskCount - fullyStartedTasks.size();
+      return desiredTaskCount - getRunningWorkerTasks();
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -346,22 +347,15 @@ public class MSQWorkerTaskLauncher
   }
 
   /**
-   * Returns the number of worker tasks that are not yet fully started.
+   * Returns a pair which contains the number of currently running worker tasks and the number of worker tasks that are
+   * not yet fully started as left and right respectively.
    */
-  public int getPendingWorkerTasks()
+  public Pair<Integer, Integer> getWorkerTaskStatus()
   {
     synchronized (taskIds) {
-      return desiredTaskCount - getRunningWorkerTasks();
-    }
-  }
-
-  /**
-   * Returns the number of fully started worker tasks.
-   */
-  public int getRunningWorkerTasks()
-  {
-    synchronized (taskIds) {
-      return fullyStartedTasks.size();
+      int runningTasks = fullyStartedTasks.size();
+      int pendingTasks = desiredTaskCount - runningTasks;
+      return Pair.of(runningTasks, pendingTasks);
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -346,6 +346,26 @@ public class MSQWorkerTaskLauncher
   }
 
   /**
+   * Returns the number of worker tasks not yet in running state or not assigned a location.
+   */
+  public int getPendingWorkerTasks()
+  {
+    synchronized (taskIds) {
+      return desiredTaskCount - fullyStartedTasks.size();
+    }
+  }
+
+  /**
+   * Returns the number of fully started worker tasks.
+   */
+  public int getRunningWorkerTasks()
+  {
+    synchronized (taskIds) {
+      return fullyStartedTasks.size();
+    }
+  }
+
+  /**
    * Used by the main loop to update {@link #taskTrackers} and {@link #fullyStartedTasks}.
    */
   private void updateTaskTrackersAndTaskIds()

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQStatusReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQStatusReport.java
@@ -46,6 +46,9 @@ public class MSQStatusReport
 
   private final long durationMs;
 
+  private final int pendingTasks;
+
+  private final int runningTasks;
 
   @JsonCreator
   public MSQStatusReport(
@@ -53,7 +56,9 @@ public class MSQStatusReport
       @JsonProperty("errorReport") @Nullable MSQErrorReport errorReport,
       @JsonProperty("warnings") Collection<MSQErrorReport> warningReports,
       @JsonProperty("startTime") @Nullable DateTime startTime,
-      @JsonProperty("durationMs") long durationMs
+      @JsonProperty("durationMs") long durationMs,
+      @JsonProperty("pendingTasks") int pendingTasks,
+      @JsonProperty("runningTasks") int runningTasks
   )
   {
     this.status = Preconditions.checkNotNull(status, "status");
@@ -61,6 +66,8 @@ public class MSQStatusReport
     this.warningReports = warningReports != null ? warningReports : Collections.emptyList();
     this.startTime = startTime;
     this.durationMs = durationMs;
+    this.pendingTasks = pendingTasks;
+    this.runningTasks = runningTasks;
   }
 
   @JsonProperty
@@ -90,6 +97,18 @@ public class MSQStatusReport
   public DateTime getStartTime()
   {
     return startTime;
+  }
+
+  @JsonProperty
+  public int getPendingTasks()
+  {
+    return pendingTasks;
+  }
+
+  @JsonProperty
+  public int getRunningTasks()
+  {
+    return runningTasks;
   }
 
   @JsonProperty

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/report/MSQTaskReportTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/report/MSQTaskReportTest.java
@@ -91,7 +91,7 @@ public class MSQTaskReportTest
     final MSQTaskReport report = new MSQTaskReport(
         TASK_ID,
         new MSQTaskReportPayload(
-            new MSQStatusReport(TaskState.SUCCESS, null, new ArrayDeque<>(), null, 0),
+            new MSQStatusReport(TaskState.SUCCESS, null, new ArrayDeque<>(), null, 0, 1, 2),
             MSQStagesReport.create(
                 QUERY_DEFINITION,
                 ImmutableMap.of(),
@@ -119,6 +119,8 @@ public class MSQTaskReportTest
     Assert.assertEquals(TASK_ID, report2.getTaskId());
     Assert.assertEquals(report.getPayload().getStatus().getStatus(), report2.getPayload().getStatus().getStatus());
     Assert.assertNull(report2.getPayload().getStatus().getErrorReport());
+    Assert.assertEquals(report.getPayload().getStatus().getRunningTasks(), report2.getPayload().getStatus().getRunningTasks());
+    Assert.assertEquals(report.getPayload().getStatus().getPendingTasks(), report2.getPayload().getStatus().getPendingTasks());
     Assert.assertEquals(report.getPayload().getStages(), report2.getPayload().getStages());
 
     Yielder<Object[]> yielder = report2.getPayload().getResults().getResultYielder();
@@ -142,7 +144,7 @@ public class MSQTaskReportTest
     final MSQTaskReport report = new MSQTaskReport(
         TASK_ID,
         new MSQTaskReportPayload(
-            new MSQStatusReport(TaskState.FAILED, errorReport, new ArrayDeque<>(), null, 0),
+            new MSQStatusReport(TaskState.FAILED, errorReport, new ArrayDeque<>(), null, 0, 1, 2),
             MSQStagesReport.create(
                 QUERY_DEFINITION,
                 ImmutableMap.of(),
@@ -179,7 +181,7 @@ public class MSQTaskReportTest
     final MSQTaskReport report = new MSQTaskReport(
         TASK_ID,
         new MSQTaskReportPayload(
-            new MSQStatusReport(TaskState.SUCCESS, null, new ArrayDeque<>(), null, 0),
+            new MSQStatusReport(TaskState.SUCCESS, null, new ArrayDeque<>(), null, 0, 1, 2),
             MSQStagesReport.create(
                 QUERY_DEFINITION,
                 ImmutableMap.of(),

--- a/website/.spelling
+++ b/website/.spelling
@@ -629,6 +629,8 @@ multiStageQuery.payload.status
 multiStageQuery.payload.status.status
 multiStageQuery.payload.status.startTime 
 multiStageQuery.payload.status.durationMs
+multiStageQuery.payload.status.pendingTasks
+multiStageQuery.payload.status.runningTasks
 multiStageQuery.payload.status.errorReport
 multiStageQuery.payload.status.errorReport.taskId
 multiStageQuery.payload.status.errorReport.host


### PR DESCRIPTION
Adds two new fields to the worker report, pendingTasks and runningTasks.

These indicate the number of tasks (including controller) that are in pending and and have already fully started. These can be used in the UI to better communicate the state of a task. Since the controller running is a prerequisite for the worker report, the running task number will be at least 1.

### New payload:

```
{
  "multiStageQuery": {
    "taskId": "query-37b4ee2e-3469-41c8-a74a-faec7b555980",
    "payload": {
      "status": {
        "status": "RUNNING",
        "startTime": "2022-10-25T08:22:52.925Z",
        "durationMs": 545,
        "pendingTasks": 2,
        "runningTasks": 2
      },
      "stages": [ <unchanged> ],
      "counters": {}
}
```
<hr>
<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
