### PR TITLE
Use lookup memory footprint in MSQ memory computations.

### DIFF
--- a/docs/multi-stage-query/concepts.md
+++ b/docs/multi-stage-query/concepts.md
@@ -249,8 +249,9 @@ Increasing the amount of available memory can improve performance in certain cas
 
 Worker tasks use both JVM heap memory and off-heap ("direct") memory.
 
-On Peons launched by Middle Managers, the bulk of the JVM heap (75%) is split up into two bundles of equal size: one
-processor bundle and one worker bundle. Each one comprises 37.5% of the available JVM heap.
+On Peons launched by Middle Managers, the bulk of the JVM heap (75%, less any space used by
+[lookups](../querying/lookups.md)) is split up into two bundles of equal size: one processor bundle and one worker
+bundle. Each one comprises 37.5% of the available JVM heap, less any space used by [lookups](../querying/lookups.md).
 
 Depending on the type of query, each worker and controller task can use a sketch for generating partition boundaries.
 Each sketch uses at most approximately 300 MB.

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManager.java
@@ -25,6 +25,7 @@ import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.server.lookup.namespace.NamespaceExtractionConfig;
 
 import java.lang.ref.WeakReference;
@@ -132,26 +133,17 @@ public class OnHeapNamespaceExtractionCacheManager extends NamespaceExtractionCa
   void monitor(ServiceEmitter serviceEmitter)
   {
     long numEntries = 0;
-    long size = 0;
+    long heapSizeInBytes = 0;
     expungeCollectedCaches();
     for (WeakReference<Map<String, String>> cacheRef : caches) {
       final Map<String, String> cache = cacheRef.get();
-      if (cache == null) {
-        continue;
-      }
-      numEntries += cache.size();
-      for (Map.Entry<String, String> sEntry : cache.entrySet()) {
-        final String key = sEntry.getKey();
-        final String value = sEntry.getValue();
-        if (key == null || value == null) {
-          LOG.debug("Missing entries for cache key");
-          continue;
-        }
-        size += key.length() + value.length();
+
+      if (cache != null) {
+        numEntries += cache.size();
+        heapSizeInBytes += MapLookupExtractor.estimateHeapFootprint(cache);
       }
     }
-    // Each String object has ~40 bytes of overhead, and x 2 for key and value strings
-    long heapSizeInBytes = (80 * numEntries) + size * Character.BYTES;
+
     serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/numEntries", numEntries));
     serviceEmitter.emit(ServiceMetricEvent.builder().build("namespace/cache/heapSizeInBytes", heapSizeInBytes));
   }

--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/PollingLookup.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/PollingLookup.java
@@ -216,6 +216,26 @@ public class PollingLookup extends LookupExtractor
   }
 
   @Override
+  public long estimateHeapFootprint()
+  {
+    PollingCache<?, ?> cache = null;
+
+    while (cache == null) {
+      final CacheRefKeeper cacheRefKeeper = refOfCacheKeeper.get();
+
+      if (cacheRefKeeper == null) {
+        // Closed.
+        return 0;
+      }
+
+      // If null, we'll do another run through the while loop.
+      cache = cacheRefKeeper.getAndIncrementRef();
+    }
+
+    return cache.estimateHeapFootprint();
+  }
+
+  @Override
   public int hashCode()
   {
     int result = (int) (pollPeriodMs ^ (pollPeriodMs >>> 32));

--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/cache/polling/OnHeapPollingCache.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/cache/polling/OnHeapPollingCache.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.lookup.cache.polling;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import org.apache.druid.query.extraction.MapLookupExtractor;
 
 import java.util.Collections;
 import java.util.List;
@@ -81,6 +82,19 @@ public class OnHeapPollingCache<K, V> implements PollingCache<K, V>
       return Collections.emptyList();
     }
     return listOfKeys;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public long estimateHeapFootprint()
+  {
+    for (final Map.Entry<K, V> entry : immutableMap.entrySet()) {
+      if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
+        return 0;
+      }
+    }
+
+    return MapLookupExtractor.estimateHeapFootprint((Map<String, String>) immutableMap);
   }
 
   @Override

--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/cache/polling/PollingCache.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/cache/polling/PollingCache.java
@@ -41,4 +41,12 @@ public interface PollingCache<K, V>
    * close and clean the resources used by the cache
    */
   void close();
+
+  /**
+   * Estimated heap footprint of this object.
+   */
+  default long estimateHeapFootprint()
+  {
+    return 0;
+  }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
@@ -223,6 +223,15 @@ public class PollingLookupTest extends InitializedNullHandlingTest
     pollingLookup.keySet();
   }
 
+  @Test
+  public void testEstimateHeapFootprint()
+  {
+    Assert.assertEquals(
+        pollingCacheFactory instanceof OffHeapPollingCache.OffHeapPollingCacheProvider ? 0L : 402L,
+        pollingLookup.estimateHeapFootprint()
+    );
+  }
+
   private void assertMapLookup(Map<String, String> map, LookupExtractor lookup)
   {
     for (Map.Entry<String, String> entry : map.entrySet()) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerWorkerContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/IndexerWorkerContextTest.java
@@ -35,7 +35,6 @@ import java.util.Collections;
 
 public class IndexerWorkerContextTest
 {
-
   private IndexerWorkerContext indexerWorkerContext = null;
 
   @Before
@@ -50,7 +49,8 @@ public class IndexerWorkerContextTest
         injectorMock,
         null,
         null,
-        null
+        null,
+        Runtime.getRuntime().maxMemory()
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
@@ -155,7 +155,8 @@ public class MSQTestWorkerContext implements WorkerContext
             injector,
             indexIO,
             null,
-            null
+            null,
+            Runtime.getRuntime().maxMemory()
         ),
         indexIO,
         injector.getInstance(DataSegmentProvider.class),

--- a/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
@@ -58,7 +58,13 @@ public class MapLookupExtractor extends LookupExtractor
     this.isOneToOne = isOneToOne;
   }
 
-  public static long estimateHeapFootprint(@Nullable final Map<String, String> map)
+  /**
+   * Estimate the heap footprint of a Map.
+   *
+   * Important note: the implementation accepts any kind of Map, but estimates zero footprint for keys and values of
+   * types other than String.
+   */
+  public static <K, V> long estimateHeapFootprint(@Nullable final Map<K, V> map)
   {
     if (map == null) {
       return 0;
@@ -67,16 +73,16 @@ public class MapLookupExtractor extends LookupExtractor
     final int numEntries = map.size();
     long numChars = 0;
 
-    for (Map.Entry<String, String> sEntry : map.entrySet()) {
-      final String key = sEntry.getKey();
-      final String value = sEntry.getValue();
+    for (Map.Entry<K, V> sEntry : map.entrySet()) {
+      final K key = sEntry.getKey();
+      final V value = sEntry.getValue();
 
-      if (key != null) {
-        numChars += key.length();
+      if (key instanceof String) {
+        numChars += ((String) key).length();
       }
 
-      if (value != null) {
-        numChars += value.length();
+      if (value instanceof String) {
+        numChars += ((String) value).length();
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
@@ -137,4 +137,16 @@ public abstract class LookupExtractor
   {
     return false;
   }
+
+  /**
+   * Estimated heap footprint of this object. Not guaranteed to be accurate. For example, some implementations return
+   * zero even though they do use on-heap structures. However, the most common class, {@link MapLookupExtractor},
+   * does have a reasonable implementation.
+   *
+   * This API is provided for best-effort memory management and monitoring.
+   */
+  public long estimateHeapFootprint()
+  {
+    return 0;
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractorTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
@@ -103,6 +104,39 @@ public class MapLookupExtractorTest
         ImmutableList.copyOf(lookupMap.entrySet()),
         ImmutableList.copyOf(fn.iterable())
     );
+  }
+
+  @Test
+  public void testEstimateHeapFootprint()
+  {
+    Assert.assertEquals(0L, new MapLookupExtractor(Collections.emptyMap(), false).estimateHeapFootprint());
+    Assert.assertEquals(388L, new MapLookupExtractor(ImmutableMap.copyOf(lookupMap), false).estimateHeapFootprint());
+  }
+
+  @Test
+  public void testEstimateHeapFootprintStatic()
+  {
+    Assert.assertEquals(0L, MapLookupExtractor.estimateHeapFootprint(null));
+    Assert.assertEquals(0L, MapLookupExtractor.estimateHeapFootprint(Collections.emptyMap()));
+    Assert.assertEquals(388L, MapLookupExtractor.estimateHeapFootprint(ImmutableMap.copyOf(lookupMap)));
+  }
+
+  @Test
+  public void testEstimateHeapFootprintStaticNullKeysAndValues()
+  {
+    final Map<String, String> mapWithNullKeysAndNullValues = new HashMap<>();
+    mapWithNullKeysAndNullValues.put("foo", "bar");
+    mapWithNullKeysAndNullValues.put("foo2", null);
+    Assert.assertEquals(180L, MapLookupExtractor.estimateHeapFootprint(mapWithNullKeysAndNullValues));
+  }
+
+  @Test
+  public void testEstimateHeapFootprintStaticNonStringKeysAndValues()
+  {
+    final Map<Long, Object> mapWithNonStringKeysAndValues = new HashMap<>();
+    mapWithNonStringKeysAndValues.put(3L, 1);
+    mapWithNonStringKeysAndValues.put(4L, 3.2);
+    Assert.assertEquals(160L, MapLookupExtractor.estimateHeapFootprint(mapWithNonStringKeysAndValues));
   }
 
   @Test


### PR DESCRIPTION
Two main changes:

1) Add estimateHeapFootprint to LookupExtractor.

2) Use this in MSQ's IndexerWorkerContext when determining the total
   amount of available memory. It's taken off the top.

This prevents MSQ tasks from running out of memory when there are lookups defined in the cluster.