### PR TITLE
Improve run time of coordinator duty MarkAsUnusedOvershadowedSegments

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/server/coordinator/NewestSegmentFirstPolicyBenchmark.java
@@ -28,7 +28,7 @@ import org.apache.druid.server.coordinator.duty.CompactionSegmentIterator;
 import org.apache.druid.server.coordinator.duty.CompactionSegmentSearchPolicy;
 import org.apache.druid.server.coordinator.duty.NewestSegmentFirstPolicy;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.DateTime;
@@ -82,7 +82,7 @@ public class NewestSegmentFirstPolicyBenchmark
   private int numCompactionTaskSlots;
 
   private Map<String, DataSourceCompactionConfig> compactionConfigs;
-  private Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources;
+  private Map<String, SegmentTimeline> dataSources;
 
   @Setup(Level.Trial)
   public void setup()

--- a/core/src/main/java/org/apache/druid/timeline/Overshadowable.java
+++ b/core/src/main/java/org/apache/druid/timeline/Overshadowable.java
@@ -27,7 +27,7 @@ package org.apache.druid.timeline;
  * An Overshadowable overshadows another if its root partition range contains that of another
  * and has a higher minorVersion. For more details, check https://github.com/apache/druid/issues/7491.
  */
-public interface Overshadowable<T extends Overshadowable>
+public interface Overshadowable<T extends Overshadowable<T>>
 {
   /**
    * Returns true if this overshadowable overshadows the other.

--- a/core/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
+++ b/core/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
@@ -17,26 +17,31 @@
  * under the License.
  */
 
-package org.apache.druid.server.coordinator.duty;
+package org.apache.druid.timeline;
 
-import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.timeline.SegmentTimeline;
-import org.joda.time.Interval;
-
-import java.util.List;
-import java.util.Map;
+import java.util.Comparator;
+import java.util.Iterator;
 
 /**
- * Segment searching policy used by {@link CompactSegments}.
+ * {@link VersionedIntervalTimeline} for {@link DataSegment} objects.
  */
-public interface CompactionSegmentSearchPolicy
+public class SegmentTimeline extends VersionedIntervalTimeline<String, DataSegment>
 {
-  /**
-   * Reset the current states of this policy. This method should be called whenever iterating starts.
-   */
-  CompactionSegmentIterator reset(
-      Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, SegmentTimeline> dataSources,
-      Map<String, List<Interval>> skipIntervals
-  );
+  public static SegmentTimeline forSegments(Iterator<DataSegment> segments)
+  {
+    final SegmentTimeline timeline = new SegmentTimeline();
+    VersionedIntervalTimeline.addSegments(timeline, segments);
+    return timeline;
+  }
+
+  public SegmentTimeline()
+  {
+    super(Comparator.naturalOrder());
+  }
+
+  public boolean isOvershadowed(DataSegment segment)
+  {
+    return isOvershadowed(segment.getInterval(), segment.getVersion(), segment);
+  }
+
 }

--- a/server/src/main/java/org/apache/druid/client/DataSourcesSnapshot.java
+++ b/server/src/main/java/org/apache/druid/client/DataSourcesSnapshot.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.apache.druid.metadata.SqlSegmentsMetadataManager;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.utils.CollectionUtils;
 
@@ -56,7 +56,7 @@ public class DataSourcesSnapshot
   }
 
   public static DataSourcesSnapshot fromUsedSegmentsTimelines(
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> usedSegmentsTimelinesPerDataSource,
+      Map<String, SegmentTimeline> usedSegmentsTimelinesPerDataSource,
       ImmutableMap<String, String> dataSourceProperties
   )
   {
@@ -73,8 +73,8 @@ public class DataSourcesSnapshot
   }
 
   private final Map<String, ImmutableDruidDataSource> dataSourcesWithAllUsedSegments;
-  private final Map<String, VersionedIntervalTimeline<String, DataSegment>> usedSegmentsTimelinesPerDataSource;
-  private final ImmutableSet<SegmentId> overshadowedSegments;
+  private final Map<String, SegmentTimeline> usedSegmentsTimelinesPerDataSource;
+  private final ImmutableSet<DataSegment> overshadowedSegments;
 
   public DataSourcesSnapshot(Map<String, ImmutableDruidDataSource> dataSourcesWithAllUsedSegments)
   {
@@ -82,14 +82,14 @@ public class DataSourcesSnapshot
         dataSourcesWithAllUsedSegments,
         CollectionUtils.mapValues(
             dataSourcesWithAllUsedSegments,
-            dataSource -> VersionedIntervalTimeline.forSegments(dataSource.getSegments())
+            dataSource -> SegmentTimeline.forSegments(dataSource.getSegments().iterator())
         )
     );
   }
 
   private DataSourcesSnapshot(
       Map<String, ImmutableDruidDataSource> dataSourcesWithAllUsedSegments,
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> usedSegmentsTimelinesPerDataSource
+      Map<String, SegmentTimeline> usedSegmentsTimelinesPerDataSource
   )
   {
     this.dataSourcesWithAllUsedSegments = dataSourcesWithAllUsedSegments;
@@ -113,12 +113,12 @@ public class DataSourcesSnapshot
     return dataSourcesWithAllUsedSegments.get(dataSourceName);
   }
 
-  public Map<String, VersionedIntervalTimeline<String, DataSegment>> getUsedSegmentsTimelinesPerDataSource()
+  public Map<String, SegmentTimeline> getUsedSegmentsTimelinesPerDataSource()
   {
     return usedSegmentsTimelinesPerDataSource;
   }
 
-  public ImmutableSet<SegmentId> getOvershadowedSegments()
+  public ImmutableSet<DataSegment> getOvershadowedSegments()
   {
     return overshadowedSegments;
   }
@@ -152,18 +152,18 @@ public class DataSourcesSnapshot
    *
    * @return overshadowed segment Ids list
    */
-  private List<SegmentId> determineOvershadowedSegments()
+  private List<DataSegment> determineOvershadowedSegments()
   {
     // It's fine to add all overshadowed segments to a single collection because only
     // a small fraction of the segments in the cluster are expected to be overshadowed,
     // so building this collection shouldn't generate a lot of garbage.
-    final List<SegmentId> overshadowedSegments = new ArrayList<>();
+    final List<DataSegment> overshadowedSegments = new ArrayList<>();
     for (ImmutableDruidDataSource dataSource : dataSourcesWithAllUsedSegments.values()) {
-      VersionedIntervalTimeline<String, DataSegment> usedSegmentsTimeline =
+      SegmentTimeline usedSegmentsTimeline =
           usedSegmentsTimelinesPerDataSource.get(dataSource.getName());
       for (DataSegment segment : dataSource.getSegments()) {
-        if (usedSegmentsTimeline.isOvershadowed(segment.getInterval(), segment.getVersion(), segment)) {
-          overshadowedSegments.add(segment.getId());
+        if (usedSegmentsTimeline.isOvershadowed(segment)) {
+          overshadowedSegments.add(segment);
         }
       }
     }

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -97,11 +97,6 @@ public interface SegmentsMetadataManager
   Collection<ImmutableDruidDataSource> getImmutableDataSourcesWithAllUsedSegments();
 
   /**
-   * Returns a set of overshadowed segment ids.
-   */
-  Set<SegmentId> getOvershadowedSegments();
-
-  /**
    * Returns a snapshot of DruidDataSources and overshadowed segments
    */
   DataSourcesSnapshot getSnapshotOfDataSourcesWithAllUsedSegments();

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -49,6 +49,7 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
 import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.joda.time.DateTime;
@@ -558,8 +559,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   private int doMarkAsUsedNonOvershadowedSegments(String dataSourceName, @Nullable Interval interval)
   {
     final List<DataSegment> unusedSegments = new ArrayList<>();
-    final VersionedIntervalTimeline<String, DataSegment> timeline =
-        VersionedIntervalTimeline.forSegments(Collections.emptyList());
+    final SegmentTimeline timeline =
+        SegmentTimeline.forSegments(Collections.emptyIterator());
 
     connector.inReadOnlyTransaction(
         (handle, status) -> {
@@ -798,12 +799,6 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   public Collection<ImmutableDruidDataSource> getImmutableDataSourcesWithAllUsedSegments()
   {
     return getSnapshotOfDataSourcesWithAllUsedSegments().getDataSourcesWithAllUsedSegments();
-  }
-
-  @Override
-  public Set<SegmentId> getOvershadowedSegments()
-  {
-    return getSnapshotOfDataSourcesWithAllUsedSegments().getOvershadowedSegments();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -394,6 +394,13 @@ public class DruidCoordinator
     return CoordinatorCompactionConfig.current(configManager);
   }
 
+  public void markSegmentsAsUnused(String datasource, Set<SegmentId> segmentIds)
+  {
+    log.debug("Marking [%d] segments of datasource [%s] as unused: %s", segmentIds.size(), datasource, segmentIds);
+    int updatedCount = segmentsMetadataManager.markSegmentsAsUnused(segmentIds);
+    log.info("Successfully marked [%d] segments of datasource [%s] as unused", updatedCount, datasource);
+  }
+
   public void markSegmentAsUnused(DataSegment segment)
   {
     log.debug("Marking segment[%s] as unused", segment.getId());

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -26,7 +26,7 @@ import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -128,7 +128,7 @@ public class DruidCoordinatorRuntimeParams
    * Creates and returns a "dataSource -> VersionedIntervalTimeline[version String, DataSegment]" map with "used"
    * segments.
    */
-  public Map<String, VersionedIntervalTimeline<String, DataSegment>> getUsedSegmentsTimelinesPerDataSource()
+  public Map<String, SegmentTimeline> getUsedSegmentsTimelinesPerDataSource()
   {
     Preconditions.checkState(dataSourcesSnapshot != null, "dataSourcesSnapshot or usedSegments must be set");
     return dataSourcesSnapshot.getUsedSegmentsTimelinesPerDataSource();
@@ -378,7 +378,7 @@ public class DruidCoordinatorRuntimeParams
     /** This method must be used in test code only. */
     @VisibleForTesting
     public Builder withUsedSegmentsTimelinesPerDataSourceInTest(
-        Map<String, VersionedIntervalTimeline<String, DataSegment>> usedSegmentsTimelinesPerDataSource
+        Map<String, SegmentTimeline> usedSegmentsTimelinesPerDataSource
     )
     {
       this.dataSourcesSnapshot = DataSourcesSnapshot.fromUsedSegmentsTimelines(

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -45,7 +45,7 @@ import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.coordinator.DruidCoordinatorConfig;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -127,7 +127,7 @@ public class CompactSegments implements CoordinatorCustomDuty
     final CoordinatorStats stats = new CoordinatorStats();
     List<DataSourceCompactionConfig> compactionConfigList = dynamicConfig.getCompactionConfigs();
     if (dynamicConfig.getMaxCompactionTaskSlots() > 0) {
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources =
+      Map<String, SegmentTimeline> dataSources =
           params.getUsedSegmentsTimelinesPerDataSource();
       if (compactionConfigList != null && !compactionConfigList.isEmpty()) {
         Map<String, DataSourceCompactionConfig> compactionConfigs = compactionConfigList

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -48,6 +48,7 @@ import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedPartitionChunk;
@@ -103,7 +104,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
   NewestSegmentFirstIterator(
       ObjectMapper objectMapper,
       Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources,
+      Map<String, SegmentTimeline> dataSources,
       Map<String, List<Interval>> skipIntervals
   )
   {
@@ -111,7 +112,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     this.compactionConfigs = compactionConfigs;
     this.timelineIterators = Maps.newHashMapWithExpectedSize(dataSources.size());
 
-    dataSources.forEach((String dataSource, VersionedIntervalTimeline<String, DataSegment> timeline) -> {
+    dataSources.forEach((String dataSource, SegmentTimeline timeline) -> {
       final DataSourceCompactionConfig config = compactionConfigs.get(dataSource);
       Granularity configuredSegmentGranularity = null;
       if (config != null && !timeline.isEmpty()) {
@@ -121,7 +122,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
           Map<Interval, Set<DataSegment>> intervalToPartitionMap = new HashMap<>();
           configuredSegmentGranularity = config.getGranularitySpec().getSegmentGranularity();
           // Create a new timeline to hold segments in the new configured segment granularity
-          VersionedIntervalTimeline<String, DataSegment> timelineWithConfiguredSegmentGranularity = new VersionedIntervalTimeline<>(Comparator.naturalOrder());
+          SegmentTimeline timelineWithConfiguredSegmentGranularity = new SegmentTimeline();
           Set<DataSegment> segments = timeline.findNonOvershadowedObjectsInInterval(Intervals.ETERNITY, Partitions.ONLY_COMPLETE);
           for (DataSegment segment : segments) {
             // Convert original segmentGranularity to new granularities bucket by configuredSegmentGranularity

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicy.java
@@ -21,8 +21,7 @@ package org.apache.druid.server.coordinator.duty;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
-import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.Interval;
 
 import java.util.List;
@@ -43,7 +42,7 @@ public class NewestSegmentFirstPolicy implements CompactionSegmentSearchPolicy
   @Override
   public CompactionSegmentIterator reset(
       Map<String, DataSourceCompactionConfig> compactionConfigs,
-      Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources,
+      Map<String, SegmentTimeline> dataSources,
       Map<String, List<Interval>> skipIntervals
   )
   {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -89,7 +89,7 @@ public class RunRules implements CoordinatorDuty
     // eventually will be unloaded from Historical servers. Segments overshadowed by *served* used segments are marked
     // as unused in MarkAsUnusedOvershadowedSegments, and then eventually Coordinator sends commands to Historical nodes
     // to unload such segments in UnloadUnusedSegments.
-    Set<SegmentId> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
+    Set<DataSegment> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
 
     for (String tier : cluster.getTierNames()) {
       replicatorThrottler.updateReplicationState(tier);
@@ -122,7 +122,7 @@ public class RunRules implements CoordinatorDuty
     }
 
     for (DataSegment segment : params.getUsedSegments()) {
-      if (overshadowed.contains(segment.getId())) {
+      if (overshadowed.contains(segment)) {
         // Skipping overshadowed segments
         continue;
       }

--- a/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
@@ -182,10 +182,10 @@ public class MetadataResource
     final Stream<DataSegment> usedSegments = dataSourcesWithUsedSegments
         .stream()
         .flatMap(t -> t.getSegments().stream());
-    final Set<SegmentId> overshadowedSegments = dataSourcesSnapshot.getOvershadowedSegments();
+    final Set<DataSegment> overshadowedSegments = dataSourcesSnapshot.getOvershadowedSegments();
 
     final Stream<SegmentWithOvershadowedStatus> usedSegmentsWithOvershadowedStatus = usedSegments
-        .map(segment -> new SegmentWithOvershadowedStatus(segment, overshadowedSegments.contains(segment.getId())));
+        .map(segment -> new SegmentWithOvershadowedStatus(segment, overshadowedSegments.contains(segment)));
 
     final Function<SegmentWithOvershadowedStatus, Iterable<ResourceAction>> raGenerator = segment -> Collections
         .singletonList(AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(segment.getDataSegment().getDataSource()));

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -86,6 +86,7 @@ import org.apache.druid.server.coordinator.UserCompactionTaskQueryTuningConfig;
 import org.apache.druid.server.coordinator.UserCompactionTaskTransformConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
@@ -176,7 +177,7 @@ public class CompactSegmentsTest
   private final PartitionsSpec partitionsSpec;
   private final BiFunction<Integer, Integer, ShardSpec> shardSpecFactory;
 
-  private Map<String, VersionedIntervalTimeline<String, DataSegment>> dataSources;
+  private Map<String, SegmentTimeline> dataSources;
   Map<String, List<DataSegment>> datasourceToSegments = new HashMap<>();
 
   public CompactSegmentsTest(PartitionsSpec partitionsSpec, BiFunction<Integer, Integer, ShardSpec> shardSpecFactory)

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkAsUnusedOvershadowedSegmentsTest.java
@@ -117,8 +117,7 @@ public class MarkAsUnusedOvershadowedSegmentsTest
             .andReturn(ImmutableSet.of(segmentV1, segmentV2))
             .anyTimes();
     EasyMock.expect(druidDataSource.getName()).andReturn("test").anyTimes();
-    coordinator.markSegmentAsUnused(segmentV1);
-    coordinator.markSegmentAsUnused(segmentV0);
+    coordinator.markSegmentsAsUnused("test", ImmutableSet.of(segmentV1.getId(), segmentV0.getId()));
     EasyMock.expectLastCall();
     EasyMock.replay(mockPeon, coordinator, druidServer, druidDataSource);
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstPolicyTest.java
@@ -55,7 +55,7 @@ import org.apache.druid.server.coordinator.UserCompactionTaskTransformConfig;
 import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.assertj.core.api.Assertions;
@@ -315,7 +315,7 @@ public class NewestSegmentFirstPolicyTest
   public void testClearSegmentsToCompactWhenSkippingSegments()
   {
     final long inputSegmentSizeBytes = 800000;
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-03T00:00:00/2017-12-04T00:00:00"),
             new Period("P1D"),
@@ -359,7 +359,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfFirstSegmentIsInSkipOffset()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-02T14:00:00/2017-12-03T00:00:00"),
             new Period("PT5H"),
@@ -380,7 +380,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfFirstSegmentOverlapsSkipOffset()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-12-01T23:00:00/2017-12-03T00:00:00"),
             new Period("PT5H"),
@@ -401,7 +401,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularityEqual()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-11-30T23:00:00/2017-12-03T00:00:00"), new Period("P1D")),
         new SegmentGenerateSpec(Intervals.of("2017-10-14T00:00:00/2017-10-15T00:00:00"), new Period("P1D"))
     );
@@ -424,7 +424,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularityLarger()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         // This contains segment that
         // - Cross between month boundary of latest month (starts in Nov and ends in Dec). This should be skipped
         // - Fully in latest month (starts in Dec and ends in Dec). This should be skipped
@@ -454,7 +454,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIfSegmentsSkipOffsetWithConfiguredSegmentGranularitySmaller()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-12-01T23:00:00/2017-12-03T00:00:00"), new Period("PT5H")),
         new SegmentGenerateSpec(Intervals.of("2017-10-14T00:00:00/2017-10-15T00:00:00"), new Period("PT5H"))
     );
@@ -563,7 +563,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsInConfiguredSegmentGranularity()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         // Segments with day interval from Oct to Dec
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-12-31T00:00:00"), new Period("P1D"))
     );
@@ -611,7 +611,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsInMultipleIntervalIfConfiguredSegmentGranularityCrossBoundary()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2020-01-01/2020-01-08"), new Period("P7D")),
         new SegmentGenerateSpec(Intervals.of("2020-01-28/2020-02-03"), new Period("P7D")),
         new SegmentGenerateSpec(Intervals.of("2020-02-08/2020-02-15"), new Period("P7D"))
@@ -648,7 +648,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorDoesNotReturnCompactedInterval()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-12-01T00:00:00/2017-12-02T00:00:00"), new Period("P1D"))
     );
 
@@ -670,7 +670,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsAllMixedVersionSegmentsInConfiguredSegmentGranularity()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"), new Period("P1D"), "1994-04-29T00:00:00.000Z", null),
         new SegmentGenerateSpec(Intervals.of("2017-10-01T01:00:00/2017-10-01T02:00:00"), new Period("PT1H"), "1994-04-30T00:00:00.000Z", null)
     );
@@ -703,7 +703,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -736,7 +736,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -769,7 +769,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -812,7 +812,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -855,7 +855,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -907,7 +907,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -961,7 +961,7 @@ public class NewestSegmentFirstPolicyTest
     // rollup=false for interval 2017-10-01T00:00:00/2017-10-02T00:00:00,
     // rollup=true for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // and rollup=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (queryGranularity was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1021,7 +1021,7 @@ public class NewestSegmentFirstPolicyTest
     // queryGranularity=DAY for interval 2017-10-01T00:00:00/2017-10-02T00:00:00,
     // queryGranularity=MINUTE for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // and queryGranularity=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (queryGranularity was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1082,7 +1082,7 @@ public class NewestSegmentFirstPolicyTest
     // Dimensions=["foo"] for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // Dimensions=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (dimensions was not set during last compaction)
     // and dimensionsSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (dimensionsSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1181,7 +1181,7 @@ public class NewestSegmentFirstPolicyTest
     // filter=SelectorDimFilter("dim1", "bar", null) for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // filter=null for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (filter was not set during last compaction)
     // and transformSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (transformSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1305,7 +1305,7 @@ public class NewestSegmentFirstPolicyTest
     // metricsSpec={CountAggregatorFactory("cnt"), LongSumAggregatorFactory("val", "val")} for interval 2017-10-02T00:00:00/2017-10-03T00:00:00,
     // metricsSpec=[] for interval 2017-10-03T00:00:00/2017-10-04T00:00:00 (filter was not set during last compaction)
     // and metricsSpec=null for interval 2017-10-04T00:00:00/2017-10-05T00:00:00 (transformSpec was not set during last compaction)
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1414,7 +1414,7 @@ public class NewestSegmentFirstPolicyTest
   @Test
   public void testIteratorReturnsSegmentsSmallerSegmentGranularityCoveringMultipleSegmentsInTimeline()
   {
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"), new Period("P1D"), "1994-04-29T00:00:00.000Z", null),
         new SegmentGenerateSpec(Intervals.of("2017-10-01T01:00:00/2017-10-01T02:00:00"), new Period("PT1H"), "1994-04-30T00:00:00.000Z", null)
     );
@@ -1450,7 +1450,7 @@ public class NewestSegmentFirstPolicyTest
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
 
     // Create segments that were compacted (CompactionState != null) and have segmentGranularity=DAY
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-02T00:00:00/2017-10-03T00:00:00"),
             new Period("P1D"),
@@ -1497,7 +1497,7 @@ public class NewestSegmentFirstPolicyTest
   {
     NullHandling.initializeForTests();
     PartitionsSpec partitionsSpec = NewestSegmentFirstIterator.findPartitionsSpecFromConfig(ClientCompactionTaskQueryTuningConfig.from(null, null, null));
-    final VersionedIntervalTimeline<String, DataSegment> timeline = createTimeline(
+    final SegmentTimeline timeline = createTimeline(
         new SegmentGenerateSpec(
             Intervals.of("2017-10-01T00:00:00/2017-10-02T00:00:00"),
             new Period("P1D"),
@@ -1629,9 +1629,7 @@ public class NewestSegmentFirstPolicyTest
     }
   }
 
-  private static VersionedIntervalTimeline<String, DataSegment> createTimeline(
-      SegmentGenerateSpec... specs
-  )
+  private static SegmentTimeline createTimeline(SegmentGenerateSpec... specs)
   {
     List<DataSegment> segments = new ArrayList<>();
     final String version = DateTimes.nowUtc().toString();
@@ -1671,7 +1669,7 @@ public class NewestSegmentFirstPolicyTest
       }
     }
 
-    return VersionedIntervalTimeline.forSegments(segments);
+    return SegmentTimeline.forSegments(segments.iterator());
   }
 
   private DataSourceCompactionConfig createCompactionConfig(

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -146,12 +146,6 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public Set<SegmentId> getOvershadowedSegments()
-  {
-    return getSnapshotOfDataSourcesWithAllUsedSegments().getOvershadowedSegments();
-  }
-
-  @Override
   public DataSourcesSnapshot getSnapshotOfDataSourcesWithAllUsedSegments()
   {
     return DataSourcesSnapshot.fromUsedSegments(usedSegments.values(), ImmutableMap.of());


### PR DESCRIPTION
In clusters with a large number of segments, the duty `MarkAsUnusedOvershadowedSegments`
can take a long very long time to finish. This is because of the costly invocation of 
`timeline.isOvershadowed` which is done for every used segment in every coordinator run.

This is extravagant as there are only a few overshadowed segments which are already identified
as part of the datasource snapshot. In clusters with ~500k segments, this duty can take several
minutes to finish even when no segment is actually overshadowed.

### Changes
- Use `DataSourceSnapshot.getOvershadowedSegments` to get all overshadowed segments
- Iterate over this set instead of all used segments to identify segments that can be marked as unused
- Mark segments as unused in the DB in batches rather than one at a time
- Refactor: Add class `SegmentTimeline` for ease of use and readability while using a
`VersionedIntervalTimeline` of segments.

### Further work
The changes here provide significant improvement in the run time of this duty.
The number of overshadowed segments in a given coordinator run is expected to be small.
Even in the very rare worst case scenario (half of all used segments are overshadowed), this change
would halve the run time of the duty. Subsequent runs would again take negligible time.

Further improvements can be made to the run time of this duty but that would require changes to the
logic of `timeline.isOvershadowed` and would provide only minor time reductions.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
