### PR TITLE
Bump Apache Curator from 5.3.0 to 5.4.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1669,7 +1669,7 @@ name: Apache Curator
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 5.3.0
+version: 5.4.0
 libraries:
   - org.apache.curator: curator-client
   - org.apache.curator: curator-framework

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <java.version>8</java.version>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
-        <apache.curator.version>5.3.0</apache.curator.version>
+        <apache.curator.version>5.4.0</apache.curator.version>
         <apache.kafka.version>3.3.1</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>


### PR DESCRIPTION
### Description

Follow up to #12939. As noted in that PR there are a few fixes in 5.4.0 that should make running on Kubernetes more reliable. Notably:
- https://issues.apache.org/jira/browse/CURATOR-538
- https://issues.apache.org/jira/browse/CURATOR-649

#### Release note

Bump Apache Curator from 5.3.0 to 5.4.0

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)