### PR TITLE
Make RecordSupplierInputSource respect sampler timeout when stream is empty

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -107,7 +107,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
           ioConfig.getStream(),
           recordSupplier,
           ioConfig.isUseEarliestSequenceNumber(),
-          samplerConfig.getTimeoutMs()
+          samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs()
       );
       inputFormat = Preconditions.checkNotNull(
           ioConfig.getInputFormat(),
@@ -175,7 +175,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
           ioConfig.getStream(),
           createRecordSupplier(),
           ioConfig.isUseEarliestSequenceNumber(),
-          samplerConfig.getTimeoutMs()
+          samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs()
       );
       this.entityIterator = inputSource.createEntityIterator();
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -106,7 +106,8 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
       inputSource = new RecordSupplierInputSource<>(
           ioConfig.getStream(),
           recordSupplier,
-          ioConfig.isUseEarliestSequenceNumber()
+          ioConfig.isUseEarliestSequenceNumber(),
+          samplerConfig.getTimeoutMs()
       );
       inputFormat = Preconditions.checkNotNull(
           ioConfig.getInputFormat(),
@@ -173,7 +174,8 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
       RecordSupplierInputSource<PartitionIdType, SequenceOffsetType, RecordType> inputSource = new RecordSupplierInputSource<>(
           ioConfig.getStream(),
           createRecordSupplier(),
-          ioConfig.isUseEarliestSequenceNumber()
+          ioConfig.isUseEarliestSequenceNumber(),
+          samplerConfig.getTimeoutMs()
       );
       this.entityIterator = inputSource.createEntityIterator();
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -1230,7 +1230,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     );
 
     SamplerResponse response = inputSourceSampler.sample(
-        new RecordSupplierInputSource("topicName", new TestRecordSupplier(jsonBlockList), true),
+        new RecordSupplierInputSource("topicName", new TestRecordSupplier(jsonBlockList), true, 3000),
         createInputFormat(),
         dataSchema,
         new SamplerConfig(200, 3000/*default timeout is 10s, shorten it to speed up*/, null, null)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -72,7 +72,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   public void testRead() throws IOException
   {
     final RandomCsvSupplier supplier = new RandomCsvSupplier();
-    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false);
+    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, 0);
     final List<String> colNames = IntStream.range(0, NUM_COLS)
                                            .mapToObj(i -> StringUtils.format("col_%d", i))
                                            .collect(Collectors.toList());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -72,7 +72,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   public void testRead() throws IOException
   {
     final RandomCsvSupplier supplier = new RandomCsvSupplier();
-    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, 0);
+    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, null);
     final List<String> colNames = IntStream.range(0, NUM_COLS)
                                            .mapToObj(i -> StringUtils.format("col_%d", i))
                                            .collect(Collectors.toList());
@@ -97,6 +97,35 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
     }
 
     Assert.assertEquals(NUM_ROWS, read);
+    Assert.assertTrue(supplier.isClosed());
+  }
+
+  @Test
+  public void testReadTimeout() throws IOException
+  {
+    final RandomCsvSupplier supplier = new RandomCsvSupplier();
+    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, -1000);
+    final List<String> colNames = IntStream.range(0, NUM_COLS)
+                                           .mapToObj(i -> StringUtils.format("col_%d", i))
+                                           .collect(Collectors.toList());
+    final InputFormat inputFormat = new CsvInputFormat(colNames, null, null, false, 0);
+    final InputSourceReader reader = inputSource.reader(
+        new InputRowSchema(
+            new TimestampSpec("col_0", "auto", null),
+            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(colNames.subList(1, colNames.size()))),
+            ColumnsFilter.all()
+        ),
+        inputFormat,
+        temporaryFolder.newFolder()
+    );
+
+    int read = 0;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      for (; read < NUM_ROWS && iterator.hasNext(); read++) {
+        iterator.next();
+      }
+    }
+    Assert.assertEquals(0, read);
     Assert.assertTrue(supplier.isClosed());
   }
 


### PR DESCRIPTION
This PR fixes an issue where sampling from a stream input (Kafka, Kinesis) can fail to respect the configured timeout, when the stream has no records available. 

The entity iterator would poll for records indefinitely when hasNext() is called. The PR adds a timeout check to that polling block.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
