### PR TITLE
fix nested column range index range computation

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.data;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.column.TypeStrategy;
 
@@ -118,6 +119,12 @@ public class FixedIndexed<T> implements Indexed<T>
   @Override
   public T get(int index)
   {
+    if (index < 0) {
+      throw new IAE("Index[%s] < 0", index);
+    }
+    if (index >= size) {
+      throw new IAE("Index[%d] >= size[%d]", index, size);
+    }
     if (hasNull) {
       if (index == 0) {
         return null;

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
@@ -215,34 +215,25 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
     }
     globalEndIndex = Math.max(globalStartIndex, globalEndIndex);
 
+    if (globalStartIndex == globalEndIndex) {
+      return new IntIntImmutablePair(0, 0);
+    }
+
     // with global dictionary id range settled, now lets map that onto a local dictionary id range
     int localFound = localDictionary.indexOf(globalStartIndex);
     if (localFound < 0) {
       // the first valid global index is not within the local dictionary, so the insertion point is where we begin
       localStartIndex = -(localFound + 1);
-      // if the computed local start index violates the global range, shift up by 1
-      int actualGlobalStartIndex = localDictionary.get(localStartIndex);
-      if (actualGlobalStartIndex < globalStartIndex) {
-        localStartIndex++;
-      } else if (actualGlobalStartIndex > globalEndIndex) {
-        // global range is not present in local dictionary, short circuit
-        return new IntIntImmutablePair(0, 0);
-      }
     } else {
       // valid global index in local dictionary, start here
       localStartIndex = localFound;
     }
-    int localEndFound = localDictionary.indexOf(globalEndIndex - 1);
+    // global end index is exclusive already, so we don't adjust local end index even for missing values
+    int localEndFound = localDictionary.indexOf(globalEndIndex);
     if (localEndFound < 0) {
       localEndIndex = -localEndFound;
-      // if the computed local ending index violates the global range, shift down by 1
-      int actualGlobalEndIndex = localDictionary.get(localEndIndex);
-      if (actualGlobalEndIndex > globalEndIndex) {
-        localEndIndex--;
-      }
     } else {
-      // add 1 because the last valid global end value is in the local dictionary, and end index is exclusive
-      localEndIndex = localEndFound + 1;
+      localEndIndex = localEndFound;
     }
 
     localStartIndex = Math.min(localStartIndex, localDictionary.size());

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -75,6 +75,9 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
       Assert.assertEquals(LONGS[i], fixedIndexed.get(i));
       Assert.assertEquals(i, fixedIndexed.indexOf(LONGS[i]));
     }
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(-1));
+    Assert.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(LONGS.length));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -803,6 +803,13 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap);
 
+    forRange = rangeIndex.forRange(8.99, true, 10.10, true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
     forRange = rangeIndex.forRange(10.00, true, 10.10, true);
     Assert.assertNotNull(forRange);
     Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
@@ -1086,6 +1093,11 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     Assert.assertEquals("300", lowLevelIndex.getValue(4));
     Assert.assertEquals("1.1", lowLevelIndex.getValue(5));
     Assert.assertEquals("9.9", lowLevelIndex.getValue(6));
+
+    Assert.assertEquals(7, lowLevelIndex.getCardinality());
+    checkBitmap(lowLevelIndex.getBitmap(0), 2, 7);
+    checkBitmap(lowLevelIndex.getBitmap(1), 1, 9);
+    checkBitmap(lowLevelIndex.getBitmap(-1));
   }
 
   private NestedFieldLiteralColumnIndexSupplier<?> makeSingleTypeStringSupplier() throws IOException


### PR DESCRIPTION
### Description
Fixes a bug with nested column range index value range computation that can lead to incorrect values matching filters when the range is not present in the nested fields local dictionary.

This PR fixes the issue by checking that the computed local start and end index values global id mapping does not violate the computed original global id range whenever the actual global ids are not present in the local dictionary. That's a lot of words thats probably hard to follow, but its basically an off by 1 error when mapping the global range to the local range in certain cases.

This wrong behavior was accidentally encoded in a test I wrote which would have caught the issue if the test had been expecting the correct answer, so I went through and manually verified that the tests are _actually_ expecting the correct thing this time, as well as tried to get 100% coverage on everything which matters in practice, which is now pretty high
<img width="649" alt="Screen Shot 2022-11-02 at 2 08 41 AM" src="https://user-images.githubusercontent.com/1577461/199449776-0d45da86-0bf1-451a-8159-48f0cc2a402a.png">

The remaining uncovered lines are largely things like safety checks that are not hit in regular operation such as calling next on an iterator before calling hasNext, etc, which I cannot hit during normal usage of the index supplier.


#### Release note
Fixes a bug with nested columns when using filters that use range indexes such as greater/less than or like filters.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
