### PR TITLE
Fixing the K8s task runner to work with MSQ

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -535,6 +535,9 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
       K8sTaskId taskId = new K8sTaskId(task.getId());
       try {
         Pod mainPod = client.getMainJobPod(new K8sTaskId(task.getId()));
+        if (mainPod.getStatus() == null || mainPod.getStatus().getPodIP() == null) {
+          return TaskLocation.unknown();
+        }
         boolean tlsEnabled = Boolean.parseBoolean(
             mainPod.getMetadata()
                    .getAnnotations()

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -446,14 +446,14 @@ class KubernetesTaskRunnerTest
     KubernetesPeonClient client = mock(KubernetesPeonClient.class);
     Pod pod = mock(Pod.class);
     PodStatus status = mock(PodStatus.class);
-    when(status.getPodIP()).thenReturn("tweak");
+    when(status.getPodIP()).thenReturn(null).thenReturn("tweak");
     when(pod.getStatus()).thenReturn(status);
 
     ObjectMeta metadata = mock(ObjectMeta.class);
     when(metadata.getAnnotations()).thenReturn(ImmutableMap.of(DruidK8sConstants.TLS_ENABLED, "false"));
 
     when(pod.getMetadata()).thenReturn(metadata);
-    when(client.getMainJobPod(any())).thenReturn(null).thenReturn(pod);
+    when(client.getMainJobPod(any())).thenReturn(pod);
 
     Task task = mock(Task.class);
     when(task.getId()).thenReturn("butters");


### PR DESCRIPTION
MSQ can work with tasks that have not yet launched, there was a bug in the k8s task runner where you could return a null host because the pod was still not up.  Fixed this to return a `TaskLocation.unknown()` if this happens to msq works.  Tested this on our internal clusters and it seemed to fix the problem with msq + k8s peon jobs. 