### PR TITLE
Update Curator in licenses.yaml.

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1679,7 +1679,7 @@ name: Apache Curator
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 5.3.0
+version: 5.4.0
 libraries:
   - org.apache.curator: curator-client
   - org.apache.curator: curator-framework


### PR DESCRIPTION
For some reason, Travis CI didn't run on #13302, so we didn't catch that the `licenses.yaml` update was missing. This patch fixes the omission.