### PR TITLE
fix bug when front-coded index has only the null value

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FixedIndexed.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment.data;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import org.apache.druid.segment.column.TypeStrategy;
 
@@ -119,12 +118,7 @@ public class FixedIndexed<T> implements Indexed<T>
   @Override
   public T get(int index)
   {
-    if (index < 0) {
-      throw new IAE("Index[%s] < 0", index);
-    }
-    if (index >= size) {
-      throw new IAE("Index[%d] >= size[%d]", index, size);
-    }
+    Indexed.checkIndex(index, size);
     if (hasNull) {
       if (index == 0) {
         return null;

--- a/processing/src/main/java/org/apache/druid/segment/data/FrontCodedIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FrontCodedIndexed.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -146,6 +147,7 @@ public final class FrontCodedIndexed implements Indexed<ByteBuffer>
     if (hasNull && index == 0) {
       return null;
     }
+    Indexed.checkIndex(index, adjustedNumValues);
 
     // due to vbyte encoding, the null value is not actually stored in the bucket (no negative values), so we adjust
     // the index
@@ -266,6 +268,9 @@ public final class FrontCodedIndexed implements Indexed<ByteBuffer>
   @Override
   public Iterator<ByteBuffer> iterator()
   {
+    if (hasNull && adjustedNumValues == 1) {
+      return Collections.<ByteBuffer>singletonList(null).iterator();
+    }
     ByteBuffer copy = buffer.asReadOnlyBuffer().order(buffer.order());
     copy.position(bucketsPosition);
     final ByteBuffer[] firstBucket = readBucket(copy, numBuckets > 1 ? bucketSize : lastBucketNumValues);

--- a/processing/src/main/java/org/apache/druid/segment/data/FrontCodedIndexedWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/FrontCodedIndexedWriter.java
@@ -224,6 +224,9 @@ public class FrontCodedIndexedWriter implements DictionaryWriter<byte[]>
 
   private void flush() throws IOException
   {
+    if (numWritten == 0) {
+      return;
+    }
     int remainder = numWritten % bucketSize;
     resetScratch();
     int written;

--- a/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/Indexed.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.data;
 
 import org.apache.druid.guice.annotations.PublicApi;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.monomorphicprocessing.CalledFromHotLoop;
 import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
 
@@ -66,5 +67,24 @@ public interface Indexed<T> extends Iterable<T>, HotLoopCallee
   default boolean isSorted()
   {
     return false;
+  }
+
+  /**
+   * Checks  if {@code index} is between 0 and {@code size}. Similar to Preconditions.checkElementIndex() except this
+   * method throws {@link IAE} with custom error message.
+   * <p>
+   * Used here to get existing behavior(same error message and exception) of V1 {@link GenericIndexed}.
+   *
+   * @param index identifying an element of an {@link Indexed}
+   * @param size size of the {@link Indexed}
+   */
+  static void checkIndex(int index, int size)
+  {
+    if (index < 0) {
+      throw new IAE("Index[%s] < 0", index);
+    }
+    if (index >= size) {
+      throw new IAE("Index[%d] >= size[%d]", index, size);
+    }
   }
 }


### PR DESCRIPTION
### Description
This PR fixes a bug with `FrontCodedIndexed` when containing only a single null value. Because the null value is not actually stored in the "value buckets", it can result in a null pointer exception in `FrontCodedIndexedWriter` when serializing the column, and a buffer underflow in `FrontCodedIndexed` when creating an iterator on a `FrontCodedIndexed` with only a null value, since the values section is actually empty.

I also added bounds checking to the `get` method of `FrontCodedIndexed` as a safety measure, which if everything is written correctly shouldn't be needed, but also doesn't seem to add much performance impact so it seems worth the sanity checks it provides in the event 
```
Benchmark              (query)  (rowsPerSegment)  (storageType)  (stringEncoding)  (vectorize)  Mode  Cnt      Score     Error  Units
SqlBenchmark.querySql       23           5000000           mmap              none        false  avgt    5  11256.550 ±  43.827  ms/op
SqlBenchmark.querySql       23           5000000           mmap              none        force  avgt    5  11255.502 ±  29.165  ms/op
SqlBenchmark.querySql       23           5000000           mmap     front-coded-4        false  avgt    5  11978.854 ±  27.574  ms/op
SqlBenchmark.querySql       23           5000000           mmap     front-coded-4        force  avgt    5  12724.125 ±  85.407  ms/op
SqlBenchmark.querySql       23           5000000           mmap    front-coded-16        false  avgt    5  13319.569 ±  41.002  ms/op
SqlBenchmark.querySql       23           5000000           mmap    front-coded-16        force  avgt    5  13300.229 ±  58.178  ms/op
SqlBenchmark.querySql       26           5000000           mmap              none        false  avgt    5     24.458 ±   0.771  ms/op
SqlBenchmark.querySql       26           5000000           mmap              none        force  avgt    5     20.168 ±   0.615  ms/op
SqlBenchmark.querySql       26           5000000           mmap     front-coded-4        false  avgt    5     24.781 ±   0.720  ms/op
SqlBenchmark.querySql       26           5000000           mmap     front-coded-4        force  avgt    5     20.343 ±   0.666  ms/op
SqlBenchmark.querySql       26           5000000           mmap    front-coded-16        false  avgt    5     24.626 ±   0.792  ms/op
SqlBenchmark.querySql       26           5000000           mmap    front-coded-16        force  avgt    5     20.578 ±   0.666  ms/op
SqlBenchmark.querySql       27           5000000           mmap              none        false  avgt    5    407.870 ±   4.176  ms/op
SqlBenchmark.querySql       27           5000000           mmap              none        force  avgt    5    245.788 ±   1.136  ms/op
SqlBenchmark.querySql       27           5000000           mmap     front-coded-4        false  avgt    5    416.001 ±   5.973  ms/op
SqlBenchmark.querySql       27           5000000           mmap     front-coded-4        force  avgt    5    248.944 ±   8.933  ms/op
SqlBenchmark.querySql       27           5000000           mmap    front-coded-16        false  avgt    5    419.480 ±   7.841  ms/op
SqlBenchmark.querySql       27           5000000           mmap    front-coded-16        force  avgt    5    256.627 ±   4.642  ms/op
```
This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
