### PR TITLE
nested column support for Parquet and Avro

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -256,9 +256,23 @@
     </dependency>
     <dependency>
       <groupId>org.apache.druid</groupId>
+      <artifactId>druid-core</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
     </dependency>
   </dependencies>
   <profiles>

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
@@ -34,7 +35,9 @@ import org.apache.druid.data.input.avro.SchemaRegistryBasedAvroBytesDecoder;
 import org.apache.druid.data.input.avro.SchemaRepoBasedAvroBytesDecoder;
 import org.apache.druid.data.input.impl.ByteEntity;
 import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.NestedInputFormat;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.data.input.schemarepo.Avro1124RESTRepositoryClientWrapper;
 import org.apache.druid.data.input.schemarepo.Avro1124SubjectAndIdConverter;
@@ -42,6 +45,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.segment.NestedDataDimensionSchema;
+import org.apache.druid.segment.nested.StructuredData;
+import org.apache.druid.segment.transform.ExpressionTransform;
+import org.apache.druid.segment.transform.TransformSpec;
+import org.apache.druid.segment.transform.TransformingInputEntityReader;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +72,7 @@ import java.util.List;
 import static org.apache.druid.data.input.AvroStreamInputRowParserTest.assertInputRowCorrect;
 import static org.apache.druid.data.input.AvroStreamInputRowParserTest.buildSomeAvroDatum;
 
-public class AvroStreamInputFormatTest
+public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
 {
   private static final String EVENT_TYPE = "eventType";
   private static final String ID = "id";
@@ -207,6 +217,147 @@ public class AvroStreamInputFormatTest
     InputRow inputRow = inputFormat2.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, null), entity, null).read().next();
 
     assertInputRowCorrect(inputRow, DIMENSIONS, false);
+  }
+
+  @Test
+  public void testParseTransform() throws SchemaValidationException, IOException
+  {
+    Repository repository = new InMemoryRepository(null);
+    AvroStreamInputFormat inputFormat = new AvroStreamInputFormat(
+        flattenSpec,
+        new SchemaRepoBasedAvroBytesDecoder<>(new Avro1124SubjectAndIdConverter(TOPIC), repository),
+        false,
+        false
+    );
+    NestedInputFormat inputFormat2 = jsonMapper.readValue(
+        jsonMapper.writeValueAsString(inputFormat),
+        NestedInputFormat.class
+    );
+    repository = ((SchemaRepoBasedAvroBytesDecoder) ((AvroStreamInputFormat) inputFormat2).getAvroBytesDecoder()).getSchemaRepository();
+
+    // prepare data
+    GenericRecord someAvroDatum = buildSomeAvroDatum();
+
+    // encode schema id
+    Avro1124SubjectAndIdConverter converter = new Avro1124SubjectAndIdConverter(TOPIC);
+    TypedSchemaRepository<Integer, Schema, String> repositoryClient = new TypedSchemaRepository<>(
+        repository,
+        new IntegerConverter(),
+        new AvroSchemaConverter(),
+        new IdentityConverter()
+    );
+    Integer id = repositoryClient.registerSchema(TOPIC, SomeAvroDatum.getClassSchema());
+    ByteBuffer byteBuffer = ByteBuffer.allocate(4);
+    converter.putSubjectAndId(id, byteBuffer);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(byteBuffer.array());
+    // encode data
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(someAvroDatum.getSchema());
+    // write avro datum to bytes
+    writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
+
+    final ByteEntity entity = new ByteEntity(ByteBuffer.wrap(out.toByteArray()));
+
+    /**
+     * {
+     *  "timestamp": 1445801400000,
+     *  "eventType": "type-a",
+     *  "id": 1976491,
+     *  "someOtherId": 6568719896,
+     *  "isValid": true,
+     *  "someIntArray": [1, 2, 4, 8],
+     *  "someStringArray": ["8", "4", "2", "1"],
+     *  "someIntValueMap": {"8": 8, "1": 1, "2": 2, "4": 4},
+     *  "someStringValueMap": {"8": "8", "1": "1", "2": "2", "4": "4"},
+     *  "someUnion": "string as union",
+     *  "someMultiMemberUnion": 1,
+     *  "someNull": null,
+     *  "someFixed": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+     *  "someBytes": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+     *  "someEnum": "ENUM1",
+     *  "someRecord": {"subInt": 4892, "subLong": 1543698},
+     *  "someLong": 679865987569912369,
+     *  "someInt": 1,
+     *  "someFloat": 0.23555,
+     *  "someRecordArray": [{"nestedString": "string in record"}]
+     *  }
+     */
+    DimensionsSpec dimensionsSpec = new DimensionsSpec(
+      ImmutableList.of(
+          new NestedDataDimensionSchema("someIntValueMap"),
+          new NestedDataDimensionSchema("someStringValueMap"),
+          new NestedDataDimensionSchema("someRecord"),
+          new NestedDataDimensionSchema("someRecordArray"),
+          new LongDimensionSchema("tSomeIntValueMap8"),
+          new StringDimensionSchema("tSomeStringValueMap8"),
+          new LongDimensionSchema("tSomeRecordSubLong"),
+          new NestedDataDimensionSchema("tSomeRecordArray0"),
+          new StringDimensionSchema("tSomeRecordArray0nestedString")
+      )
+    );
+    InputEntityReader reader = inputFormat2.createReader(new InputRowSchema(timestampSpec, dimensionsSpec, null), entity, null);
+    TransformSpec transformSpec = new TransformSpec(
+        null,
+        ImmutableList.of(
+            new ExpressionTransform(
+                "tSomeIntValueMap8",
+                "json_value(someIntValueMap, '$.8')",
+                TestExprMacroTable.INSTANCE
+            ),
+            new ExpressionTransform(
+                "tSomeStringValueMap8",
+                "json_value(someStringValueMap, '$.8')",
+                TestExprMacroTable.INSTANCE
+            ),
+            new ExpressionTransform(
+                "tSomeRecordSubLong",
+                "json_value(someRecord, '$.subLong')",
+                TestExprMacroTable.INSTANCE
+            ),
+            new ExpressionTransform(
+                "tSomeRecordArray0",
+                "json_query(someRecordArray, '$[0]')",
+                TestExprMacroTable.INSTANCE
+            ),
+            new ExpressionTransform(
+                "tSomeRecordArray0nestedString",
+                "json_value(someRecordArray, '$[0].nestedString')",
+                TestExprMacroTable.INSTANCE
+            )
+        )
+    );
+    TransformingInputEntityReader transformingReader = new TransformingInputEntityReader(
+        reader,
+        transformSpec.toTransformer()
+    );
+    InputRow inputRow = transformingReader.read().next();
+
+    Assert.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
+    Assert.assertEquals(
+        AvroStreamInputRowParserTest.SOME_INT_VALUE_MAP_VALUE,
+        StructuredData.unwrap(inputRow.getRaw("someIntValueMap"))
+    );
+    Assert.assertEquals(
+        AvroStreamInputRowParserTest.SOME_STRING_VALUE_MAP_VALUE,
+        StructuredData.unwrap(inputRow.getRaw("someStringValueMap"))
+    );
+    Assert.assertEquals(
+        ImmutableMap.of("subInt", 4892, "subLong", 1543698L),
+        StructuredData.unwrap(inputRow.getRaw("someRecord"))
+    );
+    Assert.assertEquals(
+        ImmutableList.of(ImmutableMap.of("nestedString", "string in record")),
+        StructuredData.unwrap(inputRow.getRaw("someRecordArray"))
+    );
+
+    Assert.assertEquals(8L, inputRow.getRaw("tSomeIntValueMap8"));
+    Assert.assertEquals("8", inputRow.getRaw("tSomeStringValueMap8"));
+    Assert.assertEquals(1543698L, inputRow.getRaw("tSomeRecordSubLong"));
+    Assert.assertEquals(
+        ImmutableMap.of("nestedString", "string in record"),
+        StructuredData.unwrap(inputRow.getRaw("tSomeRecordArray0"))
+    );
+    Assert.assertEquals("string in record", inputRow.getRaw("tSomeRecordArray0nestedString"));
   }
 
   @Test

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -130,7 +130,7 @@ public class AvroStreamInputRowParserTest
                                                                   .build();
   private static final List<CharSequence> SOME_STRING_ARRAY_VALUE = Arrays.asList("8", "4", "2", "1");
   private static final List<Integer> SOME_INT_ARRAY_VALUE = Arrays.asList(1, 2, 4, 8);
-  private static final Map<CharSequence, Integer> SOME_INT_VALUE_MAP_VALUE = Maps.asMap(
+  static final Map<CharSequence, Integer> SOME_INT_VALUE_MAP_VALUE = Maps.asMap(
       new HashSet<>(Arrays.asList("8", "2", "4", "1")), new Function<CharSequence, Integer>()
       {
         @Nonnull
@@ -141,7 +141,7 @@ public class AvroStreamInputRowParserTest
         }
       }
   );
-  private static final Map<CharSequence, CharSequence> SOME_STRING_VALUE_MAP_VALUE = Maps.asMap(
+  static final Map<CharSequence, CharSequence> SOME_STRING_VALUE_MAP_VALUE = Maps.asMap(
       new HashSet<>(Arrays.asList("8", "2", "4", "1")), new Function<CharSequence, CharSequence>()
       {
         @Nonnull

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.parquet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.ColumnsFilter;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.segment.NestedDataDimensionSchema;
+import org.apache.druid.segment.transform.ExpressionTransform;
+import org.apache.druid.segment.transform.TransformSpec;
+import org.apache.druid.segment.transform.TransformingInputEntityReader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
+{
+  @Test
+  public void testNestedColumnTransformsNestedTestFile() throws IOException
+  {
+    final String file = "example/flattening/test_nested_1.parquet";
+    InputRowSchema schema = new InputRowSchema(
+        new TimestampSpec("timestamp", "auto", null),
+        new DimensionsSpec(
+            ImmutableList.of(
+                new NestedDataDimensionSchema("nestedData"),
+                new NestedDataDimensionSchema("t_nestedData_listDim"),
+                new StringDimensionSchema("t_nestedData_listDim_string"),
+                new StringDimensionSchema("t_nestedData_dim2"),
+                new LongDimensionSchema("t_nestedData_dim3"),
+                new LongDimensionSchema("t_nestedData_metric2"),
+                new StringDimensionSchema("t_nestedData_listDim1"),
+                new StringDimensionSchema("t_nestedData_listDim2")
+            )
+        ),
+        ColumnsFilter.all()
+    );
+    JSONPathSpec flattenSpec = new JSONPathSpec(true, ImmutableList.of());
+    InputEntityReader reader = createReader(
+        file,
+        schema,
+        flattenSpec
+    );
+    TransformSpec transformSpec = new TransformSpec(
+        null,
+        ImmutableList.of(
+            new ExpressionTransform("t_nestedData_dim2", "json_value(nestedData, '$.dim2')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_dim3", "json_value(nestedData, '$.dim3')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_metric2", "json_value(nestedData, '$.metric2')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_listDim", "json_query(nestedData, '$.listDim')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_listDim_string", "json_query(nestedData, '$.listDim')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_listDim_1", "json_value(nestedData, '$.listDim[0]')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_nestedData_listDim_2", "json_query(nestedData, '$.listDim[1]')", TestExprMacroTable.INSTANCE)
+        )
+    );
+    TransformingInputEntityReader transformingReader = new TransformingInputEntityReader(
+        reader,
+        transformSpec.toTransformer()
+    );
+
+    List<InputRow> rows = readAllRows(transformingReader);
+    Assert.assertEquals(FlattenSpecParquetInputTest.TS1, rows.get(0).getTimestamp().toString());
+    Assert.assertEquals(1L, rows.get(0).getRaw("t_nestedData_dim3"));
+    Assert.assertEquals("d2v1", rows.get(0).getRaw("t_nestedData_dim2"));
+    Assert.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getRaw("t_nestedData_listDim"));
+    Assert.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getDimension("t_nestedData_listDim_string"));
+    Assert.assertEquals("listDim1v1", rows.get(0).getRaw("t_nestedData_listDim_1"));
+    Assert.assertEquals("listDim1v2", rows.get(0).getRaw("t_nestedData_listDim_2"));
+    Assert.assertEquals(2L, rows.get(0).getRaw("t_nestedData_metric2"));
+  }
+
+  @Test
+  public void testNestedColumnTransformsNestedNullableListFile() throws IOException
+  {
+    final String file = "example/flattening/nullable_list.snappy.parquet";
+    InputRowSchema schema = new InputRowSchema(
+        new TimestampSpec("timestamp", "auto", null),
+        new DimensionsSpec(
+            ImmutableList.of(
+                new NestedDataDimensionSchema("a1"),
+                new NestedDataDimensionSchema("a2"),
+                new NestedDataDimensionSchema("t_a2"),
+                new NestedDataDimensionSchema("t_a1_b1"),
+                new LongDimensionSchema("t_a1_b1_c1"),
+                new LongDimensionSchema("t_e2_0_b1"),
+                new LongDimensionSchema("tt_a2_0_b1")
+            )
+        ),
+        ColumnsFilter.all()
+    );
+    JSONPathSpec flattenSpec = new JSONPathSpec(true, ImmutableList.of());
+    InputEntityReader reader = createReader(
+        file,
+        schema,
+        flattenSpec
+    );
+    TransformSpec transformSpec = new TransformSpec(
+        null,
+        ImmutableList.of(
+            new ExpressionTransform("t_a1_b1", "json_query(a1, '$.b1')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_a2", "json_query(a2, '$')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_a1_b1_c1", "json_value(a1, '$.b1.c1')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_a2_0_b1", "json_value(a2, '$[0].b1')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_a2_0", "json_query(a2, '$[0]')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("t_a2_1_b1", "json_value(a2, '$[1].b1')", TestExprMacroTable.INSTANCE),
+            new ExpressionTransform("tt_a2_0_b1", "json_value(json_query(a2, '$'), '$[0].b1')", TestExprMacroTable.INSTANCE)
+        )
+    );
+    TransformingInputEntityReader transformingReader = new TransformingInputEntityReader(
+        reader,
+        transformSpec.toTransformer()
+    );
+
+    List<InputRow> rows = readAllRows(transformingReader);
+
+    Assert.assertEquals("2022-02-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assert.assertEquals(
+        ImmutableList.of(
+            ImmutableMap.of("b1", 1L, "b2", 2L), ImmutableMap.of("b1", 1L, "b2", 2L)
+        ),
+        rows.get(0).getRaw("a2")
+    );
+    // expression turns List into Object[]
+    Assert.assertArrayEquals(
+        new Object[]{
+            ImmutableMap.of("b1", 1L, "b2", 2L), ImmutableMap.of("b1", 1L, "b2", 2L)
+        },
+        (Object[]) rows.get(0).getRaw("t_a2")
+    );
+    Assert.assertEquals(ImmutableMap.of("c1", 1L, "c2", 2L), rows.get(0).getRaw("t_a1_b1"));
+    Assert.assertEquals(ImmutableMap.of("b1", 1L, "b2", 2L), rows.get(0).getRaw("t_a2_0"));
+    Assert.assertEquals(1L, rows.get(0).getRaw("t_a1_b1_c1"));
+    Assert.assertEquals(1L, rows.get(0).getRaw("t_a2_0_b1"));
+    Assert.assertEquals(1L, rows.get(0).getRaw("t_a2_1_b1"));
+    Assert.assertEquals(1L, rows.get(0).getRaw("tt_a2_0_b1"));
+  }
+}


### PR DESCRIPTION
### Description
This PR officially adds support for Parquet and Avro for Druid nested columns, including using the 'JSON' transformation functions at ingestion time. Along the way, fixes a couple of issues with using these same functions during ingest time, particularly when the top level object is a List/Array instead of an object. This particular code area was a bit obsolete, expecting only the primitive Druid ARRAY types to be handled, but that is no longer true after the introduction of nested arrays and complex expression types (e.g. arrays of complex types). I've expanded this code area to fall back on using `ExprEval.bestEffortOf` to determine the type of the array. This isn't actually specific to Parquet or Avro, these errors could occur with JSON and potentially any other nested list input values intended to be used in expressions.

#### Release note
Druid nested columns now support Parquet and Avro input formats, either to ingest directly into nested columns, or using the 'JSON' expressions as transforms, such as `JSON_VALUE` and `JSON_QUERY`.

<hr>


This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
