### PR TITLE
Optimize metadata calls in SeekableStreamSupervisor

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -3921,13 +3921,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
         supervisor.getTuningConfig()
     );
 
-    List<Task> activeTasks = ImmutableList.of(
-        taskFromStorage,
-        taskFromStorageMismatchedDataSchema,
-        taskFromStorageMismatchedTuningConfig,
-        taskFromStorageMismatchedPartitionsWithTaskGroup
+    Map<String, Task> taskMap = ImmutableMap.of(
+        taskFromStorage.getId(), taskFromStorage,
+        taskFromStorageMismatchedDataSchema.getId(), taskFromStorageMismatchedDataSchema,
+        taskFromStorageMismatchedTuningConfig.getId(), taskFromStorageMismatchedTuningConfig,
+        taskFromStorageMismatchedPartitionsWithTaskGroup.getId(), taskFromStorageMismatchedPartitionsWithTaskGroup
     );
-    final Map<String, Task> taskMap = supervisor.createActiveTaskMap(activeTasks);
 
     replayAll();
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -3906,7 +3906,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskFromStorageMismatchedTuningConfig,
         taskFromStorageMismatchedPartitionsWithTaskGroup
     );
-    final Map<String, Task> taskMap = makeTaskIdMap(tasks);
+    final Map<String, Task> taskMap = supervisor.createActiveTaskMap(tasks);
 
     replayAll();
 
@@ -4616,15 +4616,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
         Collections.emptyMap(),
         OBJECT_MAPPER
     );
-  }
-
-  private Map<String, Task> makeTaskIdMap(List<Task> tasks)
-  {
-    Map<String, Task> taskMap = new HashMap<>();
-    for (Task task : tasks) {
-      taskMap.put(task.getId(), task);
-    }
-    return taskMap;
   }
 
   private static class TestTaskRunnerWorkItem extends TaskRunnerWorkItem

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -3906,10 +3906,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         taskFromStorageMismatchedTuningConfig,
         taskFromStorageMismatchedPartitionsWithTaskGroup
     );
-    Map<String, Task> taskMap = makeTaskIdMap(tasks);
-
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE))
-            .andReturn(tasks);
+    final Map<String, Task> taskMap = makeTaskIdMap(tasks);
 
     replayAll();
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -4045,7 +4045,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         taskFromStorageMismatchedTuningConfig,
         taskFromStorageMismatchedPartitionsWithTaskGroup
     );
-    Map<String, Task> taskMap = makeTaskIdMap(tasks);
+    Map<String, Task> taskMap = supervisor.createActiveTaskMap(tasks);
 
     replayAll();
 
@@ -4913,15 +4913,6 @@ public class KinesisSupervisorTest extends EasyMockSupport
     );
     Assert.assertEquals(expectedPartitionGroups, supervisor.getPartitionGroups());
     Assert.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
-  }
-
-  private Map<String, Task> makeTaskIdMap(List<Task> tasks)
-  {
-    Map<String, Task> taskMap = new HashMap<>();
-    for (Task task : tasks) {
-      taskMap.put(task.getId(), task);
-    }
-    return taskMap;
   }
 
   private TestableKinesisSupervisor getTestableSupervisor(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -4039,13 +4039,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
         dataSchema
     );
 
-    List<Task> tasks = ImmutableList.of(
-        taskFromStorage,
-        taskFromStorageMismatchedDataSchema,
-        taskFromStorageMismatchedTuningConfig,
-        taskFromStorageMismatchedPartitionsWithTaskGroup
+    Map<String, Task> taskMap = ImmutableMap.of(
+        taskFromStorage.getId(), taskFromStorage,
+        taskFromStorageMismatchedDataSchema.getId(), taskFromStorageMismatchedDataSchema,
+        taskFromStorageMismatchedTuningConfig.getId(), taskFromStorageMismatchedTuningConfig,
+        taskFromStorageMismatchedPartitionsWithTaskGroup.getId(), taskFromStorageMismatchedPartitionsWithTaskGroup
     );
-    Map<String, Task> taskMap = supervisor.createActiveTaskMap(tasks);
 
     replayAll();
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3891,6 +3891,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     partitionIds.addAll(partitionIdsForTests);
   }
 
+  @VisibleForTesting
   public Map<String, Task> createActiveTaskMap(List<Task> tasks)
   {
     Map<String, Task> taskMap = new HashMap<>();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2289,18 +2289,16 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   @VisibleForTesting
   public boolean isTaskCurrent(int taskGroupId, String taskId, Map<String, Task> activeTaskMap)
   {
-    Task genericTask;
-    if (activeTaskMap == null || !activeTaskMap.containsKey(taskId)) {
-      Optional<Task> taskOptional = taskStorage.getTask(taskId);
-      if (!taskOptional.isPresent() || !doesTaskTypeMatchSupervisor(taskOptional.get())) {
-        return false;
-      }
-      genericTask = (SeekableStreamIndexTask<PartitionIdType, SequenceOffsetType, RecordType>) taskOptional.get();
+    final Task genericTask;
+
+    if (activeTaskMap != null && activeTaskMap.containsKey(taskId)) {
+      genericTask = activeTaskMap.get(taskId);
     } else {
-      if (!doesTaskTypeMatchSupervisor(activeTaskMap.get(taskId))) {
-        return false;
-      }
-      genericTask = (SeekableStreamIndexTask<PartitionIdType, SequenceOffsetType, RecordType>) activeTaskMap.get(taskId);
+      genericTask = taskStorage.getTask(taskId).orNull();
+    }
+
+    if (genericTask == null || !doesTaskTypeMatchSupervisor(genericTask)) {
+      return false;
     }
 
     @SuppressWarnings("unchecked")

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -395,7 +395,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
     EasyMock.expect(recordSupplier.getPartitionIds(STREAM)).andReturn(ImmutableSet.of(SHARD_ID)).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andThrow(new IllegalStateException(EXCEPTION_MSG)).times(3);
-    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).times(3);
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).times(6);
     EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andThrow(new IllegalStateException(EXCEPTION_MSG)).times(3);
     EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).anyTimes();
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Optimize the metadata calls made to get tasks and offsets from the metadata store

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

1) Minimize the number of calls made to the db by fetching all active tasks at once and storing the result to reduce the number of individual calls made to the metadata store for each task.

2) The entire set of metadata offsets was being fetched for each partition. This can be optimized by re-using the result for each partition

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->
For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).


<hr>

##### Key changed/added classes in this PR
 * `SeekableStreamSupervisor`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
