### PR TITLE
fix complex_decode_base64 function, add SQL bindings

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
+++ b/core/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.math.expr;
+
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.TypeStrategy;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BuiltInExprMacros
+{
+  public static class ComplexDecodeBase64ExprMacro implements ExprMacroTable.ExprMacro
+  {
+    public static final String NAME = "complex_decode_base64";
+
+    @Override
+    public String name()
+    {
+      return NAME;
+    }
+
+    @Override
+    public Expr apply(List<Expr> args)
+    {
+      return new ComplexDecodeBase64Expression(args);
+    }
+
+    final class ComplexDecodeBase64Expression extends ExprMacroTable.BaseScalarMacroFunctionExpr
+    {
+      private final ExpressionType complexType;
+      private final TypeStrategy<?> typeStrategy;
+
+      public ComplexDecodeBase64Expression(List<Expr> args)
+      {
+        super(NAME, args);
+        validationHelperCheckArgumentCount(args, 2);
+        final Expr arg0 = args.get(0);
+
+        if (!arg0.isLiteral()) {
+          throw validationFailed(
+              "first argument must be constant STRING expression containing a valid complex type name but got '%s' instead",
+              arg0.stringify()
+          );
+        }
+        if (arg0.isNullLiteral()) {
+          throw validationFailed("first argument must be constant STRING expression containing a valid complex type name but got NULL instead");
+        }
+        final Object literal = arg0.getLiteralValue();
+        if (!(literal instanceof String)) {
+          throw validationFailed(
+              "first argument must be constant STRING expression containing a valid complex type name but got '%s' instead",
+              arg0.getLiteralValue()
+          );
+        }
+
+        this.complexType = ExpressionTypeFactory.getInstance().ofComplex((String) literal);
+        try {
+          this.typeStrategy = complexType.getStrategy();
+        }
+        catch (IllegalArgumentException illegal) {
+          throw validationFailed(
+              "first argument must be a valid COMPLEX type name, got unknown COMPLEX type [%s]",
+              complexType.asTypeString()
+          );
+        }
+      }
+
+      @Override
+      public ExprEval<?> eval(ObjectBinding bindings)
+      {
+        ExprEval<?> toDecode = args.get(1).eval(bindings);
+        if (toDecode.value() == null) {
+          return ExprEval.ofComplex(complexType, null);
+        }
+        final Object serializedValue = toDecode.value();
+        final byte[] base64;
+        if (serializedValue instanceof String) {
+          base64 = StringUtils.decodeBase64String(toDecode.asString());
+        } else if (serializedValue instanceof byte[]) {
+          base64 = (byte[]) serializedValue;
+        } else if (complexType.getComplexTypeName().equals(toDecode.type().getComplexTypeName())) {
+          // pass it through, it is already the right thing
+          return toDecode;
+        } else {
+          throw validationFailed(
+              "second argument must be a base64 encoded STRING value but got %s instead",
+              toDecode.type()
+          );
+        }
+
+        return ExprEval.ofComplex(complexType, typeStrategy.fromBytes(base64));
+      }
+
+      @Override
+      public Expr visit(Shuttle shuttle)
+      {
+        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
+        return shuttle.visit(new ComplexDecodeBase64Expression(newArgs));
+      }
+
+      @Nullable
+      @Override
+      public ExpressionType getOutputType(InputBindingInspector inspector)
+      {
+        return complexType;
+      }
+
+      @Override
+      public boolean isLiteral()
+      {
+        return args.get(1).isLiteral();
+      }
+
+      @Override
+      public boolean isNullLiteral()
+      {
+        return args.get(1).isNullLiteral();
+      }
+
+      @Nullable
+      @Override
+      public Object getLiteralValue()
+      {
+        return eval(InputBindings.nilBindings()).value();
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/core/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -23,6 +23,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.druid.java.util.common.StringUtils;
 
@@ -42,18 +43,18 @@ import java.util.stream.Collectors;
  */
 public class ExprMacroTable
 {
+  private static final List<ExprMacro> BUILT_IN = ImmutableList.of(
+      new BuiltInExprMacros.ComplexDecodeBase64ExprMacro()
+  );
   private static final ExprMacroTable NIL = new ExprMacroTable(Collections.emptyList());
 
   private final Map<String, ExprMacro> macroMap;
 
   public ExprMacroTable(final List<ExprMacro> macros)
   {
-    this.macroMap = macros.stream().collect(
-        Collectors.toMap(
-            m -> StringUtils.toLowerCase(m.name()),
-            m -> m
-        )
-    );
+    this.macroMap = Maps.newHashMapWithExpectedSize(BUILT_IN.size() + macros.size());
+    macroMap.putAll(BUILT_IN.stream().collect(Collectors.toMap(m -> StringUtils.toLowerCase(m.name()), m -> m)));
+    macroMap.putAll(macros.stream().collect(Collectors.toMap(m -> StringUtils.toLowerCase(m.name()), m -> m)));
   }
 
   public static ExprMacroTable nil()

--- a/core/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
+++ b/core/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
@@ -68,7 +68,6 @@ public interface TypeStrategy<T> extends Comparator<T>
    */
   int estimateSizeBytes(T value);
 
-
   /**
    * Read a non-null value from the {@link ByteBuffer} at the current {@link ByteBuffer#position()}. This will move
    * the underlying position by the size of the value read.
@@ -149,5 +148,19 @@ public interface TypeStrategy<T> extends Comparator<T>
     finally {
       buffer.position(oldPosition);
     }
+  }
+
+  /**
+   * Translate raw byte array into a value. This is primarily useful for transforming self contained values that are
+   * serialized into byte arrays, such as happens with 'COMPLEX' types which serialize to base64 strings in JSON
+   * responses.
+   *
+   * 'COMPLEX' types should implement this method to participate in the expression systems built-in function
+   * to deserialize base64 encoded values,
+   * {@link org.apache.druid.math.expr.BuiltInExprMacros.ComplexDecodeBase64ExprMacro}.
+   */
+  default T fromBytes(byte[] value)
+  {
+    throw new IllegalStateException("Not supported");
   }
 }

--- a/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -925,11 +925,24 @@ public class FunctionTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testComplexDecodeBaseArg0Null()
+  {
+    expectedException.expect(ExpressionValidationException.class);
+    expectedException.expectMessage(
+        "Function[complex_decode_base64] first argument must be constant STRING expression containing a valid complex type name but got NULL instead"
+    );
+    assertExpr(
+        "complex_decode_base64(null, string)",
+        null
+    );
+  }
+
+  @Test
   public void testComplexDecodeBaseArg0BadType()
   {
     expectedException.expect(ExpressionValidationException.class);
     expectedException.expectMessage(
-        "Function[complex_decode_base64] first argument must be constant STRING expression containing a valid complex type name but got LONG instead"
+        "Function[complex_decode_base64] first argument must be constant STRING expression containing a valid complex type name but got '1' instead"
     );
     assertExpr(
         "complex_decode_base64(1, string)",

--- a/core/src/test/java/org/apache/druid/segment/column/TypeStrategiesTest.java
+++ b/core/src/test/java/org/apache/druid/segment/column/TypeStrategiesTest.java
@@ -681,5 +681,11 @@ public class TypeStrategiesTest
       }
       return written;
     }
+
+    @Override
+    public NullableLongPair fromBytes(byte[] value)
+    {
+      return read(ByteBuffer.wrap(value));
+    }
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -32,6 +32,7 @@ import org.apache.druid.query.aggregation.datasketches.SketchQueryContext;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchAggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchBuildAggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchModule;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.column.ColumnType;
@@ -160,14 +161,25 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
         dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
-      aggregatorFactory = new HllSketchBuildAggregatorFactory(
-          aggregatorName,
-          dimensionSpec.getDimension(),
-          logK,
-          tgtHllType,
-          finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
-          ROUND
-      );
+      if (HllSketchModule.TYPE_NAME.equals(inputType.getComplexTypeName())) {
+        aggregatorFactory = new HllSketchMergeAggregatorFactory(
+            aggregatorName,
+            dimensionSpec.getOutputName(),
+            logK,
+            tgtHllType,
+            finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
+            ROUND
+        );
+      } else {
+        aggregatorFactory = new HllSketchBuildAggregatorFactory(
+            aggregatorName,
+            dimensionSpec.getDimension(),
+            logK,
+            tgtHllType,
+            finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
+            ROUND
+        );
+      }
     }
 
     return toAggregation(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -32,7 +32,6 @@ import org.apache.druid.query.aggregation.datasketches.SketchQueryContext;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchAggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchBuildAggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
-import org.apache.druid.query.aggregation.datasketches.hll.HllSketchModule;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.column.ColumnType;
@@ -161,7 +160,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
         dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
-      if (HllSketchModule.TYPE_NAME.equals(inputType.getComplexTypeName())) {
+      if (inputType.is(ValueType.COMPLEX)) {
         aggregatorFactory = new HllSketchMergeAggregatorFactory(
             aggregatorName,
             dimensionSpec.getOutputName(),

--- a/processing/src/main/java/org/apache/druid/segment/column/ObjectStrategyComplexTypeStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ObjectStrategyComplexTypeStrategy.java
@@ -54,6 +54,7 @@ public class ObjectStrategyComplexTypeStrategy<T> implements TypeStrategy<T>
   {
     final int complexLength = buffer.getInt();
     ByteBuffer dupe = buffer.duplicate();
+    dupe.order(buffer.order());
     dupe.limit(dupe.position() + complexLength);
     return objectStrategy.fromByteBuffer(dupe, complexLength);
   }
@@ -84,5 +85,11 @@ public class ObjectStrategyComplexTypeStrategy<T> implements TypeStrategy<T>
   public int compare(T o1, T o2)
   {
     return objectStrategy.compare(o1, o2);
+  }
+
+  @Override
+  public T fromBytes(byte[] value)
+  {
+    return objectStrategy.fromByteBuffer(ByteBuffer.wrap(value), value.length);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/ComplexMetrics.java
@@ -53,6 +53,7 @@ public class ComplexMetrics
   {
     COMPLEX_SERIALIZERS.compute(type, (key, value) -> {
       if (value == null) {
+        TypeStrategies.registerComplex(type, serde.getTypeStrategy());
         return serde;
       } else {
         if (!value.getClass().getName().equals(serde.getClass().getName())) {
@@ -63,7 +64,6 @@ public class ComplexMetrics
               value.getClass().getName()
           );
         } else {
-          TypeStrategies.registerComplex(type, serde.getTypeStrategy());
           return value;
         }
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -121,7 +121,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
         dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
-      if (HyperUniquesAggregatorFactory.TYPE.equals(inputType)) {
+      if (inputType.is(ValueType.COMPLEX)) {
         aggregatorFactory = new HyperUniquesAggregatorFactory(
             aggregatorName,
             dimensionSpec.getOutputName(),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -121,13 +121,22 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
         dimensionSpec = new DefaultDimensionSpec(virtualColumnName, null, inputType);
       }
 
-      aggregatorFactory = new CardinalityAggregatorFactory(
-          aggregatorName,
-          null,
-          ImmutableList.of(dimensionSpec),
-          false,
-          true
-      );
+      if (HyperUniquesAggregatorFactory.TYPE.equals(inputType)) {
+        aggregatorFactory = new HyperUniquesAggregatorFactory(
+            aggregatorName,
+            dimensionSpec.getOutputName(),
+            false,
+            true
+        );
+      } else {
+        aggregatorFactory = new CardinalityAggregatorFactory(
+            aggregatorName,
+            null,
+            ImmutableList.of(dimensionSpec),
+            false,
+            true
+        );
+      }
     }
 
     return Aggregation.create(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.math.expr.BuiltInExprMacros;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.expression.DruidExpression;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.table.RowSignatures;
+
+import javax.annotation.Nullable;
+
+public class ComplexDecodeBase64OperatorConversion implements SqlOperatorConversion
+{
+
+  public static final SqlReturnTypeInference ARBITRARY_COMPLEX_RETURN_TYPE_INFERENCE = opBinding -> {
+    String typeName = opBinding.getOperandLiteralValue(0, String.class);
+    return RowSignatures.makeComplexType(
+        opBinding.getTypeFactory(),
+        ColumnType.ofComplex(typeName),
+        true
+    );
+  };
+
+  private static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder(StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME))
+      .operandTypeChecker(
+          OperandTypes.sequence(
+              "(typeName,base64)",
+              OperandTypes.and(OperandTypes.family(SqlTypeFamily.STRING), OperandTypes.LITERAL),
+              OperandTypes.ANY
+          )
+      )
+      .returnTypeInference(ARBITRARY_COMPLEX_RETURN_TYPE_INFERENCE)
+      .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
+      .build();
+
+
+  @Override
+  public SqlOperator calciteOperator()
+  {
+    return SQL_FUNCTION;
+  }
+
+  @Nullable
+  @Override
+  public DruidExpression toDruidExpression(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      RexNode rexNode
+  )
+  {
+    return OperatorConversions.convertCall(
+        plannerContext,
+        rowSignature,
+        rexNode,
+        druidExpressions -> {
+          String arg0 = druidExpressions.get(0).getExpression();
+          return DruidExpression.ofExpression(
+              ColumnType.ofComplex(arg0.substring(1, arg0.length() - 1)),
+              DruidExpression.functionCall(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME),
+              druidExpressions
+          );
+        }
+    );
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -71,6 +71,7 @@ import org.apache.druid.sql.calcite.expression.builtin.ArrayToStringOperatorConv
 import org.apache.druid.sql.calcite.expression.builtin.BTrimOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.CastOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.CeilOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.ComplexDecodeBase64OperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ConcatOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ContainsOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.DateTruncOperatorConversion;
@@ -211,6 +212,7 @@ public class DruidOperatorTable implements SqlOperatorTable
       ImmutableList.<SqlOperatorConversion>builder()
                    .add(new CastOperatorConversion())
                    .add(new ReinterpretOperatorConversion())
+                   .add(new ComplexDecodeBase64OperatorConversion())
                    .build();
 
   private static final List<SqlOperatorConversion> ARRAY_OPERATOR_CONVERSIONS =


### PR DESCRIPTION
### Description
Fixes some bugs with the `complex_decode_base64` function, which was basically broken before this PR for a few reasons, and migrates it to being implemented as an `ExprMacro` instead of a `Function`, so that the literal arguments can be computed externally to the function instead of every evaluation. This involves a slight adjustment to `ExprMacroTable` to add the concept of built-ins to make it a bit easier to add macros.

This PR also wires `complex_decode_base64` up to SQL, previously it was only a native expression. I have purposefully still not documented this function yet to save room for future adjustments and determining the best way to position this functionality, since its use cases are currently a bit limited.

The improvements do allow some pretty funny/absurd things to work now, such as round-tripping complex types through JSON serialization and back into complex types all in the same expression as shown in one of the tests added:
```
SELECT APPROX_COUNT_DISTINCT_BUILTIN(COMPLEX_DECODE_BASE64('hyperUnique',PARSE_JSON(TO_JSON_STRING(unique_dim1)))) from druid.foo
```
 😜

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
