### PR TITLE
SeekableStreamSupervisor: Don't enqueue duplicate notices.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/NoticesQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/NoticesQueue.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream.supervisor;
+
+import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.java.util.common.ISE;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Set;
+
+/**
+ * Queue that de-duplicates items on addition using {@link Object#equals}.
+ */
+public class NoticesQueue<T>
+{
+  @GuardedBy("this")
+  private final LinkedList<T> queue = new LinkedList<>();
+
+  @GuardedBy("this")
+  private final Set<T> set = new HashSet<>();
+
+  public void add(final T item)
+  {
+    Preconditions.checkNotNull(item, "item");
+
+    synchronized (this) {
+      if (set.add(item)) {
+        final boolean ok = queue.offer(item);
+        this.notifyAll();
+
+        if (!ok) {
+          set.remove(item);
+          throw new ISE("Queue is full");
+        }
+      }
+    }
+  }
+
+  public T poll(final long timeoutMillis) throws InterruptedException
+  {
+    synchronized (this) {
+      final long timeoutAt = System.currentTimeMillis() + timeoutMillis;
+
+      long waitMillis = timeoutMillis;
+      while (queue.isEmpty() && waitMillis > 0) {
+        wait(waitMillis);
+        waitMillis = timeoutAt - System.currentTimeMillis();
+      }
+
+      final T item = queue.poll();
+
+      if (item != null) {
+        set.remove(item);
+      }
+
+      return item;
+    }
+  }
+
+  public int size()
+  {
+    synchronized (this) {
+      return queue.size();
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/NoticesQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/NoticesQueueTest.java
@@ -35,7 +35,7 @@ public class NoticesQueueTest
   {
     final NoticesQueue<String> queue = new NoticesQueue<>();
 
-    for (int i = 0 ; i < 3; i++) {
+    for (int i = 0; i < 3; i++) {
       Assert.assertEquals(0, queue.size());
       queue.add("xyz");
       Assert.assertEquals(1, queue.size());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/NoticesQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/NoticesQueueTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.supervisor;
+
+import org.apache.druid.indexing.seekablestream.supervisor.NoticesQueue;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NoticesQueueTest
+{
+  @Test
+  public void testQueue() throws InterruptedException
+  {
+    final NoticesQueue<String> queue = new NoticesQueue<>();
+
+    for (int i = 0 ; i < 3; i++) {
+      Assert.assertEquals(0, queue.size());
+      queue.add("xyz");
+      Assert.assertEquals(1, queue.size());
+
+      queue.add("xyz");
+      Assert.assertEquals(1, queue.size());
+
+      queue.add("foo");
+      Assert.assertEquals(2, queue.size());
+
+      queue.add("xyz");
+      Assert.assertEquals(2, queue.size());
+
+      queue.add("bar");
+      Assert.assertEquals(3, queue.size());
+
+      Assert.assertEquals("xyz", queue.poll(10));
+      Assert.assertEquals("foo", queue.poll(10));
+      Assert.assertEquals("bar", queue.poll(10));
+      Assert.assertNull(queue.poll(10));
+      Assert.assertEquals(0, queue.size());
+    }
+  }
+}


### PR DESCRIPTION
Similar goal to #12018, but more aggressive. Don't enqueue a notice at all if it is equal to one currently in the queue.