### PR TITLE
Bind DurableStorageCleaner only on the Overlord nodes

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQDurableStorageModule.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQDurableStorageModule.java
@@ -23,10 +23,14 @@ import com.fasterxml.jackson.databind.Module;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.indexing.overlord.helpers.OverlordHelper;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.msq.indexing.DurableStorageCleaner;
@@ -34,8 +38,10 @@ import org.apache.druid.msq.indexing.DurableStorageCleanerConfig;
 import org.apache.druid.storage.StorageConnector;
 import org.apache.druid.storage.StorageConnectorProvider;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Module for functionality related to durable storage for stage output data.
@@ -49,6 +55,7 @@ public class MSQDurableStorageModule implements DruidModule
       String.join(".", MSQ_INTERMEDIATE_STORAGE_PREFIX, "enable");
 
   private Properties properties;
+  private Injector injector;
 
   @Override
   public List<? extends Module> getJacksonModules()
@@ -71,15 +78,18 @@ public class MSQDurableStorageModule implements DruidModule
             .toProvider(Key.get(StorageConnectorProvider.class, MultiStageQuery.class))
             .in(LazySingleton.class);
 
-      Multibinder.newSetBinder(binder, OverlordHelper.class)
-                 .addBinding()
-                 .to(DurableStorageCleaner.class);
+      Set<NodeRole> nodeRoles = getNodeRoles(injector);
+      if (nodeRoles != null && nodeRoles.contains(NodeRole.OVERLORD)) {
+        JsonConfigProvider.bind(
+            binder,
+            String.join(".", MSQ_INTERMEDIATE_STORAGE_PREFIX, "cleaner"),
+            DurableStorageCleanerConfig.class
+        );
 
-      JsonConfigProvider.bind(
-          binder,
-          String.join(".", MSQ_INTERMEDIATE_STORAGE_PREFIX, "cleaner"),
-          DurableStorageCleanerConfig.class
-      );
+        Multibinder.newSetBinder(binder, OverlordHelper.class)
+                   .addBinding()
+                   .to(DurableStorageCleaner.class);
+      }
     }
   }
 
@@ -87,6 +97,31 @@ public class MSQDurableStorageModule implements DruidModule
   public void setProperties(Properties properties)
   {
     this.properties = properties;
+  }
+
+  @Inject
+  public void setInjector(Injector injector)
+  {
+    this.injector = injector;
+  }
+
+
+  @Nullable
+  private static Set<NodeRole> getNodeRoles(Injector injector)
+  {
+    try {
+      return injector.getInstance(
+          Key.get(
+              new TypeLiteral<Set<NodeRole>>()
+              {
+              },
+              Self.class
+          )
+      );
+    }
+    catch (Exception e) {
+      return null;
+    }
   }
 
   private boolean isDurableShuffleStorageEnabled()


### PR DESCRIPTION
### Description

https://github.com/apache/druid/pull/13269 introduced an Overlord helper that cleaned up the durable storage config's directories which didn't correspond to an active MSQ task. This PR fixes a potential error that can occur if the durable storage configs are present in nodes other than Overlord by selectively binding the helper to only the nodes contain `Overlord` in their `NodeRoles.` 


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
