### PR TITLE
Switching emitter. This will allow for a per feed emitter designation.

### DIFF
--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
@@ -72,7 +72,7 @@ public class SwitchingEmitter implements Emitter
     // linear search is likely faster than hashed lookup
     // todo dont use a hashmap here. use something that will be more efficient for this kind of lookups
     for (Map.Entry<String, List<Emitter>> feedToEmitters : feedToEmitters.entrySet()) {
-      if (event.getFeed().equals(feedToEmitters.getKey())) {
+      if (feedToEmitters.getKey().equals(event.getFeed())) {
         for (Emitter emitter : feedToEmitters.getValue()) {
           emitter.emit(event);
         }

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
@@ -1,0 +1,112 @@
+package org.apache.druid.java.util.emitter.core;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SwitchingEmitter implements Emitter
+{
+
+  private static final Logger log = new Logger(SwitchingEmitter.class);
+
+  private final Emitter[] defaultEmitters;
+
+  private final Map<String, List<Emitter>> feedToEmitters;
+  private final Set<Emitter> knownEmitters;
+
+  public SwitchingEmitter(Map<String, List<Emitter>> feedToEmitters, Emitter[] defaultEmitter)
+  {
+    this.feedToEmitters = feedToEmitters;
+    this.defaultEmitters= defaultEmitter;
+    ImmutableSet.Builder<Emitter> emittersSetBuilder =  new ImmutableSet.Builder<>();
+    emittersSetBuilder.addAll(Arrays.stream(defaultEmitter).iterator());
+    for (List<Emitter> emitterList : feedToEmitters.values()) {
+      for (Emitter emitter : emitterList) {
+        emittersSetBuilder.add(emitter);
+      }
+    }
+    this.knownEmitters = emittersSetBuilder.build();
+  }
+
+  @Override
+  @LifecycleStart
+  public void start()
+  {
+    log.info("Starting Switching Emitter.");
+
+    for (Emitter e : knownEmitters) {
+      log.info("Starting emitter %s.", e.getClass().getName());
+      e.start();
+    }
+  }
+
+  @Override
+  public void emit(Event event)
+  {
+    // linear search is likely faster than hashed lookup
+    // todo dont use a hashmap here. use something that will be more efficient for this kind of lookups
+    for(Map.Entry<String, List<Emitter>> feedToEmitters : feedToEmitters.entrySet()) {
+      if (event.getFeed().equals(feedToEmitters.getKey())) {
+        for (Emitter emitter : feedToEmitters.getValue()) {
+          emitter.emit(event);
+        }
+        return;
+      }
+    }
+    for (Emitter emitter : defaultEmitters) {
+      emitter.emit(event);
+    }
+  }
+
+  @Override
+  public void flush() throws IOException
+  {
+    boolean fail = false;
+    log.info("Flushing Switching Emitter.");
+
+    for (Emitter e : knownEmitters) {
+      try {
+        log.info("Flushing emitter %s.", e.getClass().getName());
+        e.flush();
+      }
+      catch (IOException ex) {
+        log.error(ex, "Failed to flush emitter [%s]", e.getClass().getName());
+        fail = true;
+      }
+    }
+
+    if (fail) {
+      throw new IOException("failed to flush one or more emitters");
+    }
+  }
+
+  @Override
+  @LifecycleStop
+  public void close() throws IOException
+  {
+    boolean fail = false;
+    log.info("Closing Switching Emitter.");
+
+    for (Emitter e : knownEmitters) {
+      try {
+        log.info("Closing emitter %s.", e.getClass().getName());
+        e.close();
+      }
+      catch (IOException ex) {
+        log.error(ex, "Failed to close emitter [%s]", e.getClass().getName());
+        fail = true;
+      }
+    }
+
+    if (fail) {
+      throw new IOException("failed to close one or more emitters");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
+++ b/core/src/main/java/org/apache/druid/java/util/emitter/core/SwitchingEmitter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.java.util.emitter.core;
 
 import com.google.common.collect.ImmutableSet;
@@ -24,8 +43,8 @@ public class SwitchingEmitter implements Emitter
   public SwitchingEmitter(Map<String, List<Emitter>> feedToEmitters, Emitter[] defaultEmitter)
   {
     this.feedToEmitters = feedToEmitters;
-    this.defaultEmitters= defaultEmitter;
-    ImmutableSet.Builder<Emitter> emittersSetBuilder =  new ImmutableSet.Builder<>();
+    this.defaultEmitters = defaultEmitter;
+    ImmutableSet.Builder<Emitter> emittersSetBuilder = new ImmutableSet.Builder<>();
     emittersSetBuilder.addAll(Arrays.stream(defaultEmitter).iterator());
     for (List<Emitter> emitterList : feedToEmitters.values()) {
       for (Emitter emitter : emitterList) {
@@ -52,7 +71,7 @@ public class SwitchingEmitter implements Emitter
   {
     // linear search is likely faster than hashed lookup
     // todo dont use a hashmap here. use something that will be more efficient for this kind of lookups
-    for(Map.Entry<String, List<Emitter>> feedToEmitters : feedToEmitters.entrySet()) {
+    for (Map.Entry<String, List<Emitter>> feedToEmitters : feedToEmitters.entrySet()) {
       if (event.getFeed().equals(feedToEmitters.getKey())) {
         for (Emitter emitter : feedToEmitters.getValue()) {
           emitter.emit(event);

--- a/core/src/test/java/org/apache/druid/java/util/emitter/core/SwitchingEmitterTest.java
+++ b/core/src/test/java/org/apache/druid/java/util/emitter/core/SwitchingEmitterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.emitter.core;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SwitchingEmitterTest
+{
+
+  private static final String FEED_1 = "feed1";
+  private static final String FEED_2 = "feed2";
+  private static final String FEED_3 = "feed3";
+  private SwitchingEmitter switchingEmitter;
+
+  private Map<String, List<Emitter>> emitters;
+  private List<Emitter> defaultEmitters;
+
+  private Emitter feed1Emitter1;
+  private Emitter feed1Emitter2;
+  private Emitter feed2Emitter1;
+  private Emitter feed1AndFeed3Emitter;
+
+  private Set<Emitter> allEmitters;
+
+  @Before
+  public void setup()
+  {
+    this.defaultEmitters = ImmutableList.of(
+        EasyMock.createMock(Emitter.class),
+        EasyMock.createMock(Emitter.class)
+    );
+    this.feed1Emitter1 = EasyMock.createMock(Emitter.class);
+    this.feed1Emitter2 = EasyMock.createMock(Emitter.class);
+    this.feed2Emitter1 = EasyMock.createMock(Emitter.class);
+    this.feed1AndFeed3Emitter = EasyMock.createMock(Emitter.class);
+    this.emitters = ImmutableMap.of(FEED_1, ImmutableList.of(feed1Emitter1, feed1Emitter2, feed1AndFeed3Emitter),
+                                    FEED_2, ImmutableList.of(feed2Emitter1),
+                                    FEED_3, ImmutableList.of(feed1AndFeed3Emitter));
+
+    allEmitters = new HashSet<>();
+    allEmitters.addAll(defaultEmitters);
+    for (List<Emitter> feedEmitters : emitters.values()) {
+      allEmitters.addAll(feedEmitters);
+    }
+    this.switchingEmitter = new SwitchingEmitter(emitters, defaultEmitters.toArray(new Emitter[0]));
+  }
+
+  @Test
+  public void testStart()
+  {
+    for (Emitter emitter : allEmitters) {
+      emitter.start();
+      EasyMock.replay(emitter);
+    }
+
+    switchingEmitter.start();
+  }
+
+  @Test
+  public void testEmit()
+  {
+    // test emitting events to all 3 feeds and default emitter
+    Event feed1Event = EasyMock.createMock(Event.class);
+    Event feed2Event = EasyMock.createMock(Event.class);
+    Event feed3Event = EasyMock.createMock(Event.class);
+    Event eventWithNoMatchingFeed = EasyMock.createMock(Event.class);
+
+    EasyMock.expect(feed1Event.getFeed()).andReturn(FEED_1).anyTimes();
+    EasyMock.expect(feed2Event.getFeed()).andReturn(FEED_2).anyTimes();
+    EasyMock.expect(feed3Event.getFeed()).andReturn(FEED_3).anyTimes();
+    EasyMock.expect(eventWithNoMatchingFeed.getFeed()).andReturn("no-real-feed").anyTimes();
+    EasyMock.replay(feed1Event, feed2Event, feed3Event, eventWithNoMatchingFeed);
+
+    for (Emitter emitter : defaultEmitters) {
+      emitter.emit(eventWithNoMatchingFeed);
+    }
+    for (Emitter emitter : emitters.get("feed1")) {
+      emitter.emit(feed1Event);
+    }
+    for (Emitter emitter : emitters.get("feed2")) {
+      emitter.emit(feed2Event);
+    }
+    for (Emitter emitter : emitters.get("feed3")) {
+      emitter.emit(feed3Event);
+    }
+    for (Emitter emitter : allEmitters) {
+      EasyMock.replay(emitter);
+    }
+
+    switchingEmitter.emit(feed1Event);
+    switchingEmitter.emit(feed2Event);
+    switchingEmitter.emit(feed3Event);
+    switchingEmitter.emit(eventWithNoMatchingFeed);
+  }
+
+  @Test
+  public void testFlush() throws IOException
+  {
+    for (Emitter emitter : allEmitters) {
+      emitter.flush();
+      EasyMock.replay(emitter);
+    }
+
+    switchingEmitter.flush();
+  }
+
+  @Test
+  public void testClose() throws IOException
+  {
+    for (Emitter emitter : allEmitters) {
+      emitter.close();
+      EasyMock.replay(emitter);
+    }
+
+    switchingEmitter.close();
+  }
+
+  @After
+  public void tearDown()
+  {
+    for (Emitter emitter : allEmitters) {
+      EasyMock.verify(emitter);
+    }
+  }
+}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -490,7 +490,7 @@ To use switching as emitter set `druid.emitter=switching`.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.emitter.switching.emitters|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "requestLog":["logging"]}|{}|
+|`druid.emitter.switching.emitters|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "alerts":["logging"]}|{}|
 |`druid.emitter.switching.defaultEmitters`|List of emitter modules to load that will be used if there is no emitter specifically designated to the event feed, e.g., ["logging","http"].|[]|
 
 ### Metadata storage

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -490,8 +490,8 @@ To use switching as emitter set `druid.emitter=switching`.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.emitter.switching.emitters`|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "alerts":["logging"]}|{}|
-|`druid.emitter.switching.defaultEmitters`|List of emitter modules to load that will be used if there is no emitter specifically designated to the event feed, e.g., ["logging","http"].|[]|
+|`druid.emitter.switching.emitters`|JSON map of feed to list of emitter modules that will be used for the mapped feed, e.g., {"metrics":["http"], "alerts":["logging"]}|{}|
+|`druid.emitter.switching.defaultEmitters`|JSON list of emitter modules to load that will be used if there is no emitter specifically designated for that event's feed, e.g., ["logging","http"].|[]|
 
 ### Metadata storage
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -418,6 +418,7 @@ There are several emitters available:
 - [`parametrized`](#parametrized-http-emitter-module) operates like the `http` emitter but fine-tunes the recipient URL based on the event feed.
 - [`composing`](#composing-emitter-module) initializes multiple emitter modules.
 - [`graphite`](#graphite-emitter) emits metrics to a [Graphite](https://graphiteapp.org/) Carbon service.
+- [`switching`](#switching-emitter) initializes and emits to multiple emitter modules based on the event feed.
 
 ##### Logging Emitter Module
 
@@ -483,6 +484,14 @@ Instead use `recipientBaseUrlPattern` described in the table below.
 
 To use graphite as emitter set `druid.emitter=graphite`. For configuration details, see [Graphite emitter](../development/extensions-contrib/graphite.md) for the Graphite emitter Druid extension.
 
+##### Switching Emitter
+
+To use switching as emitter set `druid.emitter=switching`. 
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.emitter.switching.emitters|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "requestLog":["logging"]}|{}|
+|`druid.emitter.switching.defaultEmitters`|List of emitter modules to load that will be used if there is no emitter specifically designated to the event feed, e.g., ["logging","http"].|[]|
 
 ### Metadata storage
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -490,7 +490,7 @@ To use switching as emitter set `druid.emitter=switching`.
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.emitter.switching.emitters|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "alerts":["logging"]}|{}|
+|`druid.emitter.switching.emitters`|Map of feed to list of emitter modules to load that will be used for each feed, e.g., {"metrics":["http"], "alerts":["logging"]}|{}|
 |`druid.emitter.switching.defaultEmitters`|List of emitter modules to load that will be used if there is no emitter specifically designated to the event feed, e.g., ["logging","http"].|[]|
 
 ### Metadata storage

--- a/server/src/main/java/org/apache/druid/server/emitter/EmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/EmitterModule.java
@@ -78,6 +78,7 @@ public class EmitterModule implements Module
     binder.install(new HttpEmitterModule());
     binder.install(new ParametrizedUriEmitterModule());
     binder.install(new ComposingEmitterModule());
+    binder.install(new SwitchingEmitterModule());
 
     binder.bind(Emitter.class).toProvider(new EmitterProvider(emitterType)).in(LazySingleton.class);
 

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
@@ -28,6 +28,8 @@ import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
 
+/**
+ */
 public class SwitchingEmitterConfig
 {
 
@@ -36,6 +38,7 @@ public class SwitchingEmitterConfig
   private Map<String, List<String>> emitters = ImmutableMap.of();
 
   @JsonProperty
+  @NotNull
   private List<String> defaultEmitters = ImmutableList.of();
 
   public Map<String, List<String>> getEmitters()

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
@@ -1,0 +1,31 @@
+package org.apache.druid.server.emitter;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public class SwitchingEmitterConfig
+{
+
+  @JsonProperty
+  @NotNull
+  private Map<String, List<String>> emitters = ImmutableMap.of();
+
+  @JsonProperty
+  private List<String> defaultEmitters = ImmutableList.of();
+
+  public Map<String, List<String>> getEmitters()
+  {
+    return emitters;
+  }
+
+  public List<String> getDefaultEmitter()
+  {
+    return defaultEmitters;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterConfig.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.server.emitter;
 
 

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.server.emitter;
 
 import com.google.common.collect.ImmutableList;

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
@@ -1,0 +1,63 @@
+package org.apache.druid.server.emitter;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.SwitchingEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SwitchingEmitterModule implements Module
+{
+
+  public static final String EMITTER_TYPE = "switching";
+
+  private static Logger log = new Logger(SwitchingEmitterModule.class);
+
+  @Override
+  public void configure(Binder binder)
+  {
+    JsonConfigProvider.bind(binder, "druid.emitter.switching", SwitchingEmitterConfig.class);
+  }
+
+  @Provides
+  @ManageLifecycle
+  @Named(EMITTER_TYPE)
+  public Emitter makeEmitter(SwitchingEmitterConfig config, final Injector injector)
+  {
+    log.info(
+        "Crfeateing Switching emitter with %s, and default emitter %s",
+        config.getEmitters(),
+        config.getDefaultEmitter()
+    );
+    Map<String, List<Emitter>> switchingEmitters = config
+        .getEmitters()
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue()
+                              .stream()
+                              .map(
+                                  emitterName -> injector.getInstance(Key.get(Emitter.class, Names.named(emitterName))))
+                              .collect(Collectors.toList())));
+
+    ImmutableList.Builder<Emitter> defaultEmittersBuilder = new ImmutableList.Builder<>();
+    for (String emitterName : config.getDefaultEmitter()) {
+      defaultEmittersBuilder.add(injector.getInstance(Key.get(Emitter.class, Names.named(emitterName))));
+    }
+    return new SwitchingEmitter(switchingEmitters, defaultEmittersBuilder.build().toArray(new Emitter[0]));
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server.emitter;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
@@ -57,14 +57,10 @@ public class SwitchingEmitterModule implements Module
   public Emitter makeEmitter(SwitchingEmitterConfig config, final Injector injector)
   {
     log.info(
-        "Crfeateing Switching emitter with %s, and default emitter %s",
+        "Createing Switching emitter with %s, and default emitter %s",
         config.getEmitters(),
         config.getDefaultEmitter()
     );
-    //validate that there are no nulls for feed.
-    for (String feed : config.getEmitters().keySet()) {
-      Preconditions.checkNotNull(feed);
-    }
     Map<String, List<Emitter>> switchingEmitters = config
         .getEmitters()
         .entrySet()

--- a/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/SwitchingEmitterModule.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.emitter;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
@@ -60,6 +61,10 @@ public class SwitchingEmitterModule implements Module
         config.getEmitters(),
         config.getDefaultEmitter()
     );
+    //validate that there are no nulls for feed.
+    for (String feed : config.getEmitters().keySet()) {
+      Preconditions.checkNotNull(feed);
+    }
     Map<String, List<Emitter>> switchingEmitters = config
         .getEmitters()
         .entrySet()

--- a/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
@@ -1,0 +1,92 @@
+package org.apache.druid.initialization;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import org.apache.druid.guice.DruidGuiceExtensions;
+import org.apache.druid.guice.LifecycleModule;
+import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.server.emitter.SwitchingEmitterConfig;
+import org.apache.druid.server.emitter.SwitchingEmitterModule;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Properties;
+
+public class SwitchingEmitterModuleTest
+{
+
+  private static final String DEFAULT_EMITTER_TYPE = "http";
+  private static final String FEED_1_EMITTER_TYPE = "logging";
+  private static final String FEED_1 = "metrics";
+  private Emitter defaultEmitter;
+  private Emitter feed1Emitter;
+
+  @Before
+  public void setup()
+  {
+    defaultEmitter = EasyMock.createMock(Emitter.class);
+    feed1Emitter = EasyMock.createMock(Emitter.class);
+    defaultEmitter.start();
+    feed1Emitter.start();
+    EasyMock.replay(defaultEmitter);
+    EasyMock.replay(feed1Emitter);
+  }
+
+  @Test
+  public void testGetEmitter()
+  {
+    SwitchingEmitterConfig config = EasyMock.createMock(SwitchingEmitterConfig.class);
+    EasyMock.expect(config.getDefaultEmitter()).andReturn(ImmutableList.of(DEFAULT_EMITTER_TYPE)).anyTimes();
+    EasyMock.expect(config.getEmitters()).andReturn(ImmutableMap.of(FEED_1, ImmutableList.of(FEED_1_EMITTER_TYPE))).anyTimes();
+
+    Injector injector = EasyMock.createMock(Injector.class);
+    EasyMock.expect(injector.getInstance(Key.get(Emitter.class, Names.named(DEFAULT_EMITTER_TYPE)))).andReturn(
+        defaultEmitter);
+    EasyMock.expect(injector.getInstance(Key.get(Emitter.class, Names.named(FEED_1_EMITTER_TYPE)))).andReturn(
+        feed1Emitter);
+    EasyMock.replay(config, injector);
+
+    Emitter switchingEmitter = new SwitchingEmitterModule().makeEmitter(config, injector);
+    switchingEmitter.start();
+
+    EasyMock.verify(config, defaultEmitter, feed1Emitter, injector);
+  }
+
+  @Test
+  public void testGetEmitterViaRealGuice()
+  {
+    Injector injector = Guice.createInjector(
+        new DruidGuiceExtensions(),
+        new LifecycleModule(),
+        new Module()
+        {
+          @Override
+          public void configure(Binder binder)
+          {
+            Properties props = new Properties();
+            String defaultEmittersValue = "[\"" + DEFAULT_EMITTER_TYPE + "\"]";
+            String emittersValue = "{\"" + FEED_1 + "\":[\""+ FEED_1_EMITTER_TYPE+"\"]}";
+            props.put("druid.emitter.switching.defaultEmitters", defaultEmittersValue);
+            props.put("druid.emitter.switching.emitters", emittersValue);
+            binder.bind(Properties.class).toInstance(props);
+            binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+            binder.bind(Emitter.class).annotatedWith(Names.named(DEFAULT_EMITTER_TYPE)).toInstance(defaultEmitter);
+            binder.bind(Emitter.class).annotatedWith(Names.named(FEED_1_EMITTER_TYPE)).toInstance(feed1Emitter);
+          }
+        },
+        new SwitchingEmitterModule()
+    );
+    injector.getInstance(Key.get(Emitter.class, Names.named("switching"))).start();
+    EasyMock.verify(defaultEmitter);
+    EasyMock.verify(feed1Emitter);
+  }
+}

--- a/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
@@ -1,4 +1,3 @@
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -96,7 +95,7 @@ public class SwitchingEmitterModuleTest
           {
             Properties props = new Properties();
             String defaultEmittersValue = "[\"" + DEFAULT_EMITTER_TYPE + "\"]";
-            String emittersValue = "{\"" + FEED_1 + "\":[\""+ FEED_1_EMITTER_TYPE+"\"]}";
+            String emittersValue = "{\"" + FEED_1 + "\":[\"" + FEED_1_EMITTER_TYPE + "\"]}";
             props.put("druid.emitter.switching.defaultEmitters", defaultEmittersValue);
             props.put("druid.emitter.switching.emitters", emittersValue);
             binder.bind(Properties.class).toInstance(props);

--- a/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
@@ -1,3 +1,23 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.initialization;
 
 import com.google.common.collect.ImmutableList;
@@ -10,7 +30,6 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.LifecycleModule;
-import org.apache.druid.guice.ServerModule;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.server.emitter.SwitchingEmitterConfig;

--- a/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/SwitchingEmitterModuleTest.java
@@ -10,6 +10,8 @@ import com.google.inject.Module;
 import com.google.inject.name.Names;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.LifecycleModule;
+import org.apache.druid.guice.ServerModule;
+import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.server.emitter.SwitchingEmitterConfig;
 import org.apache.druid.server.emitter.SwitchingEmitterModule;
@@ -67,6 +69,7 @@ public class SwitchingEmitterModuleTest
     Injector injector = Guice.createInjector(
         new DruidGuiceExtensions(),
         new LifecycleModule(),
+        new JacksonModule(),
         new Module()
         {
           @Override
@@ -88,5 +91,6 @@ public class SwitchingEmitterModuleTest
     injector.getInstance(Key.get(Emitter.class, Names.named("switching"))).start();
     EasyMock.verify(defaultEmitter);
     EasyMock.verify(feed1Emitter);
+
   }
 }


### PR DESCRIPTION
This will work by looking at an event's feed and direct it to a specific emitter. If no specific feed is specified for a feed. The emitter can direct the event to a default emitter.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

The goal of this PR is to allow there to be a way to filter events to a different emitter. For example druid cluster might be sending metrics with the statsd emitter, but we want to emit request log events to an http emitter. Currently in druid there is no way to do this without sending all the events to both of them. And each emitter doesn't necessarily have the ability to filter out events it doesn't want to send/hold onto in memory.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Create and Wire Up Switching Emitter ...

We chose to use a linear search for finding the correct emitter based on feed because the number emitters and feeds is likely to be low enough that a linear search will likely be the fastest.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 
-->


New you can now use a specific emitter for each feed. For example this means that alerts can go to http emitter, metrics can go to statsd emitter, and requestLog events can go to a kafka emitter.


<hr>

##### Key changed/added classes in this PR
 * `SwitchingEmitter`
 * `SwitchingEmitterConfig`
 * `SwitchingEmitterModule`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
