### PR TITLE
Allow injection of node-role set to all non base modules

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQIndexingModule.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQIndexingModule.java
@@ -23,8 +23,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.google.inject.Provides;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.frame.processor.Bouncer;
@@ -95,8 +93,6 @@ public class MSQIndexingModule implements DruidModule
 {
   static final String BASE_MSQ_KEY = "druid.msq";
 
-  private Set<NodeRole> nodeRoles;
-
   public static final List<Class<? extends MSQFault>> FAULT_CLASSES = ImmutableList.of(
       BroadcastTablesTooLargeFault.class,
       CanceledFault.class,
@@ -126,12 +122,6 @@ public class MSQIndexingModule implements DruidModule
       WorkerFailedFault.class,
       WorkerRpcFailedFault.class
   );
-
-  @Inject
-  public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
-  {
-    this.nodeRoles = nodeRoles;
-  }
 
   @Override
   public List<? extends Module> getJacksonModules()
@@ -198,7 +188,7 @@ public class MSQIndexingModule implements DruidModule
 
   @Provides
   @LazySingleton
-  public Bouncer makeBouncer(final DruidProcessingConfig processingConfig, Injector injector)
+  public Bouncer makeBouncer(final DruidProcessingConfig processingConfig, @Self Set<NodeRole> nodeRoles)
   {
     if (nodeRoles.contains(NodeRole.PEON) && !nodeRoles.contains(NodeRole.INDEXER)) {
       // CliPeon -> use only one thread regardless of configured # of processing threads. This matches the expected

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -23,11 +23,16 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
 import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.indexer.partitions.DimensionBasedPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -47,14 +52,32 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class HadoopDruidIndexerConfigTest
 {
   private static final ObjectMapper JSON_MAPPER;
+  // testing member to verify that DruidModule gets node-roles set supplied through the static initialization of
+  // HadoopDruidIndexerConfig class.
+  private static final DruidModule MY_MODULE;
 
   static {
     JSON_MAPPER = new DefaultObjectMapper();
     JSON_MAPPER.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, JSON_MAPPER));
+    MY_MODULE = new DruidModule()
+    {
+      @Inject
+      public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
+      {
+        Assert.assertTrue(nodeRoles.isEmpty());
+      }
+
+      @Override
+      public void configure(Binder binder)
+      {
+
+      }
+    };
   }
 
   @Test

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -22,12 +22,14 @@ package org.apache.druid.indexing.common.task;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 import org.apache.druid.guice.ExtensionsConfig;
 import org.apache.druid.guice.ExtensionsLoader;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.initialization.ServerInjectorBuilder;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.JvmUtils;
 
@@ -50,7 +52,10 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
 {
   private static final Logger log = new Logger(HadoopTask.class);
 
-  static final Injector INJECTOR = new StartupInjectorBuilder().forServer().build();
+  static final Injector INJECTOR = new StartupInjectorBuilder()
+      .forServer()
+      .add(ServerInjectorBuilder.registerNodeRoleModule(ImmutableSet.of()))
+      .build();
   private static final ExtensionsLoader EXTENSIONS_LOADER = ExtensionsLoader.instance(INJECTOR);
 
   private final List<String> hadoopDependencyCoordinates;

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -271,6 +271,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/integration-tests/src/main/java/org/apache/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/guice/DruidTestModule.java
@@ -21,11 +21,10 @@ package org.apache.druid.testing.guice;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Supplier;
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
 import org.apache.druid.curator.CuratorConfig;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -43,8 +42,6 @@ import org.apache.druid.server.DruidNode;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.IntegrationTestingConfigProvider;
 import org.apache.druid.testing.IntegrationTestingCuratorConfig;
-
-import java.util.Set;
 
 /**
  */
@@ -66,9 +63,7 @@ public class DruidTestModule implements Module
     );
 
     // Required for MSQIndexingModule
-    binder.bind(new TypeLiteral<Set<NodeRole>>()
-    {
-    }).annotatedWith(Self.class).toInstance(ImmutableSet.of(NodeRole.PEON));
+    Multibinder.newSetBinder(binder, NodeRole.class, Self.class).addBinding().toInstance(NodeRole.PEON);
   }
 
   @Provides

--- a/server/src/main/java/org/apache/druid/initialization/ServerInjectorBuilder.java
+++ b/server/src/main/java/org/apache/druid/initialization/ServerInjectorBuilder.java
@@ -21,6 +21,7 @@ package org.apache.druid.initialization;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -45,7 +46,7 @@ import java.util.Set;
  */
 public class ServerInjectorBuilder
 {
-  private Injector baseInjector;
+  private final Injector baseInjector;
   private Set<NodeRole> nodeRoles;
   private Iterable<? extends Module> modules;
 
@@ -78,7 +79,7 @@ public class ServerInjectorBuilder
 
   public ServerInjectorBuilder nodeRoles(final Set<NodeRole> nodeRoles)
   {
-    this.nodeRoles = nodeRoles;
+    this.nodeRoles = nodeRoles == null ? ImmutableSet.of() : nodeRoles;
     return this;
   }
 
@@ -90,6 +91,9 @@ public class ServerInjectorBuilder
 
   public Injector build()
   {
+    assert baseInjector != null;
+    assert nodeRoles != null;
+
     Module registerNodeRoleModule = registerNodeRoleModule(nodeRoles);
 
     // Child injector, with the registered node roles
@@ -115,9 +119,6 @@ public class ServerInjectorBuilder
 
   public static Module registerNodeRoleModule(Set<NodeRole> nodeRoles)
   {
-    if (nodeRoles.isEmpty()) {
-      return binder -> {};
-    }
     return binder -> {
       Multibinder<NodeRole> selfBinder = Multibinder.newSetBinder(binder, NodeRole.class, Self.class);
       nodeRoles.forEach(nodeRole -> selfBinder.addBinding().toInstance(nodeRole));

--- a/server/src/main/java/org/apache/druid/initialization/ServerInjectorBuilder.java
+++ b/server/src/main/java/org/apache/druid/initialization/ServerInjectorBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.druid.initialization;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -91,8 +92,8 @@ public class ServerInjectorBuilder
 
   public Injector build()
   {
-    assert baseInjector != null;
-    assert nodeRoles != null;
+    Preconditions.checkNotNull(baseInjector);
+    Preconditions.checkNotNull(nodeRoles);
 
     Module registerNodeRoleModule = registerNodeRoleModule(nodeRoles);
 

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -180,7 +180,7 @@ public class MetricsModule implements Module
 
   @Provides
   @ManageLifecycle
-  public SysMonitor getSysMonitor(DataSourceTaskIdHolder dataSourceTaskIdHolder)
+  public SysMonitor getSysMonitor(DataSourceTaskIdHolder dataSourceTaskIdHolder, @Self Set<NodeRole> nodeRoles)
   {
     if (nodeRoles.contains(NodeRole.PEON)) {
       return new NoopSysMonitor();

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -22,11 +22,11 @@ package org.apache.druid.server.metrics;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.inject.Binder;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import io.timeandspace.cronscheduler.CronScheduler;
 import org.apache.druid.discovery.NodeRole;
@@ -50,7 +50,6 @@ import org.apache.druid.java.util.metrics.NoopSysMonitor;
 import org.apache.druid.java.util.metrics.SysMonitor;
 import org.apache.druid.query.ExecutorServiceMonitor;
 
-import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,6 +65,13 @@ public class MetricsModule implements Module
 {
   static final String MONITORING_PROPERTY_PREFIX = "druid.monitoring";
   private static final Logger log = new Logger(MetricsModule.class);
+  private Set<NodeRole> nodeRoles;
+
+  @Inject
+  public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
+  {
+    this.nodeRoles = nodeRoles;
+  }
 
   public static void register(Binder binder, Class<? extends Monitor> monitorClazz)
   {
@@ -174,14 +180,9 @@ public class MetricsModule implements Module
 
   @Provides
   @ManageLifecycle
-  public SysMonitor getSysMonitor(
-      DataSourceTaskIdHolder dataSourceTaskIdHolder,
-      Injector injector
-  )
+  public SysMonitor getSysMonitor(DataSourceTaskIdHolder dataSourceTaskIdHolder)
   {
-    final Set<NodeRole> nodeRoles = getNodeRoles(injector);
-
-    if (isPeonRole(nodeRoles)) {
+    if (nodeRoles.contains(NodeRole.PEON)) {
       return new NoopSysMonitor();
     } else {
       Map<String, String[]> dimensions = MonitorsConfig.mapOfDatasourceAndTaskID(
@@ -190,31 +191,5 @@ public class MetricsModule implements Module
       );
       return new SysMonitor(dimensions);
     }
-  }
-
-  @Nullable
-  private static Set<NodeRole> getNodeRoles(Injector injector)
-  {
-    try {
-      return injector.getInstance(
-          Key.get(
-              new TypeLiteral<Set<NodeRole>>()
-              {
-              },
-              Self.class
-          )
-      );
-    }
-    catch (Exception e) {
-      return null;
-    }
-  }
-
-  private static boolean isPeonRole(Set<NodeRole> nodeRoles)
-  {
-    if (nodeRoles == null) {
-      return false;
-    }
-    return nodeRoles.contains(NodeRole.PEON);
   }
 }

--- a/server/src/test/java/org/apache/druid/initialization/ServerInjectorBuilderTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ServerInjectorBuilderTest.java
@@ -155,6 +155,39 @@ public class ServerInjectorBuilderTest
   }
 
   @Test
+  public void testCreateInjectorWithEmptyNodeRolesAndRoleInjection()
+  {
+    final DruidNode expected = new DruidNode("test-inject", null, false, null, null, true, false);
+    Injector startupInjector = startupInjector();
+    Injector injector = ServerInjectorBuilder.makeServerInjector(
+        startupInjector,
+        ImmutableSet.of(),
+        ImmutableList.of(
+            (com.google.inject.Module) new DruidModule()
+            {
+              @Inject
+              public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
+              {
+                Assert.assertTrue(nodeRoles.isEmpty());
+              }
+
+              @Override
+              public void configure(Binder binder)
+              {
+
+              }
+            },
+            binder -> JsonConfigProvider.bindInstance(
+                binder,
+                Key.get(DruidNode.class, Self.class),
+                expected
+            )
+        )
+    );
+    Assert.assertNotNull(injector);
+  }
+
+  @Test
   public void testCreateInjectorWithNodeRoleFilter_moduleNotLoaded()
   {
     final DruidNode expected = new DruidNode("test-inject", null, false, null, null, true, false);

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
+import org.apache.druid.initialization.ServerInjectorBuilder;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -190,7 +191,8 @@ public class MetricsModuleTest
     final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
     injector.injectMembers(dimensionIdHolder);
     final MetricsModule metricsModule = new MetricsModule();
-    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder, injector);
+    injector.injectMembers(metricsModule);
+    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
@@ -204,11 +206,13 @@ public class MetricsModuleTest
     // Do not run the tests on ARM64. Sigar library has no binaries for ARM64
     Assume.assumeFalse("aarch64".equals(CPU_ARCH));
 
-    final Injector injector = createInjector(new Properties());
+    Injector injector = createInjector(new Properties());
+    injector = injector.createChildInjector(ServerInjectorBuilder.registerNodeRoleModule(ImmutableSet.of()));
     final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
     injector.injectMembers(dimensionIdHolder);
     final MetricsModule metricsModule = new MetricsModule();
-    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder, injector);
+    injector.injectMembers(metricsModule);
+    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -28,7 +28,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
-import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.GuiceInjectors;
@@ -60,7 +59,6 @@ import org.mockito.Mockito;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import java.util.Properties;
-import java.util.Set;
 
 public class MetricsModuleTest
 {
@@ -126,7 +124,8 @@ public class MetricsModuleTest
   @Test
   public void testGetBasicMonitorSchedulerByDefault()
   {
-    final MonitorScheduler monitorScheduler = createInjector(new Properties()).getInstance(MonitorScheduler.class);
+    final MonitorScheduler monitorScheduler =
+        createInjector(new Properties(), ImmutableSet.of()).getInstance(MonitorScheduler.class);
     Assert.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
   }
 
@@ -138,7 +137,8 @@ public class MetricsModuleTest
         StringUtils.format("%s.schedulerClassName", MetricsModule.MONITORING_PROPERTY_PREFIX),
         ClockDriftSafeMonitorScheduler.class.getName()
     );
-    final MonitorScheduler monitorScheduler = createInjector(properties).getInstance(MonitorScheduler.class);
+    final MonitorScheduler monitorScheduler =
+        createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
     Assert.assertSame(ClockDriftSafeMonitorScheduler.class, monitorScheduler.getClass());
   }
 
@@ -150,7 +150,8 @@ public class MetricsModuleTest
         StringUtils.format("%s.schedulerClassName", MetricsModule.MONITORING_PROPERTY_PREFIX),
         BasicMonitorScheduler.class.getName()
     );
-    final MonitorScheduler monitorScheduler = createInjector(properties).getInstance(MonitorScheduler.class);
+    final MonitorScheduler monitorScheduler =
+        createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
     Assert.assertSame(BasicMonitorScheduler.class, monitorScheduler.getClass());
   }
 
@@ -165,7 +166,7 @@ public class MetricsModuleTest
     expectedException.expect(CreationException.class);
     expectedException.expectCause(CoreMatchers.instanceOf(IllegalArgumentException.class));
     expectedException.expectMessage("Unknown monitor scheduler[UnknownScheduler]");
-    createInjector(properties).getInstance(MonitorScheduler.class);
+    createInjector(properties, ImmutableSet.of()).getInstance(MonitorScheduler.class);
   }
 
   @Test
@@ -174,25 +175,8 @@ public class MetricsModuleTest
     // Do not run the tests on ARM64. Sigar library has no binaries for ARM64
     Assume.assumeFalse("aarch64".equals(CPU_ARCH));
 
-    final NodeRole nodeRole = NodeRole.PEON;
-    final Injector injector = Guice.createInjector(
-        new JacksonModule(),
-        new LifecycleModule(),
-        binder -> {
-          binder.bindScope(LazySingleton.class, Scopes.SINGLETON);
-        },
-        binder -> {
-          binder.bind(
-              new TypeLiteral<Set<NodeRole>>()
-              {
-              }).annotatedWith(Self.class).toInstance(ImmutableSet.of(nodeRole));
-        }
-    );
-    final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
-    injector.injectMembers(dimensionIdHolder);
-    final MetricsModule metricsModule = new MetricsModule();
-    injector.injectMembers(metricsModule);
-    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder);
+    final Injector injector = createInjector(new Properties(), ImmutableSet.of(NodeRole.PEON));
+    final SysMonitor sysMonitor = injector.getInstance(SysMonitor.class);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
@@ -206,13 +190,8 @@ public class MetricsModuleTest
     // Do not run the tests on ARM64. Sigar library has no binaries for ARM64
     Assume.assumeFalse("aarch64".equals(CPU_ARCH));
 
-    Injector injector = createInjector(new Properties());
-    injector = injector.createChildInjector(ServerInjectorBuilder.registerNodeRoleModule(ImmutableSet.of()));
-    final DataSourceTaskIdHolder dimensionIdHolder = new DataSourceTaskIdHolder();
-    injector.injectMembers(dimensionIdHolder);
-    final MetricsModule metricsModule = new MetricsModule();
-    injector.injectMembers(metricsModule);
-    final SysMonitor sysMonitor = metricsModule.getSysMonitor(dimensionIdHolder);
+    Injector injector = createInjector(new Properties(), ImmutableSet.of());
+    final SysMonitor sysMonitor = injector.getInstance(SysMonitor.class);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
@@ -220,7 +199,7 @@ public class MetricsModuleTest
     Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
 
-  private static Injector createInjector(Properties properties)
+  private static Injector createInjector(Properties properties, ImmutableSet<NodeRole> nodeRoles)
   {
     return Guice.createInjector(
         new JacksonModule(),
@@ -231,6 +210,7 @@ public class MetricsModuleTest
           binder.bind(ServiceEmitter.class).toInstance(new NoopServiceEmitter());
           binder.bind(Properties.class).toInstance(properties);
         },
+        ServerInjectorBuilder.registerNodeRoleModule(nodeRoles),
         new MetricsModule()
     );
   }


### PR DESCRIPTION
Effort to supply node-role set (for role specific bindings) to all non-base modules via : 
```
  @Inject
  public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
  {
    this.nodeRoles = nodeRoles;
  }
```
block. It seems like an easier way to get the roles attached to the process and also is more inline with Guice.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
