### PR TITLE
Improve performance for ReadableInputStreamFrameChannel

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
@@ -155,7 +155,9 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
         if (!keepReading) {
           try {
             synchronized (readMonitor) {
-              readMonitor.wait(nextRetrySleepMillis(nTry));
+              if (!keepReading) {
+                readMonitor.wait(nextRetrySleepMillis(nTry));
+              }
             }
             synchronized (lock) {
               if (inputStreamFinished || inputStreamError || delegate.isErrorOrFinished()) {
@@ -192,8 +194,8 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
                   keepReading = false;
                   backpressureFuture.addListener(
                       () -> {
-                        keepReading = true;
                         synchronized (readMonitor) {
+                          keepReading = true;
                           readMonitor.notify();
                         }
                       },

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
@@ -58,6 +58,8 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
 
   private volatile boolean keepReading = true;
 
+  private final Object readMonitor = new Object();
+
   private final ExecutorService executorService;
 
   /**
@@ -152,7 +154,9 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
       while (true) {
         if (!keepReading) {
           try {
-            Thread.sleep(nextRetrySleepMillis(nTry));
+            synchronized (readMonitor) {
+              readMonitor.wait(nextRetrySleepMillis(nTry));
+            }
             synchronized (lock) {
               if (inputStreamFinished || inputStreamError || delegate.isErrorOrFinished()) {
                 return;
@@ -186,7 +190,15 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
                 totalInputStreamBytesRead += bytesRead;
                 if (backpressureFuture != null) {
                   keepReading = false;
-                  backpressureFuture.addListener(() -> keepReading = true, Execs.directExecutor());
+                  backpressureFuture.addListener(
+                      () -> {
+                        keepReading = true;
+                        synchronized (readMonitor) {
+                          readMonitor.notify();
+                        }
+                      },
+                      Execs.directExecutor()
+                  );
                 } else {
                   keepReading = true;
                   // continue adding data to delegate


### PR DESCRIPTION
Moves away from sleep wait in ReadableInputStreamFrameChannel to wait/notify model.
This improves the performance for DurableStorageOutputChannel by around 10x on local storage backed durable output channel.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
