### PR TITLE
Web console: react to user cancelation immediately

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5683,7 +5683,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.17.1
+version: 0.17.2
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -22,7 +22,7 @@
         "d3-axis": "^2.1.0",
         "d3-scale": "^3.3.0",
         "d3-selection": "^2.0.0",
-        "druid-query-toolkit": "^0.17.1",
+        "druid-query-toolkit": "^0.17.2",
         "file-saver": "^2.0.2",
         "follow-redirects": "^1.14.7",
         "fontsource-open-sans": "^3.0.9",
@@ -8967,9 +8967,9 @@
       }
     },
     "node_modules/druid-query-toolkit": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.1.tgz",
-      "integrity": "sha512-uXybPbUgY5fKMRSduPKSTLHQ8zhfvGT2/jWl+fPIXruFjFnZTDp8YPkJtYq1LzSCvEfgKLw1vwBtNhyUY/CdVg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.2.tgz",
+      "integrity": "sha512-kVnZyE/b9jBx3mebwBKn6/XRpKztM7E7RlzNmUR9LUvOE/cMVqytDKfMx4S05RbIKMTopqI7fRSuE2dc6D8oww==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -34591,9 +34591,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.1.tgz",
-      "integrity": "sha512-uXybPbUgY5fKMRSduPKSTLHQ8zhfvGT2/jWl+fPIXruFjFnZTDp8YPkJtYq1LzSCvEfgKLw1vwBtNhyUY/CdVg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.2.tgz",
+      "integrity": "sha512-kVnZyE/b9jBx3mebwBKn6/XRpKztM7E7RlzNmUR9LUvOE/cMVqytDKfMx4S05RbIKMTopqI7fRSuE2dc6D8oww==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -79,7 +79,7 @@
     "d3-axis": "^2.1.0",
     "d3-scale": "^3.3.0",
     "d3-selection": "^2.0.0",
-    "druid-query-toolkit": "^0.17.1",
+    "druid-query-toolkit": "^0.17.2",
     "file-saver": "^2.0.2",
     "follow-redirects": "^1.14.7",
     "fontsource-open-sans": "^3.0.9",

--- a/web-console/src/views/workbench-view/helper-query/helper-query.tsx
+++ b/web-console/src/views/workbench-view/helper-query/helper-query.tsx
@@ -19,6 +19,7 @@
 import { Button, ButtonGroup, InputGroup, Menu, MenuItem } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
+import axios from 'axios';
 import { QueryResult, QueryRunner, SqlQuery } from 'druid-query-toolkit';
 import React, { useEffect, useRef, useState } from 'react';
 
@@ -92,6 +93,10 @@ export const HelperQuery = React.memo(function HelperQuery(props: HelperQueryPro
     goToIngestion,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
+
+  // Store the cancellation function for natively run queries allowing us to trigger it only when the user explicitly clicks "cancel" (vs changing tab)
+  const nativeQueryCancelFnRef = useRef<() => void>();
+
   const handleQueryStringChange = usePermanentCallback((queryString: string) => {
     onQueryChange(query.changeQueryString(queryString));
   });
@@ -165,11 +170,16 @@ export const HelperQuery = React.memo(function HelperQuery(props: HelperQueryPro
               const resultPromise = queryRunner.runQuery({
                 query,
                 extraQueryContext: mandatoryQueryContext,
+                cancelToken: new axios.CancelToken(cancelFn => {
+                  nativeQueryCancelFnRef.current = cancelFn;
+                }),
               });
               WorkbenchRunningPromises.storePromise(id, { promise: resultPromise, sqlPrefixLines });
 
               result = await resultPromise;
+              nativeQueryCancelFnRef.current = undefined;
             } catch (e) {
+              nativeQueryCancelFnRef.current = undefined;
               throw new DruidError(e, sqlPrefixLines);
             }
 
@@ -236,9 +246,8 @@ export const HelperQuery = React.memo(function HelperQuery(props: HelperQueryPro
   const handleRun = usePermanentCallback(async (preview: boolean) => {
     if (!query.isValid()) return;
 
-    WorkbenchHistory.addQueryToHistory(query);
-
     if (query.getEffectiveEngine() !== 'sql-msq-task') {
+      WorkbenchHistory.addQueryToHistory(query);
       queryManager.runQuery(query);
       return;
     }
@@ -280,6 +289,11 @@ export const HelperQuery = React.memo(function HelperQuery(props: HelperQueryPro
       extraInfo = summarizeExternalConfig(fitExternalConfigPattern(parsedQuery));
     } catch {}
   }
+
+  const onUserCancel = () => {
+    queryManager.cancelCurrent();
+    nativeQueryCancelFnRef.current?.();
+  };
 
   return (
     <div className="helper-query">
@@ -419,17 +433,10 @@ export const HelperQuery = React.memo(function HelperQuery(props: HelperQueryPro
                     execution={executionState.intermediate}
                     intermediateError={executionState.intermediateError}
                     goToIngestion={goToIngestion}
-                    onCancel={() => {
-                      queryManager.cancelCurrent();
-                    }}
+                    onCancel={onUserCancel}
                   />
                 ) : (
-                  <Loader
-                    cancelText="Cancel query"
-                    onCancel={() => {
-                      queryManager.cancelCurrent();
-                    }}
-                  />
+                  <Loader cancelText="Cancel query" onCancel={onUserCancel} />
                 ))}
             </div>
           )}

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -652,11 +652,13 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
                   onClick={this.openExplainDialog}
                 />
               )}
-              <MenuItem
-                icon={IconNames.HISTORY}
-                text="Query history"
-                onClick={this.openHistoryDialog}
-              />
+              {currentTabEntry.query.getEffectiveEngine() !== 'sql-msq-task' && (
+                <MenuItem
+                  icon={IconNames.HISTORY}
+                  text="Query history"
+                  onClick={this.openHistoryDialog}
+                />
+              )}
               {currentTabEntry.query.canPrettify() && (
                 <MenuItem
                   icon={IconNames.ALIGN_LEFT}


### PR DESCRIPTION
This PR makes the following changes to the console:
- The requests on native queries are now immediately canceled, this is helpful in case a user makes a very large request (without a limit) and needs to cancel the query.
- The "Query history" dialog now avoids and does not show up for multi-stage queries because they already show up in the "Recent query tasks" panel and it is confusing that there are two somewhat-history-like places in the UI for multi-stage queries. Also multi-stage queries are sometimes huge and those overwhelm the localStorage.
- Update DQT to fix a small bug.