### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <jackson.version>2.10.5.20201202</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
-        <mysql.version>5.1.49</mysql.version>
+        <mysql.version>8.0.28</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.1.68.Final</netty4.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 5.1.49
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.49 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS