### PR TITLE
Fix shared lock acquisition criteria

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -477,8 +477,8 @@ public class TaskLockbox
           if (request.getType().equals(TaskLockType.SHARED)
               && areAllEqualOrHigherPriorityLocksSharedOrRevoked(conflictPosses, request.getPriority())) {
             // Any number of shared locks can be acquired for the same dataSource and interval
-            // Non-shared locks of equal or greater priority, if present, must already be revoked
-            // Other exclusive (or any non-shared) locks of lower priority can be revoked
+            // Exclusive locks of equal or greater priority, if present, must already be revoked
+            // Exclusive locks of lower priority can be revoked
             revokeAllLowerPriorityNonSharedLocks(conflictPosses, request.getPriority());
             return createNewTaskLockPosse(request);
           } else {
@@ -1085,7 +1085,7 @@ public class TaskLockbox
   private static boolean areAllEqualOrHigherPriorityLocksSharedOrRevoked(List<TaskLockPosse> lockPosses, int priority)
   {
     return lockPosses.stream()
-                     .filter(taskLockPosse -> taskLockPosse.getTaskLock().getPriority() >= priority)
+                     .filter(taskLockPosse -> taskLockPosse.getTaskLock().getNonNullPriority() >= priority)
                      .allMatch(taskLockPosse -> taskLockPosse.getTaskLock().getType().equals(TaskLockType.SHARED)
                                                 || taskLockPosse.getTaskLock().isRevoked());
   }
@@ -1099,7 +1099,7 @@ public class TaskLockbox
   {
     lockPosses.stream()
               .filter(taskLockPosse -> !TaskLockType.SHARED.equals(taskLockPosse.getTaskLock().getType()))
-              .filter(taskLockPosse -> taskLockPosse.getTaskLock().getPriority() < priority)
+              .filter(taskLockPosse -> taskLockPosse.getTaskLock().getNonNullPriority() < priority)
               .forEach(this::revokeLock);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -474,8 +474,12 @@ public class TaskLockbox
         if (reusablePosses.size() == 0) {
           // case 1) this task doesn't have any lock, but others do
 
-          if (request.getType().equals(TaskLockType.SHARED) && isAllSharedLocks(conflictPosses)) {
-            // Any number of shared locks can be acquired for the same dataSource and interval.
+          if (request.getType().equals(TaskLockType.SHARED)
+              && areAllEqualOrHigherPriorityLocksSharedOrRevoked(conflictPosses, request.getPriority())) {
+            // Any number of shared locks can be acquired for the same dataSource and interval
+            // Other locks must be revoked
+            // Exclusive or other non-shared locks of lower priority can be revoked
+            revokeAllLowerPriorityNonSharedLocks(conflictPosses, request.getPriority());
             return createNewTaskLockPosse(request);
           } else {
             // During a rolling update, tasks of mixed versions can be run at the same time. Old tasks would request
@@ -1070,10 +1074,20 @@ public class TaskLockbox
     return running;
   }
 
-  private static boolean isAllSharedLocks(List<TaskLockPosse> lockPosses)
+  private static boolean areAllEqualOrHigherPriorityLocksSharedOrRevoked(List<TaskLockPosse> lockPosses, int priority)
   {
     return lockPosses.stream()
-                     .allMatch(taskLockPosse -> taskLockPosse.getTaskLock().getType().equals(TaskLockType.SHARED));
+                     .filter(taskLockPosse -> taskLockPosse.getTaskLock().getPriority() >= priority)
+                     .allMatch(taskLockPosse -> taskLockPosse.getTaskLock().getType().equals(TaskLockType.SHARED)
+                                                || taskLockPosse.getTaskLock().isRevoked());
+  }
+
+  private void revokeAllLowerPriorityNonSharedLocks(List<TaskLockPosse> lockPosses, int priority)
+  {
+    lockPosses.stream()
+              .filter(taskLockPosse -> !TaskLockType.SHARED.equals(taskLockPosse.getTaskLock().getType()))
+              .filter(taskLockPosse -> taskLockPosse.getTaskLock().getPriority() < priority)
+              .forEach(this::revokeLock);
   }
 
   private static boolean isAllRevocable(List<TaskLockPosse> lockPosses, int tryLockPriority)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -169,24 +169,81 @@ public class TaskLockboxTest
   }
 
   @Test
-  public void testTrySharedLock()
+  public void testTrySharedLock() throws EntryExistsException
   {
     final Interval interval = Intervals.of("2017-01/2017-02");
     final List<Task> tasks = new ArrayList<>();
-    final Set<TaskLock> actualLocks = new HashSet<>();
+    final Set<TaskLock> activeLocks = new HashSet<>();
 
-    // test creating new locks
-    for (int i = 0; i < 5; i++) {
-      final Task task = NoopTask.create(Math.min(0, (i - 1) * 10)); // the first two tasks have the same priority
+    // Add an exclusive lock entry of the highest priority
+    Task exclusiveHigherPriorityRevokedLockTask =  NoopTask.create(100);
+    tasks.add(exclusiveHigherPriorityRevokedLockTask);
+    taskStorage.insert(
+        exclusiveHigherPriorityRevokedLockTask,
+        TaskStatus.running(exclusiveHigherPriorityRevokedLockTask.getId())
+    );
+    lockbox.add(exclusiveHigherPriorityRevokedLockTask);
+    final TaskLock exclusiveRevokedLock = tryTimeChunkLock(
+        TaskLockType.EXCLUSIVE,
+        exclusiveHigherPriorityRevokedLockTask,
+        interval
+    ).getTaskLock();
+
+    // Any equal or lower priority shared lock must fail
+    final Task sharedLockTask = NoopTask.create(100);
+    lockbox.add(sharedLockTask);
+    Assert.assertFalse(tryTimeChunkLock(TaskLockType.SHARED, sharedLockTask, interval).isOk());
+
+    // Revoke existing active exclusive lock
+    lockbox.revokeLock(exclusiveHigherPriorityRevokedLockTask.getId(), exclusiveRevokedLock);
+    Assert.assertEquals(1, getAllLocks(tasks).size());
+    Assert.assertEquals(0, getAllActiveLocks(tasks).size());
+    Assert.assertEquals(activeLocks, getAllActiveLocks(tasks));
+
+    // test creating new shared locks
+    for (int i = 0; i < 3; i++) {
+      final Task task = NoopTask.create(Math.max(0, (i - 1) * 10)); // the first two tasks have the same priority
       tasks.add(task);
+      taskStorage.insert(task, TaskStatus.running(task.getId()));
       lockbox.add(task);
       final TaskLock lock = tryTimeChunkLock(TaskLockType.SHARED, task, interval).getTaskLock();
       Assert.assertNotNull(lock);
-      actualLocks.add(lock);
+      activeLocks.add(lock);
     }
+    Assert.assertEquals(4, getAllLocks(tasks).size());
+    Assert.assertEquals(3, getAllActiveLocks(tasks).size());
+    Assert.assertEquals(activeLocks, getAllActiveLocks(tasks));
 
+    // Adding an exclusive task lock of priority 15 should revoke all existing active locks
+    Task exclusiveLowerPriorityLockTask =  NoopTask.create(15);
+    tasks.add(exclusiveLowerPriorityLockTask);
+    taskStorage.insert(exclusiveLowerPriorityLockTask, TaskStatus.running(exclusiveLowerPriorityLockTask.getId()));
+    lockbox.add(exclusiveLowerPriorityLockTask);
+    final TaskLock lowerPriorityExclusiveLock = tryTimeChunkLock(
+        TaskLockType.EXCLUSIVE,
+        exclusiveLowerPriorityLockTask,
+        interval
+    ).getTaskLock();
+    activeLocks.clear();
+    activeLocks.add(lowerPriorityExclusiveLock);
     Assert.assertEquals(5, getAllLocks(tasks).size());
-    Assert.assertEquals(getAllLocks(tasks), actualLocks);
+    Assert.assertEquals(1, getAllActiveLocks(tasks).size());
+    Assert.assertEquals(activeLocks, getAllActiveLocks(tasks));
+
+    // Add new shared locks which revoke the active exclusive task lock
+    activeLocks.clear();
+    for (int i = 3; i < 5; i++) {
+      final Task task = NoopTask.create(Math.max(0, (i - 1) * 10)); // the first two tasks have the same priority
+      tasks.add(task);
+      taskStorage.insert(task, TaskStatus.running(task.getId()));
+      lockbox.add(task);
+      final TaskLock lock = tryTimeChunkLock(TaskLockType.SHARED, task, interval).getTaskLock();
+      Assert.assertNotNull(lock);
+      activeLocks.add(lock);
+    }
+    Assert.assertEquals(7, getAllLocks(tasks).size());
+    Assert.assertEquals(2, getAllActiveLocks(tasks).size());
+    Assert.assertEquals(activeLocks, getAllActiveLocks(tasks));
   }
 
   @Test
@@ -1298,6 +1355,14 @@ public class TaskLockboxTest
     TaskLockboxSyncResult result = testLockbox.syncFromStorage();
     Assert.assertEquals(ImmutableSet.of(taskWithFailingLockAcquisition0, taskWithFailingLockAcquisition1),
                         result.getTasksToFail());
+  }
+
+  private Set<TaskLock> getAllActiveLocks(List<Task> tasks)
+  {
+    return tasks.stream()
+                .flatMap(task -> taskStorage.getLocks(task.getId()).stream())
+                .filter(taskLock -> !taskLock.isRevoked())
+                .collect(Collectors.toSet());
   }
 
   private Set<TaskLock> getAllLocks(List<Task> tasks)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -176,7 +176,7 @@ public class TaskLockboxTest
     final Set<TaskLock> activeLocks = new HashSet<>();
 
     // Add an exclusive lock entry of the highest priority
-    Task exclusiveHigherPriorityRevokedLockTask =  NoopTask.create(100);
+    Task exclusiveHigherPriorityRevokedLockTask = NoopTask.create(100);
     tasks.add(exclusiveHigherPriorityRevokedLockTask);
     taskStorage.insert(
         exclusiveHigherPriorityRevokedLockTask,
@@ -215,7 +215,7 @@ public class TaskLockboxTest
     Assert.assertEquals(activeLocks, getAllActiveLocks(tasks));
 
     // Adding an exclusive task lock of priority 15 should revoke all existing active locks
-    Task exclusiveLowerPriorityLockTask =  NoopTask.create(15);
+    Task exclusiveLowerPriorityLockTask = NoopTask.create(15);
     tasks.add(exclusiveLowerPriorityLockTask);
     taskStorage.insert(exclusiveLowerPriorityLockTask, TaskStatus.running(exclusiveLowerPriorityLockTask.getId()));
     lockbox.add(exclusiveLowerPriorityLockTask);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Shared locks are only acquired when all other locks are also shared locks.


<!-- Describe your patch: what did you change in code? How did you fix the problem? -->


However, it should be possible when all exclusive locks with the same or greater priority are revoked. If there are any exclusive locks with lower priority, it must be possible to revoke them and allocate a shared lock.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<hr>

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
