### PR TITLE
fix(sec): upgrade org.pac4j:pac4j-oidc to 5.2.0

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -34,7 +34,7 @@
   </parent>
 
   <properties>
-    <pac4j.version>3.8.3</pac4j.version>
+    <pac4j.version>5.2.0</pac4j.version>
 
     <!-- Following must be updated along with any updates to pac4j version -->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.pac4j:pac4j-oidc 3.8.3
- [CVE-2021-44878](https://www.oscs1024.com/hd/CVE-2021-44878)


### What did I do？
Upgrade org.pac4j:pac4j-oidc from 3.8.3 to 5.2.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>