### PR TITLE
SeekableStreamSupervisor: Unique type name for GracefulShutdownNotice.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -538,11 +538,19 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
   private class GracefulShutdownNotice extends ShutdownNotice
   {
+    private static final String TYPE = "graceful_shutdown_notice";
+
     @Override
     public void handle() throws InterruptedException, ExecutionException, TimeoutException
     {
       gracefulShutdownInternal();
       super.handle();
+    }
+
+    @Override
+    public String getType()
+    {
+      return TYPE;
     }
   }
 


### PR DESCRIPTION
Allows GracefulShutdownNotice to be differentiated from ShutdownNotice.