### PR TITLE
Web console: add ability to make inputFormat part of the example datasets

### DIFF
--- a/web-console/src/views/workbench-view/input-source-step/example-inputs.ts
+++ b/web-console/src/views/workbench-view/input-source-step/example-inputs.ts
@@ -16,15 +16,74 @@
  * limitations under the License.
  */
 
-import { InputSource } from '../../../druid-models';
+import { InputFormat, InputSource } from '../../../druid-models';
 
-export interface ExampleInputSource {
+export interface ExampleInput {
   name: string;
   description: string;
   inputSource: InputSource;
+  inputFormat?: InputFormat;
 }
 
-export const EXAMPLE_INPUT_SOURCES: ExampleInputSource[] = [
+const TRIPS_INPUT_FORMAT: InputFormat = {
+  type: 'csv',
+  findColumnsFromHeader: false,
+  columns: [
+    'trip_id',
+    'vendor_id',
+    'pickup_datetime',
+    'dropoff_datetime',
+    'store_and_fwd_flag',
+    'rate_code_id',
+    'pickup_longitude',
+    'pickup_latitude',
+    'dropoff_longitude',
+    'dropoff_latitude',
+    'passenger_count',
+    'trip_distance',
+    'fare_amount',
+    'extra',
+    'mta_tax',
+    'tip_amount',
+    'tolls_amount',
+    'ehail_fee',
+    'improvement_surcharge',
+    'total_amount',
+    'payment_type',
+    'trip_type',
+    'pickup',
+    'dropoff',
+    'cab_type',
+    'precipitation',
+    'snow_depth',
+    'snowfall',
+    'max_temperature',
+    'min_temperature',
+    'average_wind_speed',
+    'pickup_nyct2010_gid',
+    'pickup_ctlabel',
+    'pickup_borocode',
+    'pickup_boroname',
+    'pickup_ct2010',
+    'pickup_boroct2010',
+    'pickup_cdeligibil',
+    'pickup_ntacode',
+    'pickup_ntaname',
+    'pickup_puma',
+    'dropoff_nyct2010_gid',
+    'dropoff_ctlabel',
+    'dropoff_borocode',
+    'dropoff_boroname',
+    'dropoff_ct2010',
+    'dropoff_boroct2010',
+    'dropoff_cdeligibil',
+    'dropoff_ntacode',
+    'dropoff_ntaname',
+    'dropoff_puma',
+  ],
+};
+
+export const EXAMPLE_INPUTS: ExampleInput[] = [
   {
     name: 'Wikipedia',
     description: 'One day of wikipedia edits (JSON)',
@@ -62,6 +121,7 @@ export const EXAMPLE_INPUT_SOURCES: ExampleInputSource[] = [
         'https://static.imply.io/example-data/trips/trips_xac.csv.gz',
       ],
     },
+    inputFormat: TRIPS_INPUT_FORMAT,
   },
   {
     name: 'NYC Taxi cabs (all files)',
@@ -145,6 +205,7 @@ export const EXAMPLE_INPUT_SOURCES: ExampleInputSource[] = [
         'https://static.imply.io/example-data/trips/trips_xcv.csv.gz',
       ],
     },
+    inputFormat: TRIPS_INPUT_FORMAT,
   },
   {
     name: 'FlightCarrierOnTime (1 month)',


### PR DESCRIPTION
In the example data flow make it possible for the example to specify the inputFormat. This lets us formally declare the columns for the NYC taxi datasets (and for similar header-less datasets in the future).

This is how the NYC example data looks now in the 'inputFormat' step:

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/177816/203127757-0481b6e2-b7f7-4e57-b621-07c167d31e92.png">
