### PR TITLE
fix(sec): upgrade com.google.code.gson:gson to 2.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <apache.curator.version>5.4.0</apache.curator.version>
         <apache.kafka.version>3.3.1</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
-        <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
+        <apache.ranger.gson.version>2.8.9</apache.ranger.gson.version>
         <scala.library.version>2.13.9</scala.library.version>
         <avatica.version>1.17.0</avatica.version>
         <avro.version>1.9.2</avro.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.code.gson:gson 2.2.4
- [CVE-2022-25647](https://www.oscs1024.com/hd/CVE-2022-25647)


### What did I do？
Upgrade com.google.code.gson:gson from 2.2.4 to 2.8.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>