### PR TITLE
fix(sec): upgrade com.google.guava:guava to 30.0-jre

### DIFF
--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>30.0-jre</version>
     </dependency>
 
     <dependency>

--- a/extensions-contrib/compressed-bigdecimal/pom.xml
+++ b/extensions-contrib/compressed-bigdecimal/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>30.0-jre</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <errorprone.version>2.11.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.48.v20220622</jetty.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 16.0.1
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)


### What did I do？
Upgrade com.google.guava:guava from 16.0.1 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>