### PR TITLE
fix bug with broker parallel merge metrics emitting

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -353,6 +353,27 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   }
 
   @Override
+  public QueryMetrics<QueryType> reportParallelMergeTotalTime(long timeNs)
+  {
+    // Don't emit by default.
+    return this;
+  }
+
+  @Override
+  public QueryMetrics<QueryType> reportParallelMergeFastestPartitionTime(long timeNs)
+  {
+    // Don't emit by default.
+    return this;
+  }
+
+  @Override
+  public QueryMetrics<QueryType> reportParallelMergeSlowestPartitionTime(long timeNs)
+  {
+    // Don't emit by default.
+    return this;
+  }
+
+  @Override
   public QueryMetrics<QueryType> reportQueriedSegmentCount(long segmentCount)
   {
     // Don't emit by default.

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -397,6 +397,30 @@ public interface QueryMetrics<QueryType extends Query<?>>
   QueryMetrics<QueryType> reportParallelMergeTotalCpuTime(long timeNs);
 
   /**
+   * Reports broker total "wall" time in nanoseconds from parallel merge start sequence creation to total
+   * consumption.
+   */
+  QueryMetrics<QueryType> reportParallelMergeTotalTime(long timeNs);
+
+  /**
+   * Reports broker "wall" time in nanoseconds for the fastest parallel merge sequence partition to be 'initialized',
+   * where 'initialized' is time to the first result batch is populated from data servers and merging can begin.
+   *
+   * Similar to query 'time to first byte' metrics, except is a composite of the whole group of data servers which are
+   * present in the merge partition, which all must supply an initial result batch before merging can actually begin.
+   */
+  QueryMetrics<QueryType> reportParallelMergeFastestPartitionTime(long timeNs);
+
+  /**
+   * Reports broker "wall" time in nanoseconds for the slowest parallel merge sequence partition to be 'initialized',
+   * where 'initialized' is time to the first result batch is populated from data servers and merging can begin.
+   *
+   * Similar to query 'time to first byte' metrics, except is a composite of the whole group of data servers which are
+   * present in the merge partition, which all must supply an initial result batch before merging can actually begin.
+   */
+  QueryMetrics<QueryType> reportParallelMergeSlowestPartitionTime(long timeNs);
+
+  /**
    * Emits all metrics, registered since the last {@code emit()} call on this QueryMetrics object.
    */
   void emit(ServiceEmitter emitter);

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -304,6 +304,24 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   }
 
   @Override
+  public QueryMetrics reportParallelMergeTotalTime(long timeNs)
+  {
+    return delegateQueryMetrics.reportParallelMergeTotalTime(timeNs);
+  }
+
+  @Override
+  public QueryMetrics reportParallelMergeFastestPartitionTime(long timeNs)
+  {
+    return delegateQueryMetrics.reportParallelMergeFastestPartitionTime(timeNs);
+  }
+
+  @Override
+  public QueryMetrics reportParallelMergeSlowestPartitionTime(long timeNs)
+  {
+    return delegateQueryMetrics.reportParallelMergeSlowestPartitionTime(timeNs);
+  }
+
+  @Override
   public QueryMetrics reportQueriedSegmentCount(long segmentCount)
   {
     return delegateQueryMetrics.reportQueriedSegmentCount(segmentCount);

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -403,12 +403,17 @@ public class CachingClusteredClient implements QuerySegmentWalker
               QueryMetrics<?> queryMetrics = queryPlus.getQueryMetrics();
               if (queryMetrics != null) {
                 queryMetrics.parallelMergeParallelism(reportMetrics.getParallelism());
-                queryMetrics.reportParallelMergeParallelism(reportMetrics.getParallelism());
-                queryMetrics.reportParallelMergeInputSequences(reportMetrics.getInputSequences());
-                queryMetrics.reportParallelMergeInputRows(reportMetrics.getInputRows());
-                queryMetrics.reportParallelMergeOutputRows(reportMetrics.getOutputRows());
-                queryMetrics.reportParallelMergeTaskCount(reportMetrics.getTaskCount());
-                queryMetrics.reportParallelMergeTotalCpuTime(reportMetrics.getTotalCpuTime());
+                queryMetrics.reportParallelMergeParallelism(reportMetrics.getParallelism()).emit(emitter);
+                queryMetrics.reportParallelMergeInputSequences(reportMetrics.getInputSequences()).emit(emitter);
+                queryMetrics.reportParallelMergeInputRows(reportMetrics.getInputRows()).emit(emitter);
+                queryMetrics.reportParallelMergeOutputRows(reportMetrics.getOutputRows()).emit(emitter);
+                queryMetrics.reportParallelMergeTaskCount(reportMetrics.getTaskCount()).emit(emitter);
+                queryMetrics.reportParallelMergeTotalCpuTime(reportMetrics.getTotalCpuTime()).emit(emitter);
+                queryMetrics.reportParallelMergeTotalTime(reportMetrics.getTotalTime()).emit(emitter);
+                queryMetrics.reportParallelMergeSlowestPartitionTime(reportMetrics.getSlowestPartitionInitializedTime())
+                            .emit(emitter);
+                queryMetrics.reportParallelMergeFastestPartitionTime(reportMetrics.getFastestPartitionInitializedTime())
+                            .emit(emitter);
               }
             }
         );
@@ -884,7 +889,6 @@ public class CachingClusteredClient implements QuerySegmentWalker
         return null;
       }
       return new PartitionChunkEntry<>(spec.getInterval(), spec.getVersion(), chunk);
-
     }
   }
 }


### PR DESCRIPTION
### Description
Heh, I left out the call to `.emit` on the broker parallel merge pool metrics so they just get reported into thin air. This PR fixes this so that they now exist and look something like this (when wired up to a `QueryMetrics` implementation that actually emits them, they are currently off by default):
```
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/parallelism","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":2,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/sequences","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":4,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/rows/input","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":4,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/rows/output","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":4,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/tasks/count","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":10,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/cpu","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":0,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/time","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":65,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/partition/slowest","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":63,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
2022-11-23T04:23:50,761 INFO [sql[e4429600-e50b-4fee-90f6-941c11204924]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"numComplexMetrics":"0","mergeParallelism":2,"type":"timeseries","version":"","duration":"PT9223372036854775.807S","feed":"metrics","metric":"query/merge/partition/fastest","hasFilters":"false","service":"druid/broker","host":"localhost:8082","context":{"defaultTimeout":300000,"finalize":false,"grandTotal":false,"maxScatterGatherBytes":9223372036854775807,"populateCache":false,"queryFailTime":1669177730685,"queryId":"e4429600-e50b-4fee-90f6-941c11204924","sqlOuterLimit":1001,"sqlQueryId":"e4429600-e50b-4fee-90f6-941c11204924","useCache":false},"limit":"2147483647","interval":["-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"],"id":"e4429600-e50b-4fee-90f6-941c11204924","numMetrics":"1","value":40,"dataSource":"wikipedia_rollup_test","timestamp":"2022-11-23T04:23:50.761Z"}
```

I've also added three new metrics, one for total 'wall' time of the sequence from construction to being totally consume, and one each for the time spent waiting for the fastest and slowest partitions to initialize (fetch the first batch of results to begin work). The three of these should provide some additional insight into how time was spent by the tasks on the pool to accompany the existing set of metrics (which actually exist now).

#### Release note
* Fix an issue which cause broker parallel merge pool metrics to not be emitted.
* Added new broker query metric for total parallel merge processing 'wall' time
* Added new broker query metrics for parallel merge pool time spent waiting for results of 'fastest' and 'slowest' partitions.


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
