### PR TITLE
Correction to firehose migration doc

### DIFF
--- a/docs/ingestion/migrate-from-firehose-ingestion.md
+++ b/docs/ingestion/migrate-from-firehose-ingestion.md
@@ -23,7 +23,7 @@ sidebar_label: "Migrate from firehose"
   ~ under the License.
   -->
 
-Apache deprecated support for Druid firehoses in version 0.17. Support for firehose ingestion was removed in version 24.0.
+Apache deprecated support for Druid firehoses in version 0.17. Support for firehose ingestion will be removed in version 26.0.
 
 If you're using a firehose for batch ingestion, we strongly recommend that you follow the instructions on this page to transition to using native batch ingestion input sources as soon as possible. 
 


### PR DESCRIPTION
Correction to firehose migration doc.

This PR has:
- [x] been self-reviewed.