### PR TITLE
Web console: Index spec dialog

### DIFF
--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -16,7 +16,14 @@
  * limitations under the License.
  */
 
-import { Button, ButtonGroup, FormGroup, Intent, NumericInput } from '@blueprintjs/core';
+import {
+  Button,
+  ButtonGroup,
+  FormGroup,
+  InputGroup,
+  Intent,
+  NumericInput,
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React from 'react';
 
@@ -46,7 +53,8 @@ export interface Field<M> {
     | 'boolean'
     | 'string-array'
     | 'json'
-    | 'interval';
+    | 'interval'
+    | 'custom';
   defaultValue?: any;
   emptyValue?: any;
   suggestions?: Functor<M, Suggestion[]>;
@@ -64,6 +72,13 @@ export interface Field<M> {
   valueAdjustment?: (value: any) => any;
   adjustment?: (model: Partial<M>) => Partial<M>;
   issueWithValue?: (value: any) => string | undefined;
+
+  customSummary?: (v: any) => string;
+  customDialog?: (o: {
+    value: any;
+    onValueChange: (v: any) => void;
+    onClose: () => void;
+  }) => JSX.Element;
 }
 
 interface ComputedFieldValues {
@@ -84,6 +99,7 @@ export interface AutoFormProps<M> {
 
 export interface AutoFormState {
   showMore: boolean;
+  customDialog?: JSX.Element;
 }
 
 export class AutoForm<T extends Record<string, any>> extends React.PureComponent<
@@ -395,6 +411,36 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     );
   }
 
+  private renderCustomInput(field: Field<T>): JSX.Element {
+    const { model } = this.props;
+    const { required, defaultValue, modelValue } = AutoForm.computeFieldValues(model, field);
+    const effectiveValue = modelValue || defaultValue;
+
+    const onEdit = () => {
+      this.setState({
+        customDialog: field.customDialog?.({
+          value: effectiveValue,
+          onValueChange: v => this.fieldChange(field, v),
+          onClose: () => {
+            this.setState({ customDialog: undefined });
+          },
+        }),
+      });
+    };
+
+    return (
+      <InputGroup
+        className="custom-input"
+        value={(field.customSummary || String)(effectiveValue)}
+        intent={required && modelValue == null ? AutoForm.REQUIRED_INTENT : undefined}
+        readOnly
+        placeholder={AutoForm.evaluateFunctor(field.placeholder, model, '')}
+        rightElement={<Button icon={IconNames.EDIT} minimal onClick={onEdit} />}
+        onClick={onEdit}
+      />
+    );
+  }
+
   renderFieldInput(field: Field<T>) {
     switch (field.type) {
       case 'number':
@@ -413,6 +459,8 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         return this.renderJsonInput(field);
       case 'interval':
         return this.renderIntervalInput(field);
+      case 'custom':
+        return this.renderCustomInput(field);
       default:
         throw new Error(`unknown field type '${field.type}'`);
     }
@@ -464,7 +512,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
 
   render(): JSX.Element {
     const { fields, model, showCustom } = this.props;
-    const { showMore } = this.state;
+    const { showMore, customDialog } = this.state;
 
     let shouldShowMore = false;
     const shownFields = fields.filter(field => {
@@ -489,6 +537,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         {model && shownFields.map(this.renderField)}
         {model && showCustom && showCustom(model) && this.renderCustom()}
         {shouldShowMore && this.renderMoreOrLess()}
+        {customDialog}
       </div>
     );
   }

--- a/web-console/src/dialogs/index-spec-dialog/__snapshots__/index-spec-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/index-spec-dialog/__snapshots__/index-spec-dialog.spec.tsx.snap
@@ -1,0 +1,317 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IndexSpecDialog matches snapshot with indexSpec 1`] = `
+<Blueprint4.Dialog
+  canOutsideClickClose={false}
+  className="index-spec-dialog"
+  isOpen={true}
+  onClose={[Function]}
+  title="Index spec"
+>
+  <Memo(FormJsonSelector)
+    onChange={[Function]}
+    tab="form"
+  />
+  <div
+    className="content"
+  >
+    <AutoForm
+      fields={
+        Array [
+          Object {
+            "defaultValue": "utf8",
+            "info": <React.Fragment>
+              Encoding format for STRING value dictionaries used by STRING and COMPLEX&lt;json&gt; columns.
+            </React.Fragment>,
+            "label": "String dictionary encoding",
+            "name": "stringDictionaryEncoding.type",
+            "suggestions": Array [
+              "utf8",
+              "frontCoded",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": 4,
+            "defined": [Function],
+            "info": <React.Fragment>
+              The number of values to place in a bucket to perform delta encoding. Must be a power of 2, maximum is 128.
+            </React.Fragment>,
+            "label": "String dictionary encoding bucket size",
+            "max": 128,
+            "min": 1,
+            "name": "stringDictionaryEncoding.bucketSize",
+            "type": "number",
+          },
+          Object {
+            "defaultValue": "roaring",
+            "info": <React.Fragment>
+              Compression format for bitmap indexes.
+            </React.Fragment>,
+            "label": "Bitmap type",
+            "name": "bitmap.type",
+            "suggestions": Array [
+              "roaring",
+              "concise",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": true,
+            "defined": [Function],
+            "info": <React.Fragment>
+              Controls whether or not run-length encoding will be used when it is determined to be more space-efficient.
+            </React.Fragment>,
+            "label": "Bitmap compress run on serialization",
+            "name": "bitmap.compressRunOnSerialization",
+            "type": "boolean",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format for dimension columns.
+            </React.Fragment>,
+            "name": "dimensionCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "longs",
+            "info": <React.Fragment>
+              Encoding format for long-typed columns. Applies regardless of whether they are dimensions or metrics. 
+              <Unknown>
+                auto
+              </Unknown>
+               encodes the values using offset or lookup table depending on column cardinality, and store them with variable size. 
+              <Unknown>
+                longs
+              </Unknown>
+               stores the value as-is with 8 bytes each.
+            </React.Fragment>,
+            "name": "longEncoding",
+            "suggestions": Array [
+              "longs",
+              "auto",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format for primitive type metric columns.
+            </React.Fragment>,
+            "name": "metricCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format to use for nested column raw data. 
+            </React.Fragment>,
+            "label": "JSON compression",
+            "name": "jsonCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+        ]
+      }
+      model={
+        Object {
+          "dimensionCompression": "lzf",
+        }
+      }
+      onChange={[Function]}
+    />
+  </div>
+  <div
+    className="bp4-dialog-footer"
+  >
+    <div
+      className="bp4-dialog-footer-actions"
+    >
+      <Blueprint4.Button
+        onClick={[Function]}
+        text="Close"
+      />
+      <Blueprint4.Button
+        disabled={false}
+        intent="primary"
+        onClick={[Function]}
+        text="Save"
+      />
+    </div>
+  </div>
+</Blueprint4.Dialog>
+`;
+
+exports[`IndexSpecDialog matches snapshot without compactionConfig 1`] = `
+<Blueprint4.Dialog
+  canOutsideClickClose={false}
+  className="index-spec-dialog"
+  isOpen={true}
+  onClose={[Function]}
+  title="Index spec"
+>
+  <Memo(FormJsonSelector)
+    onChange={[Function]}
+    tab="form"
+  />
+  <div
+    className="content"
+  >
+    <AutoForm
+      fields={
+        Array [
+          Object {
+            "defaultValue": "utf8",
+            "info": <React.Fragment>
+              Encoding format for STRING value dictionaries used by STRING and COMPLEX&lt;json&gt; columns.
+            </React.Fragment>,
+            "label": "String dictionary encoding",
+            "name": "stringDictionaryEncoding.type",
+            "suggestions": Array [
+              "utf8",
+              "frontCoded",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": 4,
+            "defined": [Function],
+            "info": <React.Fragment>
+              The number of values to place in a bucket to perform delta encoding. Must be a power of 2, maximum is 128.
+            </React.Fragment>,
+            "label": "String dictionary encoding bucket size",
+            "max": 128,
+            "min": 1,
+            "name": "stringDictionaryEncoding.bucketSize",
+            "type": "number",
+          },
+          Object {
+            "defaultValue": "roaring",
+            "info": <React.Fragment>
+              Compression format for bitmap indexes.
+            </React.Fragment>,
+            "label": "Bitmap type",
+            "name": "bitmap.type",
+            "suggestions": Array [
+              "roaring",
+              "concise",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": true,
+            "defined": [Function],
+            "info": <React.Fragment>
+              Controls whether or not run-length encoding will be used when it is determined to be more space-efficient.
+            </React.Fragment>,
+            "label": "Bitmap compress run on serialization",
+            "name": "bitmap.compressRunOnSerialization",
+            "type": "boolean",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format for dimension columns.
+            </React.Fragment>,
+            "name": "dimensionCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "longs",
+            "info": <React.Fragment>
+              Encoding format for long-typed columns. Applies regardless of whether they are dimensions or metrics. 
+              <Unknown>
+                auto
+              </Unknown>
+               encodes the values using offset or lookup table depending on column cardinality, and store them with variable size. 
+              <Unknown>
+                longs
+              </Unknown>
+               stores the value as-is with 8 bytes each.
+            </React.Fragment>,
+            "name": "longEncoding",
+            "suggestions": Array [
+              "longs",
+              "auto",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format for primitive type metric columns.
+            </React.Fragment>,
+            "name": "metricCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+          Object {
+            "defaultValue": "lz4",
+            "info": <React.Fragment>
+              Compression format to use for nested column raw data. 
+            </React.Fragment>,
+            "label": "JSON compression",
+            "name": "jsonCompression",
+            "suggestions": Array [
+              "lz4",
+              "lzf",
+              "zstd",
+              "uncompressed",
+            ],
+            "type": "string",
+          },
+        ]
+      }
+      model={Object {}}
+      onChange={[Function]}
+    />
+  </div>
+  <div
+    className="bp4-dialog-footer"
+  >
+    <div
+      className="bp4-dialog-footer-actions"
+    >
+      <Blueprint4.Button
+        onClick={[Function]}
+        text="Close"
+      />
+      <Blueprint4.Button
+        disabled={false}
+        intent="primary"
+        onClick={[Function]}
+        text="Save"
+      />
+    </div>
+  </div>
+</Blueprint4.Dialog>
+`;

--- a/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.scss
+++ b/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.scss
@@ -18,18 +18,19 @@
 
 @import '../../variables';
 
-.auto-form {
-  // Popover in info label
-  label.#{$bp-ns}-label {
-    position: relative;
-
-    .#{$bp-ns}-text-muted {
-      position: absolute;
-      right: 0;
-    }
+.index-spec-dialog {
+  &.#{$bp-ns}-dialog {
+    height: 70vh;
   }
 
-  .custom-input input {
-    cursor: pointer;
+  .form-json-selector {
+    margin: 15px;
+  }
+
+  .content {
+    margin: 0 15px 10px 0;
+    padding: 0 5px 0 15px;
+    flex: 1;
+    overflow: auto;
   }
 }

--- a/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.spec.tsx
+++ b/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.spec.tsx
@@ -16,20 +16,29 @@
  * limitations under the License.
  */
 
-@import '../../variables';
+import { shallow } from 'enzyme';
+import React from 'react';
 
-.auto-form {
-  // Popover in info label
-  label.#{$bp-ns}-label {
-    position: relative;
+import { IndexSpecDialog } from './index-spec-dialog';
 
-    .#{$bp-ns}-text-muted {
-      position: absolute;
-      right: 0;
-    }
-  }
+describe('IndexSpecDialog', () => {
+  it('matches snapshot without compactionConfig', () => {
+    const compactionDialog = shallow(
+      <IndexSpecDialog onClose={() => {}} onSave={() => {}} indexSpec={undefined} />,
+    );
+    expect(compactionDialog).toMatchSnapshot();
+  });
 
-  .custom-input input {
-    cursor: pointer;
-  }
-}
+  it('matches snapshot with indexSpec', () => {
+    const compactionDialog = shallow(
+      <IndexSpecDialog
+        onClose={() => {}}
+        onSave={() => {}}
+        indexSpec={{
+          dimensionCompression: 'lzf',
+        }}
+      />,
+    );
+    expect(compactionDialog).toMatchSnapshot();
+  });
+});

--- a/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.tsx
+++ b/web-console/src/dialogs/index-spec-dialog/index-spec-dialog.tsx
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
+import React, { useState } from 'react';
+
+import { AutoForm, FormJsonSelector, FormJsonTabs, JsonInput } from '../../components';
+import { INDEX_SPEC_FIELDS, IndexSpec } from '../../druid-models';
+
+import './index-spec-dialog.scss';
+
+export interface IndexSpecDialogProps {
+  title?: string;
+  onClose: () => void;
+  onSave: (indexSpec: IndexSpec) => void;
+  indexSpec: IndexSpec | undefined;
+}
+
+export const IndexSpecDialog = React.memo(function IndexSpecDialog(props: IndexSpecDialogProps) {
+  const { title, indexSpec, onSave, onClose } = props;
+
+  const [currentTab, setCurrentTab] = useState<FormJsonTabs>('form');
+  const [currentIndexSpec, setCurrentIndexSpec] = useState<IndexSpec>(indexSpec || {});
+  const [jsonError, setJsonError] = useState<Error | undefined>();
+
+  const issueWithCurrentIndexSpec = AutoForm.issueWithModel(currentIndexSpec, INDEX_SPEC_FIELDS);
+
+  return (
+    <Dialog
+      className="index-spec-dialog"
+      isOpen
+      onClose={onClose}
+      canOutsideClickClose={false}
+      title={title ?? 'Index spec'}
+    >
+      <FormJsonSelector tab={currentTab} onChange={setCurrentTab} />
+      <div className="content">
+        {currentTab === 'form' ? (
+          <AutoForm
+            fields={INDEX_SPEC_FIELDS}
+            model={currentIndexSpec}
+            onChange={m => setCurrentIndexSpec(m)}
+          />
+        ) : (
+          <JsonInput
+            value={currentIndexSpec}
+            onChange={v => {
+              setCurrentIndexSpec(v);
+              setJsonError(undefined);
+            }}
+            onError={setJsonError}
+            issueWithValue={value => AutoForm.issueWithModel(value, INDEX_SPEC_FIELDS)}
+            height="100%"
+          />
+        )}
+      </div>
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button text="Close" onClick={onClose} />
+          <Button
+            text="Save"
+            intent={Intent.PRIMARY}
+            disabled={Boolean(jsonError || issueWithCurrentIndexSpec)}
+            onClick={() => {
+              onSave(currentIndexSpec);
+              onClose();
+            }}
+          />
+        </div>
+      </div>
+    </Dialog>
+  );
+});

--- a/web-console/src/druid-models/index-spec/index-spec.tsx
+++ b/web-console/src/druid-models/index-spec/index-spec.tsx
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Code } from '@blueprintjs/core';
+import React from 'react';
+
+import { Field } from '../../components';
+import { deepGet } from '../../utils';
+
+export interface IndexSpec {
+  bitmap?: Bitmap;
+  dimensionCompression?: string;
+  stringDictionaryEncoding?: { type: 'utf8' | 'frontCoded'; bucketSize: number };
+  metricCompression?: string;
+  longEncoding?: string;
+  jsonCompression?: string;
+}
+
+export interface Bitmap {
+  type: string;
+  compressRunOnSerialization?: boolean;
+}
+
+export function summarizeIndexSpec(indexSpec: IndexSpec | undefined): string {
+  if (!indexSpec) return '';
+
+  const { stringDictionaryEncoding, bitmap, longEncoding } = indexSpec;
+
+  const ret: string[] = [];
+  if (stringDictionaryEncoding) {
+    switch (stringDictionaryEncoding.type) {
+      case 'frontCoded':
+        ret.push(`frontCoded(${stringDictionaryEncoding.bucketSize || 4})`);
+        break;
+
+      default:
+        ret.push(stringDictionaryEncoding.type);
+        break;
+    }
+  }
+
+  if (bitmap) {
+    ret.push(bitmap.type);
+  }
+
+  if (longEncoding) {
+    ret.push(longEncoding);
+  }
+
+  return ret.join('; ');
+}
+
+export const INDEX_SPEC_FIELDS: Field<IndexSpec>[] = [
+  {
+    name: 'stringDictionaryEncoding.type',
+    label: 'String dictionary encoding',
+    type: 'string',
+    defaultValue: 'utf8',
+    suggestions: ['utf8', 'frontCoded'],
+    info: (
+      <>
+        Encoding format for STRING value dictionaries used by STRING and COMPLEX&lt;json&gt;
+        columns.
+      </>
+    ),
+  },
+  {
+    name: 'stringDictionaryEncoding.bucketSize',
+    label: 'String dictionary encoding bucket size',
+    type: 'number',
+    defaultValue: 4,
+    min: 1,
+    max: 128,
+    defined: spec => deepGet(spec, 'stringDictionaryEncoding.type') === 'frontCoded',
+    info: (
+      <>
+        The number of values to place in a bucket to perform delta encoding. Must be a power of 2,
+        maximum is 128.
+      </>
+    ),
+  },
+
+  {
+    name: 'bitmap.type',
+    label: 'Bitmap type',
+    type: 'string',
+    defaultValue: 'roaring',
+    suggestions: ['roaring', 'concise'],
+    info: <>Compression format for bitmap indexes.</>,
+  },
+  {
+    name: 'bitmap.compressRunOnSerialization',
+    label: 'Bitmap compress run on serialization',
+    type: 'boolean',
+    defaultValue: true,
+    defined: spec => (deepGet(spec, 'bitmap.type') || 'roaring') === 'roaring',
+    info: (
+      <>
+        Controls whether or not run-length encoding will be used when it is determined to be more
+        space-efficient.
+      </>
+    ),
+  },
+
+  {
+    name: 'dimensionCompression',
+    type: 'string',
+    defaultValue: 'lz4',
+    suggestions: ['lz4', 'lzf', 'zstd', 'uncompressed'],
+    info: <>Compression format for dimension columns.</>,
+  },
+
+  {
+    name: 'longEncoding',
+    type: 'string',
+    defaultValue: 'longs',
+    suggestions: ['longs', 'auto'],
+    info: (
+      <>
+        Encoding format for long-typed columns. Applies regardless of whether they are dimensions or
+        metrics. <Code>auto</Code> encodes the values using offset or lookup table depending on
+        column cardinality, and store them with variable size. <Code>longs</Code> stores the value
+        as-is with 8 bytes each.
+      </>
+    ),
+  },
+  {
+    name: 'metricCompression',
+    type: 'string',
+    defaultValue: 'lz4',
+    suggestions: ['lz4', 'lzf', 'zstd', 'uncompressed'],
+    info: <>Compression format for primitive type metric columns.</>,
+  },
+
+  {
+    name: 'jsonCompression',
+    label: 'JSON compression',
+    type: 'string',
+    defaultValue: 'lz4',
+    suggestions: ['lz4', 'lzf', 'zstd', 'uncompressed'],
+    info: <>Compression format to use for nested column raw data. </>,
+  },
+];

--- a/web-console/src/druid-models/index.ts
+++ b/web-console/src/druid-models/index.ts
@@ -25,6 +25,7 @@ export * from './execution/execution';
 export * from './external-config/external-config';
 export * from './filter/filter';
 export * from './flatten-spec/flatten-spec';
+export * from './index-spec/index-spec';
 export * from './ingest-query-pattern/ingest-query-pattern';
 export * from './ingestion-spec/ingestion-spec';
 export * from './input-format/input-format';

--- a/web-console/src/druid-models/workbench-query/workbench-query-part.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query-part.ts
@@ -62,10 +62,10 @@ export class WorkbenchQueryPart {
   static getIngestDatasourceFromQueryFragment(queryFragment: string): string | undefined {
     // Assuming the queryFragment is no parsable find the prefix that look like:
     // REPLACE<space>INTO<space><whatever><space>SELECT<space or EOF>
-    const matchInsertReplaceIndex = queryFragment.match(/(?:INSERT|REPLACE)\s+INTO/)?.index;
+    const matchInsertReplaceIndex = queryFragment.match(/(?:INSERT|REPLACE)\s+INTO/i)?.index;
     if (typeof matchInsertReplaceIndex !== 'number') return;
 
-    const matchEnd = queryFragment.match(/\b(?:SELECT|WITH)\b|$/);
+    const matchEnd = queryFragment.match(/\b(?:SELECT|WITH)\b|$/i);
     const fragmentQuery = SqlQuery.maybeParse(
       queryFragment.substring(matchInsertReplaceIndex, matchEnd?.index) + ' SELECT * FROM t',
     );

--- a/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
@@ -465,7 +465,7 @@ describe('WorkbenchQuery', () => {
     it('works with INSERT (unparsable)', () => {
       const sql = sane`
         -- Some comment
-        INSERT INTO trips2
+        INSERT into trips2
         SELECT
           TIME_PARSE(pickup_datetime) AS __time,
           *

--- a/web-console/src/helpers/spec-conversion.spec.ts
+++ b/web-console/src/helpers/spec-conversion.spec.ts
@@ -106,6 +106,9 @@ describe('spec conversion', () => {
             partitionDimension: 'isRobot',
             targetRowsPerSegment: 150000,
           },
+          indexSpec: {
+            dimensionCompression: 'lzf',
+          },
           forceGuaranteedRollup: true,
           maxNumConcurrentSubTasks: 4,
           maxParseExceptions: 3,
@@ -159,6 +162,9 @@ describe('spec conversion', () => {
       maxParseExceptions: 3,
       finalizeAggregations: false,
       maxNumTasks: 5,
+      indexSpec: {
+        dimensionCompression: 'lzf',
+      },
     });
   });
 

--- a/web-console/src/helpers/spec-conversion.ts
+++ b/web-console/src/helpers/spec-conversion.ts
@@ -70,6 +70,11 @@ export function convertSpecToSql(spec: any): QueryWithContext {
     groupByEnableMultiValueUnnesting: false,
   };
 
+  const indexSpec = deepGet(spec, 'spec.tuningConfig.indexSpec');
+  if (indexSpec) {
+    context.indexSpec = indexSpec;
+  }
+
   const lines: string[] = [];
 
   const rollup = deepGet(spec, 'spec.dataSchema.granularitySpec.rollup') ?? true;


### PR DESCRIPTION
The index spec appears in many places. Make it into a custom dialog to improve the UX. Also expose it from SQL based ingestion.

<img width="556" alt="image" src="https://user-images.githubusercontent.com/177816/203623252-98e6b314-b57b-4d75-a319-4499d8fa27d5.png">

Accessed from:

<img width="405" alt="image" src="https://user-images.githubusercontent.com/177816/203623221-45c2cb23-f761-4a2d-b419-ea7772c3211f.png">
