### PR TITLE
Experimental features backport

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2188,7 +2188,7 @@ Supported query contexts:
 |Key|Description|Default|
 |---|-----------|-------|
 |`druid.expressions.useStrictBooleans`|Controls the behavior of Druid boolean operators and functions, if set to `true` all boolean values will be either a `1` or `0`. See [expression documentation](../misc/math-expr.md#logical-operator-modes)|false|
-|`druid.expressions.allowNestedArrays`|If enabled, Druid array expressions can create nested arrays. This is experimental and should be used with caution.|false|
+|`druid.expressions.allowNestedArrays`|If enabled, Druid array expressions can create nested arrays.|false|
 ### Router
 
 #### Router Process Configs

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1375,7 +1375,7 @@ For GCE's properties, please refer to the [gce-extensions](../development/extens
 
 This section contains the configuration options for the processes that reside on Data servers (MiddleManagers/Peons and Historicals) in the suggested [three-server configuration](../design/processes.md#server-types).
 
-Configuration options for the experimental [Indexer process](../design/indexer.md) are also provided here.
+Configuration options for the [Indexer process](../design/indexer.md) are also provided here.
 
 ### MiddleManager and Peons
 

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -39,7 +39,6 @@ This document includes each page that mentions an experimental feature. To gradu
 ## Indexer process
 
 - [Indexer process](../design/indexer.md)
-- [Configuration reference](../configuration/index.md#overlord-operations)
 - [Processes and servers](../design/processes.md#indexer-process-optional)
 
 ## Kubernetes
@@ -51,10 +50,6 @@ This document includes each page that mentions an experimental feature. To gradu
 - [Configuration reference](../configuration/index.md#overlord-operations)
 - [Task reference](../ingestion/tasks.md#locking)
 - [Design](../design/architecture.md#availability-and-consistency)
-
-## Materialized view
-
-- [Materialized view](../development/extensions-contrib/materialized-view.md)
 
 ## Moments sketch
 

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -1,0 +1,109 @@
+---
+id: experimental-features
+title: "Experimental features"
+---
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+The following features are marked [experimental](./experimental.md) in the Druid docs.
+
+This document includes each page that mentions an experimental feature. To graduate a feature, remove all mentions of its experimental status on all relevant pages.
+
+## SQL-based ingestion
+
+[SQL-based ingestion](../multi-stage-query/index.md)
+
+- As an experimental feature, the task engine also supports running SELECT queries as batch tasks.
+
+[SQL-based ingestion concepts](../multi-stage-query/concepts.md)
+
+- As an experimental feature, the MSQ task engine also supports running SELECT queries as batch tasks. The behavior and result format of plain SELECT (without INSERT or REPLACE) is subject to change.
+
+[SQL-based ingestion and multi-stage query task API](../multi-stage-query/api.md)
+
+- As an experimental feature, the `/druid/v2/sql/task/` endpoint also accepts SELECT queries.
+- As an experimental feature, the MSQ task engine supports running SELECT queries.
+
+## Nested columns
+
+[Nested columns](../querying/nested-columns.md)
+
+- Nested columns is an experimental feature available starting in Apache Druid 24.0.
+
+## Indexer process
+
+[Indexer process](../design/indexer.md)
+
+- The Indexer is an optional and experimental feature. Its memory management system is still under development and will be significantly enhanced in later releases.
+
+[Configuration reference](../configuration/index.md)
+
+- Data Server: Configuration options for the experimental Indexer process are also provided here.
+
+[Processes and servers](../design/processes.md)
+
+- Indexer process (optional): The Indexer is designed to be easier to configure and deploy compared to the MiddleManager + Peon system and to better enable resource sharing across tasks. The Indexer is a newer feature and is currently designated experimental due to the fact that its memory management system is still under development. It will continue to mature in future versions of Druid.
+
+## Kubernetes
+
+[Kubernetes](../development/extensions-core/kubernetes.md)
+
+- Consider this an EXPERIMENTAL feature mostly because it has not been tested yet on a wide variety of long running Druid clusters.
+
+## Segment locking
+
+[Configuration reference](../configuration/index.md)
+
+- Overlord operations property `druid.indexer.tasklock.forceTimeChunkLock`
+   <br>Setting this to false is still experimental. If set, all tasks are enforced to use time chunk lock. If not set, each task automatically chooses a lock type to use. This configuration can be overwritten by setting `forceTimeChunkLock` in the task context.
+
+[Task reference](../ingestion/tasks.md)
+
+- Locking: The segment locking is still experimental. It could have unknown bugs which potentially lead to incorrect query results.
+- Context parameter `forceTimeChunkLock`: Setting this to false is still experimental.
+
+[Design](../design/architecture.md)
+
+- Druid also supports an experimental segment locking mode that is activated by setting `forceTimeChunkLock` to false in the context of an ingestion task.
+
+## Materialized view
+
+[Materialized view](../development/extensions-contrib/materialized-view.md)
+
+- Note that Materialized View is currently designated as experimental. Please make sure the time of all processes are the same and increase monotonically. Otherwise, some unexpected errors may happen on query results.
+
+## Moments sketch
+
+[Aggregations](../querying/aggregations.md)
+
+- Moments Sketch (Experimental): The Moments Sketch extension-provided aggregator is an experimental aggregator that provides quantile estimates using the Moments Sketch. 
+- The Moments Sketch aggregator is provided as an experimental option. It is optimized for merging speed and it can have higher aggregation performance compared to the DataSketches quantiles aggregator. However, the accuracy of the Moments Sketch is distribution-dependent, so users will need to empirically verify that the aggregator is suitable for their input data.
+- As a general guideline for experimentation, the Moments Sketch paper points out that this algorithm works better on inputs with high entropy. In particular, the algorithm is not a good fit when the input data consists of a small number of clustered discrete values.
+
+## Other configuration properties
+
+[Configuration reference](../configuration/index.md)
+
+- Task runner `httpRemote`
+   <br>Overlord operations property `druid.indexer.runner.type`: Choices "local" or "remote". Indicates whether tasks should be run locally or in a distributed environment. Experimental task runner "httpRemote" is also available which is same as "remote" but uses HTTP to interact with Middle Managers instead of Zookeeper.<br><br>
+- `CLOSED_SEGMENTS_SINKS` mode
+   <br>Peon config `druid.indexer.task.batchProcessingMode`: `CLOSED_SEGMENTS_SINKS` mode isn't as well tested as other modes so is currently considered experimental.<br><br>
+- Expression processing configuration `druid.expressions.allowNestedArrays`
+   <br>If enabled, Druid array expressions can create nested arrays. This is experimental and should be used with caution.

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -28,82 +28,41 @@ This document includes each page that mentions an experimental feature. To gradu
 
 ## SQL-based ingestion
 
-[SQL-based ingestion](../multi-stage-query/index.md)
-
-- As an experimental feature, the task engine also supports running SELECT queries as batch tasks.
-
-[SQL-based ingestion concepts](../multi-stage-query/concepts.md)
-
-- As an experimental feature, the MSQ task engine also supports running SELECT queries as batch tasks. The behavior and result format of plain SELECT (without INSERT or REPLACE) is subject to change.
-
-[SQL-based ingestion and multi-stage query task API](../multi-stage-query/api.md)
-
-- As an experimental feature, the `/druid/v2/sql/task/` endpoint also accepts SELECT queries.
-- As an experimental feature, the MSQ task engine supports running SELECT queries.
+- [SQL-based ingestion](../multi-stage-query/index.md)
+- [SQL-based ingestion concepts](../multi-stage-query/concepts.md)
+- [SQL-based ingestion and multi-stage query task API](../multi-stage-query/api.md)
 
 ## Nested columns
 
-[Nested columns](../querying/nested-columns.md)
-
-- Nested columns is an experimental feature available starting in Apache Druid 24.0.
+- [Nested columns](../querying/nested-columns.md)
 
 ## Indexer process
 
-[Indexer process](../design/indexer.md)
-
-- The Indexer is an optional and experimental feature. Its memory management system is still under development and will be significantly enhanced in later releases.
-
-[Configuration reference](../configuration/index.md)
-
-- Data Server: Configuration options for the experimental Indexer process are also provided here.
-
-[Processes and servers](../design/processes.md)
-
-- Indexer process (optional): The Indexer is designed to be easier to configure and deploy compared to the MiddleManager + Peon system and to better enable resource sharing across tasks. The Indexer is a newer feature and is currently designated experimental due to the fact that its memory management system is still under development. It will continue to mature in future versions of Druid.
+- [Indexer process](../design/indexer.md)
+- [Configuration reference](../configuration/index.md)
+- [Processes and servers](../design/processes.md)
 
 ## Kubernetes
 
-[Kubernetes](../development/extensions-core/kubernetes.md)
-
-- Consider this an EXPERIMENTAL feature mostly because it has not been tested yet on a wide variety of long running Druid clusters.
+- [Kubernetes](../development/extensions-core/kubernetes.md)
 
 ## Segment locking
 
-[Configuration reference](../configuration/index.md)
-
-- Overlord operations property `druid.indexer.tasklock.forceTimeChunkLock`
-   <br>Setting this to false is still experimental. If set, all tasks are enforced to use time chunk lock. If not set, each task automatically chooses a lock type to use. This configuration can be overwritten by setting `forceTimeChunkLock` in the task context.
-
-[Task reference](../ingestion/tasks.md)
-
-- Locking: The segment locking is still experimental. It could have unknown bugs which potentially lead to incorrect query results.
-- Context parameter `forceTimeChunkLock`: Setting this to false is still experimental.
-
-[Design](../design/architecture.md)
-
-- Druid also supports an experimental segment locking mode that is activated by setting `forceTimeChunkLock` to false in the context of an ingestion task.
+- [Configuration reference](../configuration/index.md)
+- [Task reference](../ingestion/tasks.md)
+- [Design](../design/architecture.md)
 
 ## Materialized view
 
-[Materialized view](../development/extensions-contrib/materialized-view.md)
-
-- Note that Materialized View is currently designated as experimental. Please make sure the time of all processes are the same and increase monotonically. Otherwise, some unexpected errors may happen on query results.
+- [Materialized view](../development/extensions-contrib/materialized-view.md)
 
 ## Moments sketch
 
-[Aggregations](../querying/aggregations.md)
-
-- Moments Sketch (Experimental): The Moments Sketch extension-provided aggregator is an experimental aggregator that provides quantile estimates using the Moments Sketch. 
-- The Moments Sketch aggregator is provided as an experimental option. It is optimized for merging speed and it can have higher aggregation performance compared to the DataSketches quantiles aggregator. However, the accuracy of the Moments Sketch is distribution-dependent, so users will need to empirically verify that the aggregator is suitable for their input data.
-- As a general guideline for experimentation, the Moments Sketch paper points out that this algorithm works better on inputs with high entropy. In particular, the algorithm is not a good fit when the input data consists of a small number of clustered discrete values.
+- [Aggregations](../querying/aggregations.md)
 
 ## Other configuration properties
 
-[Configuration reference](../configuration/index.md)
-
-- Task runner `httpRemote`
-   <br>Overlord operations property `druid.indexer.runner.type`: Choices "local" or "remote". Indicates whether tasks should be run locally or in a distributed environment. Experimental task runner "httpRemote" is also available which is same as "remote" but uses HTTP to interact with Middle Managers instead of Zookeeper.<br><br>
-- `CLOSED_SEGMENTS_SINKS` mode
-   <br>Peon config `druid.indexer.task.batchProcessingMode`: `CLOSED_SEGMENTS_SINKS` mode isn't as well tested as other modes so is currently considered experimental.<br><br>
-- Expression processing configuration `druid.expressions.allowNestedArrays`
-   <br>If enabled, Druid array expressions can create nested arrays. This is experimental and should be used with caution.
+- [Configuration reference](../configuration/index.md)
+   - Experimental task runner `httpRemote`
+   - `CLOSED_SEGMENTS_SINKS` mode
+   - Expression processing configuration `druid.expressions.allowNestedArrays`

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -39,8 +39,8 @@ This document includes each page that mentions an experimental feature. To gradu
 ## Indexer process
 
 - [Indexer process](../design/indexer.md)
-- [Configuration reference](../configuration/index.md)
-- [Processes and servers](../design/processes.md)
+- [Configuration reference](../configuration/index.md#overlord-operations)
+- [Processes and servers](../design/processes.md#indexer-process-optional)
 
 ## Kubernetes
 
@@ -48,9 +48,9 @@ This document includes each page that mentions an experimental feature. To gradu
 
 ## Segment locking
 
-- [Configuration reference](../configuration/index.md)
-- [Task reference](../ingestion/tasks.md)
-- [Design](../design/architecture.md)
+- [Configuration reference](../configuration/index.md#overlord-operations)
+- [Task reference](../ingestion/tasks.md#locking)
+- [Design](../design/architecture.md#availability-and-consistency)
 
 ## Materialized view
 
@@ -58,7 +58,7 @@ This document includes each page that mentions an experimental feature. To gradu
 
 ## Moments sketch
 
-- [Aggregations](../querying/aggregations.md)
+- [Aggregations](../querying/aggregations.md#moments-sketch-experimental)
 
 ## Front coding
 
@@ -67,6 +67,5 @@ This document includes each page that mentions an experimental feature. To gradu
 ## Other configuration properties
 
 - [Configuration reference](../configuration/index.md)
-   - Experimental task runner `httpRemote`
    - `CLOSED_SEGMENTS_SINKS` mode
    - Expression processing configuration `druid.expressions.allowNestedArrays`

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -26,6 +26,8 @@ The following features are marked [experimental](./experimental.md) in the Druid
 
 This document includes each page that mentions an experimental feature. To graduate a feature, remove all mentions of its experimental status on all relevant pages.
 
+Note that this document does not track the status of contrib extensions, some of which are experimental.
+
 ## SQL-based ingestion
 
 - [SQL-based ingestion](../multi-stage-query/index.md)

--- a/docs/development/experimental-features.md
+++ b/docs/development/experimental-features.md
@@ -60,6 +60,10 @@ This document includes each page that mentions an experimental feature. To gradu
 
 - [Aggregations](../querying/aggregations.md)
 
+## Front coding
+
+- [Ingestion spec reference](../ingestion/ingestion-spec.md#front-coding)
+
 ## Other configuration properties
 
 - [Configuration reference](../configuration/index.md)

--- a/docs/development/extensions-contrib/materialized-view.md
+++ b/docs/development/extensions-contrib/materialized-view.md
@@ -132,5 +132,3 @@ There are 2 parts in a view query:
 |--------|-----------|---------|
 |queryType	|The query type. This should always be view	|yes|
 |query	|The real query of this `view` query. The real query must be [groupBy](../../querying/groupbyquery.md), [topN](../../querying/topnquery.md), or [timeseries](../../querying/timeseriesquery.md) type.|yes|
-
-**Note that Materialized View is currently designated as experimental. Please make sure the time of all processes are the same and increase monotonically. Otherwise, some unexpected errors may happen on query results.**

--- a/docs/development/extensions-contrib/materialized-view.md
+++ b/docs/development/extensions-contrib/materialized-view.md
@@ -132,3 +132,5 @@ There are 2 parts in a view query:
 |--------|-----------|---------|
 |queryType	|The query type. This should always be view	|yes|
 |query	|The real query of this `view` query. The real query must be [groupBy](../../querying/groupbyquery.md), [topN](../../querying/topnquery.md), or [timeseries](../../querying/timeseriesquery.md) type.|yes|
+
+**Note that Materialized View is currently designated as experimental. Please make sure the time of all processes are the same and increase monotonically. Otherwise, some unexpected errors may happen on query results.**

--- a/docs/development/extensions-core/druid-lookups.md
+++ b/docs/development/extensions-core/druid-lookups.md
@@ -22,9 +22,6 @@ title: "Cached Lookup Module"
   ~ under the License.
   -->
 
-
-> Please note that this is an experimental module and the development/testing still at early stage. Feel free to try it and give us your feedback.
-
 ## Description
 This Apache Druid module provides a per-lookup caching mechanism for JDBC data sources.
 The main goal of this cache is to speed up the access to a high latency lookup sources and to provide a caching isolation for every lookup source.

--- a/docs/development/extensions-core/kafka-supervisor-reference.md
+++ b/docs/development/extensions-core/kafka-supervisor-reference.md
@@ -56,8 +56,6 @@ This topic contains configuration reference information for the Apache Kafka sup
 
 ## Task Autoscaler Properties
 
-> Note that Task AutoScaler is currently designated as experimental.
-
 | Property | Description | Required |
 | ------------- | ------------- | ------------- |
 | `enableTaskAutoScaler` | Enable or disable autoscaling. `false` or blank disables the `autoScaler` even when `autoScalerConfig` is not null| no (default == false) |

--- a/docs/development/extensions-core/kinesis-ingestion.md
+++ b/docs/development/extensions-core/kinesis-ingestion.md
@@ -149,8 +149,6 @@ Where the file `supervisor-spec.json` contains a Kinesis supervisor spec:
 
 #### Task Autoscaler Properties
 
-> Note that Task AutoScaler is currently designated as experimental.
-
 | Property | Description | Required |
 | ------------- | ------------- | ------------- |
 | `enableTaskAutoScaler` | Enable or disable the auto scaler. When false or absent, Druid disables the `autoScaler` even when `autoScalerConfig` is not null.| no (default == false) |

--- a/docs/querying/lookups.md
+++ b/docs/querying/lookups.md
@@ -115,8 +115,8 @@ will not detect this automatically.
 
 Dynamic Configuration
 ---------------------
-> Dynamic lookup configuration is an [experimental](../development/experimental.md) feature. Static
-> configuration is no longer supported.
+> Static configuration is no longer supported.
+
 The following documents the behavior of the cluster-wide config which is accessible through the Coordinator.
 The configuration is propagated through the concept of "tier" of servers.
 A "tier" is defined as a group of services which should receive a set of lookups.


### PR DESCRIPTION
Backport https://github.com/apache/druid/pull/13348 to 25.0.0 release branch.

This PR has:
- [x] been self-reviewed.
