### PR TITLE
fix flaky test org.apache.druid.math.expr.ParserTest#testApplyFunctio…

### DIFF
--- a/core/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/core/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -676,7 +677,7 @@ public interface Expr extends Cacheable
         java.util.function.Function<IdentifierExpr, String> mapper
     )
     {
-      Set<String> results = Sets.newHashSetWithExpectedSize(variables.size());
+      LinkedHashSet<String> results = Sets.newLinkedHashSetWithExpectedSize(variables.size());
       for (IdentifierExpr variable : variables) {
         results.add(mapper.apply(variable));
       }

--- a/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/core/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -555,7 +555,7 @@ public class ParserTest extends InitializedNullHandlingTest
     validateParser(
         "map((x) -> concat(x, y), z)",
         "(map ([x] -> (concat [x, y])), [z])",
-        ImmutableList.of("y", "z"),
+        ImmutableList.of("z", "y"),
         ImmutableSet.of("y"),
         ImmutableSet.of("z")
     );
@@ -578,14 +578,14 @@ public class ParserTest extends InitializedNullHandlingTest
     validateParser(
         "array_append(z, fold((x, acc) -> acc + x, map((x) -> x + 1, x), y))",
         "(array_append [z, (fold ([x, acc] -> (+ acc x)), [(map ([x] -> (+ x 1)), [x]), y])])",
-        ImmutableList.of("x", "y", "z"),
+        ImmutableList.of("z", "x", "y"),
         ImmutableSet.of(),
         ImmutableSet.of("x", "z")
     );
     validateParser(
         "map(z -> z + 1, array_append(z, fold((x, acc) -> acc + x, map((x) -> x + 1, x), y)))",
         "(map ([z] -> (+ z 1)), [(array_append [z, (fold ([x, acc] -> (+ acc x)), [(map ([x] -> (+ x 1)), [x]), y])])])",
-        ImmutableList.of("x", "y", "z"),
+        ImmutableList.of("z", "x", "y"),
         ImmutableSet.of(),
         ImmutableSet.of("x", "z")
     );
@@ -593,7 +593,7 @@ public class ParserTest extends InitializedNullHandlingTest
     validateParser(
         "array_append(map(z -> z + 1, array_append(z, fold((x, acc) -> acc + x, map((x) -> x + 1, x), y))), a)",
         "(array_append [(map ([z] -> (+ z 1)), [(array_append [z, (fold ([x, acc] -> (+ acc x)), [(map ([x] -> (+ x 1)), [x]), y])])]), a])",
-        ImmutableList.of("x", "y", "a", "z"),
+        ImmutableList.of("z", "x", "y", "a"),
         ImmutableSet.of("a"),
         ImmutableSet.of("x", "z")
     );


### PR DESCRIPTION

Fixes #13470.

### Description
Fix the flaky test mentioned in #13470 by replacing `HashSet` with `LinkedHashSet` in `Expr.map()`.
### Changes to fix the flaky test
1. Convert the HashSet into LinkedHashSet
2. Change the expected value into the deterministic order

### Result
Re-run these commands and it should pass now:
```
MODULE=core
TEST=org.apache.druid.math.expr.ParserTest#testApplyFunctions  
mvn install -pl $MODULE -am -DskipTests 
mvn -pl $MODULE edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=$TEST
```

Result:
```
[INFO] NonDex SUMMARY:
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/core/.nondex" -DnondexJarDir="/home/yiteng3/druid/core/.nondex" -DnondexExecid=V0S2aNJMV7Af2A8+Be1QmzoUNsMgpuDZ3IQbfiuBZbk= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=974622 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/core/.nondex" -DnondexJarDir="/home/yiteng3/druid/core/.nondex" -DnondexExecid=BRUAYRxHlbLxOPTn2BHrfmnneeNYCm9MlfK4BhV5GB4= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=1016066 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/core/.nondex" -DnondexJarDir="/home/yiteng3/druid/core/.nondex" -DnondexExecid=SUrm6oMmflgc4QfTKnVBP92yUnUqb3+947WZRegSxo= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] Across all seeds:
[INFO] Test results can be found at: 
[INFO] file:///home/yiteng3/druid/core/.nondex/V0S2aNJMV7Af2A8+Be1QmzoUNsMgpuDZ3IQbfiuBZbk=/test_results.html
[INFO] [NonDex] The id of this run is: V0S2aNJMV7Af2A8+Be1QmzoUNsMgpuDZ3IQbfiuBZbk=
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  35.726 s
[INFO] Finished at: 2022-12-01T00:36:29-06:00
[INFO] ------------------------------------------------------------------------
```

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
