### PR TITLE
fix flaky tests org.apache.druid.storage.aliyun.OssDataSegmentPusherC…

### DIFF
--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherConfigTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherConfigTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.aliyun;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.junit.Assert;
@@ -28,7 +29,7 @@ import java.io.IOException;
 
 public class OssDataSegmentPusherConfigTest
 {
-  private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
+  private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
 
   @Test
   public void testSerialization() throws IOException


### PR DESCRIPTION

Fixes #13472.
### Description
Fix the flaky test mentioned in https://github.com/apache/druid/issues/13472 by adding configuration to `ObjectMapper`.
### Changes to fix the flaky test
1. using `.configure(MapperFeature, boolean)` and `Mapper..SORT_PROPERTIES_ALPHABETICALLY` to configure the `DefaultObjectMapper` in `OssDataSegmentPusherConfigTest`.

### Result
Re-run these commands and they should pass now:
```
MODULE=extensions-contrib/aliyun-oss-extensions
TEST=org.apache.druid.storage.aliyun.OssDataSegmentPusherConfigTest
mvn install -pl $MODULE -am -DskipTests 
mvn -pl $MODULE edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=$TEST
```
Result:
```
[INFO] NonDex SUMMARY:
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexJarDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexExecid=BLiWHmCEV0wCX9Nbm9fVhFWHVGeGEvXq48tk7DKtQl8= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=974622 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexJarDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexExecid=7cokrWwa1Yj4qFDxGsdTT8upuuax9yIwGs+FP9aOb1I= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=1016066 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexJarDir="/home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex" -DnondexExecid=P1YIh9Gu9p7fcm6bzb0j8hL2hWdLfG1jHYgSboqcJU0= -DnondexLogging=CONFIG
[INFO] No Test Failed with this configuration.
[INFO] *********
[INFO] Across all seeds:
[INFO] Test results can be found at: 
[INFO] file:///home/yiteng3/druid/extensions-contrib/aliyun-oss-extensions/.nondex/BLiWHmCEV0wCX9Nbm9fVhFWHVGeGEvXq48tk7DKtQl8=/test_results.html
[INFO] [NonDex] The id of this run is: BLiWHmCEV0wCX9Nbm9fVhFWHVGeGEvXq48tk7DKtQl8=
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.552 s
[INFO] Finished at: 2022-12-01T01:40:24-06:00
[INFO] ------------------------------------------------------------------------
```
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
