### PR TITLE
First cut sql unnest

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
@@ -181,7 +181,10 @@ public class UnnestDimensionCursor implements Cursor
           @Override
           public Object getObject()
           {
-            if (indexedIntsForCurrentRow == null) {
+            if (dimSelector.getObject() == null) {
+              return null;
+            }
+            if (indexedIntsForCurrentRow.size() == 0) {
               return null;
             }
             if (allowedBitSet.isEmpty()) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -79,6 +79,7 @@ import org.apache.druid.sql.calcite.rule.DruidLogicalValuesRule;
 import org.apache.druid.sql.calcite.rule.DruidRelToDruidRule;
 import org.apache.druid.sql.calcite.rule.DruidRules;
 import org.apache.druid.sql.calcite.rule.DruidTableScanRule;
+import org.apache.druid.sql.calcite.rule.DruidUnnestRule;
 import org.apache.druid.sql.calcite.rule.ExtensionCalciteRuleProvider;
 import org.apache.druid.sql.calcite.rule.FilterJoinExcludePushToChildRule;
 import org.apache.druid.sql.calcite.rule.ProjectAggregatePruneUnusedCallRule;
@@ -253,6 +254,7 @@ public class CalciteRulesManager
         .add(DruidRelToDruidRule.instance())
         .add(new DruidTableScanRule(plannerContext))
         .add(new DruidLogicalValuesRule(plannerContext))
+        .add(new DruidUnnestRule(plannerContext))
         .add(new ExternalTableScanRule(plannerContext))
         .addAll(DruidRules.rules(plannerContext));
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -41,6 +41,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.JoinDataSource;
 import org.apache.druid.query.QueryDataSource;
@@ -286,6 +287,12 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     retVal.addAll(((DruidRel<?>) left).getDataSourceNames());
     retVal.addAll(((DruidRel<?>) right).getDataSourceNames());
     return retVal;
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    throw new UOE("Not supported yet.");
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
@@ -32,6 +32,8 @@ import org.apache.calcite.rel.RelWriter;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.QueryDataSource;
 import org.apache.druid.segment.column.RowSignature;
@@ -171,6 +173,12 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
   public Set<String> getDataSourceNames()
   {
     return ((DruidRel<?>) sourceRel).getDataSourceNames();
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    throw new UOE("Not supported yet.");
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
@@ -32,6 +32,7 @@ import org.apache.calcite.rel.logical.LogicalTableScan;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.sql.calcite.external.ExternalTableScan;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.table.DruidTable;
@@ -157,6 +158,12 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
   public Set<String> getDataSourceNames()
   {
     return druidTable.getDataSource().getTableNames();
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    return druidTable.getDataSource();
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidRel.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite.rel;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.server.QueryResponse;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
@@ -101,4 +102,6 @@ public abstract class DruidRel<T extends DruidRel<?>> extends AbstractRelNode
    * Get the set of names of table datasources read by this DruidRel
    */
   public abstract Set<String> getDataSourceNames();
+
+  public abstract DataSource getDataSourceFromRel();
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionDataSourceRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionDataSourceRel.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.UnionDataSource;
@@ -239,6 +240,12 @@ public class DruidUnionDataSourceRel extends DruidRel<DruidUnionDataSourceRel>
     }
 
     return retVal;
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    throw new UOE("Not supported yet.");
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionRel.java
@@ -33,8 +33,10 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.query.UnionDataSource;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.server.QueryResponse;
@@ -216,6 +218,12 @@ public class DruidUnionRel extends DruidRel<DruidUnionRel>
     return rels.stream()
                .flatMap(rel -> ((DruidRel<?>) rel).getDataSourceNames().stream())
                .collect(Collectors.toSet());
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    throw new UOE("Not supported yet.");
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnnestRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnnestRel.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rel;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.JoinDataSource;
+import org.apache.druid.query.TableDataSource;
+import org.apache.druid.query.UnnestDataSource;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.table.RowSignatures;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * DruidRel that uses a {@link JoinDataSource}.
+ */
+public class DruidUnnestRel extends DruidRel<DruidUnnestRel>
+{
+  private static final TableDataSource DUMMY_DATA_SOURCE = new TableDataSource("__unnest__");
+  private final PartialDruidQuery partialQuery;
+  private final PlannerConfig plannerConfig;
+  private final LogicalCorrelate logicalCorrelate;
+  private final DataSource baseDataSource;
+  private final String dimensionToUnnest;
+  private UnnestDataSource unnestDataSource;
+
+  public DruidUnnestRel(
+      RelOptCluster cluster,
+      RelTraitSet traitSet,
+      LogicalCorrelate logicalCorrelateRel,
+      PartialDruidQuery partialQuery,
+      DataSource dataSource,
+      String dimensionToUnnest,
+      PlannerContext plannerContext
+  )
+  {
+    super(cluster, traitSet, plannerContext);
+    this.logicalCorrelate = logicalCorrelateRel;
+    this.partialQuery = partialQuery;
+    this.plannerConfig = plannerContext.getPlannerConfig();
+    this.baseDataSource = dataSource;
+    this.dimensionToUnnest = dimensionToUnnest;
+  }
+
+  @Nullable
+  @Override
+  public PartialDruidQuery getPartialDruidQuery()
+  {
+    return partialQuery;
+  }
+
+  @Override
+  public DruidUnnestRel withPartialQuery(PartialDruidQuery newQueryBuilder)
+  {
+    return new DruidUnnestRel(
+        getCluster(),
+        getTraitSet().plusAll(newQueryBuilder.getRelTraits()),
+        logicalCorrelate,
+        newQueryBuilder,
+        baseDataSource,
+        dimensionToUnnest,
+        getPlannerContext()
+    );
+  }
+
+  @Override
+  public DruidQuery toDruidQuery(boolean finalizeAggregations)
+  {
+    this.unnestDataSource =
+        UnnestDataSource.create(
+            baseDataSource,
+            dimensionToUnnest,
+            // check how this would come from the as alias
+            dimensionToUnnest,
+            null
+        );
+
+
+    return partialQuery.build(
+        unnestDataSource,
+        RowSignatures.fromRelDataType(
+            logicalCorrelate.getRowType().getFieldNames(),
+            logicalCorrelate.getRowType()
+        ),
+        getPlannerContext(),
+        getCluster().getRexBuilder(),
+        finalizeAggregations
+    );
+  }
+
+  @Override
+  protected RelDataType deriveRowType()
+  {
+    return partialQuery.getRowType();
+  }
+
+  @Override
+  public DruidQuery toDruidQueryForExplaining()
+  {
+    return partialQuery.build(
+        DUMMY_DATA_SOURCE,
+        RowSignatures.fromRelDataType(
+            logicalCorrelate.getRowType().getFieldNames(),
+            logicalCorrelate.getRowType()
+        ),
+        getPlannerContext(),
+        getCluster().getRexBuilder(),
+        false
+    );
+  }
+
+  @Override
+  public DruidUnnestRel asDruidConvention()
+  {
+    return new DruidUnnestRel(
+        getCluster(),
+        getTraitSet().replace(DruidConvention.instance()),
+        (LogicalCorrelate) logicalCorrelate.copy(
+            logicalCorrelate.getTraitSet(),
+            logicalCorrelate.getInputs()
+                            .stream()
+                            .map(input -> RelOptRule.convert(input, DruidConvention.instance()))
+                            .collect(Collectors.toList())
+        ),
+        partialQuery,
+        baseDataSource,
+        dimensionToUnnest,
+        getPlannerContext()
+    );
+  }
+
+
+  @Override
+  public Set<String> getDataSourceNames()
+  {
+    return baseDataSource.getTableNames();
+  }
+
+  @Override
+  public DataSource getDataSourceFromRel()
+  {
+    return UnnestDataSource.create(
+        baseDataSource,
+        dimensionToUnnest,
+        //check how this would come from  "as alias"
+        dimensionToUnnest,
+        null
+    );
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnnestRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidUnnestRule.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Uncollect;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalValues;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexFieldAccess;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.rel.DruidRel;
+import org.apache.druid.sql.calcite.rel.DruidUnnestRel;
+import org.apache.druid.sql.calcite.rel.PartialDruidQuery;
+
+public class DruidUnnestRule extends RelOptRule
+{
+  private final PlannerContext plannerContext;
+
+  public DruidUnnestRule(final PlannerContext plannerContext)
+  {
+    /*
+                      LogicalCorrelate
+                     /      \
+              DruidRel      Uncollect
+                              \
+                            LogicalProject
+                                \
+                              LogicalValues
+    */
+    super(
+        operand(
+            LogicalCorrelate.class,
+            operand(DruidRel.class, any()),
+            operand(Uncollect.class, operand(LogicalProject.class, operand(LogicalValues.class, any())))
+        )
+    );
+
+    this.plannerContext = plannerContext;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call)
+  {
+    LogicalCorrelate logicalCorrelate = call.rel(0);
+    DruidRel druidRel = call.rel(1);
+
+    LogicalProject logicalProject = call.rel(3);
+
+    RexCall rx = (RexCall) logicalProject.getChildExps().get(0);
+    RexFieldAccess rf = (RexFieldAccess) rx.getOperands().get(0);
+    String dimensionToUnnest = rf.getField().getName();
+
+    DataSource base = druidRel.getDataSourceFromRel();
+
+
+    //create an UnnestRel here and transform using that rel
+    DruidUnnestRel druidUnnestRel = new DruidUnnestRel(
+        logicalCorrelate.getCluster(),
+        logicalCorrelate.getTraitSet(),
+        logicalCorrelate,
+        PartialDruidQuery.create(logicalCorrelate),
+        base,
+        dimensionToUnnest,
+        plannerContext
+    );
+
+    // build this based on the druidUnnestRel
+    final RelBuilder relBuilder =
+        call.builder()
+            .push(druidUnnestRel);
+
+    call.transformTo(relBuilder.build());
+  }
+}


### PR DESCRIPTION
Draft PR for SQL version of unnest

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
