### PR TITLE
Fix license checks failure in static-checks GHA

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -56,28 +56,6 @@ jobs:
           java-version: ${{ env.java_version }}
           cache: 'maven'
 
-      - name: license checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ./.github/scripts/license_checks_script.sh
-
-      - name: license checks for hadoop3
-        if: ${{ matrix.java == 'jdk8' }}
-        env:
-          HADOOP_PROFILE: -Phadoop3
-        run: ./.github/scripts/license_checks_script.sh
-
-      - name: analyze dependencies
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          ./.github/scripts/analyze_dependencies_script.sh
-
-      - name: analyze dependencies for hadoop3
-        if: ${{ matrix.java == 'jdk8' }}
-        env:
-          HADOOP_PROFILE: -Phadoop3
-        run: |
-          ./.github/scripts/analyze_dependencies_script.sh
-
       - name: packaging check
         run: |
           ./.github/scripts/setup_generate_license.sh
@@ -101,6 +79,28 @@ jobs:
           echo 'Running Maven install...' &&
           ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
           ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+
+      - name: license checks
+        if: ${{ matrix.java == 'jdk8' }}
+        run: ./.github/scripts/license_checks_script.sh
+
+      - name: license checks for hadoop3
+        if: ${{ matrix.java == 'jdk8' }}
+        env:
+          HADOOP_PROFILE: -Phadoop3
+        run: ./.github/scripts/license_checks_script.sh
+
+      - name: analyze dependencies
+        if: ${{ matrix.java == 'jdk8' }}
+        run: |
+          ./.github/scripts/analyze_dependencies_script.sh
+
+      - name: analyze dependencies for hadoop3
+        if: ${{ matrix.java == 'jdk8' }}
+        env:
+          HADOOP_PROFILE: -Phadoop3
+        run: |
+          ./.github/scripts/analyze_dependencies_script.sh
 
       - name: animal sniffer checks
         if: ${{ matrix.java == 'jdk8' }}


### PR DESCRIPTION
### Description

license checks step in static-checks GHA is failing due to maven artifact transfer error. This PR updates static-checks to perform maven clean install before license, analyze dependencies checks.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
