### PR TITLE
Better error message when theta_sketch_intersect is used on scalar expression

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSetBaseOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSetBaseOperatorConversion.java
@@ -64,7 +64,7 @@ public abstract class ThetaSketchSetBaseOperatorConversion implements SqlOperato
   )
   {
     plannerContext.setPlanningError("%s can only be used on aggregates. " +
-        "It cannot be used directly on a column or or on a scalar expression.", getFunctionName());
+        "It cannot be used directly on a column or on a scalar expression.", getFunctionName());
     return null;
   }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSetBaseOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSetBaseOperatorConversion.java
@@ -63,6 +63,8 @@ public abstract class ThetaSketchSetBaseOperatorConversion implements SqlOperato
       RexNode rexNode
   )
   {
+    plannerContext.setPlanningError("%s can only be used on aggregates. " +
+        "It cannot be used directly on a column or or on a scalar expression.", getFunctionName());
     return null;
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -1020,6 +1020,6 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
   {
     assertQueryIsUnplannable("SELECT THETA_SKETCH_INTERSECT(NULL, NULL) FROM foo",
         "Possible error: THETA_SKETCH_INTERSECT can only be used on aggregates. " +
-            "It cannot be used directly on a column or or on a scalar expression.");
+            "It cannot be used directly on a column or on a scalar expression.");
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -1014,4 +1014,12 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
         ImmutableList.of(new Object[]{"a", 0L, 0L, "0.0", "0.0"})
     );
   }
+
+  @Test
+  public void testThetaSketchIntersectOnScalarExpression()
+  {
+    assertQueryIsUnplannable("SELECT THETA_SKETCH_INTERSECT(NULL, NULL) FROM foo",
+        "Possible error: THETA_SKETCH_INTERSECT can only be used on aggregates. " +
+            "It cannot be used directly on a column or or on a scalar expression.");
+  }
 }


### PR DESCRIPTION

This PR has:

- [ ] been self-reviewed.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
