### PR TITLE
[Backport] fix issue with jetty graceful shutdown of data servers when druid.serverview.type=http

### DIFF
--- a/server/src/main/java/org/apache/druid/guice/AnnouncerModule.java
+++ b/server/src/main/java/org/apache/druid/guice/AnnouncerModule.java
@@ -54,7 +54,7 @@ public class AnnouncerModule implements Module
     JsonConfigProvider.bind(binder, "druid.announcer", BatchDataSegmentAnnouncerConfig.class);
     JsonConfigProvider.bind(binder, "druid.announcer", DataSegmentAnnouncerProvider.class);
     binder.bind(DataSegmentAnnouncer.class).toProvider(DataSegmentAnnouncerProvider.class);
-    binder.bind(BatchDataSegmentAnnouncer.class).in(LazySingleton.class);
+    binder.bind(BatchDataSegmentAnnouncer.class).in(ManageLifecycleAnnouncements.class);
 
     if (isZkEnabled) {
       binder.bind(DataSegmentServerAnnouncer.class).to(CuratorDataSegmentServerAnnouncer.class).in(LazySingleton.class);

--- a/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
@@ -36,6 +36,7 @@ import org.apache.druid.curator.announcement.Announcer;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.initialization.BatchDataSegmentAnnouncerConfig;
 import org.apache.druid.server.initialization.ZkPathsConfig;
@@ -128,6 +129,13 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
   {
     this(server, config, zkPaths, () -> announcer, jsonMapper, ZkEnablementConfig.ENABLED);
   }
+
+  @LifecycleStop
+  public void stop()
+  {
+    changes.stop();
+  }
+
 
   @Override
   public void announceSegment(DataSegment segment) throws IOException

--- a/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHistory.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHistory.java
@@ -32,6 +32,7 @@ import org.apache.druid.utils.CircularBuffer;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -43,6 +44,7 @@ import java.util.concurrent.ExecutorService;
  *
  * Clients call {@link #getRequestsSince} to get updates since given counter.
  */
+
 public class ChangeRequestHistory<T>
 {
   private static int MAX_SIZE = 1000;
@@ -74,11 +76,24 @@ public class ChangeRequestHistory<T>
     this.singleThreadedExecutor = Execs.singleThreaded("SegmentChangeRequestHistory");
   }
 
+  public void stop()
+  {
+    singleThreadedExecutor.shutdownNow();
+    final LinkedHashSet<CustomSettableFuture<?>> futures = new LinkedHashSet<>(waitingFutures.keySet());
+    waitingFutures.clear();
+    for (CustomSettableFuture<?> theFuture : futures) {
+      theFuture.setException(new IllegalStateException("Server is shutting down."));
+    }
+  }
+
   /**
    * Add batch of segment changes update.
    */
   public synchronized void addChangeRequests(List<T> requests)
   {
+    if (singleThreadedExecutor.isShutdown()) {
+      return;
+    }
     for (T request : requests) {
       changes.add(new Holder<>(request, getLastCounter().inc()));
     }
@@ -108,6 +123,10 @@ public class ChangeRequestHistory<T>
   public synchronized ListenableFuture<ChangeRequestsSnapshot<T>> getRequestsSince(final Counter counter)
   {
     final CustomSettableFuture<T> future = new CustomSettableFuture<>(waitingFutures);
+    if (singleThreadedExecutor.isShutdown()) {
+      future.setException(new IllegalStateException("Server is shutting down."));
+      return future;
+    }
 
     if (counter.counter < 0) {
       future.setException(new IAE("counter[%s] must be >= 0", counter));


### PR DESCRIPTION
Backport of #13499 to 25.0.0.