### PR TITLE
Fix typo in metric name

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1036,7 +1036,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
             }
             task.emitMetric(
                 toolbox.getEmitter(),
-                "ingest/segment/count",
+                "ingest/segments/count",
                 segmentCount
             );
           }


### PR DESCRIPTION
Correct metric name is `ingest/segments/count` as defined [in the docs](https://druid.apache.org/docs/latest/operations/metrics.html#general-native-ingestion-metrics).

<img width="785" alt="metric_doc" src="https://user-images.githubusercontent.com/18635897/206199944-0ccaf87b-adbc-43cb-907d-e3ea83afce9a.png">
