### PR TITLE
Support prometheus emitter

### DIFF
--- a/helm/druid/README.md
+++ b/helm/druid/README.md
@@ -24,7 +24,6 @@
 ## Dependency Update
 
 Before you install the Druid Chart, update the dependencies :
-
 ```bash
 helm dependency update helm/druid
 ```
@@ -87,128 +86,130 @@ Middle Managers and Historicals uses StatefulSet. Persistence is enabled by defa
 
 The following table lists the configurable parameters of the Druid chart and their default values.
 
-| Parameter                                | Description                                          | Default                                                       |
-|------------------------------------------|------------------------------------------------------|---------------------------------------------------------------|
-| `image.repository`                       | container image name                                 | `apache/druid`                                                |
-| `image.tag`                              | container image tag                                  | `0.19.0`                                                      |
-| `image.pullPolicy`                       | container pull policy                                | `IfNotPresent`                                                |
-| `image.pullSecrets`                      | image pull secrest for private repositoty            | `[]`                                                          |
-| `configMap.enabled`                      | enable druid configuration as configmap              | `true`                                                        |
-| `configVars`                             | druid configuration variables for all components     | ``                                                            |
-| `gCloudStorage.enabled`                  | look for secret to set google cloud credentials      | `false`                                                       |
-| `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials | `false`                                                       |
-| `broker.enabled`                         | enable broker                                        | `true`                                                        |
-| `broker.name`                            | broker component name                                | `broker`                                                      |
-| `broker.replicaCount`                    | broker node replicas (deployment)                    | `1`                                                           |
-| `broker.port`                            | port of broker component                             | `8082`                                                        |
-| `broker.serviceType`                     | service type for service                             | `ClusterIP`                                                   |
-| `broker.resources`                       | broker node resources requests & limits              | `{}`                                                          |
-| `broker.podAnnotations`                  | broker deployment annotations                        | `{}`                                                          |
-| `broker.nodeSelector`                    | Node labels for broker pod assignment                | `{}`                                                          |
-| `broker.tolerations`                     | broker tolerations                                   | `[]`                                                          |
-| `broker.config`                          | broker private config such as `JAVA_OPTS`            |                                                               |
-| `broker.affinity`                        | broker affinity policy                               | `{}`                                                          |
-| `broker.ingress.enabled`                 | enable ingress                                       | `false`                                                       |
-| `broker.ingress.hosts`                   | hosts for the broker api                             | `[ "chart-example.local" ]`                                   |
-| `broker.ingress.path`                    | path of the broker api                               | `/`                                                           |
-| `broker.ingress.annotations`             | annotations for the broker api ingress               | `{}`                                                          |
-| `broker.ingress.tls`                     | TLS configuration for the ingress                    | `[]`                                                          |
-| `coordinator.enabled`                    | enable coordinator                                   | `true`                                                        |
-| `coordinator.name`                       | coordinator component name                           | `coordinator`                                                 |
-| `coordinator.replicaCount`               | coordinator node replicas (deployment)               | `1`                                                           |
-| `coordinator.port`                       | port of coordinator component                        | `8081`                                                        |
-| `coordinator.serviceType`                | service type for service                             | `ClusterIP`                                                   |
-| `coordinator.resources`                  | coordinator node resources requests & limits         | `{}`                                                          |
-| `coordinator.podAnnotations`             | coordinator Deployment annotations                   | `{}`                                                          |
-| `coordinator.nodeSelector`               | node labels for coordinator pod assignment           | `{}`                                                          |
-| `coordinator.tolerations`                | coordinator tolerations                              | `[]`                                                          |
-| `coordinator.config`                     | coordinator private config such as `JAVA_OPTS`       |                                                               |
-| `coordinator.affinity`                   | coordinator affinity policy                          | `{}`                                                          |
-| `coordinator.ingress.enabled`            | enable ingress                                       | `false`                                                       |
-| `coordinator.ingress.hosts`              | hosts for the coordinator api                        | `[ "chart-example.local" ]`                                   |
-| `coordinator.ingress.path`               | path of the coordinator api                          | `/`                                                           |
-| `coordinator.ingress.annotations`        | annotations for the coordinator api ingress          | `{}`                                                          |
-| `coordinator.ingress.tls`                | TLS configuration for the ingress                    | `[]`                                                          |
-| `overlord.enabled`                       | enable overlord                                      | `false`                                                       |
-| `overlord.name`                          | overlord component name                              | `overlord`                                                    |
-| `overlord.replicaCount`                  | overlord node replicas (deployment)                  | `1`                                                           |
-| `overlord.port`                          | port of overlord component                           | `8081`                                                        |
-| `overlord.serviceType`                   | service type for service                             | `ClusterIP`                                                   |
-| `overlord.resources`                     | overlord node resources requests & limits            | `{}`                                                          |
-| `overlord.podAnnotations`                | overlord Deployment annotations                      | `{}`                                                          |
-| `overlord.nodeSelector`                  | node labels for overlord pod assignment              | `{}`                                                          |
-| `overlord.tolerations`                   | overlord tolerations                                 | `[]`                                                          |
-| `overlord.config`                        | overlord private config such as `JAVA_OPTS`          |                                                               |
-| `overlord.affinity`                      | overlord affinity policy                             | `{}`                                                          |
-| `overlord.ingress.enabled`               | enable ingress                                       | `false`                                                       |
-| `overlord.ingress.hosts`                 | hosts for the overlord api                           | `[ "chart-example.local" ]`                                   |
-| `overlord.ingress.path`                  | path of the overlord api                             | `/`                                                           |
-| `overlord.ingress.annotations`           | annotations for the overlord api ingress             | `{}`                                                          |
-| `overlord.ingress.tls`                   | TLS configuration for the ingress                    | `[]`                                                          |
-| `historical.enabled`                     | enable historical                                    | `true`                                                        |
-| `historical.name`                        | historical component name                            | `historical`                                                  |
-| `historical.replicaCount`                | historical node replicas (statefulset)               | `1`                                                           |
-| `historical.port`                        | port of historical component                         | `8083`                                                        |
-| `historical.serviceType`                 | service type for service                             | `ClusterIP`                                                   |
-| `historical.resources`                   | historical node resources requests & limits          | `{}`                                                          |
-| `historical.podAnnotations`              | historical Deployment annotations                    | `{}`                                                          |
-| `historical.nodeSelector`                | node labels for historical pod assignment            | `{}`                                                          |
-| `historical.securityContext`             | custom security context for historical containers    | `{ fsGroup: 1000 }`                                           |
-| `historical.tolerations`                 | historical tolerations                               | `[]`                                                          |
-| `historical.config`                      | historical node private config such as `JAVA_OPTS`   |                                                               |
-| `historical.persistence.enabled`         | historical persistent enabled/disabled               | `true`                                                        |
-| `historical.persistence.size`            | historical persistent volume size                    | `4Gi`                                                         |
-| `historical.persistence.storageClass`    | historical persistent volume Class                   | `nil`                                                         |
-| `historical.persistence.accessMode`      | historical persistent Access Mode                    | `ReadWriteOnce`                                               |
-| `historical.antiAffinity`                | historical anti-affinity policy                      | `soft`                                                        |
-| `historical.nodeAffinity`                | historical node affinity policy                      | `{}`                                                          |
-| `historical.ingress.enabled`             | enable ingress                                       | `false`                                                       |
-| `historical.ingress.hosts`               | hosts for the historical api                         | `[ "chart-example.local" ]`                                   |
-| `historical.ingress.path`                | path of the historical api                           | `/`                                                           |
-| `historical.ingress.annotations`         | annotations for the historical api ingress           | `{}`                                                          |
-| `historical.ingress.tls`                 | TLS configuration for the ingress                    | `[]`                                                          |
-| `middleManager.enabled`                  | enable middleManager                                 | `true`                                                        |
-| `middleManager.name`                     | middleManager component name                         | `middleManager`                                               |
-| `middleManager.replicaCount`             | middleManager node replicas (statefulset)            | `1`                                                           |
-| `middleManager.port`                     | port of middleManager component                      | `8091`                                                        |
-| `middleManager.serviceType`              | service type for service                             | `ClusterIP`                                                   |
-| `middleManager.resources`                | middleManager node resources requests & limits       | `{}`                                                          |
-| `middleManager.podAnnotations`           | middleManager Deployment annotations                 | `{}`                                                          |
-| `middleManager.nodeSelector`             | Node labels for middleManager pod assignment         | `{}`                                                          |
-| `middleManager.securityContext`          | custom security context for middleManager containers | `{ fsGroup: 1000 }`                                           |
-| `middleManager.tolerations`              | middleManager tolerations                            | `[]`                                                          |
-| `middleManager.config`                   | middleManager private config such as `JAVA_OPTS`     |                                                               |
-| `middleManager.persistence.enabled`      | middleManager persistent enabled/disabled            | `true`                                                        |
-| `middleManager.persistence.size`         | middleManager persistent volume size                 | `4Gi`                                                         |
-| `middleManager.persistence.storageClass` | middleManager persistent volume Class                | `nil`                                                         |
-| `middleManager.persistence.accessMode`   | middleManager persistent Access Mode                 | `ReadWriteOnce`                                               |
-| `middleManager.antiAffinity`             | middleManager anti-affinity policy                   | `soft`                                                        |
-| `middleManager.nodeAffinity`             | middleManager node affinity policy                   | `{}`                                                          |
-| `middleManager.autoscaling.enabled`      | enable horizontal pod autoscaling                    | `false`                                                       |
-| `middleManager.autoscaling.minReplicas`  | middleManager autoscaling min replicas               | `2`                                                           |
-| `middleManager.autoscaling.maxReplicas`  | middleManager autoscaling max replicas               | `5`                                                           |
-| `middleManager.autoscaling.metrics`      | middleManager autoscaling metrics                    | `{}`                                                          |
-| `middleManager.ingress.enabled`          | enable ingress                                       | `false`                                                       |
-| `middleManager.ingress.hosts`            | hosts for the middleManager api                      | `[ "chart-example.local" ]`                                   |
-| `middleManager.ingress.path`             | path of the middleManager api                        | `/`                                                           |
-| `middleManager.ingress.annotations`      | annotations for the middleManager api ingress        | `{}`                                                          |
-| `middleManager.ingress.tls`              | TLS configuration for the ingress                    | `[]`                                                          |
-| `router.enabled`                         | enable router                                        | `false`                                                       |
-| `router.name`                            | router component name                                | `router`                                                      |
-| `router.replicaCount`                    | router node replicas (deployment)                    | `1`                                                           |
-| `router.port`                            | port of router component                             | `8888`                                                        |
-| `router.serviceType`                     | service type for service                             | `ClusterIP`                                                   |
-| `router.resources`                       | router node resources requests & limits              | `{}`                                                          |
-| `router.podAnnotations`                  | router Deployment annotations                        | `{}`                                                          |
-| `router.nodeSelector`                    | node labels for router pod assignment                | `{}`                                                          |
-| `router.tolerations`                     | router tolerations                                   | `[]`                                                          |
-| `router.config`                          | router private config such as `JAVA_OPTS`            |                                                               |
-| `router.affinity`                        | router affinity policy                               | `{}`                                                          |
-| `router.ingress.enabled`                 | enable ingress                                       | `false`                                                       |
-| `router.ingress.hosts`                   | hosts for the router api                             | `[ "chart-example.local" ]`                                   |
-| `router.ingress.path`                    | path of the router api                               | `/`                                                           |
-| `router.ingress.annotations`             | annotations for the router api ingress               | `{}`                                                          |
-| `router.ingress.tls`                     | TLS configuration for the ingress                    | `[]`                                                          |
+| Parameter                                | Description                                             | Default                                    |
+|------------------------------------------|---------------------------------------------------------|--------------------------------------------|
+| `image.repository`                       | container image name                                    | `apache/druid`                             |
+| `image.tag`                              | container image tag                                     | `0.19.0`                                   |
+| `image.pullPolicy`                       | container pull policy                                   | `IfNotPresent`                             |
+| `image.pullSecrets`                      | image pull secrest for private repositoty               | `[]`                                       |
+| `configMap.enabled`                       | enable druid configuration as configmap                   | `true`                                     |
+| `configVars`                              | druid configuration variables for all components         | ``                                         |
+| `gCloudStorage.enabled`                  | look for secret to set google cloud credentials         | `false`                                    |
+| `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials    | `false`                                    |
+| `broker.enabled`                         | enable broker                                           | `true`                                     |
+| `broker.name`                            | broker component name                                   | `broker`                                   |
+| `broker.replicaCount`                    | broker node replicas (deployment)                       | `1`                                        |
+| `broker.port`                            | port of broker component                                | `8082`                                     |
+| `broker.serviceType`                     | service type for service                                | `ClusterIP`                                |
+| `broker.resources`                       | broker node resources requests & limits                 | `{}`                                       |
+| `broker.podAnnotations`                  | broker deployment annotations                           | `{}`                                       |
+| `broker.nodeSelector`                    | Node labels for broker pod assignment                   | `{}`                                       |
+| `broker.tolerations`                     | broker tolerations                                      | `[]`                                       |
+| `broker.config`                           | broker private config such as `JAVA_OPTS`                |                                            |
+| `broker.affinity`                         | broker affinity policy                                   | `{}`                                       |
+| `broker.ingress.enabled`                 | enable ingress                                          | `false`                                    |
+| `broker.ingress.hosts`                   | hosts for the broker api                                | `[ "chart-example.local" ]`                |
+| `broker.ingress.path`                    | path of the broker api                                  | `/`                                        |
+| `broker.ingress.annotations`             | annotations for the broker api ingress                  | `{}`                                       |
+| `broker.ingress.tls`                     | TLS configuration for the ingress                        | `[]`                                       |
+| `coordinator.enabled`                    | enable coordinator                                      | `true`                                     |
+| `coordinator.name`                       | coordinator component name                              | `coordinator`                              |
+| `coordinator.replicaCount`               | coordinator node replicas (deployment)                  | `1`                                        |
+| `coordinator.port`                       | port of coordinator component                           | `8081`                                     |
+| `coordinator.serviceType`                | service type for service                                | `ClusterIP`                                |
+| `coordinator.resources`                  | coordinator node resources requests & limits            | `{}`                                       |
+| `coordinator.podAnnotations`             | coordinator Deployment annotations                      | `{}`                                       |
+| `coordinator.nodeSelector`               | node labels for coordinator pod assignment              | `{}`                                       |
+| `coordinator.tolerations`                | coordinator tolerations                                 | `[]`                                       |
+| `coordinator.config`                      | coordinator private config such as `JAVA_OPTS`           |                                            |
+| `coordinator.affinity`                    | coordinator affinity policy                              | `{}`                                       |
+| `coordinator.ingress.enabled`            | enable ingress                                          | `false`                                    |
+| `coordinator.ingress.hosts`              | hosts for the coordinator api                           | `[ "chart-example.local" ]`                |
+| `coordinator.ingress.path`               | path of the coordinator api                             | `/`                                        |
+| `coordinator.ingress.annotations`        | annotations for the coordinator api ingress             | `{}`                                       |
+| `coordinator.ingress.tls`                | TLS configuration for the ingress                        | `[]`                                       |
+| `overlord.enabled`                       | enable overlord                                         | `false`                                    |
+| `overlord.name`                          | overlord component name                                 | `overlord`                                 |
+| `overlord.replicaCount`                  | overlord node replicas (deployment)                     | `1`                                        |
+| `overlord.port`                          | port of overlord component                              | `8081`                                     |
+| `overlord.serviceType`                   | service type for service                                | `ClusterIP`                                |
+| `overlord.resources`                     | overlord node resources requests & limits               | `{}`                                       |
+| `overlord.podAnnotations`                | overlord Deployment annotations                         | `{}`                                       |
+| `overlord.nodeSelector`                  | node labels for overlord pod assignment                 | `{}`                                       |
+| `overlord.tolerations`                   | overlord tolerations                                    | `[]`                                       |
+| `overlord.config`                         | overlord private config such as `JAVA_OPTS`              |                                            |
+| `overlord.affinity`                       | overlord affinity policy                                 | `{}`                                       |
+| `overlord.ingress.enabled`               | enable ingress                                          | `false`                                    |
+| `overlord.ingress.hosts`                 | hosts for the overlord api                              | `[ "chart-example.local" ]`                |
+| `overlord.ingress.path`                  | path of the overlord api                                | `/`                                        |
+| `overlord.ingress.annotations`           | annotations for the overlord api ingress                | `{}`                                       |
+| `overlord.ingress.tls`                   | TLS configuration for the ingress                        | `[]`                                       |
+| `historical.enabled`                     | enable historical                                       | `true`                                     |
+| `historical.name`                        | historical component name                               | `historical`                               |
+| `historical.replicaCount`                | historical node replicas (statefulset)                  | `1`                                        |
+| `historical.port`                        | port of historical component                            | `8083`                                     |
+| `historical.serviceType`                 | service type for service                                | `ClusterIP`                                |
+| `historical.resources`                   | historical node resources requests & limits             | `{}`                                       |
+| `historical.livenessProbeInitialDelaySeconds`  | historical node liveness probe initial delay in seconds  | `60`                                |
+| `historical.readinessProbeInitialDelaySeconds` | historical node readiness probe initial delay in seconds | `60`                                |
+| `historical.podAnnotations`              | historical Deployment annotations                       | `{}`                                       |
+| `historical.nodeSelector`                | node labels for historical pod assignment               | `{}`                                       |
+| `historical.securityContext`             | custom security context for historical containers       | `{ fsGroup: 1000 }`                        |
+| `historical.tolerations`                 | historical tolerations                                  | `[]`                                       |
+| `historical.config`                       | historical node private config such as `JAVA_OPTS`       |                                            |
+| `historical.persistence.enabled`         | historical persistent enabled/disabled                  | `true`                                     |
+| `historical.persistence.size`            | historical persistent volume size                       | `4Gi`                                      |
+| `historical.persistence.storageClass`    | historical persistent volume Class                      | `nil`                                      |
+| `historical.persistence.accessMode`      | historical persistent Access Mode                       | `ReadWriteOnce`                            |
+| `historical.antiAffinity`                 | historical anti-affinity policy                          | `soft`                                     |
+| `historical.nodeAffinity`                 | historical node affinity policy                          | `{}`                                       |
+| `historical.ingress.enabled`             | enable ingress                                          | `false`                                    |
+| `historical.ingress.hosts`               | hosts for the historical api                            | `[ "chart-example.local" ]`                |
+| `historical.ingress.path`                | path of the historical api                              | `/`                                        |
+| `historical.ingress.annotations`         | annotations for the historical api ingress              | `{}`                                       |
+| `historical.ingress.tls`                 | TLS configuration for the ingress                        | `[]`                                       |
+| `middleManager.enabled`                  | enable middleManager                                    | `true`                                     |
+| `middleManager.name`                     | middleManager component name                            | `middleManager`                            |
+| `middleManager.replicaCount`             | middleManager node replicas (statefulset)               | `1`                                        |
+| `middleManager.port`                     | port of middleManager component                         | `8091`                                     |
+| `middleManager.serviceType`              | service type for service                                | `ClusterIP`                                |
+| `middleManager.resources`                | middleManager node resources requests & limits          | `{}`                                       |
+| `middleManager.podAnnotations`           | middleManager Deployment annotations                    | `{}`                                       |
+| `middleManager.nodeSelector`             | Node labels for middleManager pod assignment            | `{}`                                       |
+| `middleManager.securityContext`          | custom security context for middleManager containers    | `{ fsGroup: 1000 }`                        |
+| `middleManager.tolerations`              | middleManager tolerations                               | `[]`                                       |
+| `middleManager.config`                    | middleManager private config such as `JAVA_OPTS`         |                                            |
+| `middleManager.persistence.enabled`      | middleManager persistent enabled/disabled               | `true`                                     |
+| `middleManager.persistence.size`         | middleManager persistent volume size                    | `4Gi`                                      |
+| `middleManager.persistence.storageClass` | middleManager persistent volume Class                   | `nil`                                      |
+| `middleManager.persistence.accessMode`   | middleManager persistent Access Mode                    | `ReadWriteOnce`                            |
+| `middleManager.antiAffinity`              | middleManager anti-affinity policy                       | `soft`                                     |
+| `middleManager.nodeAffinity`              | middleManager node affinity policy                       | `{}`                                       |
+| `middleManager.autoscaling.enabled`      | enable horizontal pod autoscaling                       | `false`                                    |
+| `middleManager.autoscaling.minReplicas`  | middleManager autoscaling min replicas                  | `2`                                        |
+| `middleManager.autoscaling.maxReplicas`  | middleManager autoscaling max replicas                  | `5`                                        |
+| `middleManager.autoscaling.metrics`      | middleManager autoscaling metrics                       | `{}`                                       |
+| `middleManager.ingress.enabled`          | enable ingress                                          | `false`                                    |
+| `middleManager.ingress.hosts`            | hosts for the middleManager api                         | `[ "chart-example.local" ]`                |
+| `middleManager.ingress.path`             | path of the middleManager api                           | `/`                                        |
+| `middleManager.ingress.annotations`      | annotations for the middleManager api ingress           | `{}`                                       |
+| `middleManager.ingress.tls`              | TLS configuration for the ingress                        | `[]`                                       |
+| `router.enabled`                         | enable router                                           | `false`                                    |
+| `router.name`                            | router component name                                   | `router`                                   |
+| `router.replicaCount`                    | router node replicas (deployment)                       | `1`                                        |
+| `router.port`                            | port of router component                                | `8888`                                     |
+| `router.serviceType`                     | service type for service                                | `ClusterIP`                                |
+| `router.resources`                       | router node resources requests & limits                 | `{}`                                       |
+| `router.podAnnotations`                  | router Deployment annotations                           | `{}`                                       |
+| `router.nodeSelector`                    | node labels for router pod assignment                   | `{}`                                       |
+| `router.tolerations`                     | router tolerations                                      | `[]`                                       |
+| `router.config`                           | router private config such as `JAVA_OPTS`                |                                            |
+| `router.affinity`                         | router affinity policy                                   | `{}`                                       |
+| `router.ingress.enabled`                 | enable ingress                                          | `false`                                    |
+| `router.ingress.hosts`                   | hosts for the router api                                | `[ "chart-example.local" ]`                |
+| `router.ingress.path`                    | path of the router api                                  | `/`                                        |
+| `router.ingress.annotations`             | annotations for the router api ingress                  | `{}`                                       |
+| `router.ingress.tls`                     | TLS configuration for the ingress                        | `[]`                                       |
 | `prometheus.enabled`                     | Support scraping from prometheus                     | `false`                                                       |
 | `prometheus.port`                        | expose prometheus port                               | `9090`                                                        |
 | `prometheus.annotation`                  | pods annotation to notify prometheus scraping        | `{prometheus.io/scrape: "true", prometheus.io/port: "9090"}`  |

--- a/helm/druid/README.md
+++ b/helm/druid/README.md
@@ -24,6 +24,7 @@
 ## Dependency Update
 
 Before you install the Druid Chart, update the dependencies :
+
 ```bash
 helm dependency update helm/druid
 ```
@@ -86,127 +87,130 @@ Middle Managers and Historicals uses StatefulSet. Persistence is enabled by defa
 
 The following table lists the configurable parameters of the Druid chart and their default values.
 
-| Parameter                                | Description                                             | Default                                    |
-|------------------------------------------|---------------------------------------------------------|--------------------------------------------|
-| `image.repository`                       | container image name                                    | `apache/druid`                             |
-| `image.tag`                              | container image tag                                     | `0.19.0`                                   |
-| `image.pullPolicy`                       | container pull policy                                   | `IfNotPresent`                             |
-| `image.pullSecrets`                      | image pull secrest for private repositoty               | `[]`                                       |
-| `configMap.enabled`                       | enable druid configuration as configmap                   | `true`                                     |
-| `configVars`                              | druid configuration variables for all components         | ``                                         |
-| `gCloudStorage.enabled`                  | look for secret to set google cloud credentials         | `false`                                    |
-| `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials    | `false`                                    |
-| `broker.enabled`                         | enable broker                                           | `true`                                     |
-| `broker.name`                            | broker component name                                   | `broker`                                   |
-| `broker.replicaCount`                    | broker node replicas (deployment)                       | `1`                                        |
-| `broker.port`                            | port of broker component                                | `8082`                                     |
-| `broker.serviceType`                     | service type for service                                | `ClusterIP`                                |
-| `broker.resources`                       | broker node resources requests & limits                 | `{}`                                       |
-| `broker.podAnnotations`                  | broker deployment annotations                           | `{}`                                       |
-| `broker.nodeSelector`                    | Node labels for broker pod assignment                   | `{}`                                       |
-| `broker.tolerations`                     | broker tolerations                                      | `[]`                                       |
-| `broker.config`                           | broker private config such as `JAVA_OPTS`                |                                            |
-| `broker.affinity`                         | broker affinity policy                                   | `{}`                                       |
-| `broker.ingress.enabled`                 | enable ingress                                          | `false`                                    |
-| `broker.ingress.hosts`                   | hosts for the broker api                                | `[ "chart-example.local" ]`                |
-| `broker.ingress.path`                    | path of the broker api                                  | `/`                                        |
-| `broker.ingress.annotations`             | annotations for the broker api ingress                  | `{}`                                       |
-| `broker.ingress.tls`                     | TLS configuration for the ingress                        | `[]`                                       |
-| `coordinator.enabled`                    | enable coordinator                                      | `true`                                     |
-| `coordinator.name`                       | coordinator component name                              | `coordinator`                              |
-| `coordinator.replicaCount`               | coordinator node replicas (deployment)                  | `1`                                        |
-| `coordinator.port`                       | port of coordinator component                           | `8081`                                     |
-| `coordinator.serviceType`                | service type for service                                | `ClusterIP`                                |
-| `coordinator.resources`                  | coordinator node resources requests & limits            | `{}`                                       |
-| `coordinator.podAnnotations`             | coordinator Deployment annotations                      | `{}`                                       |
-| `coordinator.nodeSelector`               | node labels for coordinator pod assignment              | `{}`                                       |
-| `coordinator.tolerations`                | coordinator tolerations                                 | `[]`                                       |
-| `coordinator.config`                      | coordinator private config such as `JAVA_OPTS`           |                                            |
-| `coordinator.affinity`                    | coordinator affinity policy                              | `{}`                                       |
-| `coordinator.ingress.enabled`            | enable ingress                                          | `false`                                    |
-| `coordinator.ingress.hosts`              | hosts for the coordinator api                           | `[ "chart-example.local" ]`                |
-| `coordinator.ingress.path`               | path of the coordinator api                             | `/`                                        |
-| `coordinator.ingress.annotations`        | annotations for the coordinator api ingress             | `{}`                                       |
-| `coordinator.ingress.tls`                | TLS configuration for the ingress                        | `[]`                                       |
-| `overlord.enabled`                       | enable overlord                                         | `false`                                    |
-| `overlord.name`                          | overlord component name                                 | `overlord`                                 |
-| `overlord.replicaCount`                  | overlord node replicas (deployment)                     | `1`                                        |
-| `overlord.port`                          | port of overlord component                              | `8081`                                     |
-| `overlord.serviceType`                   | service type for service                                | `ClusterIP`                                |
-| `overlord.resources`                     | overlord node resources requests & limits               | `{}`                                       |
-| `overlord.podAnnotations`                | overlord Deployment annotations                         | `{}`                                       |
-| `overlord.nodeSelector`                  | node labels for overlord pod assignment                 | `{}`                                       |
-| `overlord.tolerations`                   | overlord tolerations                                    | `[]`                                       |
-| `overlord.config`                         | overlord private config such as `JAVA_OPTS`              |                                            |
-| `overlord.affinity`                       | overlord affinity policy                                 | `{}`                                       |
-| `overlord.ingress.enabled`               | enable ingress                                          | `false`                                    |
-| `overlord.ingress.hosts`                 | hosts for the overlord api                              | `[ "chart-example.local" ]`                |
-| `overlord.ingress.path`                  | path of the overlord api                                | `/`                                        |
-| `overlord.ingress.annotations`           | annotations for the overlord api ingress                | `{}`                                       |
-| `overlord.ingress.tls`                   | TLS configuration for the ingress                        | `[]`                                       |
-| `historical.enabled`                     | enable historical                                       | `true`                                     |
-| `historical.name`                        | historical component name                               | `historical`                               |
-| `historical.replicaCount`                | historical node replicas (statefulset)                  | `1`                                        |
-| `historical.port`                        | port of historical component                            | `8083`                                     |
-| `historical.serviceType`                 | service type for service                                | `ClusterIP`                                |
-| `historical.resources`                   | historical node resources requests & limits             | `{}`                                       |
-| `historical.podAnnotations`              | historical Deployment annotations                       | `{}`                                       |
-| `historical.nodeSelector`                | node labels for historical pod assignment               | `{}`                                       |
-| `historical.securityContext`             | custom security context for historical containers       | `{ fsGroup: 1000 }`                        |
-| `historical.tolerations`                 | historical tolerations                                  | `[]`                                       |
-| `historical.config`                       | historical node private config such as `JAVA_OPTS`       |                                            |
-| `historical.persistence.enabled`         | historical persistent enabled/disabled                  | `true`                                     |
-| `historical.persistence.size`            | historical persistent volume size                       | `4Gi`                                      |
-| `historical.persistence.storageClass`    | historical persistent volume Class                      | `nil`                                      |
-| `historical.persistence.accessMode`      | historical persistent Access Mode                       | `ReadWriteOnce`                            |
-| `historical.antiAffinity`                 | historical anti-affinity policy                          | `soft`                                     |
-| `historical.nodeAffinity`                 | historical node affinity policy                          | `{}`                                       |
-| `historical.ingress.enabled`             | enable ingress                                          | `false`                                    |
-| `historical.ingress.hosts`               | hosts for the historical api                            | `[ "chart-example.local" ]`                |
-| `historical.ingress.path`                | path of the historical api                              | `/`                                        |
-| `historical.ingress.annotations`         | annotations for the historical api ingress              | `{}`                                       |
-| `historical.ingress.tls`                 | TLS configuration for the ingress                        | `[]`                                       |
-| `middleManager.enabled`                  | enable middleManager                                    | `true`                                     |
-| `middleManager.name`                     | middleManager component name                            | `middleManager`                            |
-| `middleManager.replicaCount`             | middleManager node replicas (statefulset)               | `1`                                        |
-| `middleManager.port`                     | port of middleManager component                         | `8091`                                     |
-| `middleManager.serviceType`              | service type for service                                | `ClusterIP`                                |
-| `middleManager.resources`                | middleManager node resources requests & limits          | `{}`                                       |
-| `middleManager.podAnnotations`           | middleManager Deployment annotations                    | `{}`                                       |
-| `middleManager.nodeSelector`             | Node labels for middleManager pod assignment            | `{}`                                       |
-| `middleManager.securityContext`          | custom security context for middleManager containers    | `{ fsGroup: 1000 }`                        |
-| `middleManager.tolerations`              | middleManager tolerations                               | `[]`                                       |
-| `middleManager.config`                    | middleManager private config such as `JAVA_OPTS`         |                                            |
-| `middleManager.persistence.enabled`      | middleManager persistent enabled/disabled               | `true`                                     |
-| `middleManager.persistence.size`         | middleManager persistent volume size                    | `4Gi`                                      |
-| `middleManager.persistence.storageClass` | middleManager persistent volume Class                   | `nil`                                      |
-| `middleManager.persistence.accessMode`   | middleManager persistent Access Mode                    | `ReadWriteOnce`                            |
-| `middleManager.antiAffinity`              | middleManager anti-affinity policy                       | `soft`                                     |
-| `middleManager.nodeAffinity`              | middleManager node affinity policy                       | `{}`                                       |
-| `middleManager.autoscaling.enabled`      | enable horizontal pod autoscaling                       | `false`                                    |
-| `middleManager.autoscaling.minReplicas`  | middleManager autoscaling min replicas                  | `2`                                        |
-| `middleManager.autoscaling.maxReplicas`  | middleManager autoscaling max replicas                  | `5`                                        |
-| `middleManager.autoscaling.metrics`      | middleManager autoscaling metrics                       | `{}`                                       |
-| `middleManager.ingress.enabled`          | enable ingress                                          | `false`                                    |
-| `middleManager.ingress.hosts`            | hosts for the middleManager api                         | `[ "chart-example.local" ]`                |
-| `middleManager.ingress.path`             | path of the middleManager api                           | `/`                                        |
-| `middleManager.ingress.annotations`      | annotations for the middleManager api ingress           | `{}`                                       |
-| `middleManager.ingress.tls`              | TLS configuration for the ingress                        | `[]`                                       |
-| `router.enabled`                         | enable router                                           | `false`                                    |
-| `router.name`                            | router component name                                   | `router`                                   |
-| `router.replicaCount`                    | router node replicas (deployment)                       | `1`                                        |
-| `router.port`                            | port of router component                                | `8888`                                     |
-| `router.serviceType`                     | service type for service                                | `ClusterIP`                                |
-| `router.resources`                       | router node resources requests & limits                 | `{}`                                       |
-| `router.podAnnotations`                  | router Deployment annotations                           | `{}`                                       |
-| `router.nodeSelector`                    | node labels for router pod assignment                   | `{}`                                       |
-| `router.tolerations`                     | router tolerations                                      | `[]`                                       |
-| `router.config`                           | router private config such as `JAVA_OPTS`                |                                            |
-| `router.affinity`                         | router affinity policy                                   | `{}`                                       |
-| `router.ingress.enabled`                 | enable ingress                                          | `false`                                    |
-| `router.ingress.hosts`                   | hosts for the router api                                | `[ "chart-example.local" ]`                |
-| `router.ingress.path`                    | path of the router api                                  | `/`                                        |
-| `router.ingress.annotations`             | annotations for the router api ingress                  | `{}`                                       |
-| `router.ingress.tls`                     | TLS configuration for the ingress                        | `[]`                                       |
+| Parameter                                | Description                                          | Default                                                       |
+|------------------------------------------|------------------------------------------------------|---------------------------------------------------------------|
+| `image.repository`                       | container image name                                 | `apache/druid`                                                |
+| `image.tag`                              | container image tag                                  | `0.19.0`                                                      |
+| `image.pullPolicy`                       | container pull policy                                | `IfNotPresent`                                                |
+| `image.pullSecrets`                      | image pull secrest for private repositoty            | `[]`                                                          |
+| `configMap.enabled`                      | enable druid configuration as configmap              | `true`                                                        |
+| `configVars`                             | druid configuration variables for all components     | ``                                                            |
+| `gCloudStorage.enabled`                  | look for secret to set google cloud credentials      | `false`                                                       |
+| `gCloudStorage.secretName`               | secretName to be mounted as google cloud credentials | `false`                                                       |
+| `broker.enabled`                         | enable broker                                        | `true`                                                        |
+| `broker.name`                            | broker component name                                | `broker`                                                      |
+| `broker.replicaCount`                    | broker node replicas (deployment)                    | `1`                                                           |
+| `broker.port`                            | port of broker component                             | `8082`                                                        |
+| `broker.serviceType`                     | service type for service                             | `ClusterIP`                                                   |
+| `broker.resources`                       | broker node resources requests & limits              | `{}`                                                          |
+| `broker.podAnnotations`                  | broker deployment annotations                        | `{}`                                                          |
+| `broker.nodeSelector`                    | Node labels for broker pod assignment                | `{}`                                                          |
+| `broker.tolerations`                     | broker tolerations                                   | `[]`                                                          |
+| `broker.config`                          | broker private config such as `JAVA_OPTS`            |                                                               |
+| `broker.affinity`                        | broker affinity policy                               | `{}`                                                          |
+| `broker.ingress.enabled`                 | enable ingress                                       | `false`                                                       |
+| `broker.ingress.hosts`                   | hosts for the broker api                             | `[ "chart-example.local" ]`                                   |
+| `broker.ingress.path`                    | path of the broker api                               | `/`                                                           |
+| `broker.ingress.annotations`             | annotations for the broker api ingress               | `{}`                                                          |
+| `broker.ingress.tls`                     | TLS configuration for the ingress                    | `[]`                                                          |
+| `coordinator.enabled`                    | enable coordinator                                   | `true`                                                        |
+| `coordinator.name`                       | coordinator component name                           | `coordinator`                                                 |
+| `coordinator.replicaCount`               | coordinator node replicas (deployment)               | `1`                                                           |
+| `coordinator.port`                       | port of coordinator component                        | `8081`                                                        |
+| `coordinator.serviceType`                | service type for service                             | `ClusterIP`                                                   |
+| `coordinator.resources`                  | coordinator node resources requests & limits         | `{}`                                                          |
+| `coordinator.podAnnotations`             | coordinator Deployment annotations                   | `{}`                                                          |
+| `coordinator.nodeSelector`               | node labels for coordinator pod assignment           | `{}`                                                          |
+| `coordinator.tolerations`                | coordinator tolerations                              | `[]`                                                          |
+| `coordinator.config`                     | coordinator private config such as `JAVA_OPTS`       |                                                               |
+| `coordinator.affinity`                   | coordinator affinity policy                          | `{}`                                                          |
+| `coordinator.ingress.enabled`            | enable ingress                                       | `false`                                                       |
+| `coordinator.ingress.hosts`              | hosts for the coordinator api                        | `[ "chart-example.local" ]`                                   |
+| `coordinator.ingress.path`               | path of the coordinator api                          | `/`                                                           |
+| `coordinator.ingress.annotations`        | annotations for the coordinator api ingress          | `{}`                                                          |
+| `coordinator.ingress.tls`                | TLS configuration for the ingress                    | `[]`                                                          |
+| `overlord.enabled`                       | enable overlord                                      | `false`                                                       |
+| `overlord.name`                          | overlord component name                              | `overlord`                                                    |
+| `overlord.replicaCount`                  | overlord node replicas (deployment)                  | `1`                                                           |
+| `overlord.port`                          | port of overlord component                           | `8081`                                                        |
+| `overlord.serviceType`                   | service type for service                             | `ClusterIP`                                                   |
+| `overlord.resources`                     | overlord node resources requests & limits            | `{}`                                                          |
+| `overlord.podAnnotations`                | overlord Deployment annotations                      | `{}`                                                          |
+| `overlord.nodeSelector`                  | node labels for overlord pod assignment              | `{}`                                                          |
+| `overlord.tolerations`                   | overlord tolerations                                 | `[]`                                                          |
+| `overlord.config`                        | overlord private config such as `JAVA_OPTS`          |                                                               |
+| `overlord.affinity`                      | overlord affinity policy                             | `{}`                                                          |
+| `overlord.ingress.enabled`               | enable ingress                                       | `false`                                                       |
+| `overlord.ingress.hosts`                 | hosts for the overlord api                           | `[ "chart-example.local" ]`                                   |
+| `overlord.ingress.path`                  | path of the overlord api                             | `/`                                                           |
+| `overlord.ingress.annotations`           | annotations for the overlord api ingress             | `{}`                                                          |
+| `overlord.ingress.tls`                   | TLS configuration for the ingress                    | `[]`                                                          |
+| `historical.enabled`                     | enable historical                                    | `true`                                                        |
+| `historical.name`                        | historical component name                            | `historical`                                                  |
+| `historical.replicaCount`                | historical node replicas (statefulset)               | `1`                                                           |
+| `historical.port`                        | port of historical component                         | `8083`                                                        |
+| `historical.serviceType`                 | service type for service                             | `ClusterIP`                                                   |
+| `historical.resources`                   | historical node resources requests & limits          | `{}`                                                          |
+| `historical.podAnnotations`              | historical Deployment annotations                    | `{}`                                                          |
+| `historical.nodeSelector`                | node labels for historical pod assignment            | `{}`                                                          |
+| `historical.securityContext`             | custom security context for historical containers    | `{ fsGroup: 1000 }`                                           |
+| `historical.tolerations`                 | historical tolerations                               | `[]`                                                          |
+| `historical.config`                      | historical node private config such as `JAVA_OPTS`   |                                                               |
+| `historical.persistence.enabled`         | historical persistent enabled/disabled               | `true`                                                        |
+| `historical.persistence.size`            | historical persistent volume size                    | `4Gi`                                                         |
+| `historical.persistence.storageClass`    | historical persistent volume Class                   | `nil`                                                         |
+| `historical.persistence.accessMode`      | historical persistent Access Mode                    | `ReadWriteOnce`                                               |
+| `historical.antiAffinity`                | historical anti-affinity policy                      | `soft`                                                        |
+| `historical.nodeAffinity`                | historical node affinity policy                      | `{}`                                                          |
+| `historical.ingress.enabled`             | enable ingress                                       | `false`                                                       |
+| `historical.ingress.hosts`               | hosts for the historical api                         | `[ "chart-example.local" ]`                                   |
+| `historical.ingress.path`                | path of the historical api                           | `/`                                                           |
+| `historical.ingress.annotations`         | annotations for the historical api ingress           | `{}`                                                          |
+| `historical.ingress.tls`                 | TLS configuration for the ingress                    | `[]`                                                          |
+| `middleManager.enabled`                  | enable middleManager                                 | `true`                                                        |
+| `middleManager.name`                     | middleManager component name                         | `middleManager`                                               |
+| `middleManager.replicaCount`             | middleManager node replicas (statefulset)            | `1`                                                           |
+| `middleManager.port`                     | port of middleManager component                      | `8091`                                                        |
+| `middleManager.serviceType`              | service type for service                             | `ClusterIP`                                                   |
+| `middleManager.resources`                | middleManager node resources requests & limits       | `{}`                                                          |
+| `middleManager.podAnnotations`           | middleManager Deployment annotations                 | `{}`                                                          |
+| `middleManager.nodeSelector`             | Node labels for middleManager pod assignment         | `{}`                                                          |
+| `middleManager.securityContext`          | custom security context for middleManager containers | `{ fsGroup: 1000 }`                                           |
+| `middleManager.tolerations`              | middleManager tolerations                            | `[]`                                                          |
+| `middleManager.config`                   | middleManager private config such as `JAVA_OPTS`     |                                                               |
+| `middleManager.persistence.enabled`      | middleManager persistent enabled/disabled            | `true`                                                        |
+| `middleManager.persistence.size`         | middleManager persistent volume size                 | `4Gi`                                                         |
+| `middleManager.persistence.storageClass` | middleManager persistent volume Class                | `nil`                                                         |
+| `middleManager.persistence.accessMode`   | middleManager persistent Access Mode                 | `ReadWriteOnce`                                               |
+| `middleManager.antiAffinity`             | middleManager anti-affinity policy                   | `soft`                                                        |
+| `middleManager.nodeAffinity`             | middleManager node affinity policy                   | `{}`                                                          |
+| `middleManager.autoscaling.enabled`      | enable horizontal pod autoscaling                    | `false`                                                       |
+| `middleManager.autoscaling.minReplicas`  | middleManager autoscaling min replicas               | `2`                                                           |
+| `middleManager.autoscaling.maxReplicas`  | middleManager autoscaling max replicas               | `5`                                                           |
+| `middleManager.autoscaling.metrics`      | middleManager autoscaling metrics                    | `{}`                                                          |
+| `middleManager.ingress.enabled`          | enable ingress                                       | `false`                                                       |
+| `middleManager.ingress.hosts`            | hosts for the middleManager api                      | `[ "chart-example.local" ]`                                   |
+| `middleManager.ingress.path`             | path of the middleManager api                        | `/`                                                           |
+| `middleManager.ingress.annotations`      | annotations for the middleManager api ingress        | `{}`                                                          |
+| `middleManager.ingress.tls`              | TLS configuration for the ingress                    | `[]`                                                          |
+| `router.enabled`                         | enable router                                        | `false`                                                       |
+| `router.name`                            | router component name                                | `router`                                                      |
+| `router.replicaCount`                    | router node replicas (deployment)                    | `1`                                                           |
+| `router.port`                            | port of router component                             | `8888`                                                        |
+| `router.serviceType`                     | service type for service                             | `ClusterIP`                                                   |
+| `router.resources`                       | router node resources requests & limits              | `{}`                                                          |
+| `router.podAnnotations`                  | router Deployment annotations                        | `{}`                                                          |
+| `router.nodeSelector`                    | node labels for router pod assignment                | `{}`                                                          |
+| `router.tolerations`                     | router tolerations                                   | `[]`                                                          |
+| `router.config`                          | router private config such as `JAVA_OPTS`            |                                                               |
+| `router.affinity`                        | router affinity policy                               | `{}`                                                          |
+| `router.ingress.enabled`                 | enable ingress                                       | `false`                                                       |
+| `router.ingress.hosts`                   | hosts for the router api                             | `[ "chart-example.local" ]`                                   |
+| `router.ingress.path`                    | path of the router api                               | `/`                                                           |
+| `router.ingress.annotations`             | annotations for the router api ingress               | `{}`                                                          |
+| `router.ingress.tls`                     | TLS configuration for the ingress                    | `[]`                                                          |
+| `prometheus.enabled`                     | Support scraping from prometheus                     | `false`                                                       |
+| `prometheus.port`                        | expose prometheus port                               | `9090`                                                        |
+| `prometheus.annotation`                  | pods annotation to notify prometheus scraping        | `{prometheus.io/scrape: "true", prometheus.io/port: "9090"}`  |
 
 Full and up-to-date documentation can be found in the comments of the `values.yaml` file.

--- a/helm/druid/templates/broker/deployment.yaml
+++ b/helm/druid/templates/broker/deployment.yaml
@@ -41,9 +41,14 @@ spec:
         app: {{ include "druid.name" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.broker.name }}
-      {{- with .Values.broker.podAnnotations }}
       annotations:
+      {{- with .Values.broker.podAnnotations }}
 {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       containers:

--- a/helm/druid/templates/broker/deployment.yaml
+++ b/helm/druid/templates/broker/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - name: http
               containerPort: {{ .Values.broker.port }}
               protocol: TCP
+            {{- if .Values.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.prometheus.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 60
             httpGet:

--- a/helm/druid/templates/coordinator/deployment.yaml
+++ b/helm/druid/templates/coordinator/deployment.yaml
@@ -41,9 +41,14 @@ spec:
         app: {{ include "druid.name" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.coordinator.name }}
-      {{- with .Values.coordinator.podAnnotations }}
       annotations:
+      {{- with .Values.coordinator.podAnnotations }}
 {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       containers:

--- a/helm/druid/templates/coordinator/deployment.yaml
+++ b/helm/druid/templates/coordinator/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - name: http
               containerPort: {{ .Values.coordinator.port }}
               protocol: TCP
+            {{- if .Values.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.prometheus.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 60
             httpGet:

--- a/helm/druid/templates/historical/statefulset.yaml
+++ b/helm/druid/templates/historical/statefulset.yaml
@@ -123,6 +123,11 @@ spec:
         ports:
         - containerPort: {{ .Values.historical.port }}
           name: http
+        {{- if .Values.prometheus.enabled }}
+        - name: prometheus
+          containerPort: {{ .Values.prometheus.port }}
+          protocol: TCP
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/druid/var/druid/
           name: data

--- a/helm/druid/templates/historical/statefulset.yaml
+++ b/helm/druid/templates/historical/statefulset.yaml
@@ -42,10 +42,15 @@ spec:
         app: {{ template "druid.name" . }}
         component: {{ .Values.historical.name }}
         release: {{ .Release.Name }}
-        {{- with .Values.historical.podAnnotations }}
       annotations:
+      {{- with .Values.historical.podAnnotations }}
 {{ toYaml . | indent 8 }}
-        {{- end }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- end }}
     spec:
       {{- if or .Values.historical.antiAffinity .Values.historical.nodeAffinity }}
       affinity:

--- a/helm/druid/templates/middleManager/statefulset.yaml
+++ b/helm/druid/templates/middleManager/statefulset.yaml
@@ -42,10 +42,15 @@ spec:
         app: {{ template "druid.name" . }}
         component: {{ .Values.middleManager.name }}
         release: {{ .Release.Name }}
-        {{- if .Values.middleManager.podAnnotations }}
       annotations:
-{{ toYaml .Values.middleManager.podAnnotations | indent 8 }}
-        {{- end }}
+      {{- with .Values.middleManager.podAnnotations }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- end }}
     spec:
       {{- if or .Values.middleManager.antiAffinity .Values.middleManager.nodeAffinity }}
       affinity:

--- a/helm/druid/templates/middleManager/statefulset.yaml
+++ b/helm/druid/templates/middleManager/statefulset.yaml
@@ -123,6 +123,11 @@ spec:
         ports:
         - containerPort: {{ .Values.middleManager.port }}
           name: http
+        {{- if .Values.prometheus.enabled}}
+        - name: prometheus
+          containerPort: {{ .Values.prometheus.port }}
+          protocol: TCP
+        {{- end }}
         volumeMounts:
         - mountPath: /opt/druid/var/druid/
           name: data

--- a/helm/druid/templates/overlord/deployment.yaml
+++ b/helm/druid/templates/overlord/deployment.yaml
@@ -41,9 +41,14 @@ spec:
         app: {{ include "druid.name" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.overlord.name }}
-      {{- with .Values.overlord.podAnnotations }}
       annotations:
+      {{- with .Values.overlord.podAnnotations }}
 {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       containers:

--- a/helm/druid/templates/overlord/deployment.yaml
+++ b/helm/druid/templates/overlord/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - name: http
               containerPort: {{ .Values.overlord.port }}
               protocol: TCP
+            {{- if .Values.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.prometheus.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 60
             httpGet:

--- a/helm/druid/templates/router/deployment.yaml
+++ b/helm/druid/templates/router/deployment.yaml
@@ -67,6 +67,11 @@ spec:
             - name: http
               containerPort: {{ .Values.router.port }}
               protocol: TCP
+            {{- .Values.prometheus.enabled }}
+            - name: prometheus
+              containerPort: {{ .Values.prometheus.port }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             initialDelaySeconds: 60
             httpGet:

--- a/helm/druid/templates/router/deployment.yaml
+++ b/helm/druid/templates/router/deployment.yaml
@@ -41,9 +41,14 @@ spec:
         app: {{ include "druid.name" . }}
         release: {{ .Release.Name }}
         component: {{ .Values.router.name }}
-      {{- with .Values.router.podAnnotations }}
       annotations:
+      {{- with .Values.router.podAnnotations }}
 {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- if .Values.prometheus.enabled }}
+      {{- with .Values.prometheus.annotation }}
+{{ toYaml . | indent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       containers:

--- a/helm/druid/templates/router/deployment.yaml
+++ b/helm/druid/templates/router/deployment.yaml
@@ -67,7 +67,7 @@ spec:
             - name: http
               containerPort: {{ .Values.router.port }}
               protocol: TCP
-            {{- .Values.prometheus.enabled }}
+            {{- if .Values.prometheus.enabled }}
             - name: prometheus
               containerPort: {{ .Values.prometheus.port }}
               protocol: TCP

--- a/helm/druid/values.yaml
+++ b/helm/druid/values.yaml
@@ -417,3 +417,10 @@ postgresql:
     port: 5432
 
 # Secrets
+prometheus:
+  enabled: false
+  #pick the any port what you want
+  port: 9090
+  annotation:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"


### PR DESCRIPTION
### Description

modify helm chart to support scraping from prometheus automatically
Relates to [Issue 13530](https://github.com/apache/druid/issues/13530)

prometheus emitter metric is scraped by prometheus 
![스크린샷 2022-12-08 오후 7 08 18](https://user-images.githubusercontent.com/90180644/206419413-40699d4a-5d12-4e01-af60-6fa4502d25cd.png)

##### Key changed/added classes in this PR
 * `change helm chart` 
   * `add pods annotation`
   * `expose port to scrap from prometheus`


This PR has:
- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
