### PR TITLE
Update Guava to 19.0.

### DIFF
--- a/extendedset/pom.xml
+++ b/extendedset/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
     </dependency>
 
     <dependency>

--- a/extensions-contrib/compressed-bigdecimal/pom.xml
+++ b/extensions-contrib/compressed-bigdecimal/pom.xml
@@ -138,7 +138,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -353,7 +353,7 @@ name: Guava
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 16.0.1
+version: 19.0
 libraries:
   - com.google.guava: guava
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>
         <errorprone.version>2.11.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>19.0</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.48.v20220622</jetty.version>


### PR DESCRIPTION
Currently we use Guava 16.0.1. This is a very old version, but we continue to use it in order to maintain compatibility with Hadoop 2, which also bundles a very old version of Guava. As a community we have not yet made the decision to drop support for Hadoop 2 (https://lists.apache.org/thread/1j5w9dmt1gp8hx31tvrmyomcko4mlp03), but nevertheless, we'd like to update Calcite (https://github.com/apache/druid/issues/13532). Current versions of Calcite support a minimum of Guava 19.0, so this patch updates us to that version. We'll need to test it with Hadoop 2 to make sure nothing breaks.