### PR TITLE
perf: core/TextReader for faster json ingestion

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JsonLineReaderBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JsonLineReaderBenchmark.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.benchmark;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.data.input.ColumnsFilter;
+import org.apache.druid.data.input.InputEntityReader;
+import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
+import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 10)
+@Measurement(iterations = 25)
+@Fork(value = 1)
+public class JsonLineReaderBenchmark
+{
+  private static final int NUM_EVENTS = 1000;
+
+  InputEntityReader reader;
+  JsonInputFormat format;
+  byte[] data;
+
+  @Setup(Level.Invocation)
+  public void prepareReader()
+  {
+    ByteEntity source = new ByteEntity(data);
+    reader = format.createReader(
+            new InputRowSchema(
+                    new TimestampSpec("timestamp", "iso", null),
+                    new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "foo"))),
+                    ColumnsFilter.all()
+            ),
+            source,
+            null
+    );
+  }
+
+  @Setup
+  public void prepareData() throws Exception
+  {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    String dataString = "{" +
+            "\"stack\":\"mainstack\"," +
+            "\"metadata\":" +
+            "{" +
+            "\"application\":\"applicationname\"," +
+            "\"detail\":\"tm\"," +
+            "\"id\":\"123456789012345678901234567890346973eb4c30eca8a4df79c8219d152cfe0d7d6bdb11a12e609c0c\"," +
+            "\"idtwo\":\"123456789012345678901234567890346973eb4c30eca8a4df79c8219d152cfe0d7d6bdb11a12e609c0c\"," +
+            "\"sequence\":\"v008\"," +
+            "\"stack\":\"mainstack\"," +
+            "\"taskId\":\"12345678-1234-1234-1234-1234567890ab\"," +
+            "\"taskIdTwo\":\"12345678-1234-1234-1234-1234567890ab\"" +
+            "}," +
+            "\"_cluster_\":\"kafka\"," +
+            "\"_id_\":\"12345678-1234-1234-1234-1234567890ab\"," +
+            "\"_offset_\":12111398526," +
+            "\"type\":\"CUMULATIVE_DOUBLE\"," +
+            "\"version\":\"v1\"," +
+            "\"timestamp\":1670425782281," +
+            "\"point\":{\"seconds\":1670425782,\"nanos\":217000000,\"value\":0}," +
+            "\"_kafka_timestamp_\":1670425782304," +
+            "\"_partition_\":60," +
+            "\"ec2_instance_id\":\"i-1234567890\"," +
+            "\"name\":\"packets_received\"," +
+            "\"_topic_\":\"test_topic\"}";
+    for (int i = 0; i < NUM_EVENTS; i++) {
+      baos.write(StringUtils.toUtf8(dataString));
+      baos.write(new byte[]{'\n'});
+    }
+
+    data = baos.toByteArray();
+  }
+
+  @Setup
+  public void prepareFormat()
+  {
+    format = new JsonInputFormat(
+            new JSONPathSpec(
+                    true,
+                    ImmutableList.of(
+                            new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz", "baz"),
+                            new JSONPathFieldSpec(JSONPathFieldType.ROOT, "root_baz2", "baz2"),
+                            new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg", "$.o.mg"),
+                            new JSONPathFieldSpec(JSONPathFieldType.PATH, "path_omg2", "$.o.mg2"),
+                            new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg", ".o.mg"),
+                            new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
+                    )
+            ),
+            null,
+            null,
+            null,
+            null
+    );
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void baseline(final Blackhole blackhole) throws IOException
+  {
+    int counted = 0;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      while (iterator.hasNext()) {
+        final InputRow row = iterator.next();
+        if (row != null) {
+          counted += 1;
+        }
+        blackhole.consume(row);
+      }
+    }
+
+    if (counted != NUM_EVENTS) {
+      throw new RuntimeException("invalid number of loops, counted = " + counted);
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException
+  {
+    Options opt = new OptionsBuilder()
+        .include(JsonLineReaderBenchmark.class.getSimpleName())
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -192,6 +192,10 @@
       <artifactId>fastutil-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-extra</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-buffer</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/druid/data/input/TextReader.java
+++ b/core/src/main/java/org/apache/druid/data/input/TextReader.java
@@ -20,14 +20,13 @@
 package org.apache.druid.data.input;
 
 import com.google.common.base.Strings;
-import org.apache.commons.io.LineIterator;
-import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.data.input.impl.FastLineIterator;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.CloseableIteratorWithMetadata;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.java.util.common.parsers.ParserUtils;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,15 +54,13 @@ public abstract class TextReader extends IntermediateRowParsingReader<String>
   @Override
   public CloseableIteratorWithMetadata<String> intermediateRowIteratorWithMetadata() throws IOException
   {
-    final LineIterator delegate = new LineIterator(
-        new InputStreamReader(source.open(), StringUtils.UTF8_STRING)
-    );
+    final CloseableIterator<String> delegate = new FastLineIterator(source.open());
     final int numHeaderLines = getNumHeaderLinesToSkip();
     for (int i = 0; i < numHeaderLines && delegate.hasNext(); i++) {
-      delegate.nextLine(); // skip lines
+      delegate.next(); // skip lines
     }
     if (needsToProcessHeaderLine() && delegate.hasNext()) {
-      processHeaderLine(delegate.nextLine());
+      processHeaderLine(delegate.next());
     }
 
     return new CloseableIteratorWithMetadata<String>()
@@ -87,7 +84,7 @@ public abstract class TextReader extends IntermediateRowParsingReader<String>
       public String next()
       {
         currentLineNumber++;
-        return delegate.nextLine();
+        return delegate.next();
       }
 
       @Override

--- a/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.bytes.ByteArrayList;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.parsers.CloseableIterator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.NoSuchElementException;
+
+/**
+ * Like the Apache Commons LineIterator, but faster.
+ */
+public class FastLineIterator implements CloseableIterator<String>
+{
+  private static final ThreadLocal<byte[]> BUFFER_LOCAL = ThreadLocal.withInitial(() -> new byte[512]);
+
+  static final byte CR = (byte) '\r';
+  static final byte LF = (byte) '\n';
+
+  final InputStream source;
+  final ByteArrayList buffer;
+
+  boolean finished;
+  String nextLine;
+
+  /**
+   * Constructor; a local buffer will be created
+   * @param source
+   */
+  public FastLineIterator(InputStream source)
+  {
+    this(source, new ByteArrayList());
+  }
+
+  /**
+   * Constructor; BYO buffer.
+   *
+   * Existing contents of the buffer will be destroyed.
+   * @param source
+   * @param buffer
+   */
+  public FastLineIterator(InputStream source, ByteArrayList buffer)
+  {
+    Preconditions.checkNotNull(source);
+    this.source = source;
+    this.finished = false;
+    this.nextLine = null;
+    this.buffer = buffer;
+    this.buffer.size(0);
+  }
+
+  @Override
+  public void close() throws IOException
+  {
+    nextLine = null;
+    finished = true;
+    source.close();
+    // Note: do not remove the thread local buffer; retain it for reuse later
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    //noinspection VariableNotUsedInsideIf
+    if (nextLine != null) {
+      return true;
+    }
+
+    if (finished) {
+      return false;
+    }
+
+    readNextLine();
+
+    return nextLine != null;
+  }
+
+  @Override
+  public String next()
+  {
+    if (!hasNext()) {
+      throw new NoSuchElementException("no more lines");
+    }
+
+    String result = nextLine;
+    nextLine = null;
+    return result;
+  }
+
+  void readNextLine()
+  {
+    byte[] load = BUFFER_LOCAL.get();
+
+    // load data until finished or found a line feed
+    int indexOfLf = buffer.indexOf(LF);
+    while (!finished && indexOfLf < 0) {
+      int readCount;
+
+      try {
+        readCount = source.read(load);
+      }
+      catch (IOException e) {
+        nextLine = null;
+        finished = true;
+        throw new IllegalStateException(e);
+      }
+
+      if (readCount < 0) {
+        finished = true;
+      } else {
+        int sizeBefore = buffer.size();
+        buffer.addElements(buffer.size(), load, 0, readCount);
+
+        // check if there were any LFs in the newly collected data
+        for (int i = 0; i < readCount; i++) {
+          if (load[i] == LF) {
+            indexOfLf = sizeBefore + i;
+            break;
+          }
+        }
+      }
+    }
+
+    if (finished && buffer.size() == 0) {
+      // empty line and end of file
+      nextLine = null;
+
+    } else if (indexOfLf < 0) {
+      // no LF at all; end of input
+      nextLine = StringUtils.fromUtf8(buffer);
+      buffer.removeElements(0, buffer.size());
+
+    } else if (indexOfLf > 1 && buffer.getByte(indexOfLf - 1) == CR) {
+      // CR LF
+      nextLine = StringUtils.fromUtf8(buffer.elements(), 0, indexOfLf - 1);
+      buffer.removeElements(0, indexOfLf + 1);
+
+    } else {
+      // LF only
+      nextLine = StringUtils.fromUtf8(buffer.elements(), 0, indexOfLf);
+      buffer.removeElements(0, indexOfLf + 1);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
@@ -33,7 +33,8 @@ import java.util.NoSuchElementException;
  */
 public class FastLineIterator implements CloseableIterator<String>
 {
-  private static final ThreadLocal<byte[]> BUFFER_LOCAL = ThreadLocal.withInitial(() -> new byte[512]);
+  static final int BUFFER_SIZE = 512;
+  private static final ThreadLocal<byte[]> BUFFER_LOCAL = ThreadLocal.withInitial(() -> new byte[BUFFER_SIZE]);
 
   static final byte CR = (byte) '\r';
   static final byte LF = (byte) '\n';

--- a/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
@@ -149,7 +149,7 @@ public class FastLineIterator implements CloseableIterator<String>
       nextLine = StringUtils.fromUtf8(buffer);
       buffer.removeElements(0, buffer.size());
 
-    } else if (indexOfLf > 1 && buffer.getByte(indexOfLf - 1) == CR) {
+    } else if (indexOfLf >= 1 && buffer.getByte(indexOfLf - 1) == CR) {
       // CR LF
       nextLine = StringUtils.fromUtf8(buffer.elements(), 0, indexOfLf - 1);
       buffer.removeElements(0, indexOfLf + 1);

--- a/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
+++ b/core/src/main/java/org/apache/druid/data/input/impl/FastLineIterator.java
@@ -33,17 +33,19 @@ import java.util.NoSuchElementException;
  */
 public class FastLineIterator implements CloseableIterator<String>
 {
+  // visible for tests
   static final int BUFFER_SIZE = 512;
+
   private static final ThreadLocal<byte[]> BUFFER_LOCAL = ThreadLocal.withInitial(() -> new byte[BUFFER_SIZE]);
 
-  static final byte CR = (byte) '\r';
-  static final byte LF = (byte) '\n';
+  private static final byte CR = (byte) '\r';
+  private static final byte LF = (byte) '\n';
 
-  final InputStream source;
-  final ByteArrayList buffer;
+  private final InputStream source;
+  private final ByteArrayList buffer;
 
-  boolean finished;
-  String nextLine;
+  private boolean finished;
+  private String nextLine;
 
   /**
    * Constructor; a local buffer will be created
@@ -64,6 +66,7 @@ public class FastLineIterator implements CloseableIterator<String>
   public FastLineIterator(InputStream source, ByteArrayList buffer)
   {
     Preconditions.checkNotNull(source);
+    Preconditions.checkNotNull(buffer);
     this.source = source;
     this.finished = false;
     this.nextLine = null;

--- a/core/src/main/java/org/apache/druid/java/util/common/StringUtils.java
+++ b/core/src/main/java/org/apache/druid/java/util/common/StringUtils.java
@@ -20,6 +20,8 @@
 package org.apache.druid.java.util.common;
 
 import com.google.common.base.Strings;
+import it.unimi.dsi.fastutil.bytes.ByteArrayList;
+import it.unimi.dsi.fastutil.bytes.ByteList;
 import org.apache.commons.io.IOUtils;
 
 import javax.annotation.Nonnull;
@@ -225,8 +227,13 @@ public class StringUtils
 
   public static String fromUtf8(final byte[] bytes)
   {
+    return fromUtf8(bytes, 0, bytes.length);
+  }
+
+  public static String fromUtf8(final byte[] bytes, int offset, int length)
+  {
     try {
-      return new String(bytes, UTF8_STRING);
+      return new String(bytes, offset, length, UTF8_STRING);
     }
     catch (UnsupportedEncodingException e) {
       // Should never happen
@@ -254,6 +261,16 @@ public class StringUtils
   public static String fromUtf8(final ByteBuffer buffer)
   {
     return StringUtils.fromUtf8(buffer, buffer.remaining());
+  }
+
+  public static String fromUtf8(final ByteArrayList buffer)
+  {
+    return StringUtils.fromUtf8(buffer.elements(), 0, buffer.size());
+  }
+
+  public static String fromUtf8(final ByteList buffer)
+  {
+    return StringUtils.fromUtf8(buffer.toByteArray());
   }
 
   /**

--- a/core/src/test/java/org/apache/druid/data/input/impl/FastLineIteratorTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/FastLineIteratorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.druid.common.config.NullHandling;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.NoSuchElementException;
+
+public class FastLineIteratorTest
+{
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @BeforeClass
+  public static void setup()
+  {
+    NullHandling.initializeForTests();
+  }
+
+  @Test
+  public void testNullInputThrows()
+  {
+    expectedException.expect(NullPointerException.class);
+    //noinspection ResultOfObjectAllocationIgnored
+    new FastLineIterator(null);
+  }
+
+  @Test
+  public void testEmptyInput()
+  {
+    byte[] input = new byte[0];
+    FastLineIterator iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertFalse(iterator.hasNext());
+
+    expectedException.expect(NoSuchElementException.class);
+    iterator.next();
+  }
+
+  @Test
+  public void testSingleLine()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // without an end
+    input = "abcd".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+
+    // with an end
+    input = "abcd\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+
+    // with an end
+    input = "abcd\r\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testMultipleLines()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    input = "abcd\ndefg\nhijk".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertEquals("defg", iterator.next());
+    Assert.assertEquals("hijk", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testEmptyMiddleLine()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    input = "abcd\n\nhijk\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertEquals("", iterator.next());
+    Assert.assertEquals("hijk", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testEmptyLastLine()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    input = "abcd\ndefg\nhijk\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("abcd", iterator.next());
+    Assert.assertEquals("defg", iterator.next());
+    Assert.assertEquals("hijk", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testOverlappingBuffer()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    String line1 = RandomStringUtils.random(FastLineIterator.BUFFER_SIZE - 20);
+    String line2 = RandomStringUtils.random(40);
+    String line3 = RandomStringUtils.random(20);
+
+    input = (line1 + "\n" + line2 + "\n" + line3 + "\n").getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals(line1, iterator.next());
+    Assert.assertEquals(line2, iterator.next());
+    Assert.assertEquals(line3, iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testLineLargerThanBufferSize()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // random lengths that force multiple buffer trips
+    String line1 = RandomStringUtils.random(FastLineIterator.BUFFER_SIZE * 3 + 10);
+    String line2 = RandomStringUtils.random(FastLineIterator.BUFFER_SIZE * 2 + 15);
+    String line3 = RandomStringUtils.random(FastLineIterator.BUFFER_SIZE + 9);
+
+    input = (line1 + "\r\n" + line2 + "\r\n" + line3 + "\r\n").getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals(line1, iterator.next());
+    Assert.assertEquals(line2, iterator.next());
+    Assert.assertEquals(line3, iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+}

--- a/core/src/test/java/org/apache/druid/data/input/impl/FastLineIteratorTest.java
+++ b/core/src/test/java/org/apache/druid/data/input/impl/FastLineIteratorTest.java
@@ -63,6 +63,72 @@ public class FastLineIteratorTest
   }
 
   @Test
+  public void testSoloCr()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // a single \r
+    // it is expected that this emits a complete line with \r since a return on its own is not a line break
+    input = "\r".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("\r", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testSoloLf()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // a single \n
+    // should emit a single complete 'line' as "", and no trailing line (since EOF)
+    input = "\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testBackwardsLfCr()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // should emit two lines:
+    // first one is an empty line for before the \n,
+    // second is the \r alone
+    input = "\n\r".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("", iterator.next());
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("\r", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testForwardsSoloCrLf()
+  {
+    byte[] input;
+    FastLineIterator iterator;
+
+    // should emit one (empty) line
+    input = "\r\n".getBytes(StandardCharsets.UTF_8);
+    iterator = new FastLineIterator(new ByteArrayInputStream(input));
+
+    Assert.assertTrue(iterator.hasNext());
+    Assert.assertEquals("", iterator.next());
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
   public void testSingleLine()
   {
     byte[] input;

--- a/pom.xml
+++ b/pom.xml
@@ -809,6 +809,11 @@
                 <version>${fastutil.version}</version>
             </dependency>
             <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil-extra</artifactId>
+                <version>${fastutil.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>4.6</version>


### PR DESCRIPTION
### Description

Use a smaller default buffer in the TextReader during parsing. By default, the [LineIterator creates a BufferedReader if one is not provided](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/LineIterator.java#L84-L88); the default [BufferedReader creates an 8KB buffer](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/9a751dc19fae78ce58fb0eb176522070c992fb6f/jdk/src/share/classes/java/io/BufferedReader.java#L88).

Improve this by creating a `FastLineIterator` which minimises the repeated creation of buffers.

Before vs after
```
Benchmark                         Mode  Cnt     Score    Error  Units
JsonLineReaderBenchmark.baseline  avgt   15  3459.871 ± 106.175  us/op      [before]
JsonLineReaderBenchmark.baseline  avgt   15  3022.053 ± 51.286  us/op       [after]
```
Existing tests cover the change (JsonLineReader, CSVReader). Replacement for #12302.

### Changes

- Introduces a new benchmark `JsonLineReaderBenchmark`
- Adds a `FastLineIterator` and switches the `TextReader` to use it.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.