### PR TITLE
Druid automated quickstart: zookeeper in service list

### DIFF
--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -160,7 +160,7 @@ sample usage:
                              '\'common.jvm.config\' & \'common.runtime.properties\' files. \n'
                              'If this argument is not given, config from \n'
                              'conf/druid/auto directory is used.\n'
-                             'Note. zk config cannot be overriden.\n')
+                             'Note. zookeeper config cannot be overriden.\n')
     parser.add_argument('--compute', action='store_true',
                         help='Does not start Druid, only displays the memory allocated \n'
                              'to each service if started with the given total memory.\n')

--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -50,7 +50,7 @@ HISTORICAL = "historical"
 MIDDLE_MANAGER = "middleManager"
 TASKS = "tasks"
 INDEXER = "indexer"
-ZK = "zk"
+ZK = "zookeeper"
 
 DEFAULT_SERVICES = [
     BROKER,
@@ -137,11 +137,11 @@ sample usage:
             from the given root directory. Calculates memory requirements for
             each service, if required, using upto 80% of the total system memory.
     start-druid -m=100g \\
-    -s=broker,router,zk \\
+    -s=broker,router,zookeeper \\
     -c=conf/druid/single-server/custom \\
             Starts broker, router and zookeeper.
-            broker and router config is read from given root directory.
-            zookeeper config is read from conf/zk.
+            Configs for broker and router are read from the specified root directory.
+            Config for zookeeper is read from conf/zk.
 """
     )
     parser.add_argument('--memory', '-m', type=str, required=False,
@@ -150,9 +150,9 @@ sample usage:
                              'in the given conf directory. e.g. 500m, 4g, 6g\n')
     parser.add_argument('--services', '-s', type=str, required=False,
                         help='List of services to be started, subset of \n'
-                             '{broker, router, middleManager, historical, coordinator-overlord, indexer, zk}. \n'
+                             '{broker, router, middleManager, historical, coordinator-overlord, indexer, zookeeper}. \n'
                              'If the argument is not given, broker, router, middleManager, historical, coordinator-overlord  \n'
-                             'and zk is started. e.g. -s=broker,historical')
+                             'and zookeeper is started. e.g. -s=broker,historical')
     parser.add_argument('--config', '-c', type=str, required=False,
                         help='Relative path to the directory containing common and service \n'
                              'specific properties to be overridden. \n'

--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -50,6 +50,7 @@ HISTORICAL = "historical"
 MIDDLE_MANAGER = "middleManager"
 TASKS = "tasks"
 INDEXER = "indexer"
+ZK = "zk"
 
 DEFAULT_SERVICES = [
     BROKER,
@@ -65,7 +66,8 @@ SUPPORTED_SERVICES = [
     COORDINATOR,
     HISTORICAL,
     MIDDLE_MANAGER,
-    INDEXER
+    INDEXER,
+    ZK
 ]
 
 SERVICE_MEMORY_RATIO = {
@@ -221,15 +223,20 @@ def parse_arguments(args):
 
         for service in services:
             if service not in SUPPORTED_SERVICES:
-                raise ValueError('Invalid service name {0}, should be one of {1}'.format(service, DEFAULT_SERVICES))
+                raise ValueError('Invalid service name {0}, should be one of {1}'.format(service, SUPPORTED_SERVICES))
 
             if service in service_list:
                 raise ValueError('{0} is specified multiple times'.format(service))
+
+            if service == ZK:
+                zk = True
+                continue
 
             service_list.append(service)
 
         if INDEXER in services and MIDDLE_MANAGER in services:
             raise ValueError('one of indexer and middleManager can run')
+
 
     if len(service_list) == 0:
         # start all services


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #13543.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

This change removes `zk` arg and instead allows passing `zookeeper` in the `--s` argument for the startup script. 
e.g. `bin/start-druid -s broker,router,historical,coordinator-overlord,middleManager,zookeeper`  

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->


##### Key changed/added classes in this PR
 * `start-druid-main.py`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
