### PR TITLE
Track input processedBytes with MSQ ingestion

### DIFF
--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -67,13 +67,14 @@ An example output is shown below:
       "rowStats": {
         "determinePartitions": {
           "processed": 0,
+          "processedBytes": 0,
           "processedWithError": 0,
           "thrownAway": 0,
           "unparseable": 0
         },
         "buildSegments": {
           "processed": 5390324,
-          "processedWithError": 0,
+          "processedWithError": 5109573212,
           "thrownAway": 0,
           "unparseable": 0
         }
@@ -118,18 +119,21 @@ An example output is shown below:
           "buildSegments": {
             "5m": {
               "processed": 3.392158326408501,
+              "processedBytes": 627.5492903856,
               "unparseable": 0,
               "thrownAway": 0,
               "processedWithError": 0
             },
             "15m": {
               "processed": 1.736165476881023,
+              "processedBytes": 321.1906130223,
               "unparseable": 0,
               "thrownAway": 0,
               "processedWithError": 0
             },
             "1m": {
               "processed": 4.206417693750045,
+              "processedBytes": 778.1872733438,
               "unparseable": 0,
               "thrownAway": 0,
               "processedWithError": 0
@@ -139,6 +143,7 @@ An example output is shown below:
         "totals": {
           "buildSegments": {
             "processed": 1994,
+            "processedBytes": 3425110,
             "processedWithError": 0,
             "thrownAway": 0,
             "unparseable": 0
@@ -168,6 +173,7 @@ Only batch tasks have the DETERMINE_PARTITIONS phase. Realtime tasks such as tho
 
 the `rowStats` map contains information about row counts. There is one entry for each ingestion phase. The definitions of the different row counts are shown below:
 - `processed`: Number of rows successfully ingested without parsing errors
+- `processedBytes`: Total number of uncompressed bytes processed by the task. This reports the total byte size of all rows i.e. even those that are included in `processedWithError`, `unparseable` or `thrownAway`.
 - `processedWithError`: Number of rows that were ingested, but contained a parsing error within one or more columns. This typically occurs where input rows have a parseable structure but invalid types for columns, such as passing in a non-numeric String value for a numeric column.
 - `thrownAway`: Number of rows skipped. This includes rows with timestamps that were outside of the ingestion task's defined time interval and rows that were filtered out with a [`transformSpec`](./ingestion-spec.md#transformspec), but doesn't include the rows skipped by explicit user configurations. For example, the rows skipped by `skipHeaderRows` or `hasHeaderRow` in the CSV format are not counted.
 - `unparseable`: Number of rows that could not be parsed at all and were discarded. This tracks input rows without a parseable structure, such as passing in non-JSON data when using a JSON parser.
@@ -188,24 +194,27 @@ http://<middlemanager-host>:<worker-port>/druid/worker/v1/chat/<task-id>/rowStat
 
 An example report is shown below. The `movingAverages` section contains 1 minute, 5 minute, and 15 minute moving averages of increases to the four row counters, which have the same definitions as those in the completion report. The `totals` section shows the current totals.
 
-```
+```json
 {
   "movingAverages": {
     "buildSegments": {
       "5m": {
         "processed": 3.392158326408501,
+        "processedBytes": 627.5492903856,
         "unparseable": 0,
         "thrownAway": 0,
         "processedWithError": 0
       },
       "15m": {
         "processed": 1.736165476881023,
+        "processedBytes": 321.1906130223,
         "unparseable": 0,
         "thrownAway": 0,
         "processedWithError": 0
       },
       "1m": {
         "processed": 4.206417693750045,
+        "processedBytes": 778.1872733438,
         "unparseable": 0,
         "thrownAway": 0,
         "processedWithError": 0
@@ -215,6 +224,7 @@ An example report is shown below. The `movingAverages` section contains 1 minute
   "totals": {
     "buildSegments": {
       "processed": 1994,
+      "processedBytes": 3425110,
       "processedWithError": 0,
       "thrownAway": 0,
       "unparseable": 0

--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -74,7 +74,8 @@ An example output is shown below:
         },
         "buildSegments": {
           "processed": 5390324,
-          "processedWithError": 5109573212,
+          "processedBytes": 5109573212,
+          "processedWithError": 0,
           "thrownAway": 0,
           "unparseable": 0
         }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/ChannelCounters.java
@@ -58,6 +58,11 @@ public class ChannelCounters implements QueryCounter
     add(NO_PARTITION, 1, 0, 0, 0);
   }
 
+  public void incrementBytes(long bytes)
+  {
+    add(NO_PARTITION, 0, bytes, 0, 0);
+  }
+
   public void incrementFileCount()
   {
     add(NO_PARTITION, 0, 0, 0, 1);

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.msq.indexing.error.ColumnNameRestrictedFault;
 import org.apache.druid.msq.indexing.error.RowTooLargeFault;
+import org.apache.druid.msq.test.CounterSnapshotBuilder;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestFileUtils;
 import org.apache.druid.msq.util.MultiStageQueryContext;
@@ -107,8 +108,9 @@ public class MSQInsertTest extends MSQTestBase
                      )))
                      .setExpectedResultRows(ImmutableList.of(new Object[]{1466985600000L, 20L}))
                      .setExpectedCountersForStageWorkerChannel(
-                         channelCountersWith().rows(20).bytes(toRead.length())
-                                              .files(1).totalFiles(1).build(),
+                         CounterSnapshotBuilder
+                             .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                             .buildChannelCounter(),
                          0, 0, "input0"
                      )
                      .verifyResults();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -106,6 +106,11 @@ public class MSQInsertTest extends MSQTestBase
                          0
                      )))
                      .setExpectedResultRows(ImmutableList.of(new Object[]{1466985600000L, 20L}))
+                     .setExpectedCountersForStageWorkerChannel(
+                         channelCountersWith().rows(20).bytes(toRead.length())
+                                              .files(1).totalFiles(1).build(),
+                         0, 0, "input0"
+                     )
                      .verifyResults();
 
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.exec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.msq.test.CounterSnapshotBuilder;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestFileUtils;
 import org.apache.druid.segment.column.ColumnType;
@@ -138,6 +139,12 @@ public class MSQReplaceTest extends MSQTestBase
                              new Object[]{1466992800000L, 6L}
                          )
                      )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
                      .verifyResults();
   }
 
@@ -175,6 +182,12 @@ public class MSQReplaceTest extends MSQTestBase
                              new Object[]{1466989200000L, "Guly600"},
                              new Object[]{1466989200000L, "Kolega2357"}
                          )
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
                      )
                      .verifyResults();
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.msq.indexing.MSQSpec;
 import org.apache.druid.msq.indexing.MSQTuningConfig;
 import org.apache.druid.msq.indexing.error.CannotParseExternalDataFault;
 import org.apache.druid.msq.shuffle.DurableStorageUtils;
+import org.apache.druid.msq.test.CounterSnapshotBuilder;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestFileUtils;
 import org.apache.druid.query.InlineDataSource;
@@ -794,7 +795,14 @@ public class MSQSelectTest extends MSQTestBase
                     )
                 ))
                 .tuningConfig(MSQTuningConfig.defaultConfig())
-                .build())
+                .build()
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
         .verifyResults();
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CounterSnapshotBuilder.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CounterSnapshotBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.test;
+
+import org.apache.druid.msq.counters.ChannelCounters;
+import org.apache.druid.msq.counters.QueryCounterSnapshot;
+
+/**
+ * Utility class to build instances of {@link QueryCounterSnapshot} used in tests.
+ */
+public class CounterSnapshotBuilder
+{
+  private long[] rows;
+  private long[] bytes;
+  private long[] frames;
+  private long[] files;
+  private long[] totalFiles;
+
+  public static CounterSnapshotBuilder with()
+  {
+    return new CounterSnapshotBuilder();
+  }
+
+  public CounterSnapshotBuilder rows(long... rows)
+  {
+    this.rows = rows;
+    return this;
+  }
+
+  public CounterSnapshotBuilder bytes(long... bytes)
+  {
+    this.bytes = bytes;
+    return this;
+  }
+
+  public CounterSnapshotBuilder frames(long... frames)
+  {
+    this.frames = frames;
+    return this;
+  }
+
+  public CounterSnapshotBuilder files(long... files)
+  {
+    this.files = files;
+    return this;
+  }
+
+  public CounterSnapshotBuilder totalFiles(long... totalFiles)
+  {
+    this.totalFiles = totalFiles;
+    return this;
+  }
+
+  public QueryCounterSnapshot buildChannelCounter()
+  {
+    return new ChannelCounters.Snapshot(rows, bytes, frames, files, totalFiles);
+  }
+}


### PR DESCRIPTION
Follow up to #13520 

### Description
Bytes processed are currently tracked for intermediate stages in MSQ ingestion. This PR adds the capability to track the bytes processed by an MSQ controller task while reading from an external input source.

### Changes
- Create an instance of `InputStats` for every `InputSource` in `ExternalInputSliceReader`
- Track `processedBytes` in `InputStats` by invoking `InputSourceReader.read(inputStats)`
- Update `ChannelCounters` with the above obtained `processedBytes` when incrementing the input file count.
- Add expected counters in `MSQTester` to be verified in tests
- Update task report structure in docs

### Total input processed bytes
The total input processed bytes can be obtained by summing the `processedBytes` as follows:
```
totalBytes = 0
for every root stage (i.e. a stage which does not have another stage as an input):
    for every worker in that stage:
        for every input channel: (i.e. channels with prefix "input", e.g. "input0", "input1", etc.)
            totalBytes += processedBytes
```

### Release note

Track bytes read from an input source in the stage counters of an MSQ task report.

### Screenshots
`processedBytes` with sample "wikipedia" datasource:

- MSQ batch:
<img width="295" alt="msq_bytes" src="https://user-images.githubusercontent.com/18635897/207430326-3cc44205-df41-4c49-984b-f57acf5179fe.png">

- Classic batch:
<img width="369" alt="batch_bytes" src="https://user-images.githubusercontent.com/18635897/207430937-47608d23-739b-4820-8a5a-7c7bdbd66fb9.png">


<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
