### PR TITLE
fix cool nested column bug caused by not properly validating that global id is present in global dictionary before lookup up local id

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
@@ -336,17 +336,21 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
         @Override
         public double estimateSelectivity(int totalRows)
         {
-          return (double) getBitmap(
-              localDictionary.indexOf(stringDictionary.indexOf(StringUtils.toUtf8ByteBuffer(value)))
-          ).size() / totalRows;
+          final int globalId = stringDictionary.indexOf(StringUtils.toUtf8ByteBuffer(value));
+          if (globalId < 0) {
+            return 0.0;
+          }
+          return (double) getBitmap(localDictionary.indexOf(globalId)).size() / totalRows;
         }
 
         @Override
         public <T> T computeBitmapResult(BitmapResultFactory<T> bitmapResultFactory)
         {
-          return bitmapResultFactory.wrapDimensionValue(
-              getBitmap(localDictionary.indexOf(stringDictionary.indexOf(StringUtils.toUtf8ByteBuffer(value))))
-          );
+          final int globalId = stringDictionary.indexOf(StringUtils.toUtf8ByteBuffer(value));
+          if (globalId < 0) {
+            return bitmapResultFactory.wrapDimensionValue(bitmapFactory.makeEmptyImmutableBitmap());
+          }
+          return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(globalId)));
         }
       };
     }
@@ -576,9 +580,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
           if (longValue == null) {
             return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
           }
-          return (double) getBitmap(
-              localDictionary.indexOf(longDictionary.indexOf(longValue) + adjustLongId)
-          ).size() / totalRows;
+          final int globalId = longDictionary.indexOf(longValue);
+          if (globalId < 0) {
+            return 0.0;
+          }
+          return (double) getBitmap(localDictionary.indexOf(globalId + adjustLongId)).size() / totalRows;
         }
 
         @Override
@@ -587,9 +593,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
           if (longValue == null) {
             return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
           }
-          return bitmapResultFactory.wrapDimensionValue(
-              getBitmap(localDictionary.indexOf(longDictionary.indexOf(longValue) + adjustLongId))
-          );
+          final int globalId = longDictionary.indexOf(longValue);
+          if (globalId < 0) {
+            return bitmapResultFactory.wrapDimensionValue(bitmapFactory.makeEmptyImmutableBitmap());
+          }
+          return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(globalId + adjustLongId)));
         }
       };
     }
@@ -770,9 +778,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
           if (doubleValue == null) {
             return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
           }
-          return (double) getBitmap(
-              localDictionary.indexOf(doubleDictionary.indexOf(doubleValue) + adjustDoubleId)
-          ).size() / totalRows;
+          final int globalId = doubleDictionary.indexOf(doubleValue);
+          if (globalId < 0) {
+            return 0.0;
+          }
+          return (double) getBitmap(localDictionary.indexOf(globalId + adjustDoubleId)).size() / totalRows;
         }
 
         @Override
@@ -781,9 +791,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
           if (doubleValue == null) {
             return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
           }
-          return bitmapResultFactory.wrapDimensionValue(
-              getBitmap(localDictionary.indexOf(doubleDictionary.indexOf(doubleValue) + adjustDoubleId))
-          );
+          final int globalId = doubleDictionary.indexOf(doubleValue);
+          if (globalId < 0) {
+            return bitmapResultFactory.wrapDimensionValue(bitmapFactory.makeEmptyImmutableBitmap());
+          }
+          return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(globalId + adjustDoubleId)));
         }
       };
     }
@@ -964,25 +976,31 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
 
       // multi-type, return all that match
       int globalId = stringDictionary.indexOf(StringUtils.toUtf8ByteBuffer(value));
-      int localId = localDictionary.indexOf(globalId);
-      if (localId >= 0) {
-        intList.add(localId);
+      if (globalId >= 0) {
+        int localId = localDictionary.indexOf(globalId);
+        if (localId >= 0) {
+          intList.add(localId);
+        }
       }
       Long someLong = GuavaUtils.tryParseLong(value);
       if (someLong != null) {
         globalId = longDictionary.indexOf(someLong);
-        localId = localDictionary.indexOf(globalId + adjustLongId);
-        if (localId >= 0) {
-          intList.add(localId);
+        if (globalId >= 0) {
+          int localId = localDictionary.indexOf(globalId + adjustLongId);
+          if (localId >= 0) {
+            intList.add(localId);
+          }
         }
       }
 
       Double someDouble = Doubles.tryParse(value);
       if (someDouble != null) {
         globalId = doubleDictionary.indexOf(someDouble);
-        localId = localDictionary.indexOf(globalId + adjustDoubleId);
-        if (localId >= 0) {
-          intList.add(localId);
+        if (globalId >= 0) {
+          int localId = localDictionary.indexOf(globalId + adjustDoubleId);
+          if (localId >= 0) {
+            intList.add(localId);
+          }
         }
       }
       return intList;

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplier.java
@@ -568,6 +568,7 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
     @Override
     public BitmapColumnIndex forValue(@Nullable String value)
     {
+      final boolean inputNull = value == null;
       final Long longValue = GuavaUtils.tryParseLong(value);
       return new SimpleBitmapColumnIndex()
       {
@@ -578,7 +579,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
         public double estimateSelectivity(int totalRows)
         {
           if (longValue == null) {
-            return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
+            if (inputNull) {
+              return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
+            } else {
+              return 0.0;
+            }
           }
           final int globalId = longDictionary.indexOf(longValue);
           if (globalId < 0) {
@@ -591,7 +596,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
         public <T> T computeBitmapResult(BitmapResultFactory<T> bitmapResultFactory)
         {
           if (longValue == null) {
-            return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
+            if (inputNull) {
+              return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
+            } else {
+              return bitmapResultFactory.wrapDimensionValue(bitmapFactory.makeEmptyImmutableBitmap());
+            }
           }
           final int globalId = longDictionary.indexOf(longValue);
           if (globalId < 0) {
@@ -767,6 +776,7 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
     @Override
     public BitmapColumnIndex forValue(@Nullable String value)
     {
+      final boolean inputNull = value == null;
       final Double doubleValue = Strings.isNullOrEmpty(value) ? null : Doubles.tryParse(value);
       return new SimpleBitmapColumnIndex()
       {
@@ -776,7 +786,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
         public double estimateSelectivity(int totalRows)
         {
           if (doubleValue == null) {
-            return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
+            if (inputNull) {
+              return (double) getBitmap(localDictionary.indexOf(0)).size() / totalRows;
+            } else {
+              return 0.0;
+            }
           }
           final int globalId = doubleDictionary.indexOf(doubleValue);
           if (globalId < 0) {
@@ -789,7 +803,11 @@ public class NestedFieldLiteralColumnIndexSupplier<TStringDictionary extends Ind
         public <T> T computeBitmapResult(BitmapResultFactory<T> bitmapResultFactory)
         {
           if (doubleValue == null) {
-            return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
+            if (inputNull) {
+              return bitmapResultFactory.wrapDimensionValue(getBitmap(localDictionary.indexOf(0)));
+            } else {
+              return bitmapResultFactory.wrapDimensionValue(bitmapFactory.makeEmptyImmutableBitmap());
+            }
           }
           final int globalId = doubleDictionary.indexOf(doubleValue);
           if (globalId < 0) {

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralDictionaryEncodedColumn.java
@@ -25,7 +25,6 @@ import com.google.common.base.Predicates;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
@@ -246,7 +245,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
         final int globalId = dictionary.get(localId);
         if (globalId == 0) {
           // zero
-          assert NullHandling.replaceWithDefault();
           return 0f;
         } else if (globalId < adjustLongId) {
           // try to convert string to float
@@ -266,7 +264,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
         final int globalId = dictionary.get(localId);
         if (globalId == 0) {
           // zero
-          assert NullHandling.replaceWithDefault();
           return 0.0;
         } else if (globalId < adjustLongId) {
           // try to convert string to double
@@ -286,7 +283,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
         final int globalId = dictionary.get(localId);
         if (globalId == 0) {
           // zero
-          assert NullHandling.replaceWithDefault();
           return 0L;
         } else if (globalId < adjustLongId) {
           // try to convert string to long
@@ -541,9 +537,9 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
         {
           final int localId = column.get(offset.getOffset());
           final int globalId = dictionary.get(localId);
-          if (globalId < globalDictionary.size()) {
+          if (globalId < adjustLongId) {
             return StringUtils.fromUtf8Nullable(globalDictionary.get(globalId));
-          } else if (globalId < globalDictionary.size() + globalLongDictionary.size()) {
+          } else if (globalId < adjustDoubleId) {
             return globalLongDictionary.get(globalId - adjustLongId);
           } else {
             return globalDoubleDictionary.get(globalId - adjustDoubleId);
@@ -557,7 +553,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
           final int globalId = dictionary.get(localId);
           if (globalId == 0) {
             // zero
-            assert NullHandling.replaceWithDefault();
             return 0f;
           } else if (globalId < adjustLongId) {
             // try to convert string to float
@@ -577,7 +572,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
           final int globalId = dictionary.get(localId);
           if (globalId == 0) {
             // zero
-            assert NullHandling.replaceWithDefault();
             return 0.0;
           } else if (globalId < adjustLongId) {
             // try to convert string to double
@@ -597,7 +591,6 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
           final int globalId = dictionary.get(localId);
           if (globalId == 0) {
             // zero
-            assert NullHandling.replaceWithDefault();
             return 0L;
           } else if (globalId < adjustLongId) {
             // try to convert string to long

--- a/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
@@ -43,7 +43,6 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
-import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DoubleColumnSelector;
 import org.apache.druid.segment.LongColumnSelector;
 import org.apache.druid.segment.Segment;
@@ -438,13 +437,13 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
         NESTED_MIXED_NUMERIC_FIELD
     );
     Assert.assertNotNull(mixedNumericValueSelector);
-    Assert.assertTrue(mixedNumericValueSelector instanceof DimensionDictionarySelector);
+    Assert.assertTrue(mixedNumericValueSelector instanceof ColumnValueSelector);
 
     ColumnValueSelector mixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
         NESTED_MIXED_FIELD
     );
     Assert.assertNotNull(mixedValueSelector);
-    Assert.assertTrue(mixedValueSelector instanceof DimensionDictionarySelector);
+    Assert.assertTrue(mixedValueSelector instanceof ColumnValueSelector);
 
 
     ColumnValueSelector sparseLongValueSelector = columnSelectorFactory.makeColumnValueSelector(
@@ -463,13 +462,13 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
         NESTED_SPARSE_MIXED_NUMERIC_FIELD
     );
     Assert.assertNotNull(sparseMixedNumericValueSelector);
-    Assert.assertTrue(sparseMixedNumericValueSelector instanceof DimensionDictionarySelector);
+    Assert.assertTrue(sparseMixedNumericValueSelector instanceof ColumnValueSelector);
 
     ColumnValueSelector sparseMixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
         NESTED_SPARSE_MIXED_FIELD
     );
     Assert.assertNotNull(sparseMixedValueSelector);
-    Assert.assertTrue(sparseMixedValueSelector instanceof DimensionDictionarySelector);
+    Assert.assertTrue(sparseMixedValueSelector instanceof ColumnValueSelector);
     //CHECKSTYLE.ON: Regexp
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -300,6 +300,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       } else if (ColumnType.DOUBLE.equals(singleType)) {
         Assert.assertEquals((double) row.get(path), valueSelector.getDouble(), 0.0);
       }
+      Assert.assertFalse(valueSelector.isNull());
 
       final String theString = String.valueOf(row.get(path));
       Assert.assertEquals(theString, dimSelector.getObject());

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -1164,6 +1164,143 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     checkBitmap(lowLevelIndex.getBitmap(-1));
   }
 
+  @Test
+  public void testEnsureNoImproperSelectionFromAdjustedGlobals() throws IOException
+  {
+    // make sure we only pick matching values, not "matching" values from not validating that
+    // globalId actually exists before looking it up in local dictionary
+    ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 10).order(ByteOrder.nativeOrder());
+    ByteBuffer bitmapsBuffer = ByteBuffer.allocate(1 << 10);
+
+    ByteBuffer stringBuffer = ByteBuffer.allocate(1 << 10);
+    ByteBuffer longBuffer = ByteBuffer.allocate(1 << 10).order(ByteOrder.nativeOrder());
+    ByteBuffer doubleBuffer = ByteBuffer.allocate(1 << 10).order(ByteOrder.nativeOrder());
+
+    GenericIndexedWriter<String> stringWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "strings",
+        GenericIndexed.STRING_STRATEGY
+    );
+    stringWriter.open();
+    stringWriter.write(null);
+    stringWriter.write("1");
+    writeToBuffer(stringBuffer, stringWriter);
+
+    FixedIndexedWriter<Long> longWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.LONG,
+        ByteOrder.nativeOrder(),
+        Long.BYTES,
+        true
+    );
+    longWriter.open();
+    longWriter.write(-2L);
+    writeToBuffer(longBuffer, longWriter);
+
+    FixedIndexedWriter<Double> doubleWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        TypeStrategies.DOUBLE,
+        ByteOrder.nativeOrder(),
+        Double.BYTES,
+        true
+    );
+    doubleWriter.open();
+    writeToBuffer(doubleBuffer, doubleWriter);
+
+    GenericIndexed<ByteBuffer> strings = GenericIndexed.read(stringBuffer, GenericIndexed.UTF8_STRATEGY);
+    Supplier<Indexed<ByteBuffer>> stringIndexed = () -> strings.singleThreaded();
+    Supplier<FixedIndexed<Long>> longIndexed = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES);
+    Supplier<FixedIndexed<Double>> doubleIndexed = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
+
+    FixedIndexedWriter<Integer> localDictionaryWriter = new FixedIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES,
+        true
+    );
+    localDictionaryWriter.open();
+    GenericIndexedWriter<ImmutableBitmap> bitmapWriter = new GenericIndexedWriter<>(
+        new OnHeapMemorySegmentWriteOutMedium(),
+        "bitmaps",
+        roaringFactory.getObjectStrategy()
+    );
+    bitmapWriter.setObjectsNotSorted();
+    bitmapWriter.open();
+
+    // 10 rows
+    // globals: [
+    //    [null, '1'],
+    //    [-2],
+    //    []
+    // ]
+    // local: [null, '1', -2]
+    // column: ['1', null, -2]
+
+    // null
+    localDictionaryWriter.write(0);
+    bitmapWriter.write(fillBitmap(1));
+
+    // '1'
+    localDictionaryWriter.write(1);
+    bitmapWriter.write(fillBitmap(0));
+
+    // -2
+    localDictionaryWriter.write(2);
+    bitmapWriter.write(fillBitmap(2));
+
+    writeToBuffer(localDictionaryBuffer, localDictionaryWriter);
+    writeToBuffer(bitmapsBuffer, bitmapWriter);
+
+    Supplier<FixedIndexed<Integer>> dictionarySupplier = FixedIndexed.read(
+        localDictionaryBuffer,
+        NestedDataColumnSerializer.INT_TYPE_STRATEGY,
+        ByteOrder.nativeOrder(),
+        Integer.BYTES
+    );
+
+    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+
+    NestedFieldLiteralColumnIndexSupplier<?> indexSupplier = new NestedFieldLiteralColumnIndexSupplier<>(
+        new NestedLiteralTypeInfo.TypeSet(
+            new NestedLiteralTypeInfo.MutableTypeSet().add(ColumnType.STRING)
+                                                      .add(ColumnType.LONG)
+                                                      .getByteValue()
+        ),
+        roaringFactory.getBitmapFactory(),
+        bitmaps,
+        dictionarySupplier,
+        stringIndexed,
+        longIndexed,
+        doubleIndexed
+    );
+
+    StringValueSetIndex valueSetIndex = indexSupplier.as(StringValueSetIndex.class);
+    Assert.assertNotNull(valueSetIndex);
+
+    // 3 rows
+    // local: [null, '1', -2]
+    // column: ['1', null, -2]
+
+    BitmapColumnIndex columnIndex = valueSetIndex.forValue("1");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3333, columnIndex.estimateSelectivity(3), 0.001);
+    ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0);
+
+    columnIndex = valueSetIndex.forValue("-2");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.3333, columnIndex.estimateSelectivity(3), 0.001);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2);
+
+    columnIndex = valueSetIndex.forValue("2");
+    Assert.assertNotNull(columnIndex);
+    Assert.assertEquals(0.0, columnIndex.estimateSelectivity(3), 0.0);
+    bitmap = columnIndex.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+  }
+
   private NestedFieldLiteralColumnIndexSupplier<?> makeSingleTypeStringSupplier() throws IOException
   {
     ByteBuffer localDictionaryBuffer = ByteBuffer.allocate(1 << 12).order(ByteOrder.nativeOrder());

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnIndexSupplierTest.java
@@ -210,7 +210,32 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap);
 
+    forRange = rangeIndex.forRange(null, true, "a", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(null, false, "b", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
     forRange = rangeIndex.forRange(null, false, "b", false);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.4, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 7, 8);
+
+
+    forRange = rangeIndex.forRange("a", false, "b", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange("a", true, "b", false);
     Assert.assertNotNull(forRange);
     Assert.assertEquals(0.4, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
@@ -491,6 +516,24 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 3, 5, 9);
 
+    forRange = rangeIndex.forRange(null, false, "a", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(null, false, "b", true);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(null, false, "b", false);
+    Assert.assertNotNull(forRange);
+    Assert.assertEquals(0.1, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 3);
+
     forRange = rangeIndex.forRange("f", false, null, true);
     Assert.assertNotNull(forRange);
     Assert.assertEquals(0.6, forRange.estimateSelectivity(10), 0.0);
@@ -607,6 +650,45 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     Assert.assertEquals(0.5, forRange.estimateSelectivity(10), 0.0);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 2, 6, 7, 8);
+
+    forRange = rangeIndex.forRange(1, true, 3, true);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(1, false, 3, true);
+    Assert.assertEquals(0.3, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 9);
+
+    forRange = rangeIndex.forRange(1, false, 3, false);
+    Assert.assertEquals(0.5, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 4, 5, 9);
+
+
+    forRange = rangeIndex.forRange(100L, true, 300L, true);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+
+    forRange = rangeIndex.forRange(100L, true, 300L, false);
+    Assert.assertEquals(0.3, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 2, 7, 8);
+
+
+    forRange = rangeIndex.forRange(100L, false, 300L, true);
+    Assert.assertEquals(0.2, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 6);
+
+
+    forRange = rangeIndex.forRange(100L, false, 300L, false);
+    Assert.assertEquals(0.5, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 6, 7, 8);
 
     forRange = rangeIndex.forRange(null, true, null, true);
@@ -726,6 +808,26 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 6, 7);
 
+    forRange = rangeIndex.forRange(100, true, 300, true);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(100, false, 300, true);
+    Assert.assertEquals(0.2, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 6);
+
+    forRange = rangeIndex.forRange(100, true, 300, false);
+    Assert.assertEquals(0.1, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 7);
+
+    forRange = rangeIndex.forRange(100, false, 300, false);
+    Assert.assertEquals(0.3, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 6, 7);
+
     forRange = rangeIndex.forRange(null, true, null, true);
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
@@ -735,6 +837,21 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 1, 3, 4, 6, 7, 9);
+
+    forRange = rangeIndex.forRange(null, false, 0, false);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(null, false, 1, false);
+    Assert.assertEquals(0.3, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 1, 3, 9);
+
+    forRange = rangeIndex.forRange(null, false, 1, true);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
   }
 
   @Test
@@ -997,6 +1114,26 @@ public class NestedFieldLiteralColumnIndexSupplierTest extends InitializedNullHa
     Assert.assertEquals(0.7, forRange.estimateSelectivity(10), 0.0);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory);
     checkBitmap(bitmap, 0, 2, 4, 5, 7, 8, 9);
+
+    forRange = rangeIndex.forRange(null, true, 1.0, true);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
+
+    forRange = rangeIndex.forRange(null, true, 1.1, false);
+    Assert.assertEquals(0.2, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 0, 8);
+
+    forRange = rangeIndex.forRange(6.6, false, null, false);
+    Assert.assertEquals(0.1, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap, 5);
+
+    forRange = rangeIndex.forRange(6.6, true, null, false);
+    Assert.assertEquals(0.0, forRange.estimateSelectivity(10), 0.0);
+    bitmap = forRange.computeBitmapResult(bitmapResultFactory);
+    checkBitmap(bitmap);
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR fixes a bug with nested column "value set" indexes caused by not properly validating that the globalId looked up for value is present in the global dictionary prior to looking it up in the local dictionary, which when "adjusting" the global ids for value type can cause incorrect selection of value indexes.

To use an example of a variant typed nested column with 3 values `["1", null, -2]` (the test case I added). The string dictionary is `[null, "1"]` and the long dictionary is `[-2]` and our local dictionary is `[0, 1, 2]`.

The code for variant typed indexes checks if the value is present in all global dictionaries and returns indexes for all matches. So in this case, we first lookup "1" in the string dictionary, find it at global id 1, all is good. Now, we check the long dictionary for `1`, which due to `-(insertionpoint + 1)` gives us `-(1 + 2) = -2`. Since the global id space is actually stacked dictionaries, global ids for long and double values must be "adjusted" by the size of string dictionary, and size of string + size of long for doubles.

Back to indexOf for longs and doubles. Since prior to this patch we were not checking that the globalId is 0 or larger, we then immediately looked up the `localDictionary.indexOf(-2 + adjustLong) = localDictionary.indexOf(-2 + 2) = localDictionary.indexOf(0)` ... which is an actual value contained in the dictionary! We should have skipped the longs completely since there were no global matches, but instead we randomly picked the 'null' value index since it is 0.

On to doubles, `-(insertionPoint + 1)` gives us `-(0 + 1) = -1`. The double adjust value is '3' since 2 strings and 1 long, so `localDictionary.indexOf(-1 + 3)` = `localDictionary.indexOf(2)` which is also a real value in our local dictionary that is definitely not '1'.

So in this one case, looking for '1' actually ended up matching every row, fun! Anyway, my bad, nested column indexes are pretty complicated 😅 

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
