### PR TITLE
Add clarification about JSONPath syntax to doc

### DIFF
--- a/docs/querying/sql-json-functions.md
+++ b/docs/querying/sql-json-functions.md
@@ -47,7 +47,7 @@ You can use the following JSON functions to extract, transform, and create `COMP
 
 ### JSONPath syntax
 
-Druid supports a subset of the [JSONPath syntax](https://github.com/json-path/JsonPath/blob/master/README.md) operators, primarily limited to extracting individual values from nested data structures.
+Druid supports a subset of the [JSONPath syntax](https://github.com/json-path/JsonPath/blob/master/README.md) operators, primarily limited to extracting individual values from nested data structures. You can't use wildcards, invoke functions, or filter expressions.
 
 |Operator|Description|
 | --- | --- |


### PR DESCRIPTION
Add clarification about JSONPath syntax to SQL JSON functions doc.

This PR has:
- [ ] been self-reviewed.