### PR TITLE
Suppress CVE-2022-45685 and CVE-2022-45693 from jettison-1.3

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -228,6 +228,8 @@
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@1.*$</packageUrl>
     <cve>CVE-2022-40149</cve>
     <cve>CVE-2022-40150</cve>
+    <cve>CVE-2022-45685</cve>
+    <cve>CVE-2022-45693</cve>
   </suppress>
   <suppress>
     <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->


### PR DESCRIPTION
Suppresses CVE-2022-45685 and CVE-2022-45693 from jettison-1.3
The jettison dependency is pulled by the cassandra-storage contrib extension.