### PR TITLE
Web console: fix preview dropping out of MSQ mode

### DIFF
--- a/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
@@ -157,7 +157,6 @@ describe('WorkbenchQuery', () => {
             '[{"name":"timestamp","type":"string"}]'
           )
         )
-        ORDER BY FLOOR("__time" TO HOUR), browser, session
       `);
     });
   });

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -464,10 +464,10 @@ export class WorkbenchQuery {
       }
     }
 
-    // Adjust the context, remove maxNumTasks and add in ingest mode flags
-    const cleanContext = deleteKeys(this.queryContext, ['maxNumTasks']);
-    ret = ret.changeQueryContext({
-      ...cleanContext,
+    // Explicitly select MSQ, adjust the context, set maxNumTasks to the lowest possible and add in ingest mode flags
+    ret = ret.changeEngine('sql-msq-task').changeQueryContext({
+      ...this.queryContext,
+      maxNumTasks: 2,
       finalizeAggregations: false,
       groupByEnableMultiValueUnnesting: false,
     });
@@ -479,12 +479,6 @@ export class WorkbenchQuery {
           .changeReplaceClause(undefined)
           .changePartitionedByClause(undefined)
           .changeClusteredByClause(undefined)
-          .changeOrderByClause(
-            WorkbenchQuery.makeOrderByClause(
-              parsedQuery.partitionedByClause,
-              parsedQuery.clusteredByClause,
-            ),
-          )
           .toString()
       : WorkbenchQuery.commentOutIngestParts(this.getQueryString());
 


### PR DESCRIPTION
Make it so that preview has to run in MSQ to prevent this error when in `auto` engine selector mode:

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/177816/208139135-b9262539-79d8-4c52-8ef3-918e7eeddbb6.png">
