### PR TITLE
Docs: remove large data file

### DIFF
--- a/docs/tutorials/tutorial-kafka.md
+++ b/docs/tutorials/tutorial-kafka.md
@@ -76,15 +76,14 @@ In this section, you download sample data to the tutorial's directory and send t
 
    ```bash
    cd sample-data
-   curl -O https://druid.apache.org/docs/latest/assets/files/kttm-nested-data.json.tgz
-   tar -xzf kttm-nested-data.json.tgz
+   curl -O https://static.imply.io/example-data/kttm-nested-v2/kttm-nested-v2-2019-08-25.json.gz
    ```
 
 3. In your Kafka root directory, run the following commands to post sample events to the `kttm` Kafka topic:
 
    ```bash
    export KAFKA_OPTS="-Dfile.encoding=UTF-8"
-   ./bin/kafka-console-producer.sh --broker-list localhost:9092 --topic kttm < ./sample-data/kttm-nested-data.json
+   gzcat ./sample-data/kttm-nested-v2-2019-08-25.json.gz | ./bin/kafka-console-producer.sh --broker-list localhost:9092 --topic kttm
    ```
 
 ## Load data into Druid


### PR DESCRIPTION
https://github.com/apache/druid/pull/13261 committed a large data file to the repo blowing up the distribution size. This file is already available elsewhere - same place as where the console pulls it from.

<img width="1780" alt="image" src="https://user-images.githubusercontent.com/177816/208350313-6fd23bb9-249e-4825-ae5f-b4e0dfab5ae5.png">

So just pull it from there.