### PR TITLE
Fix flaky test `KillUnusedSegmentsTest`

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -120,10 +120,11 @@ public class KillUnusedSegmentsTest
         )
     ).thenAnswer(invocation -> {
       DateTime maxEndTime = invocation.getArgument(1);
+      long maxEndMillis = maxEndTime.getMillis();
       List<Interval> unusedIntervals =
           unusedSegments.stream()
                         .map(DataSegment::getInterval)
-                        .filter(i -> i.getEnd().isBefore(maxEndTime))
+                        .filter(i -> i.getEnd().getMillis() <= maxEndMillis)
                         .collect(Collectors.toList());
 
       int limit = invocation.getArgument(2);


### PR DESCRIPTION
Example failure: https://github.com/imply-elliott/druid/actions/runs/3744183838/jobs/6357286967

Changes:
- In the test impl of `SegmentsMetadataManager`, consider segments with end time less than _or equal to_ the given `maxEndTime` (same as the actual impl)