### PR TITLE
fix issue with jdbc and query metrics

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -238,12 +238,12 @@ public class DruidJdbcResultSet implements Closeable
       // Execute the first step: plan the query and return a sequence to use
       // to get values.
       final Sequence<Object[]> sequence = queryExecutor.submit(stmt::execute).get().getResults();
-
+      final Yielder<Object[]> yielder = queryExecutor.submit(() -> Yielders.each(sequence)).get();
       // Subsequent fetch steps are done via the async "fetcher".
       fetcher = fetcherFactory.newFetcher(
           // We can't apply limits greater than Integer.MAX_VALUE, ignore them.
           maxRowCount >= 0 && maxRowCount <= Integer.MAX_VALUE ? (int) maxRowCount : Integer.MAX_VALUE,
-          Yielders.each(sequence)
+          yielder
       );
       signature = AbstractDruidJdbcStatement.createSignature(
           stmt.prepareResult(),

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -26,7 +26,6 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
-import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -237,8 +236,7 @@ public class DruidJdbcResultSet implements Closeable
 
       // Execute the first step: plan the query and return a sequence to use
       // to get values.
-      final Sequence<Object[]> sequence = queryExecutor.submit(stmt::execute).get().getResults();
-      final Yielder<Object[]> yielder = queryExecutor.submit(() -> Yielders.each(sequence)).get();
+      final Yielder<Object[]> yielder = queryExecutor.submit(() -> Yielders.each(stmt.execute().getResults())).get();
       // Subsequent fetch steps are done via the async "fetcher".
       fetcher = fetcherFactory.newFetcher(
           // We can't apply limits greater than Integer.MAX_VALUE, ignore them.


### PR DESCRIPTION
### Description
This PR fixes an issue which can occur when the broker tries to emit metrics for parallel merge on an empty result set over jdbc. There might be other ways to trigger this as well, but this was the most reliable one.

The issue happens with an empty result set because it causes the `Yielders.each` call to close the sequence on the main thread instead of the query executor thread, which owns the metrics.

The fix is to create the yielder on the query executor thread as well, so that if the sequence is consumed, any baggages that might be emitting metrics, such as broker parallel merge metrics, will not be called in the wrong thread.

relevant stacktrace snippet:
```
2022-12-22T00:06:56,479 ERROR [qtp614516107-165] org.apache.druid.sql.avatica.DruidMeta - DefaultQueryMetrics must not be modified from multiple threads. If it is needed to gather dimension or metric information from multiple threads or from an async thread, this information should explicitly be passed between threads (e. g. using Futures), or this DefaultQueryMetrics's ownerThread should be reassigned explicitly
java.lang.IllegalStateException: DefaultQueryMetrics must not be modified from multiple threads. If it is needed to gather dimension or metric information from multiple threads or from an async thread, this information should explicitly be passed between threads (e. g. using Futures), or this DefaultQueryMetrics's ownerThread should be reassigned explicitly
	at org.apache.druid.query.DefaultQueryMetrics.checkModifiedFromOwnerThread(DefaultQueryMetrics.java:67) ~[classes/:?]
	at org.apache.druid.query.DefaultQueryMetrics.emit(DefaultQueryMetrics.java:386) ~[classes/:?]
	at org.apache.druid.client.CachingClusteredClient$SpecificQueryRunnable.lambda$merge$2(CachingClusteredClient.java:406) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.ParallelMergeCombiningSequence.lambda$toYielder$0(ParallelMergeCombiningSequence.java:154) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.Sequences$1.after(Sequences.java:85) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingYielder.close(WrappingYielder.java:99) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingYielder.close(WrappingYielder.java:83) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.MergeSequence.lambda$toYielder$1(MergeSequence.java:95) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.BaseSequence.accumulate(BaseSequence.java:44) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.MergeSequence.toYielder(MergeSequence.java:63) ~[classes/:?]
	at org.apache.druid.query.RetryQueryRunner$1.toYielder(RetryQueryRunner.java:133) ~[classes/:?]
	at org.apache.druid.common.guava.CombiningSequence.toYielder(CombiningSequence.java:78) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:88) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:84) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.SequenceWrapper.wrap(SequenceWrapper.java:55) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence.toYielder(WrappingSequence.java:83) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.MappedSequence.toYielder(MappedSequence.java:49) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:88) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:84) ~[classes/:?]
	at org.apache.druid.query.CPUTimeMetricQueryRunner$1.wrap(CPUTimeMetricQueryRunner.java:77) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence.toYielder(WrappingSequence.java:83) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:88) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence$2.get(WrappingSequence.java:84) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.SequenceWrapper.wrap(SequenceWrapper.java:55) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.WrappingSequence.toYielder(WrappingSequence.java:83) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.MappedSequence.toYielder(MappedSequence.java:49) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.MappedSequence.toYielder(MappedSequence.java:49) ~[classes/:?]
	at org.apache.druid.java.util.common.guava.Yielders.each(Yielders.java:32) ~[classes/:?]
	at org.apache.druid.sql.avatica.DruidJdbcResultSet.execute(DruidJdbcResultSet.java:246) ~[classes/:?]
	at org.apache.druid.sql.avatica.DruidJdbcPreparedStatement.execute(DruidJdbcPreparedStatement.java:104) ~[classes/:?]
	at org.apache.druid.sql.avatica.DruidMeta.execute(DruidMeta.java:479) ~[classes/:?]
...
```


<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
