### PR TITLE
Validate response headers and fix exception logging

### DIFF
--- a/core/src/main/java/org/apache/druid/query/QueryException.java
+++ b/core/src/main/java/org/apache/druid/query/QueryException.java
@@ -152,7 +152,12 @@ public class QueryException extends RuntimeException implements SanitizableExcep
 
   protected QueryException(Throwable cause, String errorCode, String errorClass, String host)
   {
-    super(cause == null ? null : cause.getMessage(), cause);
+    this(cause, errorCode, cause == null ? null : cause.getMessage(), errorClass, host);
+  }
+
+  protected QueryException(Throwable cause, String errorCode, String errorMessage, String errorClass, String host)
+  {
+    super(errorMessage, cause);
     this.errorCode = errorCode;
     this.errorClass = errorClass;
     this.host = host;

--- a/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
+++ b/core/src/test/java/org/apache/druid/query/QueryExceptionTest.java
@@ -95,6 +95,24 @@ public class QueryExceptionTest
     expectFailTypeForCode(FailType.USER_ERROR, QueryException.SQL_QUERY_UNSUPPORTED_ERROR_CODE);
   }
 
+  /**
+   * This test exists primarily to get branch coverage of the null check on the QueryException constructor.
+   * The validations done in this test are not actually intended to be set-in-stone or anything.
+   */
+  @Test
+  public void testCanConstructWithoutThrowable()
+  {
+    QueryException exception = new QueryException(
+        (Throwable) null,
+        QueryException.UNKNOWN_EXCEPTION_ERROR_CODE,
+        "java.lang.Exception",
+        "test"
+    );
+
+    Assert.assertEquals(QueryException.UNKNOWN_EXCEPTION_ERROR_CODE, exception.getErrorCode());
+    Assert.assertNull(exception.getMessage());
+  }
+
   private void expectFailTypeForCode(FailType expected, String code)
   {
     QueryException exception = new QueryException(new Exception(), code, "java.lang.Exception", "test");

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/cache/CoordinatorPollingBasicAuthorizerCacheManager.java
@@ -420,12 +420,18 @@ public class CoordinatorPollingBasicAuthorizerCacheManager implements BasicAutho
         new BytesFullResponseHandler()
     );
 
+    final HttpResponseStatus status = responseHolder.getStatus();
+
     // cachedSerializedGroupMappingMap is a new endpoint introduced in Druid 0.17.0. For backwards compatibility, if we
     // get a 404 from the coordinator we stop retrying. This can happen during a rolling upgrade when a process
     // running 0.17.0+ tries to access this endpoint on an older coordinator.
-    if (responseHolder.getStatus().equals(HttpResponseStatus.NOT_FOUND)) {
+    if (HttpResponseStatus.NOT_FOUND.equals(status)) {
       LOG.warn("cachedSerializedGroupMappingMap is not available from the coordinator, skipping fetch of group mappings for now.");
       return null;
+    }
+
+    if (!HttpResponseStatus.OK.equals(status)) {
+      LOG.warn("Got an unexpected response status[%s] when loading group mappings.", status);
     }
 
     byte[] groupRoleMapBytes = responseHolder.getContent();

--- a/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
+++ b/processing/src/main/java/org/apache/druid/query/BadJsonQueryException.java
@@ -29,7 +29,7 @@ public class BadJsonQueryException extends BadQueryException
 
   public BadJsonQueryException(JsonParseException e)
   {
-    this(JSON_PARSE_ERROR_CODE, e.getMessage(), ERROR_CLASS);
+    this(e, JSON_PARSE_ERROR_CODE, e.getMessage(), ERROR_CLASS);
   }
 
   @JsonCreator
@@ -39,6 +39,16 @@ public class BadJsonQueryException extends BadQueryException
       @JsonProperty("errorClass") String errorClass
   )
   {
-    super(errorCode, errorMessage, errorClass);
+    this(null, errorCode, errorMessage, errorClass);
+  }
+
+  private BadJsonQueryException(
+      Throwable cause,
+      String errorCode,
+      String errorMessage,
+      String errorClass
+  )
+  {
+    super(cause, errorCode, errorMessage, errorClass, null);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/BadQueryException.java
+++ b/processing/src/main/java/org/apache/druid/query/BadQueryException.java
@@ -30,11 +30,16 @@ public abstract class BadQueryException extends QueryException
 
   protected BadQueryException(String errorCode, String errorMessage, String errorClass)
   {
-    super(errorCode, errorMessage, errorClass, null);
+    this(errorCode, errorMessage, errorClass, null);
   }
 
   protected BadQueryException(String errorCode, String errorMessage, String errorClass, String host)
   {
-    super(errorCode, errorMessage, errorClass, host);
+    this(null, errorCode, errorMessage, errorClass, host);
+  }
+
+  protected BadQueryException(Throwable cause, String errorCode, String errorMessage, String errorClass, String host)
+  {
+    super(cause, errorCode, errorMessage, errorClass, host);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -172,12 +172,21 @@ public class PreResponseAuthorizationCheckFilter implements Filter
 
   private static boolean statusShouldBeHidden(int status)
   {
-    // We allow 404s to not be rewritten to forbidden because consistently returning 404s is a way to leak less
-    // information when something wasn't able to be done anyway.  I.e. if we pretend that the thing didn't exist
+    // We allow 404s (not found) to not be rewritten to forbidden because consistently returning 404s is a way to leak
+    // less information when something wasn't able to be done anyway.  I.e. if we pretend that the thing didn't exist
     // when the authorization fails, then there is no information about whether the thing existed.  If we return
     // a 403 when authorization fails and a 404 when authorization succeeds, but it doesn't exist, then we have
     // leaked that it could maybe exist, if the authentication credentials were good.
-    return !(status == HttpServletResponse.SC_FORBIDDEN || status == HttpServletResponse.SC_NOT_FOUND);
+    //
+    // We also allow 307s (temporary redirect) to not be hidden as they are used to redirect to the leader.
+    switch (status) {
+      case HttpServletResponse.SC_FORBIDDEN:
+      case HttpServletResponse.SC_NOT_FOUND:
+      case HttpServletResponse.SC_TEMPORARY_REDIRECT:
+        return false;
+      default:
+        return true;
+    }
   }
 
   public static void sendJsonError(HttpServletResponse resp, int error, String errorJson, OutputStream outputStream)

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -88,7 +88,10 @@ public class PreResponseAuthorizationCheckFilter implements Filter
       // since the request didn't have any authorization checks performed. However, this breaks proxying
       // (e.g. OverlordServletProxy), so this is not implemented for now.
       handleAuthorizationCheckError(
-          "Request did not have an authorization check performed.",
+          String.format(
+              "Request did not have an authorization check performed, origin response status[%s].",
+              response.getStatus()
+          ),
           request,
           response
       );
@@ -171,7 +174,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
     // We allow 404s to not be rewritten to forbidden because consistently returning 404s is a way to leak less
     // information when something wasn't able to be done anyway.  I.e. if we pretend that the thing didn't exist
     // when the authorization fails, then there is no information about whether the thing existed.  If we return
-    // a 403 when fails authorization and a 404 when authorization succeeds, but it doesn't exist.  Then we have
+    // a 403 when authorization fails and a 404 when authorization succeeds, but it doesn't exist, then we have
     // leaked that it could maybe exist, if the authentication credentials were good.
     return !(status == HttpServletResponse.SC_FORBIDDEN || status == HttpServletResponse.SC_NOT_FOUND);
   }

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -90,7 +90,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
       // (e.g. OverlordServletProxy), so this is not implemented for now.
       handleAuthorizationCheckError(
           StringUtils.format(
-              "Request did not have an authorization check performed, origin response status[%s].",
+              "Request did not have an authorization check performed, original response status[%s].",
               response.getStatus()
           ),
           request,

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -155,11 +155,10 @@ public class PreResponseAuthorizationCheckFilter implements Filter
        .addData("queryId", queryId)
        .emit();
 
-    if (servletResponse.isCommitted()) {
-      log.warn("%s for queryId[%s]", errorMsg, queryId);
-    } else {
+    if (!servletResponse.isCommitted()) {
       try {
-        servletResponse.sendError(HttpServletResponse.SC_FORBIDDEN);
+        servletResponse.reset();
+        servletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
       }
       catch (Exception e) {
         throw new RuntimeException(e);
@@ -169,7 +168,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
 
   private static boolean statusNotForbidden(int status)
   {
-    return status != 503;
+    return status != HttpServletResponse.SC_FORBIDDEN;
   }
 
   public static void sendJsonError(HttpServletResponse resp, int error, String errorJson, OutputStream outputStream)

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -173,7 +173,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
     // when the authorization fails, then there is no information about whether the thing existed.  If we return
     // a 403 when fails authorization and a 404 when authorization succeeds, but it doesn't exist.  Then we have
     // leaked that it could maybe exist, if the authentication credentials were good.
-    return ! (status == HttpServletResponse.SC_FORBIDDEN || status == HttpServletResponse.SC_NOT_FOUND);
+    return !(status == HttpServletResponse.SC_FORBIDDEN || status == HttpServletResponse.SC_NOT_FOUND);
   }
 
   public static void sendJsonError(HttpServletResponse resp, int error, String errorJson, OutputStream outputStream)

--- a/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
+++ b/server/src/main/java/org/apache/druid/server/security/PreResponseAuthorizationCheckFilter.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.QueryException;
 import org.apache.druid.query.QueryInterruptedException;
@@ -88,7 +89,7 @@ public class PreResponseAuthorizationCheckFilter implements Filter
       // since the request didn't have any authorization checks performed. However, this breaks proxying
       // (e.g. OverlordServletProxy), so this is not implemented for now.
       handleAuthorizationCheckError(
-          String.format(
+          StringUtils.format(
               "Request did not have an authorization check performed, origin response status[%s].",
               response.getStatus()
           ),

--- a/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -127,6 +127,7 @@ public class PreResponseAuthorizationCheckFilterTest
 
     Assert.assertEquals(403, resp.getStatus());
   }
+
   @Test
   public void testMissingAuthorizationCheckWith404Keeps404() throws Exception
   {
@@ -147,5 +148,27 @@ public class PreResponseAuthorizationCheckFilterTest
     });
 
     Assert.assertEquals(404, resp.getStatus());
+  }
+
+  @Test
+  public void testMissingAuthorizationCheckWith307Keeps307() throws Exception
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+    AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+
+    MockHttpServletResponse resp = new MockHttpServletResponse();
+    resp.setStatus(307);
+
+    PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
+        authenticators,
+        new DefaultObjectMapper()
+    );
+    filter.doFilter(req, resp, (request, response) -> {
+    });
+
+    Assert.assertEquals(307, resp.getStatus());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -20,141 +20,110 @@
 package org.apache.druid.server.http.security;
 
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.apache.druid.server.mocks.MockHttpServletRequest;
+import org.apache.druid.server.mocks.MockHttpServletResponse;
 import org.apache.druid.server.security.AllowAllAuthenticator;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authenticator;
 import org.apache.druid.server.security.PreResponseAuthorizationCheckFilter;
-import org.easymock.EasyMock;
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletException;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
 public class PreResponseAuthorizationCheckFilterTest
 {
-  private static List<Authenticator> authenticators = Collections.singletonList(new AllowAllAuthenticator());
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private static final List<Authenticator> authenticators = Collections.singletonList(new AllowAllAuthenticator());
 
   @Test
   public void testValidRequest() throws Exception
   {
     AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
 
-    HttpServletRequest req = EasyMock.createStrictMock(HttpServletRequest.class);
-    HttpServletResponse resp = EasyMock.createStrictMock(HttpServletResponse.class);
-    FilterChain filterChain = EasyMock.createNiceMock(FilterChain.class);
-    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    MockHttpServletResponse resp = new MockHttpServletResponse();
 
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(authenticationResult).once();
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(true).once();
-    EasyMock.replay(req, resp, filterChain, outputStream);
+    req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+    req.attributes.put(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
 
     PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
         authenticators,
         new DefaultObjectMapper()
     );
-    filter.doFilter(req, resp, filterChain);
-    EasyMock.verify(req, resp, filterChain, outputStream);
+    filter.doFilter(req, resp, (request, response) -> {
+    });
   }
 
   @Test
   public void testAuthenticationFailedRequest() throws Exception
   {
-    HttpServletRequest req = EasyMock.createStrictMock(HttpServletRequest.class);
-    HttpServletResponse resp = EasyMock.createStrictMock(HttpServletResponse.class);
-    FilterChain filterChain = EasyMock.createNiceMock(FilterChain.class);
-    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
-
-    EasyMock.expect(resp.getOutputStream()).andReturn(outputStream).once();
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(null).once();
-    resp.setStatus(401);
-    EasyMock.expectLastCall().once();
-    resp.setContentType("application/json");
-    EasyMock.expectLastCall().once();
-    resp.setCharacterEncoding("UTF-8");
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(req, resp, filterChain, outputStream);
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    MockHttpServletResponse resp = new MockHttpServletResponse();
 
     PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
         authenticators,
         new DefaultObjectMapper()
     );
-    filter.doFilter(req, resp, filterChain);
-    EasyMock.verify(req, resp, filterChain, outputStream);
+    filter.doFilter(req, resp, (request, response) -> {
+    });
+
+    Assert.assertEquals(401, resp.getStatus());
+    Assert.assertEquals("application/json", resp.getContentType());
+    Assert.assertEquals("UTF-8", resp.getCharacterEncoding());
   }
 
   @Test
-  public void testMissingAuthorizationCheck() throws Exception
+  public void testMissingAuthorizationCheckAndNotCommitted() throws ServletException, IOException
   {
-    EmittingLogger.registerEmitter(EasyMock.createNiceMock(ServiceEmitter.class));
-
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage("Request did not have an authorization check performed.");
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
 
     AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
 
-    HttpServletRequest req = EasyMock.createStrictMock(HttpServletRequest.class);
-    HttpServletResponse resp = EasyMock.createStrictMock(HttpServletResponse.class);
-    FilterChain filterChain = EasyMock.createNiceMock(FilterChain.class);
-    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.requestUri = "uri";
+    req.method = "GET";
+    req.remoteAddr = "1.2.3.4";
+    req.remoteHost = "aHost";
 
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(authenticationResult).once();
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).once();
-    EasyMock.expect(resp.getStatus()).andReturn(200).once();
-    EasyMock.expect(req.getRequestURI()).andReturn("uri").once();
-    EasyMock.expect(req.getMethod()).andReturn("GET").once();
-    EasyMock.expect(req.getRemoteAddr()).andReturn("1.2.3.4").once();
-    EasyMock.expect(req.getRemoteHost()).andReturn("ahostname").once();
-    EasyMock.expect(resp.isCommitted()).andReturn(true).once();
+    MockHttpServletResponse resp = new MockHttpServletResponse();
+
+    req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+
+    PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
+        authenticators,
+        new DefaultObjectMapper()
+    );
+    filter.doFilter(req, resp, (request, response) -> {
+    });
+
+    Assert.assertEquals(403, resp.getStatus());
+  }
+
+  @Test
+  public void testMissingAuthorizationCheckWithForbidden() throws Exception
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+    AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+
+    MockHttpServletResponse resp = new MockHttpServletResponse();
     resp.setStatus(403);
-    EasyMock.expectLastCall().once();
-    resp.setContentType("application/json");
-    EasyMock.expectLastCall().once();
-    resp.setCharacterEncoding("UTF-8");
-    EasyMock.expectLastCall().once();
-    EasyMock.replay(req, resp, filterChain, outputStream);
 
     PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
         authenticators,
         new DefaultObjectMapper()
     );
-    filter.doFilter(req, resp, filterChain);
-    EasyMock.verify(req, resp, filterChain, outputStream);
-  }
+    filter.doFilter(req, resp, (request, response) -> {
+    });
 
-  @Test
-  public void testMissingAuthorizationCheckWithError() throws Exception
-  {
-    EmittingLogger.registerEmitter(EasyMock.createNiceMock(ServiceEmitter.class));
-    AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
-
-    HttpServletRequest req = EasyMock.createStrictMock(HttpServletRequest.class);
-    HttpServletResponse resp = EasyMock.createStrictMock(HttpServletResponse.class);
-    FilterChain filterChain = EasyMock.createNiceMock(FilterChain.class);
-    ServletOutputStream outputStream = EasyMock.createNiceMock(ServletOutputStream.class);
-
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(authenticationResult).once();
-    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).once();
-    EasyMock.expect(resp.getStatus()).andReturn(404).once();
-    EasyMock.replay(req, resp, filterChain, outputStream);
-
-    PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
-        authenticators,
-        new DefaultObjectMapper()
-    );
-    filter.doFilter(req, resp, filterChain);
-    EasyMock.verify(req, resp, filterChain, outputStream);
+    Assert.assertEquals(403, resp.getStatus());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/security/PreResponseAuthorizationCheckFilterTest.java
@@ -92,6 +92,7 @@ public class PreResponseAuthorizationCheckFilterTest
     req.remoteHost = "aHost";
 
     MockHttpServletResponse resp = new MockHttpServletResponse();
+    resp.setStatus(200);
 
     req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
 
@@ -125,5 +126,26 @@ public class PreResponseAuthorizationCheckFilterTest
     });
 
     Assert.assertEquals(403, resp.getStatus());
+  }
+  @Test
+  public void testMissingAuthorizationCheckWith404Keeps404() throws Exception
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+    AuthenticationResult authenticationResult = new AuthenticationResult("so-very-valid", "so-very-valid", null, null);
+
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+
+    MockHttpServletResponse resp = new MockHttpServletResponse();
+    resp.setStatus(404);
+
+    PreResponseAuthorizationCheckFilter filter = new PreResponseAuthorizationCheckFilter(
+        authenticators,
+        new DefaultObjectMapper()
+    );
+    filter.doFilter(req, resp, (request, response) -> {
+    });
+
+    Assert.assertEquals(404, resp.getStatus());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/mocks/MockHttpServletRequest.java
+++ b/server/src/test/java/org/apache/druid/server/mocks/MockHttpServletRequest.java
@@ -54,9 +54,11 @@ import java.util.function.Supplier;
  */
 public class MockHttpServletRequest implements HttpServletRequest
 {
+  public String requestUri = null;
   public String method = null;
   public String contentType = null;
   public String remoteAddr = null;
+  public String remoteHost = null;
 
   public LinkedHashMap<String, String> headers = new LinkedHashMap<>();
   public LinkedHashMap<String, Object> attributes = new LinkedHashMap<>();
@@ -110,7 +112,7 @@ public class MockHttpServletRequest implements HttpServletRequest
   @Override
   public String getMethod()
   {
-    return method;
+    return unsupportedIfNull(method);
   }
 
   @Override
@@ -164,7 +166,7 @@ public class MockHttpServletRequest implements HttpServletRequest
   @Override
   public String getRequestURI()
   {
-    throw new UnsupportedOperationException();
+    return unsupportedIfNull(requestUri);
   }
 
   @Override
@@ -296,7 +298,7 @@ public class MockHttpServletRequest implements HttpServletRequest
   @Override
   public String getContentType()
   {
-    return contentType;
+    return unsupportedIfNull(contentType);
   }
 
   @Override
@@ -362,13 +364,13 @@ public class MockHttpServletRequest implements HttpServletRequest
   @Override
   public String getRemoteAddr()
   {
-    return remoteAddr;
+    return unsupportedIfNull(remoteAddr);
   }
 
   @Override
   public String getRemoteHost()
   {
-    throw new UnsupportedOperationException();
+    return unsupportedIfNull(remoteHost);
   }
 
   @Override
@@ -486,6 +488,9 @@ public class MockHttpServletRequest implements HttpServletRequest
   @Override
   public AsyncContext getAsyncContext()
   {
+    if (currAsyncContext == null) {
+      throw new IllegalStateException("Must be put into Async mode before async context can be gottendid");
+    }
     return currAsyncContext;
   }
 
@@ -513,5 +518,14 @@ public class MockHttpServletRequest implements HttpServletRequest
     retVal.remoteAddr = remoteAddr;
 
     return retVal;
+  }
+
+  private <T> T unsupportedIfNull(T obj)
+  {
+    if (obj == null) {
+      throw new UnsupportedOperationException();
+    } else {
+      return obj;
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/mocks/MockHttpServletResponse.java
+++ b/server/src/test/java/org/apache/druid/server/mocks/MockHttpServletResponse.java
@@ -22,12 +22,12 @@ package org.apache.druid.server.mocks;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -63,6 +63,21 @@ public class MockHttpServletResponse implements HttpServletResponse
 
   private int statusCode;
   private String contentType;
+  private String characterEncoding;
+
+  @Override
+  public void reset()
+  {
+    if (isCommitted()) {
+      throw new IllegalStateException("Cannot reset a committed ServletResponse");
+    }
+
+    headers.clear();
+    statusCode = 0;
+    contentType = null;
+    characterEncoding = null;
+  }
+
 
   @Override
   public void addCookie(Cookie cookie)
@@ -198,7 +213,7 @@ public class MockHttpServletResponse implements HttpServletResponse
   @Override
   public String getCharacterEncoding()
   {
-    throw new UnsupportedOperationException();
+    return characterEncoding;
   }
 
   @Override
@@ -231,13 +246,13 @@ public class MockHttpServletResponse implements HttpServletResponse
       }
 
       @Override
-      public void write(@Nonnull byte[] b)
+      public void write(@NotNull byte[] b)
       {
         baos.write(b, 0, b.length);
       }
 
       @Override
-      public void write(@Nonnull byte[] b, int off, int len)
+      public void write(@NotNull byte[] b, int off, int len)
       {
         baos.write(b, off, len);
       }
@@ -253,7 +268,7 @@ public class MockHttpServletResponse implements HttpServletResponse
   @Override
   public void setCharacterEncoding(String charset)
   {
-    throw new UnsupportedOperationException();
+    characterEncoding = charset;
   }
 
   @Override
@@ -298,16 +313,17 @@ public class MockHttpServletResponse implements HttpServletResponse
     throw new UnsupportedOperationException();
   }
 
+  public void forceCommitted()
+  {
+    if (!isCommitted()) {
+      baos.write(1234);
+    }
+  }
+
   @Override
   public boolean isCommitted()
   {
     return baos.size() > 0;
-  }
-
-  @Override
-  public void reset()
-  {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlPlanningException.java
@@ -61,22 +61,27 @@ public class SqlPlanningException extends BadQueryException
 
   public SqlPlanningException(SqlParseException e)
   {
-    this(PlanningError.SQL_PARSE_ERROR, e.getMessage());
+    this(e, PlanningError.SQL_PARSE_ERROR, e.getMessage());
   }
 
   public SqlPlanningException(ValidationException e)
   {
-    this(PlanningError.VALIDATION_ERROR, e.getMessage());
+    this(e, PlanningError.VALIDATION_ERROR, e.getMessage());
   }
 
   public SqlPlanningException(CalciteContextException e)
   {
-    this(PlanningError.VALIDATION_ERROR, e.getMessage());
+    this(e, PlanningError.VALIDATION_ERROR, e.getMessage());
   }
 
   public SqlPlanningException(PlanningError planningError, String errorMessage)
   {
-    this(planningError.errorCode, errorMessage, planningError.errorClass);
+    this(null, planningError, errorMessage);
+  }
+
+  public SqlPlanningException(Throwable cause, PlanningError planningError, String errorMessage)
+  {
+    this(cause, planningError.errorCode, errorMessage, planningError.errorClass);
   }
 
   @JsonCreator
@@ -86,6 +91,17 @@ public class SqlPlanningException extends BadQueryException
       @JsonProperty("errorClass") String errorClass
   )
   {
-    super(errorCode, errorMessage, errorClass);
+    this(null, errorCode, errorMessage, errorClass);
   }
+
+  private SqlPlanningException(
+      Throwable cause,
+      String errorCode,
+      String errorMessage,
+      String errorClass
+  )
+  {
+    super(cause, errorCode, errorMessage, errorClass, null);
+  }
+
 }

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -2101,6 +2101,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     MockHttpServletRequest req = new MockHttpServletRequest();
     req.attributes.put(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
+    req.remoteAddr = "1.2.3.4";
     return req;
   }
 


### PR DESCRIPTION
A class of QueryException were throwing away their causes making it really hard to determine what's
going wrong when something goes wrong in the SQL
planner specifically.  Fix that and adjust tests
 to do more validation of response headers as well.

This PR has:

- [x] been self-reviewed.