### PR TITLE
Use correct ObjectMapper in BloomFilterSqlAggregatorTest

### DIFF
--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregatorTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregatorTest.java
@@ -178,7 +178,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected1)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected1)}
         )
     );
   }
@@ -239,8 +239,8 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[] {
-                CalciteTests.getJsonMapper().writeValueAsString(expected1),
-                CalciteTests.getJsonMapper().writeValueAsString(expected2)
+                queryFramework().queryJsonMapper().writeValueAsString(expected1),
+                queryFramework().queryJsonMapper().writeValueAsString(expected2)
             }
         )
     );
@@ -288,7 +288,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected1)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected1)}
         )
     );
 
@@ -335,7 +335,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected3)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected3)}
         )
     );
   }
@@ -388,7 +388,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected1)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected1)}
         )
     );
   }
@@ -442,7 +442,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected1)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected1)}
         )
     );
   }
@@ -496,7 +496,7 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
                   .build()
         ),
         ImmutableList.of(
-            new Object[]{CalciteTests.getJsonMapper().writeValueAsString(expected1)}
+            new Object[]{queryFramework().queryJsonMapper().writeValueAsString(expected1)}
         )
     );
   }
@@ -540,8 +540,8 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[] {
-                CalciteTests.getJsonMapper().writeValueAsString(expected1),
-                CalciteTests.getJsonMapper().writeValueAsString(expected2)
+                queryFramework().queryJsonMapper().writeValueAsString(expected1),
+                queryFramework().queryJsonMapper().writeValueAsString(expected2)
             }
         )
     );
@@ -596,8 +596,8 @@ public class BloomFilterSqlAggregatorTest extends BaseCalciteQueryTest
         ImmutableList.of(
             new Object[] {
                 "a",
-                CalciteTests.getJsonMapper().writeValueAsString(expected1),
-                CalciteTests.getJsonMapper().writeValueAsString(expected2)
+                queryFramework().queryJsonMapper().writeValueAsString(expected1),
+                queryFramework().queryJsonMapper().writeValueAsString(expected2)
             }
         )
     );


### PR DESCRIPTION
This test fails consistently locally, both using IDE and from CLI. But hasn't been flagged by Travis even once.
e.g. successful run: https://app.travis-ci.com/github/apache/druid/jobs/591589652#L4131

This has already been fixed on master with #13426 . Not backporting the entirety of those changes as they are not required.

The other usages of `CalciteTests.getJsonMapper()` need not be fixed in this branch as they don't seem to be deserializing any object that requires a custom deserializer.