### PR TITLE
use AmazonEC2ClientBuilder to create aws ec2 client

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSModule.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSModule.java
@@ -50,6 +50,6 @@ public class AWSModule implements DruidModule
   @LazySingleton
   public AmazonEC2 getEc2Client(AWSCredentialsProvider credentials)
   {
-    return AmazonEC2ClientBuilder.defaultClient();
+    return AmazonEC2ClientBuilder.standard().withCredentials(credentials).build();
   }
 }

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSModule.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSModule.java
@@ -21,7 +21,7 @@ package org.apache.druid.common.aws;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import org.apache.druid.guice.JsonConfigProvider;
@@ -50,6 +50,6 @@ public class AWSModule implements DruidModule
   @LazySingleton
   public AmazonEC2 getEc2Client(AWSCredentialsProvider credentials)
   {
-    return new AmazonEC2Client(credentials);
+    return AmazonEC2ClientBuilder.defaultClient();
   }
 }


### PR DESCRIPTION
# What's this PR

Use `AmazonEC2ClientBuilder` rather than `new AmazonEC2Client` to automatically determine the region.
[Reference: AWS Java SDK Docs](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#automatically-determine-the-aws-region-from-the-environment)

# Why I did it

I tried to use auto scaler but failed cause I can't call EC2 API of my region(ap-northeast-1). I deployed druid on my private subnet of VPC that cannot go out to internet, so I must use VPC endpoints. But VPC endpoints is not supported another region. I tried to add `-Daws.region=ap-northeast-1` to the jvm.config or set environment variable `AWS_REGION=ap-northeast-1` but both not worked. So I found source code and aws documentation and realized it should use ec2 client builder.

Below is the sample log.

```
2022-12-22T11:43:04,581 ERROR [SimpleResourceManagement-manager--0] org.apache.druid.indexing.overlord.autoscaling.AbstractWorkerProvisioningStrategy - Uncaught exception.
com.amazonaws.SdkClientException: Unable to execute HTTP request: Connect to ec2.us-east-1.amazonaws.com:443 [ec2.us-east-1.amazonaws.com/52.46.159.174] failed: connect timed out
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleRetryableException(AmazonHttpClient.java:1216) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1162) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:811) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:779) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:753) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:713) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:695) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:559) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:539) ~[aws-java-sdk-core-1.12.37.jar:?]
	at com.amazonaws.services.ec2.AmazonEC2Client.doInvoke(AmazonEC2Client.java:30331) ~[aws-java-sdk-ec2-1.12.37.jar:?]
	at com.amazonaws.services.ec2.AmazonEC2Client.invoke(AmazonEC2Client.java:30298) ~[aws-java-sdk-ec2-1.12.37.jar:?]
	at com.amazonaws.services.ec2.AmazonEC2Client.invoke(AmazonEC2Client.java:30287) ~[aws-java-sdk-ec2-1.12.37.jar:?]
	at com.amazonaws.services.ec2.AmazonEC2Client.executeDescribeInstances(AmazonEC2Client.java:14350) ~[aws-java-sdk-ec2-1.12.37.jar:?]
	at com.amazonaws.services.ec2.AmazonEC2Client.describeInstances(AmazonEC2Client.java:14318) ~[aws-java-sdk-ec2-1.12.37.jar:?]
	at org.apache.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler$6.apply(EC2AutoScaler.java:262) ~[?:?]
	at org.apache.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler$6.apply(EC2AutoScaler.java:258) ~[?:?]
	at com.google.common.collect.Iterators$8.transform(Iterators.java:794) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:48) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.Iterators$5.hasNext(Iterators.java:543) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:43) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:43) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.Iterators$5.hasNext(Iterators.java:542) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:43) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:268) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.ImmutableList.copyOf(ImmutableList.java:226) ~[guava-16.0.1.jar:?]
	at com.google.common.collect.FluentIterable.toList(FluentIterable.java:334) ~[guava-16.0.1.jar:?]
	at org.apache.druid.indexing.overlord.autoscaling.ec2.EC2AutoScaler.ipToIdLookup(EC2AutoScaler.java:282) ~[?:?]
	at org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningStrategy$SimpleProvisioner.doProvision(SimpleWorkerProvisioningStrategy.java:132) ~[druid-indexing-service-0.23.0.jar:0.23.0]
	at org.apache.druid.indexing.overlord.autoscaling.AbstractWorkerProvisioningStrategy$WorkerProvisioningService$1.run(AbstractWorkerProvisioningStrategy.java:75) [druid-indexing-service-0.23.0.jar:0.23.0]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_352]
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [?:1.8.0_352]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_352]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_352]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_352]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_352]
```


This PR has:

- [x] been self-reviewed.
