### PR TITLE
Update docker-compose to use Druid 24.0.1

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -32,6 +32,8 @@ services:
   postgres:
     container_name: postgres
     image: postgres:latest
+    ports:
+      - "5432:5432"
     volumes:
       - metadata_data:/var/lib/postgresql/data
     environment:
@@ -54,7 +56,7 @@ services:
     volumes:
       - druid_shared:/opt/shared
       - coordinator_var:/opt/druid/var
-    depends_on: 
+    depends_on:
       - zookeeper
       - postgres
     ports:
@@ -65,11 +67,11 @@ services:
       - environment
 
   broker:
-    image: apache/druid:0.24.0
+    image: apache/druid:24.0.1
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
-    depends_on: 
+    depends_on:
       - zookeeper
       - postgres
       - coordinator
@@ -81,7 +83,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:0.24.0
+    image: apache/druid:24.0.1
     container_name: historical
     volumes:
       - druid_shared:/opt/shared
@@ -98,7 +100,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:0.24.0
+    image: apache/druid:24.0.1
     container_name: middlemanager
     volumes:
       - druid_shared:/opt/shared
@@ -116,7 +118,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:0.24.0
+    image: apache/druid:24.0.1
     container_name: router
     volumes:
       - router_var:/opt/druid/var


### PR DESCRIPTION
This PR updates the docker image version of druid to 24.0.1 instead of 0.24.0 in the docker-compose file. Since many people use the docker-compose from the main branch. The fellow developers who are experiencing or experimenting with druid are using version 0.24.0 as mentioned earlier and encountered an issue whereby the docker is unable to find the manifest on the stated druid image version. 

Release Note/Changelogs:
- Add configuration to bind postgres instance on the default port ("5432") to docker-compose file
- Update broker, historical, middlemanager and router instance to use druid 24.0.1 on docker-compose file
- Remove trailing space on docker-compose file

This PR has been self-reviewed and added a release note entry in the PR description.
