### PR TITLE
Quote and escape literals in JDBC lookup to allow reserved identifiers.

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -88,7 +88,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
     this.filter = filter;
     if (pollPeriod == null) {
       // Warning because if JdbcExtractionNamespace is being used for lookups, any updates to the database will not
-      // be picked up after the node starts. So for use casses where nodes start at different times (like streaming
+      // be picked up after the node starts. So for use cases where nodes start at different times (like streaming
       // ingestion with peons) there can be data inconsistencies across the cluster.
       LOG.warn("No pollPeriod configured for JdbcExtractionNamespace - entries will be loaded only once at startup");
       this.pollPeriod = new Period(0L);

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -179,7 +179,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
 
   private static String escapeQuotedIdentifier(String identifier)
   {
-    return identifier.replace("\"", "\"\"");
+    return StringUtils.replace(identifier, "\"", "\"\"");
   }
 
   private DBI ensureDBI(CacheScheduler.EntryImpl<JdbcExtractionNamespace> key, JdbcExtractionNamespace namespace)

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.lookup.namespace;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.apache.druid.data.input.MapPopulator;
 import org.apache.druid.java.util.common.ISE;
@@ -154,32 +155,33 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
             .map((index1, r1, ctx1) -> new Pair<>(r1.getString(1), r1.getString(2)))
             .iterator();
   }
-
+  
   private static String buildLookupQuery(String table, String filter, String keyColumn, String valueColumn)
   {
     if (Strings.isNullOrEmpty(filter)) {
       return StringUtils.format(
-          "SELECT \"%s\", \"%s\" FROM \"%s\" WHERE \"%s\" IS NOT NULL",
-          escapeQuotedIdentifier(keyColumn),
-          escapeQuotedIdentifier(valueColumn),
-          escapeQuotedIdentifier(table),
-          escapeQuotedIdentifier(valueColumn)
+          "SELECT %s, %s FROM %s WHERE %s IS NOT NULL",
+          toDoublyQuotedEscapedIdentifier(keyColumn),
+          toDoublyQuotedEscapedIdentifier(valueColumn),
+          toDoublyQuotedEscapedIdentifier(table),
+          toDoublyQuotedEscapedIdentifier(valueColumn)
       );
     }
 
     return StringUtils.format(
-        "SELECT \"%s\", \"%s\" FROM \"%s\" WHERE %s AND \"%s\" IS NOT NULL",
-        escapeQuotedIdentifier(keyColumn),
-        escapeQuotedIdentifier(valueColumn),
-        escapeQuotedIdentifier(table),
+        "SELECT %s, %s FROM %s WHERE %s AND %s IS NOT NULL",
+        toDoublyQuotedEscapedIdentifier(keyColumn),
+        toDoublyQuotedEscapedIdentifier(valueColumn),
+        toDoublyQuotedEscapedIdentifier(table),
         filter,
-        escapeQuotedIdentifier(valueColumn)
+        toDoublyQuotedEscapedIdentifier(valueColumn)
     );
   }
 
-  private static String escapeQuotedIdentifier(String identifier)
+  @VisibleForTesting
+  public static String toDoublyQuotedEscapedIdentifier(String identifier)
   {
-    return StringUtils.replace(identifier, "\"", "\"\"");
+    return "\"" + StringUtils.replace(identifier, "\"", "\"\"") + "\"";
   }
 
   private DBI ensureDBI(CacheScheduler.EntryImpl<JdbcExtractionNamespace> key, JdbcExtractionNamespace namespace)
@@ -212,8 +214,8 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
     final Timestamp update = dbi.withHandle(
         handle -> {
           final String query = StringUtils.format(
-              "SELECT MAX(\"%s\") FROM \"%s\"",
-              escapeQuotedIdentifier(tsColumn), escapeQuotedIdentifier(table)
+              "SELECT MAX(%s) FROM %s",
+              toDoublyQuotedEscapedIdentifier(tsColumn), toDoublyQuotedEscapedIdentifier(table)
           );
           return handle
               .createQuery(query)

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -159,22 +159,27 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
   {
     if (Strings.isNullOrEmpty(filter)) {
       return StringUtils.format(
-          "SELECT %s, %s FROM %s WHERE %s IS NOT NULL",
-          keyColumn,
-          valueColumn,
-          table,
-          valueColumn
+          "SELECT \"%s\", \"%s\" FROM \"%s\" WHERE \"%s\" IS NOT NULL",
+          escapeQuotedIdentifier(keyColumn),
+          escapeQuotedIdentifier(valueColumn),
+          escapeQuotedIdentifier(table),
+          escapeQuotedIdentifier(valueColumn)
       );
     }
 
     return StringUtils.format(
-        "SELECT %s, %s FROM %s WHERE %s AND %s IS NOT NULL",
-        keyColumn,
-        valueColumn,
-        table,
+        "SELECT \"%s\", \"%s\" FROM \"%s\" WHERE %s AND \"%s\" IS NOT NULL",
+        escapeQuotedIdentifier(keyColumn),
+        escapeQuotedIdentifier(valueColumn),
+        escapeQuotedIdentifier(table),
         filter,
-        valueColumn
+        escapeQuotedIdentifier(valueColumn)
     );
+  }
+
+  private static String escapeQuotedIdentifier(String identifier)
+  {
+    return identifier.replace("\"", "\"\"");
   }
 
   private DBI ensureDBI(CacheScheduler.EntryImpl<JdbcExtractionNamespace> key, JdbcExtractionNamespace namespace)

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -155,7 +155,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
             .map((index1, r1, ctx1) -> new Pair<>(r1.getString(1), r1.getString(2)))
             .iterator();
   }
-  
+
   private static String buildLookupQuery(String table, String filter, String keyColumn, String valueColumn)
   {
     if (Strings.isNullOrEmpty(filter)) {

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -212,8 +212,8 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
     final Timestamp update = dbi.withHandle(
         handle -> {
           final String query = StringUtils.format(
-              "SELECT MAX(%s) FROM %s",
-              tsColumn, table
+              "SELECT MAX(\"%s\") FROM \"%s\"",
+              escapeQuotedIdentifier(tsColumn), escapeQuotedIdentifier(table)
           );
           return handle
               .createQuery(query)

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -131,7 +131,7 @@ public class JdbcExtractionNamespaceTest
               0,
               handle.createStatement(
                   StringUtils.format(
-                      "CREATE TABLE %s (%s TIMESTAMP, %s VARCHAR(64), %s VARCHAR(64), %s VARCHAR(64))",
+                      "CREATE TABLE \"%s\" (\"%s\" TIMESTAMP, \"%s\" VARCHAR(64), \"%s\" VARCHAR(64), \"%s\" VARCHAR(64))",
                       TABLE_NAME,
                       TS_COLUMN,
                       FILTER_COLUMN,
@@ -140,10 +140,10 @@ public class JdbcExtractionNamespaceTest
                   )
               ).setQueryTimeout(1).execute()
           );
-          handle.createStatement(StringUtils.format("TRUNCATE TABLE %s", TABLE_NAME)).setQueryTimeout(1).execute();
+          handle.createStatement(StringUtils.format("TRUNCATE TABLE \"%s\"", TABLE_NAME)).setQueryTimeout(1).execute();
           handle.commit();
           closer.register(() -> {
-            handle.createStatement("DROP TABLE " + TABLE_NAME).setQueryTimeout(1).execute();
+            handle.createStatement(StringUtils.format("DROP TABLE \"%s\"", TABLE_NAME)).setQueryTimeout(1).execute();
             final ListenableFuture future = setupTeardownService.submit(new Runnable()
             {
               @Override
@@ -292,17 +292,17 @@ public class JdbcExtractionNamespaceTest
     final String statementVal = val != null ? "'%s'" : "%s";
     if (tsColumn == null) {
       handle.createStatement(
-          StringUtils.format("DELETE FROM %s WHERE %s='%s'", TABLE_NAME, KEY_NAME, key)
+          StringUtils.format("DELETE FROM \"%s\" WHERE \"%s\"='%s'", TABLE_NAME, KEY_NAME, key)
       ).setQueryTimeout(1).execute();
       query = StringUtils.format(
-          "INSERT INTO %s (%s, %s, %s) VALUES ('%s', '%s', " + statementVal + ")",
+          "INSERT INTO \"%s\" (\"%s\", \"%s\", \"%s\") VALUES ('%s', '%s', " + statementVal + ")",
           TABLE_NAME,
           FILTER_COLUMN, KEY_NAME, VAL_NAME,
           filter, key, val
       );
     } else {
       query = StringUtils.format(
-          "INSERT INTO %s (%s, %s, %s, %s) VALUES ('%s', '%s', '%s', " + statementVal + ")",
+          "INSERT INTO \"%s\" (\"%s\", \"%s\", \"%s\", \"%s\") VALUES ('%s', '%s', '%s', " + statementVal + ")",
           TABLE_NAME,
           tsColumn, FILTER_COLUMN, KEY_NAME, VAL_NAME,
           updateTs, filter, key, val

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -131,19 +131,21 @@ public class JdbcExtractionNamespaceTest
               0,
               handle.createStatement(
                   StringUtils.format(
-                      "CREATE TABLE \"%s\" (\"%s\" TIMESTAMP, \"%s\" VARCHAR(64), \"%s\" VARCHAR(64), \"%s\" VARCHAR(64))",
-                      TABLE_NAME,
-                      TS_COLUMN,
-                      FILTER_COLUMN,
-                      KEY_NAME,
-                      VAL_NAME
+                      "CREATE TABLE %s (%s TIMESTAMP, %s VARCHAR(64), %s VARCHAR(64), %s VARCHAR(64))",
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TS_COLUMN),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(KEY_NAME),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(VAL_NAME)
                   )
               ).setQueryTimeout(1).execute()
           );
-          handle.createStatement(StringUtils.format("TRUNCATE TABLE \"%s\"", TABLE_NAME)).setQueryTimeout(1).execute();
+          handle.createStatement(StringUtils.format("TRUNCATE TABLE %s",
+              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME))).setQueryTimeout(1).execute();
           handle.commit();
           closer.register(() -> {
-            handle.createStatement(StringUtils.format("DROP TABLE \"%s\"", TABLE_NAME)).setQueryTimeout(1).execute();
+            handle.createStatement(StringUtils.format("DROP TABLE %s",
+                JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME))).setQueryTimeout(1).execute();
             final ListenableFuture future = setupTeardownService.submit(new Runnable()
             {
               @Override
@@ -292,19 +294,25 @@ public class JdbcExtractionNamespaceTest
     final String statementVal = val != null ? "'%s'" : "%s";
     if (tsColumn == null) {
       handle.createStatement(
-          StringUtils.format("DELETE FROM \"%s\" WHERE \"%s\"='%s'", TABLE_NAME, KEY_NAME, key)
+          StringUtils.format("DELETE FROM %s WHERE %s='%s'", JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME),
+              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(KEY_NAME), key)
       ).setQueryTimeout(1).execute();
       query = StringUtils.format(
-          "INSERT INTO \"%s\" (\"%s\", \"%s\", \"%s\") VALUES ('%s', '%s', " + statementVal + ")",
-          TABLE_NAME,
-          FILTER_COLUMN, KEY_NAME, VAL_NAME,
+          "INSERT INTO %s (%s, %s, %s) VALUES ('%s', '%s', " + statementVal + ")",
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(KEY_NAME),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(VAL_NAME),
           filter, key, val
       );
     } else {
       query = StringUtils.format(
-          "INSERT INTO \"%s\" (\"%s\", \"%s\", \"%s\", \"%s\") VALUES ('%s', '%s', '%s', " + statementVal + ")",
-          TABLE_NAME,
-          tsColumn, FILTER_COLUMN, KEY_NAME, VAL_NAME,
+          "INSERT INTO %s (%s, %s, %s, %s) VALUES ('%s', '%s', '%s', " + statementVal + ")",
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TABLE_NAME),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tsColumn),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(KEY_NAME),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(VAL_NAME),
           updateTs, filter, key, val
       );
     }
@@ -358,7 +366,7 @@ public class JdbcExtractionNamespaceTest
         KEY_NAME,
         VAL_NAME,
         tsColumn,
-        "\"" + FILTER_COLUMN + "\"" + "='1'",
+        JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN) + "='1'",
         new Period(0),
         null,
         new JdbcAccessSecurityConfig()

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -88,11 +88,11 @@ public class JdbcExtractionNamespaceTest
   );
 
 
-  @Parameterized.Parameters(name = "table name={0}, key column={1}, val column={2}, tsColumn={3}")
+  @Parameterized.Parameters(name = "tableName={0}, keyName={1}, valName={2}, tsColumn={3}")
   public static Collection<Object[]> getParameters()
   {
     return ImmutableList.of(
-        new Object[]{"table", "select", "foo \" column;", "tsColumn"}, // reserved identifiers as table, key and value columnns.
+        new Object[]{"table", "select", "foo \" column;", "tsColumn"}, // reserved identifiers as table, key and value columns.
         new Object[]{"abstractDbRenameTest", "keyName", "valName", "tsColumn"},
         new Object[]{"abstractDbRenameTest", "keyName", "valName", null}
     );
@@ -101,24 +101,20 @@ public class JdbcExtractionNamespaceTest
   public JdbcExtractionNamespaceTest(
       String tableName,
       String keyName,
-      String valueName,
+      String valName,
       String tsColumn
   )
   {
     this.tableName = tableName;
     this.keyName = keyName;
-    this.valName = valueName;
+    this.valName = valName;
     this.tsColumn = tsColumn;
   }
 
   private final String tableName;
-
   private final String keyName;
-
   private final String valName;
-
   private final String tsColumn;
-
   private CacheScheduler scheduler;
   private Lifecycle lifecycle;
   private AtomicLong updates;
@@ -144,20 +140,20 @@ public class JdbcExtractionNamespaceTest
               handle.createStatement(
                   StringUtils.format(
                       "CREATE TABLE %s (%s TIMESTAMP, %s VARCHAR(64), %s VARCHAR(64), %s VARCHAR(64))",
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
                       JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TS_COLUMN),
                       JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.keyName),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.valName)
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
+                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName)
                   )
               ).setQueryTimeout(1).execute()
           );
           handle.createStatement(StringUtils.format("TRUNCATE TABLE %s",
-              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName))).setQueryTimeout(1).execute();
+              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName))).setQueryTimeout(1).execute();
           handle.commit();
           closer.register(() -> {
             handle.createStatement(StringUtils.format("DROP TABLE %s",
-                JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName))).setQueryTimeout(1).execute();
+                JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName))).setQueryTimeout(1).execute();
             final ListenableFuture future = setupTeardownService.submit(new Runnable()
             {
               @Override
@@ -306,25 +302,25 @@ public class JdbcExtractionNamespaceTest
     final String statementVal = val != null ? "'%s'" : "%s";
     if (tsColumn == null) {
       handle.createStatement(
-          StringUtils.format("DELETE FROM %s WHERE %s='%s'", JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName),
-              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.keyName), key)
+          StringUtils.format("DELETE FROM %s WHERE %s='%s'", JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
+              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName), key)
       ).setQueryTimeout(1).execute();
       query = StringUtils.format(
           "INSERT INTO %s (%s, %s, %s) VALUES ('%s', '%s', " + statementVal + ")",
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
           JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.keyName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.valName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName),
           filter, key, val
       );
     } else {
       query = StringUtils.format(
           "INSERT INTO %s (%s, %s, %s, %s) VALUES ('%s', '%s', '%s', " + statementVal + ")",
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.tableName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
           JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tsColumn),
           JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.keyName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(this.valName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
+          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName),
           updateTs, filter, key, val
       );
     }
@@ -341,10 +337,10 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        this.tableName,
-        this.keyName,
-        this.valName,
-        this.tsColumn,
+        tableName,
+        keyName,
+        valName,
+        tsColumn,
         null,
         new Period(0),
         null,
@@ -374,10 +370,10 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        this.tableName,
-        this.keyName,
-        this.valName,
-        this.tsColumn,
+        tableName,
+        keyName,
+        valName,
+        tsColumn,
         JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN) + "='1'",
         new Period(0),
         null,
@@ -412,7 +408,7 @@ public class JdbcExtractionNamespaceTest
   {
     try (final CacheScheduler.Entry entry = ensureEntry()) {
       assertUpdated(entry, "foo", "bar");
-      if (this.tsColumn != null) {
+      if (tsColumn != null) {
         insertValues(handleRef, "foo", "baz", null, "1900-01-01 00:00:00");
       }
       assertUpdated(entry, "foo", "bar");
@@ -449,10 +445,10 @@ public class JdbcExtractionNamespaceTest
     final JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig();
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        this.tableName,
-        this.keyName,
-        this.valName,
-        this.tsColumn,
+        tableName,
+        keyName,
+        valName,
+        tsColumn,
         "some filter",
         new Period(10),
         null,
@@ -474,10 +470,10 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        this.tableName,
-        this.keyName,
-        this.valName,
-        this.tsColumn,
+        tableName,
+        keyName,
+        valName,
+        tsColumn,
         null,
         new Period(10),
         null,

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -358,7 +358,7 @@ public class JdbcExtractionNamespaceTest
         KEY_NAME,
         VAL_NAME,
         tsColumn,
-        FILTER_COLUMN + "='1'",
+        "\"" + FILTER_COLUMN + "\"" + "='1'",
         new Period(0),
         null,
         new JdbcAccessSecurityConfig()


### PR DESCRIPTION
Before this change, JDBC lookups with reserved keywords present in table, key, or column names will not parse correctly. Table, key, and column names need to be double-quoted and escaped to allow any reserved words.

For example, 
```sql
SELECT select, value FROM intervals
```
will not parse since `select` is specified as a column name. Whereas the following quoted query will parse correctly:
```sql
SELECT “select”, "value" FROM “intervals”
```

- Add a new parameter with reserved identifiers for table, key and column names.
- Update the tests that use the Derby connector, which now uses quoted and escaped identifiers consistently for creation, insertion, and other operations.


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
