### PR TITLE
Changed combine old data with new data and overwrite data and ingesti…

### DIFF
--- a/examples/quickstart/tutorial/updates-append-index.json
+++ b/examples/quickstart/tutorial/updates-append-index.json
@@ -9,7 +9,7 @@
         ]
       },
       "timestampSpec": {
-        "column": "timestamp",
+        "column": "__time",
         "format": "iso"
       },
       "metricsSpec": [

--- a/examples/quickstart/tutorial/updates-append-index2.json
+++ b/examples/quickstart/tutorial/updates-append-index2.json
@@ -4,7 +4,7 @@
     "dataSchema" : {
       "dataSource" : "updates-tutorial",
       "timestampSpec": {
-        "column": "timestamp",
+        "column": "__time",
         "format": "iso"
       },
       "dimensionsSpec" : {

--- a/examples/quickstart/tutorial/updates-data.json
+++ b/examples/quickstart/tutorial/updates-data.json
@@ -1,3 +1,3 @@
-{"timestamp":"2018-01-01T01:01:35Z","animal":"tiger", "number":100}
-{"timestamp":"2018-01-01T03:01:35Z","animal":"aardvark", "number":42}
-{"timestamp":"2018-01-01T03:01:35Z","animal":"giraffe", "number":14124}
+{"__time":"2018-01-01T01:01:35Z","animal":"tiger", "number":100}
+{"__time":"2018-01-01T03:01:35Z","animal":"aardvark", "number":42}
+{"__time":"2018-01-01T03:01:35Z","animal":"giraffe", "number":14124}

--- a/examples/quickstart/tutorial/updates-data2.json
+++ b/examples/quickstart/tutorial/updates-data2.json
@@ -1,3 +1,3 @@
-{"timestamp":"2018-01-01T01:01:35Z","animal":"lion", "number":100}
-{"timestamp":"2018-01-01T03:01:35Z","animal":"aardvark", "number":9999}
-{"timestamp":"2018-01-01T04:01:35Z","animal":"bear", "number":111}
+{"__time":"2018-01-01T01:01:35Z","animal":"lion", "number":100}
+{"__time":"2018-01-01T03:01:35Z","animal":"aardvark", "number":9999}
+{"__time":"2018-01-01T04:01:35Z","animal":"bear", "number":111}

--- a/examples/quickstart/tutorial/updates-data3.json
+++ b/examples/quickstart/tutorial/updates-data3.json
@@ -1,4 +1,4 @@
-{"timestamp":"2018-01-01T07:01:35Z","animal":"octopus", "number":115}
-{"timestamp":"2018-01-01T05:01:35Z","animal":"mongoose", "number":737}
-{"timestamp":"2018-01-01T06:01:35Z","animal":"snake", "number":1234}
-{"timestamp":"2018-01-01T01:01:35Z","animal":"lion", "number":300}
+{"__time":"2018-01-01T07:01:35Z","animal":"octopus", "number":115}
+{"__time":"2018-01-01T05:01:35Z","animal":"mongoose", "number":737}
+{"__time":"2018-01-01T06:01:35Z","animal":"snake", "number":1234}
+{"__time":"2018-01-01T01:01:35Z","animal":"lion", "number":300}

--- a/examples/quickstart/tutorial/updates-data4.json
+++ b/examples/quickstart/tutorial/updates-data4.json
@@ -1,2 +1,2 @@
-{"timestamp":"2018-01-01T04:01:35Z","animal":"bear", "number":222}
-{"timestamp":"2018-01-01T09:01:35Z","animal":"falcon", "number":1241}
+{"__time":"2018-01-01T04:01:35Z","animal":"bear", "number":222}
+{"__time":"2018-01-01T09:01:35Z","animal":"falcon", "number":1241}

--- a/examples/quickstart/tutorial/updates-init-index.json
+++ b/examples/quickstart/tutorial/updates-init-index.json
@@ -4,7 +4,7 @@
     "dataSchema" : {
       "dataSource" : "updates-tutorial",
       "timestampSpec": {
-        "column": "timestamp",
+        "column": "__time",
         "format": "iso"
       },
       "dimensionsSpec" : {

--- a/examples/quickstart/tutorial/updates-overwrite-index.json
+++ b/examples/quickstart/tutorial/updates-overwrite-index.json
@@ -4,7 +4,7 @@
     "dataSchema" : {
       "dataSource" : "updates-tutorial",
       "timestampSpec": {
-        "column": "timestamp",
+        "column": "__time",
         "format": "iso"
       },
       "dimensionsSpec" : {


### PR DESCRIPTION
### Description
Found the issue with the "[Combine old data with new data and overwrite](https://druid.apache.org/docs/latest/tutorials/tutorial-update-data.html#combine-old-data-with-new-data-and-overwrite)" section in the Druid update data tutorial.
The ingestion (file spec [updates-append-index2.json](https://github.com/apache/druid/blob/master/examples/quickstart/tutorial/updates-append-index2.json)) ) uses combining input source type with two different types: `druid` and `local` file data sources. As a result, the time dimension columns are different: the `__time` in the druid type input source and the `timestamp` in the local input source. The result is the incorrect data rollup result.

#### Changes

1. Changed the timestamp column name to `__time` in the ingestion specs. for [Updating existing data tutorial](https://druid.apache.org/docs/latest/tutorials/tutorial-update-data.html) :

```json
"timestampSpec": {
        "column": "__time",
        "format": "iso"
  }
```
2. Renamed timestamp column to `__time` in the  [Updating existing data tutorial](https://druid.apache.org/docs/latest/tutorials/tutorial-update-data.html) data files.


<hr>


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ x] been tested in a test Druid cluster.
