### PR TITLE
docs: Call out potential pitfall when using the combining input source

### DIFF
--- a/docs/ingestion/native-batch-input-source.md
+++ b/docs/ingestion/native-batch-input-source.md
@@ -756,6 +756,8 @@ Use the Combining input source only if all the delegates are splittable and can 
 
 Similar to other input sources, the Combining input source supports a single `inputFormat`.
 Delegate input sources that require an `inputFormat` must have the same format for input data.
+If you include the [Druid input source](#druid-input-source), the timestamp column is stored in the `__time` field.
+To correctly combine the data from the Druid input source with another source, ensure that other delegate input sources also store the timestamp column in `__time`.
 
 |Property|Description|Required|
 |--------|-----------|---------|


### PR DESCRIPTION
Relates to https://github.com/apache/druid/pull/13638 in which it was observed that rollup doesn't work correctly when using the combining input source to read data from an existing Druid segment and a local file. The issue is that the timestamp is renamed in the Druid source so it doesn't get correctly combined with the timestamp column in the local file.

This PR has:

- [x] been self-reviewed.
