### PR TITLE
Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1536,6 +1536,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
### Description

This PR aims to publish SBOM artifacts along with the other Apache projects.

- https://cwiki.apache.org/confluence/display/COMDEV/SBOM

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

We can use one of the Maven plugin, [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

https://maven.apache.org/plugins/index.html#misc

**The expected results**
```
$ mvn install -DskipTests
...

$ ls -al ~/.m2/repository/org/apache/druid/druid-core/26.0.0-SNAPSHOT
total 10136
drwxr-xr-x  9 dongjoon  staff      288 Jan  9 18:18 .
drwxr-xr-x  4 dongjoon  staff      128 Jan  9 18:18 ..
-rw-r--r--  1 dongjoon  staff      332 Jan  9 18:18 _remote.repositories
-rw-r--r--  1 dongjoon  staff   170448 Jan  9 18:18 druid-core-26.0.0-SNAPSHOT-cyclonedx.json
-rw-r--r--  1 dongjoon  staff   149722 Jan  9 18:18 druid-core-26.0.0-SNAPSHOT-cyclonedx.xml
-rw-r--r--  1 dongjoon  staff   963881 Jan  9 18:18 druid-core-26.0.0-SNAPSHOT-tests.jar
-rw-r--r--  1 dongjoon  staff  3872936 Jan  9 18:18 druid-core-26.0.0-SNAPSHOT.jar
-rw-r--r--  1 dongjoon  staff    13951 Jan  9 18:12 druid-core-26.0.0-SNAPSHOT.pom
-rw-r--r--  1 dongjoon  staff     1336 Jan  9 18:18 maven-metadata-local.xml
```

<hr>

This PR has:

- [x] been self-reviewed.