### PR TITLE
Updating dependency check version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1520,7 +1520,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.0.4</version>
+                <version>7.4.4</version>
                 <configuration>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>


### PR DESCRIPTION
Dependency check is failing with the following error -
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:7.0.4:aggregate (default-cli) on project druid: Fatal exception(s) analyzing Druid: One or more exceptions occurred during analysis: [ERROR]     UpdateException: org.owasp.dependencycheck.data.nvdcve.DatabaseException: Error updating 'CVE-2020-36569' [ERROR]         caused by DatabaseException: Error updating 'CVE-2020-36569' [ERROR]         caused by JdbcBatchUpdateException: Value too long for column "VERSIONENDEXCLUDING CHARACTER VARYING(60)": "'0.0.0-20160722212129-ac0cc4484ad4_before_v0.0.0-20200131131040-063a3fb69896' (75)"; SQL statement: [ERROR] INSERT INTO software (cveid, cpeEntryId, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding, vulnerable) VALUES (?, ?, ?, ?, ?, ?, ?) [22001-210] [ERROR]     NoDataException: No documents exist

This is resolved by upgrading the version to 7.4.4

ref - https://github.com/jeremylong/DependencyCheck/issues/5220