### PR TITLE
fix(sec): upgrade io.kubernetes:client-java to 12.0.1

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>11.0.1</kubernetes.client.version>
+    <kubernetes.client.version>12.0.1</kubernetes.client.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.kubernetes:client-java 11.0.1
- [CVE-2021-25738](https://www.oscs1024.com/hd/CVE-2021-25738)


### What did I do？
Upgrade io.kubernetes:client-java from 11.0.1 to 12.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS