### PR TITLE
Better sidecar support

### DIFF
--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -57,7 +57,7 @@ Additional Configuration
 |`druid.indexer.runner.debugJobs`|`boolean`|Clean up K8s jobs after tasks complete.|False|No|
 |`druid.indexer.runner.sidecarSupport`|`boolean`|If your overlord pod has sidecars, this will attempt to start the task with the same sidecars as the overlord pod.|False|No|
 |`druid.indexer.runner.primaryContainerName`|`String`|If running with sidecars, the `primaryContainerName` should be that of your druid container like `druid-overlord`.|First container in `podSpec` list|No|
-|`druid.indexer.runner.containersToExclude`|`JsonArray`|Any sidecars present in the overlord you do not wish to carry to your peon pod.  For example sidecars that are automatically injected by a controller like istio-proxy. |[]|No|
+|`druid.indexer.runner.containersToExclude`|`JsonArray`|Any sidecars present in the overlord you do not wish to carry to your peon pod.  For example sidecars that are automatically injected by a controller like `istio-proxy`. |[]|No|
 |`druid.indexer.runner.kubexitImage`|`String`|Used kubexit project to help shutdown sidecars when the main pod completes.  Otherwise jobs with sidecars never terminate.|karlkfi/kubexit:latest|No|
 |`druid.indexer.runner.disableClientProxy`|`boolean`|Use this if you have a global http(s) proxy and you wish to bypass it.|false|No|
 |`druid.indexer.runner.maxTaskDuration`|`Duration`|Max time a task is allowed to run for before getting killed|`PT4H`|No|

--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -57,7 +57,6 @@ Additional Configuration
 |`druid.indexer.runner.debugJobs`|`boolean`|Clean up K8s jobs after tasks complete.|False|No|
 |`druid.indexer.runner.sidecarSupport`|`boolean`|If your overlord pod has sidecars, this will attempt to start the task with the same sidecars as the overlord pod.|False|No|
 |`druid.indexer.runner.primaryContainerName`|`String`|If running with sidecars, the `primaryContainerName` should be that of your druid container like `druid-overlord`.|First container in `podSpec` list|No|
-|`druid.indexer.runner.containersToExclude`|`JsonArray`|Any sidecars present in the overlord you do not wish to carry to your peon pod.  For example sidecars that are automatically injected by a controller like `istio-proxy`. |[]|No|
 |`druid.indexer.runner.kubexitImage`|`String`|Used kubexit project to help shutdown sidecars when the main pod completes.  Otherwise jobs with sidecars never terminate.|karlkfi/kubexit:latest|No|
 |`druid.indexer.runner.disableClientProxy`|`boolean`|Use this if you have a global http(s) proxy and you wish to bypass it.|false|No|
 |`druid.indexer.runner.maxTaskDuration`|`Duration`|Max time a task is allowed to run for before getting killed|`PT4H`|No|

--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -56,6 +56,8 @@ Additional Configuration
 |--------|---------------|-----------|-------|--------|
 |`druid.indexer.runner.debugJobs`|`boolean`|Clean up K8s jobs after tasks complete.|False|No|
 |`druid.indexer.runner.sidecarSupport`|`boolean`|If your overlord pod has sidecars, this will attempt to start the task with the same sidecars as the overlord pod.|False|No|
+|`druid.indexer.runner.primaryContainerName`|`String`|If running with sidecars, the `primaryContainerName` should be that of your druid container like `druid-overlord`.|First container in `podSpec` list|No|
+|`druid.indexer.runner.containersToExclude`|`JsonArray`|Any sidecars present in the overlord you do not wish to carry to your peon pod.  For example sidecars that are automatically injected by a controller like istio-proxy. |[]|No|
 |`druid.indexer.runner.kubexitImage`|`String`|Used kubexit project to help shutdown sidecars when the main pod completes.  Otherwise jobs with sidecars never terminate.|karlkfi/kubexit:latest|No|
 |`druid.indexer.runner.disableClientProxy`|`boolean`|Use this if you have a global http(s) proxy and you wish to bypass it.|false|No|
 |`druid.indexer.runner.maxTaskDuration`|`Duration`|Max time a task is allowed to run for before getting killed|`PT4H`|No|

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -25,10 +25,8 @@ import org.joda.time.Period;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class KubernetesTaskRunnerConfig
 {
@@ -49,14 +47,6 @@ public class KubernetesTaskRunnerConfig
   // in fact place the istio-proxy container as the first container.  Thus you would specify this value to
   // the name of your primary container.  eg) druid-overlord
   public String primaryContainerName = null;
-
-  @JsonProperty
-  // sometimes you will have a service mesh like istio-proxy that will automatically inject sidecars for
-  // all resources in a particular namespace, because it is automatically injected by some controller, you
-  // do not wish to have this as part of the spec you create for the peon pods, as you could end up with 2
-  // istio containers, one you manually provide in the peon spec from the overlord and one injected by the
-  // overlord.  For any sidecar you wish not to carry over from the overlord, specify the container names here.
-  public Set<String> containersToExclude = new HashSet<>();
 
   @JsonProperty
   // for multi-container jobs, we need this image to shut down sidecars after the main container

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -25,8 +25,10 @@ import org.joda.time.Period;
 
 import javax.validation.constraints.NotNull;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class KubernetesTaskRunnerConfig
 {
@@ -40,6 +42,21 @@ public class KubernetesTaskRunnerConfig
 
   @JsonProperty
   public boolean sidecarSupport = false;
+
+  @JsonProperty
+  // if this is not set, then the first container in your pod spec is assumed to be the overlord container.
+  // usually this is fine, but when you are dynamically adding sidecars like istio, the service mesh could
+  // in fact place the istio-proxy container as the first container.  Thus you would specify this value to
+  // the name of your primary container.  eg) druid-overlord
+  public String primaryContainerName = null;
+
+  @JsonProperty
+  // sometimes you will have a service mesh like istio-proxy that will automatically inject sidecars for
+  // all resources in a particular namespace, because it is automatically injected by some controller, you
+  // do not wish to have this as part of the spec you create for the peon pods, as you could end up with 2
+  // istio containers, one you manually provide in the peon spec from the overlord and one injected by the
+  // overlord.  For any sidecar you wish not to carry over from the overlord, specify the container names here.
+  public Set<String> containersToExclude = new HashSet<>();
 
   @JsonProperty
   // for multi-container jobs, we need this image to shut down sidecars after the main container

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClient.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClient.java
@@ -167,6 +167,7 @@ public class DruidKubernetesPeonClient implements KubernetesPeonClient
                               .jobs()
                               .inNamespace(namespace)
                               .withName(taskId.getK8sTaskId())
+                              .inContainer("main")
                               .getLogReader();
         if (reader == null) {
           return Optional.absent();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapter.java
@@ -88,13 +88,17 @@ public abstract class K8sTaskAdapter implements TaskAdapter<Pod, Job>
   {
     String myPodName = System.getenv("HOSTNAME");
     Pod pod = client.executeRequest(client -> client.pods().inNamespace(config.namespace).withName(myPodName).get());
-    return createJobFromPodSpec(pod.getSpec(), task, context);
+    PodSpec podSpec = pod.getSpec();
+    massageSpec(config, podSpec);
+    return createJobFromPodSpec(podSpec, task, context);
   }
 
   @Override
   public Task toTask(Pod from) throws IOException
   {
-    List<EnvVar> envVars = from.getSpec().getContainers().get(0).getEnv();
+    PodSpec podSpec = from.getSpec();
+    massageSpec(config, podSpec);
+    List<EnvVar> envVars = podSpec.getContainers().get(0).getEnv();
     Optional<EnvVar> taskJson = envVars.stream().filter(x -> "TASK_JSON".equals(x.getName())).findFirst();
     String contents = taskJson.map(envVar -> taskJson.get().getValue()).orElse(null);
     if (contents == null) {
@@ -104,12 +108,13 @@ public abstract class K8sTaskAdapter implements TaskAdapter<Pod, Job>
   }
 
   @VisibleForTesting
-  public abstract Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException;
+  abstract Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException;
 
   protected Job buildJob(
       K8sTaskId k8sTaskId,
       Map<String, String> labels,
-      Map<String, String> annotations, PodTemplateSpec podTemplate
+      Map<String, String> annotations,
+      PodTemplateSpec podTemplate
   )
   {
     return new JobBuilder()
@@ -273,6 +278,29 @@ public abstract class K8sTaskAdapter implements TaskAdapter<Pod, Job>
     podTemplate.setMetadata(objectMeta);
     podTemplate.setSpec(podSpec);
     return podTemplate;
+  }
+
+  @VisibleForTesting
+  static void massageSpec(KubernetesTaskRunnerConfig config, PodSpec spec)
+  {
+    spec.getContainers().removeIf(candidate -> config.containersToExclude.contains(candidate.getName()));
+    // find the primary container and make it first,
+    if (org.apache.commons.lang.StringUtils.isNotBlank(config.primaryContainerName)) {
+      int i = 0;
+      while (i < spec.getContainers().size()) {
+        if (config.primaryContainerName.equals(spec.getContainers().get(i).getName())) {
+          break;
+        }
+        i++;
+      }
+      // if the primaryContainer is not found, assume the primary container is the first container.
+      if (i >= spec.getContainers().size()) {
+        i = 0;
+      }
+      Container primary = spec.getContainers().get(i);
+      spec.getContainers().remove(i);
+      spec.getContainers().add(0, primary);
+    }
   }
 
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapter.java
@@ -54,7 +54,7 @@ public class MultiContainerTaskAdapter extends K8sTaskAdapter
   }
 
   @Override
-  public Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
+  Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
   {
     K8sTaskId k8sTaskId = new K8sTaskId(task.getId());
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapter.java
@@ -42,7 +42,7 @@ public class SingleContainerTaskAdapter extends K8sTaskAdapter
   }
 
   @Override
-  public Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
+  Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
   {
     K8sTaskId k8sTaskId = new K8sTaskId(task.getId());
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -193,7 +193,7 @@ class K8sTaskAdapterTest
   }
 
   @Test
-  void testNoPrimaryFound() throws Exception
+  void testNoPrimaryFound()
   {
     PodSpec spec = new PodSpec();
     List<Container> containers = new ArrayList<>();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -48,10 +48,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -173,23 +171,19 @@ class K8sTaskAdapterTest
     PodSpec spec = new PodSpec();
     List<Container> containers = new ArrayList<>();
     containers.add(new ContainerBuilder()
-                       .withName("excludeSidecar").build());
+                       .withName("secondary").build());
     containers.add(new ContainerBuilder()
                        .withName("sidecar").build());
     containers.add(new ContainerBuilder()
                        .withName("primary").build());
     spec.setContainers(containers);
-    KubernetesTaskRunnerConfig config = new KubernetesTaskRunnerConfig();
-    config.primaryContainerName = "primary";
-    Set<String> containersToExclude = new HashSet<>();
-    containersToExclude.add("excludeSidecar");
-    config.containersToExclude = containersToExclude;
-    K8sTaskAdapter.massageSpec(config, spec);
+    K8sTaskAdapter.massageSpec(spec, "primary");
 
     List<Container> actual = spec.getContainers();
-    Assertions.assertEquals(2, containers.size());
+    Assertions.assertEquals(3, containers.size());
     Assertions.assertEquals("primary", actual.get(0).getName());
-    Assertions.assertEquals("sidecar", actual.get(1).getName());
+    Assertions.assertEquals("secondary", actual.get(1).getName());
+    Assertions.assertEquals("sidecar", actual.get(2).getName());
   }
 
   @Test
@@ -204,17 +198,11 @@ class K8sTaskAdapterTest
     containers.add(new ContainerBuilder()
                        .withName("sidecar").build());
     spec.setContainers(containers);
-    KubernetesTaskRunnerConfig config = new KubernetesTaskRunnerConfig();
-    config.primaryContainerName = "primary";
-    Set<String> containersToExclude = new HashSet<>();
-    containersToExclude.add("istio-proxy");
-    config.containersToExclude = containersToExclude;
-    K8sTaskAdapter.massageSpec(config, spec);
 
-    List<Container> actual = spec.getContainers();
-    Assertions.assertEquals(2, actual.size());
-    Assertions.assertEquals("main", actual.get(0).getName());
-    Assertions.assertEquals("sidecar", actual.get(1).getName());
+
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      K8sTaskAdapter.massageSpec(spec, "primary");
+    });
   }
 
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
@@ -116,7 +116,7 @@ class MultiContainerTaskAdapterTest
     MultiContainerTaskAdapter adapter = new MultiContainerTaskAdapter(testClient, config, jsonMapper);
     NoopTask task = NoopTask.create("id", 1);
     PodSpec spec = pod.getSpec();
-    K8sTaskAdapter.massageSpec(config, spec);
+    K8sTaskAdapter.massageSpec(spec, "primary");
     Job actual = adapter.createJobFromPodSpec(
             spec,
             task,

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -94,6 +95,52 @@ class MultiContainerTaskAdapterTest
           .get(0)
           .getEnv()
           .removeIf(x -> x.getName().equals("TASK_JSON"));
+    expected.getSpec()
+            .getTemplate()
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getEnv()
+            .removeIf(x -> x.getName().equals("TASK_JSON"));
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testMultiContainerSupportWithNamedContainer() throws IOException
+  {
+    TestKubernetesClient testClient = new TestKubernetesClient(client);
+    Pod pod = client.pods().load(this.getClass().getClassLoader().getResourceAsStream("multiContainerPodSpecOrder.yaml")).get();
+    KubernetesTaskRunnerConfig config = new KubernetesTaskRunnerConfig();
+    config.namespace = "test";
+    config.primaryContainerName = "primary";
+    MultiContainerTaskAdapter adapter = new MultiContainerTaskAdapter(testClient, config, jsonMapper);
+    NoopTask task = NoopTask.create("id", 1);
+    PodSpec spec = pod.getSpec();
+    K8sTaskAdapter.massageSpec(config, spec);
+    Job actual = adapter.createJobFromPodSpec(
+            spec,
+            task,
+            new PeonCommandContext(Collections.singletonList("/peon.sh /druid/data/baseTaskDir/noop_2022-09-26T22:08:00.582Z_352988d2-5ff7-4b70-977c-3de96f9bfca6 1"),
+                    new ArrayList<>(),
+                    new File("/tmp")
+            )
+    );
+    Job expected = client.batch()
+            .v1()
+            .jobs()
+            .load(this.getClass().getClassLoader().getResourceAsStream("expectedMultiContainerOutputOrder.yaml"))
+            .get();
+
+    // something is up with jdk 17, where if you compress with jdk < 17 and try and decompress you get different results,
+    // this would never happen in real life, but for the jdk 17 tests this is a problem
+    // could be related to: https://bugs.openjdk.org/browse/JDK-8081450
+    actual.getSpec()
+            .getTemplate()
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getEnv()
+            .removeIf(x -> x.getName().equals("TASK_JSON"));
     expected.getSpec()
             .getTemplate()
             .getSpec()

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutputOrder.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutputOrder.yaml
@@ -1,0 +1,108 @@
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  annotations:
+    task.id: "id"
+    tls.enabled: "false"
+  labels:
+    druid.k8s.peons: "true"
+  name: "id"
+spec:
+  activeDeadlineSeconds: 14400
+  backoffLimit: 0
+  template:
+    metadata:
+      annotations:
+        task.id: "id"
+        tls.enabled: "false"
+      labels:
+        druid.k8s.peons: "true"
+    spec:
+      hostname: "id"
+      containers:
+        - args:
+            - "/kubexit/kubexit /bin/sh -c \"/peon.sh /druid/data/baseTaskDir/noop_2022-09-26T22:08:00.582Z_352988d2-5ff7-4b70-977c-3de96f9bfca6 1\""
+          command:
+            - "/bin/sh"
+            - "-c"
+          env:
+            - name: "TASK_DIR"
+              value: "/tmp"
+            - name: "TASK_JSON"
+              value: "H4sIAAAAAAAAAEVOOw7CMAy9i+cOBYmlK0KItWVhNI0BSyEOToKoqt4doxZYLPv9/EbIQyRoIIhEqICd7TYquKqUePidDjN2UrSfxYEM0xKOfDdgvalr86aW0A0z9L9bSsVnc512nZkurHSTZJJQvK+gl5DpZfwIUVmU8wDNarJ0Ssu/EfCJ7PHM3tj9p9i3ltKjWKDbYsR+sU5vP86oMNUAAAA="
+            - name: "JAVA_OPTS"
+              value: ""
+            - name: "druid_host"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "status.podIP"
+            - name: "HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.name"
+            - name: "KUBEXIT_NAME"
+              value: "main"
+            - name: "KUBEXIT_GRAVEYARD"
+              value: "/graveyard"
+
+          image: "one"
+          name: "main"
+          ports:
+            - containerPort: 8091
+              name: "druid-tls-port"
+              protocol: "TCP"
+            - containerPort: 8100
+              name: "druid-port"
+              protocol: "TCP"
+          resources:
+            limits:
+              cpu: "1000m"
+              memory: "2400000000"
+            requests:
+              cpu: "1000m"
+              memory: "2400000000"
+          volumeMounts:
+            - mountPath: "/graveyard"
+              name: "graveyard"
+            - mountPath: "/kubexit"
+              name: "kubexit"
+        - args:
+            - "/kubexit/kubexit /bin/sh -c \"/bin/sidekick -loggingEnabled=true -platform=platform\
+          \ -splunkCluster=cluster -splunkIndexName=druid -splunkSourceType=json -splunkWorkingDir=/opt/splunkforwarder\
+          \ -dataCenter=dc -environment=env -application=druid -instance=instance\
+          \ -logFiles=/logs/druid/*.log\" || true"
+          command:
+            - "/bin/sh"
+            - "-c"
+          env:
+            - name: "KUBEXIT_NAME"
+              value: "sidecar"
+            - name: "KUBEXIT_GRAVEYARD"
+              value: "/graveyard"
+            - name: "KUBEXIT_DEATH_DEPS"
+              value: "main"
+          image: "two"
+          name: "sidecar"
+          volumeMounts:
+            - mountPath: "/graveyard"
+              name: "graveyard"
+            - mountPath: "/kubexit"
+              name: "kubexit"
+      initContainers:
+        - command:
+            - "cp"
+            - "/bin/kubexit"
+            - "/kubexit/kubexit"
+          image: "karlkfi/kubexit:v0.3.2"
+          name: "kubexit"
+          volumeMounts:
+            - mountPath: "/kubexit"
+              name: "kubexit"
+      restartPolicy: "Never"
+      volumes:
+        - emptyDir:
+            medium: "Memory"
+          name: "graveyard"
+        - emptyDir: {}
+          name: "kubexit"
+  ttlSecondsAfterFinished: 172800

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/multiContainerPodSpecOrder.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/multiContainerPodSpecOrder.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+    - image: two
+      name: sidecar
+      args:
+        - -loggingEnabled=true
+        - -platform=platform
+        - -splunkCluster=cluster
+        - -splunkIndexName=druid
+        - -splunkSourceType=json
+        - -splunkWorkingDir=/opt/splunkforwarder
+        - -dataCenter=dc
+        - -environment=env
+        - -application=druid
+        - -instance=instance
+        - -logFiles=/logs/druid/*.log
+      command:
+        - /bin/sidekick
+    - image: one
+      name: primary
+      command:
+        - "tail -f /dev/null"


### PR DESCRIPTION
When testing mm-less druid with istio-proxy, I noticed that when you have a controller that automatically injects the sidecar for all pods in a namespace.  The istio-proxy sidecar gets injected as the first container.  The problem here was the assumption that the first container was always the `druid` container.  

I added a configuration option which should assist with this. 

if you are running with `druid.indexer.runner.sidecarSupport=true`

you can specify `druid.indexer.runner.primaryContainerName=<overlord_container_name>` to be the container name for your overlord. 

For example if we have this for your overlord podSpec: 

```
spec:
  containers:
      - image: istio:latest
        name: istio-proxy
      - image: druid:latest
        name: druid-overlord
      - image: splunk:latest
        name: splunk
```

If your istio is automatically injected by a controller then you would specify this in your overlord config: 
```
druid.indexer.runner.primaryContainerName=druid-overlord
```

I encountered this problem exactly, patched our druid which fixed the problem on our clusters. 


