### PR TITLE
Fix behaviour of downsampling buckets to a single key

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImpl.java
@@ -375,7 +375,7 @@ public class ClusterByStatisticsCollectorImpl implements ClusterByStatisticsColl
    * number the same, if downsampling is not possible. (For example: downsampling is not possible if all buckets
    * have been downsampled all the way to one key each.)
    */
-  private void downSample()
+  void downSample()
   {
     long newTotalRetainedBytes = totalRetainedBytes;
     final long targetTotalRetainedBytes = totalRetainedBytes / 2;
@@ -405,7 +405,7 @@ public class ClusterByStatisticsCollectorImpl implements ClusterByStatisticsColl
       bucketHolder.keyCollector.downSample();
       newTotalRetainedBytes += bucketHolder.updateRetainedBytes();
 
-      if (i == sortedHolders.size() - 1 || sortedHolders.get(i + 1).retainedBytes > bucketHolder.retainedBytes) {
+      if (i == sortedHolders.size() - 1 || sortedHolders.get(i + 1).retainedBytes > bucketHolder.retainedBytes || bucketHolder.keyCollector.estimatedRetainedKeys() <= 1) {
         i++;
       }
     }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
@@ -66,8 +66,11 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 {
   private static final double PARTITION_SIZE_LEEWAY = 0.3;
 
-  private static final RowSignature SIGNATURE =
-      RowSignature.builder().add("x", ColumnType.LONG).add("y", ColumnType.LONG).build();
+  private static final RowSignature SIGNATURE = RowSignature.builder()
+                                                            .add("x", ColumnType.LONG)
+                                                            .add("y", ColumnType.LONG)
+                                                            .add("z", ColumnType.STRING)
+                                                            .build();
 
   private static final ClusterBy CLUSTER_BY_X = new ClusterBy(
       ImmutableList.of(new SortColumn("x", false)),
@@ -76,6 +79,10 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
 
   private static final ClusterBy CLUSTER_BY_XY_BUCKET_BY_X = new ClusterBy(
       ImmutableList.of(new SortColumn("x", false), new SortColumn("y", false)),
+      1
+  );
+  private static final ClusterBy CLUSTER_BY_XYZ_BUCKET_BY_X = new ClusterBy(
+      ImmutableList.of(new SortColumn("x", false), new SortColumn("y", false), new SortColumn("z", false)),
       1
   );
 
@@ -436,6 +443,17 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
           verifySnapshotSerialization(testName, collector, aggregate);
         }
     );
+  }
+
+  @Test
+  public void testBucketDownsampledToSingleKeyFinishesCorrectly()
+  {
+    ClusterByStatisticsCollectorImpl clusterByStatisticsCollector = makeCollector(CLUSTER_BY_XYZ_BUCKET_BY_X, false);
+
+    clusterByStatisticsCollector.add(createKey(CLUSTER_BY_XYZ_BUCKET_BY_X, 1, 1, "Extremely long key string for unit test; Extremely long key string for unit test;"), 2);
+    clusterByStatisticsCollector.add(createKey(CLUSTER_BY_XYZ_BUCKET_BY_X, 2, 1, "b"), 2);
+
+    clusterByStatisticsCollector.downSample();
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
### Description

While downsampling, we exclude buckets which contain only a single key. However, there is an issue where if a bucket is downsampled to a single key (which is contained as the min value in a DelegateOrMinCollector), and if the same bucket is still the largest bucket that remains to be downsampled, the collector continues trying to downsample the same bucket infinitely. This adds a check to prevent this condition.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
