### PR TITLE
Add missing documentation for constant post-aggregator

### DIFF
--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -95,6 +95,49 @@ This returns a summary of the sketch that can be used for debugging. This is the
 }
 ```
 
+
+
+### Constant Theta Sketch 
+
+This post aggregator allows the user to add a constant theta sketch which can be used in other post-aggregators e.g. `thetaSketchSetOp` 
+
+```json
+{
+  "type"  : "thetaSketchConstant",
+  "name": <output name>,
+  "value"  : <base64-encoded value of sketch>
+}
+```
+
+### Example of Constant Theta Sketch 
+
+Assume we have a datasource of a variety of users. Using `filters` and `aggregation`, we generate a theta sketch of all `football fans`.  
+
+We have a third-party provider who has provided us a constant theta sketch of all `cricket fans`. We would like to `INTERSECT` both in a `post-aggregation` stage to identify users who are interested in both `cricket` and `football` and then use `thetaSketchEstimate` to calculate the number of unique users.
+
+```json
+{
+   "type":"thetaSketchEstimate",
+   "name":"football_cricket_users_count",
+   "field":{
+      "type":"thetaSketchSetOp",
+      "name":"football_cricket_fans_users_theta_sketch",
+      "func":"INTERSECT",
+      "fields":[
+         {
+            "type":"fieldAccess",
+            "fieldName":"football_fans_users_theta_sketch"
+         },
+         {
+            "type":"thetaSketchConstant",
+            "name":"cricket_fans_users_theta_sketch",
+            "value":"AgMDAAAazJMCAAAAAACAPzz9j7pWTMdROWGf15uY1nI="
+         }
+      ]
+   }
+}
+```
+
 ## Examples
 
 Assuming, you have a dataset containing (timestamp, product, user_id). You want to answer questions like

--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -99,19 +99,19 @@ This returns a summary of the sketch that can be used for debugging. This is the
 
 ### Constant Theta Sketch 
 
-This post aggregator allows the user to add a constant theta sketch which can be used in other post-aggregators e.g. `thetaSketchSetOp` 
+You can use the constant theta sketch post aggregator to add a Base64-encoded constant theta sketch value for use in other post-aggregators. For example,  `thetaSketchSetOp` 
 
 ```json
 {
   "type"  : "thetaSketchConstant",
-  "name": <output name>,
-  "value"  : <base64-encoded value of sketch>
+  "name": DESTINATION_COLUMN_NAME,
+  "value"  : CONSTANT_SKETCH_VALUE
 }
 ```
 
 ### Example of Constant Theta Sketch 
 
-Assume we have a datasource of a variety of users. Using `filters` and `aggregation`, we generate a theta sketch of all `football fans`.  
+Assume you have a datasource with a variety of a variety of users. Using `filters` and `aggregation`, you generate a theta sketch of all `football fans`.  
 
 We have a third-party provider who has provided us a constant theta sketch of all `cricket fans`. We would like to `INTERSECT` both in a `post-aggregation` stage to identify users who are interested in both `cricket` and `football` and then use `thetaSketchEstimate` to calculate the number of unique users.
 

--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -113,7 +113,7 @@ You can use the constant theta sketch post aggregator to add a Base64-encoded co
 
 Assume you have a datasource with a variety of a variety of users. Using `filters` and `aggregation`, you generate a theta sketch of all `football fans`.  
 
-A third-party provider has provided a constant theta sketch of all `cricket fans` and you want to `INTERSECT` both cricket fans and football fans in a `post-aggregation` stage to identify users who are interested in both `cricket`. The you want to use `thetaSketchEstimate` to calculate the number of unique users.
+A third-party provider has provided a constant theta sketch of all `cricket fans` and you want to `INTERSECT` both cricket fans and football fans in a `post-aggregation` stage to identify users who are interested in both `cricket`. Then you want to use `thetaSketchEstimate` to calculate the number of unique users.
 
 ```json
 {

--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -113,7 +113,7 @@ You can use the constant theta sketch post aggregator to add a Base64-encoded co
 
 Assume you have a datasource with a variety of a variety of users. Using `filters` and `aggregation`, you generate a theta sketch of all `football fans`.  
 
-We have a third-party provider who has provided us a constant theta sketch of all `cricket fans`. We would like to `INTERSECT` both in a `post-aggregation` stage to identify users who are interested in both `cricket` and `football` and then use `thetaSketchEstimate` to calculate the number of unique users.
+A third-party provider has provided a constant theta sketch of all `cricket fans` and you want to `INTERSECT` both cricket fans and football fans in a `post-aggregation` stage to identify users who are interested in both `cricket`. The you want to use `thetaSketchEstimate` to calculate the number of unique users.
 
 ```json
 {

--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -99,7 +99,7 @@ This returns a summary of the sketch that can be used for debugging. This is the
 
 ### Constant Theta Sketch 
 
-You can use the constant theta sketch post aggregator to add a Base64-encoded constant theta sketch value for use in other post-aggregators. For example,  `thetaSketchSetOp` 
+You can use the constant theta sketch post aggregator to add a Base64-encoded constant theta sketch value for use in other post-aggregators. For example,  `thetaSketchSetOp`.
 
 ```json
 {

--- a/docs/development/extensions-core/datasketches-theta.md
+++ b/docs/development/extensions-core/datasketches-theta.md
@@ -109,7 +109,7 @@ You can use the constant theta sketch post aggregator to add a Base64-encoded co
 }
 ```
 
-### Example of Constant Theta Sketch 
+### Example using a constant Theta Sketch 
 
 Assume you have a datasource with a variety of a variety of users. Using `filters` and `aggregation`, you generate a theta sketch of all `football fans`.  
 


### PR DESCRIPTION
### Description
Adding missing documentation for post aggregator of type `thetaSketchConstant` in `data-sketches` extension.  
This was found while understanding the druid source code. 



This PR has:
- [x] added missing documentation for already existing features.

