### PR TITLE
fix: [druid-kubernetes-extensions] Do not propagate k8s add/delete events for nodes with no services

### DIFF
--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -188,7 +188,8 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
     private final LifecycleLock lifecycleLock = new LifecycleLock();
 
     private final AtomicReference<Closeable> watchRef = new AtomicReference<>();
-    private static final Closeable STOP_MARKER = () -> {};
+    private static final Closeable STOP_MARKER = () -> {
+    };
 
     private final NodeRole nodeRole;
     private final BaseNodeRoleWatcher baseNodeRoleWatcher;
@@ -270,12 +271,31 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
               if (item != null && item.type != null && item.object != null) {
                 switch (item.type) {
                   case WatchResult.ADDED:
-                    baseNodeRoleWatcher.childAdded(item.object.getNode());
+                    if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
+                      LOGGER.warn(
+                          "no services found on [%s] druid [%s] node [%s], skipping",
+                          item.type,
+                          item.object.getNode().getNodeRole(),
+                          item.object.getNode().getDruidNode().getHostAndPort()
+                      );
+                    } else {
+                      baseNodeRoleWatcher.childAdded(item.object.getNode());
+                    }
                     break;
                   case WatchResult.DELETED:
-                    baseNodeRoleWatcher.childRemoved(item.object.getNode());
+                    if (item.object.getNode().getServices() == null || item.object.getNode().getServices().isEmpty()) {
+                      LOGGER.warn(
+                          "no services found on [%s] druid [%s] node [%s], skipping",
+                          item.type,
+                          item.object.getNode().getNodeRole(),
+                          item.object.getNode().getDruidNode().getHostAndPort()
+                      );
+                    } else {
+                      baseNodeRoleWatcher.childRemoved(item.object.getNode());
+                    }
                     break;
                   default:
+                    // Ignore all other types as only pod ADD and DELETE matter.
                 }
 
                 // This should be updated after the action has been dealt with successfully
@@ -344,7 +364,8 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
       try {
         LOGGER.info("Stopping NodeRoleWatcher for [%s]...", nodeRole);
         // STOP_MARKER cannot throw exceptions on close(), so this is OK.
-        CloseableUtils.closeAndSuppressExceptions(STOP_MARKER, e -> {});
+        CloseableUtils.closeAndSuppressExceptions(STOP_MARKER, e -> {
+        });
         watchExecutor.shutdownNow();
 
         if (!watchExecutor.awaitTermination(15, TimeUnit.SECONDS)) {

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import io.kubernetes.client.util.Watch;
 import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.discovery.DruidNodeDiscovery;
+import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -40,6 +41,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import static org.easymock.EasyMock.mock;
+
 public class K8sDruidNodeDiscoveryProviderTest
 {
   private static final Logger LOGGER = new Logger(K8sDruidNodeDiscoveryProviderTest.class);
@@ -47,31 +50,31 @@ public class K8sDruidNodeDiscoveryProviderTest
   private final DiscoveryDruidNode testNode1 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host1", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode2 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host2", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode3 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host3", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode4 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host4", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final DiscoveryDruidNode testNode5 = new DiscoveryDruidNode(
       new DruidNode("druid/router", "test-host5", true, 80, null, true, false),
       NodeRole.ROUTER,
-      null
+      ImmutableMap.of("lookupNodeService", mock(LookupNodeService.class))
   );
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");


### PR DESCRIPTION
* fix: Do not propagate k8s add/delete events for nodes with no services
* apply druid code formatting
* formatting and test fixes

Co-authored-by: Liam Newman <96086065+liam-verta@users.noreply.github.com>

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

At startup the indexer node announces both an INDEXER (with services) and a PEON (with no services). When the indexer is shut down and the INDEXER and PEON are un-announced the processing of the events is non-deterministic. If the PEON is processed first it generates a NPE in the DruidNodeDiscoveryProvider.ServiceDruidNodeDiscovery.FilteringUpstreamListener.nodesRemoved method. This results in the leakage of a ChangeRequestHttpSyncer that is syncing the segments on the INDEXER.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

The K8sDruidDiscoveryNodeProvider.NodeRoleWatcher.keepWatching method that processes the kubernetes events explicitly prevents the propagation of events for nodes with no services. This prevents the NPE by preventing the events from flowing to the listeners that require services.



#### Release note

[druid-kubernetes-extensions] Prevent propagation of k8s add/delete events for nodes with no services


##### Key changed/added classes in this PR
 * `K8sDruidDiscoveryNodeProvider.NodeRoleWatcher` explicitly prevents propagation of k8s events for nodes with no services

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
