### PR TITLE
When a task fails and doesn't throw an exception, report it correctly…

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
@@ -28,6 +28,8 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
 
+import java.util.Objects;
+
 public class UpdateStatusAction implements TaskAction<Void>
 {
   @JsonIgnore
@@ -81,5 +83,24 @@ public class UpdateStatusAction implements TaskAction<Void>
     return "UpdateStatusAction{" +
            "status=" + status +
            '}';
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UpdateStatusAction that = (UpdateStatusAction) o;
+    return Objects.equals(status, that.status);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(status);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -166,7 +166,11 @@ public abstract class AbstractTask implements Task
       if (org.apache.commons.lang3.StringUtils.isNotBlank(errorMessage)) {
         return TaskStatus.failure(getId(), errorMessage);
       }
-      return runTask(taskToolbox);
+      TaskStatus taskStatus = runTask(taskToolbox);
+      if (taskStatus.isFailure()) {
+        failure = true;
+      }
+      return taskStatus;
     }
     catch (Exception e) {
       failure = true;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -165,7 +165,7 @@ public class AbstractTaskTest
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null, null, null)
     {
       @Override
-      public TaskStatus runTask(TaskToolbox toolbox) throws Exception
+      public TaskStatus runTask(TaskToolbox toolbox) 
       {
         return TaskStatus.failure("myId", "failed");
       }


### PR DESCRIPTION
Noticed when running in MM-less mode, that when a task failed and then the runTask() method would swallow the exception.  Thus it was reported as a success when it had in fact failed.  This fixes that issue. 