### PR TITLE
Swap LazySingleton for Singleton

### DIFF
--- a/core/src/main/java/org/apache/druid/guice/LazySingleton.java
+++ b/core/src/main/java/org/apache/druid/guice/LazySingleton.java
@@ -28,6 +28,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * A replacement for Guice's Singleton scope.
+ *
+ * This scope exists because deep down in the bowels of Guice, there are times when it looks for bindings of Singleton
+ * scope and magically promotes them to be eagerly bound.  When Guice eagerly instantiates things, it does it in an
+ * order that is not based on the object dependency graph, which can do things like cause objects to be registered on
+ * the lifecycle out-of-dependency order.
+ *
+ * Generally speaking, LazySingleton should <em>always</em> be used and {@link com.google.inject.Singleton} should
+ * <em>never</em> be used.  That said, there might be times when interacting with external libraries that make it
+ * necessary to use Singleton.  In these cases, it is best to figure out if there is a way to use LazySingleton, if it
+ * is prohibitively difficult to use LazySingleton, then Singleton should be used with knowledge that the object will
+ * be instantiated in a non-deterministic ordering compared to other objects in the JVM.
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/DruidGuiceContainer.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/DruidGuiceContainer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Scope;
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import com.sun.jersey.api.core.ResourceConfig;
+import com.sun.jersey.core.spi.component.ComponentScope;
+import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.sun.jersey.spi.container.WebApplication;
+import com.sun.jersey.spi.container.servlet.WebConfig;
+import org.apache.druid.guice.DruidScopes;
+import org.apache.druid.guice.annotations.JSR311Resource;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Set;
+
+public class DruidGuiceContainer extends GuiceContainer
+{
+  @Nonnull
+  public static Map<Scope, ComponentScope> populateScopeMap(Map<Scope, ComponentScope> map)
+  {
+    // Add the LazySingleton scope to the known scopes.
+    map.put(DruidScopes.SINGLETON, ComponentScope.Singleton);
+    return map;
+  }
+
+  private final Set<Class<?>> resources;
+  private final Injector injector;
+
+  private WebApplication webapp;
+
+  @Inject
+  public DruidGuiceContainer(
+      Injector injector,
+      @JSR311Resource Set<Class<?>> resources
+  )
+  {
+    super(injector);
+    this.injector = injector;
+    this.resources = resources;
+  }
+
+  @Override
+  protected ResourceConfig getDefaultResourceConfig(
+      Map<String, Object> props, WebConfig webConfig
+  )
+  {
+    return new DefaultResourceConfig(resources);
+  }
+
+  @Override
+  protected void initiate(ResourceConfig config, WebApplication webapp)
+  {
+    this.webapp = webapp;
+    // We need to initiate the webapp ourselves so that we can register the lazy singleton annotation with
+    // the app such that it realizes that it is Singleton scoped.
+    webapp.initiate(config, new ServletGuiceComponentProviderFactory(config, injector)
+    {
+      @Override
+      public Map<Scope, ComponentScope> createScopeMap()
+      {
+        return populateScopeMap(super.createScopeMap());
+      }
+    });
+  }
+
+  @Override
+  public WebApplication getWebApplication()
+  {
+    return webapp;
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
@@ -61,7 +61,6 @@ import org.apache.druid.sql.calcite.view.InProcessViewManager;
 import org.apache.druid.sql.calcite.view.ViewManager;
 import org.apache.druid.timeline.DataSegment;
 
-import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
@@ -154,7 +153,7 @@ public class SqlTestFramework
     /**
      * Configure the JSON mapper.
      *
-     * @see {@link #configureGuice(DruidInjectorBuilder)} for the preferred solution.
+     * @see #configureGuice(DruidInjectorBuilder) for the preferred solution.
      */
     void configureJsonMapper(ObjectMapper mapper);
 
@@ -473,14 +472,14 @@ public class SqlTestFramework
     }
 
     @Provides
-    @Singleton
+    @LazySingleton
     public QueryRunnerFactoryConglomerate conglomerate()
     {
       return componentSupplier.createCongolmerate(builder, resourceCloser);
     }
 
     @Provides
-    @Singleton
+    @LazySingleton
     public JoinableFactoryWrapper joinableFactoryWrapper(final Injector injector)
     {
       return builder.componentSupplier.createJoinableFactoryWrapper(
@@ -507,7 +506,7 @@ public class SqlTestFramework
     }
 
     @Provides
-    @Singleton
+    @LazySingleton
     public QueryLifecycleFactory queryLifecycleFactory(final Injector injector)
     {
       return QueryFrameworkUtils.createMockQueryLifecycleFactory(


### PR DESCRIPTION
Swaps some usages of Guice's Singleton for LazySingleton in an effort to try to make things more consistent in the code base.

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.