### PR TITLE
Use shared lock for appends by default

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -301,7 +301,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
     );
     IngestionMode ingestionMode = getIngestionMode();
     final boolean useSharedLock = ingestionMode == IngestionMode.APPEND
-                                  && getContextValue(Tasks.USE_SHARED_LOCK, false);
+                                  && getContextValue(Tasks.USE_SHARED_LOCK, true);
     // Respect task context value most.
     if (forceTimeChunkLock || ingestionMode == IngestionMode.REPLACE) {
       log.info(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -160,6 +160,7 @@ public interface Task
   String getClasspathPrefix();
 
   /**
+   *
    * Execute preflight actions for a task. This can be used to acquire locks, check preconditions, and so on. The
    * actions must be idempotent, since this method may be executed multiple times. This typically runs on the
    * Overlord. If this method throws an exception, the task should be considered a failure.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -139,7 +139,8 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
     if (!getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals().isEmpty()) {
       return tryTimeChunkLock(
           new SurrogateTaskActionClient(supervisorTaskId, taskActionClient),
-          getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()
+          getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals(),
+          false
       );
     } else {
       return true;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
@@ -180,7 +180,8 @@ public class PartialDimensionDistributionTask extends PerfectRollupWorkerTask
     if (!getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals().isEmpty()) {
       return tryTimeChunkLock(
           new SurrogateTaskActionClient(supervisorTaskId, taskActionClient),
-          getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()
+          getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals(),
+          false
       );
     } else {
       return true;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -136,7 +136,8 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
   {
     return tryTimeChunkLock(
         new SurrogateTaskActionClient(supervisorTaskId, taskActionClient),
-        getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()
+        getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals(),
+        false
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
@@ -153,7 +153,8 @@ public class PartialRangeSegmentGenerateTask extends PartialSegmentGenerateTask<
   {
     return tryTimeChunkLock(
         new SurrogateTaskActionClient(supervisorTaskId, taskActionClient),
-        getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals()
+        getIngestionSchema().getDataSchema().getGranularitySpec().inputIntervals(),
+        false
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -106,7 +106,7 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
     this.lockGranularityToUse = getContextValue(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, Tasks.DEFAULT_FORCE_TIME_CHUNK_LOCK)
                                 ? LockGranularity.TIME_CHUNK
                                 : LockGranularity.SEGMENT;
-    this.lockTypeToUse = getContextValue(Tasks.USE_SHARED_LOCK, false) ? TaskLockType.SHARED : TaskLockType.EXCLUSIVE;
+    this.lockTypeToUse = getContextValue(Tasks.USE_SHARED_LOCK, true) ? TaskLockType.SHARED : TaskLockType.EXCLUSIVE;
   }
 
   protected static String getFormattedGroupId(String dataSource, String type)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -509,7 +509,7 @@ public class TaskQueueTest extends IngestionTestBase
     @Override
     public boolean isReady(TaskActionClient taskActionClient) throws Exception
     {
-      return tryTimeChunkLock(taskActionClient, ImmutableList.of(interval));
+      return tryTimeChunkLock(taskActionClient, ImmutableList.of(interval), false);
     }
 
     @Override


### PR DESCRIPTION

Use shared locks for appending batch ingestion jobs and streaming ingestion by default

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
