### PR TITLE
doc: fix markdown spacing

### DIFF
--- a/docs/tutorials/tutorial-jupyter-index.md
+++ b/docs/tutorials/tutorial-jupyter-index.md
@@ -43,24 +43,24 @@ Make sure you meet the following requirements before starting the Jupyter-based 
   - Install JupyterLab or Notebook:
   
      ```bash
-    # Install JupyterLab
-    pip3 install jupyterlab  
-    # Install Jupyter Notebook
-    pip3 install notebook
+     # Install JupyterLab
+     pip3 install jupyterlab  
+     # Install Jupyter Notebook
+     pip3 install notebook
      ```
-  -  Start Jupyter
+  - Start Jupyter
       - JupyterLab 
          ```bash
          # Start JupyterLab on port 3001
-        jupyter lab --port 3001
-          ```
+         jupyter lab --port 3001
+         ```
       - Jupyter Notebook
-          ```bash
-          # Start Jupyter Notebook on port 3001
-          jupyter notebook --port 3001
-          ```
+         ```bash
+         # Start Jupyter Notebook on port 3001
+         jupyter notebook --port 3001
+         ```
 
-- An available Druid instance. You can use the `micro-quickstart` configuration described in [Quickstart (local)](./index.md). The tutorials assume that you are using the quickstart, so no authentication or authorization is expected unless explicitly mentioned.
+- An available Druid instance. You can use the [Quickstart (local)](./index.md) instance. The tutorials assume that you are using the quickstart, so no authentication or authorization is expected unless explicitly mentioned.
 
 ## Tutorials
 

--- a/docs/tutorials/tutorial-jupyter-index.md
+++ b/docs/tutorials/tutorial-jupyter-index.md
@@ -58,7 +58,7 @@ Make sure you meet the following requirements before starting the Jupyter-based 
           ```bash
           # Start Jupyter Notebook on port 3001
           jupyter notebook --port 3001
-      ```
+          ```
 
 - An available Druid instance. You can use the `micro-quickstart` configuration described in [Quickstart (local)](./index.md). The tutorials assume that you are using the quickstart, so no authentication or authorization is expected unless explicitly mentioned.
 


### PR DESCRIPTION
Fixes an extra blank code block

This PR has:

- [x] been self-reviewed.
