### PR TITLE
Convert from DRUID_INTEGRATION_TEST_INDEXER to USE_INDEXER

### DIFF
--- a/integration-tests-ex/cases/cluster.sh
+++ b/integration-tests-ex/cases/cluster.sh
@@ -142,18 +142,18 @@ function build_shared_dir {
 # docker-compose-indexer.yaml which uses the Indexer in place of Middle Manager.
 function docker_file {
 	compose_args=""
-	if [ -n "$DRUID_INTEGRATION_TEST_INDEXER" ]; then
-	    # Sanity check: DRUID_INTEGRATION_TEST_INDEXER must be "indexer" or "middleManager"
+	if [ -n "$USE_INDEXER" ]; then
+	    # Sanity check: USE_INDEXER must be "indexer" or "middleManager"
 	    # if it is set at all.
-		if [ "$DRUID_INTEGRATION_TEST_INDEXER" != "indexer" ] && [ "$DRUID_INTEGRATION_TEST_INDEXER" != "middleManager" ]
+		if [ "$USE_INDEXER" != "indexer" ] && [ "$USE_INDEXER" != "middleManager" ]
 		then
-		  echo "DRUID_INTEGRATION_TEST_INDEXER must be 'indexer' or 'middleManager' (is '$DRUID_INTEGRATION_TEST_INDEXER')" 1>&2
+		  echo "USE_INDEXER must be 'indexer' or 'middleManager' (is '$USE_INDEXER')" 1>&2
 		  exit 1
 		fi
-		if [ "$DRUID_INTEGRATION_TEST_INDEXER" == "indexer" ]; then
+		if [ "$USE_INDEXER" == "indexer" ]; then
 			compose_file=docker-compose-indexer.yaml
 			if [ ! -f "$CLUSTER_DIR/$compose_file" ]; then
-			  echo "DRUID_INTEGRATION_TEST_INDEXER=$DRUID_INTEGRATION_TEST_INDEXER, but $CLUSTER_DIR/$compose_file is missing" 1>&2
+			  echo "USE_INDEXER=$USE_INDEXER, but $CLUSTER_DIR/$compose_file is missing" 1>&2
 			  exit 1
 		    fi
 		   compose_args="-f $compose_file"

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/ClusterConfig.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/ClusterConfig.java
@@ -173,13 +173,13 @@ public class ClusterConfig
   /**
    * Create the set of configuration tags for this run. At present, the only options
    * are "middleManager" or "indexer" corresponding to the value of the
-   * {@code DRUID_INTEGRATION_TEST_INDEXER} env var which says whether this cluster has
+   * {@code USE_INDEXER} env var which says whether this cluster has
    * an indexer or middle manager.
    */
   private Set<String> createConfigTags()
   {
     String indexer = "middleManager";
-    String indexerValue = System.getenv("DRUID_INTEGRATION_TEST_INDEXER");
+    String indexerValue = System.getenv("USE_INDEXER");
     if (indexerValue != null) {
       indexer = indexerValue;
     }

--- a/integration-tests-ex/docs/guide.md
+++ b/integration-tests-ex/docs/guide.md
@@ -244,7 +244,7 @@ another build task.
 Tests should run on the Middle Manager by default. Tests can optionally run on the
 Indexer. To run on Indexer:
 
-* In the environment, `export DRUID_INTEGRATION_TEST_INDEXER=indexer`. (Use `middleManager`
+* In the environment, `export USE_INDEXER=indexer`. (Use `middleManager`
   otherwise. If the variable is not set, `middleManager` is the default.)
 * The `cluster/<category>/docker-compose.yaml` file should be for the Middle manager. Create
   a separate file called `cluster/<category>/docker-compose-indexer.yaml` to define the

--- a/it.sh
+++ b/it.sh
@@ -54,7 +54,7 @@ Usage: $0 cmd [category]
 
 Environment:
   OVERRIDE_ENV: optional, name of env file to pass to Docker
-  DRUID_INTEGRATION_TEST_INDEXER: Set to middleManager (default if not set)
+  USE_INDEXER: Set to middleManager (default if not set)
       or "indexer". If "indexer", requires docker-compose-indexer.yaml exist.
   druid_*: passed to the container.
   Other, test-specific variables.


### PR DESCRIPTION
The old ITs use DRUID_INTEGRATION_TEST_INDEXER. The new ones use the USE_INDEXER env var passed in from the build environment.

The old ITs set an environment variable `USE_INDEXER` in `travis.yml`, which Maven then converts to `DRUID_INTEGRATION_TEST_INDEXER`. The previous "indexer" PR used the `DRUID_INTEGRATION_TEST_INDEXER` to control the indexer settings in the new ITs.

However, it turns out that the new ITs streamline the process: they just use `USE_INDEXER` passed in from `travis.yml` without the (unnecessary) translation step. This PR, rips out the use of `DRUID_INTEGRATION_TEST_INDEXER` in the new IT scripts and replaces that use with `USE_INDEXER` so we get a simple, straight pass-through from Travis (or GHA) to the script using the shell variables without the need of mucking about in Maven.

<hr>

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
