### PR TITLE
Fix broken links to Oracle JDK docs

### DIFF
--- a/docs/development/extensions-core/simple-client-sslcontext.md
+++ b/docs/development/extensions-core/simple-client-sslcontext.md
@@ -23,7 +23,7 @@ title: "Simple SSLContext Provider Module"
   -->
 
 
-This Apache Druid module contains a simple implementation of [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext)
+This Apache Druid module contains a simple implementation of [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html)
 that will be injected to be used with HttpClient that Druid processes use internally to communicate with each other. To learn more about
 Java's SSL support, please refer to [this](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide) guide.
 

--- a/docs/development/extensions-core/simple-client-sslcontext.md
+++ b/docs/development/extensions-core/simple-client-sslcontext.md
@@ -25,7 +25,7 @@ title: "Simple SSLContext Provider Module"
 
 This Apache Druid module contains a simple implementation of [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html)
 that will be injected to be used with HttpClient that Druid processes use internally to communicate with each other. To learn more about
-Java's SSL support, please refer to [this](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide) guide.
+Java's SSL support, please refer to [this](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html) guide.
 
 
 |Property|Description|Default|Required|
@@ -48,5 +48,5 @@ The following table contains optional parameters for supporting client certifica
 |`druid.client.https.keyManagerPassword`|The [Password Provider](../../operations/password-provider.md) or String password for the Key Manager.|none|no|
 |`druid.client.https.validateHostnames`|Validate the hostname of the server. This should not be disabled unless you are using [custom TLS certificate checks](../../operations/tls-support.md) and know that standard hostname validation is not needed.|true|no|
 
-This [document](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames) lists all the possible
+This [document](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html) lists all the possible
 values for the above mentioned configs among others provided by Java implementation.

--- a/docs/operations/tls-support.md
+++ b/docs/operations/tls-support.md
@@ -80,9 +80,7 @@ The following table contains non-mandatory advanced configuration options, use c
 ## Internal communication over TLS
 
 Whenever possible Druid processes will use HTTPS to talk to each other. To enable this communication Druid's HttpClient needs to
-be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) 
-
-to validate the Server Certificates, otherwise communication will fail.
+be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) to validate the Server Certificates, otherwise communication will fail.
 
 Since, there are various ways to configure SSLContext, by default, Druid looks for an instance of SSLContext Guice binding
 while creating the HttpClient. This binding can be achieved writing a [Druid extension](../development/extensions.md)

--- a/docs/operations/tls-support.md
+++ b/docs/operations/tls-support.md
@@ -80,7 +80,8 @@ The following table contains non-mandatory advanced configuration options, use c
 ## Internal communication over TLS
 
 Whenever possible Druid processes will use HTTPS to talk to each other. To enable this communication Druid's HttpClient needs to
-be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) to validate the Server Certificates, otherwise communication will fail.
+be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) that is able
+to validate the Server Certificates, otherwise communication will fail.
 
 Since, there are various ways to configure SSLContext, by default, Druid looks for an instance of SSLContext Guice binding
 while creating the HttpClient. This binding can be achieved writing a [Druid extension](../development/extensions.md)

--- a/docs/operations/tls-support.md
+++ b/docs/operations/tls-support.md
@@ -80,7 +80,8 @@ The following table contains non-mandatory advanced configuration options, use c
 ## Internal communication over TLS
 
 Whenever possible Druid processes will use HTTPS to talk to each other. To enable this communication Druid's HttpClient needs to
-be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext) that is able
+be configured with a proper [SSLContext](http://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) 
+
 to validate the Server Certificates, otherwise communication will fail.
 
 Since, there are various ways to configure SSLContext, by default, Druid looks for an instance of SSLContext Guice binding


### PR DESCRIPTION
This simple docs PR fix several broken links to docs.oracle.com. These links were broken due to missing .html (perhaps the server has stopped accepting the original links).