### PR TITLE
Fix Parquet Reader for schema-less ingestion need to read all columns

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/indexing/ReaderUtils.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/ReaderUtils.java
@@ -60,9 +60,8 @@ public class ReaderUtils
 
     // Find columns we need to read from the flattenSpec
     if (flattenSpec != null) {
-      if ((dimensionsSpec.getDimensionNames() == null || dimensionsSpec.getDimensionNames().isEmpty()) &&
-          flattenSpec.isUseFieldDiscovery()) {
-        // Schemaless ingestion needs to read all columns
+      if (dimensionsSpec.getDimensions().isEmpty() && flattenSpec.isUseFieldDiscovery()) {
+        // Schemaless ingestion with useFieldDiscovery needs to read all columns
         return fullInputSchema;
       }
 
@@ -126,7 +125,7 @@ public class ReaderUtils
     } else {
       // Without flattenSpec, useFieldDiscovery is default to true and thus needs to read all columns since this is
       // schemaless
-      if ((dimensionsSpec.getDimensionNames() == null || dimensionsSpec.getDimensionNames().isEmpty())) {
+      if (dimensionsSpec.getDimensions().isEmpty()) {
         return fullInputSchema;
       }
     }

--- a/server/src/test/java/org/apache/druid/segment/indexing/ReaderUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/ReaderUtilsTest.java
@@ -328,4 +328,40 @@ public class ReaderUtilsTest extends InitializedNullHandlingTest
     Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
     Assert.assertEquals(ImmutableSet.of("B", "C"), actual);
   }
+
+  @Test
+  public void testGetColumnsRequiredForSchemalessIngestionWithoutFlattenSpec()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("A", "iso", null);
+    DimensionsSpec dimensionsSpec = DimensionsSpec.EMPTY;
+
+    Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, null);
+    Assert.assertEquals(fullInputSchema, actual);
+  }
+
+  @Test
+  public void testGetColumnsRequiredForSchemalessIngestionWithFlattenSpecAndUseFieldDiscovery()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("A", "iso", null);
+    DimensionsSpec dimensionsSpec = DimensionsSpec.EMPTY;
+    List<JSONPathFieldSpec> flattenExpr = ImmutableList.of(
+        new JSONPathFieldSpec(JSONPathFieldType.PATH, "CFlat", "$.C.time")
+    );
+    JSONPathSpec flattenSpec = new JSONPathSpec(true, flattenExpr);
+    Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
+    Assert.assertEquals(fullInputSchema, actual);
+  }
+
+  @Test
+  public void testGetColumnsRequiredForSchemalessIngestionWithFlattenSpecAndNotUseFieldDiscovery()
+  {
+    TimestampSpec timestampSpec = new TimestampSpec("A", "iso", null);
+    DimensionsSpec dimensionsSpec = DimensionsSpec.EMPTY;
+    List<JSONPathFieldSpec> flattenExpr = ImmutableList.of(
+        new JSONPathFieldSpec(JSONPathFieldType.PATH, "CFlat", "$.C.time")
+    );
+    JSONPathSpec flattenSpec = new JSONPathSpec(false, flattenExpr);
+    Set<String> actual = ReaderUtils.getColumnsRequiredForIngestion(fullInputSchema, timestampSpec, dimensionsSpec, TransformSpec.NONE, new AggregatorFactory[]{}, flattenSpec);
+    Assert.assertEquals(ImmutableSet.of("A", "C"), actual);
+  }
 }


### PR DESCRIPTION
Fix Parquet Reader for schema-less ingestion need to read all columns

### Description

When we have either schema-less ingestion without having a flattenSpec (which set useFieldDiscovery to true by default) or 
schema-less ingestion with flattenSpec that has useFieldDiscovery to true, we need to read all the columns of the input file.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
