### PR TITLE
Install node for unit-tests Github Workflow runners

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,6 +60,11 @@ jobs:
           ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
           ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.17.0
+
       - name: setup variables
         run: |
           export base_ref=${{ github.base_ref }}


### PR DESCRIPTION
GitHub workflow `unit-tests` needs node installed. Although GitHub-provided runners have node installed by default, some of the self-hosted runners might not have the same installed. This PR installs node on all runners through GH action.