### PR TITLE
Add more log statements for authorization

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
@@ -160,7 +160,12 @@ public abstract class AbstractStatement implements Closeable
 
     // Authentication is done by the planner using the function provided
     // here. The planner ensures that this step is done before planning.
-    authResult = planner.authorize(authorizer, contextResources);
+    try {
+      authResult = planner.authorize(authorizer, contextResources);
+    } catch (Exception e) {
+      log.error(e, "Planner threw an exception during authorization");
+      throw new RuntimeException("Could not authorize resources for query", e);
+    }
     if (!authResult.authorizationResult.isAllowed()) {
       throw new ForbiddenException(authResult.authorizationResult.toMessage());
     }


### PR DESCRIPTION
Adds logging and for the case that an exception is thrown during authorization

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
