### PR TITLE
Add configuration for max S3 connections

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -36,6 +36,9 @@ public class AWSClientConfig
   @JsonProperty
   protected boolean forceGlobalBucketAccessEnabled = S3ClientOptions.DEFAULT_FORCE_GLOBAL_BUCKET_ACCESS_ENABLED;
 
+  @JsonProperty
+  protected Integer maxConnections;
+
   public String getProtocol()
   {
     return protocol;
@@ -56,6 +59,11 @@ public class AWSClientConfig
     return forceGlobalBucketAccessEnabled;
   }
 
+  public Integer getMaxConnections()
+  {
+    return maxConnections;
+  }
+
   @Override
   public String toString()
   {
@@ -64,6 +72,7 @@ public class AWSClientConfig
            ", disableChunkedEncoding=" + disableChunkedEncoding +
            ", enablePathStyleAccess=" + enablePathStyleAccess +
            ", forceGlobalBucketAccessEnabled=" + forceGlobalBucketAccessEnabled +
+           ", maxConnections=" + maxConnections +
            '}';
   }
 }

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -131,6 +131,7 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.s3.disableChunkedEncoding`|Disables chunked encoding. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details.|false|
 |`druid.s3.enablePathStyleAccess`|Enables path style access. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#enablePathStyleAccess--) for details.|false|
 |`druid.s3.forceGlobalBucketAccessEnabled`|Enables global bucket access. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#setForceGlobalBucketAccessEnabled-java.lang.Boolean-) for details.|false|
+|`druid.s3.maxConnections`|Max concurrent connections to S3 per task.|None (fallbacks to AWS SDK default)|
 |`druid.s3.endpoint.url`|Service endpoint either with or without the protocol.|None|
 |`druid.s3.endpoint.signingRegion`|Region to use for SigV4 signing of requests (e.g. us-west-1).|None|
 |`druid.s3.proxy.host`|Proxy host to connect through.|None|

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageDruidModule.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3StorageDruidModule.java
@@ -135,6 +135,9 @@ public class S3StorageDruidModule implements DruidModule
   {
     final ClientConfiguration configuration = new ClientConfigurationFactory().getConfig();
     final Protocol protocol = S3Utils.determineProtocol(clientConfig, endpointConfig);
+    if (clientConfig.getMaxConnections() != null) {
+      configuration.setMaxConnections(clientConfig.getMaxConnections());
+    }
     final AmazonS3ClientBuilder amazonS3ClientBuilder = AmazonS3Client
         .builder()
         .withCredentials(provider)


### PR DESCRIPTION
For large MSQ jobs with durable storage, the default number of maximum connections (50 as of now) is sometimes a bottleneck leading to job failures. This provides a configuration to bump the maximum s3 connections for AWS S3 Client.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
