### PR TITLE
Add Perl 5 to druid requirements

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -41,6 +41,7 @@ The software requirements for the installation machine are:
 * Linux, Mac OS X, or other Unix-like OS. (Windows is not supported)
 * [Java 8u92+ or Java 11](../operations/java.md)
 * [Python2 or Python3](../operations/python.md)
+* Perl 5
 
 > Druid relies on the environment variables `JAVA_HOME` or `DRUID_JAVA_HOME` to find Java on the machine. You can set
 `DRUID_JAVA_HOME` if there is more than one instance of Java. To verify Java requirements for your environment, run the 


### PR DESCRIPTION
Without perl 5 I was unable to start druid using the instructions in the quickstart guide. For my testing, perl5 got it working.

> This is perl 5, version 36, subversion 0 (v5.36.0) built for x86_64-linux-thread-multi

### Description

Missing requirement for running the startup script. Without Perl 5 apache druid would not start.

Just added in "Perl 5" to the quick start guide requirements under the list that includes python and java.


