### PR TITLE
Web console: Data loader should allow for multiline JSON messages in kafka

### DIFF
--- a/web-console/lib/keywords.js
+++ b/web-console/lib/keywords.js
@@ -64,6 +64,10 @@ exports.SQL_KEYWORDS = [
   'OVER',
   'PARTITION BY',
   'WINDOW',
+  'RANGE',
+  'PRECEDING',
+  'FOLLOWING',
+  'EXTEND',
 ];
 
 exports.SQL_EXPRESSION_PARTS = [

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -2133,7 +2133,12 @@ export function updateIngestionType(
   return newSpec;
 }
 
-export function issueWithSampleData(sampleData: string[]): JSX.Element | undefined {
+export function issueWithSampleData(
+  sampleData: string[],
+  spec: Partial<IngestionSpec>,
+): JSX.Element | undefined {
+  if (getSpecType(spec) === 'kafka') return;
+
   if (sampleData.length) {
     const firstData = sampleData[0];
 
@@ -2166,14 +2171,18 @@ export function fillInputFormatIfNeeded(
   sampleData: string[],
 ): Partial<IngestionSpec> {
   if (deepGet(spec, 'spec.ioConfig.inputFormat.type')) return spec;
-  return deepSet(spec, 'spec.ioConfig.inputFormat', guessInputFormat(sampleData));
+  return deepSet(
+    spec,
+    'spec.ioConfig.inputFormat',
+    guessInputFormat(sampleData, getSpecType(spec) === 'kafka'),
+  );
 }
 
 function noNumbers(xs: string[]): boolean {
   return xs.every(x => isNaN(Number(x)));
 }
 
-export function guessInputFormat(sampleData: string[]): InputFormat {
+export function guessInputFormat(sampleData: string[], canBeMultiLineJson = false): InputFormat {
   let sampleDatum = sampleData[0];
   if (sampleDatum) {
     sampleDatum = String(sampleDatum); // Really ensure it is a string
@@ -2260,6 +2269,11 @@ export function guessInputFormat(sampleData: string[]): InputFormat {
         findColumnsFromHeader: noNumbers(lineAsTsvPipe),
         numColumns: lineAsTsvPipe.length,
       });
+    }
+
+    // If the object is a single json object spanning multiple lines than the first one will just start with `{`
+    if (canBeMultiLineJson && sampleDatum.startsWith('{')) {
+      return { type: 'json', useJsonNodeReader: true };
     }
   }
 

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -2137,7 +2137,7 @@ export function issueWithSampleData(
   sampleData: string[],
   spec: Partial<IngestionSpec>,
 ): JSX.Element | undefined {
-  if (getSpecType(spec) === 'kafka') return;
+  if (isStreamingSpec(spec)) return;
 
   if (sampleData.length) {
     const firstData = sampleData[0];
@@ -2174,7 +2174,7 @@ export function fillInputFormatIfNeeded(
   return deepSet(
     spec,
     'spec.ioConfig.inputFormat',
-    guessInputFormat(sampleData, getSpecType(spec) === 'kafka'),
+    guessInputFormat(sampleData, isStreamingSpec(spec)),
   );
 }
 

--- a/web-console/src/druid-models/input-format/input-format.tsx
+++ b/web-console/src/druid-models/input-format/input-format.tsx
@@ -114,6 +114,7 @@ function generateInputFormatFields(streaming: boolean) {
     streaming
       ? {
           name: 'useJsonNodeReader',
+          title: 'Use JSON node reader',
           type: 'boolean',
           defined: typeIs('json'),
           disabled: (inputFormat: InputFormat) => inputFormat.assumeNewlineDelimited,

--- a/web-console/src/singletons/api.ts
+++ b/web-console/src/singletons/api.ts
@@ -19,6 +19,8 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import * as JSONBig from 'json-bigint-native';
 
+import { nonEmptyString } from '../utils';
+
 export class Api {
   static instance: AxiosInstance;
 
@@ -32,11 +34,11 @@ export class Api {
       (error: AxiosError) => {
         const responseData = error.response?.data;
         const message = responseData?.message;
-        if (typeof message === 'string') {
+        if (nonEmptyString(message)) {
           return Promise.reject(new Error(message));
         }
 
-        if (error.config.method?.toLowerCase() === 'get' && typeof responseData === 'string') {
+        if (error.config.method?.toLowerCase() === 'get' && nonEmptyString(responseData)) {
           return Promise.reject(new Error(responseData));
         }
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -36,7 +36,11 @@ export function isNumberLikeNaN(x: NumberLike): boolean {
   return isNaN(Number(x));
 }
 
-export function nonEmptyArray(a: any): a is unknown[] {
+export function nonEmptyString(s: unknown): s is string {
+  return typeof s === 'string' && s !== '';
+}
+
+export function nonEmptyArray(a: unknown): a is unknown[] {
   return Array.isArray(a) && Boolean(a.length);
 }
 

--- a/web-console/src/views/home-view/tasks-card/tasks-card.tsx
+++ b/web-console/src/views/home-view/tasks-card/tasks-card.tsx
@@ -76,7 +76,7 @@ export interface TasksCardProps {
 export const TasksCard = React.memo(function TasksCard(props: TasksCardProps) {
   const [cardState] = useQueryManager<Capabilities, TaskCountsAndCapacity>({
     processQuery: async capabilities => {
-      const taskCounts = getTaskCounts(capabilities);
+      const taskCounts = await getTaskCounts(capabilities);
       if (!capabilities.hasOverlordAccess()) return taskCounts;
 
       const capacity = await getClusterCapacity();

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -1364,7 +1364,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 l.input ? l.input.raw : undefined,
               );
 
-              const issue = issueWithSampleData(sampleLines);
+              const issue = issueWithSampleData(sampleLines, spec);
               if (issue) {
                 AppToaster.show({
                   icon: IconNames.WARNING_SIGN,


### PR DESCRIPTION
Right now if you have multi-line JSON messages in a kafka stream the data loader will (unhelpfully) warn you that that type of data is not allowed.

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/177816/214710362-17bd1865-1055-4ce2-b1ba-7880f2c9965c.png">


Instead it should know that in Kafka based ingestion it is allowed (and to guess the format well)