### PR TITLE
fix nested column handling of null and "null"

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/SimpleDictionaryMergingIterator.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleDictionaryMergingIterator.java
@@ -90,7 +90,11 @@ public class SimpleDictionaryMergingIterator<T extends Comparable<T>> implements
     }
 
     while (!pQueue.isEmpty() && Objects.equals(value, pQueue.peek().peek())) {
-      pQueue.remove();
+      PeekingIterator<T> same = pQueue.remove();
+      same.next();
+      if (same.hasNext()) {
+        pQueue.add(same);
+      }
     }
     counter++;
 

--- a/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryEncodedFieldColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryEncodedFieldColumnWriter.java
@@ -134,9 +134,15 @@ public abstract class GlobalDictionaryEncodedFieldColumnWriter<T>
       fillNull(row);
     }
     final T value = processValue(val);
-    final int globalId = lookupGlobalId(value);
-    Preconditions.checkArgument(globalId >= 0, "Value [%s] is not present in global dictionary", value);
-    final int localId = localDictionary.add(globalId);
+    final int localId;
+    // null is always 0
+    if (value == null) {
+      localId = localDictionary.add(0);
+    } else {
+      final int globalId = lookupGlobalId(value);
+      Preconditions.checkArgument(globalId >= 0, "Value [%s] is not present in global dictionary", value);
+      localId = localDictionary.add(globalId);
+    }
     intermediateValueWriter.write(localId);
     writeValue(value);
     cursorPosition++;

--- a/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryEncodedFieldColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryEncodedFieldColumnWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.nested;
 
+import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrays;
@@ -52,7 +53,7 @@ import java.nio.channels.WritableByteChannel;
  * for all literal writers, which for this type of writer entails building a local dictionary to map into to the global
  * dictionary ({@link #localDictionary}) and writes this unsorted localId to an intermediate integer column,
  * {@link #intermediateValueWriter}.
- *
+ * <p>
  * When processing the 'raw' value column is complete, the {@link #writeTo(int, FileSmoosher)} method will sort the
  * local ids and write them out to a local sorted dictionary, iterate over {@link #intermediateValueWriter} swapping
  * the unsorted local ids with the sorted ids and writing to the compressed id column writer
@@ -134,6 +135,7 @@ public abstract class GlobalDictionaryEncodedFieldColumnWriter<T>
     }
     final T value = processValue(val);
     final int globalId = lookupGlobalId(value);
+    Preconditions.checkArgument(globalId >= 0, "Value [%s] is not present in global dictionary", value);
     final int localId = localDictionary.add(globalId);
     intermediateValueWriter.write(localId);
     writeValue(value);

--- a/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryIdLookup.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/GlobalDictionaryIdLookup.java
@@ -46,8 +46,11 @@ public class GlobalDictionaryIdLookup
   public GlobalDictionaryIdLookup()
   {
     this.stringLookup = new Object2IntLinkedOpenHashMap<>();
+    stringLookup.defaultReturnValue(-1);
     this.longLookup = new Long2IntLinkedOpenHashMap();
+    longLookup.defaultReturnValue(-1);
     this.doubleLookup = new Double2IntLinkedOpenHashMap();
+    doubleLookup.defaultReturnValue(-1);
   }
 
   public void addString(@Nullable String value)

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
@@ -238,11 +238,12 @@ public class NestedDataColumnSerializer implements GenericColumnSerializer<Struc
     dictionaryWriter.write(null);
     globalDictionaryIdLookup.addString(null);
     for (String value : dictionaryValues) {
-      if (NullHandling.emptyToNullIfNeeded(value) == null) {
+      value = NullHandling.emptyToNullIfNeeded(value);
+      if (value == null) {
         continue;
       }
+
       dictionaryWriter.write(value);
-      value = NullHandling.emptyToNullIfNeeded(value);
       globalDictionaryIdLookup.addString(value);
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldLiteralDictionaryEncodedColumn.java
@@ -147,9 +147,10 @@ public class NestedFieldLiteralDictionaryEncodedColumn<TStringDictionary extends
       return StringUtils.fromUtf8Nullable(globalDictionary.get(globalId));
     } else if (globalId < globalDictionary.size() + globalLongDictionary.size()) {
       return String.valueOf(globalLongDictionary.get(globalId - adjustLongId));
-    } else {
+    } else if (globalId < globalDictionary.size() + globalLongDictionary.size() + globalDoubleDictionary.size()) {
       return String.valueOf(globalDoubleDictionary.get(globalId - adjustDoubleId));
     }
+    return null;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/nested/StringFieldColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/StringFieldColumnWriter.java
@@ -45,6 +45,9 @@ public final class StringFieldColumnWriter extends GlobalDictionaryEncodedFieldC
   @Override
   String processValue(Object value)
   {
+    if (value == null) {
+      return null;
+    }
     return String.valueOf(value);
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/nested/StringFieldColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/StringFieldColumnWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.nested;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
@@ -48,7 +49,7 @@ public final class StringFieldColumnWriter extends GlobalDictionaryEncodedFieldC
     if (value == null) {
       return null;
     }
-    return String.valueOf(value);
+    return NullHandling.emptyToNullIfNeeded(String.valueOf(value));
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -63,6 +63,9 @@ public class NestedDataTestUtils
   public static final String SIMPLE_PARSER_TSV_TRANSFORM_FILE = "simple-nested-test-data-tsv-transform.json";
   public static final String SIMPLE_AGG_FILE = "simple-nested-test-data-aggs.json";
 
+  public static final String TYPES_DATA_FILE = "types-test-data.json";
+  public static final String TYPES_PARSER_FILE = "types-test-data-parser.json";
+
   public static final String NUMERIC_DATA_FILE = "numeric-nested-test-data.json";
   public static final String NUMERIC_PARSER_FILE = "numeric-nested-test-data-parser.json";
 

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -154,7 +154,7 @@ public class NestedDataTestUtils
   {
     File segmentDir = tempFolder.newFolder();
     File inputFile = readFileFromClasspath(inputFileName);
-    FileInputStream inputDataStream = closer.register(new FileInputStream(inputFile));
+    FileInputStream inputDataStream = new FileInputStream(inputFile);
     String parserJson = readFileFromClasspathAsString(parserJsonFileName);
     String aggJson = readFileFromClasspathAsString(aggJsonFileName);
 
@@ -168,6 +168,7 @@ public class NestedDataTestUtils
         maxRowCount,
         rollup
     );
+    inputDataStream.close();
 
     final List<Segment> segments = Lists.transform(
         ImmutableList.of(segmentDir),
@@ -199,7 +200,7 @@ public class NestedDataTestUtils
   {
     File segmentDir = tempFolder.newFolder();
     File inputFile = readFileFromClasspath(inputFileName);
-    FileInputStream inputDataStream = closer.register(new FileInputStream(inputFile));
+    FileInputStream inputDataStream = new FileInputStream(inputFile);
     String parserJson = readFileFromClasspathAsString(parserJsonFileName);
     String transformSpecJson = readFileFromClasspathAsString(transformSpecJsonFileName);
     String aggJson = readFileFromClasspathAsString(aggJsonFileName);
@@ -215,6 +216,7 @@ public class NestedDataTestUtils
         maxRowCount,
         rollup
     );
+    inputDataStream.close();
 
     final List<Segment> segments = Lists.transform(
         ImmutableList.of(segmentDir),
@@ -284,7 +286,7 @@ public class NestedDataTestUtils
     for (int i = 0; i < numSegments; i++) {
       List<InputStream> inputStreams = Lists.newArrayListWithCapacity(numCopies);
       for (int j = 0; j < numCopies; j++) {
-        inputStreams.add(closer.register(new FileInputStream(readFileFromClasspath(inputFileName))));
+        inputStreams.add(new FileInputStream(readFileFromClasspath(inputFileName)));
         if (j + 1 < numCopies) {
           inputStreams.add(new ByteArrayInputStream(StringUtils.toUtf8("\n")));
         }
@@ -302,6 +304,7 @@ public class NestedDataTestUtils
           maxRowCount,
           rollup
       );
+      inputDataStream.close();
       segmentDirs.add(segmentDir);
     }
 

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.druid.data.input.impl.StringInputRowParser;
 import org.apache.druid.guice.NestedDataModule;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.nary.TrinaryFn;
@@ -42,6 +43,7 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.timeline.SegmentId;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -280,6 +282,9 @@ public class NestedDataTestUtils
       List<InputStream> inputStreams = Lists.newArrayListWithCapacity(numCopies);
       for (int j = 0; j < numCopies; j++) {
         inputStreams.add(new FileInputStream(readFileFromClasspath(inputFileName)));
+        if (j + 1 < numCopies) {
+          inputStreams.add(new ByteArrayInputStream(StringUtils.toUtf8("\n")));
+        }
       }
       SequenceInputStream inputDataStream = new SequenceInputStream(Collections.enumeration(inputStreams));
       File segmentDir = tempFolder.newFolder();

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -154,7 +154,7 @@ public class NestedDataTestUtils
   {
     File segmentDir = tempFolder.newFolder();
     File inputFile = readFileFromClasspath(inputFileName);
-    FileInputStream inputDataStream = new FileInputStream(inputFile);
+    FileInputStream inputDataStream = closer.register(new FileInputStream(inputFile));
     String parserJson = readFileFromClasspathAsString(parserJsonFileName);
     String aggJson = readFileFromClasspathAsString(aggJsonFileName);
 
@@ -199,7 +199,7 @@ public class NestedDataTestUtils
   {
     File segmentDir = tempFolder.newFolder();
     File inputFile = readFileFromClasspath(inputFileName);
-    FileInputStream inputDataStream = new FileInputStream(inputFile);
+    FileInputStream inputDataStream = closer.register(new FileInputStream(inputFile));
     String parserJson = readFileFromClasspathAsString(parserJsonFileName);
     String transformSpecJson = readFileFromClasspathAsString(transformSpecJsonFileName);
     String aggJson = readFileFromClasspathAsString(aggJsonFileName);
@@ -284,7 +284,7 @@ public class NestedDataTestUtils
     for (int i = 0; i < numSegments; i++) {
       List<InputStream> inputStreams = Lists.newArrayListWithCapacity(numCopies);
       for (int j = 0; j < numCopies; j++) {
-        inputStreams.add(new FileInputStream(readFileFromClasspath(inputFileName)));
+        inputStreams.add(closer.register(new FileInputStream(readFileFromClasspath(inputFileName))));
         if (j + 1 < numCopies) {
           inputStreams.add(new ByteArrayInputStream(StringUtils.toUtf8("\n")));
         }
@@ -355,6 +355,7 @@ public class NestedDataTestUtils
         maxRowCount,
         rollup
     );
+    inputDataStream.close();
     return new IncrementalIndexSegment(index, SegmentId.dummy("test_datasource"));
   }
 

--- a/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SchemaEvolutionTest.java
@@ -375,7 +375,7 @@ public class SchemaEvolutionTest
 
     // Only nonexistent(4)
     Assert.assertEquals(
-        timeseriesResult(TestHelper.createExpectedMap(
+        timeseriesResult(TestHelper.makeMap(
             "a",
             NullHandling.defaultLongValue(),
             "b",

--- a/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
@@ -336,8 +336,8 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
         closer,
         Granularities.HOUR,
         false,
-        100,
-        100,
+        5,
+        10,
         1
     );
     final Sequence<ScanResultValue> seq = helper.runQueryOnSegmentsObjs(segs, scanQuery);
@@ -345,7 +345,7 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
     List<ScanResultValue> results = seq.toList();
     logResults(results);
     Assert.assertEquals(1, results.size());
-    Assert.assertEquals(100, ((List) results.get(0).getEvents()).size());
+    Assert.assertEquals(80, ((List) results.get(0).getEvents()).size());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
@@ -24,41 +24,21 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.guice.NestedDataModule;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
-import org.apache.druid.java.util.common.guava.Yielder;
-import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
-import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.filter.BoundDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
-import org.apache.druid.segment.ColumnSelectorFactory;
-import org.apache.druid.segment.ColumnValueSelector;
-import org.apache.druid.segment.Cursor;
-import org.apache.druid.segment.DoubleColumnSelector;
-import org.apache.druid.segment.LongColumnSelector;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.StorageAdapter;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
-import org.apache.druid.segment.nested.NestedPathFinder;
-import org.apache.druid.segment.nested.NestedPathPart;
-import org.apache.druid.segment.vector.BaseDoubleVectorValueSelector;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
-import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
-import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
-import org.apache.druid.segment.vector.VectorCursor;
-import org.apache.druid.segment.vector.VectorObjectSelector;
-import org.apache.druid.segment.vector.VectorValueSelector;
 import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.After;
@@ -74,14 +54,6 @@ import java.util.List;
 public class NestedDataScanQueryTest extends InitializedNullHandlingTest
 {
   private static final Logger LOG = new Logger(NestedDataScanQueryTest.class);
-  private static final String NESTED_LONG_FIELD = "long";
-  private static final String NESTED_DOUBLE_FIELD = "double";
-  private static final String NESTED_MIXED_NUMERIC_FIELD = "mixed_numeric";
-  private static final String NESTED_MIXED_FIELD = "mixed";
-  private static final String NESTED_SPARSE_LONG_FIELD = "sparse_long";
-  private static final String NESTED_SPARSE_DOUBLE_FIELD = "sparse_double";
-  private static final String NESTED_SPARSE_MIXED_NUMERIC_FIELD = "sparse_mixed_numeric";
-  private static final String NESTED_SPARSE_MIXED_FIELD = "sparse_mixed";
 
   private final AggregationTestHelper helper;
   private final Closer closer;
@@ -409,291 +381,6 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
     logResults(results);
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(4, ((List) results.get(0).getEvents()).size());
-  }
-
-  @Test
-  public void testExpectedTypes() throws Exception
-  {
-    // "Line matches the illegal pattern 'ObjectColumnSelector, LongColumnSelector, FloatColumnSelector
-    // and DoubleColumnSelector must not be used in an instanceof statement, see Javadoc of those interfaces."
-    //CHECKSTYLE.OFF: Regexp
-    ColumnSelectorFactory columnSelectorFactory = getNumericColumnSelectorFactory(
-        makeNestedNumericVirtualColumns()
-    );
-
-    ColumnValueSelector longValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_LONG_FIELD
-    );
-    Assert.assertNotNull(longValueSelector);
-    Assert.assertTrue(longValueSelector instanceof LongColumnSelector);
-
-    ColumnValueSelector doubleValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_DOUBLE_FIELD
-    );
-    Assert.assertNotNull(doubleValueSelector);
-    Assert.assertTrue(doubleValueSelector instanceof DoubleColumnSelector);
-
-    ColumnValueSelector mixedNumericValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_MIXED_NUMERIC_FIELD
-    );
-    Assert.assertNotNull(mixedNumericValueSelector);
-    Assert.assertTrue(mixedNumericValueSelector instanceof ColumnValueSelector);
-
-    ColumnValueSelector mixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_MIXED_FIELD
-    );
-    Assert.assertNotNull(mixedValueSelector);
-    Assert.assertTrue(mixedValueSelector instanceof ColumnValueSelector);
-
-
-    ColumnValueSelector sparseLongValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_SPARSE_LONG_FIELD
-    );
-    Assert.assertNotNull(sparseLongValueSelector);
-    Assert.assertTrue(sparseLongValueSelector instanceof LongColumnSelector);
-
-    ColumnValueSelector sparseDoubleValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_SPARSE_DOUBLE_FIELD
-    );
-    Assert.assertNotNull(sparseDoubleValueSelector);
-    Assert.assertTrue(sparseDoubleValueSelector instanceof DoubleColumnSelector);
-
-    ColumnValueSelector sparseMixedNumericValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_SPARSE_MIXED_NUMERIC_FIELD
-    );
-    Assert.assertNotNull(sparseMixedNumericValueSelector);
-    Assert.assertTrue(sparseMixedNumericValueSelector instanceof ColumnValueSelector);
-
-    ColumnValueSelector sparseMixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
-        NESTED_SPARSE_MIXED_FIELD
-    );
-    Assert.assertNotNull(sparseMixedValueSelector);
-    Assert.assertTrue(sparseMixedValueSelector instanceof ColumnValueSelector);
-    //CHECKSTYLE.ON: Regexp
-  }
-
-  @Test
-  public void testExpectedTypesVectorSelectors() throws Exception
-  {
-    // "Line matches the illegal pattern 'ObjectColumnSelector, LongColumnSelector, FloatColumnSelector
-    // and DoubleColumnSelector must not be used in an instanceof statement, see Javadoc of those interfaces."
-    //CHECKSTYLE.OFF: Regexp
-    VectorColumnSelectorFactory factory = getVectorColumnSelectorFactory(
-        makeNestedNumericVirtualColumns()
-    );
-
-    // can make numeric value selectors for single typed numeric types
-    VectorValueSelector longValueSelector = factory.makeValueSelector(
-        NESTED_LONG_FIELD
-    );
-    Assert.assertNotNull(longValueSelector);
-    Assert.assertTrue(longValueSelector instanceof BaseLongVectorValueSelector);
-
-    VectorValueSelector doubleValueSelector = factory.makeValueSelector(
-        NESTED_DOUBLE_FIELD
-    );
-    Assert.assertNotNull(doubleValueSelector);
-    Assert.assertTrue(doubleValueSelector instanceof BaseDoubleVectorValueSelector);
-
-    Assert.assertThrows(UOE.class, () -> factory.makeValueSelector(NESTED_MIXED_NUMERIC_FIELD));
-    Assert.assertThrows(UOE.class, () -> factory.makeValueSelector(NESTED_MIXED_FIELD));
-
-    // can also make single value dimension selectors for all nested column types
-    SingleValueDimensionVectorSelector longDimensionSelector = factory.makeSingleValueDimensionSelector(
-        DefaultDimensionSpec.of(NESTED_LONG_FIELD)
-    );
-    Assert.assertNotNull(longDimensionSelector);
-
-    SingleValueDimensionVectorSelector doubleDimensionSelector = factory.makeSingleValueDimensionSelector(
-        DefaultDimensionSpec.of(NESTED_DOUBLE_FIELD)
-    );
-    Assert.assertNotNull(doubleDimensionSelector);
-
-    SingleValueDimensionVectorSelector mixedNumericValueSelector = factory.makeSingleValueDimensionSelector(
-        DefaultDimensionSpec.of(NESTED_MIXED_NUMERIC_FIELD)
-    );
-    Assert.assertNotNull(mixedNumericValueSelector);
-
-    SingleValueDimensionVectorSelector mixedValueSelector = factory.makeSingleValueDimensionSelector(
-        DefaultDimensionSpec.of(NESTED_MIXED_FIELD)
-    );
-    Assert.assertNotNull(mixedValueSelector);
-
-    // and object selectors
-    VectorObjectSelector longObjectSelector = factory.makeObjectSelector(
-        NESTED_LONG_FIELD
-    );
-    Assert.assertNotNull(longObjectSelector);
-
-    VectorObjectSelector doubleObjectSelector = factory.makeObjectSelector(
-        NESTED_DOUBLE_FIELD
-    );
-    Assert.assertNotNull(doubleObjectSelector);
-
-    VectorObjectSelector mixedNumericObjectSelector = factory.makeObjectSelector(
-        NESTED_MIXED_NUMERIC_FIELD
-    );
-    Assert.assertNotNull(mixedNumericObjectSelector);
-
-    VectorObjectSelector mixedObjectSelector = factory.makeObjectSelector(
-        NESTED_MIXED_FIELD
-    );
-    Assert.assertNotNull(mixedObjectSelector);
-    //CHECKSTYLE.ON: Regexp
-  }
-
-  private VirtualColumns makeNestedNumericVirtualColumns()
-  {
-    List<NestedPathPart> longParts = NestedPathFinder.parseJqPath(".long");
-    List<NestedPathPart> doubleParts = NestedPathFinder.parseJqPath(".double");
-    List<NestedPathPart> mixedNumericParts = NestedPathFinder.parseJqPath(".mixed_numeric");
-    List<NestedPathPart> mixedParts = NestedPathFinder.parseJqPath(".mixed");
-    List<NestedPathPart> sparseLongParts = NestedPathFinder.parseJqPath(".sparse_long");
-    List<NestedPathPart> sparseDoubleParts = NestedPathFinder.parseJqPath(".sparse_double");
-    List<NestedPathPart> sparseMixedNumericParts = NestedPathFinder.parseJqPath(".sparse_mixed_numeric");
-    List<NestedPathPart> sparseMixedParts = NestedPathFinder.parseJqPath(".sparse_mixed");
-
-    NestedFieldVirtualColumn longVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_LONG_FIELD,
-        ColumnType.LONG,
-        longParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn doubleVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_DOUBLE_FIELD,
-        ColumnType.DOUBLE,
-        doubleParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn mixedNumericVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_MIXED_NUMERIC_FIELD,
-        null,
-        mixedNumericParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn mixedVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_MIXED_FIELD,
-        null,
-        mixedParts,
-        false,
-        null,
-        null
-    );
-
-    NestedFieldVirtualColumn sparseLongVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_SPARSE_LONG_FIELD,
-        ColumnType.LONG,
-        sparseLongParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn sparseDoubleVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_SPARSE_DOUBLE_FIELD,
-        ColumnType.DOUBLE,
-        sparseDoubleParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn sparseMixedNumericVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_SPARSE_MIXED_NUMERIC_FIELD,
-        null,
-        sparseMixedNumericParts,
-        false,
-        null,
-        null
-    );
-    NestedFieldVirtualColumn sparseMixedVirtualColumn = new NestedFieldVirtualColumn(
-        "nest",
-        NESTED_SPARSE_MIXED_FIELD,
-        null,
-        sparseMixedParts,
-        false,
-        null,
-        null
-    );
-
-    return VirtualColumns.create(
-        ImmutableList.of(
-            longVirtualColumn,
-            doubleVirtualColumn,
-            mixedNumericVirtualColumn,
-            mixedVirtualColumn,
-            sparseLongVirtualColumn,
-            sparseDoubleVirtualColumn,
-            sparseMixedNumericVirtualColumn,
-            sparseMixedVirtualColumn
-        )
-    );
-  }
-
-  private ColumnSelectorFactory getNumericColumnSelectorFactory(VirtualColumns virtualColumns) throws Exception
-  {
-    List<Segment> segments = NestedDataTestUtils.createSegments(
-        helper,
-        tempFolder,
-        closer,
-        NestedDataTestUtils.NUMERIC_DATA_FILE,
-        NestedDataTestUtils.NUMERIC_PARSER_FILE,
-        NestedDataTestUtils.SIMPLE_AGG_FILE,
-        Granularities.DAY,
-        true,
-        1000
-    );
-    Assert.assertEquals(1, segments.size());
-    StorageAdapter storageAdapter = segments.get(0).asStorageAdapter();
-    Sequence<Cursor> cursorSequence = storageAdapter.makeCursors(
-        null,
-        Intervals.ETERNITY,
-        virtualColumns,
-        Granularities.DAY,
-        false,
-        null
-    );
-    final Yielder<Cursor> yielder = Yielders.each(cursorSequence);
-    closer.register(yielder);
-    final Cursor cursor = yielder.get();
-    return cursor.getColumnSelectorFactory();
-  }
-
-  private VectorColumnSelectorFactory getVectorColumnSelectorFactory(VirtualColumns virtualColumns) throws Exception
-  {
-    List<Segment> segments = NestedDataTestUtils.createSegments(
-        helper,
-        tempFolder,
-        closer,
-        NestedDataTestUtils.NUMERIC_DATA_FILE,
-        NestedDataTestUtils.NUMERIC_PARSER_FILE,
-        NestedDataTestUtils.SIMPLE_AGG_FILE,
-        Granularities.DAY,
-        true,
-        1000
-    );
-    Assert.assertEquals(1, segments.size());
-    StorageAdapter storageAdapter = segments.get(0).asStorageAdapter();
-    VectorCursor cursor = storageAdapter.makeVectorCursor(
-        null,
-        Intervals.ETERNITY,
-        virtualColumns,
-        false,
-        512,
-        null
-    );
-    return cursor.getColumnSelectorFactory();
   }
 
   private static void logResults(List<ScanResultValue> results)

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -651,7 +651,7 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
         new Result<>(
             QueryRunnerTestHelper.EMPTY_INTERVAL.getIntervals().get(0).getStart(),
             new TimeseriesResultValue(
-                TestHelper.createExpectedMap(
+                TestHelper.makeMap(
                     "rows",
                     0L,
                     "index",

--- a/processing/src/test/java/org/apache/druid/segment/NestedDataColumnIndexerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/NestedDataColumnIndexerTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
@@ -46,8 +45,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class NestedDataColumnIndexerTest extends InitializedNullHandlingTest
 {
@@ -563,20 +562,8 @@ public class NestedDataColumnIndexerTest extends InitializedNullHandlingTest
       Object... kv
   )
   {
-    HashMap<String, Object> event = new HashMap<>();
+    final Map<String, Object> event = TestHelper.makeMap(explicitNull, kv);
     event.put("time", timestamp);
-    Preconditions.checkArgument(kv.length % 2 == 0);
-    String currentKey = null;
-    for (int i = 0; i < kv.length; i++) {
-      if (i % 2 == 0) {
-        currentKey = (String) kv[i];
-      } else {
-        if (explicitNull || kv[i] != null) {
-          event.put(currentKey, kv[i]);
-        }
-      }
-    }
-
     return new MapBasedInputRow(timestamp, ImmutableList.copyOf(event.keySet()), event);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessTestFullTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessTestFullTest.java
@@ -866,7 +866,7 @@ public class SchemalessTestFullTest extends InitializedNullHandlingTest
         new Result<>(
             DateTimes.of("2011-01-12T00:00:00.000Z"),
             new TimeseriesResultValue(
-                TestHelper.createExpectedMap(
+                TestHelper.makeMap(
                     "rows", 1L,
                     "index", NullHandling.replaceWithDefault() ? 0.0D : null,
                     "addRowsIndexConstant", NullHandling.replaceWithDefault() ? 2.0D : null,
@@ -881,7 +881,7 @@ public class SchemalessTestFullTest extends InitializedNullHandlingTest
         new Result<>(
             DateTimes.of("2011-01-12T00:00:00.000Z"),
             new TimeseriesResultValue(
-                TestHelper.createExpectedMap(
+                TestHelper.makeMap(
                     "rows", 0L,
                     "index", NullHandling.replaceWithDefault() ? 0.0D : null,
                     "addRowsIndexConstant", NullHandling.replaceWithDefault() ? 1.0D : null,

--- a/processing/src/test/java/org/apache/druid/segment/SimpleDictionaryMergingIteratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SimpleDictionaryMergingIteratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.data.ListIndexed;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class SimpleDictionaryMergingIteratorTest
+{
+  @Test
+  public void testMergingIterator()
+  {
+    final Indexed[] sortedLookups = new Indexed[]{
+        new ListIndexed(null, "", "null", "z"),
+        new ListIndexed("", "a", "b", "c", "d", "e", "f", "g", "h"),
+        new ListIndexed(null, "b", "c", "null", "z"),
+        new ListIndexed(null, "hello")
+    };
+    SimpleDictionaryMergingIterator<String> dictionaryMergeIterator = new SimpleDictionaryMergingIterator<>(
+        sortedLookups,
+        NestedDataColumnMerger.STRING_MERGING_COMPARATOR
+    );
+
+    List<String> expectedSequence = Lists.newArrayListWithExpectedSize(13);
+    expectedSequence.add(null);
+    expectedSequence.addAll(ImmutableList.of("", "a", "b", "c", "d", "e", "f", "g", "h", "hello", "null", "z"));
+
+    List<String> actualSequence = Lists.newArrayListWithExpectedSize(13);
+    while (dictionaryMergeIterator.hasNext()) {
+      actualSequence.add(dictionaryMergeIterator.next());
+    }
+    Assert.assertEquals(expectedSequence, actualSequence);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/TestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestHelper.java
@@ -449,13 +449,20 @@ public class TestHelper
     }
   }
 
-  public static Map<String, Object> createExpectedMap(Object... vals)
+  public static Map<String, Object> makeMap(Object... vals)
+  {
+    return makeMap(true, vals);
+  }
+
+  public static Map<String, Object> makeMap(boolean explicitNulls, Object... vals)
   {
     Preconditions.checkArgument(vals.length % 2 == 0);
 
     Map<String, Object> theVals = new HashMap<>();
     for (int i = 0; i < vals.length; i += 2) {
-      theVals.put(vals[i].toString(), vals[i + 1]);
+      if (explicitNulls || vals[i + 1] != null) {
+        theVals.put(vals[i].toString(), vals[i + 1]);
+      }
     }
     return theVals;
   }

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldLiteralColumnSelectorsTest.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.nested;
+
+import com.fasterxml.jackson.databind.Module;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.guice.NestedDataModule;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.Yielder;
+import org.apache.druid.java.util.common.guava.Yielders;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.query.aggregation.AggregationTestHelper;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.Cursor;
+import org.apache.druid.segment.DoubleColumnSelector;
+import org.apache.druid.segment.LongColumnSelector;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.StorageAdapter;
+import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.vector.BaseDoubleVectorValueSelector;
+import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
+import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
+import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
+import org.apache.druid.segment.vector.VectorCursor;
+import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
+import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.List;
+
+public class NestedFieldLiteralColumnSelectorsTest
+{
+  private static final String NESTED_LONG_FIELD = "long";
+  private static final String NESTED_DOUBLE_FIELD = "double";
+  private static final String NESTED_MIXED_NUMERIC_FIELD = "mixed_numeric";
+  private static final String NESTED_MIXED_FIELD = "mixed";
+  private static final String NESTED_SPARSE_LONG_FIELD = "sparse_long";
+  private static final String NESTED_SPARSE_DOUBLE_FIELD = "sparse_double";
+  private static final String NESTED_SPARSE_MIXED_NUMERIC_FIELD = "sparse_mixed_numeric";
+  private static final String NESTED_SPARSE_MIXED_FIELD = "sparse_mixed";
+
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private final AggregationTestHelper helper;
+  private final Closer closer;
+
+  public NestedFieldLiteralColumnSelectorsTest()
+  {
+    NestedDataModule.registerHandlersAndSerde();
+    List<? extends Module> mods = NestedDataModule.getJacksonModulesList();
+    this.helper = AggregationTestHelper.createScanQueryAggregationTestHelper(
+        mods,
+        tempFolder
+    );
+    this.closer = Closer.create();
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    closer.close();
+  }
+
+  @Test
+  public void testExpectedTypes() throws Exception
+  {
+    // "Line matches the illegal pattern 'ObjectColumnSelector, LongColumnSelector, FloatColumnSelector
+    // and DoubleColumnSelector must not be used in an instanceof statement, see Javadoc of those interfaces."
+    //CHECKSTYLE.OFF: Regexp
+    ColumnSelectorFactory columnSelectorFactory = getNumericColumnSelectorFactory(
+        makeNestedNumericVirtualColumns()
+    );
+
+    ColumnValueSelector longValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_LONG_FIELD
+    );
+    Assert.assertNotNull(longValueSelector);
+    Assert.assertTrue(longValueSelector instanceof LongColumnSelector);
+
+    ColumnValueSelector doubleValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_DOUBLE_FIELD
+    );
+    Assert.assertNotNull(doubleValueSelector);
+    Assert.assertTrue(doubleValueSelector instanceof DoubleColumnSelector);
+
+    ColumnValueSelector mixedNumericValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_MIXED_NUMERIC_FIELD
+    );
+    Assert.assertNotNull(mixedNumericValueSelector);
+    Assert.assertTrue(mixedNumericValueSelector instanceof ColumnValueSelector);
+
+    ColumnValueSelector mixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_MIXED_FIELD
+    );
+    Assert.assertNotNull(mixedValueSelector);
+    Assert.assertTrue(mixedValueSelector instanceof ColumnValueSelector);
+
+
+    ColumnValueSelector sparseLongValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_SPARSE_LONG_FIELD
+    );
+    Assert.assertNotNull(sparseLongValueSelector);
+    Assert.assertTrue(sparseLongValueSelector instanceof LongColumnSelector);
+
+    ColumnValueSelector sparseDoubleValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_SPARSE_DOUBLE_FIELD
+    );
+    Assert.assertNotNull(sparseDoubleValueSelector);
+    Assert.assertTrue(sparseDoubleValueSelector instanceof DoubleColumnSelector);
+
+    ColumnValueSelector sparseMixedNumericValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_SPARSE_MIXED_NUMERIC_FIELD
+    );
+    Assert.assertNotNull(sparseMixedNumericValueSelector);
+    Assert.assertTrue(sparseMixedNumericValueSelector instanceof ColumnValueSelector);
+
+    ColumnValueSelector sparseMixedValueSelector = columnSelectorFactory.makeColumnValueSelector(
+        NESTED_SPARSE_MIXED_FIELD
+    );
+    Assert.assertNotNull(sparseMixedValueSelector);
+    Assert.assertTrue(sparseMixedValueSelector instanceof ColumnValueSelector);
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  @Test
+  public void testExpectedTypesVectorSelectors() throws Exception
+  {
+    // "Line matches the illegal pattern 'ObjectColumnSelector, LongColumnSelector, FloatColumnSelector
+    // and DoubleColumnSelector must not be used in an instanceof statement, see Javadoc of those interfaces."
+    //CHECKSTYLE.OFF: Regexp
+    VectorColumnSelectorFactory factory = getVectorColumnSelectorFactory(
+        makeNestedNumericVirtualColumns()
+    );
+
+    // can make numeric value selectors for single typed numeric types
+    VectorValueSelector longValueSelector = factory.makeValueSelector(
+        NESTED_LONG_FIELD
+    );
+    Assert.assertNotNull(longValueSelector);
+    Assert.assertTrue(longValueSelector instanceof BaseLongVectorValueSelector);
+
+    VectorValueSelector doubleValueSelector = factory.makeValueSelector(
+        NESTED_DOUBLE_FIELD
+    );
+    Assert.assertNotNull(doubleValueSelector);
+    Assert.assertTrue(doubleValueSelector instanceof BaseDoubleVectorValueSelector);
+
+    Assert.assertThrows(UOE.class, () -> factory.makeValueSelector(NESTED_MIXED_NUMERIC_FIELD));
+    Assert.assertThrows(UOE.class, () -> factory.makeValueSelector(NESTED_MIXED_FIELD));
+
+    // can also make single value dimension selectors for all nested column types
+    SingleValueDimensionVectorSelector longDimensionSelector = factory.makeSingleValueDimensionSelector(
+        DefaultDimensionSpec.of(NESTED_LONG_FIELD)
+    );
+    Assert.assertNotNull(longDimensionSelector);
+
+    SingleValueDimensionVectorSelector doubleDimensionSelector = factory.makeSingleValueDimensionSelector(
+        DefaultDimensionSpec.of(NESTED_DOUBLE_FIELD)
+    );
+    Assert.assertNotNull(doubleDimensionSelector);
+
+    SingleValueDimensionVectorSelector mixedNumericValueSelector = factory.makeSingleValueDimensionSelector(
+        DefaultDimensionSpec.of(NESTED_MIXED_NUMERIC_FIELD)
+    );
+    Assert.assertNotNull(mixedNumericValueSelector);
+
+    SingleValueDimensionVectorSelector mixedValueSelector = factory.makeSingleValueDimensionSelector(
+        DefaultDimensionSpec.of(NESTED_MIXED_FIELD)
+    );
+    Assert.assertNotNull(mixedValueSelector);
+
+    // and object selectors
+    VectorObjectSelector longObjectSelector = factory.makeObjectSelector(
+        NESTED_LONG_FIELD
+    );
+    Assert.assertNotNull(longObjectSelector);
+
+    VectorObjectSelector doubleObjectSelector = factory.makeObjectSelector(
+        NESTED_DOUBLE_FIELD
+    );
+    Assert.assertNotNull(doubleObjectSelector);
+
+    VectorObjectSelector mixedNumericObjectSelector = factory.makeObjectSelector(
+        NESTED_MIXED_NUMERIC_FIELD
+    );
+    Assert.assertNotNull(mixedNumericObjectSelector);
+
+    VectorObjectSelector mixedObjectSelector = factory.makeObjectSelector(
+        NESTED_MIXED_FIELD
+    );
+    Assert.assertNotNull(mixedObjectSelector);
+    //CHECKSTYLE.ON: Regexp
+  }
+
+  private VirtualColumns makeNestedNumericVirtualColumns()
+  {
+    List<NestedPathPart> longParts = NestedPathFinder.parseJqPath(".long");
+    List<NestedPathPart> doubleParts = NestedPathFinder.parseJqPath(".double");
+    List<NestedPathPart> mixedNumericParts = NestedPathFinder.parseJqPath(".mixed_numeric");
+    List<NestedPathPart> mixedParts = NestedPathFinder.parseJqPath(".mixed");
+    List<NestedPathPart> sparseLongParts = NestedPathFinder.parseJqPath(".sparse_long");
+    List<NestedPathPart> sparseDoubleParts = NestedPathFinder.parseJqPath(".sparse_double");
+    List<NestedPathPart> sparseMixedNumericParts = NestedPathFinder.parseJqPath(".sparse_mixed_numeric");
+    List<NestedPathPart> sparseMixedParts = NestedPathFinder.parseJqPath(".sparse_mixed");
+
+    NestedFieldVirtualColumn longVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_LONG_FIELD,
+        ColumnType.LONG,
+        longParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn doubleVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_DOUBLE_FIELD,
+        ColumnType.DOUBLE,
+        doubleParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn mixedNumericVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_MIXED_NUMERIC_FIELD,
+        null,
+        mixedNumericParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn mixedVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_MIXED_FIELD,
+        null,
+        mixedParts,
+        false,
+        null,
+        null
+    );
+
+    NestedFieldVirtualColumn sparseLongVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_SPARSE_LONG_FIELD,
+        ColumnType.LONG,
+        sparseLongParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn sparseDoubleVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_SPARSE_DOUBLE_FIELD,
+        ColumnType.DOUBLE,
+        sparseDoubleParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn sparseMixedNumericVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_SPARSE_MIXED_NUMERIC_FIELD,
+        null,
+        sparseMixedNumericParts,
+        false,
+        null,
+        null
+    );
+    NestedFieldVirtualColumn sparseMixedVirtualColumn = new NestedFieldVirtualColumn(
+        "nest",
+        NESTED_SPARSE_MIXED_FIELD,
+        null,
+        sparseMixedParts,
+        false,
+        null,
+        null
+    );
+
+    return VirtualColumns.create(
+        ImmutableList.of(
+            longVirtualColumn,
+            doubleVirtualColumn,
+            mixedNumericVirtualColumn,
+            mixedVirtualColumn,
+            sparseLongVirtualColumn,
+            sparseDoubleVirtualColumn,
+            sparseMixedNumericVirtualColumn,
+            sparseMixedVirtualColumn
+        )
+    );
+  }
+
+  private ColumnSelectorFactory getNumericColumnSelectorFactory(VirtualColumns virtualColumns) throws Exception
+  {
+    List<Segment> segments = NestedDataTestUtils.createSegments(
+        helper,
+        tempFolder,
+        closer,
+        NestedDataTestUtils.NUMERIC_DATA_FILE,
+        NestedDataTestUtils.NUMERIC_PARSER_FILE,
+        NestedDataTestUtils.SIMPLE_AGG_FILE,
+        Granularities.DAY,
+        true,
+        1000
+    );
+    Assert.assertEquals(1, segments.size());
+    StorageAdapter storageAdapter = segments.get(0).asStorageAdapter();
+    Sequence<Cursor> cursorSequence = storageAdapter.makeCursors(
+        null,
+        Intervals.ETERNITY,
+        virtualColumns,
+        Granularities.DAY,
+        false,
+        null
+    );
+    final Yielder<Cursor> yielder = Yielders.each(cursorSequence);
+    closer.register(yielder);
+    final Cursor cursor = yielder.get();
+    return cursor.getColumnSelectorFactory();
+  }
+
+  private VectorColumnSelectorFactory getVectorColumnSelectorFactory(VirtualColumns virtualColumns) throws Exception
+  {
+    List<Segment> segments = NestedDataTestUtils.createSegments(
+        helper,
+        tempFolder,
+        closer,
+        NestedDataTestUtils.NUMERIC_DATA_FILE,
+        NestedDataTestUtils.NUMERIC_PARSER_FILE,
+        NestedDataTestUtils.SIMPLE_AGG_FILE,
+        Granularities.DAY,
+        true,
+        1000
+    );
+    Assert.assertEquals(1, segments.size());
+    StorageAdapter storageAdapter = segments.get(0).asStorageAdapter();
+    VectorCursor cursor = storageAdapter.makeVectorCursor(
+        null,
+        Intervals.ETERNITY,
+        virtualColumns,
+        false,
+        512,
+        null
+    );
+    return cursor.getColumnSelectorFactory();
+  }
+}

--- a/processing/src/test/resources/types-test-data-parser.json
+++ b/processing/src/test/resources/types-test-data-parser.json
@@ -1,0 +1,16 @@
+{
+  "type": "string",
+  "parseSpec": {
+    "format": "json",
+    "timestampSpec": {
+      "column": "timestamp",
+      "format": "auto"
+    },
+    "dimensionsSpec": {
+      "dimensions": [],
+      "dimensionExclusions": [],
+      "spatialDimensions": [],
+      "useNestedColumnIndexerForSchemaDiscovery": true
+    }
+  }
+}

--- a/processing/src/test/resources/types-test-data.json
+++ b/processing/src/test/resources/types-test-data.json
@@ -1,0 +1,8 @@
+{"timestamp": "2021-01-01", "str":"a", "long":1, "double":1.0, "variant": 1}
+{"timestamp": "2021-01-01", "str":"", "long":2, "variant": "b"}
+{"timestamp": "2021-01-01", "str":"null", "long":3, "double":2.0, "variant": 3.0}
+{"timestamp": "2021-01-01", "str":"b", "long":4, "double":3.3, "variant": "4"}
+{"timestamp": "2021-01-01", "str":"c", "long": null, "double":4.4, "variant": "hello"}
+{"timestamp": "2021-01-01", "str":"d", "long":5, "double":5.9}
+{"timestamp": "2021-01-01", "str":null, "double":null, "variant": 51}
+{"timestamp": "2021-01-01", "long":6, "double":1.0, "variant": null}

--- a/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
+++ b/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
@@ -140,11 +140,11 @@ public class LookupDimensionSpecTest
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, null, null, true, null),
-            TestHelper.createExpectedMap("not there", null)
+            TestHelper.makeMap("not there", null)
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", null, false, null, "lookupName", true, LOOKUP_REF_MANAGER),
-            TestHelper.createExpectedMap("not there", null)
+            TestHelper.makeMap("not there", null)
         },
         new Object[]{
             new LookupDimensionSpec("dimName", "outputName", MAP_LOOKUP_EXTRACTOR, false, "Missing_value", null,


### PR DESCRIPTION
### Description
Fixes an issue with nested columns that can occur when both actual `null` and the string `"null"` are present in any nested path that results in the `null` values incorrectly becoming associated with the `"null"` values.

The bug was caused by a usage of `String.valueOf` in `StringFieldColumnWriter` that was not checking for null values when writing out the column. This still worked by dumb luck because the fastutils 2Int maps that were backing the globalId lookup when writing out segments had a default value of 0, which happens to be `null` global id, so even though `"null"` wasn't present in the global dictionary it ended up with the correct id. However, if `"null"` was present, `null` would incorrectly be written out as the `"null"` global id and associated to that value instead.

As a safety measure, I've changed the 2int maps to have a default value of -1, and check that the globalid is in range before writing it to the column to ensure mistakes like this don't happen in the future, which caught a pretty serious regression introduced by #13653, caused by the simplified dictionary merging iterator that would result in segment dictionaries getting completely mangled if the same value was in more than 1 segment's dictionary. Luckily this didn't make it into any releases.

The added test data in `NestedDataColumnSupplierTest` would fail prior to this PR.

Unrelated, this PR also moves some column selector tests that had nothing to do with scan queries out of `NestedDataScanQueryTest` into their own file.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
