### PR TITLE
Make batch segment allocation logs less noisy

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -263,19 +263,20 @@ public class SegmentAllocationQueue
     clearQueueIfNotLeader();
 
     int numProcessedBatches = 0;
-
     AllocateRequestKey nextKey = processingQueue.peekFirst();
     while (nextKey != null && nextKey.isDue()) {
       processingQueue.pollFirst();
-      AllocateRequestBatch nextBatch = keyToBatch.remove(nextKey);
 
+      // Process the next batch in the queue
       boolean processed;
+      AllocateRequestBatch nextBatch = keyToBatch.remove(nextKey);
       try {
         processed = processBatch(nextBatch);
       }
       catch (Throwable t) {
         nextBatch.failPendingRequests(t);
         processed = true;
+        log.error(t, "Error while processing batch [%s]", nextKey);
       }
 
       // Requeue if not fully processed yet

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -353,10 +353,9 @@ public class SegmentAllocationQueue
 
     emitBatchMetric("task/action/batch/attempts", 1L, requestKey);
     emitBatchMetric("task/action/batch/runTime", (System.currentTimeMillis() - startTimeMillis), requestKey);
-    log.debug("Successfully processed [%d / %d] requests in batch [%s].", successCount, batchSize, requestKey);
+    log.info("Successfully processed [%d / %d] requests in batch [%s].", successCount, batchSize, requestKey);
 
     if (requestBatch.isEmpty()) {
-      log.debug("All requests in batch [%s] have been processed.", requestKey);
       return true;
     }
 
@@ -599,7 +598,7 @@ public class SegmentAllocationQueue
         emitTaskMetric("task/action/success/count", 1L, request);
         requestToFuture.remove(request).complete(result.getSegmentId());
       } else if (request.canRetry()) {
-        log.debug(
+        log.info(
             "Allocation failed in attempt [%d] due to error [%s]. Can still retry. Action: %s",
             request.getAttempts(),
             result.getErrorMessage(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -262,8 +262,6 @@ public class SegmentAllocationQueue
   {
     clearQueueIfNotLeader();
 
-    // Process all batches which are due
-    log.debug("Processing batches which are due. Queue size [%d].", processingQueue.size());
     int numProcessedBatches = 0;
 
     AllocateRequestKey nextKey = processingQueue.peekFirst();
@@ -278,7 +276,6 @@ public class SegmentAllocationQueue
       catch (Throwable t) {
         nextBatch.failPendingRequests(t);
         processed = true;
-        log.error(t, "Error while processing batch [%s]", nextKey);
       }
 
       // Requeue if not fully processed yet

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -301,7 +301,7 @@ public class SegmentAllocationQueue
       nextScheduleDelay = Math.max(0, maxWaitTimeMillis - timeElapsed);
     }
     scheduleQueuePoll(nextScheduleDelay);
-    log.info("Processed [%d] batches, next execution in [%d ms]", numProcessedBatches, nextScheduleDelay);
+    log.debug("Processed [%d] batches, next execution in [%d ms]", numProcessedBatches, nextScheduleDelay);
   }
 
   /**
@@ -355,7 +355,7 @@ public class SegmentAllocationQueue
 
     emitBatchMetric("task/action/batch/attempts", 1L, requestKey);
     emitBatchMetric("task/action/batch/runTime", (System.currentTimeMillis() - startTimeMillis), requestKey);
-    log.info("Successfully processed [%d / %d] requests in batch [%s].", successCount, batchSize, requestKey);
+    log.debug("Successfully processed [%d / %d] requests in batch [%s].", successCount, batchSize, requestKey);
 
     if (requestBatch.isEmpty()) {
       log.debug("All requests in batch [%s] have been processed.", requestKey);
@@ -601,7 +601,7 @@ public class SegmentAllocationQueue
         emitTaskMetric("task/action/success/count", 1L, request);
         requestToFuture.remove(request).complete(result.getSegmentId());
       } else if (request.canRetry()) {
-        log.info(
+        log.debug(
             "Allocation failed in attempt [%d] due to error [%s]. Can still retry. Action: %s",
             request.getAttempts(),
             result.getErrorMessage(),


### PR DESCRIPTION
### Changes

- Change some batch allocation logs from info to debug as these are noisy and make debugging actual issues difficult