### PR TITLE
Add assertions for counters from reports

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -99,6 +99,40 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedSegment(expectedFooSegments())
                      .setExpectedResultRows(expectedFooRows())
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
 
   }
@@ -139,6 +173,34 @@ public class MSQInsertTest extends MSQTestBase
                              .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
                              .buildChannelCounter(),
                          0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(68).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(68).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(81).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(81).frames(1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
                      )
                      .verifyResults();
 
@@ -186,6 +248,40 @@ public class MSQInsertTest extends MSQTestBase
                      .setQueryContext(MSQInsertTest.this.context)
                      .setExpectedSegment(expectedFooSegments())
                      .setExpectedResultRows(expectedFooRows())
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
 
   }
@@ -300,6 +396,40 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedSegment(expectedFooSegments())
                      .setExpectedResultRows(expectedFooRows())
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
 
   }
@@ -323,6 +453,40 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedRowSignature(rowSignature)
                      .setExpectedSegment(expectedFooSegments())
                      .setExpectedResultRows(expectedFooRows())
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(5).bytes(251).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1).bytes(92, 89, 89, 91, 91).frames(1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                          null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
 
   }
@@ -410,6 +574,40 @@ public class MSQInsertTest extends MSQTestBase
                          0
                      )))
                      .setExpectedResultRows(ImmutableList.of(new Object[]{1466985600000L, 20L}))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(68).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(68).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(81).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(81).frames(1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -455,6 +653,40 @@ public class MSQInsertTest extends MSQTestBase
                          new Object[]{1466985600000L, "Wikipedia", 1L},
                          new Object[]{1466985600000L, "Википедия", 1L}
                      ))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(343).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(343).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(421).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(421).frames(1)
+                             .buildChannelCounter(),
+                         2, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
 
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -105,6 +105,28 @@ public class MSQReplaceTest extends MSQTestBase
                              new Object[]{978480000000L, 6.0f}
                          )
                      )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1, 1).bytes(90, 90, 90, 90, 90, 90).frames(1, 1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1, 1, 1, 1).bytes(90, 90, 90, 90, 90, 90).frames(1, 1, 1, 1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -134,6 +156,28 @@ public class MSQReplaceTest extends MSQTestBase
                          0
                      )))
                      .setExpectedResultRows(ImmutableList.of(new Object[]{946771200000L, 2.0f}))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(90).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1).bytes(90).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -195,6 +239,28 @@ public class MSQReplaceTest extends MSQTestBase
                              .buildChannelCounter(),
                          0, 0, "input0"
                      )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(3).bytes(136).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(3).bytes(136).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(1, 1, 1).bytes(81, 81, 81).frames(1, 1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         2, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -246,6 +312,22 @@ public class MSQReplaceTest extends MSQTestBase
                              .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
                              .buildChannelCounter(),
                          0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(4).bytes(312).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(4).bytes(312).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
                      )
                      .verifyResults();
   }
@@ -300,6 +382,28 @@ public class MSQReplaceTest extends MSQTestBase
                          )
                      )
                      .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo", Intervals.ETERNITY, "test", 0)))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(292).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(6).bytes(292).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -341,6 +445,28 @@ public class MSQReplaceTest extends MSQTestBase
                                              SegmentId.of("foo", Intervals.of("2001-01-01T/P1M"), "test", 0)
                                          )
                      )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(3, 3).bytes(202, 202).frames(1, 1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(3, 3).bytes(202, 202).frames(1, 1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -380,6 +506,28 @@ public class MSQReplaceTest extends MSQTestBase
                          "test",
                          0
                      )))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(2).bytes(146).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(2).bytes(146).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 
@@ -419,6 +567,28 @@ public class MSQReplaceTest extends MSQTestBase
                          "test",
                          0
                      )))
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().totalFiles(1)
+                             .buildChannelCounter(),
+                         0, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(2).bytes(146).frames(1)
+                             .buildChannelCounter(),
+                         0, 0, "shuffle"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         CounterSnapshotBuilder
+                             .with().rows(2).bytes(146).frames(1)
+                             .buildChannelCounter(),
+                         1, 0, "input0"
+                     )
+                     .setExpectedCountersForStageWorkerChannel(
+                         null,
+                         1, 0, "output"
+                     )
                      .verifyResults();
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -163,6 +163,24 @@ public class MSQSelectTest extends MSQTestBase
         )
         .setQueryContext(context)
         .setExpectedRowSignature(resultSignature)
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(316).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(292).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .setExpectedResultRows(ImmutableList.of(
             new Object[]{1L, !useDefault ? "" : null},
             new Object[]{1L, "10.1"},
@@ -207,7 +225,26 @@ public class MSQSelectTest extends MSQTestBase
             new Object[]{1L, "en"},
             new Object[]{1L, "ru"},
             new Object[]{1L, "he"}
-        )).verifyResults();
+        ))
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(3).bytes(175).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(3).bytes(163).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
+        .verifyResults();
   }
 
   @Test
@@ -248,6 +285,24 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(rowSignature)
         .setExpectedResultRows(ImmutableList.of(new Object[]{1L, 6L}))
         .setQueryContext(context)
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(1).bytes(72).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(1).bytes(68).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 
@@ -306,6 +361,24 @@ public class MSQSelectTest extends MSQTestBase
                 new Object[]{1f, 1L}
             )
         )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(238).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(214).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 
@@ -345,6 +418,24 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(resultSignature)
         .setExpectedResultRows(ImmutableList.of(new Object[]{6L}))
         .setQueryContext(context)
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(160).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(136).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 
@@ -476,6 +567,24 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(resultSignature)
         .setExpectedResultRows(expectedResults)
         .setQueryContext(context)
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(261).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(261).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 
@@ -594,6 +703,24 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(resultSignature)
         .setExpectedResultRows(expectedResults)
         .setQueryContext(context)
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(261).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(261).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 
@@ -654,7 +781,26 @@ public class MSQSelectTest extends MSQTestBase
                 new Object[]{2f, 2d},
                 new Object[]{1f, 1d}
             )
-        ).verifyResults();
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(238).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(214).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
+        .verifyResults();
   }
 
   @Test
@@ -711,7 +857,26 @@ public class MSQSelectTest extends MSQTestBase
                 new Object[]{5f, 5d},
                 new Object[]{4f, 4d}
             )
-        ).verifyResults();
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(238).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(214).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
+        .verifyResults();
   }
 
   @Test
@@ -768,7 +933,26 @@ public class MSQSelectTest extends MSQTestBase
                 new Object[]{5f, 5d},
                 new Object[]{4f, 4d}
             )
-        ).verifyResults();
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(238).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(6).bytes(214).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
+        .verifyResults();
   }
 
   @Test
@@ -842,6 +1026,18 @@ public class MSQSelectTest extends MSQTestBase
                 .with().rows(20).bytes(toRead.length()).files(1).totalFiles(1)
                 .buildChannelCounter(),
             0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(1).bytes(72).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(1).bytes(68).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
         )
         .verifyResults();
   }
@@ -963,6 +1159,24 @@ public class MSQSelectTest extends MSQTestBase
             new Object[]{1L, "ru"},
             new Object[]{1L, "he"}
         ))
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().totalFiles(1)
+                .buildChannelCounter(),
+            0, 0, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(3).bytes(175).frames(1)
+                .buildChannelCounter(),
+            0, 0, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotBuilder
+                .with().rows(3).bytes(163).frames(1)
+                .buildChannelCounter(),
+            0, 0, "shuffle"
+        )
         .verifyResults();
   }
 


### PR DESCRIPTION
Adds assertions for counters to MSQ unit tests

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
