### PR TITLE
Compaction history returns empty list instead of 404 when not found

### DIFF
--- a/docs/operations/api-reference.md
+++ b/docs/operations/api-reference.md
@@ -474,7 +474,7 @@ Returns an automatic compaction config of a dataSource.
 
 Returns the history of the automatic compaction config for a dataSource. Optionally accepts `interval` and  `count`
 query string parameters to filter by interval and limit the number of results respectively. If the dataSource does not
-exist or there is no compaction history for the dataSource, a 404 response is returned.
+exist or there is no compaction history for the dataSource, an empty list is returned.
 
 The response contains a list of objects with the following keys:
 * `globalConfig`: A json object containing automatic compaction config that applies to the entire cluster. 

--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -223,9 +223,6 @@ public class CoordinatorCompactionConfigsResource
         );
         history.add(coordinatorCompactionConfig, audit.getAuditInfo(), audit.getAuditTime());
       }
-      if (history.getHistory().isEmpty()) {
-        return Response.status(Response.Status.NOT_FOUND).build();
-      }
       return Response.ok(history.getHistory()).build();
     }
     catch (IllegalArgumentException e) {

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -416,6 +416,6 @@ public class CoordinatorCompactionConfigsResourceTest
         null
     );
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertTrue(((Collection)response.getEntity()).isEmpty());
+    Assert.assertTrue(((Collection) response.getEntity()).isEmpty());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResourceTest.java
@@ -45,6 +45,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -407,13 +408,14 @@ public class CoordinatorCompactionConfigsResourceTest
   }
 
   @Test
-  public void testGetCompactionConfigHistoryForUnknownDataSourceShouldReturnNotFound()
+  public void testGetCompactionConfigHistoryForUnknownDataSourceShouldReturnEmptyList()
   {
     Response response = coordinatorCompactionConfigsResource.getCompactionConfigHistory(
         DATASOURCE_NOT_EXISTS,
         null,
         null
     );
-    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Assert.assertTrue(((Collection)response.getEntity()).isEmpty());
   }
 }


### PR DESCRIPTION
Follow up to #13699

Returning an empty list instead of a 404 makes for a easier to use API