### PR TITLE
Fix GHA workflow maven build erroring incase of version updates

### DIFF
--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run IT
         env:
           MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }}
-          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && 'dependency:go-offline' || '-U')) }}
+          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '-o' || '-U')) }}
         run: |
           # Debug echo
           echo "Mysql driver: ${MYSQL_DRIVER_CLASSNAME}"

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -91,5 +91,5 @@ jobs:
       - name: test & coverage
         env:
           MAVEN_PROJECTS: ${{ inputs.maven_projects }}
-          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && 'dependency:go-offline' || '-U')) }}
+          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '-o' || '-U')) }}
         run: ./.github/scripts/unit_tests_script.sh

--- a/it.sh
+++ b/it.sh
@@ -194,7 +194,7 @@ case $CMD in
     usage
     ;;
   "ci" )
-    mvn -q clean package dependency:go-offline -P dist $MAVEN_IGNORE -T1.0C
+    mvn -q clean package dependency:go-offline -P dist $MAVEN_IGNORE
     ;;
   "build" )
     mvn clean package -P dist $MAVEN_IGNORE -T1.0C


### PR DESCRIPTION
- Runs maven build sequentially to package dependencies rather than downloading.
- Runs maven test in offline mode after retrieving cached artifacts.