### PR TITLE
Fix GHA tests workflow

### DIFF
--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run IT
         env:
           MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }}
-          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '-o' || '-U')) }}
+          MVN: ${{ format('{0}{1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '' || ' -U')) }}
         run: |
           # Debug echo
           echo "Mysql driver: ${MYSQL_DRIVER_CLASSNAME}"

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -91,5 +91,5 @@ jobs:
       - name: test & coverage
         env:
           MAVEN_PROJECTS: ${{ inputs.maven_projects }}
-          MVN: ${{ format('{0} {1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '-o' || '-U')) }}
+          MVN: ${{ format('{0}{1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '' || ' -U')) }}
         run: ./.github/scripts/unit_tests_script.sh

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -43,15 +43,6 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Cache Maven m2 repository
-        id: maven
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-${{ matrix.jdk }}
-
       - name: Setup java
         uses: actions/setup-java@v3
         with:
@@ -62,6 +53,15 @@ jobs:
         id: maven_build
         run: |
           ./it.sh ci
+
+      - name: Cache Maven m2 repository
+        id: maven
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-${{ matrix.jdk }}
 
       - name: Cache targets
         id: target


### PR DESCRIPTION
Can't run mvn test in offline mode since not all test mvn dependencies are downloaded during the build phase due to skipTests.