### PR TITLE
NPE fix in MSQ in the post cleanup stage

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -574,7 +574,12 @@ public class WorkerImpl implements Worker
         holder -> {
           cleanStageOutput(stageId, true);
           // Mark the stage as FINISHED
-          holder.getStageKernelMap().get(stageId).setStageFinished();
+          WorkerStageKernel stageKernel = holder.getStageKernelMap().get(stageId);
+          if (stageKernel == null) {
+            log.warn("Stage id [%s] non existent. Unable to mark the stage kernel for it as FINISHED", stageId);
+          } else {
+            stageKernel.setStageFinished();
+          }
         }
     );
   }


### PR DESCRIPTION
### Description

With fault tolerance enabled in MSQ, not all the work orders might be populated if the worker is restarted. In case it gets the request for cleaning up the stage which is not present in the worker's map, it can throw an NPE. Added a check to ensure that the stage is present in the map before cleaning it up, or else logging it as a warning.

<hr>

##### Key changed/added classes in this PR
 * `WorkerImpl`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.