### PR TITLE
helm: Stop helm chart from failing if zkHosts is not set

### DIFF
--- a/helm/druid/Chart.yaml
+++ b/helm/druid/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     version: 8.6.4
     repository: https://charts.helm.sh/stable
     condition: postgresql.enabled
-version: 0.3.2
+version: 0.3.3
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 sources:

--- a/helm/druid/templates/configmap.yaml
+++ b/helm/druid/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
 {{ toYaml .Values.configVars | indent 2 }}
 {{- if .Values.zookeeper.enabled }}
   druid_zk_service_host: {{ .Release.Name }}-zookeeper-headless:2181
-{{- else }}
+{{- else if .Values.zkHosts }}
   druid_zk_service_host: {{ .Values.zkHosts }}
 {{- end }}
 {{- if .Values.mysql.enabled }}

--- a/helm/druid/values.yaml
+++ b/helm/druid/values.yaml
@@ -376,6 +376,7 @@ router:
 # Zookeeper:
 # ------------------------------------------------------------------------------
 
+# If using a zookeeper installed outside of this chart you must uncomment and set this line
 # zkHosts: druid-zookeeper-headless:2181
 
 zookeeper:


### PR DESCRIPTION
Fixes #13745 

### Description
If a user deploying via the Apache Druid helm chart is while using `druid-kubernetes-extensions` then there is no need to set a zookeeper host however the helm chart will fail if the user does not. 

This change will remove the requirement for setting a zookeeper host and adds a comment to the values file to help helm chart consumers understand.

### Alternatives
An alternative design could have been to look for the druid config settings required [in the documentation](https://druid.apache.org/docs/latest/development/extensions-core/kubernetes.html) and base the conditional off of those but since they can be set at a per-process or global config level I thought it better to keep it simple.

#### Release note
Fixed: Helm chart no longer requires a ZooKeeper host be set for users using `druid-kubernetes-extensions`

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
