### PR TITLE
Use durable super sorter intermediate storage only with composable storage

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -691,26 +691,23 @@ public class WorkerImpl implements Worker
     final FileOutputChannelFactory fileOutputChannelFactory =
         new FileOutputChannelFactory(fileChannelDirectory, frameSize, intermediateSuperSorterLocalStorageTracker);
 
-    if (MultiStageQueryContext.isComposedIntermediateSuperSorterStorageEnabled(QueryContext.of(task.getContext()))) {
-      if (durableStageStorageEnabled) {
-        return new ComposingOutputChannelFactory(
-            ImmutableList.of(
-                fileOutputChannelFactory,
-                DurableStorageOutputChannelFactory.createStandardImplementation(
-                    task.getControllerTaskId(),
-                    task().getWorkerNumber(),
-                    stageNumber,
-                    task().getId(),
-                    frameSize,
-                    MSQTasks.makeStorageConnector(context.injector()),
-                    tmpDir
-                )
-            ),
-            frameSize
-        );
-      } else {
-        return fileOutputChannelFactory;
-      }
+    if (MultiStageQueryContext.isComposedIntermediateSuperSorterStorageEnabled(QueryContext.of(task.getContext())) &&
+        durableStageStorageEnabled) {
+      return new ComposingOutputChannelFactory(
+          ImmutableList.of(
+              fileOutputChannelFactory,
+              DurableStorageOutputChannelFactory.createStandardImplementation(
+                  task.getControllerTaskId(),
+                  task().getWorkerNumber(),
+                  stageNumber,
+                  task().getId(),
+                  frameSize,
+                  MSQTasks.makeStorageConnector(context.injector()),
+                  tmpDir
+              )
+          ),
+          frameSize
+      );
     } else {
       return fileOutputChannelFactory;
     }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -711,16 +711,6 @@ public class WorkerImpl implements Worker
       } else {
         return fileOutputChannelFactory;
       }
-    } else if (durableStageStorageEnabled) {
-      return DurableStorageOutputChannelFactory.createStandardImplementation(
-          task.getControllerTaskId(),
-          task().getWorkerNumber(),
-          stageNumber,
-          task().getId(),
-          frameSize,
-          MSQTasks.makeStorageConnector(context.injector()),
-          tmpDir
-      );
     } else {
       return fileOutputChannelFactory;
     }


### PR DESCRIPTION
This enables usage of durable storage connector only incase the composable storage feature is enabled.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
