### PR TITLE
Fix GHA tests cache hit miss scenario

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -62,6 +62,13 @@ jobs:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-${{ github.sha }}
 
+      - name: Restore targets
+        id: targets-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: ./**/target
+          key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-targets-${{ github.sha }}
+
       - name: Retrieve cached docker image
         id: docker-image-restore
         uses: actions/cache/restore@v3
@@ -72,21 +79,16 @@ jobs:
             ./integration-tests-ex/image/target/env.sh
 
       - name: Maven build
-        if: steps.maven-restore.outputs.cache-hit != 'true'
+        if: steps.maven-restore.outputs.cache-hit != 'true' || ( steps.docker-image-restore.outputs.cache-hit != 'true' && steps.targets-restore.outputs.cache-hit != 'true' )
         run: |
           ./it.sh ci
 
-      - name: Container build
+      - name: Create docker image
         if: steps.docker-image-restore.outputs.cache-hit != 'true'
         run: |
           ./it.sh image
           source ./integration-tests-ex/image/target/env.sh
           docker tag $DRUID_IT_IMAGE_NAME $DRUID_IT_IMAGE_NAME-jdk${{ matrix.jdk }}
-
-      - name: Save docker container to archive
-        if: steps.docker-image-restore.outputs.cache-hit != 'true'
-        run: |
-          source ./integration-tests-ex/image/target/env.sh
           echo $DRUID_IT_IMAGE_NAME
           docker save "$DRUID_IT_IMAGE_NAME" | gzip > druid-container-jdk${{ matrix.jdk }}.tar.gz
 

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -88,8 +88,6 @@ jobs:
         env:
           docker-restore: ${{ toJson(steps.docker-restore.outputs) }}
         run: |
-          echo "docker-restore.outputs - ${docker-restore}"
-          echo "docker-restore.outputs.cache-hit - ${{ steps.docker-restore.outputs.cache-hit }}"
           ./it.sh image
           source ./integration-tests-ex/image/target/env.sh
           docker tag $DRUID_IT_IMAGE_NAME $DRUID_IT_IMAGE_NAME-jdk${{ matrix.jdk }}

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -70,7 +70,7 @@ jobs:
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-targets-${{ github.sha }}
 
       - name: Retrieve cached docker image
-        id: docker-image-restore
+        id: docker-restore
         uses: actions/cache/restore@v3
         with:
           key: druid-container-jdk${{ inputs.build_jdk }}.tar.gz
@@ -79,13 +79,14 @@ jobs:
             ./integration-tests-ex/image/target/env.sh
 
       - name: Maven build
-        if: steps.maven-restore.outputs.cache-hit != 'true' || ( steps.docker-image-restore.outputs.cache-hit != 'true' && steps.targets-restore.outputs.cache-hit != 'true' )
+        if: steps.maven-restore.outputs.cache-hit != 'true' || ( steps.docker-restore.outputs.cache-hit != 'true' && steps.targets-restore.outputs.cache-hit != 'true' )
         run: |
           ./it.sh ci
 
       - name: Create docker image
-        if: steps.docker-image-restore.outputs.cache-hit != 'true'
+        if: steps.docker-restore.outputs.cache-hit != 'true'
         run: |
+          echo "docker-restore.outputs - ${{ steps.docker-restore.outputs }}"
           ./it.sh image
           source ./integration-tests-ex/image/target/env.sh
           docker tag $DRUID_IT_IMAGE_NAME $DRUID_IT_IMAGE_NAME-jdk${{ matrix.jdk }}

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -61,16 +61,34 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-${{ github.sha }}
-          fail-on-cache-miss: true
 
       - name: Retrieve cached docker image
+        id: docker-image-restore
         uses: actions/cache/restore@v3
         with:
           key: druid-container-jdk${{ inputs.build_jdk }}.tar.gz
           path: |
             ./druid-container-jdk${{ inputs.build_jdk }}.tar.gz
             ./integration-tests-ex/image/target/env.sh
-          fail-on-cache-miss: true
+
+      - name: Maven build
+        if: steps.maven-restore.outputs.cache-hit != 'true'
+        run: |
+          ./it.sh ci
+
+      - name: Container build
+        if: steps.docker-image-restore.outputs.cache-hit != 'true'
+        run: |
+          ./it.sh image
+          source ./integration-tests-ex/image/target/env.sh
+          docker tag $DRUID_IT_IMAGE_NAME $DRUID_IT_IMAGE_NAME-jdk${{ matrix.jdk }}
+
+      - name: Save docker container to archive
+        if: steps.docker-image-restore.outputs.cache-hit != 'true'
+        run: |
+          source ./integration-tests-ex/image/target/env.sh
+          echo $DRUID_IT_IMAGE_NAME
+          docker save "$DRUID_IT_IMAGE_NAME" | gzip > druid-container-jdk${{ matrix.jdk }}.tar.gz
 
       - name: Load docker image
         run: |

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -85,8 +85,11 @@ jobs:
 
       - name: Create docker image
         if: steps.docker-restore.outputs.cache-hit != 'true'
+        env:
+          docker-restore: ${{ toJson(steps.docker-restore.outputs) }}
         run: |
-          echo "docker-restore.outputs - ${{ steps.docker-restore.outputs }}"
+          echo "docker-restore.outputs - ${docker-restore}"
+          echo "docker-restore.outputs.cache-hit - ${{ steps.docker-restore.outputs.cache-hit }}"
           ./it.sh image
           source ./integration-tests-ex/image/target/env.sh
           docker tag $DRUID_IT_IMAGE_NAME $DRUID_IT_IMAGE_NAME-jdk${{ matrix.jdk }}

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -73,7 +73,7 @@ jobs:
         id: docker-restore
         uses: actions/cache/restore@v3
         with:
-          key: druid-container-jdk${{ inputs.build_jdk }}.tar.gz
+          key: druid-container-jdk${{ inputs.build_jdk }}.tar.gz-${{ github.sha }}
           path: |
             ./druid-container-jdk${{ inputs.build_jdk }}.tar.gz
             ./integration-tests-ex/image/target/env.sh

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -74,12 +74,15 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-${{ github.sha }}
-          fail-on-cache-miss: true
+
+      - name: Maven build
+        if: steps.maven-restore.outputs.cache-hit != 'true'
+        run: |
+          ./it.sh ci
 
       - name: Run IT
         env:
           MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }}
-          MVN: ${{ format('{0}{1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '' || ' -U')) }}
         run: |
           # Debug echo
           echo "Mysql driver: ${MYSQL_DRIVER_CLASSNAME}"

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.jdk }}-${{ github.sha }}
-          fail-on-cache-miss: true
 
       - name: setup node
         uses: actions/setup-node@v3
@@ -89,8 +88,12 @@ jobs:
       - name: setup diff-test-coverage
         run: npm install @connectis/diff-test-coverage@1.5.3
 
+      - name: Maven build
+        if: steps.maven-restore.outputs.cache-hit != 'true'
+        run: |
+          ./it.sh ci
+
       - name: test & coverage
         env:
           MAVEN_PROJECTS: ${{ inputs.maven_projects }}
-          MVN: ${{ format('{0}{1}', env.MVN, (steps.maven-restore.outputs.cache-hit && '' || ' -U')) }}
         run: ./.github/scripts/unit_tests_script.sh

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -126,5 +126,5 @@ jobs:
     uses: ./.github/workflows/standard-its.yml
 
   revised-its:
-    needs: build
+    needs: unit-tests
     uses: ./.github/workflows/revised-its.yml

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -126,5 +126,5 @@ jobs:
     uses: ./.github/workflows/standard-its.yml
 
   revised-its:
-    needs: unit-tests
+    needs: build
     uses: ./.github/workflows/revised-its.yml


### PR DESCRIPTION
Unit & IT tests in GHA workflows currently cache maven dependencies and docker images during build phase and if the cache retrieval fails in unit or IT test jobs, they'll fail. This PR instead does maven build again in the same job and creates docker image.