### PR TITLE
Improve the wording around the `InvalidNullByteException`

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
@@ -230,9 +230,9 @@ public class FrameWriterUtils
 
       if (!allowNullBytes && b == 0) {
         throw new InvalidNullByteException(
-            "Added frame contains null bytes. This usually happens when the added data contains the hidden "
-            + "null bytes (0x0000). Consider sanitizing the string columns by deleting the null bytes using SQL replace"
-            + "function like REPLACE(column, U&'\\0000', '')."
+            "Unable to add the frame because it contains null bytes. This usually happens when the added string columns "
+            + "contain the hidden null bytes (0x0000). Consider sanitizing the string columns by removing the null "
+            + "bytes from the original data source or using SQL replace function like REPLACE(column, U&'\\0000', '')."
         );
       }
 

--- a/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
@@ -229,7 +229,11 @@ public class FrameWriterUtils
       final byte b = src.get(p);
 
       if (!allowNullBytes && b == 0) {
-        throw new InvalidNullByteException();
+        throw new InvalidNullByteException(
+            "Added frame contains null bytes. This usually happens when the added data contains the hidden "
+            + "null bytes (0x0000). Consider sanitizing the string columns by deleting the null bytes using SQL replace"
+            + "function like REPLACE(column, U&'\\0000', '')."
+        );
       }
 
       dst.putByte(q, b);

--- a/processing/src/main/java/org/apache/druid/frame/write/InvalidNullByteException.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/InvalidNullByteException.java
@@ -25,4 +25,8 @@ package org.apache.druid.frame.write;
  */
 public class InvalidNullByteException extends RuntimeException
 {
+  public InvalidNullByteException(String message)
+  {
+    super(message);
+  }
 }


### PR DESCRIPTION
### Description

This PR improves the wording around the mysterious `InvalidNullByteException`. The exception occurs when the strings that are added to the frame contain the 0x0000 byte which is internally being used as a delimiter in the case of a string column. The current use case for the frames is MSQ exclusively, and this error will only be generated if the ingested external data contains hidden null bytes, which in most cases can safely be sanitized.


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
