### PR TITLE
Add ability to add config files when using druid on Kubernetes

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -40,9 +40,9 @@
 # - DRUID_CONFIG_COMMON -- full path to a file for druid 'common' properties
 # - DRUID_CONFIG_${service} -- full path to a file for druid 'service' properties
 # - DRUID_SINGLE_NODE_CONF -- config to use at runtime. Choose from: {large, medium, micro-quickstart, nano-quickstart, small, xlarge}
-# - DRUID_ADDITIONAL_CLASSPATH -- a list of paths of folders containing additional configuration files.
-#                                 It is important to ensure that the folders in the mentioned paths exist within the container.
-#                                 Useful for Kubernetes. Seperate folders with a ':' character and end the variable with ':' as well
+# - DRUID_ADDITIONAL_CLASSPATH -- a list of colon-separated paths that will be added to the classpath of druid processes. 
+#                                 These paths can include jars, additional configuration folders (such as HDFS config), etc.
+#                                 It is important to ensure that these paths must exist in the environment druid runs in if they are not part of the distribution.
 
 
 set -e
@@ -199,6 +199,5 @@ if [ -n "${DRUID_DIRS_TO_CREATE}" ]
 then
     mkdir -p ${DRUID_DIRS_TO_CREATE}
 fi
-
 
 exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*:$DRUID_ADDITIONAL_CLASSPATH org.apache.druid.cli.Main server $@

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -40,8 +40,9 @@
 # - DRUID_CONFIG_COMMON -- full path to a file for druid 'common' properties
 # - DRUID_CONFIG_${service} -- full path to a file for druid 'service' properties
 # - DRUID_SINGLE_NODE_CONF -- config to use at runtime. Choose from: {large, medium, micro-quickstart, nano-quickstart, small, xlarge}
-# - DRUID_ADDITIONAL_CONF_DIRS -- full path to a directory containing configuration files needed for extentions and will be copied to the common directory.
-#                                 Useful for Kubernetes. Seperate folders with ':' and end the variable with one
+# - DRUID_ADDITIONAL_CLASSPATH -- a list of paths of folders containing additional configuration files.
+#                                 It is important to ensure that the folders in the mentioned paths exist within the container.
+#                                 Useful for Kubernetes. Seperate folders with a ':' character and end the variable with ':' as well
 
 
 set -e
@@ -200,4 +201,4 @@ then
 fi
 
 
-exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*:$DRUID_ADDITIONAL_CONF_DIR org.apache.druid.cli.Main server $@
+exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*:$DRUID_ADDITIONAL_CLASSPATH org.apache.druid.cli.Main server $@

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -40,6 +40,8 @@
 # - DRUID_CONFIG_COMMON -- full path to a file for druid 'common' properties
 # - DRUID_CONFIG_${service} -- full path to a file for druid 'service' properties
 # - DRUID_SINGLE_NODE_CONF -- config to use at runtime. Choose from: {large, medium, micro-quickstart, nano-quickstart, small, xlarge}
+# - DRUID_ADDITIONAL_CONF_DIR -- full path to a directory containing configuration files needed for extentions and will be copied to the common directory. Useful for Kubernetes
+
 
 set -e
 SERVICE="$1"
@@ -195,5 +197,15 @@ if [ -n "${DRUID_DIRS_TO_CREATE}" ]
 then
     mkdir -p ${DRUID_DIRS_TO_CREATE}
 fi
+
+# Check if the other configuration directorie variable is set and if it is, copy the files from there
+if [ -z "$DRUID_ADDITIONAL_CONF_DIR" ]
+then
+    if [  -d "$DRUID_ADDITIONAL_CONF_DIR" ]
+    then
+        cp $DRUID_ADDITIONAL_CONF_DIR/* $COMMON_CONF_DIR
+    fi
+fi
+
 
 exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main server $@

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -40,7 +40,8 @@
 # - DRUID_CONFIG_COMMON -- full path to a file for druid 'common' properties
 # - DRUID_CONFIG_${service} -- full path to a file for druid 'service' properties
 # - DRUID_SINGLE_NODE_CONF -- config to use at runtime. Choose from: {large, medium, micro-quickstart, nano-quickstart, small, xlarge}
-# - DRUID_ADDITIONAL_CONF_DIR -- full path to a directory containing configuration files needed for extentions and will be copied to the common directory. Useful for Kubernetes
+# - DRUID_ADDITIONAL_CONF_DIRS -- full path to a directory containing configuration files needed for extentions and will be copied to the common directory.
+#                                 Useful for Kubernetes. Seperate folders with ':' and end the variable with one
 
 
 set -e
@@ -198,14 +199,5 @@ then
     mkdir -p ${DRUID_DIRS_TO_CREATE}
 fi
 
-# Check if the other configuration directorie variable is set and if it is, copy the files from there
-if [ -n "$DRUID_ADDITIONAL_CONF_DIR" ]
-then
-    if [  -d "$DRUID_ADDITIONAL_CONF_DIR" ]
-    then
-        cp $DRUID_ADDITIONAL_CONF_DIR/* $COMMON_CONF_DIR
-    fi
-fi
 
-
-exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main server $@
+exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*:$DRUID_ADDITIONAL_CONF_DIR org.apache.druid.cli.Main server $@

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -199,7 +199,7 @@ then
 fi
 
 # Check if the other configuration directorie variable is set and if it is, copy the files from there
-if [ -z "$DRUID_ADDITIONAL_CONF_DIR" ]
+if [ -n "$DRUID_ADDITIONAL_CONF_DIR" ]
 then
     if [  -d "$DRUID_ADDITIONAL_CONF_DIR" ]
     then


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->




### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Added a line in the docker entrypoint that copies an additional directory into the common conf directory

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

Before this change, adding files to the common conf dir when deploying on Kubernetes was impossible due to the entrypoint script copying from a single source and that the source folder has a configMap Mounted to it in a read-only mode.

My Solution is to add an environment variable that will point to a directory where a configmap containing all the wanted files will be mounted to.

The need that led was configuring the hdfs extension and needing to provide multiple XML files to that directory.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed in this PR
 * `New: You can now add additional configuration files to be copied to the final conf directory on startup when running in a containerized environment. Useful for running on Kubernetes and needing to add more files with a config map. To specify the path where the configMap is mounted, utilize the DRUID_ADDITIONAL_CONF_DIR environment variable.`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
