### PR TITLE
fix bug with sql planner when virtual column capabilities are null

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/groupby/NestedDataGroupByQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/NestedDataGroupByQueryTest.java
@@ -579,6 +579,7 @@ public class NestedDataGroupByQueryTest extends InitializedNullHandlingTest
             "java.lang.UnsupportedOperationException: GroupBy v1 does not support dimension selectors with unknown cardinality.",
             t.getMessage()
         );
+        return;
       } else if (vectorize == QueryContexts.Vectorize.FORCE) {
         Throwable t = Assert.assertThrows(
             RuntimeException.class,
@@ -591,20 +592,19 @@ public class NestedDataGroupByQueryTest extends InitializedNullHandlingTest
         );
         return;
       }
-    } else {
-
-      Sequence<ResultRow> seq = helper.runQueryOnSegmentsObjs(
-          segmentsGenerator.apply(helper, tempFolder, closer),
-          groupQuery
-      );
-
-      List<ResultRow> results = seq.toList();
-      verifyResults(
-          groupQuery.getResultRowSignature(),
-          results,
-          expectedResults
-      );
     }
+
+    Sequence<ResultRow> seq = helper.runQueryOnSegmentsObjs(
+        segmentsGenerator.apply(helper, tempFolder, closer),
+        groupQuery
+    );
+
+    List<ResultRow> results = seq.toList();
+    verifyResults(
+        groupQuery.getResultRowSignature(),
+        results,
+        expectedResults
+    );
   }
 
   private static void verifyResults(RowSignature rowSignature, List<ResultRow> results, List<Object[]> expected)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -781,6 +781,41 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testGroupByRootSingleTypeStringMixed2SparseJsonValueNonExistentPath()
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(string_sparse, '$[1]'), "
+        + "SUM(cnt) "
+        + "FROM druid.nested_mix_2 GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE_MIXED_2)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0")
+                            )
+                        )
+                        .setVirtualColumns(
+                            new NestedFieldVirtualColumn("string_sparse", "$[1]", "v0", ColumnType.STRING)
+                        )
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{NullHandling.defaultStringValue(), 14L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
   public void testGroupByJsonValues()
   {
     testQuery(


### PR DESCRIPTION
### Description
`VirtualColumnRegistry` was missing a null check for the `ColumnCapabilities` returned by a `VirtualColumn`, resulting in a null pointer exception. The added test triggers the condition without the change to `VirtualColumnRegistry`.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
