### PR TITLE
Fix MySQL drivers setup for Revised ITs

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -37,8 +37,14 @@ on:
         description: 'IT test Category'
         required: true
         type: string
+      mysql_driver:
+        description: 'MySQL driver to use'
+        required: false
+        type: string
+        default: com.mysql.jdbc.Driver
 
 env:
+  MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }} # Used by tests to connect to metadata store directly.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 jobs:

--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -34,4 +34,4 @@ jobs:
       use_indexer: ${{ matrix.indexer }}
       script: ./it.sh github ${{ matrix.it }}
       it: ${{ matrix.it }}
-      mysql_driver: org.mariadb.jdbc.Driver
+      mysql_driver: com.mysql.jdbc.Driver

--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -34,3 +34,4 @@ jobs:
       use_indexer: ${{ matrix.indexer }}
       script: ./it.sh github ${{ matrix.it }}
       it: ${{ matrix.it }}
+      mysql_driver: org.mariadb.jdbc.Driver

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -29,6 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  MYSQL_DRIVER_CLASSNAME: org.mariadb.jdbc.Driver # Used to set druid config in docker image for revised ITs
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 jobs:

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MYSQL_DRIVER_CLASSNAME: org.mariadb.jdbc.Driver # Used to set druid config in docker image for revised ITs
+  MYSQL_DRIVER_CLASSNAME: com.mysql.jdbc.Driver # Used to set druid config in docker image for revised ITs
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 jobs:

--- a/integration-tests-ex/cases/pom.xml
+++ b/integration-tests-ex/cases/pom.xml
@@ -202,10 +202,17 @@
             <version>${com.google.apis.client.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Tests can choose either the MySQL or MariaDB driver. -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>${mysql.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/Initializer.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/Initializer.java
@@ -275,6 +275,7 @@ public class Initializer
       property("druid.client.https.certAlias", "druid");
       property("druid.client.https.keyManagerPassword", "druid123");
       property("druid.client.https.keyStorePassword", "druid123");
+      propertyEnvVarBinding("druid.metadata.mysql.driver.driverClassName", "MYSQL_DRIVER_CLASSNAME");
 
       // More env var bindings for properties formerly passed in via
       // a generated config file.

--- a/integration-tests-ex/image/docker/launch.sh
+++ b/integration-tests-ex/image/docker/launch.sh
@@ -41,6 +41,9 @@ cd /
 
 # Test-specific way to define extensions. Compose defines two test-specific
 # variables. We combine these to create the final form converted to a property.
+if [ -n "$MYSQL_DRIVER_CLASSNAME" ]; then
+  export druid_metadata_mysql_driver_driverClassName="$MYSQL_DRIVER_CLASSNAME"
+fi
 if [ -n "$druid_extensions_loadList" ]; then
 	echo "Using the provided druid_extensions_loadList=$druid_extensions_loadList"
 else

--- a/integration-tests-ex/image/pom.xml
+++ b/integration-tests-ex/image/pom.xml
@@ -202,7 +202,6 @@ Reference: https://dzone.com/articles/build-docker-image-from-maven
                                     <environmentVariables>
                                         <MYSQL_VERSION>${mysql.version}</MYSQL_VERSION>
                                         <MARIADB_VERSION>${mariadb.version}</MARIADB_VERSION>
-                                        <MYSQL_DRIVER_CLASSNAME>com.mysql.jdbc.Driver</MYSQL_DRIVER_CLASSNAME>
                                         <MYSQL_IMAGE_VERSION>${mysql.image.version}</MYSQL_IMAGE_VERSION>
                                         <CONFLUENT_VERSION>${confluent-version}</CONFLUENT_VERSION>
                                         <KAFKA_VERSION>${apache.kafka.version}</KAFKA_VERSION>


### PR DESCRIPTION
Existing revised ITs download both MariaDB and MySQL drivers during the docker image build phase and pack them with the docker image. But only the MySQL connector is added as a maven dependency during the test phase. This PR adds MariaDB connector as a dependency too and sets env var `MYSQL_DRIVER_CLASSNAME` (using `org.mariadb.jdbc.Driver` until decided to test with both drivers) as dynamic `druid.metadata.mysql.driver.driverClassName` config to be used by druid server and by tests while connecting to metadata store directly.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
