### PR TITLE
GHA Pipeline: Use built-in java rather than spending time to install

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -56,10 +56,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ inputs.build_jdk }}
+        run: export JAVA_HOME=$JAVA_HOME_${{ inputs.build_jdk }}_X64
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -63,10 +63,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ inputs.runtime_jdk }}
+        run: export JAVA_HOME=$JAVA_HOME_${{ inputs.runtime_jdk }}_X64
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -54,10 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup jdk${{ inputs.jdk }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ inputs.jdk }}
+        run: export JAVA_HOME=$JAVA_HOME_${{ inputs.jdk }}_X64
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -117,10 +117,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 8
+        run: export JAVA_HOME=$JAVA_HOME_8_X64
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -51,11 +51,7 @@ jobs:
           echo "java_version=${jdk:3}" >> $GITHUB_ENV
 
       - name: setup ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ env.java_version }}
-          cache: 'maven'
+        run: export JAVA_HOME=$JAVA_HOME_${{ env.java_version }}_X64
 
       - name: packaging check
         run: |

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -55,10 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: ${{ matrix.jdk }}
+        run: export JAVA_HOME=$JAVA_HOME_${{ matrix.jdk }}_X64
 
       - name: Cache Maven m2 repository
         id: maven


### PR DESCRIPTION
### Description

Github Actions Ubuntu 22.04 runners have Java (Eclipse Temurin) 8, 11 and 17 built in, so we do not need to spend time downloading and installing.  Simply set the `JAVA_HOME` env variable to the appropriate java version.
See here for details: [Java versions](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java)

This PR has:

- [x] been self-reviewed.