### PR TITLE
add sampling factor for DeterminePartitionsJob

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
@@ -199,7 +199,8 @@ public class MaterializedViewSupervisorSpec implements SupervisorSpec
         tuningConfig.isLogParseExceptions(),
         tuningConfig.getMaxParseExceptions(),
         tuningConfig.isUseYarnRMJobStatusFallback(),
-        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis()
+        tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
+        HadoopTuningConfig.DEFAULT_SAMPLING_FACTOR
     );
 
     // generate granularity

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
@@ -200,7 +200,7 @@ public class MaterializedViewSupervisorSpec implements SupervisorSpec
         tuningConfig.getMaxParseExceptions(),
         tuningConfig.isUseYarnRMJobStatusFallback(),
         tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(),
-        HadoopTuningConfig.DEFAULT_SAMPLING_FACTOR
+        HadoopTuningConfig.DEFAULT_DETERMINE_PARTITIONS_SAMPLING_FACTOR
     );
 
     // generate granularity

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -872,7 +872,7 @@ public class DeterminePartitionsJob implements Jobby
         // Make sure none of these shards are oversized
         boolean oversized = false;
         for (final DimPartition partition : dimPartitions.partitions) {
-          if (partition.rows > sampler.getSampledMaxSegmentSize()) {
+          if (partition.rows > sampler.getSampledMaxRowsPerSegment()) {
             log.info("Dimension[%s] has an oversized shard: %s", dimPartitions.dims, partition.shardSpec);
             oversized = true;
           }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -332,10 +332,22 @@ public class DeterminePartitionsJob implements Jobby
     return failureCause;
   }
 
+  private static DeterminePartitionsJobSampler createSampler(HadoopDruidIndexerConfig config)
+  {
+    HadoopTuningConfig tuningConfig = config.getSchema().getTuningConfig();
+    final DimensionRangePartitionsSpec partitionsSpec = (DimensionRangePartitionsSpec) config.getPartitionsSpec();
+    return new DeterminePartitionsJobSampler(
+        tuningConfig.getSamplingFactor(),
+        config.getTargetPartitionSize(),
+        partitionsSpec.getMaxRowsPerSegment()
+    );
+  }
+
   public static class DeterminePartitionsGroupByMapper extends HadoopDruidIndexerMapper<BytesWritable, NullWritable>
   {
     @Nullable
     private Granularity rollupGranularity = null;
+    private DeterminePartitionsJobSampler sampler;
 
     @Override
     protected void setup(Context context)
@@ -343,6 +355,7 @@ public class DeterminePartitionsJob implements Jobby
     {
       super.setup(context);
       rollupGranularity = getConfig().getGranularitySpec().getQueryGranularity();
+      sampler = createSampler(getConfig());
     }
 
     @Override
@@ -355,10 +368,14 @@ public class DeterminePartitionsJob implements Jobby
           rollupGranularity.bucketStart(inputRow.getTimestamp()).getMillis(),
           inputRow
       );
-      context.write(
-          new BytesWritable(HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsBytes(groupKey)),
-          NullWritable.get()
-      );
+
+      final byte[] groupKeyBytes = HadoopDruidIndexerConfig.JSON_MAPPER.writeValueAsBytes(groupKey);
+      if (sampler.shouldEmitRow(groupKeyBytes)) {
+        context.write(
+            new BytesWritable(groupKeyBytes),
+            NullWritable.get()
+        );
+      }
 
       context.getCounter(HadoopDruidIndexerConfig.IndexJobCounters.ROWS_PROCESSED_COUNTER).increment(1);
     }
@@ -413,6 +430,7 @@ public class DeterminePartitionsJob implements Jobby
       extends HadoopDruidIndexerMapper<BytesWritable, Text>
   {
     private DeterminePartitionsDimSelectionMapperHelper helper;
+    private DeterminePartitionsJobSampler sampler;
 
     @Override
     protected void setup(Context context)
@@ -421,6 +439,7 @@ public class DeterminePartitionsJob implements Jobby
       super.setup(context);
       final HadoopDruidIndexerConfig config = HadoopDruidIndexerConfig.fromConfiguration(context.getConfiguration());
       helper = new DeterminePartitionsDimSelectionMapperHelper(config);
+      sampler = createSampler(getConfig());
     }
 
     @Override
@@ -429,11 +448,13 @@ public class DeterminePartitionsJob implements Jobby
         Context context
     ) throws IOException, InterruptedException
     {
-      final Map<String, Iterable<String>> dims = new HashMap<>();
-      for (final String dim : inputRow.getDimensions()) {
-        dims.put(dim, inputRow.getDimension(dim));
+      if (sampler.shouldEmitRow()) {
+        final Map<String, Iterable<String>> dims = new HashMap<>();
+        for (final String dim : inputRow.getDimensions()) {
+          dims.put(dim, inputRow.getDimension(dim));
+        }
+        helper.emitDimValueCounts(context, DateTimes.utc(inputRow.getTimestampFromEpoch()), dims);
       }
-      helper.emitDimValueCounts(context, DateTimes.utc(inputRow.getTimestampFromEpoch()), dims);
     }
   }
 
@@ -705,6 +726,7 @@ public class DeterminePartitionsJob implements Jobby
       // We'll store possible partitions in here
       final Map<List<String>, DimPartitions> dimPartitionss = new HashMap<>();
       final DimensionRangePartitionsSpec partitionsSpec = (DimensionRangePartitionsSpec) config.getPartitionsSpec();
+      final DeterminePartitionsJobSampler sampler = createSampler(config);
 
       while (iterator.hasNext()) {
         final DimValueCount dvc = iterator.next();
@@ -728,7 +750,7 @@ public class DeterminePartitionsJob implements Jobby
         }
 
         // See if we need to cut a new partition ending immediately before this dimension value
-        if (currentDimPartition.rows > 0 && currentDimPartition.rows + dvc.numRows > config.getTargetPartitionSize()) {
+        if (currentDimPartition.rows > 0 && currentDimPartition.rows + dvc.numRows > sampler.getSampledTargetPartitionSize()) {
           final ShardSpec shardSpec = createShardSpec(
               partitionsSpec instanceof SingleDimensionPartitionsSpec,
               currentDimPartitions.dims,
@@ -764,7 +786,7 @@ public class DeterminePartitionsJob implements Jobby
             // One more shard to go
             final ShardSpec shardSpec;
 
-            if (currentDimPartition.rows < config.getTargetPartitionSize() * SHARD_COMBINE_THRESHOLD &&
+            if (currentDimPartition.rows < sampler.getSampledTargetPartitionSize() * SHARD_COMBINE_THRESHOLD &&
                 !currentDimPartitions.partitions.isEmpty()) {
               // Combine with previous shard if it exists and the current shard is small enough
               final DimPartition previousDimPartition = currentDimPartitions.partitions.remove(
@@ -850,7 +872,7 @@ public class DeterminePartitionsJob implements Jobby
         // Make sure none of these shards are oversized
         boolean oversized = false;
         for (final DimPartition partition : dimPartitions.partitions) {
-          if (partition.rows > partitionsSpec.getMaxRowsPerSegment()) {
+          if (partition.rows > sampler.getSampledMaxSegmentSize()) {
             log.info("Dimension[%s] has an oversized shard: %s", dimPartitions.dims, partition.shardSpec);
             oversized = true;
           }
@@ -861,7 +883,7 @@ public class DeterminePartitionsJob implements Jobby
         }
 
         final int cardinality = dimPartitions.getCardinality();
-        final long distance = dimPartitions.getDistanceSquaredFromTarget(config.getTargetPartitionSize());
+        final long distance = dimPartitions.getDistanceSquaredFromTarget(sampler.getSampledTargetPartitionSize());
 
         if (cardinality > maxCardinality) {
           maxCardinality = cardinality;

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -337,7 +337,7 @@ public class DeterminePartitionsJob implements Jobby
     HadoopTuningConfig tuningConfig = config.getSchema().getTuningConfig();
     final DimensionRangePartitionsSpec partitionsSpec = (DimensionRangePartitionsSpec) config.getPartitionsSpec();
     return new DeterminePartitionsJobSampler(
-        tuningConfig.getSamplingFactor(),
+        tuningConfig.getDeterminePartitionsSamplingFactor(),
         config.getTargetPartitionSize(),
         partitionsSpec.getMaxRowsPerSegment()
     );

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer;
+
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class DeterminePartitionsJobSampler
+{
+  private static final HashFunction HASH_FUNCTION = Hashing.murmur3_32();
+
+  private final int samplingFactor;
+
+  private final int sampledTargetPartitionSize;
+
+  private final int sampledMaxSegmentSize;
+
+  public DeterminePartitionsJobSampler(int samplingFactor, int targetPartitionSize, int maxRowsPerSegment)
+  {
+    this.samplingFactor = Math.max(samplingFactor, 1);
+    this.sampledTargetPartitionSize = targetPartitionSize / this.samplingFactor;
+    this.sampledMaxSegmentSize = maxRowsPerSegment / this.samplingFactor;
+  }
+
+  /**
+   * If input rows is duplicate, we can use hash and mod to do sample. As we hash on whole group key,
+   * there will not likely data skew if the hash function is balanced enough.
+   */
+  boolean shouldEmitRow(byte[] groupKeyBytes)
+  {
+    return samplingFactor == 1 || Math.abs(HASH_FUNCTION.hashBytes(groupKeyBytes).asInt()) % samplingFactor == 0;
+  }
+
+  /**
+   * If input rows is not duplicate, we can sample at random.
+   */
+  boolean shouldEmitRow()
+  {
+    return samplingFactor == 1 || ThreadLocalRandom.current().nextInt(samplingFactor) == 0;
+  }
+
+  public int getSampledTargetPartitionSize()
+  {
+    return sampledTargetPartitionSize;
+  }
+
+  public int getSampledMaxSegmentSize()
+  {
+    return sampledMaxSegmentSize;
+  }
+}

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
@@ -47,7 +47,7 @@ public class DeterminePartitionsJobSampler
    */
   boolean shouldEmitRow(byte[] groupKeyBytes)
   {
-    return samplingFactor == 1 || Math.abs(HASH_FUNCTION.hashBytes(groupKeyBytes).asInt()) % samplingFactor == 0;
+    return samplingFactor == 1 || HASH_FUNCTION.hashBytes(groupKeyBytes).asInt() % samplingFactor == 0;
   }
 
   /**

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJobSampler.java
@@ -32,13 +32,13 @@ public class DeterminePartitionsJobSampler
 
   private final int sampledTargetPartitionSize;
 
-  private final int sampledMaxSegmentSize;
+  private final int sampledMaxRowsPerSegment;
 
   public DeterminePartitionsJobSampler(int samplingFactor, int targetPartitionSize, int maxRowsPerSegment)
   {
     this.samplingFactor = Math.max(samplingFactor, 1);
     this.sampledTargetPartitionSize = targetPartitionSize / this.samplingFactor;
-    this.sampledMaxSegmentSize = maxRowsPerSegment / this.samplingFactor;
+    this.sampledMaxRowsPerSegment = maxRowsPerSegment / this.samplingFactor;
   }
 
   /**
@@ -63,8 +63,8 @@ public class DeterminePartitionsJobSampler
     return sampledTargetPartitionSize;
   }
 
-  public int getSampledMaxSegmentSize()
+  public int getSampledMaxRowsPerSegment()
   {
-    return sampledMaxSegmentSize;
+    return sampledMaxRowsPerSegment;
   }
 }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -41,7 +41,7 @@ import java.util.Map;
 @JsonTypeName("hadoop")
 public class HadoopTuningConfig implements TuningConfig
 {
-  public static final int DEFAULT_SAMPLING_FACTOR = 1;
+  public static final int DEFAULT_DETERMINE_PARTITIONS_SAMPLING_FACTOR = 1;
 
   private static final DimensionBasedPartitionsSpec DEFAULT_PARTITIONS_SPEC = HashedPartitionsSpec.defaultSpec();
   private static final Map<Long, List<HadoopyShardSpec>> DEFAULT_SHARD_SPECS = ImmutableMap.of();
@@ -77,7 +77,7 @@ public class HadoopTuningConfig implements TuningConfig
         null,
         null,
         null,
-        DEFAULT_SAMPLING_FACTOR
+        DEFAULT_DETERMINE_PARTITIONS_SAMPLING_FACTOR
     );
   }
   @Nullable

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -113,7 +113,7 @@ public class HadoopTuningConfig implements TuningConfig
   // For example, if we ingest 10,000,000,000 rows and the targetRowsPerSegment is 5,000,000,
   // we can sample by 500, so the mr job need only process 20,000,000 rows, this helps save
   // a lot of time.
-  private final int samplingFactor;
+  private final int determinePartitionsSamplingFactor;
 
   @JsonCreator
   public HadoopTuningConfig(
@@ -143,7 +143,7 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
       final @JsonProperty("useYarnRMJobStatusFallback") @Nullable Boolean useYarnRMJobStatusFallback,
       final @JsonProperty("awaitSegmentAvailabilityTimeoutMillis") @Nullable Long awaitSegmentAvailabilityTimeoutMillis,
-      final @JsonProperty("samplingFactor") int samplingFactor
+      final @JsonProperty("determinePartitionsSamplingFactor") @Nullable Integer determinePartitionsSamplingFactor
   )
   {
     this.workingPath = workingPath;
@@ -195,7 +195,11 @@ public class HadoopTuningConfig implements TuningConfig
     } else {
       this.awaitSegmentAvailabilityTimeoutMillis = awaitSegmentAvailabilityTimeoutMillis;
     }
-    this.samplingFactor = Math.max(samplingFactor, 1);
+    if (determinePartitionsSamplingFactor == null || determinePartitionsSamplingFactor < 1) {
+      this.determinePartitionsSamplingFactor = 1;
+    } else {
+      this.determinePartitionsSamplingFactor = determinePartitionsSamplingFactor;
+    }
   }
 
   @Nullable
@@ -351,9 +355,9 @@ public class HadoopTuningConfig implements TuningConfig
   }
 
   @JsonProperty
-  public int getSamplingFactor()
+  public int getDeterminePartitionsSamplingFactor()
   {
-    return samplingFactor;
+    return determinePartitionsSamplingFactor;
   }
 
   public HadoopTuningConfig withWorkingPath(String path)
@@ -384,7 +388,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-        samplingFactor
+            determinePartitionsSamplingFactor
     );
   }
 
@@ -416,7 +420,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-        samplingFactor
+            determinePartitionsSamplingFactor
     );
   }
 
@@ -448,7 +452,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-        samplingFactor
+            determinePartitionsSamplingFactor
     );
   }
 }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -388,7 +388,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-            determinePartitionsSamplingFactor
+        determinePartitionsSamplingFactor
     );
   }
 
@@ -420,7 +420,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-            determinePartitionsSamplingFactor
+        determinePartitionsSamplingFactor
     );
   }
 
@@ -452,7 +452,7 @@ public class HadoopTuningConfig implements TuningConfig
         maxParseExceptions,
         useYarnRMJobStatusFallback,
         awaitSegmentAvailabilityTimeoutMillis,
-            determinePartitionsSamplingFactor
+        determinePartitionsSamplingFactor
     );
   }
 }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
@@ -489,7 +489,8 @@ public class BatchDeltaIngestionTest
                 null,
                 null,
                 null,
-                null
+                null,
+                1
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -233,7 +233,8 @@ public class DetermineHashedPartitionsJobTest
             null,
             null,
             null,
-            null
+            null,
+            1
         )
     );
     this.indexerConfig = new HadoopDruidIndexerConfig(ingestionSpec);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeterminePartitionsJobSamplerTest
+{
+  @Test
+  public void testSampled()
+  {
+    int sample = 10;
+    int targetPartitionSize = 1000000;
+    int maxRowsPerSegment = 5000000;
+    DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
+        sample,
+        targetPartitionSize,
+        maxRowsPerSegment
+    );
+    Assert.assertEquals(100000, sampler.getSampledTargetPartitionSize());
+    Assert.assertEquals(500000, sampler.getSampledMaxSegmentSize());
+  }
+
+  @Test
+  public void testNotSampled()
+  {
+    int sample = 0;
+    int targetPartitionSize = 1000000;
+    int maxRowsPerSegment = 5000000;
+    DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
+        sample,
+        targetPartitionSize,
+        maxRowsPerSegment
+    );
+    Assert.assertEquals(targetPartitionSize, sampler.getSampledTargetPartitionSize());
+    Assert.assertEquals(maxRowsPerSegment, sampler.getSampledMaxSegmentSize());
+  }
+}

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
@@ -66,7 +66,7 @@ public class DeterminePartitionsJobSamplerTest
         1000,
         5000
     );
-    long total = 10000000L;
+    long total = 100000L;
     long hit = 0;
     for (long i = 0; i < total; i++) {
       String str = UUID.randomUUID().toString();

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
@@ -74,9 +74,9 @@ public class DeterminePartitionsJobSamplerTest
         hit++;
       }
     }
-    double sample = total * 1.0 / samplingFactor;
-    double error_ratio = Math.abs(hit - sample) / sample;
-    Assert.assertTrue(error_ratio < 0.01);
+    double expect = total * 1.0 / samplingFactor;
+    double error = Math.abs(hit - expect) / expect;
+    Assert.assertTrue(error < 0.01);
   }
 
   @Test
@@ -95,8 +95,8 @@ public class DeterminePartitionsJobSamplerTest
         hit++;
       }
     }
-    double sample = total * 1.0 / samplingFactor;
-    double error_ratio = Math.abs(hit - sample) / sample;
-    Assert.assertTrue(error_ratio < 0.01);
+    double expect = total * 1.0 / samplingFactor;
+    double error = Math.abs(hit - expect) / expect;
+    Assert.assertTrue(error < 0.01);
   }
 }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
@@ -36,7 +36,7 @@ public class DeterminePartitionsJobSamplerTest
         maxRowsPerSegment
     );
     Assert.assertEquals(100000, sampler.getSampledTargetPartitionSize());
-    Assert.assertEquals(500000, sampler.getSampledMaxSegmentSize());
+    Assert.assertEquals(500000, sampler.getSampledMaxRowsPerSegment());
   }
 
   @Test
@@ -51,6 +51,6 @@ public class DeterminePartitionsJobSamplerTest
         maxRowsPerSegment
     );
     Assert.assertEquals(targetPartitionSize, sampler.getSampledTargetPartitionSize());
-    Assert.assertEquals(maxRowsPerSegment, sampler.getSampledMaxSegmentSize());
+    Assert.assertEquals(maxRowsPerSegment, sampler.getSampledMaxRowsPerSegment());
   }
 }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobSamplerTest.java
@@ -30,11 +30,11 @@ public class DeterminePartitionsJobSamplerTest
   @Test
   public void testSampled()
   {
-    int sample = 10;
+    int samplingFactor = 10;
     int targetPartitionSize = 1000000;
     int maxRowsPerSegment = 5000000;
     DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
-        sample,
+        samplingFactor,
         targetPartitionSize,
         maxRowsPerSegment
     );
@@ -45,11 +45,11 @@ public class DeterminePartitionsJobSamplerTest
   @Test
   public void testNotSampled()
   {
-    int sample = 0;
+    int samplingFactor = 0;
     int targetPartitionSize = 1000000;
     int maxRowsPerSegment = 5000000;
     DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
-        sample,
+        samplingFactor,
         targetPartitionSize,
         maxRowsPerSegment
     );
@@ -60,43 +60,43 @@ public class DeterminePartitionsJobSamplerTest
   @Test
   public void testShouldEmitRowByHash()
   {
-    int sample = 10;
+    int samplingFactor = 10;
     DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
-        sample,
+        samplingFactor,
         1000,
         5000
     );
-    long n = 10000000L;
-    long m = 0;
-    for (long i = 0; i < n; i++) {
+    long total = 10000000L;
+    long hit = 0;
+    for (long i = 0; i < total; i++) {
       String str = UUID.randomUUID().toString();
       if (sampler.shouldEmitRow(str.getBytes(StandardCharsets.UTF_8))) {
-        m++;
+        hit++;
       }
     }
-    double p = n * 1.0 / sample;
-    double d = Math.abs(m - p) / p;
-    Assert.assertTrue(d < 0.01);
+    double sample = total * 1.0 / samplingFactor;
+    double error_ratio = Math.abs(hit - sample) / sample;
+    Assert.assertTrue(error_ratio < 0.01);
   }
 
   @Test
   public void testShouldEmitRowByRandom()
   {
-    int sample = 10;
+    int samplingFactor = 10;
     DeterminePartitionsJobSampler sampler = new DeterminePartitionsJobSampler(
-        sample,
+        samplingFactor,
         1000,
         5000
     );
-    long n = 1000000L;
-    long m = 0;
-    for (long i = 0; i < n; i++) {
+    long total = 1000000L;
+    long hit = 0;
+    for (long i = 0; i < total; i++) {
       if (sampler.shouldEmitRow()) {
-        m++;
+        hit++;
       }
     }
-    double p = n * 1.0 / sample;
-    double d = Math.abs(m - p) / p;
-    Assert.assertTrue(d < 0.01);
+    double sample = total * 1.0 / samplingFactor;
+    double error_ratio = Math.abs(hit - sample) / sample;
+    Assert.assertTrue(error_ratio < 0.01);
   }
 }

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
@@ -342,7 +342,8 @@ public class DeterminePartitionsJobTest
                 null,
                 null,
                 null,
-                null
+                null,
+                1
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineRangePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineRangePartitionsJobTest.java
@@ -397,7 +397,8 @@ public class DetermineRangePartitionsJobTest
                 null,
                 null,
                 null,
-                null
+                null,
+                1
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -280,7 +280,8 @@ public class HadoopDruidIndexerConfigTest
           null,
           null,
           null,
-          null
+          null,
+          1
       );
 
       return new HadoopIngestionSpec(

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
@@ -63,7 +63,8 @@ public class HadoopTuningConfigTest
         null,
         null,
         null,
-        null
+        null,
+        1
     );
 
     HadoopTuningConfig actual = jsonReadWriteRead(JSON_MAPPER.writeValueAsString(expected), HadoopTuningConfig.class);

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
@@ -547,7 +547,8 @@ public class IndexGeneratorJobTest
                 null,
                 null,
                 null,
-                null
+                null,
+                1
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
@@ -185,7 +185,8 @@ public class JobHelperTest
                 null,
                 null,
                 null,
-                null
+                null,
+                1
             )
         )
     );

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
@@ -79,7 +79,8 @@ public class GranularityPathSpecTest
       null,
       null,
       null,
-      null
+      null,
+      1
   );
 
   private GranularityPathSpec granularityPathSpec;


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Let's first recall that there are two type of DeterminePartitionsJob.
-  When the input data is not assume grouped, there may be duplicate rows. We will launch two mr job. The first one do group job to remove duplicate rows. Then the second one do global sorting to find lower and upper bound for target segments.
- When the input data is assume grouped, we only need to launch the global sorting mr job to find lower and upper bound for segments.

As we don't need a segment size which exactly equals the targetRowsPerSegment parameter, we can sample the input data to improve the DeterminePartitionsJob. Let me explain how to use the sampling factor to improve  the DeterminePartitionsJob.
- If the input data is assume grouped, we just do sample by random at the mapper side of the global sort mr job.
- If the input data is not assume grouped, we do sample at the mapper of the group job. We use hash on time and all dimensions and mod by sampling factor to do sample, we don't use random method because there may be duplicate rows.

For example, if we ingest 10,000,000,000 rows and the targetRowsPerSegment is 5,000,000, we can sample by 500, so the DeterminePartitionsJob only need process 20,000,000 rows, this helps save a lot of time.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `DeterminePartitionsJobSampler`
 * `DeterminePartitionsJob`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
