### PR TITLE
Add missing license for jakarta.activation against module druid-avro-extensions

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -56,7 +56,7 @@ jobs:
       - name: packaging check
         run: |
           ./.github/scripts/setup_generate_license.sh
-          ${MVN} clean install -Prat -Pbundle-contrib-exts --fail-at-end \
+          ${MVN} clean install -Prat --fail-at-end \
           -pl '!benchmarks, !distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
           ${MVN} install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end \
           -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5067,7 +5067,7 @@ libraries:
 name: jakarta.activation
 license_category: binary
 module: extensions/druid-avro-extensions
-license_name: Eclipse Distribution License 2.0
+license_name: Eclipse Distribution License 1.0
 version: 1.2.1
 libraries:
   - com.sun.activation: jakarta.activation

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5064,6 +5064,15 @@ libraries:
 
 ---
 
+name: jakarta.activation
+license_category: binary
+module: extensions/druid-avro-extensions
+license_name: Eclipse Distribution License 2.0
+version: 1.2.1
+libraries:
+  - com.sun.activation: jakarta.activation
+
+---
 
 # Web console modules start
 name: "@babel/code-frame"

--- a/server/src/main/java/org/apache/druid/server/coordinator/BalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/BalancerStrategy.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public interface BalancerStrategy
 {
   /**
-   * Find the best server to move a {@link DataSegment} to according the balancing strategy.
+   * Finds the best server to move a {@link DataSegment} to according the balancing strategy.
    * @param proposalSegment segment to move
    * @param serverHolders servers to consider as move destinations
    * @return The server to move to, or null if no move should be made or no server is suitable

--- a/server/src/main/java/org/apache/druid/server/coordinator/BalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/BalancerStrategy.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public interface BalancerStrategy
 {
   /**
-   * Finds the best server to move a {@link DataSegment} to according the balancing strategy.
+   * Find the best server to move a {@link DataSegment} to according the balancing strategy.
    * @param proposalSegment segment to move
    * @param serverHolders servers to consider as move destinations
    * @return The server to move to, or null if no move should be made or no server is suitable


### PR DESCRIPTION
Example failing license check:
https://github.com/apache/druid/actions/runs/4259979145/jobs/7412698385