### PR TITLE
Web console: upgrade druid query toolkit to make scan results normalize correctly

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5684,7 +5684,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.17.2
+version: 0.17.4
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -22,7 +22,7 @@
         "d3-axis": "^2.1.0",
         "d3-scale": "^3.3.0",
         "d3-selection": "^2.0.0",
-        "druid-query-toolkit": "^0.17.2",
+        "druid-query-toolkit": "^0.17.4",
         "file-saver": "^2.0.2",
         "follow-redirects": "^1.14.7",
         "fontsource-open-sans": "^3.0.9",
@@ -8542,9 +8542,9 @@
       }
     },
     "node_modules/druid-query-toolkit": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.2.tgz",
-      "integrity": "sha512-kVnZyE/b9jBx3mebwBKn6/XRpKztM7E7RlzNmUR9LUvOE/cMVqytDKfMx4S05RbIKMTopqI7fRSuE2dc6D8oww==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.4.tgz",
+      "integrity": "sha512-d/mNJ9ausAfxQaxgGWfP4dHpwcIqjkbdz1NNmTk6DHMbwlskk96MnXrvPsOCmeoKMb0iYVeVtq9CbB1vNaPZ5A==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -33236,9 +33236,9 @@
       }
     },
     "druid-query-toolkit": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.2.tgz",
-      "integrity": "sha512-kVnZyE/b9jBx3mebwBKn6/XRpKztM7E7RlzNmUR9LUvOE/cMVqytDKfMx4S05RbIKMTopqI7fRSuE2dc6D8oww==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/druid-query-toolkit/-/druid-query-toolkit-0.17.4.tgz",
+      "integrity": "sha512-d/mNJ9ausAfxQaxgGWfP4dHpwcIqjkbdz1NNmTk6DHMbwlskk96MnXrvPsOCmeoKMb0iYVeVtq9CbB1vNaPZ5A==",
       "requires": {
         "tslib": "^2.3.1"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -79,7 +79,7 @@
     "d3-axis": "^2.1.0",
     "d3-scale": "^3.3.0",
     "d3-selection": "^2.0.0",
-    "druid-query-toolkit": "^0.17.2",
+    "druid-query-toolkit": "^0.17.4",
     "file-saver": "^2.0.2",
     "follow-redirects": "^1.14.7",
     "fontsource-open-sans": "^3.0.9",


### PR DESCRIPTION
This is an upgrade to get this commit: https://github.com/implydata/druid-query-toolkit/commit/e1e4508f81aa3debf1592dc8afee23517185fed9

It fixes the issue that scan results from segments with varying schemas were not normalized correctly.

The datasource `w2` has several rows from two completely different datasets ingested into one place

Before:

<img width="1444" alt="image" src="https://user-images.githubusercontent.com/177816/221297355-55092f9c-5435-415e-a2cb-1e6f3ae23b9f.png">

After:

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/177816/221297454-6fd01524-89a5-44ca-b57a-232fc449a1f3.png">
