### PR TITLE
Fix durable storage cleanup

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -822,25 +822,24 @@ public class WorkerImpl implements Worker
         continue;
       }
       output.close();
-
-      // One caveat with this approach is that in case of a worker crash, while the MM/Indexer systems will delete their
-      // temp directories where intermediate results were stored, it won't be the case for the external storage.
-      // Therefore, the logic for cleaning the stage output in case of a worker/machine crash has to be external.
-      // We currently take care of this in the controller.
-      if (durableStageStorageEnabled && removeDurableStorageFiles) {
-        final String folderName = DurableStorageUtils.getTaskIdOutputsFolderName(
-            task.getControllerTaskId(),
-            stageId.getStageNumber(),
-            task.getWorkerNumber(),
-            task.getId()
-        );
-        try {
-          MSQTasks.makeStorageConnector(context.injector()).deleteRecursively(folderName);
-        }
-        catch (Exception e) {
-          // If an error is thrown while cleaning up a file, log it and try to continue with the cleanup
-          log.warn(e, "Error while cleaning up folder at path " + folderName);
-        }
+    }
+    // One caveat with this approach is that in case of a worker crash, while the MM/Indexer systems will delete their
+    // temp directories where intermediate results were stored, it won't be the case for the external storage.
+    // Therefore, the logic for cleaning the stage output in case of a worker/machine crash has to be external.
+    // We currently take care of this in the controller.
+    if (durableStageStorageEnabled && removeDurableStorageFiles) {
+      final String folderName = DurableStorageUtils.getTaskIdOutputsFolderName(
+          task.getControllerTaskId(),
+          stageId.getStageNumber(),
+          task.getWorkerNumber(),
+          task.getId()
+      );
+      try {
+        MSQTasks.makeStorageConnector(context.injector()).deleteRecursively(folderName);
+      }
+      catch (Exception e) {
+        // If an error is thrown while cleaning up a file, log it and try to continue with the cleanup
+        log.warn(e, "Error while cleaning up folder at path " + folderName);
       }
     }
   }


### PR DESCRIPTION
While testing durable shuffle storage, intermittently rate limiting on DELETE object operations is observed in the logs. Further, sometimes there are failures in the job due to us trying to open streams on s3 objects which have been already deleted.
A couple of changes are done to fix these problems : 
1. Do the worker level DELETE op only once which cleans up all the partitions for a stage for that worker
2. When the S3 input stream (Sequence stream of chunks) is closed, avoid the default behavior of the `SequenceInputStream` to open/close all the chunks. Since our chunking is lazy, we can just close the current chunk stream and then exit.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
