### PR TITLE
Fix flaky BatchIndex IT failures.

### DIFF
--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractITBatchIndexTest.java
@@ -456,6 +456,9 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
       Pair<Boolean, Boolean> segmentAvailabilityConfirmationPair
   )
   {
+    // Wait for any existing kill tasks to complete before submitting new index task otherwise
+    // kill tasks can fail with interval lock revoked.
+    waitForAllTasksToCompleteForDataSource(dataSourceName);
     final List<DataSegment> oldVersions = waitForNewVersion ? coordinator.getAvailableSegments(dataSourceName) : null;
 
     long startSubTaskCount = -1;

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractITBatchIndexTest.java
@@ -340,6 +340,9 @@ public abstract class AbstractITBatchIndexTest extends AbstractIndexerTest
       Pair<Boolean, Boolean> segmentAvailabilityConfirmationPair
   )
   {
+    // Wait for any existing kill tasks to complete before submitting new index task otherwise
+    // kill tasks can fail with interval lock revoked.
+    waitForAllTasksToCompleteForDataSource(dataSourceName);
     final List<DataSegment> oldVersions = waitForNewVersion ? coordinator.getAvailableSegments(dataSourceName) : null;
 
     long startSubTaskCount = -1;

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/AbstractIndexerTest.java
@@ -47,7 +47,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 public abstract class AbstractIndexerTest
 {
@@ -110,6 +109,9 @@ public abstract class AbstractIndexerTest
 
   protected String submitIndexTask(String indexTask, final String fullDatasourceName) throws Exception
   {
+    // Wait for any existing kill tasks to complete before submitting new index task otherwise
+    // kill tasks can fail with interval lock revoked.
+    waitForAllTasksToCompleteForDataSource(fullDatasourceName);
     String taskSpec = getResourceAsString(indexTask);
     taskSpec = StringUtils.replace(taskSpec, "%%DATASOURCE%%", fullDatasourceName);
     taskSpec = StringUtils.replace(
@@ -142,14 +144,8 @@ public abstract class AbstractIndexerTest
     Interval interval = Intervals.of(start + "/" + end);
     coordinator.unloadSegmentsForDataSource(dataSource);
     ITRetryUtil.retryUntilFalse(
-        new Callable<Boolean>()
-        {
-          @Override
-          public Boolean call()
-          {
-            return coordinator.areSegmentsLoaded(dataSource);
-          }
-        }, "Segment Unloading"
+        () -> coordinator.areSegmentsLoaded(dataSource),
+        "Segment Unloading"
     );
     coordinator.deleteSegmentsDataSource(dataSource, interval);
     waitForAllTasksToCompleteForDataSource(dataSource);


### PR DESCRIPTION
Fixed the Lock for interval was revoked for kill tasks bug in BatchIndex ITs

```
2023-02-16T06:10:14,026 INFO [main] org.apache.druid.indexing.worker.executor.ExecutorLifecycle - Attempting to lock file[/tmp/persistent/task/api-issued_kill_wikipedia_parallel_index_test_jbhgipfi_2013-08-31T00:00:00.000Z_2013-09-02T00:00:00.000Z_2023-02-16T06:10:07.749Z/lock].
2023-02-16T06:10:14,029 INFO [main] org.apache.druid.indexing.worker.executor.ExecutorLifecycle - Acquired lock file[/tmp/persistent/task/api-issued_kill_wikipedia_parallel_index_test_jbhgipfi_2013-08-31T00:00:00.000Z_2013-09-02T00:00:00.000Z_2023-02-16T06:10:07.749Z/lock] in 2ms.
2023-02-16T06:10:14,131 ERROR [main] org.apache.druid.cli.CliPeon - Error when starting up.  Failing.
java.lang.reflect.InvocationTargetException: null
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_342]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_342]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_342]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_342]
	at org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler.start(Lifecycle.java:446) ~[druid-core-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.common.lifecycle.Lifecycle.start(Lifecycle.java:341) ~[druid-core-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.guice.LifecycleModule$2.start(LifecycleModule.java:152) ~[druid-core-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:136) ~[druid-services-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:94) ~[druid-services-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.cli.CliPeon.run(CliPeon.java:310) ~[druid-services-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.cli.Main.main(Main.java:112) ~[druid-services-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
Caused by: org.apache.druid.java.util.common.ISE: Failed to run task[api-issued_kill_wikipedia_parallel_index_test_jbhgipfi_2013-08-31T00:00:00.000Z_2013-09-02T00:00:00.000Z_2023-02-16T06:10:07.749Z] isReady
	at org.apache.druid.indexing.worker.executor.ExecutorLifecycle.start(ExecutorLifecycle.java:173) ~[druid-indexing-service-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	... 11 more
Caused by: org.apache.druid.java.util.common.ISE: Lock for interval [2013-08-31T00:00:00.000Z/2013-09-02T00:00:00.000Z] was revoked.
	at org.apache.druid.indexing.common.task.AbstractFixedIntervalTask.isReady(AbstractFixedIntervalTask.java:92) ~[druid-indexing-service-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.worker.executor.ExecutorLifecycle.start(ExecutorLifecycle.java:168) ~[druid-indexing-service-2023.02.0-iap-SNAPSHOT.jar:2023.02.0-iap-SNAPSHOT]
	... 11 more

ITBestEffortRollupParallelIndexTest.testIndexData:142->AbstractIndexerTest.lambda$unloader$0:71->AbstractIndexerTest.unloadAndKillData:85 » ISE Error while making request to indexer [404 Not Found No task reports were found for this task. The task may not exist, or it may not have completed yet.]
```