### PR TITLE
We never want to restore caches that aren't an exact match to the SHA

### DIFF
--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -65,8 +65,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
-          restore-keys: |
-            maven-${{ runner.os }}-${{ matrix.jdk }}
 
       - name: Cache targets
         id: target
@@ -75,8 +73,6 @@ jobs:
           path: |
             ./**/target
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-targets-${{ github.sha }}
-          restore-keys: |
-            maven-${{ runner.os }}-${{ matrix.jdk }}-targets
 
       - name: Cache image
         id: docker_container
@@ -86,8 +82,6 @@ jobs:
           path: |
             ./druid-container-jdk${{ matrix.jdk }}.tar.gz
             ./integration-tests-ex/image/target/env.sh
-          restore-keys: |
-            druid-container-jdk${{ matrix.jdk }}.tar.gz-
 
       - name: Maven build
         id: maven_build


### PR DESCRIPTION
Fixes the possibility to restore and then re-cache only partially matching cache'd keys.  This will force a fresh build unless there's a cache that directly matches the commit SHA (and thus, is identical).

### Description

Remove partial key match restores before the initial build.  There will be a minor increase in build time without existing local artifacts to use, but this will guarantee the build is fresh and only related to the current commit.

This PR has:

- [x] been self-reviewed.
