### PR TITLE
Update datasources.md: Fix Documentation.

### DIFF
--- a/docs/querying/datasource.md
+++ b/docs/querying/datasource.md
@@ -233,7 +233,7 @@ FROM
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 Query datasources allow you to issue subqueries. In native queries, they can appear anywhere that accepts a
-`dataSource`. In SQL, they can appear in the following places, always surrounded by parentheses:
+`dataSource` (except underneath a `union`). In SQL, they can appear in the following places, always surrounded by parentheses:
 
 - The FROM clause: `FROM (<subquery>)`.
 - As inputs to a JOIN: `<table-or-subquery-1> t1 INNER JOIN <table-or-subquery-2> t2 ON t1.<col1> = t2.<col2>`.


### PR DESCRIPTION

### Description

Correction of doc based on https://apachedruidworkspace.slack.com/archives/C0303FDCZEZ/p1677634303697319?thread_ts=1677154559.554039&cid=C0303FDCZEZ


#### Release note
Fixed documentation to clarify that `union` query cant be run over `query` datasources.


This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.