### PR TITLE
Workaround for CycloneDX is causing POM build errors

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -106,7 +106,9 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       MVN: mvn --no-snapshot-updates
-      MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
+      # Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
+      # May be fixed in the future
+      MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true
       CONFIG_FILE: k8s_run_config_file.json
       IT_TEST: -Dit.test=ITNestedQueryPushDownTest
       POD_NAME: int-test

--- a/it.sh
+++ b/it.sh
@@ -193,7 +193,9 @@ fi
 
 CMD=$1
 shift
-MAVEN_IGNORE="-P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true"
+# Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
+# May be fixed in the future
+MAVEN_IGNORE="-P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true"
 
 case $CMD in
   "help" )


### PR DESCRIPTION
### Description

Fixes CycloneDX POM errors like this `error [ERROR] An error occurred attempting to read POM`

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
