### PR TITLE
Include workaround for CycloneDX causing build errors in the web-console project

### DIFF
--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -55,8 +55,10 @@ function _build_distribution() {
 
   (
     # Add HEAD as an allowed HTTP method since this is how we check when the Druid service is ready.
+    # Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
+    # May be fixed in the future. See https://github.com/apache/druid/pull/13867
     cd "$(_get_code_root)" \
-    && mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -q -T1C install \
+    && mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -q -T1C install \
     && cd distribution/target \
     && tar xzf "apache-druid-$(_get_druid_version)-bin.tar.gz" \
     && cd apache-druid-$(_get_druid_version) \


### PR DESCRIPTION
Follow up to https://github.com/apache/druid/pull/13867 -- include the CycloneDX workaround to the druid web console project as well since there are errors with the web-console end-to-end tests:
```
+ mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -q install
Error: [ERROR] An error occurred attempting to read POM
org.codehaus.plexus.util.xml.pull.XmlPullParserException: UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42) 
    at org.codehaus.plexus.util.xml.pull.MXParser.parseXmlDeclWithVersion (MXParser.java:3423)
    at org.codehaus.plexus.util.xml.pull.MXParser.parseXmlDecl (MXParser.java:3345)
    at org.codehaus.plexus.util.xml.pull.MXParser.parsePI (MXParser.java:3197)
```

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
