### PR TITLE
do not run non sql compatible tests for all JDK flavours

### DIFF
--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -117,13 +117,12 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11, 17]
-        sql_compatibility: [ false, true ]
     name: unit tests (jdk${{ matrix.jdk }}, sql-compat=${{ matrix.sql_compatibility }})
     uses: ./.github/workflows/unit-tests.yml
     needs: unit-tests
     with:
       jdk: ${{ matrix.jdk }}
-      sql_compatibility: ${{ matrix.sql_compatibility }}
+      sql_compatibility: true
 
   standard-its:
     needs: unit-tests


### PR DESCRIPTION
Because there is really no need. 
