### PR TITLE
Bump CycloneDX module to address POM errors

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -106,9 +106,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       MVN: mvn --no-snapshot-updates
-      # Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
-      # May be fixed in the future
-      MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true
+      MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
       CONFIG_FILE: k8s_run_config_file.json
       IT_TEST: -Dit.test=ITNestedQueryPushDownTest
       POD_NAME: int-test

--- a/it.sh
+++ b/it.sh
@@ -193,9 +193,7 @@ fi
 
 CMD=$1
 shift
-# Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
-# May be fixed in the future
-MAVEN_IGNORE="-P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true"
+MAVEN_IGNORE="-P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true"
 
 case $CMD in
   "help" )

--- a/pom.xml
+++ b/pom.xml
@@ -1536,7 +1536,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.3</version>
+                <version>2.7.5</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/web-console/script/druid
+++ b/web-console/script/druid
@@ -55,10 +55,8 @@ function _build_distribution() {
 
   (
     # Add HEAD as an allowed HTTP method since this is how we check when the Druid service is ready.
-    # Added -Dcyclonedx.skip=true to avoid ISO-8859-1 [ERROR]s
-    # May be fixed in the future. See https://github.com/apache/druid/pull/13867
     cd "$(_get_code_root)" \
-    && mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -q -T1C install \
+    && mvn -Pdist,skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -q -T1C install \
     && cd distribution/target \
     && tar xzf "apache-druid-$(_get_druid_version)-bin.tar.gz" \
     && cd apache-druid-$(_get_druid_version) \


### PR DESCRIPTION
### Description

- CycloneDX 2.7.5 does not cause the same `error [ERROR] An error occurred attempting to read POM` errors that we were seeing.

This PR has:

- [x] been self-reviewed.
