### PR TITLE
Adding forbidden api for Properties#getOrDefault()

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -41,6 +41,7 @@ java.util.HashSet#<init>(int, float) @ Use com.google.collect.Sets#newHashSetWit
 java.util.LinkedHashSet#<init>(int) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedHashSet#<init>(int, float) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedList @ Use ArrayList or ArrayDeque instead
+java.util.Properties#getOrDefault(java.lang.Object,java.lang.Object) @ Properties#getOrDefault method does not check the default map for values. Use Properties#getProperty() instead.
 java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor with a seed (the latter in tests only!)
 java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Added a check so that we donot call Propeties#getOrDefault accidentally. I donot think we would have a legit use case of calling this API ever. Motivation for this change: https://github.com/apache/druid/pull/13881 . 

`Properties#getOrDefault` method does not check the default map for values where as` Properties#getProperty()` does.


This PR has:

- [x] been self-reviewed.
