### PR TITLE
relax native expression multi-value string usage validation for conditional and null coalescing functions

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -224,7 +224,7 @@ public interface Expr extends Cacheable
         if (argType == null) {
           continue;
         }
-        numeric &= argType.isNumeric();
+        numeric = numeric && argType.isNumeric();
       }
       return numeric;
     }
@@ -265,7 +265,7 @@ public interface Expr extends Cacheable
         if (currentType == null) {
           currentType = argType;
         }
-        allSame &= Objects.equals(argType, currentType);
+        allSame = allSame && Objects.equals(argType, currentType);
       }
       return allSame;
     }
@@ -302,7 +302,7 @@ public interface Expr extends Cacheable
         if (argType == null) {
           continue;
         }
-        scalar &= argType.isPrimitive();
+        scalar = scalar && argType.isPrimitive();
       }
       return scalar;
     }
@@ -330,7 +330,7 @@ public interface Expr extends Cacheable
     {
       boolean canVectorize = true;
       for (Expr arg : args) {
-        canVectorize &= arg.canVectorize(this);
+        canVectorize = canVectorize && arg.canVectorize(this);
       }
       return canVectorize;
     }
@@ -498,7 +498,7 @@ public interface Expr extends Cacheable
     /**
      * Set of {@link IdentifierExpr#binding} which are used as scalar inputs to operators and functions.
      */
-    Set<String> getScalarBindings()
+    public Set<String> getScalarBindings()
     {
       return map(scalarVariables, IdentifierExpr::getBindingIfIdentifier);
     }

--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -1962,14 +1962,11 @@ public interface Function extends NamedFunction
         ExpressionType castTo = ExpressionType.fromString(
             StringUtils.toUpperCase(args.get(1).getLiteralValue().toString())
         );
-        switch (castTo.getType()) {
-          case ARRAY:
-            return Collections.emptySet();
-          default:
-            return ImmutableSet.of(args.get(0));
+        if (!castTo.getType().isArray()) {
+          return ImmutableSet.of(args.get(0));
         }
       }
-      // unknown cast, can't safely assume either way
+      // either has array inputs or unknown inputs
       return Collections.emptySet();
     }
 
@@ -1980,16 +1977,11 @@ public interface Function extends NamedFunction
         ExpressionType castTo = ExpressionType.fromString(
             StringUtils.toUpperCase(args.get(1).getLiteralValue().toString())
         );
-        switch (castTo.getType()) {
-          case LONG:
-          case DOUBLE:
-          case STRING:
-            return Collections.emptySet();
-          default:
-            return ImmutableSet.of(args.get(0));
+        if (castTo.getType().isArray()) {
+          return ImmutableSet.of(args.get(0));
         }
       }
-      // unknown cast, can't safely assume either way
+      // not an array, or unknown input types
       return Collections.emptySet();
     }
 
@@ -2087,6 +2079,13 @@ public interface Function extends NamedFunction
     {
       return ExpressionTypeConversion.conditional(inspector, args.subList(1, 3));
     }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // could potentially look for constants in the return positions and examine type...
+      return Collections.emptySet();
+    }
   }
 
   /**
@@ -2133,6 +2132,13 @@ public interface Function extends NamedFunction
       // add else
       results.add(args.get(args.size() - 1));
       return ExpressionTypeConversion.conditional(inspector, results);
+    }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // could potentially look for constants in the return positions and examine type...
+      return Collections.emptySet();
     }
   }
 
@@ -2181,6 +2187,13 @@ public interface Function extends NamedFunction
       results.add(args.get(args.size() - 1));
       return ExpressionTypeConversion.conditional(inspector, results);
     }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // could potentially look for constants in the return positions and examine type...
+      return Collections.emptySet();
+    }
   }
 
   class NvlFunc implements Function
@@ -2221,6 +2234,13 @@ public interface Function extends NamedFunction
     public <T> ExprVectorProcessor<T> asVectorProcessor(Expr.VectorInputBindingInspector inspector, List<Expr> args)
     {
       return VectorProcessors.nvl(inspector, args.get(0), args.get(1));
+    }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // output is same as input, doesn't matter the type
+      return Collections.emptySet();
     }
   }
 
@@ -2263,6 +2283,13 @@ public interface Function extends NamedFunction
     {
       return VectorProcessors.isNull(inspector, args.get(0));
     }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // null or not, doesnt matter if the inputs are arrays or scalars
+      return Collections.emptySet();
+    }
   }
 
   class IsNotNullFunc implements Function
@@ -2293,7 +2320,6 @@ public interface Function extends NamedFunction
       return ExpressionType.LONG;
     }
 
-
     @Override
     public boolean canVectorize(Expr.InputBindingInspector inspector, List<Expr> args)
     {
@@ -2304,6 +2330,13 @@ public interface Function extends NamedFunction
     public <T> ExprVectorProcessor<T> asVectorProcessor(Expr.VectorInputBindingInspector inspector, List<Expr> args)
     {
       return VectorProcessors.isNotNull(inspector, args.get(0));
+    }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      // null or not, doesnt matter if the inputs are arrays or scalars
+      return Collections.emptySet();
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
@@ -142,6 +142,7 @@ public class ExpressionPlanner
                      c -> !definitelyArray.contains(c)
                           && definitelyMultiValued.contains(c)
                           && !analysis.getArrayBindings().contains(c)
+                          && analysis.getScalarBindings().contains(c)
                  )
                  .collect(Collectors.toList());
 

--- a/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -470,7 +470,12 @@ public class ParserTest extends InitializedNullHandlingTest
   public void testFunctions()
   {
     validateParser("sqrt(x)", "(sqrt [x])", ImmutableList.of("x"));
-    validateParser("if(cond,then,else)", "(if [cond, then, else])", ImmutableList.of("cond", "else", "then"));
+    validateParser("if(cond,then,else)", "(if [cond, then, else])", ImmutableList.of("cond", "else", "then"), Collections.emptySet(), Collections.emptySet());
+    validateParser("case_simple(cond,then,else)", "(case_simple [cond, then, else])", ImmutableList.of("cond", "else", "then"), Collections.emptySet(), Collections.emptySet());
+    validateParser("case_searched(cond,then,else)", "(case_searched [cond, then, else])", ImmutableList.of("cond", "else", "then"), Collections.emptySet(), Collections.emptySet());
+    validateParser("nvl(x, fallback)", "(nvl [x, fallback])", ImmutableList.of("x", "fallback"), Collections.emptySet(), Collections.emptySet());
+    validateParser("nvl(x, 1)", "(nvl [x, 1])", ImmutableList.of("x"), ImmutableSet.of(), Collections.emptySet());
+    validateParser("nvl(x, [1,2,3])", "(nvl [x, [1, 2, 3]])", ImmutableList.of("x"), Collections.emptySet(), ImmutableSet.of());
     validateParser("cast(x, 'STRING')", "(cast [x, STRING])", ImmutableList.of("x"));
     validateParser("cast(x, 'LONG')", "(cast [x, LONG])", ImmutableList.of("x"));
     validateParser("cast(x, 'DOUBLE')", "(cast [x, DOUBLE])", ImmutableList.of("x"));

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -20,7 +20,6 @@
 package org.apache.druid.sql.calcite.expression.builtin;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -29,7 +28,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
-import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -39,45 +38,10 @@ import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.Period;
 
-import java.util.Map;
 import java.util.function.Function;
 
 public class CastOperatorConversion implements SqlOperatorConversion
 {
-  private static final Map<SqlTypeName, ExprType> EXPRESSION_TYPES;
-
-  static {
-    final ImmutableMap.Builder<SqlTypeName, ExprType> builder = ImmutableMap.builder();
-
-    for (SqlTypeName type : SqlTypeName.FRACTIONAL_TYPES) {
-      builder.put(type, ExprType.DOUBLE);
-    }
-
-    for (SqlTypeName type : SqlTypeName.INT_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    for (SqlTypeName type : SqlTypeName.STRING_TYPES) {
-      builder.put(type, ExprType.STRING);
-    }
-
-    // Booleans are treated as longs in Druid expressions, using two-value logic (positive = true, nonpositive = false).
-    builder.put(SqlTypeName.BOOLEAN, ExprType.LONG);
-
-    // Timestamps are treated as longs (millis since the epoch) in Druid expressions.
-    builder.put(SqlTypeName.TIMESTAMP, ExprType.LONG);
-    builder.put(SqlTypeName.DATE, ExprType.LONG);
-
-    for (SqlTypeName type : SqlTypeName.DAY_INTERVAL_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    for (SqlTypeName type : SqlTypeName.YEAR_INTERVAL_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    EXPRESSION_TYPES = builder.build();
-  }
 
   @Override
   public SqlOperator calciteOperator()
@@ -103,6 +67,7 @@ public class CastOperatorConversion implements SqlOperatorConversion
       return null;
     }
 
+
     final SqlTypeName fromType = operand.getType().getSqlTypeName();
     final SqlTypeName toType = rexNode.getType().getSqlTypeName();
 
@@ -118,28 +83,32 @@ public class CastOperatorConversion implements SqlOperatorConversion
     } else {
       // Handle other casts. If either type is ANY, use the other type instead. If both are ANY, this means nulls
       // downstream, Druid will try its best
-      final ExprType fromExprType = SqlTypeName.ANY.equals(fromType)
-                                    ? EXPRESSION_TYPES.get(toType)
-                                    : EXPRESSION_TYPES.get(fromType);
-      final ExprType toExprType = SqlTypeName.ANY.equals(toType)
-                                  ? EXPRESSION_TYPES.get(fromType)
-                                  : EXPRESSION_TYPES.get(toType);
 
-      if (fromExprType == null || toExprType == null) {
+      final ColumnType fromDruidType = Calcites.getColumnTypeForRelDataType(operand.getType());
+      final ColumnType toDruidType = Calcites.getColumnTypeForRelDataType(rexNode.getType());
+
+      final ExpressionType fromExpressionType = SqlTypeName.ANY.equals(fromType)
+                                    ? ExpressionType.fromColumnType(toDruidType)
+                                    : ExpressionType.fromColumnType(fromDruidType);
+      final ExpressionType toExpressionType = SqlTypeName.ANY.equals(toType)
+                                  ? ExpressionType.fromColumnType(fromDruidType)
+                                  : ExpressionType.fromColumnType(toDruidType);
+
+      if (fromExpressionType == null || toExpressionType == null) {
         // We have no runtime type for these SQL types.
         return null;
       }
 
       final DruidExpression typeCastExpression;
 
-      if (fromExprType != toExprType) {
-        // Ignore casts for simple extractions (use Function.identity) since it is ok in many cases.
+      if (fromExpressionType.equals(toExpressionType)) {
+        // Ignore casts for simple extractions since it is ok in many cases.
+        typeCastExpression = operandExpression;
+      } else {
         typeCastExpression = operandExpression.map(
             Function.identity(),
-            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExprType.toString())
+            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExpressionType.asTypeString())
         );
-      } else {
-        typeCastExpression = operandExpression;
       }
 
       if (toType == SqlTypeName.DATE) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -188,7 +188,9 @@ public class Calcites
     return SqlTypeName.TIMESTAMP == sqlTypeName ||
            SqlTypeName.DATE == sqlTypeName ||
            SqlTypeName.BOOLEAN == sqlTypeName ||
-           SqlTypeName.INT_TYPES.contains(sqlTypeName);
+           SqlTypeName.INT_TYPES.contains(sqlTypeName) ||
+           SqlTypeName.DAY_INTERVAL_TYPES.contains(sqlTypeName) ||
+           SqlTypeName.YEAR_INTERVAL_TYPES.contains(sqlTypeName);
   }
 
   public static StringComparator getStringComparatorForRelDataType(RelDataType dataType)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -29,8 +29,10 @@ import org.apache.druid.query.Druids;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.filter.AndDimFilter;
+import org.apache.druid.query.filter.ExpressionDimFilter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.LikeDimFilter;
+import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
@@ -39,6 +41,7 @@ import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.query.scan.ScanQuery;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.virtual.ListFilteredVirtualColumn;
 import org.apache.druid.sql.SqlPlanningException;
 import org.apache.druid.sql.calcite.filtration.Filtration;
@@ -276,6 +279,88 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
             new Object[]{"[\"a\",\"b\"]"},
             new Object[]{"[\"b\",\"c\"]"}
         )
+    );
+  }
+
+  @Test
+  public void testMultiValueStringOverlapFilterCoalesceNvl()
+  {
+    testQuery(
+        "SELECT COALESCE(dim3, 'other') FROM druid.numfoo "
+        + "WHERE MV_OVERLAP(COALESCE(dim3, 'other'), ARRAY['a', 'b', 'other']) OR "
+        + "MV_OVERLAP(NVL(dim3, 'other'), ARRAY['a', 'b', 'other']) OR "
+        + "MV_OVERLAP(COALESCE(MV_TO_ARRAY(dim3), ARRAY['other']), ARRAY['a', 'b', 'other']) OR "
+        + "MV_OVERLAP(NVL(MV_TO_ARRAY(dim3), ARRAY['other']), ARRAY['a', 'b', 'other']) LIMIT 5",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .eternityInterval()
+                .virtualColumns(
+                    new ExpressionVirtualColumn(
+                        "v0",
+                        "case_searched(notnull(\"dim3\"),\"dim3\",'other')",
+                        ColumnType.STRING,
+                        queryFramework().macroTable()
+                    )
+                )
+                .filters(
+                    new OrDimFilter(
+                      new ExpressionDimFilter(
+                          "case_searched(notnull(\"dim3\"),array_overlap(\"dim3\",array('a','b','other')),1)",
+                          null,
+                          queryFramework().macroTable()
+                      ),
+                      new ExpressionDimFilter(
+                          "case_searched(notnull(\"dim3\"),array_overlap(\"dim3\",array('a','b','other')),1)",
+                          null,
+                          queryFramework().macroTable()
+                      ),
+                      new ExpressionDimFilter(
+                          "case_searched(notnull(mv_to_array(\"dim3\")),array_overlap(mv_to_array(\"dim3\"),array('a','b','other')),1)",
+                          null,
+                          queryFramework().macroTable()
+                      ),
+                      new ExpressionDimFilter(
+                          "case_searched(notnull(mv_to_array(\"dim3\")),array_overlap(mv_to_array(\"dim3\"),array('a','b','other')),1)",
+                          null,
+                          queryFramework().macroTable()
+                      )
+                    )
+                )
+                .columns("v0")
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(5)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        NullHandling.replaceWithDefault()
+        ? ImmutableList.of(
+            new Object[]{"[\"a\",\"b\"]"},
+            new Object[]{"[\"b\",\"c\"]"},
+            new Object[]{"other"},
+            new Object[]{"other"},
+            new Object[]{"other"}
+        )
+        : ImmutableList.of(
+            new Object[]{"[\"a\",\"b\"]"},
+            new Object[]{"[\"b\",\"c\"]"},
+            new Object[]{"other"},
+            new Object[]{"other"}
+        )
+    );
+  }
+
+  @Test
+  public void testMultiValueStringOverlapFilterInconsistentUsage()
+  {
+    testQueryThrows(
+        "SELECT COALESCE(dim3, 'other') FROM druid.numfoo "
+        + "WHERE MV_OVERLAP(COALESCE(dim3, ARRAY['other']), ARRAY['a', 'b', 'other']) LIMIT 5",
+        e -> {
+          e.expect(SqlPlanningException.class);
+          e.expectMessage("Illegal mixing of types in CASE or COALESCE statement");
+        }
+
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1751,8 +1751,7 @@ public class ExpressionsTest extends ExpressionTestBase
             (args) -> "(" + args.get(0).getExpression() + " - " + args.get(1).getExpression() + ")",
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                // RexNode type of "interval day to minute" is not converted to druid long... yet
-                DruidExpression.ofLiteral(null, "90060000")
+                DruidExpression.ofLiteral(ColumnType.LONG, "90060000")
             )
         ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
@@ -1779,8 +1778,7 @@ public class ExpressionsTest extends ExpressionTestBase
             DruidExpression.functionCall("timestamp_shift"),
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                // RexNode type "interval year to month" is not reported as ColumnType.STRING
-                DruidExpression.ofLiteral(null, DruidExpression.stringLiteral("P13M")),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.stringLiteral("P13M")),
                 DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.longLiteral(-1)),
                 DruidExpression.ofStringLiteral("UTC")
             )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
@@ -246,10 +246,8 @@ public class GreatestExpressionTest extends ExpressionTestBase
   }
 
   @Test
-  public void testInvalidType()
+  public void testBigDecimal()
   {
-    expectException(IllegalArgumentException.class, "Argument 0 has invalid type: INTERVAL_YEAR_MONTH");
-
     testExpression(
         Collections.singletonList(
             testHelper.makeLiteral(
@@ -257,8 +255,8 @@ public class GreatestExpressionTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        null,
-        null
+        buildExpectedExpression(13),
+        13L
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
@@ -247,10 +247,8 @@ public class LeastExpressionTest extends ExpressionTestBase
   }
 
   @Test
-  public void testInvalidType()
+  public void testBigDecimal()
   {
-    expectException(IllegalArgumentException.class, "Argument 0 has invalid type: INTERVAL_YEAR_MONTH");
-
     testExpression(
         Collections.singletonList(
             testHelper.makeLiteral(
@@ -258,8 +256,8 @@ public class LeastExpressionTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        null,
-        null
+        buildExpectedExpression(13),
+        13L
     );
   }
 


### PR DESCRIPTION
### Description
This PR relaxes multi-value string usage consistency validation to allow expressions like `nvl`, `isnull`, `notnull`, case and if statements, etc, to no longer automatically assume that their inputs must be scalar arguments.

This validation was added way back in #7588 as a means to ensure that a multi-value string column was being used consistently within an expression so that it cannot be considered both as an array and as a scalar value (which must be mapped across the multiple values). This system basically divided expressions up into expressions that definitely take array inputs and output arrays, and everything else. This worked well enough for lots of expressions, but a small handful don't fit this model, which is what this PR aims to help fix.

This system predates the native expression layer having full type inference, and I think it could be done a lot better, so I am also going to be trying to merge this much older analysis system into the type inference system in a follow-up PR, since all of the analysis of contextual usage and validation can be done at the same places where we doing the newer stuff (expression planner, etc).

While here I also consolidated some calcite -> native druid type stuff for the cast operator, which allowed some additional expressions to plan correctly.

<hr>

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
