### PR TITLE
use Calcites.getColumnTypeForRelDataType for SQL CAST operator conversion

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
+import org.apache.druid.math.expr.ExprType;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -99,6 +100,9 @@ public class CastOperatorConversion implements SqlOperatorConversion
       final DruidExpression typeCastExpression;
 
       if (fromExpressionType.equals(toExpressionType)) {
+        typeCastExpression = operandExpression;
+      } else if (SqlTypeName.INTERVAL_TYPES.contains(fromType) && toExpressionType.is(ExprType.LONG)) {
+        // intervals can be longs without an explicit cast
         typeCastExpression = operandExpression;
       } else {
         // Ignore casts for simple extractions (use Function.identity) since it is ok in many cases.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -99,7 +99,6 @@ public class CastOperatorConversion implements SqlOperatorConversion
       final DruidExpression typeCastExpression;
 
       if (fromExpressionType.equals(toExpressionType)) {
-        // Ignore casts for simple extractions since it is ok in many cases.
         typeCastExpression = operandExpression;
       } else {
         // Ignore casts for simple extractions (use Function.identity) since it is ok in many cases.

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -20,7 +20,6 @@
 package org.apache.druid.sql.calcite.expression.builtin;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -29,7 +28,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
-import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -39,46 +38,10 @@ import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.Period;
 
-import java.util.Map;
 import java.util.function.Function;
 
 public class CastOperatorConversion implements SqlOperatorConversion
 {
-  private static final Map<SqlTypeName, ExprType> EXPRESSION_TYPES;
-
-  static {
-    final ImmutableMap.Builder<SqlTypeName, ExprType> builder = ImmutableMap.builder();
-
-    for (SqlTypeName type : SqlTypeName.FRACTIONAL_TYPES) {
-      builder.put(type, ExprType.DOUBLE);
-    }
-
-    for (SqlTypeName type : SqlTypeName.INT_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    for (SqlTypeName type : SqlTypeName.STRING_TYPES) {
-      builder.put(type, ExprType.STRING);
-    }
-
-    // Booleans are treated as longs in Druid expressions, using two-value logic (positive = true, nonpositive = false).
-    builder.put(SqlTypeName.BOOLEAN, ExprType.LONG);
-
-    // Timestamps are treated as longs (millis since the epoch) in Druid expressions.
-    builder.put(SqlTypeName.TIMESTAMP, ExprType.LONG);
-    builder.put(SqlTypeName.DATE, ExprType.LONG);
-
-    for (SqlTypeName type : SqlTypeName.DAY_INTERVAL_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    for (SqlTypeName type : SqlTypeName.YEAR_INTERVAL_TYPES) {
-      builder.put(type, ExprType.LONG);
-    }
-
-    EXPRESSION_TYPES = builder.build();
-  }
-
   @Override
   public SqlOperator calciteOperator()
   {
@@ -118,28 +81,32 @@ public class CastOperatorConversion implements SqlOperatorConversion
     } else {
       // Handle other casts. If either type is ANY, use the other type instead. If both are ANY, this means nulls
       // downstream, Druid will try its best
-      final ExprType fromExprType = SqlTypeName.ANY.equals(fromType)
-                                    ? EXPRESSION_TYPES.get(toType)
-                                    : EXPRESSION_TYPES.get(fromType);
-      final ExprType toExprType = SqlTypeName.ANY.equals(toType)
-                                  ? EXPRESSION_TYPES.get(fromType)
-                                  : EXPRESSION_TYPES.get(toType);
+      final ColumnType fromDruidType = Calcites.getColumnTypeForRelDataType(operand.getType());
+      final ColumnType toDruidType = Calcites.getColumnTypeForRelDataType(rexNode.getType());
 
-      if (fromExprType == null || toExprType == null) {
+      final ExpressionType fromExpressionType = SqlTypeName.ANY.equals(fromType)
+                                                ? ExpressionType.fromColumnType(toDruidType)
+                                                : ExpressionType.fromColumnType(fromDruidType);
+      final ExpressionType toExpressionType = SqlTypeName.ANY.equals(toType)
+                                              ? ExpressionType.fromColumnType(fromDruidType)
+                                              : ExpressionType.fromColumnType(toDruidType);
+
+      if (fromExpressionType == null || toExpressionType == null) {
         // We have no runtime type for these SQL types.
         return null;
       }
 
       final DruidExpression typeCastExpression;
 
-      if (fromExprType != toExprType) {
+      if (fromExpressionType.equals(toExpressionType)) {
+        // Ignore casts for simple extractions since it is ok in many cases.
+        typeCastExpression = operandExpression;
+      } else {
         // Ignore casts for simple extractions (use Function.identity) since it is ok in many cases.
         typeCastExpression = operandExpression.map(
             Function.identity(),
-            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExprType.toString())
+            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExpressionType.asTypeString())
         );
-      } else {
-        typeCastExpression = operandExpression;
       }
 
       if (toType == SqlTypeName.DATE) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ReductionOperatorConversionHelper.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ReductionOperatorConversionHelper.java
@@ -56,9 +56,16 @@ class ReductionOperatorConversionHelper
         boolean hasDouble = false;
         boolean isString = false;
         for (int i = 0; i < n; i++) {
-          RelDataType type = opBinding.getOperandType(i);
-          SqlTypeName sqlTypeName = type.getSqlTypeName();
-          ColumnType valueType = Calcites.getColumnTypeForRelDataType(type);
+          final RelDataType type = opBinding.getOperandType(i);
+          final SqlTypeName sqlTypeName = type.getSqlTypeName();
+          final ColumnType valueType;
+
+          if (SqlTypeName.INTERVAL_TYPES.contains(type.getSqlTypeName())) {
+            // handle intervals as a LONG type even though it is a string
+            valueType = ColumnType.LONG;
+          } else {
+            valueType = Calcites.getColumnTypeForRelDataType(type);
+          }
 
           // Return types are listed in order of preference:
           if (valueType != null) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -188,7 +188,9 @@ public class Calcites
     return SqlTypeName.TIMESTAMP == sqlTypeName ||
            SqlTypeName.DATE == sqlTypeName ||
            SqlTypeName.BOOLEAN == sqlTypeName ||
-           SqlTypeName.INT_TYPES.contains(sqlTypeName);
+           SqlTypeName.INT_TYPES.contains(sqlTypeName) ||
+           SqlTypeName.DAY_INTERVAL_TYPES.contains(sqlTypeName) ||
+           SqlTypeName.YEAR_INTERVAL_TYPES.contains(sqlTypeName);
   }
 
   public static StringComparator getStringComparatorForRelDataType(RelDataType dataType)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -160,7 +160,7 @@ public class Calcites
       return ColumnType.DOUBLE;
     } else if (isLongType(sqlTypeName)) {
       return ColumnType.LONG;
-    } else if (SqlTypeName.CHAR_TYPES.contains(sqlTypeName)) {
+    } else if (isStringType(sqlTypeName)) {
       return ColumnType.STRING;
     } else if (SqlTypeName.OTHER == sqlTypeName) {
       if (type instanceof RowSignatures.ComplexSqlType) {
@@ -178,6 +178,12 @@ public class Calcites
     }
   }
 
+  public static boolean isStringType(SqlTypeName sqlTypeName)
+  {
+    return SqlTypeName.CHAR_TYPES.contains(sqlTypeName) ||
+           SqlTypeName.INTERVAL_TYPES.contains(sqlTypeName);
+  }
+
   public static boolean isDoubleType(SqlTypeName sqlTypeName)
   {
     return SqlTypeName.FRACTIONAL_TYPES.contains(sqlTypeName) || SqlTypeName.APPROX_TYPES.contains(sqlTypeName);
@@ -188,9 +194,7 @@ public class Calcites
     return SqlTypeName.TIMESTAMP == sqlTypeName ||
            SqlTypeName.DATE == sqlTypeName ||
            SqlTypeName.BOOLEAN == sqlTypeName ||
-           SqlTypeName.INT_TYPES.contains(sqlTypeName) ||
-           SqlTypeName.DAY_INTERVAL_TYPES.contains(sqlTypeName) ||
-           SqlTypeName.YEAR_INTERVAL_TYPES.contains(sqlTypeName);
+           SqlTypeName.INT_TYPES.contains(sqlTypeName);
   }
 
   public static StringComparator getStringComparatorForRelDataType(RelDataType dataType)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1751,8 +1751,7 @@ public class ExpressionsTest extends ExpressionTestBase
             (args) -> "(" + args.get(0).getExpression() + " - " + args.get(1).getExpression() + ")",
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                // RexNode type of "interval day to minute" is not converted to druid long... yet
-                DruidExpression.ofLiteral(null, "90060000")
+                DruidExpression.ofLiteral(ColumnType.LONG, "90060000")
             )
         ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
@@ -1779,8 +1778,7 @@ public class ExpressionsTest extends ExpressionTestBase
             DruidExpression.functionCall("timestamp_shift"),
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                // RexNode type "interval year to month" is not reported as ColumnType.STRING
-                DruidExpression.ofLiteral(null, DruidExpression.stringLiteral("P13M")),
+                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.stringLiteral("P13M")),
                 DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.longLiteral(-1)),
                 DruidExpression.ofStringLiteral("UTC")
             )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -1751,7 +1751,7 @@ public class ExpressionsTest extends ExpressionTestBase
             (args) -> "(" + args.get(0).getExpression() + " - " + args.get(1).getExpression() + ")",
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                DruidExpression.ofLiteral(ColumnType.LONG, "90060000")
+                DruidExpression.ofLiteral(ColumnType.STRING, "90060000")
             )
         ),
         DateTimes.of("2000-02-03T04:05:06").minus(period).getMillis()
@@ -1778,7 +1778,7 @@ public class ExpressionsTest extends ExpressionTestBase
             DruidExpression.functionCall("timestamp_shift"),
             ImmutableList.of(
                 DruidExpression.ofColumn(ColumnType.LONG, "t"),
-                DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.stringLiteral("P13M")),
+                DruidExpression.ofLiteral(ColumnType.STRING, DruidExpression.stringLiteral("P13M")),
                 DruidExpression.ofLiteral(ColumnType.LONG, DruidExpression.longLiteral(-1)),
                 DruidExpression.ofStringLiteral("UTC")
             )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
@@ -246,10 +246,8 @@ public class GreatestExpressionTest extends ExpressionTestBase
   }
 
   @Test
-  public void testInvalidType()
+  public void testIntervalYearMonth()
   {
-    expectException(IllegalArgumentException.class, "Argument 0 has invalid type: INTERVAL_YEAR_MONTH");
-
     testExpression(
         Collections.singletonList(
             testHelper.makeLiteral(
@@ -257,8 +255,8 @@ public class GreatestExpressionTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        null,
-        null
+        buildExpectedExpression(13),
+        13L
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
@@ -247,10 +247,8 @@ public class LeastExpressionTest extends ExpressionTestBase
   }
 
   @Test
-  public void testInvalidType()
+  public void testIntervalYearMonth()
   {
-    expectException(IllegalArgumentException.class, "Argument 0 has invalid type: INTERVAL_YEAR_MONTH");
-
     testExpression(
         Collections.singletonList(
             testHelper.makeLiteral(
@@ -258,8 +256,8 @@ public class LeastExpressionTest extends ExpressionTestBase
                 new SqlIntervalQualifier(TimeUnit.YEAR, TimeUnit.MONTH, SqlParserPos.ZERO)
             )
         ),
-        null,
-        null
+        buildExpectedExpression(13),
+        13L
     );
   }
 


### PR DESCRIPTION
### Description
This PR modifies the SQL `CAST` operator conversion to use `Calcites.getColumnTypeForRelDataType` to convert calcite types to native Druid types instead of using its own custom `SqlTypeName ` to `ExprType` mapping to make it more consistent with other SQL to Druid type conversions done for most other operators. This allows it to handle some additional casts which were not previously supported, such as those with ARRAY types. The test added to `CalciteMultiValueStringQueryTest` was not able to be planned prior to the changes to the `CAST` operator since during planning explicit casts would be added which would then fail since the mapping table was missing arrays.

Switching `CAST` to use `Calcites.getColumnTypeForRelDataType` also required making a small adjustment to this method to be able to handle `SqlTypeName.DAY_INTERVAL_TYPES` and `SqlTypeName.YEAR_INTERVAL_TYPES` as a Druid `LONG` type. This also allows some additional expressions to be planned that were not previously supported, shown in the changes to `ExpressionsTest`, `GreatestExpressionTest`, and `LeastExpressionTest`.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
