### PR TITLE
Fix start-druid for indexers.

### DIFF
--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -471,7 +471,7 @@ def build_memory_config(service, allocated_memory):
         heap_memory = HEAP_TO_TOTAL_MEM_RATIO.get(service) * allocated_memory
         direct_memory = int(allocated_memory - heap_memory)
         heap_memory = int(heap_memory)
-        memory_type, task_count, task_memory = compute_tasks_memory(allocated_memory)
+        task_count, task_memory = compute_tasks_memory(allocated_memory)
         return ['-D{0}={1}'.format(TASK_WORKER_CAPACITY_PROPERTY, task_count),
                 '-Xms{0}m -Xmx{0}m -XX:MaxDirectMemorySize={1}m'.format(heap_memory, direct_memory)], \
                task_memory * task_count


### PR DESCRIPTION
There was an unused parameter causing the unpack to fail.