### PR TITLE
Fix for OOM in the Tombstone generating logic in MSQ

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -748,9 +748,7 @@ public class MSQReplaceTest extends MSQTestBase
                      .setExpectedShardSpec(DimensionRangeShardSpec.class)
                      .setExpectedTombstoneIntervals(
                          ImmutableSet.of(
-                             Intervals.of("2001-04-01/P3M"),
-                             Intervals.of("2001-07-01/P3M"),
-                             Intervals.of("2001-10-01/P3M")
+                             Intervals.of("2001-04-01/2002-01-01")
                          )
                      )
                      .setExpectedResultRows(expectedResults)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
@@ -211,7 +211,7 @@ public class TombstoneHelper
         // the overlap would be 22/02/2023 01:00:00 - 23/02/2023 02:00:00. When iterating over the overlap we will get
         // the intervals from 22/02/2023 - 23/02/2023, and 23/02/2023 - 24/02/2023
 
-        // If the end is aligned, then we donot alter it, else we align the end by geting the earliest time later
+        // If the end is aligned, then we do not alter it, else we align the end by geting the earliest time later
         // than the overlap's end which aligns with the replace granularity. Using the above-mentioned logic for the
         // start time, we can also argue that the rounded up end would be contained in the intervalToDrop
         DateTime alignedIntervalEnd;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
@@ -147,7 +147,7 @@ public class TombstoneHelperTest
         replaceGranularity
     );
     Assert.assertEquals(
-        ImmutableSet.of(Intervals.of("2020-03-05/2020-03-06"), Intervals.of("2020-03-06/2020-03-07")),
+        ImmutableSet.of(Intervals.of("2020-03-05/2020-03-07")),
         tombstoneIntervals
     );
   }
@@ -183,8 +183,7 @@ public class TombstoneHelperTest
     Assert.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-03-01/2020-04-01"),
-            Intervals.of("2020-07-01/2020-08-01"),
-            Intervals.of("2020-08-01/2020-09-01")
+            Intervals.of("2020-07-01/2020-09-01")
         ),
         tombstoneIntervals
     );


### PR DESCRIPTION
While generating tombstones for MSQ (https://github.com/apache/druid/pull/13706) the controller might run into OOM while trying to compute the intervals for which the tombstones need to be generated because we are materializing all the intervals which need to be marked by a tombstone, partitioned by granularity. So for a query that replaces over all, and the existing data source contains a segment for the eternity, this would generate a large number of intervals (given a finite granularity such as DAY).

This PR changes the behavior of the tombstones generating logic wherein for the overlap, we only generate completely disjointed tombstones so that the number of intervals for which tombstones need to be generated do not explode. 

#### Release note
(none)

<hr>

##### Key changed/added classes in this PR
 * `TombstoneHelper`
 * `TombstoneHelperTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
