### PR TITLE
Fix for a merge conflict

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
@@ -183,7 +183,14 @@ public class SegmentTransactionalInsertActionTest
         actionTestKit.getTaskActionToolbox()
     );
 
-    Assert.assertEquals(SegmentPublishResult.fail("java.lang.RuntimeException: Aborting transaction!"), result);
+    Assert.assertEquals(
+        SegmentPublishResult.fail(
+          "java.lang.RuntimeException: Inconsistent metadata state. " +
+          "This can happen if you update input topic in a spec without changing the supervisor name. " +
+          "Stored state: [null], Target state: [ObjectMetadata{theObject=[1]}]."
+        ),
+        result
+    );
   }
 
   @Test
@@ -203,7 +210,13 @@ public class SegmentTransactionalInsertActionTest
         actionTestKit.getTaskActionToolbox()
     );
 
-    Assert.assertEquals(SegmentPublishResult.fail("org.apache.druid.metadata.RetryTransactionException: Aborting transaction!"), result);
+    Assert.assertEquals(
+        SegmentPublishResult.fail(
+            "org.apache.druid.metadata.RetryTransactionException: " +
+            "Failed to drop some segments. Only 0 could be dropped out of 1. Trying again"
+        ),
+        result
+    );
   }
 
   @Test


### PR DESCRIPTION
Fixes a merge conflict that arose when I merged an older PR on top of more recent changes. The build in that PR was against the master at that time; some files changed since and caused a conflict.

Basically tests checked for old error messages when the merged PR changed those messages.

This PR uses the correct, newer messages.

#### Release note

No user-visible changes.

<hr>

- [X] been self-reviewed.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
