### PR TITLE
Avoid creating new RelDataTypeFactory during SQL planning.

### DIFF
--- a/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalSqlAggregatorBase.java
+++ b/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalSqlAggregatorBase.java
@@ -90,6 +90,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -114,6 +115,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
 
     if (aggregateCall.getArgList().size() >= 2) {
       RexNode sizeArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(1)
@@ -127,6 +129,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
 
     if (aggregateCall.getArgList().size() >= 3) {
       RexNode scaleArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)
@@ -139,6 +142,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
 
     if (aggregateCall.getArgList().size() >= 4) {
       RexNode useStrictNumberParsingArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(3)

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
@@ -74,6 +74,7 @@ public class TDigestGenerateSketchSqlAggregator implements SqlAggregator
   )
   {
     final RexNode inputOperand = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(0)
@@ -93,6 +94,7 @@ public class TDigestGenerateSketchSqlAggregator implements SqlAggregator
     Integer compression = TDigestSketchAggregatorFactory.DEFAULT_COMPRESSION;
     if (aggregateCall.getArgList().size() > 1) {
       RexNode compressionOperand = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(1)

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
@@ -81,6 +81,7 @@ public class TDigestSketchQuantileSqlAggregator implements SqlAggregator
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -95,6 +96,7 @@ public class TDigestSketchQuantileSqlAggregator implements SqlAggregator
 
     // this is expected to be quantile fraction
     final RexNode quantileArg = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)
@@ -109,6 +111,7 @@ public class TDigestSketchQuantileSqlAggregator implements SqlAggregator
     Integer compression = TDigestSketchAggregatorFactory.DEFAULT_COMPRESSION;
     if (aggregateCall.getArgList().size() > 2) {
       final RexNode compressionArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -76,6 +76,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
     // Don't use Aggregations.getArgumentsForSimpleAggregator, since it won't let us use direct column access
     // for string columns.
     final RexNode columnRexNode = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(0)
@@ -89,6 +90,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
     final int logK;
     if (aggregateCall.getArgList().size() >= 2) {
       final RexNode logKarg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(1)
@@ -107,6 +109,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
     final String tgtHllType;
     if (aggregateCall.getArgList().size() >= 3) {
       final RexNode tgtHllTypeArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
@@ -83,6 +83,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -95,6 +96,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
     final String histogramName = StringUtils.format("%s:agg", name);
     final RexNode probabilityArg = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)
@@ -110,6 +112,7 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
 
     if (aggregateCall.getArgList().size() >= 3) {
       final RexNode resolutionArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
@@ -79,6 +79,7 @@ public class DoublesSketchObjectSqlAggregator implements SqlAggregator
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -94,6 +95,7 @@ public class DoublesSketchObjectSqlAggregator implements SqlAggregator
 
     if (aggregateCall.getArgList().size() >= 2) {
       final RexNode resolutionArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(1)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -73,6 +73,7 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
     // Don't use Aggregations.getArgumentsForSimpleAggregator, since it won't let us use direct column access
     // for string columns.
     final RexNode columnRexNode = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(0)
@@ -86,6 +87,7 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
     final int sketchSize;
     if (aggregateCall.getArgList().size() >= 2) {
       final RexNode sketchSizeArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(1)

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
@@ -76,6 +76,7 @@ public class BloomFilterSqlAggregator implements SqlAggregator
   )
   {
     final RexNode inputOperand = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(0)
@@ -92,6 +93,7 @@ public class BloomFilterSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
     final String aggName = StringUtils.format("%s:agg", name);
     final RexNode maxNumEntriesOperand = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
@@ -79,6 +79,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -91,6 +92,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
     final String histogramName = StringUtils.format("%s:agg", name);
     final RexNode probabilityArg = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)
@@ -106,6 +108,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     final int numBuckets;
     if (aggregateCall.getArgList().size() >= 3) {
       final RexNode numBucketsArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)
@@ -124,6 +127,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     final double lowerLimit;
     if (aggregateCall.getArgList().size() >= 4) {
       final RexNode lowerLimitArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(3)
@@ -142,6 +146,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     final double upperLimit;
     if (aggregateCall.getArgList().size() >= 5) {
       final RexNode upperLimitArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(4)
@@ -160,6 +165,7 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     final FixedBucketsHistogram.OutlierHandlingMode outlierHandlingMode;
     if (aggregateCall.getArgList().size() >= 6) {
       final RexNode outlierHandlingModeArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(5)

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -81,6 +81,7 @@ public class QuantileSqlAggregator implements SqlAggregator
         plannerContext,
         rowSignature,
         Expressions.fromFieldAccess(
+            rexBuilder.getTypeFactory(),
             rowSignature,
             project,
             aggregateCall.getArgList().get(0)
@@ -93,6 +94,7 @@ public class QuantileSqlAggregator implements SqlAggregator
     final AggregatorFactory aggregatorFactory;
     final String histogramName = StringUtils.format("%s:agg", name);
     final RexNode probabilityArg = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)
@@ -108,6 +110,7 @@ public class QuantileSqlAggregator implements SqlAggregator
 
     if (aggregateCall.getArgList().size() >= 3) {
       final RexNode resolutionArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
@@ -66,6 +66,7 @@ public abstract class BaseVarianceSqlAggregator implements SqlAggregator
   )
   {
     final RexNode inputOperand = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(0)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/Aggregations.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/Aggregations.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.aggregation;
 
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
@@ -57,6 +58,7 @@ public class Aggregations
    */
   @Nullable
   public static List<DruidExpression> getArgumentsForSimpleAggregator(
+      final RexBuilder rexBuilder,
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
       final AggregateCall call,
@@ -66,7 +68,7 @@ public class Aggregations
     final List<DruidExpression> args = call
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .map(rexNode -> toDruidExpressionForNumericAggregator(plannerContext, rowSignature, rexNode))
         .collect(Collectors.toList());
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArrayConcatSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArrayConcatSqlAggregator.java
@@ -80,7 +80,7 @@ public class ArrayConcatSqlAggregator implements SqlAggregator
     final List<RexNode> arguments = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .collect(Collectors.toList());
 
     Integer maxSizeBytes = null;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
@@ -82,7 +82,7 @@ public class ArraySqlAggregator implements SqlAggregator
     final List<RexNode> arguments = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .collect(Collectors.toList());
 
     Integer maxSizeBytes = null;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/AvgSqlAggregator.java
@@ -70,6 +70,7 @@ public class AvgSqlAggregator implements SqlAggregator
   {
 
     final List<DruidExpression> arguments = Aggregations.getArgumentsForSimpleAggregator(
+        rexBuilder,
         plannerContext,
         rowSignature,
         aggregateCall,
@@ -108,6 +109,7 @@ public class AvgSqlAggregator implements SqlAggregator
       fieldName = arg.getDirectColumn();
     } else {
       final RexNode resolutionArg = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           Iterables.getOnlyElement(aggregateCall.getArgList())

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BitwiseSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BitwiseSqlAggregator.java
@@ -133,7 +133,7 @@ public class BitwiseSqlAggregator implements SqlAggregator
     final List<DruidExpression> arguments = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .map(rexNode -> Expressions.toDruidExpression(plannerContext, rowSignature, rexNode))
         .collect(Collectors.toList());
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -85,6 +85,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
     // Don't use Aggregations.getArgumentsForSimpleAggregator, since it won't let us use direct column access
     // for string columns.
     final RexNode rexNode = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         Iterables.getOnlyElement(aggregateCall.getArgList())

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/CountSqlAggregator.java
@@ -73,6 +73,7 @@ public class CountSqlAggregator implements SqlAggregator
   )
   {
     final RexNode rexNode = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         Iterables.getOnlyElement(aggregateCall.getArgList())
@@ -112,6 +113,7 @@ public class CountSqlAggregator implements SqlAggregator
   )
   {
     final List<DruidExpression> args = Aggregations.getArgumentsForSimpleAggregator(
+        rexBuilder,
         plannerContext,
         rowSignature,
         aggregateCall,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
@@ -176,7 +176,7 @@ public class EarliestLatestAnySqlAggregator implements SqlAggregator
     final List<RexNode> rexNodes = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .collect(Collectors.toList());
 
     final List<DruidExpression> args = Expressions.toDruidExpressions(plannerContext, rowSignature, rexNodes);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
@@ -89,7 +89,7 @@ public class EarliestLatestBySqlAggregator implements SqlAggregator
     final List<RexNode> rexNodes = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .collect(Collectors.toList());
 
     final List<DruidExpression> args = Expressions.toDruidExpressions(plannerContext, rowSignature, rexNodes);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/GroupingSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/GroupingSqlAggregator.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.aggregation.builtin;
 
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -69,6 +70,7 @@ public class GroupingSqlAggregator implements SqlAggregator
                                               rowSignature,
                                               project,
                                               virtualColumnRegistry,
+                                              rexBuilder.getTypeFactory(),
                                               i
                                           ))
                                           .filter(Objects::nonNull)
@@ -100,10 +102,11 @@ public class GroupingSqlAggregator implements SqlAggregator
       RowSignature rowSignature,
       Project project,
       VirtualColumnRegistry virtualColumnRegistry,
+      RelDataTypeFactory typeFactory,
       int fieldNumber
   )
   {
-    RexNode node = Expressions.fromFieldAccess(rowSignature, project, fieldNumber);
+    RexNode node = Expressions.fromFieldAccess(typeFactory, rowSignature, project, fieldNumber);
     if (null == node) {
       return null;
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MultiColumnSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/MultiColumnSqlAggregator.java
@@ -90,6 +90,7 @@ public abstract class MultiColumnSqlAggregator implements SqlAggregator
     }
 
     final List<DruidExpression> arguments = Aggregations.getArgumentsForSimpleAggregator(
+        rexBuilder,
         plannerContext,
         rowSignature,
         aggregateCall,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/SimpleSqlAggregator.java
@@ -64,6 +64,7 @@ public abstract class SimpleSqlAggregator implements SqlAggregator
     }
 
     final List<DruidExpression> arguments = Aggregations.getArgumentsForSimpleAggregator(
+        rexBuilder,
         plannerContext,
         rowSignature,
         aggregateCall,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
@@ -88,7 +88,7 @@ public class StringSqlAggregator implements SqlAggregator
     final List<DruidExpression> arguments = aggregateCall
         .getArgList()
         .stream()
-        .map(i -> Expressions.fromFieldAccess(rowSignature, project, i))
+        .map(i -> Expressions.fromFieldAccess(rexBuilder.getTypeFactory(), rowSignature, project, i))
         .map(rexNode -> Expressions.toDruidExpression(plannerContext, rowSignature, rexNode))
         .collect(Collectors.toList());
 
@@ -97,6 +97,7 @@ public class StringSqlAggregator implements SqlAggregator
     }
 
     RexNode separatorNode = Expressions.fromFieldAccess(
+        rexBuilder.getTypeFactory(),
         rowSignature,
         project,
         aggregateCall.getArgList().get(1)
@@ -115,6 +116,7 @@ public class StringSqlAggregator implements SqlAggregator
     Integer maxSizeBytes = null;
     if (arguments.size() > 2) {
       RexNode maxBytes = Expressions.fromFieldAccess(
+          rexBuilder.getTypeFactory(),
           rowSignature,
           project,
           aggregateCall.getArgList().get(2)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -21,8 +21,8 @@ package org.apache.druid.sql.calcite.expression;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
@@ -83,6 +83,7 @@ public class Expressions
   /**
    * Translate a field access, possibly through a projection, to an underlying Druid dataSource.
    *
+   * @param typeFactory  factory for creating SQL types
    * @param rowSignature row signature of underlying Druid dataSource
    * @param project      projection, or null
    * @param fieldNumber  number of the field to access
@@ -90,19 +91,14 @@ public class Expressions
    * @return row expression
    */
   public static RexNode fromFieldAccess(
+      final RelDataTypeFactory typeFactory,
       final RowSignature rowSignature,
       @Nullable final Project project,
       final int fieldNumber
   )
   {
     if (project == null) {
-      // Gian doesn't think the factory impl matters here, he's likely correct.  But, upon reading what this is doing,
-      // we are re-building the list of things in the RelDataType for every single call to `fromFieldAccess`.
-      // `fromFieldAccess` is called pretty regularly in pretty low-level areas of the code, so it would make sense
-      // that we are perhaps re-creating the exact same object over and over and over and over again and wasting CPU
-      // cycles.  It would likely be good to refactor the code such that we ensure we only ever compute the thing
-      // once and then reuse it.
-      return RexInputRef.of(fieldNumber, RowSignatures.toRelDataType(rowSignature, new JavaTypeFactoryImpl()));
+      return RexInputRef.of(fieldNumber, RowSignatures.toRelDataType(rowSignature, typeFactory));
     } else {
       return project.getChildExps().get(fieldNumber);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
@@ -420,7 +421,8 @@ public class DruidQuery
         partialQuery,
         plannerContext,
         rowSignature,
-        virtualColumnRegistry
+        virtualColumnRegistry,
+        rexBuilder.getTypeFactory()
     );
 
     final Subtotals subtotals = computeSubtotals(
@@ -469,6 +471,7 @@ public class DruidQuery
    * @param plannerContext        planner context
    * @param rowSignature          source row signature
    * @param virtualColumnRegistry re-usable virtual column references
+   * @param typeFactory           factory for SQL types
    * @return dimensions
    * @throws CannotBuildQueryException if dimensions cannot be computed
    */
@@ -476,7 +479,8 @@ public class DruidQuery
       final PartialDruidQuery partialQuery,
       final PlannerContext plannerContext,
       final RowSignature rowSignature,
-      final VirtualColumnRegistry virtualColumnRegistry
+      final VirtualColumnRegistry virtualColumnRegistry,
+      final RelDataTypeFactory typeFactory
   )
   {
     final Aggregate aggregate = Preconditions.checkNotNull(partialQuery.getAggregate());
@@ -488,6 +492,7 @@ public class DruidQuery
     for (int i : aggregate.getGroupSet()) {
       // Dimension might need to create virtual columns. Avoid giving it a name that would lead to colliding columns.
       final RexNode rexNode = Expressions.fromFieldAccess(
+          typeFactory,
           rowSignature,
           partialQuery.getSelectProject(),
           i

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -26,6 +26,7 @@ import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
@@ -83,25 +84,26 @@ public class Windowing
 {
   private static final ImmutableMap<String, ProcessorMaker> KNOWN_WINDOW_FNS = ImmutableMap
       .<String, ProcessorMaker>builder()
-      .put("LAG", (agg) -> new WindowOffsetProcessor(agg.getColumn(0), agg.getOutputName(), -agg.getConstantInt(1)))
-      .put("LEAD", (agg) -> new WindowOffsetProcessor(agg.getColumn(0), agg.getOutputName(), agg.getConstantInt(1)))
-      .put("FIRST_VALUE", (agg) -> new WindowFirstProcessor(agg.getColumn(0), agg.getOutputName()))
-      .put("LAST_VALUE", (agg) -> new WindowLastProcessor(agg.getColumn(0), agg.getOutputName()))
-      .put(
-          "CUME_DIST",
-          (agg) -> new WindowCumeDistProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName())
-      )
-      .put(
-          "DENSE_RANK",
-          (agg) -> new WindowDenseRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName())
-      )
-      .put("NTILE", (agg) -> new WindowPercentileProcessor(agg.getOutputName(), agg.getConstantInt(0)))
-      .put(
-          "PERCENT_RANK",
-          (agg) -> new WindowRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName(), true)
-      )
-      .put("RANK", (agg) -> new WindowRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName(), false))
-      .put("ROW_NUMBER", (agg) -> new WindowRowNumberProcessor(agg.getOutputName()))
+      .put("LAG", (agg, typeFactory) ->
+          new WindowOffsetProcessor(agg.getColumn(typeFactory, 0), agg.getOutputName(), -agg.getConstantInt(1)))
+      .put("LEAD", (agg, typeFactory) ->
+          new WindowOffsetProcessor(agg.getColumn(typeFactory, 0), agg.getOutputName(), agg.getConstantInt(1)))
+      .put("FIRST_VALUE", (agg, typeFactory) ->
+          new WindowFirstProcessor(agg.getColumn(typeFactory, 0), agg.getOutputName()))
+      .put("LAST_VALUE", (agg, typeFactory) ->
+          new WindowLastProcessor(agg.getColumn(typeFactory, 0), agg.getOutputName()))
+      .put("CUME_DIST", (agg, typeFactory) ->
+          new WindowCumeDistProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName()))
+      .put("DENSE_RANK", (agg, typeFactory) ->
+          new WindowDenseRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName()))
+      .put("NTILE", (agg, typeFactory) ->
+          new WindowPercentileProcessor(agg.getOutputName(), agg.getConstantInt(0)))
+      .put("PERCENT_RANK", (agg, typeFactory) ->
+          new WindowRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName(), true))
+      .put("RANK", (agg, typeFactory) ->
+          new WindowRankProcessor(agg.getGroup().getOrderingColumNames(), agg.getOutputName(), false))
+      .put("ROW_NUMBER", (agg, typeFactory) ->
+          new WindowRowNumberProcessor(agg.getOutputName()))
       .build();
   private final List<OperatorFactory> ops;
 
@@ -185,7 +187,8 @@ public class Windowing
                   partialQuery.getSelectProject(),
                   window.constants,
                   group
-              )
+              ),
+              rexBuilder.getTypeFactory()
           ));
         }
       }
@@ -242,7 +245,7 @@ public class Windowing
 
   private interface ProcessorMaker
   {
-    Processor make(WindowAggregate agg);
+    Processor make(WindowAggregate agg, RelDataTypeFactory typeFactory);
   }
 
   private static class WindowGroup
@@ -376,9 +379,10 @@ public class Windowing
       return group;
     }
 
-    public String getColumn(int argPosition)
+    public String getColumn(final RelDataTypeFactory typeFactory, int argPosition)
     {
-      RexNode columnArgument = Expressions.fromFieldAccess(sig, project, call.getArgList().get(argPosition));
+      final RexNode columnArgument =
+          Expressions.fromFieldAccess(typeFactory, sig, project, call.getArgList().get(argPosition));
       final DruidExpression expression = Expressions.toDruidExpression(context, sig, columnArgument);
       if (expression == null) {
         throw new ISE("Couldn't get an expression from columnArgument[%s]", columnArgument);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import org.apache.calcite.DataContext;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.rel.type.RelDataType;
@@ -59,7 +58,6 @@ import org.apache.druid.sql.calcite.table.DruidTable;
 import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import javax.annotation.Nullable;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -330,7 +328,7 @@ public class InformationSchema extends AbstractSchema
                 public Iterable<Object[]> apply(final String schemaName)
                 {
                   final SchemaPlus subSchema = rootSchema.getSubSchema(schemaName);
-                  final JavaTypeFactoryImpl typeFactory = new JavaTypeFactoryImpl(TYPE_SYSTEM);
+                  final RelDataTypeFactory typeFactory = root.getTypeFactory();
 
                   final AuthenticationResult authenticationResult =
                       (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);


### PR DESCRIPTION
Reduces unnecessary CPU cycles.