### PR TITLE
Report engine as a dimension for sqlQuery metrics

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -61,9 +61,9 @@ Metrics may have additional dimensions beyond those listed above.
 |`query/timeout/count`|Number of timed out queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/segments/count`|This metric is not enabled by default. See the `QueryMetrics` Interface for reference regarding enabling this metric. Number of segments that will be touched by the query. In the broker, it makes a plan to distribute the query to realtime tasks and historicals based on a snapshot of segment distribution state. If there are some segments moved after this snapshot is created, certain historicals and realtime tasks can report those segments as missing to the broker. The broker will resend the query to the new servers that serve those segments after move. In this case, those segments can be counted more than once in this metric.||Varies|
 |`query/priority`|Assigned lane and priority, only if Laning strategy is enabled. Refer to [Laning strategies](../configuration/index.md#laning-strategies)|`lane`, `dataSource`, `type`|0|
-|`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`|< 1s|
-|`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
-|`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`| |
+|`sqlQuery/time`|Milliseconds taken to complete a SQL query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`|< 1s|
+|`sqlQuery/planningTimeMs`|Milliseconds taken to plan a SQL to native query.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |
+|`sqlQuery/bytes`|Number of bytes returned in the SQL query response.|`id`, `nativeQueryIds`, `dataSource`, `remoteAddress`, `success`, `engine`| |
 |`init/serverview/time`|Time taken to initialize the broker server view. Useful to detect if brokers are taking too long to start.||Depends on the number of segments.|
 |`init/metadatacache/time`|Time taken to initialize the broker segment metadata cache. Useful to detect if brokers are taking too long to start||Depends on the number of segments.|
 

--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -94,6 +94,9 @@ public class SqlExecutionReporter
         metricBuilder.setDimension("id", plannerContext.getSqlQueryId());
         metricBuilder.setDimension("nativeQueryIds", plannerContext.getNativeQueryIds().toString());
       }
+      if (stmt.sqlToolbox.engine != null) {
+        metricBuilder.setDimension("engine", stmt.sqlToolbox.engine.name());
+      }
       if (stmt.authResult != null) {
         // Note: the dimension is "dataSource" (sic), so we log only the SQL resource
         // actions. Even here, for external tables, those actions are not always


### PR DESCRIPTION
### Description

Add engine as a dimension to all sqlQuery metrics. This will make it possible for users to distinguish between query times based on the type of query that is run.

```
2023-03-09T05:32:06,622 INFO [qtp92340202-127] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"version":"26.0.0-SNAPSHOT","nativeQueryIds":"[]","feed":"metrics","metric":"sqlQuery/time","engine":"msq-task","service":"druid/broker","success":"true","host":"localhost:8082","id":"26a781d4-4bbe-4204-afe9-8cede71d79d6","value":43,"dataSource":"[EXTERNAL]","remoteAddress":"127.0.0.1","timestamp":"2023-03-09T05:32:06.620Z"}
2023-03-09T05:32:06,622 INFO [qtp92340202-127] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"version":"26.0.0-SNAPSHOT","nativeQueryIds":"[]","feed":"metrics","metric":"sqlQuery/bytes","engine":"msq-task","service":"druid/broker","success":"true","host":"localhost:8082","id":"26a781d4-4bbe-4204-afe9-8cede71d79d6","value":0,"dataSource":"[EXTERNAL]","remoteAddress":"127.0.0.1","timestamp":"2023-03-09T05:32:06.622Z"}
2023-03-09T05:32:06,622 INFO [sql[8a5aa00a-65e8-472d-83ab-6705cb5a18e0]] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"version":"26.0.0-SNAPSHOT","nativeQueryIds":"[]","feed":"metrics","metric":"sqlQuery/time","engine":"native","service":"druid/broker","success":"true","host":"localhost:8082","id":"8a5aa00a-65e8-472d-83ab-6705cb5a18e0","value":44,"dataSource":"[]","remoteAddress":"127.0.0.1","timestamp":"2023-03-09T05:32:06.622Z"}
2023-03-09T05:32:06,622 INFO [qtp92340202-127] org.apache.druid.java.util.emitter.core.LoggingEmitter - {"version":"26.0.0-SNAPSHOT","nativeQueryIds":"[]","feed":"metrics","metric":"sqlQuery/planningTimeMs","engine":"msq-task","service":"druid/broker","success":"true","host":"localhost:8082","id":"26a781d4-4bbe-4204-afe9-8cede71d79d6","value":27,"dataSource":"[EXTERNAL]","remoteAddress":"127.0.0.1","timestamp":"2023-03-09T05:32:06.622Z"}
```

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
