### PR TITLE
Improve documentation for tombstone generation and minor improvement

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
@@ -26,6 +26,7 @@ import org.apache.druid.indexing.common.actions.RetrieveUsedSegmentsAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.segment.indexing.DataSchema;
@@ -229,7 +230,7 @@ public class TombstoneHelper
           alignedIntervalEnd = replaceGranularity.bucketEnd(overlap.getEnd());
         }
         long alignedIntervalEndMillis = Math.min(alignedIntervalEnd.getMillis(), JodaUtils.MAX_INSTANT);
-        Interval alignedTombstoneInterval = new Interval(alignedIntervalStartMillis, alignedIntervalEndMillis);
+        Interval alignedTombstoneInterval = Intervals.utc(alignedIntervalStartMillis, alignedIntervalEndMillis);
 
         retVal.add(alignedTombstoneInterval);
       }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelper.java
@@ -93,7 +93,7 @@ public class TombstoneHelper
     List<Interval> retVal = new ArrayList<>();
     GranularitySpec granularitySpec = dataSchema.getGranularitySpec();
     List<Interval> pushedSegmentsIntervals = getCondensedPushedSegmentsIntervals(pushedSegments);
-    List<Interval> intervalsForUsedSegments = getCondensedUsedIntervals(
+    List<Interval> intervalsForUsedSegments = getExistingNonEmptyIntervalsOfDatasource(
         dataSchema.getGranularitySpec().inputIntervals(),
         dataSchema.getDataSource()
     );
@@ -165,11 +165,12 @@ public class TombstoneHelper
   }
 
   /**
-   * @param intervalsToDrop Empty intervals in the query that need to be dropped. They should be aligned with the
-   *                        replaceGranularity
+   * See the method body for an example and an indepth explanation as to how the replace interval is created
+   * @param intervalsToDrop    Empty intervals in the query that need to be dropped. They should be aligned with the
+   *                           replaceGranularity
    * @param intervalsToReplace Intervals in the query which are eligible for replacement with new data.
    *                           They should be aligned with the replaceGranularity
-   * @param dataSource Datasource on which the replace is to be performed
+   * @param dataSource         Datasource on which the replace is to be performed
    * @param replaceGranularity Granularity of the replace query
    * @return Intervals computed for the tombstones
    * @throws IOException
@@ -182,7 +183,7 @@ public class TombstoneHelper
   ) throws IOException
   {
     Set<Interval> retVal = new HashSet<>();
-    List<Interval> usedIntervals = getCondensedUsedIntervals(intervalsToReplace, dataSource);
+    List<Interval> usedIntervals = getExistingNonEmptyIntervalsOfDatasource(intervalsToReplace, dataSource);
 
     for (Interval intervalToDrop : intervalsToDrop) {
       for (Interval usedInterval : usedIntervals) {
@@ -194,22 +195,29 @@ public class TombstoneHelper
           continue;
         }
 
-        // Overlap might not be aligned with the granularity if the used interval is not aligned with the granularity
-        // However we align the boundaries manually, in the following code.
+        // "overlap" might not be aligned with the if the used interval is not aligned with the granularity of
+        // the REPLACE i.e. datasource's original granularity and replace's granularity are different
 
-        // If the start is aligned, then bucketStart is idempotent, else it will return the latest timestamp less than
-        // overlap.getStart() which aligns with the replace granularity. That extra interval that we are including
-        // before the overlap should be contained in intervalToDrop because intervalToDrop is aligned by the
-        // replaceGranularity, and the overlap's beginning would always be later than intervalToDrop (trivially,
-        // because its the overlap) and if bucketStart floors the overlap beginning, it cannot floor it before
-        // the intervalToDrop's start
+        // However, we align the boundaries of the overlap with the replaceGranularity manually, in the following code.
+
         DateTime alignedIntervalStart = replaceGranularity.bucketStart(overlap.getStart());
+        long alignedIntervalStartMillis = Math.max(alignedIntervalStart.getMillis(), JodaUtils.MIN_INSTANT);
+        // If the start is aligned, then 'bucketStart()' is unchanged.
+        // Else 'bucketStart()' will return the latest timestamp less than overlap.getStart() which aligns with the REPLACE granularity.
+
+        // That extra interval that we are adding before the overlap should be contained in 'intervalToDrop' because
+        // intervalToDrop is aligned by the replaceGranularity.
+        // If the drop's interval is n, then the extra interval would start from n + 1 (where 1 denotes the replaceGranularity)
+        // The overlap's beginning would always be later than intervalToDrop (trivially,
+        // because it is the overlap) and if bucketStart floors the overlap beginning, it cannot floor it before
+        // the intervalToDrop's start
 
         // For example, if the replace granularity is DAY, intervalsToReplace are 20/02/2023 - 24/02/2023 (always
         // aligned with the replaceGranularity), intervalsToDrop are 22/02/2023 - 24/02/2023 (they must also be aligned with the replaceGranularity)
         // If the relevant usedIntervals for the datasource are from 22/02/2023 01:00:00 - 23/02/2023 02:00:00, then
         // the overlap would be 22/02/2023 01:00:00 - 23/02/2023 02:00:00. When iterating over the overlap we will get
-        // the intervals from 22/02/2023 - 23/02/2023, and 23/02/2023 - 24/02/2023
+        // the intervals from 22/02/2023 01:00:00 - 23/02/2023 02:00:00. After aligning it would become
+        // 22/02/2023T00:00:00Z - 23/02/2023T23:59:59Z
 
         // If the end is aligned, then we do not alter it, else we align the end by geting the earliest time later
         // than the overlap's end which aligns with the replace granularity. Using the above-mentioned logic for the
@@ -220,7 +228,8 @@ public class TombstoneHelper
         } else {
           alignedIntervalEnd = replaceGranularity.bucketEnd(overlap.getEnd());
         }
-        Interval alignedTombstoneInterval = new Interval(alignedIntervalStart, alignedIntervalEnd);
+        long alignedIntervalEndMillis = Math.min(alignedIntervalEnd.getMillis(), JodaUtils.MAX_INSTANT);
+        Interval alignedTombstoneInterval = new Interval(alignedIntervalStartMillis, alignedIntervalEndMillis);
 
         retVal.add(alignedTombstoneInterval);
       }
@@ -259,13 +268,16 @@ public class TombstoneHelper
   /**
    * Helper method to prune required tombstones. Only tombstones that cover used intervals will be created
    * since those that not cover used intervals will be redundant.
+   * Example:
+   * For a datasource having segments for 2020-01-01/2020-12-31 and 2022-01-01/2022-12-31, this method would return
+   * the segment 2020-01-01/2020-12-31 if the input intervals asked for the segment between 2019 and 2021.
    *
    * @param inputIntervals   Intervals corresponding to the task
    * @param dataSource       Datasource corresponding to the task
    * @return Intervals corresponding to used segments that overlap with any of the spec's input intervals
    * @throws IOException If used segments cannot be retrieved
    */
-  private List<Interval> getCondensedUsedIntervals(
+  private List<Interval> getExistingNonEmptyIntervalsOfDatasource(
       List<Interval> inputIntervals,
       String dataSource
   ) throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
@@ -376,8 +376,8 @@ public class TombstoneHelperTest
     Interval usedInterval = Intervals.ETERNITY;
     Interval replaceInterval = Intervals.ETERNITY;
     List<Interval> intervalsToDrop = ImmutableList.of(
-        new Interval(JodaUtils.MIN_INSTANT, 10000),
-        new Interval(100000, JodaUtils.MAX_INSTANT)
+        Intervals.utc(JodaUtils.MIN_INSTANT, 10000),
+        Intervals.utc(100000, JodaUtils.MAX_INSTANT)
     );
     Granularity replaceGranularity = Granularities.DAY;
 


### PR DESCRIPTION
### Description
As a follow up to https://github.com/apache/druid/pull/13893, this PR improves the comments added along with examples for the code, as well as adds handling for an edge case where the generated tombstone boundaries were overshooting the bounds of MIN_TIME (or MAX_TIME). 

#### Release note
(none)



<hr>

##### Key changed/added classes in this PR
 * `TombstoneHelper`
 * `TombstoneHelperTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
