### PR TITLE
Removing the properties#get forbidden check until we find a fix for java 8. 

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -41,7 +41,6 @@ java.util.HashSet#<init>(int, float) @ Use com.google.collect.Sets#newHashSetWit
 java.util.LinkedHashSet#<init>(int) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedHashSet#<init>(int, float) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedList @ Use ArrayList or ArrayDeque instead
-java.util.Properties#get(java.lang.Object) @ Properties#get method does not check the default map for values. Use Properties#getProperty() instead.
 java.util.Properties#getOrDefault(java.lang.Object,java.lang.Object) @ Properties#getOrDefault method does not check the default map for values. Use Properties#getProperty() instead.
 java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor with a seed (the latter in tests only!)
 java.lang.Math#random() @ Use ThreadLocalRandom.current()


### PR DESCRIPTION
PR #13882 introduced a check which does not seem to work on java 8 but passed on java 11 and java 17.
Removed the check from the forbidden API's to allow CICD to unblock for now. 

