### PR TITLE
Toward catalog completion

### DIFF
--- a/extensions-core/druid-catalog/pom.xml
+++ b/extensions-core/druid-catalog/pom.xml
@@ -50,19 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
-            <artifactId>druid-indexing-service</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.druid</groupId>
             <artifactId>druid-sql</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.druid</groupId>
-            <artifactId>druid-services</artifactId>
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -72,18 +60,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -99,11 +77,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -143,11 +116,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-smile</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi</artifactId>
             <scope>provided</scope>
@@ -163,11 +131,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
@@ -175,36 +138,6 @@
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-server</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.datasketches</groupId>
-            <artifactId>datasketches-java</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.datasketches</groupId>
-            <artifactId>datasketches-memory</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil-core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -215,28 +148,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>nl.jqno.equalsverifier</groupId>
-            <artifactId>equalsverifier</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -262,4 +175,34 @@
         </dependency>
 
     </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+             <!-- tool gets confused between these two items. -->
+             <usedDependencies>
+                <dependency>javax.inject:javax.inject</dependency>
+             </usedDependencies>
+             <ignoredUsedUndeclaredDependencies>
+                <ignoredUsedUndeclaredDependency>javax.inject:javax.inject</ignoredUsedUndeclaredDependency>
+                <ignoredUsedUndeclaredDependency>jakarta.inject:jakarta.inject-api</ignoredUsedUndeclaredDependency>
+            </ignoredUsedUndeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogListenerResource.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogListenerResource.java
@@ -67,4 +67,22 @@ public class CatalogListenerResource
     listener.updated(event);
     return Response.status(Response.Status.ACCEPTED).build();
   }
+
+  @POST
+  @Path("flush")
+  @ResourceFilters(ConfigResourceFilter.class)
+  public Response flush()
+  {
+    listener.flush();
+    return Response.status(Response.Status.ACCEPTED).build();
+  }
+
+  @POST
+  @Path("resync")
+  @ResourceFilters(ConfigResourceFilter.class)
+  public Response resync()
+  {
+    listener.resync();
+    return Response.status(Response.Status.ACCEPTED).build();
+  }
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogResource.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/http/CatalogResource.java
@@ -278,8 +278,7 @@ public class CatalogResource
   // Retrieval
 
   /**
-   * Retrieves the list of all Druid schema names, all table names, or
-   * all table metadata.
+   * Retrieves the list of all Druid schema names.
    *
    * @param format the format of the response. See the code for the
    *        available formats

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogClient.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogClient.java
@@ -86,7 +86,7 @@ public class CatalogClient implements CatalogSource
   @Override
   public List<TableMetadata> tablesForSchema(String dbSchema)
   {
-    String url = StringUtils.replace(SCHEMA_SYNC_PATH, "{dbSchema}", dbSchema);
+    String url = StringUtils.replace(SCHEMA_SYNC_PATH, "{schema}", dbSchema);
     List<TableMetadata> results = send(url, LIST_OF_TABLE_METADATA_TYPE);
 
     // Not found for a list is an empty list.
@@ -96,7 +96,7 @@ public class CatalogClient implements CatalogSource
   @Override
   public TableMetadata table(TableId id)
   {
-    String url = StringUtils.replace(TABLE_SYNC_PATH, "{dbSchema}", id.schema());
+    String url = StringUtils.replace(TABLE_SYNC_PATH, "{schema}", id.schema());
     url = StringUtils.replace(url, "{name}", id.name());
     return send(url, TABLE_METADATA_TYPE);
   }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateListener.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateListener.java
@@ -28,4 +28,6 @@ package org.apache.druid.catalog.sync;
 public interface CatalogUpdateListener
 {
   void updated(UpdateEvent event);
+  void flush();
+  void resync();
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateNotifier.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateNotifier.java
@@ -87,19 +87,31 @@ public class CatalogUpdateNotifier implements CatalogUpdateListener
   public void start()
   {
     notifier.start();
-    LOG.info("Catalog catalog update notifier started");
+    LOG.info("Catalog update notifier started");
   }
 
   @LifecycleStop
   public void stop()
   {
     notifier.stop();
-    LOG.info("Catalog catalog update notifier stopped");
+    LOG.info("Catalog update notifier stopped");
   }
 
   @Override
   public void updated(UpdateEvent event)
   {
     notifier.send(JacksonUtils.toBytes(smileMapper, event));
+  }
+
+  @Override
+  public void flush()
+  {
+    // Not generated on this path
+  }
+
+  @Override
+  public void resync()
+  {
+    // Not generated on this path
   }
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateReceiver.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogUpdateReceiver.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.sync;
+
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+
+import javax.inject.Inject;
+
+/**
+ * Receiver which runs in the Broker to listen for catalog updates from the
+ * Coordinator. To prevent slowing initial queries, this class loads the
+ * current catalog contents into the local cache on lifecycle start, which
+ * avoids the on-demand reads that would otherwise occur. After the first load,
+ * events from the Coordinator keep the local cache evergreen.
+ */
+@ManageLifecycle
+public class CatalogUpdateReceiver
+{
+  private static final EmittingLogger LOG = new EmittingLogger(CatalogUpdateReceiver.class);
+
+  private final CachedMetadataCatalog cachedCatalog;
+
+  @Inject
+  public CatalogUpdateReceiver(
+      final CachedMetadataCatalog cachedCatalog
+  )
+  {
+    this.cachedCatalog = cachedCatalog;
+  }
+
+  @LifecycleStart
+  public void start()
+  {
+    cachedCatalog.resync();
+    LOG.info("Catalog update receiver started");
+  }
+}

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/storage/TableManagerTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/storage/TableManagerTest.java
@@ -207,8 +207,8 @@ public class TableManagerTest
         DatasourceDefn.TARGET_SEGMENT_ROWS_PROPERTY, 1_000_000
     );
     List<ColumnSpec> cols = Arrays.asList(
-        new ColumnSpec("a", Columns.VARCHAR, null),
-        new ColumnSpec("b", Columns.BIGINT, null)
+        new ColumnSpec("a", Columns.STRING, null),
+        new ColumnSpec("b", Columns.LONG, null)
     );
     ColumnSpec colC = new ColumnSpec("c", Columns.DOUBLE, null);
 

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/CatalogCacheTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/CatalogCacheTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.sync;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.catalog.CatalogException.DuplicateKeyException;
+import org.apache.druid.catalog.model.Columns;
+import org.apache.druid.catalog.model.TableId;
+import org.apache.druid.catalog.model.TableMetadata;
+import org.apache.druid.catalog.model.table.TableBuilder;
+import org.apache.druid.catalog.storage.CatalogStorage;
+import org.apache.druid.catalog.storage.CatalogTests;
+import org.apache.druid.metadata.TestDerbyConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Builds on the generic {@link CatalogSyncTest} to focus on cache-specific
+ * operations.
+ */
+public class CatalogCacheTest
+{
+  @Rule
+  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+
+  private CatalogTests.DbFixture dbFixture;
+  private CatalogStorage storage;
+  private ObjectMapper jsonMapper;
+
+  @Before
+  public void setUp()
+  {
+    dbFixture = new CatalogTests.DbFixture(derbyConnectorRule);
+    storage = dbFixture.storage;
+    jsonMapper = new ObjectMapper();
+  }
+
+  @After
+  public void tearDown()
+  {
+    CatalogTests.tearDown(dbFixture);
+  }
+
+  /**
+   * Test overall cache lifecycle. Detailed checks of contents is done
+   * in {@link CatalogSyncTest} and is not repeated here.
+   */
+  @Test
+  public void testLifecycle() throws DuplicateKeyException
+  {
+    // Create entries with no listener.
+    TableMetadata table1 = TableBuilder.datasource("table1", "P1D")
+        .timeColumn()
+        .column("a", Columns.STRING)
+        .build();
+    storage.validate(table1);
+    storage.tables().create(table1);
+
+    // Create a listener. Starts with the cache empty
+    CachedMetadataCatalog cache1 = new CachedMetadataCatalog(storage, storage.schemaRegistry(), jsonMapper);
+    storage.register(cache1);
+    assertTrue(cache1.tableNames(TableId.DRUID_SCHEMA).isEmpty());
+
+    // Load table on demand.
+    assertNotNull(cache1.getTable(table1.id()));
+    assertEquals(1, cache1.tableNames(TableId.DRUID_SCHEMA).size());
+
+    // Flush to empty the cache.
+    cache1.flush();
+    assertTrue(cache1.tableNames(TableId.DRUID_SCHEMA).isEmpty());
+
+    // Resync to reload the cache.
+    cache1.resync();
+    assertEquals(1, cache1.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache1.getTable(table1.id()));
+
+    // Add a table: cache is updated.
+    TableMetadata table2 = TableBuilder.datasource("table2", "P1D")
+        .timeColumn()
+        .column("dim", Columns.STRING)
+        .column("measure", Columns.LONG)
+        .build();
+    storage.validate(table2);
+    storage.tables().create(table2);
+    assertEquals(2, cache1.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache1.getTable(table2.id()));
+
+    // Second listener. Starts with the cache empty.
+    CachedMetadataCatalog cache2 = new CachedMetadataCatalog(storage, storage.schemaRegistry(), jsonMapper);
+    storage.register(cache2);
+    assertTrue(cache2.tableNames(TableId.DRUID_SCHEMA).isEmpty());
+
+    // Second listener resyncs.
+    cache2.resync();
+    assertEquals(2, cache2.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache2.getTable(table1.id()));
+    assertNotNull(cache2.getTable(table2.id()));
+
+    // Add a third table: both caches updated.
+    TableMetadata table3 = TableBuilder.datasource("table3", "PT1H")
+        .timeColumn()
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
+        .build();
+    storage.validate(table3);
+    storage.tables().create(table3);
+    assertEquals(3, cache1.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache1.getTable(table3.id()));
+    assertEquals(3, cache2.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache2.getTable(table3.id()));
+
+    // Another resync puts us back where we are.
+    cache1.flush();
+    assertTrue(cache1.tableNames(TableId.DRUID_SCHEMA).isEmpty());
+    cache1.resync();
+    assertEquals(3, cache1.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache1.getTable(table3.id()));
+
+    cache2.resync();
+    assertEquals(3, cache2.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache2.getTable(table3.id()));
+
+    // Third cache, managed by the receiver.
+    CachedMetadataCatalog cache3 = new CachedMetadataCatalog(storage, storage.schemaRegistry(), jsonMapper);
+    storage.register(cache3);
+    CatalogUpdateReceiver receiver = new CatalogUpdateReceiver(cache3);
+    receiver.start();
+    assertEquals(3, cache3.tableNames(TableId.DRUID_SCHEMA).size());
+    assertNotNull(cache3.getTable(table3.id()));
+  }
+}

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/CatalogSyncTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/CatalogSyncTest.java
@@ -96,7 +96,7 @@ public class CatalogSyncTest
       TableMetadata table = TableBuilder.external("externTable")
           .inputSource(toMap(new InlineInputSource("a\nc")))
           .inputFormat(BaseExternTableTest.CSV_FORMAT)
-          .column("a", Columns.VARCHAR)
+          .column("a", Columns.STRING)
           .build();
       storage.validate(table);
     }
@@ -114,7 +114,7 @@ public class CatalogSyncTest
     {
       TableMetadata table = TableBuilder.external("externTable")
           .inputSource(toMap(new InlineInputSource("a\nc")))
-           .column("a", Columns.VARCHAR)
+           .column("a", Columns.STRING)
           .build();
       assertThrows(IAE.class, () -> storage.validate(table));
     }
@@ -195,15 +195,15 @@ public class CatalogSyncTest
   {
     TableMetadata table1 = TableBuilder.datasource("table1", "P1D")
         .timeColumn()
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     storage.validate(table1);
     storage.tables().create(table1);
 
     TableMetadata table2 = TableBuilder.datasource("table2", "P1D")
         .timeColumn()
-        .column("dim", Columns.VARCHAR)
-        .column("measure", "BIGINT")
+        .column("dim", Columns.STRING)
+        .column("measure", Columns.LONG)
         .build();
     storage.validate(table2);
     storage.tables().create(table2);
@@ -211,7 +211,7 @@ public class CatalogSyncTest
     TableMetadata table3 = TableBuilder.external("table3")
         .inputFormat(BaseExternTableTest.CSV_FORMAT)
         .inputSource(toMap(new InlineInputSource("a\nc")))
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     storage.validate(table3);
     storage.tables().create(table3);
@@ -230,9 +230,9 @@ public class CatalogSyncTest
       List<ColumnSpec> cols = dsSpec.columns();
       assertEquals(2, cols.size());
       assertEquals(Columns.TIME_COLUMN, cols.get(0).name());
-      assertEquals(Columns.TIMESTAMP, cols.get(0).sqlType());
+      assertEquals(Columns.LONG, cols.get(0).dataType());
       assertEquals("a", cols.get(1).name());
-      assertEquals(Columns.VARCHAR, cols.get(1).sqlType());
+      assertEquals(Columns.STRING, cols.get(1).dataType());
 
       DatasourceFacade ds = new DatasourceFacade(catalog.resolveTable(id));
       assertEquals("P1D", ds.segmentGranularityString());
@@ -249,11 +249,11 @@ public class CatalogSyncTest
       assertEquals(3, cols.size());
       assertEquals("__time", cols.get(0).name());
       assertEquals(Columns.TIME_COLUMN, cols.get(0).name());
-      assertEquals(Columns.TIMESTAMP, cols.get(0).sqlType());
+      assertEquals(Columns.LONG, cols.get(0).dataType());
       assertEquals("dim", cols.get(1).name());
-      assertEquals(Columns.VARCHAR, cols.get(1).sqlType());
+      assertEquals(Columns.STRING, cols.get(1).dataType());
       assertEquals("measure", cols.get(2).name());
-      assertEquals("BIGINT", cols.get(2).sqlType());
+      assertEquals(Columns.LONG, cols.get(2).dataType());
 
       DatasourceFacade ds = new DatasourceFacade(catalog.resolveTable(id));
       assertEquals("P1D", ds.segmentGranularityString());
@@ -273,7 +273,7 @@ public class CatalogSyncTest
       List<ColumnSpec> cols = inputSpec.columns();
       assertEquals(1, cols.size());
       assertEquals("a", cols.get(0).name());
-      assertEquals(Columns.VARCHAR, cols.get(0).sqlType());
+      assertEquals(Columns.STRING, cols.get(0).dataType());
 
       assertNotNull(inputSpec.properties());
     }
@@ -303,7 +303,7 @@ public class CatalogSyncTest
     // Create a table 3
     TableMetadata table3 = TableBuilder.datasource("table3", "P1D")
         .timeColumn()
-        .column("x", "FLOAT")
+        .column("x", Columns.FLOAT)
         .build();
     storage.tables().create(table3);
   }
@@ -320,7 +320,7 @@ public class CatalogSyncTest
       assertEquals(Columns.TIME_COLUMN, cols.get(0).name());
       assertEquals("a", cols.get(1).name());
       assertEquals("b", cols.get(2).name());
-      assertEquals(Columns.DOUBLE, cols.get(2).sqlType());
+      assertEquals(Columns.DOUBLE, cols.get(2).dataType());
     }
     {
       TableId id = TableId.datasource("table3");

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/MockCatalogSync.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/sync/MockCatalogSync.java
@@ -55,4 +55,14 @@ public class MockCatalogSync implements CatalogUpdateListener
   {
     return catalog;
   }
+
+  @Override
+  public void flush()
+  {
+  }
+
+  @Override
+  public void resync()
+  {
+  }
 }

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/CatalogResourceTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/CatalogResourceTest.java
@@ -150,9 +150,9 @@ public class CatalogResourceTest
     TableSpec inputSpec = TableBuilder.external("inline")
         .inputSource(toMap(new InlineInputSource("a,b,1\nc,d,2\n")))
         .inputFormat(BaseExternTableTest.CSV_FORMAT)
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.VARCHAR)
-        .column("c", Columns.BIGINT)
+        .column("a", Columns.STRING)
+        .column("b", Columns.STRING)
+        .column("c", Columns.LONG)
         .buildSpec();
     resp = resource.postTable(TableId.EXTERNAL_SCHEMA, "inline", inputSpec, 0, false, postBy(CatalogTests.WRITER_USER));
     assertEquals(Response.Status.OK.getStatusCode(), resp.getStatus());

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/EditorTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/server/http/catalog/EditorTest.java
@@ -401,7 +401,7 @@ public class EditorTest
     // Add a column
     cmd = new UpdateColumns(
         Collections.singletonList(
-            new ColumnSpec("d", Columns.VARCHAR, null)
+            new ColumnSpec("d", Columns.STRING, null)
          )
     );
     TableMetadata revised = doEdit(tableName, cmd);
@@ -411,14 +411,14 @@ public class EditorTest
     );
     ColumnSpec colD = revised.spec().columns().get(3);
     assertEquals("d", colD.name());
-    assertEquals(Columns.VARCHAR, colD.sqlType());
+    assertEquals(Columns.STRING, colD.dataType());
 
     // Update a column
     cmd = new UpdateColumns(
         Collections.singletonList(
             new ColumnSpec(
                 "a",
-                Columns.BIGINT,
+                Columns.LONG,
                 ImmutableMap.of("foo", "bar")
             )
          )
@@ -430,13 +430,13 @@ public class EditorTest
     );
     ColumnSpec colA = revised.spec().columns().get(0);
     assertEquals("a", colA.name());
-    assertEquals(Columns.BIGINT, colA.sqlType());
+    assertEquals(Columns.LONG, colA.dataType());
     assertEquals(ImmutableMap.of("foo", "bar"), colA.properties());
 
     // Duplicates
     UpdateColumns cmd2 = new UpdateColumns(
         Arrays.asList(
-            new ColumnSpec("e", Columns.VARCHAR, null),
+            new ColumnSpec("e", Columns.STRING, null),
             new ColumnSpec("e", null, null)
          )
     );
@@ -445,7 +445,7 @@ public class EditorTest
     // Valid time column type
     cmd = new UpdateColumns(
         Collections.singletonList(
-            new ColumnSpec(Columns.TIME_COLUMN, Columns.TIMESTAMP, null)
+            new ColumnSpec(Columns.TIME_COLUMN, Columns.LONG, null)
          )
     );
     revised = doEdit(tableName, cmd);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
@@ -68,8 +68,8 @@ import static org.junit.Assert.assertTrue;
 public class S3InputSourceDefnTest
 {
   private static final List<ColumnSpec> COLUMNS = Arrays.asList(
-      new ColumnSpec("x", Columns.VARCHAR, null),
-      new ColumnSpec("y", Columns.BIGINT, null)
+      new ColumnSpec("x", Columns.STRING, null),
+      new ColumnSpec("y", Columns.LONG, null)
   );
 
   /**
@@ -110,7 +110,7 @@ public class S3InputSourceDefnTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(ImmutableMap.of("type", S3StorageDruidModule.SCHEME))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -175,7 +175,7 @@ public class S3InputSourceDefnTest
         Collections.singletonList("s3://foo/bar/file.csv"), null, null, null);
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(s3InputSource))
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -214,7 +214,7 @@ public class S3InputSourceDefnTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -227,7 +227,7 @@ public class S3InputSourceDefnTest
         .inputSource(ImmutableMap.of("type", S3StorageDruidModule.SCHEME))
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "s3://foo.com")
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -242,7 +242,7 @@ public class S3InputSourceDefnTest
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "foo.com")
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -261,7 +261,7 @@ public class S3InputSourceDefnTest
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "foo.com")
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -280,7 +280,7 @@ public class S3InputSourceDefnTest
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "foo.com")
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -297,7 +297,7 @@ public class S3InputSourceDefnTest
             )
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "foo.com")
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -556,8 +556,8 @@ public class S3InputSourceDefnTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -592,8 +592,8 @@ public class S3InputSourceDefnTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(s3InputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -635,8 +635,8 @@ public class S3InputSourceDefnTest
         .inputSource(ImmutableMap.of("type", S3StorageDruidModule.SCHEME))
         .inputFormat(CSV_FORMAT)
         .property(S3InputSourceDefn.BUCKET_PROPERTY, "foo.com")
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation

--- a/server/src/main/java/org/apache/druid/catalog/model/CatalogUtils.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/CatalogUtils.java
@@ -98,7 +98,7 @@ public class CatalogUtils
       return type.cast(value);
     }
     catch (ClassCastException e) {
-      throw new IAE("Value [%s] is not valid for property %s, expected type %s",
+      throw new IAE("Value [%s] is not valid for property [%s], expected type [%s]",
           value,
           key,
           type.getSimpleName()

--- a/server/src/main/java/org/apache/druid/catalog/model/TableId.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/TableId.java
@@ -85,6 +85,11 @@ public class TableId
     return StringUtils.format("\"%s\".\"%s\"", schema, name);
   }
 
+  public String unquoted()
+  {
+    return StringUtils.format("%s.%s", schema, name);
+  }
+
   @Override
   public String toString()
   {

--- a/server/src/main/java/org/apache/druid/catalog/model/facade/ExternalTableFacade.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/facade/ExternalTableFacade.java
@@ -22,7 +22,6 @@ package org.apache.druid.catalog.model.facade;
 import org.apache.druid.catalog.model.ColumnSpec;
 import org.apache.druid.catalog.model.Columns;
 import org.apache.druid.catalog.model.ResolvedTable;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 
@@ -40,7 +39,7 @@ public class ExternalTableFacade extends TableFacade
     List<ColumnSpec> columns = spec().columns();
     RowSignature.Builder builder = RowSignature.builder();
     for (ColumnSpec col : columns) {
-      ColumnType druidType = Columns.SQL_TO_DRUID_TYPES.get(StringUtils.toUpperCase(col.sqlType()));
+      ColumnType druidType = Columns.druidType(col);
       if (druidType == null) {
         druidType = ColumnType.STRING;
       }

--- a/server/src/main/java/org/apache/druid/catalog/model/facade/TableFacade.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/facade/TableFacade.java
@@ -61,11 +61,7 @@ public class TableFacade extends ObjectFacade
 
   public static ColumnType druidType(ColumnSpec col)
   {
-    if (Columns.isTimeColumn(col.name())) {
-      return ColumnType.LONG;
-    }
-    final String sqlType = col.sqlType();
-    return sqlType == null ? null : Columns.druidType(sqlType);
+    return Columns.druidType(col);
   }
 
   public ObjectMapper jsonMapper()

--- a/server/src/main/java/org/apache/druid/catalog/model/table/BaseInputSourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/BaseInputSourceDefn.java
@@ -272,7 +272,7 @@ public abstract class BaseInputSourceDefn implements InputSourceDefn
       return columns;
     } else if (!CollectionUtils.isNullOrEmpty(columns)) {
       throw new IAE(
-          "Catalog definition for the %s input source already contains column definitions",
+          "Catalog definition for the [%s] input source already contains column definitions",
           typeValue()
       );
     } else {

--- a/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/DatasourceDefn.java
@@ -148,7 +148,7 @@ public class DatasourceDefn extends TableDefn
   protected void validateColumn(ColumnSpec spec)
   {
     super.validateColumn(spec);
-    if (Columns.isTimeColumn(spec.name()) && spec.sqlType() != null) {
+    if (Columns.isTimeColumn(spec.name()) && spec.dataType() != null) {
       // Validate type in next PR
     }
   }

--- a/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableDefn.java
@@ -206,6 +206,11 @@ public class ExternalTableDefn extends TableDefn
   public static final String TABLE_TYPE = "extern";
 
   /**
+   * Column type for external tables.
+   */
+  public static final String EXTERNAL_COLUMN_TYPE = "extern";
+
+  /**
    * Property which holds the input source specification as serialized as JSON.
    */
   public static final String SOURCE_PROPERTY = "source";

--- a/server/src/main/java/org/apache/druid/catalog/model/table/FormattedInputSourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/FormattedInputSourceDefn.java
@@ -108,7 +108,7 @@ public abstract class FormattedInputSourceDefn extends BaseInputSourceDefn
           toAdd.add(prop);
         } else if (existing.type() != prop.type()) {
           throw new ISE(
-              "Format %s, property %s of class %s conflicts with another format property of class %s",
+              "Format [%s], property [%s] of class [%s] conflicts with another format property of class [%s]",
               format.typeValue(),
               prop.name(),
               prop.type().sqlName(),
@@ -130,7 +130,7 @@ public abstract class FormattedInputSourceDefn extends BaseInputSourceDefn
     final InputFormatDefn formatDefn = formats.get(formatTag);
     if (formatDefn == null) {
       throw new IAE(
-          "Format type [%s] for property %s is not valid",
+          "Format type [%s] for property [%s] is not valid",
           formatTag,
           InputFormat.TYPE_PROPERTY
       );

--- a/server/src/main/java/org/apache/druid/catalog/model/table/TableBuilder.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/TableBuilder.java
@@ -188,7 +188,7 @@ public class TableBuilder
 
   public TableBuilder timeColumn()
   {
-    return column(Columns.TIME_COLUMN, Columns.TIMESTAMP);
+    return column(Columns.TIME_COLUMN, Columns.LONG);
   }
 
   public TableBuilder column(String name, String sqlType)

--- a/server/src/test/java/org/apache/druid/catalog/model/table/BaseExternTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/BaseExternTableTest.java
@@ -39,8 +39,8 @@ public class BaseExternTableTest
 {
   public static final Map<String, Object> CSV_FORMAT = ImmutableMap.of("type", CsvInputFormat.TYPE_KEY);
   protected static final List<ColumnSpec> COLUMNS = Arrays.asList(
-      new ColumnSpec("x", Columns.VARCHAR, null),
-      new ColumnSpec("y", Columns.BIGINT, null)
+      new ColumnSpec("x", Columns.STRING, null),
+      new ColumnSpec("y", Columns.LONG, null)
   );
 
   protected final ObjectMapper mapper = DefaultObjectMapper.INSTANCE;

--- a/server/src/test/java/org/apache/druid/catalog/model/table/CsvInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/CsvInputFormatTest.java
@@ -48,7 +48,7 @@ public class CsvInputFormatTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(CSV_FORMAT)
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -70,8 +70,8 @@ public class CsvInputFormatTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(formatToMap(format))
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.BIGINT)
+        .column("a", Columns.STRING)
+        .column("b", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();

--- a/server/src/test/java/org/apache/druid/catalog/model/table/DelimitedInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/DelimitedInputFormatTest.java
@@ -55,7 +55,7 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
             DelimitedFormatDefn.DELIMITER_FIELD, "|"
             )
          )
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -78,8 +78,8 @@ public class DelimitedInputFormatTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(formatToMap(format))
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.BIGINT)
+        .column("a", Columns.STRING)
+        .column("b", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();

--- a/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/ExternalTableTest.java
@@ -126,7 +126,7 @@ public class ExternalTableTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(formatToMap(format))
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -147,16 +147,16 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputSource(toMap(inputSource))
         .inputFormat(formatToMap(format))
         .description("Sample Wikipedia data")
-        .column("timetamp", Columns.VARCHAR)
-        .column("page", Columns.VARCHAR)
-        .column("language", Columns.VARCHAR)
-        .column("unpatrolled", Columns.VARCHAR)
-        .column("newPage", Columns.VARCHAR)
-        .column("robot", Columns.VARCHAR)
-        .column("added", Columns.VARCHAR)
-        .column("namespace", Columns.BIGINT)
-        .column("deleted", Columns.BIGINT)
-        .column("delta", Columns.BIGINT)
+        .column("timetamp", Columns.STRING)
+        .column("page", Columns.STRING)
+        .column("language", Columns.STRING)
+        .column("unpatrolled", Columns.STRING)
+        .column("newPage", Columns.STRING)
+        .column("robot", Columns.STRING)
+        .column("added", Columns.STRING)
+        .column("namespace", Columns.LONG)
+        .column("deleted", Columns.LONG)
+        .column("delta", Columns.LONG)
         .build();
     LOG.info(table.spec().toString());
   }
@@ -178,9 +178,9 @@ public class ExternalTableTest extends BaseExternTableTest
         .inputFormat(CSV_FORMAT)
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "https://example.com/{}")
         .description("Example parameterized external table")
-        .column("timetamp", Columns.VARCHAR)
-        .column("metric", Columns.VARCHAR)
-        .column("value", Columns.BIGINT)
+        .column("timetamp", Columns.STRING)
+        .column("metric", Columns.STRING)
+        .column("value", Columns.LONG)
         .build();
     LOG.info(table.spec().toString());
   }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
@@ -68,8 +68,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(ImmutableMap.of("type", HttpInputSource.TYPE_KEY))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -83,8 +83,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of("type", HttpInputSource.TYPE_KEY))
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://example.com/")
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -102,8 +102,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     );
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -217,8 +217,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -252,8 +252,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .inputSource(ImmutableMap.of("type", HttpInputSource.TYPE_KEY))
         .inputFormat(CSV_FORMAT)
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://foo.com/{}")
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -301,8 +301,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
          ))
         .inputFormat(CSV_FORMAT)
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://foo.com/{}")
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     table.validate();
@@ -381,8 +381,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -413,8 +413,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         .inputSource(httpToMap(inputSource))
         .inputFormat(CSV_FORMAT)
         .property(HttpInputSourceDefn.URI_TEMPLATE_PROPERTY, "http://foo.com/{}")
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -478,8 +478,8 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation

--- a/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
@@ -51,7 +51,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(ImmutableMap.of("type", InlineInputSource.TYPE_KEY))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -63,7 +63,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     // No format: not valid. For inline, format must be provided to match data
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -86,7 +86,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
+        .column("x", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -130,8 +130,8 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     args.put(InlineInputSourceDefn.DATA_PROPERTY, Arrays.asList("a,b", "c,d"));
     args.put(FormattedInputSourceDefn.FORMAT_PARAMETER, CsvFormatDefn.TYPE_KEY);
     final List<ColumnSpec> columns = Arrays.asList(
-        new ColumnSpec("a", Columns.VARCHAR, null),
-        new ColumnSpec("b", Columns.VARCHAR, null)
+        new ColumnSpec("a", Columns.STRING, null),
+        new ColumnSpec("b", Columns.STRING, null)
     );
 
     final TableFunction fn = defn.adHocTableFn();
@@ -156,8 +156,8 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a,b\nc,d\n")))
         .inputFormat(CSV_FORMAT)
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.VARCHAR)
+        .column("a", Columns.STRING)
+        .column("b", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -181,8 +181,8 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
 
     // Cannot supply columns with the function
     List<ColumnSpec> columns = Arrays.asList(
-        new ColumnSpec("a", Columns.VARCHAR, null),
-        new ColumnSpec("b", Columns.VARCHAR, null)
+        new ColumnSpec("a", Columns.STRING, null),
+        new ColumnSpec("b", Columns.STRING, null)
     );
     assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), columns, mapper));
   }
@@ -196,8 +196,8 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a,b\nc,d")))
         .inputFormat(formatToMap(format))
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.VARCHAR)
+        .column("a", Columns.STRING)
+        .column("b", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();

--- a/server/src/test/java/org/apache/druid/catalog/model/table/JsonInputFormatTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/JsonInputFormatTest.java
@@ -48,7 +48,7 @@ public class JsonInputFormatTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(ImmutableMap.of("type", JsonInputFormat.TYPE_KEY))
-        .column("a", Columns.VARCHAR)
+        .column("a", Columns.STRING)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -70,8 +70,8 @@ public class JsonInputFormatTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(new InlineInputSource("a\n")))
         .inputFormat(formatToMap(format))
-        .column("a", Columns.VARCHAR)
-        .column("b", Columns.BIGINT)
+        .column("a", Columns.STRING)
+        .column("b", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();

--- a/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
@@ -61,8 +61,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(ImmutableMap.of("type", LocalInputSource.TYPE_KEY))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -75,8 +75,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     LocalInputSource inputSource = new LocalInputSource(new File("/tmp"), "*");
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -129,8 +129,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -149,8 +149,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     resolved.validate();
@@ -168,8 +168,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(source)
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
     ResolvedTable resolved = registry.resolve(table.spec());
     assertThrows(IAE.class, () -> resolved.validate());
@@ -319,8 +319,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -370,8 +370,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(toMap(inputSource))
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation
@@ -415,8 +415,8 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     TableMetadata table = TableBuilder.external("foo")
         .inputSource(BASE_DIR_ONLY)
         .inputFormat(CSV_FORMAT)
-        .column("x", Columns.VARCHAR)
-        .column("y", Columns.BIGINT)
+        .column("x", Columns.STRING)
+        .column("y", Columns.LONG)
         .build();
 
     // Check validation

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidTableMacro.java
@@ -87,7 +87,7 @@ public class DruidTableMacro implements ExtendedTableMacro
     final ExternalTableSpec externSpec = fn.apply(
         name,
         Externals.convertArguments(fn, arguments),
-        schema == null ? null : Externals.convertColumns(schema),
+        schema == null ? null : Externals.convertSqlToDruidColumns(schema),
         jsonMapper
     );
     return Externals.buildExternalTable(externSpec, jsonMapper);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -256,15 +256,15 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
       buf.append(sig.getColumnName(i)).append(" ");
       ColumnType type = sig.getColumnType(i).get();
       if (type == ColumnType.STRING) {
-        buf.append(Columns.VARCHAR);
+        buf.append(Columns.SQL_VARCHAR);
       } else if (type == ColumnType.LONG) {
-        buf.append(Columns.BIGINT);
+        buf.append(Columns.SQL_BIGINT);
       } else if (type == ColumnType.DOUBLE) {
-        buf.append(Columns.DOUBLE);
+        buf.append(Columns.SQL_DOUBLE);
       } else if (type == ColumnType.FLOAT) {
-        buf.append(Columns.FLOAT);
+        buf.append(Columns.SQL_FLOAT);
       } else {
-        throw new UOE("Unsupported native type %s", type);
+        throw new UOE("Unsupported native type [%s]", type);
       }
     }
     return buf.append(")").toString();


### PR DESCRIPTION
Breaks out catalog-specific changes from the [Catalog Calcite integration PR](https://github.com/apache/druid/pull/13686) to allow easier reviewing.

* Changes catalog table entries to Druid types
* Enhanced support for external tables, including functions
* Revised catalog sync API

The key change here is to use Druid types, rather than SQL types, when declaring the schema of a table in the catalog. Druid types better match the actual Druid implementation whereas SQL types are just a SQL "view" on top of the actual Druid types. This change will allow us to use complex types which will be useful for specifying aggregate columns.

#### Release note

No user-visible changes yet. The docs for the catalog will appear in a later PR after the Calcite integration is complete.

<hr>

This PR has:

- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
