### PR TITLE
Add back function signature for compat

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/MaxSizeSplitHintSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/MaxSizeSplitHintSpec.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
  */
 public class MaxSizeSplitHintSpec implements SplitHintSpec
 {
+  @SuppressWarnings("unused")
   public static final String TYPE = "maxSize";
 
   @VisibleForTesting

--- a/processing/src/main/java/org/apache/druid/data/input/SegmentsSplitHintSpec.java
+++ b/processing/src/main/java/org/apache/druid/data/input/SegmentsSplitHintSpec.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
  */
 public class SegmentsSplitHintSpec implements SplitHintSpec
 {
+  @SuppressWarnings("unused")
   public static final String TYPE = "segments";
 
   private static final HumanReadableBytes DEFAULT_MAX_INPUT_SEGMENT_BYTES_PER_TASK = new HumanReadableBytes("1GiB");

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.expression;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexCall;
@@ -78,6 +79,30 @@ public class Expressions
   private Expressions()
   {
     // No instantiation.
+  }
+
+  /**
+   * Old method used to translate a field access, possibly through a projection, to an underlying Druid dataSource.
+   *
+   * This exists to provide API compatibility to extensions, but is deprecated because there is a 4 argument version
+   * that should be used instead.  Call sites should have access to a RexBuilder instance that they can get the
+   * typeFactory from.
+   *
+   * @param rowSignature row signature of underlying Druid dataSource
+   * @param project      projection, or null
+   * @param fieldNumber  number of the field to access
+   *
+   * @return row expression
+   */
+  @Deprecated
+  public static RexNode fromFieldAccess(
+      final RowSignature rowSignature,
+      @Nullable final Project project,
+      final int fieldNumber
+  )
+  {
+    //noinspection VariableNotUsedInsideIf
+    return fromFieldAccess(project == null ? new JavaTypeFactoryImpl() : null, rowSignature, project, fieldNumber);
   }
 
   /**


### PR DESCRIPTION
https://github.com/apache/druid/pull/13904

Added a 4th argument to a commonly-used public static method on `Expressions`.  This is commonly used in anything that happens to be planning aggregation from an extension, which means that it risks breaking extensions.  This PR re-adds the original signature, deprecated, with comments about how to update to avoid extension breakage.