### PR TITLE
Removing the forbidden check on getOrDefault due to java8 incompatibility. 

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -41,7 +41,6 @@ java.util.HashSet#<init>(int, float) @ Use com.google.collect.Sets#newHashSetWit
 java.util.LinkedHashSet#<init>(int) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedHashSet#<init>(int, float) @ Use com.google.collect.Sets#newLinkedHashSatWithExpectedSize(int) instead
 java.util.LinkedList @ Use ArrayList or ArrayDeque instead
-java.util.Properties#getOrDefault(java.lang.Object,java.lang.Object) @ Properties#getOrDefault method does not check the default map for values. Use Properties#getProperty() instead.
 java.util.Random#<init>() @ Use ThreadLocalRandom.current() or the constructor with a seed (the latter in tests only!)
 java.lang.Math#random() @ Use ThreadLocalRandom.current()
 java.util.regex.Pattern#matches(java.lang.String,java.lang.CharSequence) @ Use String.startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly


### PR DESCRIPTION
PR #13882 introduced a change which fails builds on java 8. Reverting the forbidden check  to allow the builds to proceed. 
