### PR TITLE
[MSQ] Regression bug fix where ever LimitFrameProcessor's were used.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/MixShuffleSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/MixShuffleSpec.java
@@ -80,6 +80,6 @@ public class MixShuffleSpec implements ShuffleSpec
   @Override
   public String toString()
   {
-    return "MuxShuffleSpec{}";
+    return "MixShuffleSpec{}";
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/ShuffleSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/ShuffleSpec.java
@@ -27,7 +27,6 @@ import org.apache.druid.frame.key.ClusterBy;
  * Describes how outputs of a stage are shuffled. Property of {@link StageDefinition}.
  *
  * When the output of a stage is shuffled, it is globally sorted and partitioned according to the {@link ClusterBy}.
- * Hash-based (non-sorting) shuffle is not currently implemented.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerStageTracker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerStageTracker.java
@@ -883,6 +883,9 @@ class ControllerStageTracker
             workerCount,
             resultPartitionBoundaries.size()
         );
+      } else if (shuffleSpec.kind() == ShuffleKind.MIX) {
+        resultPartitionBoundaries = ClusterByPartitions.oneUniversalPartition();
+        resultPartitions = ReadablePartitions.striped(stageNumber, workerCount, shuffleSpec.partitionCount());
       } else {
         resultPartitions = ReadablePartitions.striped(stageNumber, workerCount, shuffleSpec.partitionCount());
       }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
@@ -28,7 +28,6 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.msq.input.stage.StageInputSpec;
-import org.apache.druid.msq.kernel.MixShuffleSpec;
 import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.QueryDefinitionBuilder;
 import org.apache.druid.msq.kernel.StageDefinition;
@@ -158,13 +157,12 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
 
     if (doLimitOrOffset) {
       final DefaultLimitSpec limitSpec = (DefaultLimitSpec) queryToRun.getLimitSpec();
-
       queryDefBuilder.add(
           StageDefinition.builder(firstStageNumber + 2)
                          .inputs(new StageInputSpec(firstStageNumber + 1))
                          .signature(resultSignature)
                          .maxWorkerCount(1)
-                         .shuffleSpec(MixShuffleSpec.instance())
+                         .shuffleSpec(null) // no shuffling should be required after a limit processor.
                          .processorFactory(
                              new OffsetLimitFrameProcessorFactory(
                                  limitSpec.getOffset(),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
@@ -161,7 +161,7 @@ public class ScanQueryKit implements QueryKit<ScanQuery>
                          .inputs(new StageInputSpec(firstStageNumber))
                          .signature(signatureToUse)
                          .maxWorkerCount(1)
-                         .shuffleSpec(MixShuffleSpec.instance())
+                         .shuffleSpec(null) // no shuffling should be required after a limit processor.
                          .processorFactory(
                              new OffsetLimitFrameProcessorFactory(
                                  queryToRun.getScanRowsOffset(),

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -942,7 +942,10 @@ public class MSQTestBase extends BaseCalciteQueryTest
                     worker,
                     channel
                 );
-                Assert.assertTrue(channelToCounters.containsKey(channel));
+                Assert.assertTrue(StringUtils.format("Counters not found for stage [%d], worker [%d], channel [%s]",
+                                                     stage,
+                                                     worker,
+                                                     channel), channelToCounters.containsKey(channel));
                 counter.matchQuerySnapshot(errorMessageFormat, channelToCounters.get(channel));
               }
           );


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

An MSQ insert statement with LIMIT and PARTITIONED BY ALL TIME no longer works.  It returns a Result partition information is not ready yet error.  This is a regression introduced because of #13506 .

This is reproducible using any source datasource, for example, this 2-row, 1-column mytest
```
select * from mytest
__time                   c1
2022-01-01T00:00:00.000Z 1
2022-01-01T00:00:00.000Z 2
```
The insert statement that fails:
```
insert into new_ds
select __time, c1
from mytest
limit 1
partitioned by ALL TIME
clustered by c1
```
```
UnknownError: org.apache.druid.java.util.common.ISE: Result partition information is not ready yet (Stack trace)
Failed task ID: query-17a6a628-473d-4b54-a41a-64143b680e3a (on host: ip-10-201-4-98.ec2.internal:8100)
Debug: get query detail archive
```
The stack trace:
```
org.apache.druid.java.util.common.ISE: Result partition information is not ready yet
	at org.apache.druid.msq.kernel.controller.ControllerStageTracker.getResultPartitionBoundaries(ControllerStageTracker.java:224)
	at org.apache.druid.msq.kernel.controller.ControllerQueryKernel.getResultPartitionBoundariesForStage(ControllerQueryKernel.java:394)
	at org.apache.druid.msq.exec.ControllerImpl$RunQueryUntilDone.startStages(ControllerImpl.java:2385)
	at org.apache.druid.msq.exec.ControllerImpl$RunQueryUntilDone.run(ControllerImpl.java:2164)
	at org.apache.druid.msq.exec.ControllerImpl$RunQueryUntilDone.access$000(ControllerImpl.java:2121)
	at org.apache.druid.msq.exec.ControllerImpl.runTask(ControllerImpl.java:373)
	at org.apache.druid.msq.exec.ControllerImpl.run(ControllerImpl.java:317)
	at org.apache.druid.msq.indexing.MSQControllerTask.runTask(MSQControllerTask.java:179)
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:169)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:477)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:449)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```

Thanks @weishiuntsai for catching this. 
 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### The fix

The limitprocessors are fed shuffled data already. Hence they need not add a shuffling step for the next stage. 
Adjusted the `ScanQuerKit`, `GroupByQueryKit` for that. 

Added a case in` ControllerStageTracker#generateResultPartitionsAndBoundariesWithoutKeyStatistics` for `ShuffleKind.MIX`

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
Release notes are not needed since #13506 did not go out. 



<hr>

##### Key changed/added classes in this PR
 * `ScanQueryKit`
 * `GroupByQueryKit`
 * `ControllerStageTracker`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
