### PR TITLE
fix join and unnest planning to ensure that duplicate join prefixes are not used

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidCorrelateUnnestRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidCorrelateUnnestRel.java
@@ -336,7 +336,8 @@ public class DruidCorrelateUnnestRel extends DruidRel<DruidCorrelateUnnestRel>
         RowSignature.builder().add(
             BASE_UNNEST_OUTPUT_COLUMN,
             Calcites.getColumnTypeForRelDataType(unnestedType)
-        ).build()
+        ).build(),
+        DruidJoinQueryRel.findExistingJoinPrefixes(leftQuery.getDataSource())
     ).rhs;
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -394,15 +394,10 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
     Set<String> prefixes = new HashSet<>();
     while (!copy.isEmpty()) {
       DataSource current = copy.remove(0);
+      copy.addAll(current.getChildren());
       if (current instanceof JoinDataSource) {
         JoinDataSource joiner = (JoinDataSource) current;
         prefixes.add(joiner.getRightPrefix());
-        if (joiner.getLeft() instanceof JoinDataSource) {
-          copy.add(joiner.getLeft());
-        }
-        if (joiner.getRight() instanceof JoinDataSource) {
-          copy.add(joiner.getRight());
-        }
       }
     }
     return prefixes;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -4769,8 +4769,8 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                                 .context(queryContext)
                                 .build()
                         ),
-                        "j0.",
-                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("j0.v0")),
+                        "_j0.",
+                        equalsCondition(makeColumnExpression("v0"), makeColumnExpression("_j0.v0")),
                         JoinType.INNER
                     )
                 )
@@ -4781,7 +4781,7 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
                     ImmutableSet.of("a"),
                     true
                 ))
-                .columns("dim3", "j0.dim3")
+                .columns("_j0.dim3", "dim3")
                 .context(queryContext)
                 .build()
         ),


### PR DESCRIPTION
### Description
This PR fixes a join query planning regression caused by #13902. After that change, this query will actually plan "correctly" but then later explode due to duplicate join prefix. The planner was selecting a join prefix only looking at the `RowSignature` of the left and right side datasources, but if those queries had any nested join prefixes, the query would later fail because the native prefix checker flattens the join to check prefixes (so losing the context of what is used directly in outside layers).

The solution Ive added is to just dig through the datasources to extract any existing prefixes and add that to the checked set when selecting new prefixes, to ensure the planner never picks duplicate prefixes even if it can't see them at the top level.

The added test plans and produces the same result as prior to #13902. Full disclaimer, I didn't actually work out the answer by hand to ensure that it was correct (the repro query was relayed to me), but at least it isn't different than before the change 😅 .

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
