### PR TITLE
Update DruidSchemaManager methods to provide SegmentMetadataCache

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchema.java
@@ -53,7 +53,7 @@ public class DruidSchema extends AbstractTableSchema
   public Table getTable(String name)
   {
     if (druidSchemaManager != null) {
-      return druidSchemaManager.getTable(name);
+      return druidSchemaManager.getTable(name, segmentCache);
     } else {
       DatasourceTable.PhysicalDatasourceMetadata dsMetadata = segmentCache.getDatasource(name);
       return dsMetadata == null ? null : new DatasourceTable(dsMetadata);
@@ -64,7 +64,7 @@ public class DruidSchema extends AbstractTableSchema
   public Set<String> getTableNames()
   {
     if (druidSchemaManager != null) {
-      return druidSchemaManager.getTableNames();
+      return druidSchemaManager.getTableNames(segmentCache);
     } else {
       return segmentCache.getDatasourceNames();
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
@@ -40,8 +40,8 @@ public interface DruidSchemaManager
   /**
    * Return all tables known to this schema manager. Deprecated because getting
    * all tables is never actually needed in the current code. Calcite asks for
-   * the information for a single table (via {@link #getTable(String)}, or
-   * the list of all table <i>names</i> (via {@link #getTableNames()}. This
+   * the information for a single table (via {@link #getTable(String, SegmentMetadataCache)}, or
+   * the list of all table <i>names</i> (via {@link #getTableNames(SegmentMetadataCache)}. This
    * method was originally used to allow Calcite's {@link
    * org.apache.calcite.schema.impl.AbstractSchema AbstractSchema} class to do
    * the lookup. The current code implements the operations directly. For

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/DruidSchemaManager.java
@@ -51,12 +51,12 @@ public interface DruidSchemaManager
   @Deprecated
   Map<String, DruidTable> getTables();
 
-  default DruidTable getTable(String name)
+  default DruidTable getTable(String name, SegmentMetadataCache segmentMetadataCache)
   {
     return getTables().get(name);
   }
 
-  default Set<String> getTableNames()
+  default Set<String> getTableNames(SegmentMetadataCache segmentMetadataCache)
   {
     return getTables().keySet();
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
@@ -441,12 +441,12 @@ public class SegmentMetadataCache
     initialized.await();
   }
 
-  protected DatasourceTable.PhysicalDatasourceMetadata getDatasource(String name)
+  public DatasourceTable.PhysicalDatasourceMetadata getDatasource(String name)
   {
     return tables.get(name);
   }
 
-  protected Set<String> getDatasourceNames()
+  public Set<String> getDatasourceNames()
   {
     return tables.keySet();
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/DruidCalciteSchemaModuleTest.java
@@ -59,6 +59,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @RunWith(EasyMockRunner.class)
@@ -234,5 +235,14 @@ public class DruidCalciteSchemaModuleTest extends CalciteTestBase
     InformationSchema expectedSchema = injector.getInstance(InformationSchema.class);
     Assert.assertNotNull(rootSchema);
     Assert.assertSame(expectedSchema, rootSchema.getSubSchema("INFORMATION_SCHEMA").unwrap(InformationSchema.class));
+  }
+
+  @Test
+  public void testDruidSchemaManagerIsInjected()
+  {
+    DruidSchemaManager druidSchemaManager = injector.getInstance(DruidSchemaManager.class);
+    Assert.assertNotNull(druidSchemaManager);
+    Assert.assertNull(druidSchemaManager.getTable("test", null));
+    Assert.assertEquals(ImmutableSet.of(), druidSchemaManager.getTableNames(null));
   }
 }


### PR DESCRIPTION
This PR updates the methods on the `DruidSchemaManager` interface to provide the segment metadata cache to the extension implementation, for use cases where the extension also needs to consider what metadata is present in the Druid segments.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
