### PR TITLE
Added TYPE(native) data type for external tables

### DIFF
--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -402,11 +402,12 @@ FROM TABLE(
   ) (x VARCHAR, y VARCHAR)
 ```
 
-The JSON function allows columns to be of type `VARIANT` which indicates that the column contains
+The JSON function allows columns to be of type `TYPE('COMPLEX<json>')` which indicates that the column contains
 some form of complex JSON: a JSON object, a JSON array, or an array of JSON objects or arrays.
-The SQL `VARIANT` type corresponds to the native Druid type `complex<json>`. However, the actual
+Note that the case must exactly match that given: upper case `COMPLEX`, lower case `json`.
+The SQL type simply names a native Druid type. However, the actual
 segment column produced may be of some other type if Druid infers that it can use a simpler type
-instead. This is why the column type can "vary" and is thus called `VARIANT`.
+instead.
 
 ### Parameters
 

--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -402,6 +402,12 @@ FROM TABLE(
   ) (x VARCHAR, y VARCHAR)
 ```
 
+The JSON function allows columns to be of type `VARIANT` which indicates that the column contains
+some form of complex JSON: a JSON object, a JSON array, or an array of JSON objects or arrays.
+The SQL `VARIANT` type corresponds to the native Druid type `complex<json>`. However, the actual
+segment column produced may be of some other type if Druid infers that it can use a simpler type
+instead. This is why the column type can "vary" and is thus called `VARIANT`.
+
 ### Parameters
 
 Starting with the Druid 26.0 release, you can use query parameters with MSQ queries. You may find

--- a/server/src/main/java/org/apache/druid/catalog/model/Columns.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/Columns.java
@@ -25,6 +25,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ public class Columns
   public static final String FLOAT = "FLOAT";
   public static final String DOUBLE = "DOUBLE";
   public static final String TIMESTAMP = "TIMESTAMP";
+  public static final String VARIANT = "VARIANT";
 
   public static final Set<String> NUMERIC_TYPES =
       ImmutableSet.of(BIGINT, FLOAT, DOUBLE);
@@ -52,6 +54,7 @@ public class Columns
         .put(FLOAT, ColumnType.FLOAT)
         .put(DOUBLE, ColumnType.DOUBLE)
         .put(VARCHAR, ColumnType.STRING)
+        .put(VARIANT, NestedDataComplexTypeSerde.TYPE)
         .build();
 
   public static final Map<ColumnType, String> DRUID_TO_SQL_TYPES =

--- a/server/src/main/java/org/apache/druid/catalog/model/Columns.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/Columns.java
@@ -25,7 +25,6 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,6 @@ public class Columns
   public static final String FLOAT = "FLOAT";
   public static final String DOUBLE = "DOUBLE";
   public static final String TIMESTAMP = "TIMESTAMP";
-  public static final String VARIANT = "VARIANT";
 
   public static final Set<String> NUMERIC_TYPES =
       ImmutableSet.of(BIGINT, FLOAT, DOUBLE);
@@ -54,7 +52,6 @@ public class Columns
         .put(FLOAT, ColumnType.FLOAT)
         .put(DOUBLE, ColumnType.DOUBLE)
         .put(VARCHAR, ColumnType.STRING)
-        .put(VARIANT, NestedDataComplexTypeSerde.TYPE)
         .build();
 
   public static final Map<ColumnType, String> DRUID_TO_SQL_TYPES =
@@ -84,7 +81,11 @@ public class Columns
     if (sqlType == null) {
       return null;
     }
-    return SQL_TO_DRUID_TYPES.get(StringUtils.toUpperCase(sqlType));
+    ColumnType druidType = SQL_TO_DRUID_TYPES.get(StringUtils.toUpperCase(sqlType));
+    if (druidType != null) {
+      return druidType;
+    }
+    return ColumnType.fromString(sqlType);
   }
 
   public static void validateScalarColumn(String name, String type)
@@ -108,7 +109,7 @@ public class Columns
     for (ColumnSpec col : columns) {
       ColumnType druidType = null;
       if (col.sqlType() != null) {
-        druidType = Columns.SQL_TO_DRUID_TYPES.get(StringUtils.toUpperCase(col.sqlType()));
+        druidType = Columns.druidType(col.sqlType());
       }
       if (druidType == null) {
         druidType = ColumnType.STRING;

--- a/sql/src/main/codegen/config.fmpp
+++ b/sql/src/main/codegen/config.fmpp
@@ -60,6 +60,7 @@ data: {
       "org.apache.druid.sql.calcite.parser.DruidSqlParserUtils"
       "org.apache.druid.sql.calcite.external.ExtendOperator"
       "org.apache.druid.sql.calcite.external.ParameterizeOperator"
+      "org.apache.druid.sql.calcite.planner.DruidTypeSystem"
     ]
 
     # List of new keywords. Example: "DATABASES", "TABLES". If the keyword is not a reserved
@@ -68,6 +69,7 @@ data: {
       "CLUSTERED"
       "OVERWRITE"
       "PARTITIONED"
+      "VARIANT"
     ]
 
     # List of keywords from "keywords" section that are not reserved.
@@ -402,6 +404,7 @@ data: {
     # Return type of method implementation should be "SqlTypeNameSpec".
     # Example: SqlParseTimeStampZ().
     dataTypeParserMethods: [
+      "VariantType()"
     ]
 
     # List of methods for parsing builtin function calls.

--- a/sql/src/main/codegen/config.fmpp
+++ b/sql/src/main/codegen/config.fmpp
@@ -60,7 +60,6 @@ data: {
       "org.apache.druid.sql.calcite.parser.DruidSqlParserUtils"
       "org.apache.druid.sql.calcite.external.ExtendOperator"
       "org.apache.druid.sql.calcite.external.ParameterizeOperator"
-      "org.apache.druid.sql.calcite.planner.DruidTypeSystem"
     ]
 
     # List of new keywords. Example: "DATABASES", "TABLES". If the keyword is not a reserved
@@ -69,7 +68,6 @@ data: {
       "CLUSTERED"
       "OVERWRITE"
       "PARTITIONED"
-      "VARIANT"
     ]
 
     # List of keywords from "keywords" section that are not reserved.
@@ -404,7 +402,7 @@ data: {
     # Return type of method implementation should be "SqlTypeNameSpec".
     # Example: SqlParseTimeStampZ().
     dataTypeParserMethods: [
-      "VariantType()"
+      "DruidType()"
     ]
 
     # List of methods for parsing builtin function calls.

--- a/sql/src/main/codegen/includes/common.ftl
+++ b/sql/src/main/codegen/includes/common.ftl
@@ -92,3 +92,14 @@ SqlNodeList ClusterItems() :
     return new SqlNodeList(list, s.addAll(list).pos());
   }
 }
+
+SqlTypeNameSpec VariantType() :
+{
+}
+{
+  <VARIANT>
+  {
+    return new SqlUserDefinedTypeNameSpec("VARIANT", span().pos());
+  }
+}
+

--- a/sql/src/main/codegen/includes/common.ftl
+++ b/sql/src/main/codegen/includes/common.ftl
@@ -95,11 +95,15 @@ SqlNodeList ClusterItems() :
 
 SqlTypeNameSpec VariantType() :
 {
+  String typeName;
 }
 {
-  <VARIANT>
+  <TYPE> <LPAREN> <QUOTED_STRING>
   {
-    return new SqlUserDefinedTypeNameSpec("VARIANT", span().pos());
+    typeName = SqlParserUtil.trim(token.image, "'");
+  }
+  <RPAREN>
+  {
+    return new SqlUserDefinedTypeNameSpec(typeName, span().pos());
   }
 }
-

--- a/sql/src/main/codegen/includes/common.ftl
+++ b/sql/src/main/codegen/includes/common.ftl
@@ -93,7 +93,7 @@ SqlNodeList ClusterItems() :
   }
 }
 
-SqlTypeNameSpec VariantType() :
+SqlTypeNameSpec DruidType() :
 {
   String typeName;
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -242,10 +242,11 @@ public class Externals
     if (typeName == null || !typeName.isSimple()) {
       throw unsupportedType(name, dataType);
     }
-    if (DruidTypeSystem.VARIANT_TYPE_NAME.equals(typeName.getSimple())) {
-      return typeName.getSimple();
+    String simpleName = typeName.getSimple();
+    if (StringUtils.toLowerCase(simpleName).startsWith(("complex<"))) {
+      return simpleName;
     }
-    SqlTypeName type = SqlTypeName.get(typeName.getSimple());
+    SqlTypeName type = SqlTypeName.get(simpleName);
     if (type == null) {
       throw unsupportedType(name, dataType);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -238,11 +238,11 @@ public class Externals
     if (spec == null) {
       throw unsupportedType(name, dataType);
     }
-    SqlIdentifier typeName = spec.getTypeName();
-    if (typeName == null || !typeName.isSimple()) {
+    SqlIdentifier typeNameIdentifier = spec.getTypeName();
+    if (typeNameIdentifier == null || !typeNameIdentifier.isSimple()) {
       throw unsupportedType(name, dataType);
     }
-    String simpleName = typeName.getSimple();
+    String simpleName = typeNameIdentifier.getSimple();
     if (StringUtils.toLowerCase(simpleName).startsWith(("complex<"))) {
       return simpleName;
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -242,6 +242,9 @@ public class Externals
     if (typeName == null || !typeName.isSimple()) {
       throw unsupportedType(name, dataType);
     }
+    if (DruidTypeSystem.VARIANT_TYPE_NAME.equals(typeName.getSimple())) {
+      return typeName.getSimple();
+    }
     SqlTypeName type = SqlTypeName.get(typeName.getSimple());
     if (type == null) {
       throw unsupportedType(name, dataType);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidTypeSystem.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidTypeSystem.java
@@ -35,6 +35,8 @@ public class DruidTypeSystem implements RelDataTypeSystem
    */
   public static final int DEFAULT_TIMESTAMP_PRECISION = 3;
 
+  public static final String VARIANT_TYPE_NAME = "VARIANT";
+
   private DruidTypeSystem()
   {
     // Singleton.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 import org.apache.druid.sql.calcite.external.ExternalDataSource;
 import org.apache.druid.sql.calcite.external.Externals;
 import org.apache.druid.sql.calcite.filtration.Filtration;
@@ -204,6 +205,45 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
                 .build()
          )
         .expectLogicalPlanFrom("httpExtern")
+        .verify();
+  }
+
+  @Test
+  public void testHttpJson()
+  {
+    final ExternalDataSource httpDataSource = new ExternalDataSource(
+        new HttpInputSource(
+            Collections.singletonList(toURI("http://foo.com/bar.json")),
+            "bob",
+            new DefaultPasswordProvider("secret"),
+            new HttpInputSourceConfig(null)
+        ),
+        new CsvInputFormat(ImmutableList.of("x", "y", "z"), null, false, false, 0),
+        RowSignature.builder()
+                    .add("x", ColumnType.STRING)
+                    .add("y", ColumnType.STRING)
+                    .add("z", NestedDataComplexTypeSerde.TYPE)
+                    .build()
+        );
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT *\n" +
+             "FROM TABLE(http(userName => 'bob',\n" +
+            "                 password => 'secret',\n" +
+             "                uris => ARRAY['http://foo.com/bar.json'],\n" +
+             "                format => 'csv'))\n" +
+             "     EXTEND (x VARCHAR, y VARCHAR, z VARIANT)\n" +
+             "PARTITIONED BY ALL TIME")
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .expectTarget("dst", httpDataSource.getSignature())
+        .expectResources(dataSourceWrite("dst"), Externals.EXTERNAL_RESOURCE_ACTION)
+        .expectQuery(
+            newScanQueryBuilder()
+                .dataSource(httpDataSource)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .columns("x", "y", "z")
+                .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
+                .build()
+         )
         .verify();
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -231,7 +231,7 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
             "                 password => 'secret',\n" +
              "                uris => ARRAY['http://foo.com/bar.json'],\n" +
              "                format => 'csv'))\n" +
-             "     EXTEND (x VARCHAR, y VARCHAR, z VARIANT)\n" +
+             "     EXTEND (x VARCHAR, y VARCHAR, z TYPE('COMPLEX<json>'))\n" +
              "PARTITIONED BY ALL TIME")
         .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
         .expectTarget("dst", httpDataSource.getSignature())


### PR DESCRIPTION
Druid recently added support for nested JSON types. The JSON-style of `extern()` can label input columns as a JSON object or array using the Druid `complex<json>` type. This PR adds an equivalent of the type to SQL using the `TYPE` keyword. Example:

```sql
INSERT INTO dst SELECT *
FROM TABLE(http(uris => ARRAY['http://foo.com/bar.json'],
                format => 'csv'))
     (x VARCHAR, y VARCHAR, z TYPE('COMPLEX<json>'))
PARTITIONED BY ALL TIME
```

The semantics are that the `z` column above is _some_ complex JSON type, but we don't care which: Druid's indexer will figure it out. Since we don't know the exact type (other than that it isn't simple), we let Druid do the work by declaring that the input column type varies: it is of Druid's type `COMPLEX<json>`. At run time, Druid will pick the actual type, which may be `COMPLEX<json>` or may be something else.

The argument to `TYPE()` is the name of a Druid type exactly as Druid expects it: upper case `COMPLEX` and lower case `json`.

#### Release note

See the comments above and the modified `reference.md` file.

<hr>

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
