### PR TITLE
OOM fix for running MSQ jobs with `intermediateSuperSorterStorageMaxLocalBytes` set

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/channel/ComposingWritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ComposingWritableFrameChannel.java
@@ -131,9 +131,7 @@ public class ComposingWritableFrameChannel implements WritableFrameChannel
   @Override
   public boolean isClosed()
   {
-    return currentIndex == writableChannelSuppliers.size() || writableChannelSuppliers.get(currentIndex)
-                                                                                      .get()
-                                                                                      .isClosed();
+    return currentIndex == writableChannelSuppliers.size();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/frame/channel/ComposingWritableFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ComposingWritableFrameChannel.java
@@ -90,18 +90,23 @@ public class ComposingWritableFrameChannel implements WritableFrameChannel
 
       // We are converting the corresponding channel to read only after exhausting it because that channel won't be used
       // for writes anymore
-      if (outputChannelSuppliers != null) {
-        outputChannelSuppliers.get(currentIndex).get().convertToReadOnly();
-      }
-      if (partitionedOutputChannelSuppliers != null) {
-        partitionedOutputChannelSuppliers.get(currentIndex).get().convertToReadOnly();
-      }
+      convertChannelSuppliersToReadOnly(currentIndex);
 
       currentIndex++;
       if (currentIndex >= writableChannelSuppliers.size()) {
         throw rlee;
       }
       write(frameWithPartition);
+    }
+  }
+
+  private void convertChannelSuppliersToReadOnly(int index)
+  {
+    if (outputChannelSuppliers != null) {
+      outputChannelSuppliers.get(index).get().convertToReadOnly();
+    }
+    if (partitionedOutputChannelSuppliers != null) {
+      partitionedOutputChannelSuppliers.get(index).get().convertToReadOnly();
     }
   }
 
@@ -118,6 +123,7 @@ public class ComposingWritableFrameChannel implements WritableFrameChannel
   {
     if (currentIndex < writableChannelSuppliers.size()) {
       writableChannelSuppliers.get(currentIndex).get().close();
+      convertChannelSuppliersToReadOnly(currentIndex);
       currentIndex = writableChannelSuppliers.size();
     }
   }
@@ -125,7 +131,9 @@ public class ComposingWritableFrameChannel implements WritableFrameChannel
   @Override
   public boolean isClosed()
   {
-    return currentIndex == writableChannelSuppliers.size();
+    return currentIndex == writableChannelSuppliers.size() || writableChannelSuppliers.get(currentIndex)
+                                                                                      .get()
+                                                                                      .isClosed();
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/frame/channel/ComposingWritableFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ComposingWritableFrameChannelTest.java
@@ -27,8 +27,11 @@ import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
 import org.apache.druid.frame.processor.OutputChannel;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.ResourceLimitExceededException;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
@@ -89,8 +92,26 @@ public class ComposingWritableFrameChannelTest
     Assert.assertEquals(ImmutableSet.of(0), partitionToChannelMap.get(2));
     Assert.assertEquals(ImmutableSet.of(1), partitionToChannelMap.get(3));
 
+
     // Test if the older channel has been converted to read only
     Assert.assertThrows(ISE.class, outputChannel1::getWritableChannel);
+    composingWritableFrameChannel.close();
+
+    Exception ise1 = Assert.assertThrows(IllegalStateException.class, () -> outputChannel1.getFrameMemoryAllocator());
+    MatcherAssert.assertThat(
+        ise1,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
+            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+    );
+
+
+    Exception ise2 = Assert.assertThrows(IllegalStateException.class, () -> outputChannel2.getFrameMemoryAllocator());
+    MatcherAssert.assertThat(
+        ise2,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
+            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+    );
+
   }
 
   static class LimitedWritableFrameChannel implements WritableFrameChannel


### PR DESCRIPTION
While using `intermediateSuperSorterStorageMaxLocalBytes` the super sorter was retaining references of the memory allocator. 
![Screenshot 2023-03-24 at 5 50 43 PM](https://user-images.githubusercontent.com/2260045/227519789-acff9bb3-6e81-4f20-a5e2-682dba52e8a4.png)

The fix clears the current `outputChannel` when close() is called on the `ComposingWritableFrameChannel.java`