### PR TITLE
Fixing regression issues on unnest

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -400,6 +400,9 @@ public class UnnestStorageAdapter implements StorageAdapter
           }
           // add the entire query filter to unnest filter to be used in Value matcher
           filterSplitter.addPostFilterWithPreFilterIfRewritePossible(queryFilter, true);
+        } else {
+          // case where the outer filter has reference to the outputcolumn
+          filterSplitter.addPostFilterWithPreFilterIfRewritePossible(queryFilter, false);
         }
       } else {
         // normal case without any filter on unnested column

--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -183,7 +183,7 @@ public class UnnestStorageAdapter implements StorageAdapter
   @Nullable
   public Filter getUnnestFilter()
   {
-    return unnestFilter.toFilter();
+    return unnestFilter == null ? null : unnestFilter.toFilter();
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
@@ -63,7 +63,6 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
   private static IncrementalIndexStorageAdapter INCREMENTAL_INDEX_STORAGE_ADAPTER;
   private static UnnestStorageAdapter UNNEST_STORAGE_ADAPTER;
   private static UnnestStorageAdapter UNNEST_STORAGE_ADAPTER1;
-  private static UnnestStorageAdapter UNNEST_STORAGE_ADAPTER2;
   private static List<StorageAdapter> ADAPTERS;
   private static String COLUMNNAME = "multi-string1";
   private static String OUTPUT_COLUMN_NAME = "unnested-multi-string1";
@@ -100,13 +99,6 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
         new ExpressionVirtualColumn(OUTPUT_COLUMN_NAME1, "\"" + COLUMNNAME + "\"", null, ExprMacroTable.nil()),
         null
     );
-
-    UNNEST_STORAGE_ADAPTER2 = new UnnestStorageAdapter(
-        INCREMENTAL_INDEX_STORAGE_ADAPTER,
-        new ExpressionVirtualColumn(OUTPUT_COLUMN_NAME, "\"" + COLUMNNAME + "\"", null, ExprMacroTable.nil()),
-        new SelectorDimFilter(OUTPUT_COLUMN_NAME, "1", null)
-    );
-
 
     ADAPTERS = ImmutableList.of(
         UNNEST_STORAGE_ADAPTER,
@@ -344,14 +336,8 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
       Assert.assertEquals(unnestStorageAdapter.getUnnestFilter(), postFilter);
 
-      ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
-      DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(OUTPUT_COLUMN_NAME));
       int count = 0;
       while (!cursor.isDone()) {
-        Object dimSelectorVal = dimSelector.getObject();
-        if (dimSelectorVal == null) {
-          Assert.assertNull(dimSelectorVal);
-        }
         cursor.advance();
         count++;
       }

--- a/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
@@ -397,14 +397,8 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
       Assert.assertEquals(queryFilter, postFilter);
 
-      ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
-      DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(OUTPUT_COLUMN_NAME));
       int count = 0;
       while (!cursor.isDone()) {
-        Object dimSelectorVal = dimSelector.getObject();
-        if (dimSelectorVal == null) {
-          Assert.assertNull(dimSelectorVal);
-        }
         cursor.advance();
         count++;
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidFilterUnnestRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidFilterUnnestRule.java
@@ -24,6 +24,7 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.sql.calcite.rel.DruidUnnestRel;
 
 public class DruidFilterUnnestRule extends RelOptRule
@@ -94,9 +95,15 @@ public class DruidFilterUnnestRule extends RelOptRule
     public boolean matches(RelOptRuleCall call)
     {
       final Project rightP = call.rel(0);
-      final SqlKind rightProjectKind = rightP.getChildExps().get(0).getKind();
-      // allow rule to trigger only if there's a string CAST or numeric literal cast
-      return rightP.getProjects().size() == 1 && (rightProjectKind == SqlKind.CAST || rightProjectKind == SqlKind.LITERAL);
+      if (rightP.getChildExps().size() > 0) {
+        final SqlKind rightProjectKind = rightP.getChildExps().get(0).getKind();
+        final SqlTypeName rightType = rightP.getChildExps().get(0).getType().getSqlTypeName();
+        // allow rule to trigger only if there's a non-decimal CAST or numeric literal cast
+        return rightP.getProjects().size() == 1 && ((rightProjectKind == SqlKind.CAST
+                                                     && rightType != SqlTypeName.DECIMAL)
+                                                    || rightProjectKind == SqlKind.LITERAL);
+      }
+      return false;
     }
 
     @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidFilterUnnestRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidFilterUnnestRule.java
@@ -97,11 +97,11 @@ public class DruidFilterUnnestRule extends RelOptRule
       final Project rightP = call.rel(0);
       if (rightP.getChildExps().size() > 0) {
         final SqlKind rightProjectKind = rightP.getChildExps().get(0).getKind();
-        final SqlTypeName rightType = rightP.getChildExps().get(0).getType().getSqlTypeName();
-        // allow rule to trigger only if there's a non-decimal CAST or numeric literal cast
-        return rightP.getProjects().size() == 1 && ((rightProjectKind == SqlKind.CAST
-                                                     && rightType != SqlTypeName.DECIMAL)
-                                                    || rightProjectKind == SqlKind.LITERAL);
+        final SqlTypeName projectType = rightP.getChildExps().get(0).getType().getSqlTypeName();
+        final SqlTypeName unnestDataType = call.rel(1).getRowType().getFieldList().get(0).getType().getSqlTypeName();
+        // allow rule to trigger only if project involves a cast on the same row type
+        return rightP.getProjects().size() == 1 && ((rightProjectKind == SqlKind.CAST || rightProjectKind == SqlKind.LITERAL)
+                                                     && projectType == unnestDataType);
       }
       return false;
     }


### PR DESCRIPTION
This PR fixes following regression issues on unnest:
<img width="457" alt="Screen Shot 2023-03-24 at 2 29 28 PM" src="https://user-images.githubusercontent.com/93540295/227645239-04b570d3-a26e-491e-bea3-89444c6a10b6.png">
<img width="513" alt="Screen Shot 2023-03-24 at 2 29 36 PM" src="https://user-images.githubusercontent.com/93540295/227645240-8a24c448-0eed-4b8c-b08e-1fcadcac3259.png">


1. select sum(c) on an unnested column now does not return 'Type mismatch' error and works properly
```
select sum(c) col from mytest1, unnest(mv_to_array(c2)) as u(c)

col
10
```
2. Making sure an inner join query works properly 
```
select t1long, t2long, t2c from
(select c1 t1long, c t1c from mytest, unnest(mv_to_array(c2)) as u(c)) t1 
inner join 
(select c1 t2long, c t2c from mytest, unnest(mv_to_array(c2)) as u(c)) t2  
on t1long=t2long 
```
3. Having on unnested column with a group by now works correctly
```
select c, count(*) cnt from mytest1, unnest(mv_to_array(c2)) as u(c) group by c having c='A'

c cnt
A 1
```
4. count(*) on an unnested query now works correctly
```
select count(*) c from mytest1, unnest(mv_to_array(c2)) as u(c)

cnt
4
```

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
