### PR TITLE
helm: Add metrics port exposure via service and Prometheus ServiceMonitors

### DIFF
--- a/helm/druid/Chart.yaml
+++ b/helm/druid/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     version: 8.6.4
     repository: https://charts.helm.sh/stable
     condition: postgresql.enabled
-version: 0.3.5
+version: 0.3.6
 home: https://druid.apache.org/
 icon: https://druid.apache.org/img/favicon.png
 sources:

--- a/helm/druid/README.md
+++ b/helm/druid/README.md
@@ -109,6 +109,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `broker.serviceType`                     | service type for service                                | `ClusterIP`                                |
 | `broker.resources`                       | broker node resources requests & limits                 | `{}`                                       |
 | `broker.podAnnotations`                  | broker deployment annotations                           | `{}`                                       |
+| `broker.metrics.port`                    | Service port to expose metrics on                       | `8080`                                     |
+| `broker.metrics.serviceMonitor.enabled`  | Create Prometheus serviceMonitor resource               | `false`                                    |
 | `broker.nodeSelector`                    | Node labels for broker pod assignment                   | `{}`                                       |
 | `broker.tolerations`                     | broker tolerations                                      | `[]`                                       |
 | `broker.config`                           | broker private config such as `JAVA_OPTS`                |                                            |
@@ -130,6 +132,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `coordinator.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account | `true`                          |
 | `coordinator.resources`                  | coordinator node resources requests & limits            | `{}`                                       |
 | `coordinator.podAnnotations`             | coordinator Deployment annotations                      | `{}`                                       |
+| `coordinator.metrics.port`               | Service port to expose metrics on                       | `8080`                                     |
+| `coordinator.metrics.serviceMonitor.enabled`  | Create Prometheus serviceMonitor resource          | `false`                                    |
 | `coordinator.nodeSelector`               | node labels for coordinator pod assignment              | `{}`                                       |
 | `coordinator.tolerations`                | coordinator tolerations                                 | `[]`                                       |
 | `coordinator.config`                      | coordinator private config such as `JAVA_OPTS`           |                                            |
@@ -151,6 +155,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `overlord.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account | `true`                             |
 | `overlord.resources`                     | overlord node resources requests & limits               | `{}`                                       |
 | `overlord.podAnnotations`                | overlord Deployment annotations                         | `{}`                                       |
+| `overlord.metrics.port`                  | Service port to expose metrics on                       | `8080`                                     |
+| `overlord.metrics.serviceMonitor.enabled`| Create Prometheus serviceMonitor resource               | `false`                                    |
 | `overlord.nodeSelector`                  | node labels for overlord pod assignment                 | `{}`                                       |
 | `overlord.tolerations`                   | overlord tolerations                                    | `[]`                                       |
 | `overlord.config`                         | overlord private config such as `JAVA_OPTS`              |                                            |
@@ -174,6 +180,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `historical.livenessProbeInitialDelaySeconds`  | historical node liveness probe initial delay in seconds  | `60`                                |
 | `historical.readinessProbeInitialDelaySeconds` | historical node readiness probe initial delay in seconds | `60`                                |
 | `historical.podAnnotations`              | historical Deployment annotations                       | `{}`                                       |
+| `historical.metrics.port`                | Service port to expose metrics on                       | `8080`                                     |
+| `historical.metrics.serviceMonitor.enabled`| Create Prometheus serviceMonitor resource             | `false`                                    |
 | `historical.nodeSelector`                | node labels for historical pod assignment               | `{}`                                       |
 | `historical.securityContext`             | custom security context for historical containers       | `{ fsGroup: 1000 }`                        |
 | `historical.tolerations`                 | historical tolerations                                  | `[]`                                       |
@@ -201,6 +209,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `middleManager.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account | `true`                        |
 | `middleManager.resources`                | middleManager node resources requests & limits          | `{}`                                       |
 | `middleManager.podAnnotations`           | middleManager Deployment annotations                    | `{}`                                       |
+| `middleManager.metrics.port`             | Service port to expose metrics on                       | `8080`                                     |
+| `middleManager.metrics.serviceMonitor.enabled`| Create Prometheus serviceMonitor resource          | `false`                                    |
 | `middleManager.nodeSelector`             | Node labels for middleManager pod assignment            | `{}`                                       |
 | `middleManager.securityContext`          | custom security context for middleManager containers    | `{ fsGroup: 1000 }`                        |
 | `middleManager.tolerations`              | middleManager tolerations                               | `[]`                                       |
@@ -232,6 +242,8 @@ The following table lists the configurable parameters of the Druid chart and the
 | `router.serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account | `true`                               |
 | `router.resources`                       | router node resources requests & limits                 | `{}`                                       |
 | `router.podAnnotations`                  | router Deployment annotations                           | `{}`                                       |
+| `router.metrics.port`                    | Service port to expose metrics on                       | `8080`                                     |
+| `router.metrics.serviceMonitor.enabled`  | Create Prometheus serviceMonitor resource               | `false`                                    |
 | `router.nodeSelector`                    | node labels for router pod assignment                   | `{}`                                       |
 | `router.tolerations`                     | router tolerations                                      | `[]`                                       |
 | `router.config`                           | router private config such as `JAVA_OPTS`                |                                            |

--- a/helm/druid/templates/broker/serviceMonitor.yaml
+++ b/helm/druid/templates/broker/serviceMonitor.yaml
@@ -16,10 +16,9 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.broker.enabled .Values.broker.metrics.port .Values.broker.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
   name: {{ include "druid.broker.fullname" . }}
   labels:
@@ -29,20 +28,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.broker.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/templates/coordinator/service.yaml
+++ b/helm/druid/templates/coordinator/service.yaml
@@ -35,6 +35,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if and .Values.coordinator.metrics.port (or .Values.coordinator.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
+    - port: {{ .Values.coordinator.metrics.port }}
+      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.coordinator.config.druid_emitter_prometheus_port }}
+      protocol: TCP
+      name: druid-metrics
+  {{- end }}
   selector:
     app: {{ include "druid.name" . }}
     release: {{ .Release.Name }}

--- a/helm/druid/templates/coordinator/serviceMonitor.yaml
+++ b/helm/druid/templates/coordinator/serviceMonitor.yaml
@@ -16,33 +16,26 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.coordinator.enabled .Values.coordinator.metrics.port .Values.coordinator.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: {{ include "druid.broker.fullname" . }}
+  name: {{ include "druid.coordinator.fullname" . }}
   labels:
     app: {{ include "druid.name" . }}
     chart: {{ include "druid.chart" . }}
-    component: {{ .Values.broker.name }}
+    component: {{ .Values.coordinator.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.coordinator.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/templates/historical/service.yaml
+++ b/helm/druid/templates/historical/service.yaml
@@ -35,6 +35,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if and .Values.historical.metrics.port (or .Values.historical.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
+    - port: {{ .Values.historical.metrics.port }}
+      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.historical.config.druid_emitter_prometheus_port }}
+      protocol: TCP
+      name: druid-metrics
+  {{- end }}
   selector:
     app: {{ include "druid.name" . }}
     release: {{ .Release.Name }}

--- a/helm/druid/templates/historical/serviceMonitor.yaml
+++ b/helm/druid/templates/historical/serviceMonitor.yaml
@@ -16,33 +16,26 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.historical.enabled .Values.historical.metrics.port .Values.historical.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: {{ include "druid.broker.fullname" . }}
+  name: {{ include "druid.historical.fullname" . }}
   labels:
     app: {{ include "druid.name" . }}
     chart: {{ include "druid.chart" . }}
-    component: {{ .Values.broker.name }}
+    component: {{ .Values.historical.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.historical.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/templates/middleManager/service.yaml
+++ b/helm/druid/templates/middleManager/service.yaml
@@ -35,6 +35,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if and .Values.middleManager.metrics.port (or .Values.middleManager.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
+    - port: {{ .Values.middleManager.metrics.port }}
+      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.middleManager.config.druid_emitter_prometheus_port }}
+      protocol: TCP
+      name: druid-metrics
+  {{- end }}
   selector:
     app: {{ include "druid.name" . }}
     release: {{ .Release.Name }}

--- a/helm/druid/templates/middleManager/serviceMonitor.yaml
+++ b/helm/druid/templates/middleManager/serviceMonitor.yaml
@@ -16,33 +16,26 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.middleManager.enabled .Values.middleManager.metrics.port .Values.middleManager.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: {{ include "druid.broker.fullname" . }}
+  name: {{ include "druid.middleManager.fullname" . }}
   labels:
     app: {{ include "druid.name" . }}
     chart: {{ include "druid.chart" . }}
-    component: {{ .Values.broker.name }}
+    component: {{ .Values.middleManager.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.middleManager.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/templates/overlord/service.yaml
+++ b/helm/druid/templates/overlord/service.yaml
@@ -35,6 +35,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if and .Values.overlord.metrics.port (or .Values.overlord.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
+    - port: {{ .Values.overlord.metrics.port }}
+      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.overlord.config.druid_emitter_prometheus_port }}
+      protocol: TCP
+      name: druid-metrics
+  {{- end }}
   selector:
     app: {{ include "druid.name" . }}
     release: {{ .Release.Name }}

--- a/helm/druid/templates/overlord/serviceMonitor.yaml
+++ b/helm/druid/templates/overlord/serviceMonitor.yaml
@@ -16,33 +16,26 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.overlord.enabled .Values.overlord.metrics.port .Values.overlord.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: {{ include "druid.broker.fullname" . }}
+  name: {{ include "druid.overlord.fullname" . }}
   labels:
     app: {{ include "druid.name" . }}
     chart: {{ include "druid.chart" . }}
-    component: {{ .Values.broker.name }}
+    component: {{ .Values.overlord.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.overlord.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/templates/router/service.yaml
+++ b/helm/druid/templates/router/service.yaml
@@ -35,6 +35,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  {{- if and .Values.router.metrics.port (or .Values.router.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
+    - port: {{ .Values.router.metrics.port }}
+      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.router.config.druid_emitter_prometheus_port }}
+      protocol: TCP
+      name: druid-metrics
+  {{- end }}
   selector:
     app: {{ include "druid.name" . }}
     release: {{ .Release.Name }}

--- a/helm/druid/templates/router/serviceMonitor.yaml
+++ b/helm/druid/templates/router/serviceMonitor.yaml
@@ -16,33 +16,26 @@
  limitations under the License.
 
 */}}
-
-{{- if .Values.broker.enabled -}}
-apiVersion: v1
-kind: Service
+{{- if and .Values.router.enabled .Values.router.metrics.port .Values.router.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: {{ include "druid.broker.fullname" . }}
+  name: {{ include "druid.router.fullname" . }}
   labels:
     app: {{ include "druid.name" . }}
     chart: {{ include "druid.chart" . }}
-    component: {{ .Values.broker.name }}
+    component: {{ .Values.router.name }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.broker.serviceType }}
-  ports:
-    - port: {{ .Values.broker.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  {{- if and .Values.broker.metrics.port (or .Values.broker.config.druid_emitter_prometheus_port .Values.configVars.druid_emitter_prometheus_port) }}
-    - port: {{ .Values.broker.metrics.port }}
-      targetPort: {{ default .Values.configVars.druid_emitter_prometheus_port .Values.broker.config.druid_emitter_prometheus_port }}
-      protocol: TCP
-      name: druid-metrics
-  {{- end }}
   selector:
-    app: {{ include "druid.name" . }}
-    release: {{ .Release.Name }}
-    component: {{ .Values.broker.name }}
+    matchLabels:
+      app: {{ include "druid.name" . }}
+      component: {{ .Values.router.name }}
+  endpoints:
+    - port: druid-metrics
+      interval: 20s
+      path: /metrics
+      scheme: http
+      honorLabels: true
 {{- end }}

--- a/helm/druid/values.yaml
+++ b/helm/druid/values.yaml
@@ -107,6 +107,11 @@ broker:
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
 
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
+
   nodeSelector: {}
 
   tolerations: []
@@ -162,6 +167,11 @@ coordinator:
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
 
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
+
   nodeSelector: {}
 
   tolerations: []
@@ -207,6 +217,11 @@ overlord:
     labels: {}
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
+
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
 
   nodeSelector: {}
 
@@ -284,6 +299,11 @@ historical:
     labels: {}
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
+
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
 
   livenessProbeInitialDelaySeconds: 60
   readinessProbeInitialDelaySeconds: 60
@@ -382,6 +402,11 @@ middleManager:
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
 
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
+
   ## (dict) If specified, apply these annotations to each master Pod
   podAnnotations: {}
 
@@ -439,6 +464,11 @@ router:
     labels: {}
     # -- Automount API credentials for the service account
     automountServiceAccountToken: true
+
+  metrics:
+    port: 8080
+    serviceMonitor:
+      enabled: false
 
   nodeSelector: {}
 


### PR DESCRIPTION
Fixes #13990.

### Description
This PR provides a way to easy way to expose a configured metrics port via the existing services and also optionally generate `ServiceMonitor` resources for users leveraging Prometheus.

#### Release note
Add metrics port exposure via services and optional Prometheus ServiceMonitors to helm chart

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
