### PR TITLE
lower segment heap footprint and fix bug with expression type coercion

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -2129,13 +2129,12 @@ public class CompactionTaskTest
             file,
             new SimpleQueryableIndex(
                 index.getDataInterval(),
-                index.getColumnNames(),
                 index.getAvailableDimensions(),
                 index.getBitmapFactoryForDimensions(),
                 index.getColumns(),
                 index.getFileMapper(),
                 null,
-                () -> index.getDimensionHandlers()
+                false
             )
         );
       }

--- a/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -48,7 +48,11 @@ import java.util.TreeMap;
  */
 public class SmooshedFileMapper implements Closeable
 {
-  private static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
+  /**
+   * Interner for smoosh internal files, which includes all column names since very column has an internal file
+   * associated with it
+   */
+  public static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();
 
   public static SmooshedFileMapper load(File baseDir) throws IOException
   {

--- a/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java
@@ -49,7 +49,7 @@ import java.util.TreeMap;
 public class SmooshedFileMapper implements Closeable
 {
   /**
-   * Interner for smoosh internal files, which includes all column names since very column has an internal file
+   * Interner for smoosh internal files, which includes all column names since every column has an internal file
    * associated with it
    */
   public static final Interner<String> STRING_INTERNER = Interners.newWeakInterner();

--- a/processing/src/main/java/org/apache/druid/math/expr/ExpressionTypeConversion.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExpressionTypeConversion.java
@@ -88,10 +88,10 @@ public class ExpressionTypeConversion
       return type;
     }
     if (type.is(ExprType.COMPLEX) || other.is(ExprType.COMPLEX)) {
-      if (type.getElementType() == null) {
+      if (type.getComplexTypeName() == null) {
         return other;
       }
-      if (other.getElementType() == null) {
+      if (other.getComplexTypeName() == null) {
         return type;
       }
       if (!Objects.equals(type, other)) {

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -60,7 +60,9 @@ import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.CompressedColumnarLongsSupplier;
 import org.apache.druid.segment.data.GenericIndexed;
 import org.apache.druid.segment.data.ImmutableRTreeObjectStrategy;
+import org.apache.druid.segment.data.Indexed;
 import org.apache.druid.segment.data.IndexedIterable;
+import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.data.VSizeColumnarMultiInts;
 import org.apache.druid.segment.serde.ComplexColumnPartSupplier;
 import org.apache.druid.segment.serde.DictionaryEncodedColumnSupplier;
@@ -639,14 +641,12 @@ public class IndexIO
           loadFailed
       );
 
-      final GenericIndexed<String> finalCols, finalDims;
+      final Indexed<String> finalCols, finalDims;
 
       if (allCols != null) {
         // To restore original column order, we merge allCols/allDims and nonNullCols/nonNullDims, respectively.
-        final List<String> mergedCols = restoreColumns(nonNullCols, allCols);
-        final List<String> mergedDims = restoreColumns(nonNullDims, allDims);
-        finalCols = GenericIndexed.fromIterable(mergedCols, GenericIndexed.STRING_STRATEGY);
-        finalDims = GenericIndexed.fromIterable(mergedDims, GenericIndexed.STRING_STRATEGY);
+        finalCols = new ListIndexed<>(restoreColumns(nonNullCols, allCols));
+        finalDims = new ListIndexed<>(restoreColumns(nonNullDims, allDims));
       } else {
         finalCols = nonNullCols;
         finalDims = nonNullDims;
@@ -701,9 +701,9 @@ public class IndexIO
               + "while allColsIterator expects one. This is likely a potential bug in creating this segment. "
               + "Try reingesting your data with storeEmptyColumns setting to false in task context."
           );
-          mergedCols.add(nonNullColsIterator.next());
+          mergedCols.add(SmooshedFileMapper.STRING_INTERNER.intern(nonNullColsIterator.next()));
         } else {
-          mergedCols.add(next);
+          mergedCols.add(SmooshedFileMapper.STRING_INTERNER.intern(next));
         }
       }
 
@@ -712,7 +712,7 @@ public class IndexIO
 
     private void registerColumnHolders(
         File inDir,
-        GenericIndexed<String> cols,
+        Indexed<String> cols,
         boolean lazy,
         Map<String, Supplier<ColumnHolder>> columns,
         ObjectMapper mapper,
@@ -726,7 +726,7 @@ public class IndexIO
           continue;
         }
 
-        ByteBuffer colBuffer = smooshedFiles.mapFile(columnName);
+        final ByteBuffer colBuffer = smooshedFiles.mapFile(columnName);
         registerColumnHolder(
             lazy,
             columns,
@@ -749,12 +749,16 @@ public class IndexIO
         SegmentLazyLoadFailCallback loadFailed
     ) throws IOException
     {
+
+      // we use the interner here too even though it might have already been added by restoreColumns(..) because that
+      // only happens if there are some null columns
+      final String internedColumnName = SmooshedFileMapper.STRING_INTERNER.intern(columnName);
       if (lazy) {
-        columns.put(columnName, Suppliers.memoize(
+        columns.put(internedColumnName, Suppliers.memoize(
             () -> {
               try {
                 return deserializeColumn(
-                    columnName,
+                    internedColumnName,
                     mapper,
                     colBuffer,
                     smooshedFiles
@@ -768,13 +772,13 @@ public class IndexIO
             }
         ));
       } else {
-        ColumnHolder columnHolder = deserializeColumn(
-            columnName,
+        final ColumnHolder columnHolder = deserializeColumn(
+            internedColumnName,
             mapper,
             colBuffer,
             smooshedFiles
         );
-        columns.put(columnName, () -> columnHolder);
+        columns.put(internedColumnName, () -> columnHolder);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -83,40 +83,6 @@ public class SimpleQueryableIndex extends AbstractIndex implements QueryableInde
     }
   }
 
-  private Map<String, DimensionHandler> initDimensionHandlers(Indexed<String> availableDimensions)
-  {
-    Map<String, DimensionHandler> dimensionHandlerMap = Maps.newLinkedHashMap();
-    for (String dim : availableDimensions) {
-      final ColumnHolder columnHolder = getColumnHolder(dim);
-      ColumnCapabilities capabilities = columnHolder.getHandlerCapabilities();
-      DimensionHandler handler = DimensionHandlerUtils.getHandlerFromCapabilities(dim, capabilities, null);
-      dimensionHandlerMap.put(dim, handler);
-    }
-    return dimensionHandlerMap;
-  }
-
-  @VisibleForTesting
-  public SimpleQueryableIndex(
-      Interval interval,
-      List<String> columnNames,
-      Indexed<String> availableDimensions,
-      BitmapFactory bitmapFactory,
-      Map<String, Supplier<ColumnHolder>> columns,
-      SmooshedFileMapper fileMapper,
-      @Nullable Metadata metadata,
-      Supplier<Map<String, DimensionHandler>> dimensionHandlers
-  )
-  {
-    this.dataInterval = interval;
-    this.columnNames = columnNames;
-    this.availableDimensions = availableDimensions;
-    this.bitmapFactory = bitmapFactory;
-    this.columns = columns;
-    this.fileMapper = fileMapper;
-    this.metadata = metadata;
-    this.dimensionHandlers = dimensionHandlers;
-  }
-
   @Override
   public Interval getDataInterval()
   {
@@ -193,4 +159,15 @@ public class SimpleQueryableIndex extends AbstractIndex implements QueryableInde
     return dimensionHandlers.get();
   }
 
+  private Map<String, DimensionHandler> initDimensionHandlers(Indexed<String> availableDimensions)
+  {
+    Map<String, DimensionHandler> dimensionHandlerMap = Maps.newLinkedHashMap();
+    for (String dim : availableDimensions) {
+      final ColumnHolder columnHolder = getColumnHolder(dim);
+      ColumnCapabilities capabilities = columnHolder.getHandlerCapabilities();
+      DimensionHandler handler = DimensionHandlerUtils.getHandlerFromCapabilities(dim, capabilities, null);
+      dimensionHandlerMap.put(dim, handler);
+    }
+    return dimensionHandlerMap;
+  }
 }

--- a/processing/src/test/java/org/apache/druid/math/expr/OutputTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/OutputTypeTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.math.expr;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -537,6 +538,20 @@ public class OutputTypeTest extends InitializedNullHandlingTest
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.STRING_ARRAY, ExpressionType.STRING_ARRAY)
     );
+
+    ExpressionType nested = ExpressionType.fromColumnType(NestedDataComplexTypeSerde.TYPE);
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.operator(nested, nested)
+    );
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.operator(nested, ExpressionType.UNKNOWN_COMPLEX)
+    );
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.operator(ExpressionType.UNKNOWN_COMPLEX, nested)
+    );
   }
 
   @Test
@@ -600,6 +615,19 @@ public class OutputTypeTest extends InitializedNullHandlingTest
     Assert.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.STRING_ARRAY, ExpressionType.STRING_ARRAY)
+    );
+    ExpressionType nested = ExpressionType.fromColumnType(NestedDataComplexTypeSerde.TYPE);
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.function(nested, nested)
+    );
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.function(nested, ExpressionType.UNKNOWN_COMPLEX)
+    );
+    Assert.assertEquals(
+        nested,
+        ExpressionTypeConversion.function(ExpressionType.UNKNOWN_COMPLEX, nested)
     );
   }
 


### PR DESCRIPTION
### Description
While working on some other stuff I noticed that we were doing something when loading segments which results in some extra heap usage storing redundant stuff we don't really need. Specifically, the changes in #12279 causes us to make a combined column and dimension list in the form of `Indexed` to pass to the `SimpleQueryableIndex`, which it was doing prior to this PR with https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/segment/IndexIO.java#L648 `GenericIndexed.fromIterable` which is going to make new heap bytebuffers of the column and dimension lists. The columns `Indexed` is thrown away basically, but the dimensions list is kept around forever.

We actually already have to have all of these column names on heap, and are already interning them via the `FileSmooshMapper` https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/java/util/common/io/smoosh/SmooshedFileMapper.java#L88 which does so whenever it reads `meta.smoosh` to get the internal file list of a smoosh. There is an internal file as the entry point for every column name, so if we re-use this interner for the map of `ColumnHolder` suppliers as well as to back the `Indexed<String>` for the dimension list then we can save some heap.

With my laptop test cluster of ~5k segments it reduces the heap footprint by ~20MB

Before:
![Screenshot 2023-03-29 at 8 27 59 PM](https://user-images.githubusercontent.com/1577461/228732099-bcea909c-c400-4d42-b6db-c5ec2033af19.png)

After:
![Screenshot 2023-03-29 at 8 28 22 PM](https://user-images.githubusercontent.com/1577461/228732186-f4c6f7a5-1718-4edb-b3dc-28bd402166c7.png)

Looking specifically at strings, we now have about 1/3 as many on heap (from the map of ColumnHolder suppliers), not counting all of the heap bytebuffers which were backing the dimensions lists.
![Screenshot 2023-03-29 at 8 38 54 PM](https://user-images.githubusercontent.com/1577461/228732287-5166a7c4-3342-4cee-8240-6ba32ba51f13.png)
![Screenshot 2023-03-29 at 8 39 00 PM](https://user-images.githubusercontent.com/1577461/228732298-0dfc568e-0d3f-488d-9ae9-af19de3dc033.png)


Completely unrelated, this PR also fixes a bug with native expression type coercion with complex types. The added test would fail where it would return "unknown complex" sometimes when using the `ExpressionTypeCoercion.operator` method. I guess I could have made it its own PR, but both things were small...




This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
