### PR TITLE
New error message for task deletion

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClient.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClient.java
@@ -133,7 +133,7 @@ public class DruidKubernetesPeonClient implements KubernetesPeonClient
       if (result) {
         log.info("Cleaned up k8s task: %s", taskId);
       } else {
-        log.info("Failed to cleanup task: %s", taskId);
+        log.info("K8s task does not exist: %s", taskId);
       }
       return result;
     } else {

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClientTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidKubernetesPeonClientTest.java
@@ -141,6 +141,26 @@ public class DruidKubernetesPeonClientTest
   }
 
   @Test
+  void testCleanupReturnValue() throws KubernetesResourceNotFoundException
+  {
+    DruidKubernetesPeonClient peonClient = new DruidKubernetesPeonClient(new TestKubernetesClient(this.client), "test",
+        false
+    );
+    Assertions.assertFalse(peonClient.cleanUpJob(new K8sTaskId("sometask")));
+
+    Job job = new JobBuilder()
+        .withNewMetadata()
+        .withName("sometask")
+        .addToLabels(DruidK8sConstants.LABEL_KEY, "true")
+        .endMetadata()
+        .withNewSpec()
+        .withTemplate(new PodTemplateSpec(new ObjectMeta(), K8sTestUtils.getDummyPodSpec()))
+        .endSpec().build();
+    client.batch().v1().jobs().inNamespace("test").create(job);
+    Assertions.assertTrue(peonClient.cleanUpJob(new K8sTaskId("sometask")));
+  }
+
+  @Test
   void watchingALogThatDoesntExist()
   {
     DruidKubernetesPeonClient peonClient = new DruidKubernetesPeonClient(


### PR DESCRIPTION
### Description
The fabric8 API returns false only if the K8s API returns a 404 on a delete attempt (resource not found). If there is a actual error than fabric8 will rethrow the client exception. Updating the log message to account for this.

See:
https://javadoc.io/static/io.fabric8/kubernetes-client/4.6.4/io/fabric8/kubernetes/client/dsl/base/BaseOperation.html#delete--


##### Key changed/added classes in this PR
Update DruidKubernetesPeonClient to handle false results from job.delete() differently.
This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
