### PR TITLE
Remove duplicate trigger in Cron Job ITs workflow

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -24,10 +24,6 @@ on:
       - master
       - /^\d+\.\d+\.\d+(-\S*)?$/ # release branches
 
-  pull_request:
-    paths:
-      'owasp-dependency-check-suppressions.xml'
-
 jobs:
   build:
     if: github.event_name == 'schedule'


### PR DESCRIPTION
This [commit](https://github.com/apache/druid/commit/3c096c01a2c4554b6f107627fb55755b4f2a6cb0) added duplicate trigger on pull-request in `Cron Job ITs` workflow. Hence removing this duplicate that is failing Cron Job ITs workflow to start.