### PR TITLE
Fix the order of aggregator finalization in GroupByPostShuffleFrameProcessor (MSQ)

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleFrameProcessor.java
@@ -227,7 +227,8 @@ public class GroupByPostShuffleFrameProcessor implements FrameProcessor<Long>
       return false;
     }
 
-    // Finalize aggregators.
+    // Finalize aggregators after checking if they are passing the havingSpec, because havingSpec expects the
+    // unfinalized row (and finalizes it internally after making a copy of it)
     finalizeFn.accept(outputRow);
 
     if (frameWriter.addSelection()) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleFrameProcessor.java
@@ -221,14 +221,16 @@ public class GroupByPostShuffleFrameProcessor implements FrameProcessor<Long>
       outputRowAsMap.put(postAggregator.getName(), value);
     }
 
-    // Finalize aggregators.
-    finalizeFn.accept(outputRow);
-
     if (havingSpec != null && !havingSpec.eval(outputRow)) {
       // Didn't match HAVING.
       outputRow = null;
       return false;
-    } else if (frameWriter.addSelection()) {
+    }
+
+    // Finalize aggregators.
+    finalizeFn.accept(outputRow);
+
+    if (frameWriter.addSelection()) {
       outputRow = null;
       return false;
     } else if (frameWriter.getNumRows() > 0) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -1208,10 +1208,10 @@ public class MSQSelectTest extends MSQTestBase
                                    .build())
         .setQueryContext(context)
         .setExpectedRowSignature(resultSignature)
-        .setExpectedResultRows(ImmutableList.of(
-                                   new Object[]{null, 3L},
-                                   new Object[]{"a", 2L}
-                               )
+        .setExpectedResultRows(
+            NullHandling.replaceWithDefault()
+            ? ImmutableList.of(new Object[]{null, 3L}, new Object[]{"a", 2L})
+            : ImmutableList.of(new Object[]{null, 2L}, new Object[]{"a", 2L})
 
         )
         .verifyResults();


### PR DESCRIPTION
### Description

Fixes the order in which the row's results are finalized in the `GroupByPostShuffleFrameProcessor`. This fixes the bug which prevents the queries containing a `HAVING` clause with complex aggregators from executing.

```sql
SELECT count(distinct __time)
FROM foo
GROUP BY c1
HAVING count(distinct __time) > 5
```

The bug arises because `DimFilterHavingSpec` expects the unfinalized rows to check if the row passes the `HAVING` clause (it finalizes it internally), however in the `GroupByPostShuffleFrameProcessor`, we finalize the rows before that. 

###### NOTE 
This should also allow the following test cases to pass, however, they are not enabled due to the null handling discrepancy in the MSQ test cases:
```
CalciteQueryTest#testHavingOnApproximateCountDistinct()
CalciteQueryTest#testHavingOnExactCountDistinct
```
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `GroupByPostShuffleFrameProcessor`

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
