### PR TITLE
Clean docker environment before Revised ITs test in GHA

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -108,6 +108,7 @@ jobs:
   security_vulnerabilities:
     name: security vulnerabilities
     strategy:
+      fail-fast: false
       matrix:
         HADOOP_PROFILE: [ '', '-Phadoop3' ]
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -119,6 +119,9 @@ jobs:
 
       - name: Load docker image
         run: |
+          echo "Stopping and pruning any remnant docker containers from previous run"
+          docker ps -aq | xargs -r docker rm -f
+          docker system prune -af --volumes
           docker load --input druid-container-jdk${{ inputs.build_jdk }}.tar.gz
           docker images
 

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -117,7 +117,7 @@ jobs:
           echo $DRUID_IT_IMAGE_NAME
           docker save "$DRUID_IT_IMAGE_NAME" | gzip > druid-container-jdk${{ inputs.build_jdk }}.tar.gz
 
-      - name: Load docker image
+      - name: Clean docker environment and Load docker image
         run: |
           echo "Stopping and pruning any remnant docker containers from previous run"
           docker ps -aq | xargs -r docker rm -f


### PR DESCRIPTION
Revised ITs fail to run if zookeeper, metadata docker containers exist already (Could be remnants from previous runs on the runner after unsuccessful cleanup job) with the following error.

```
Creating metadata ... 
Creating zookeeper ... 
Creating zookeeper ... error

ERROR: for zookeeper  Cannot create container for service zookeeper: Conflict. The container name "/zookeeper" is already in use by container "9c599e6f36f5cda67d98c39f5c3397b967b4d52e432e1c7949268a961c06ddac". You have to remove (or rename) that container to be able to reuse that name.
Creating metadata  ... error

ERROR: for metadata  Cannot create container for service metadata: Conflict. The container name "/metadata" is already in use by container "df90f24f5c561a9c8f1e1d2b4288c18f93b269c6181ae6f439e94c947c27b4b1". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for zookeeper  Cannot create container for service zookeeper: Conflict. The container name "/zookeeper" is already in use by container "9c599e6f36f5cda67d98c39f5c3397b967b4d52e432e1c7949268a961c06ddac". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for metadata  Cannot create container for service metadata: Conflict. The container name "/metadata" is already in use by container "df90f24f5c561a9c8f1e1d2b4288c18f93b269c6181ae6f439e94c947c27b4b1". You have to remove (or rename) that container to be able to reuse that name.
Encountered errors while bringing up the project.
```

This PR cleans up any existing docker containers and prunes the volumes before the test run.