### PR TITLE
Update documentation for Kafka Supervisor IdleConfig

### DIFF
--- a/docs/development/extensions-core/kafka-supervisor-reference.md
+++ b/docs/development/extensions-core/kafka-supervisor-reference.md
@@ -87,7 +87,7 @@ This topic contains configuration reference information for the Apache Kafka sup
 | `enabled` | If `true`, Kafka supervisor will become idle if there is no data on input stream/topic for some time. | no (default == false) |
 | `inactiveAfterMillis` | Supervisor is marked as idle if all existing data has been read from input topic and no new data has been published for `inactiveAfterMillis` milliseconds. | no (default == `600_000`) |
 
-> When the supervisor enters the idle state, no new tasks will be launched subsequent to the completion of the currently executing tasks. This strategy may lead to reduced costs for cluster operators while using topics that experience sporadic data.
+> When the supervisor enters the idle state, no new tasks will be launched subsequent to the completion of the currently executing tasks. This strategy may lead to reduced costs for cluster operators while using topics that get sporadic data.
 
 The following example demonstrates supervisor spec with `lagBased` autoScaler and idle config enabled:
 ```json

--- a/docs/development/extensions-core/kafka-supervisor-reference.md
+++ b/docs/development/extensions-core/kafka-supervisor-reference.md
@@ -87,7 +87,7 @@ This topic contains configuration reference information for the Apache Kafka sup
 | `enabled` | If `true`, Kafka supervisor will become idle if there is no data on input stream/topic for some time. | no (default == false) |
 | `inactiveAfterMillis` | Supervisor is marked as idle if all existing data has been read from input topic and no new data has been published for `inactiveAfterMillis` milliseconds. | no (default == `600_000`) |
 
-> When the supervisor enters an idle state, no new tasks will be launched subsequent to the completion of the currently executing tasks. This strategy may lead to reduced costs for cluster operators while using topics that experience sporadic data.
+> When the supervisor enters the idle state, no new tasks will be launched subsequent to the completion of the currently executing tasks. This strategy may lead to reduced costs for cluster operators while using topics that experience sporadic data.
 
 The following example demonstrates supervisor spec with `lagBased` autoScaler and idle config enabled:
 ```json

--- a/docs/development/extensions-core/kafka-supervisor-reference.md
+++ b/docs/development/extensions-core/kafka-supervisor-reference.md
@@ -87,6 +87,8 @@ This topic contains configuration reference information for the Apache Kafka sup
 | `enabled` | If `true`, Kafka supervisor will become idle if there is no data on input stream/topic for some time. | no (default == false) |
 | `inactiveAfterMillis` | Supervisor is marked as idle if all existing data has been read from input topic and no new data has been published for `inactiveAfterMillis` milliseconds. | no (default == `600_000`) |
 
+> When the supervisor enters an idle state, no new tasks will be launched subsequent to the completion of the currently executing tasks. This strategy may lead to reduced costs for cluster operators while using topics that experience sporadic data.
+
 The following example demonstrates supervisor spec with `lagBased` autoScaler and idle config enabled:
 ```json
 {


### PR DESCRIPTION
This PR updates documentation on the advantages of using Kafka Supervisor `IdleConfig`.