### PR TITLE
Revert quoting lookup fix.

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -88,7 +88,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
     this.filter = filter;
     if (pollPeriod == null) {
       // Warning because if JdbcExtractionNamespace is being used for lookups, any updates to the database will not
-      // be picked up after the node starts. So for use cases where nodes start at different times (like streaming
+      // be picked up after the node starts. So for use casses where nodes start at different times (like streaming
       // ingestion with peons) there can be data inconsistencies across the cluster.
       LOG.warn("No pollPeriod configured for JdbcExtractionNamespace - entries will be loaded only once at startup");
       this.pollPeriod = new Period(0L);

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -88,7 +88,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
     this.filter = filter;
     if (pollPeriod == null) {
       // Warning because if JdbcExtractionNamespace is being used for lookups, any updates to the database will not
-      // be picked up after the node starts. So for use casses where nodes start at different times (like streaming
+      // be picked up after the node starts. So for use cases where nodes start at different times (like streaming
       // ingestion with peons) there can be data inconsistencies across the cluster.
       LOG.warn("No pollPeriod configured for JdbcExtractionNamespace - entries will be loaded only once at startup");
       this.pollPeriod = new Period(0L);

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -40,7 +40,6 @@ import org.skife.jdbi.v2.util.TimestampMapper;
 
 import javax.annotation.Nullable;
 import java.sql.Timestamp;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -192,21 +191,10 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
       dbi = dbiCache.get(key);
     }
     if (dbi == null) {
-      Properties props = new Properties();
-      if (namespace.getConnectorConfig().getUser() != null) {
-        props.setProperty("user", namespace.getConnectorConfig().getUser());
-      }
-      if (namespace.getConnectorConfig().getPassword() != null) {
-        props.setProperty("password", namespace.getConnectorConfig().getPassword());
-      }
-
-      // We use double quotes to quote identifiers. This enables us to write SQL
-      // that works with most databases that are SQL compliant.
-      props.setProperty("sessionVariables", "sql_mode='ANSI_QUOTES'");
-
       final DBI newDbi = new DBI(
           namespace.getConnectorConfig().getConnectURI(),
-          props
+          namespace.getConnectorConfig().getUser(),
+          namespace.getConnectorConfig().getPassword()
       );
       dbiCache.putIfAbsent(key, newDbi);
       dbi = dbiCache.get(key);

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/JdbcCacheGenerator.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.server.lookup.namespace;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import org.apache.druid.data.input.MapPopulator;
 import org.apache.druid.java.util.common.ISE;
@@ -161,27 +160,21 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
     if (Strings.isNullOrEmpty(filter)) {
       return StringUtils.format(
           "SELECT %s, %s FROM %s WHERE %s IS NOT NULL",
-          toDoublyQuotedEscapedIdentifier(keyColumn),
-          toDoublyQuotedEscapedIdentifier(valueColumn),
-          toDoublyQuotedEscapedIdentifier(table),
-          toDoublyQuotedEscapedIdentifier(valueColumn)
+          keyColumn,
+          valueColumn,
+          table,
+          valueColumn
       );
     }
 
     return StringUtils.format(
         "SELECT %s, %s FROM %s WHERE %s AND %s IS NOT NULL",
-        toDoublyQuotedEscapedIdentifier(keyColumn),
-        toDoublyQuotedEscapedIdentifier(valueColumn),
-        toDoublyQuotedEscapedIdentifier(table),
+        keyColumn,
+        valueColumn,
+        table,
         filter,
-        toDoublyQuotedEscapedIdentifier(valueColumn)
+        valueColumn
     );
-  }
-
-  @VisibleForTesting
-  public static String toDoublyQuotedEscapedIdentifier(String identifier)
-  {
-    return "\"" + StringUtils.replace(identifier, "\"", "\"\"") + "\"";
   }
 
   private DBI ensureDBI(CacheScheduler.EntryImpl<JdbcExtractionNamespace> key, JdbcExtractionNamespace namespace)
@@ -215,7 +208,7 @@ public final class JdbcCacheGenerator implements CacheGenerator<JdbcExtractionNa
         handle -> {
           final String query = StringUtils.format(
               "SELECT MAX(%s) FROM %s",
-              toDoublyQuotedEscapedIdentifier(tsColumn), toDoublyQuotedEscapedIdentifier(table)
+              tsColumn, table
           );
           return handle
               .createQuery(query)

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -77,7 +77,9 @@ public class JdbcExtractionNamespaceTest
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
 
   private static final Logger log = new Logger(JdbcExtractionNamespaceTest.class);
-
+  private static final String TABLE_NAME = "abstractDbRenameTest";
+  private static final String KEY_NAME = "keyName";
+  private static final String VAL_NAME = "valName";
   private static final String TS_COLUMN = "tsColumn";
   private static final String FILTER_COLUMN = "filterColumn";
   private static final Map<String, String[]> RENAMES = ImmutableMap.of(
@@ -88,32 +90,22 @@ public class JdbcExtractionNamespaceTest
   );
 
 
-  @Parameterized.Parameters(name = "tableName={0}, keyName={1}, valName={2}, tsColumn={3}")
+  @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> getParameters()
   {
     return ImmutableList.of(
-        new Object[]{"table", "select", "foo \" column;", "tsColumn"}, // reserved identifiers as table, key and value columns.
-        new Object[]{"abstractDbRenameTest", "keyName", "valName", "tsColumn"},
-        new Object[]{"abstractDbRenameTest", "keyName", "valName", null}
+        new Object[]{"tsColumn"},
+        new Object[]{null}
     );
   }
 
   public JdbcExtractionNamespaceTest(
-      String tableName,
-      String keyName,
-      String valName,
       String tsColumn
   )
   {
-    this.tableName = tableName;
-    this.keyName = keyName;
-    this.valName = valName;
     this.tsColumn = tsColumn;
   }
 
-  private final String tableName;
-  private final String keyName;
-  private final String valName;
   private final String tsColumn;
   private CacheScheduler scheduler;
   private Lifecycle lifecycle;
@@ -140,20 +132,18 @@ public class JdbcExtractionNamespaceTest
               handle.createStatement(
                   StringUtils.format(
                       "CREATE TABLE %s (%s TIMESTAMP, %s VARCHAR(64), %s VARCHAR(64), %s VARCHAR(64))",
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(TS_COLUMN),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
-                      JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName)
+                      TABLE_NAME,
+                      TS_COLUMN,
+                      FILTER_COLUMN,
+                      KEY_NAME,
+                      VAL_NAME
                   )
               ).setQueryTimeout(1).execute()
           );
-          handle.createStatement(StringUtils.format("TRUNCATE TABLE %s",
-              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName))).setQueryTimeout(1).execute();
+          handle.createStatement(StringUtils.format("TRUNCATE TABLE %s", TABLE_NAME)).setQueryTimeout(1).execute();
           handle.commit();
           closer.register(() -> {
-            handle.createStatement(StringUtils.format("DROP TABLE %s",
-                JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName))).setQueryTimeout(1).execute();
+            handle.createStatement("DROP TABLE " + TABLE_NAME).setQueryTimeout(1).execute();
             final ListenableFuture future = setupTeardownService.submit(new Runnable()
             {
               @Override
@@ -302,25 +292,19 @@ public class JdbcExtractionNamespaceTest
     final String statementVal = val != null ? "'%s'" : "%s";
     if (tsColumn == null) {
       handle.createStatement(
-          StringUtils.format("DELETE FROM %s WHERE %s='%s'", JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
-              JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName), key)
+          StringUtils.format("DELETE FROM %s WHERE %s='%s'", TABLE_NAME, KEY_NAME, key)
       ).setQueryTimeout(1).execute();
       query = StringUtils.format(
           "INSERT INTO %s (%s, %s, %s) VALUES ('%s', '%s', " + statementVal + ")",
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName),
+          TABLE_NAME,
+          FILTER_COLUMN, KEY_NAME, VAL_NAME,
           filter, key, val
       );
     } else {
       query = StringUtils.format(
           "INSERT INTO %s (%s, %s, %s, %s) VALUES ('%s', '%s', '%s', " + statementVal + ")",
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tableName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(tsColumn),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(keyName),
-          JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(valName),
+          TABLE_NAME,
+          tsColumn, FILTER_COLUMN, KEY_NAME, VAL_NAME,
           updateTs, filter, key, val
       );
     }
@@ -337,9 +321,9 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        tableName,
-        keyName,
-        valName,
+        TABLE_NAME,
+        KEY_NAME,
+        VAL_NAME,
         tsColumn,
         null,
         new Period(0),
@@ -370,11 +354,11 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        tableName,
-        keyName,
-        valName,
+        TABLE_NAME,
+        KEY_NAME,
+        VAL_NAME,
         tsColumn,
-        JdbcCacheGenerator.toDoublyQuotedEscapedIdentifier(FILTER_COLUMN) + "='1'",
+        FILTER_COLUMN + "='1'",
         new Period(0),
         null,
         new JdbcAccessSecurityConfig()
@@ -445,9 +429,9 @@ public class JdbcExtractionNamespaceTest
     final JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig();
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        tableName,
-        keyName,
-        valName,
+        TABLE_NAME,
+        KEY_NAME,
+        VAL_NAME,
         tsColumn,
         "some filter",
         new Period(10),
@@ -470,9 +454,9 @@ public class JdbcExtractionNamespaceTest
   {
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
-        tableName,
-        keyName,
-        valName,
+        TABLE_NAME,
+        KEY_NAME,
+        VAL_NAME,
         tsColumn,
         null,
         new Period(10),


### PR DESCRIPTION
Lookup values can have expressions and functions, amongst other things. So, while naive escaping works for simple things, it will not work for functions, etc. Instead of parsing the keys and values, which can be tricky, I'm reverting this quoting logic. Users using reserved identifiers as keys and values can still escape them while configuring lookups.


Reverts the following two PRs:
- https://github.com/apache/druid/pull/13632
- https://github.com/apache/druid/pull/13826
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
