### PR TITLE
#14033 Updated case statement for ISO Year

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
@@ -138,7 +138,7 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
           case YEAR:
             return ExprEval.of(dateTime.year().get());
           case ISOYEAR:
-            return ExprEval.of(dateTime.year().get());
+            return ExprEval.of(dateTime.weekyear().get());
           case DECADE:
             // The year field divided by 10, See https://www.postgresql.org/docs/10/functions-datetime.html
             return ExprEval.of(dateTime.year().get() / 10);

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
@@ -140,13 +140,13 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
           case YEAR:
             return ExprEval.of(dateTime.year().get());
           case ISOYEAR:
-            if(isoWeek == 1 && dateTime.getMonthOfYear() == 12) {
+            if(isoWeek == 1 && dateTime.getMonthOfYear() == 12){
               // special case: if the date is in the last week of the previous year
               isoYear--;
             } 
-            else if(isoWeek >= 52 && dateTime.getMonthOfYear() == 1) {
-            // special case: if the date is in the first week of the next year
-            isoYear++;
+            else if(isoWeek >= 52 && dateTime.getMonthOfYear() == 1){
+              // special case: if the date is in the first week of the next year
+              isoYear++;
             }
             return ExprEval.of(isoYear);
           case DECADE:

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
@@ -107,6 +107,8 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
         }
         final DateTime dateTime = new DateTime(val, chronology);
         long epoch = dateTime.getMillis() / 1000;
+        int isoWeek = dateTime.weekOfWeekyear().get(); // get ISO week of year
+        int isoYear = dateTime.getWeekyear(); // get ISO year
 
         switch (unit) {
           case EPOCH:
@@ -138,7 +140,15 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
           case YEAR:
             return ExprEval.of(dateTime.year().get());
           case ISOYEAR:
-            return ExprEval.of(dateTime.weekyear().get());
+            if(isoWeek == 1 && dateTime.getMonthOfYear() == 12) {
+              // special case: if the date is in the last week of the previous year
+              isoYear--;
+            } 
+            else if(isoWeek >= 52 && dateTime.getMonthOfYear() == 1) {
+            // special case: if the date is in the first week of the next year
+            isoYear++;
+            }
+            return ExprEval.of(isoYear);
           case DECADE:
             // The year field divided by 10, See https://www.postgresql.org/docs/10/functions-datetime.html
             return ExprEval.of(dateTime.year().get() / 10);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #14036.

### Description

In Druid Console, enter the following SQL query and execute:

select EXTRACT(ISOYEAR FROM TIMESTAMP '2023-01-01')
Result: 2023

Expected result: 2022

Explanation: The ISO week of the date 2023-01-01 is the 52nd week of the year 2022, which should be returned by EXTRACT(ISOYEAR ...).

#### Fixed the bug by replacing dateTime.year().get() with dateTime.weekyear().get()

#### Release note
Fixed:  EXTRACT(ISOYEAR ...) now returns ISO year instead of only year. An ISO week-numbering year (also called ISO year informally) has 52 or 53 full weeks. That is 364 or 371 days instead of the usual 365 or 366 days.



This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
