### PR TITLE
Run intellij inspections only on changed files in a PR

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -125,11 +125,11 @@ jobs:
 #        if: ${{ matrix.java == 'jdk8' }}
 #        run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
-      - name: Run intellij inspections only on changed files in PR
+      - name: intellij inspections on changed files in PR
         if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull_request' }}
         run: |
-          git diff ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF} > ./pr_diff.patch
-          git checkout -b ${GITHUB_BASE_REF}-intellij-inspections ${GITHUB_BASE_REF}
+          git diff origin/${GITHUB_BASE_REF}..HEAD > ./pr_diff.patch
+          git checkout -b ${GITHUB_BASE_REF}-intellij-inspections origin/${GITHUB_BASE_REF}
           git apply ./pr_diff.patch
           sudo snap install intellij-idea-community --classic
           /bin/idea.sh inspect . ./.idea/inspectionProfiles/Druid.xml -v2 -changes

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -125,8 +125,22 @@ jobs:
         if: ${{ matrix.java == 'jdk8' }}
         run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
+      - name: Run intellij inspections only on changed files in PR
+        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull-request' }}
+        run: |
+          git diff ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF} > ./pr_diff.patch
+          git checkout -b ${GITHUB_BASE_REF}-intellij-inspections ${GITHUB_BASE_REF}
+          git apply ./pr_diff.patch
+          sudo snap install intellij-idea-community --classic
+          /bin/idea.sh inspect . ./.idea/inspectionProfiles/Druid.xml -v2 -changes
+
+      # Checkout PR branch after running intellij-inspections
+      - name: checkout branch
+        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull-request' }}
+        uses: actions/checkout@v3
+
       - name: intellij inspections
-        if: ${{ matrix.java == 'jdk8' }}
+        if: ${{ matrix.java == 'jdk8' && github.event_name == 'push' }}
         run: |
           docker run --rm \
           -v $(pwd):/project \

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -128,6 +128,8 @@ jobs:
       - name: intellij inspections on changed files in PR
         if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull_request' }}
         run: |
+          echo $JAVA_HOME
+          git remote set-branches --add origin ${GITHUB_BASE_REF} && git fetch
           git diff origin/${GITHUB_BASE_REF}..HEAD > ./pr_diff.patch
           git checkout -b ${GITHUB_BASE_REF}-intellij-inspections origin/${GITHUB_BASE_REF}
           git apply ./pr_diff.patch

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -126,7 +126,7 @@ jobs:
 #        run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
       - name: Run intellij inspections only on changed files in PR
-        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull-request' }}
+        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull_request' }}
         run: |
           git diff ${GITHUB_BASE_REF}..${GITHUB_HEAD_REF} > ./pr_diff.patch
           git checkout -b ${GITHUB_BASE_REF}-intellij-inspections ${GITHUB_BASE_REF}
@@ -136,7 +136,7 @@ jobs:
 
       # Checkout PR branch after running intellij-inspections
       - name: checkout branch
-        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull-request' }}
+        if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull_request' }}
         uses: actions/checkout@v3
 
       - name: intellij inspections

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -53,77 +53,77 @@ jobs:
       - name: setup ${{ matrix.java }}
         run: export JAVA_HOME=$JAVA_HOME_${{ env.java_version }}_X64
 
-      - name: packaging check
-        run: |
-          ./.github/scripts/setup_generate_license.sh
-          ${MVN} clean install -Prat --fail-at-end \
-          -pl '!benchmarks, !distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
-          ${MVN} install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end \
-          -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
-
-      - name: script checks
-        # who watches the watchers?
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ./check_test_suite_test.py
-
-      - name: (openjdk11) strict compilation
-        if: ${{ matrix.java == 'jdk11' }}
-        # errorprone requires JDK 11
-        # Strict compilation requires more than 2 GB
-        run: ${MVN} clean -DstrictCompile compile test-compile --fail-at-end ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
-
-      - name: maven install
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          echo 'Running Maven install...' &&
-          ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
-          ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
-
-      - name: license checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ./.github/scripts/license_checks_script.sh
-
-      - name: license checks for hadoop3
-        if: ${{ matrix.java == 'jdk8' }}
-        env:
-          HADOOP_PROFILE: -Phadoop3
-        run: ./.github/scripts/license_checks_script.sh
-
-      - name: analyze dependencies
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          ./.github/scripts/analyze_dependencies_script.sh
-
-      - name: analyze dependencies for hadoop3
-        if: ${{ matrix.java == 'jdk8' }}
-        env:
-          HADOOP_PROFILE: -Phadoop3
-        run: |
-          ./.github/scripts/analyze_dependencies_script.sh
-
-      - name: animal sniffer checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} animal-sniffer:check --fail-at-end
-
-      - name: checkstyle
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} checkstyle:checkstyle --fail-at-end
-
-      - name: enforcer checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} enforcer:enforce --fail-at-end
-
-      - name: forbidden api checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
-
-      - name: pmd checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} pmd:check --fail-at-end  # TODO: consider adding pmd:cpd-check
-
-      - name: spotbugs checks
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
+#      - name: packaging check
+#        run: |
+#          ./.github/scripts/setup_generate_license.sh
+#          ${MVN} clean install -Prat --fail-at-end \
+#          -pl '!benchmarks, !distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
+#          ${MVN} install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end \
+#          -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
+#
+#      - name: script checks
+#        # who watches the watchers?
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ./check_test_suite_test.py
+#
+#      - name: (openjdk11) strict compilation
+#        if: ${{ matrix.java == 'jdk11' }}
+#        # errorprone requires JDK 11
+#        # Strict compilation requires more than 2 GB
+#        run: ${MVN} clean -DstrictCompile compile test-compile --fail-at-end ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+#
+#      - name: maven install
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: |
+#          echo 'Running Maven install...' &&
+#          ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
+#          ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+#
+#      - name: license checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ./.github/scripts/license_checks_script.sh
+#
+#      - name: license checks for hadoop3
+#        if: ${{ matrix.java == 'jdk8' }}
+#        env:
+#          HADOOP_PROFILE: -Phadoop3
+#        run: ./.github/scripts/license_checks_script.sh
+#
+#      - name: analyze dependencies
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: |
+#          ./.github/scripts/analyze_dependencies_script.sh
+#
+#      - name: analyze dependencies for hadoop3
+#        if: ${{ matrix.java == 'jdk8' }}
+#        env:
+#          HADOOP_PROFILE: -Phadoop3
+#        run: |
+#          ./.github/scripts/analyze_dependencies_script.sh
+#
+#      - name: animal sniffer checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} animal-sniffer:check --fail-at-end
+#
+#      - name: checkstyle
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} checkstyle:checkstyle --fail-at-end
+#
+#      - name: enforcer checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} enforcer:enforce --fail-at-end
+#
+#      - name: forbidden api checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} forbiddenapis:check forbiddenapis:testCheck --fail-at-end
+#
+#      - name: pmd checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} pmd:check --fail-at-end  # TODO: consider adding pmd:cpd-check
+#
+#      - name: spotbugs checks
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
       - name: Run intellij inspections only on changed files in PR
         if: ${{ matrix.java == 'jdk8' && github.event_name == 'pull-request' }}
@@ -151,32 +151,32 @@ jobs:
           --levels ERROR \
           --scope JavaInspectionsScope
 
-      - name: setup node
-        if: ${{ matrix.java == 'jdk8' }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.17.0
-
-      - name: docs
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          (cd website && npm install)
-          cd website
-          npm run link-lint
-          npm run spellcheck
-
-      - name: web console
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          ${MVN} test -pl 'web-console'
-          cd web-console
-          { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
-
-      - name: web console end-to-end test
-        if: ${{ matrix.java == 'jdk8' }}
-        run: |
-          ./.github/scripts/setup_generate_license.sh
-          web-console/script/druid build
-          web-console/script/druid start
-          (cd web-console && npm run test-e2e)
-          web-console/script/druid stop
+#      - name: setup node
+#        if: ${{ matrix.java == 'jdk8' }}
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: 16.17.0
+#
+#      - name: docs
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: |
+#          (cd website && npm install)
+#          cd website
+#          npm run link-lint
+#          npm run spellcheck
+#
+#      - name: web console
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: |
+#          ${MVN} test -pl 'web-console'
+#          cd web-console
+#          { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
+#
+#      - name: web console end-to-end test
+#        if: ${{ matrix.java == 'jdk8' }}
+#        run: |
+#          ./.github/scripts/setup_generate_license.sh
+#          web-console/script/druid build
+#          web-console/script/druid start
+#          (cd web-console && npm run test-e2e)
+#          web-console/script/druid stop

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -134,7 +134,9 @@ jobs:
           git checkout -b ${GITHUB_BASE_REF}-intellij-inspections origin/${GITHUB_BASE_REF}
           git apply ./pr_diff.patch
           sudo snap install intellij-idea-community --classic
-          /bin/idea.sh inspect . ./.idea/inspectionProfiles/Druid.xml -v2 -changes
+          ls /snap/
+          ls /snap/intellij-idea-community/
+          /snap/intellij-idea-community/current/bin/idea.sh inspect . ./.idea/inspectionProfiles/Druid.xml -v2 -changes
 
       # Checkout PR branch after running intellij-inspections
       - name: checkout branch


### PR DESCRIPTION
### Description:
IntelliJ-inspections in Static-checks CI runs on all files and is stalling the workflow for approximately 30 mins. In the case of a PR, these inspections are sufficient to run only on updated files. In case of commits on master and release branches, inspections continue to run on all files.