### PR TITLE
Minor tweaks to error strings & javadocs.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
@@ -230,7 +230,7 @@ public class MSQTasks
 
     if (errorReport.getExceptionStackTrace() != null) {
       if (errorReport.getFault() instanceof UnknownFault || errorReport.getFault() instanceof QueryRuntimeFault) {
-        // Log full stack trace for unknown and QueryStack faults
+        // Log full stack trace for UnknownFault and QueryRuntimeFault
         logMessage.append('\n').append(errorReport.getExceptionStackTrace());
       } else {
         // Log first line only (error class, message) for known faults, to avoid polluting logs.

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
@@ -194,7 +194,7 @@ public class MSQErrorReport
         return new RowTooLargeFault(((FrameRowTooLargeException) cause).getMaxFrameSize());
       } else if (cause instanceof UnexpectedMultiValueDimensionException) {
         return new QueryRuntimeFault(StringUtils.format(
-            "Column [%s] is a multi value string. Please wrap the column using MV_TO_ARRAY() to proceed further.",
+            "Column [%s] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.",
             ((UnexpectedMultiValueDimensionException) cause).getDimensionName()
         ), cause.getMessage());
       } else if (cause.getClass().getPackage().getName().startsWith("org.apache.druid.query")) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/QueryRuntimeFault.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/QueryRuntimeFault.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
- * Fault to throw when the error comes from the druid native query runtime while running in the MSQ engine .
+ * Fault to throw when the error comes from the druid native query runtime while running in the MSQ engine.
  */
 @JsonTypeName(QueryRuntimeFault.CODE)
 public class QueryRuntimeFault extends BaseMSQFault

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -497,7 +497,7 @@ public class MSQInsertTest extends MSQTestBase
                      .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
                          CoreMatchers.instanceOf(ISE.class),
                          ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                             "Column [dim3] is a multi value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
+                             "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
                          )
                      ))
                      .verifyExecutionError();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -1316,7 +1316,7 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
             CoreMatchers.instanceOf(ISE.class),
             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
-                "Column [dim3] is a multi value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
+                "Column [dim3] is a multi-value string. Please wrap the column using MV_TO_ARRAY() to proceed further.")
             )
         ))
         .verifyExecutionError();


### PR DESCRIPTION
A follow-up to https://github.com/apache/druid/pull/13926.

- Hyphenate multi-value string as it's consistent with [docs](https://druid.apache.org/docs/latest/querying/multi-value-dimensions.html) and other code references.
- Fixup a comment and javadoc.

This PR has:

- [x] been self-reviewed.
