### PR TITLE
fix compile with java 8

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicer.java
@@ -161,7 +161,7 @@ public class ExternalInputSpecSlicer implements InputSpecSlicer
         ((SplittableInputSource<?>) splittableInputSource.withSplit((InputSplit) split))
             .createSplits(spec.getInputFormat(), FilePerSplitHintSpec.INSTANCE)
             .map(subSplit -> splittableInputSource.withSplit((InputSplit) subSplit))
-            .forEach(subSources::add);
+            .forEach(s -> ((List) subSources).add(s));
       }
 
       if (subSources.isEmpty()) {


### PR DESCRIPTION
not sure why this didn't fail CI, looking into it, but fails to compile with 

```
[ERROR] /Users/clint/workspace/clintropolis/druid/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicer.java:[164,22] incompatible types: invalid method reference
[ERROR]     no suitable method found for add(java.lang.Object)
[ERROR]         method java.util.Collection.add(org.apache.druid.data.input.InputSource) is not applicable
[ERROR]           (argument mismatch; java.lang.Object cannot be converted to org.apache.druid.data.input.InputSource)
[ERROR]         method java.util.List.add(org.apache.druid.data.input.InputSource) is not applicable
[ERROR]           (argument mismatch; java.lang.Object cannot be converted to org.apache.druid.data.input.InputSource)
```