### PR TITLE
MSQ: Support for querying lookup and inline data directly.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -126,6 +126,10 @@ import org.apache.druid.msq.input.InputSpecs;
 import org.apache.druid.msq.input.MapInputSpecSlicer;
 import org.apache.druid.msq.input.external.ExternalInputSpec;
 import org.apache.druid.msq.input.external.ExternalInputSpecSlicer;
+import org.apache.druid.msq.input.inline.InlineInputSpec;
+import org.apache.druid.msq.input.inline.InlineInputSpecSlicer;
+import org.apache.druid.msq.input.lookup.LookupInputSpec;
+import org.apache.druid.msq.input.lookup.LookupInputSpecSlicer;
 import org.apache.druid.msq.input.stage.InputChannels;
 import org.apache.druid.msq.input.stage.ReadablePartition;
 import org.apache.druid.msq.input.stage.StageInputSlice;
@@ -2018,6 +2022,8 @@ public class ControllerImpl implements Controller
         ImmutableMap.<Class<? extends InputSpec>, InputSpecSlicer>builder()
                     .put(StageInputSpec.class, new StageInputSpecSlicer(stagePartitionsMap))
                     .put(ExternalInputSpec.class, new ExternalInputSpecSlicer())
+                    .put(InlineInputSpec.class, new InlineInputSpecSlicer())
+                    .put(LookupInputSpec.class, new LookupInputSpecSlicer())
                     .put(TableInputSpec.class, new TableInputSpecSlicer(timelineView))
                     .build()
     );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -98,6 +98,10 @@ import org.apache.druid.msq.input.NilInputSlice;
 import org.apache.druid.msq.input.NilInputSliceReader;
 import org.apache.druid.msq.input.external.ExternalInputSlice;
 import org.apache.druid.msq.input.external.ExternalInputSliceReader;
+import org.apache.druid.msq.input.inline.InlineInputSlice;
+import org.apache.druid.msq.input.inline.InlineInputSliceReader;
+import org.apache.druid.msq.input.lookup.LookupInputSlice;
+import org.apache.druid.msq.input.lookup.LookupInputSliceReader;
 import org.apache.druid.msq.input.stage.InputChannels;
 import org.apache.druid.msq.input.stage.ReadablePartition;
 import org.apache.druid.msq.input.stage.StageInputSlice;
@@ -1046,6 +1050,8 @@ public class WorkerImpl implements Worker
                       .put(NilInputSlice.class, NilInputSliceReader.INSTANCE)
                       .put(StageInputSlice.class, new StageInputSliceReader(queryId, inputChannels))
                       .put(ExternalInputSlice.class, new ExternalInputSliceReader(frameContext.tempDir()))
+                      .put(InlineInputSlice.class, new InlineInputSliceReader(frameContext.segmentWrangler()))
+                      .put(LookupInputSlice.class, new LookupInputSliceReader(frameContext.segmentWrangler()))
                       .put(SegmentsInputSlice.class, new SegmentsInputSliceReader(frameContext.dataSegmentProvider()))
                       .build()
       );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerMemoryParameters.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerMemoryParameters.java
@@ -35,7 +35,7 @@ import org.apache.druid.msq.kernel.StageDefinition;
 import org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImpl;
 import org.apache.druid.query.lookup.LookupExtractor;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
-import org.apache.druid.query.lookup.LookupReferencesManager;
+import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.segment.realtime.appenderator.AppenderatorsManager;
 import org.apache.druid.segment.realtime.appenderator.UnifiedIndexerAppenderatorsManager;
 
@@ -563,7 +563,8 @@ public class WorkerMemoryParameters
     // Subtract memory taken up by lookups. Correctness of this operation depends on lookups being loaded *before*
     // we create this instance. Luckily, this is the typical mode of operation, since by default
     // druid.lookup.enableLookupSyncOnStartup = true.
-    final LookupReferencesManager lookupManager = injector.getInstance(LookupReferencesManager.class);
+    final LookupExtractorFactoryContainerProvider lookupManager =
+        injector.getInstance(LookupExtractorFactoryContainerProvider.class);
 
     int lookupCount = 0;
     long lookupFootprint = 0;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQIndexingModule.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/guice/MSQIndexingModule.java
@@ -74,6 +74,10 @@ import org.apache.druid.msq.input.NilInputSlice;
 import org.apache.druid.msq.input.NilInputSource;
 import org.apache.druid.msq.input.external.ExternalInputSlice;
 import org.apache.druid.msq.input.external.ExternalInputSpec;
+import org.apache.druid.msq.input.inline.InlineInputSlice;
+import org.apache.druid.msq.input.inline.InlineInputSpec;
+import org.apache.druid.msq.input.lookup.LookupInputSlice;
+import org.apache.druid.msq.input.lookup.LookupInputSpec;
 import org.apache.druid.msq.input.stage.StageInputSlice;
 import org.apache.druid.msq.input.stage.StageInputSpec;
 import org.apache.druid.msq.input.table.SegmentsInputSlice;
@@ -174,11 +178,15 @@ public class MSQIndexingModule implements DruidModule
 
         // InputSpec classes
         ExternalInputSpec.class,
+        InlineInputSpec.class,
+        LookupInputSpec.class,
         StageInputSpec.class,
         TableInputSpec.class,
 
         // InputSlice classes
         ExternalInputSlice.class,
+        InlineInputSlice.class,
+        LookupInputSlice.class,
         NilInputSlice.class,
         SegmentsInputSlice.class,
         StageInputSlice.class,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerFrameContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerFrameContext.java
@@ -26,8 +26,8 @@ import org.apache.druid.msq.querykit.DataSegmentProvider;
 import org.apache.druid.query.groupby.strategy.GroupByStrategySelector;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMergerV9;
+import org.apache.druid.segment.SegmentWrangler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
-import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.loading.DataSegmentPusher;
 
 import java.io.File;
@@ -53,9 +53,9 @@ public class IndexerFrameContext implements FrameContext
   }
 
   @Override
-  public JoinableFactory joinableFactory()
+  public SegmentWrangler segmentWrangler()
   {
-    return context.injector().getInstance(JoinableFactory.class);
+    return context.injector().getInstance(SegmentWrangler.class);
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/InputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/InputSpecSlicer.java
@@ -26,6 +26,9 @@ import java.util.List;
  */
 public interface InputSpecSlicer
 {
+  /**
+   * Whether {@link #sliceDynamic(InputSpec, int, int, long)} is usable for a given {@link InputSpec}.
+   */
   boolean canSliceDynamic(InputSpec inputSpec);
 
   /**
@@ -51,6 +54,8 @@ public interface InputSpecSlicer
    * {@link org.apache.druid.msq.kernel.StageDefinition} would be created with two {@link InputSpec} other than
    * {@link org.apache.druid.msq.input.stage.StageInputSpec} (which is not dynamically splittable, so would not
    * use this method anyway). If this changes in the future, we'll want to revisit the design of this method.
+   *
+   * @throws UnsupportedOperationException if {@link #canSliceDynamic(InputSpec)} returns false
    */
   List<InputSlice> sliceDynamic(InputSpec inputSpec, int maxNumSlices, int maxFilesPerSlice, long maxBytesPerSlice);
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSlice.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.msq.input.inline;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.query.InlineDataSource;
 
@@ -31,11 +34,13 @@ public class InlineInputSlice implements InputSlice
 {
   private final InlineDataSource dataSource;
 
-  public InlineInputSlice(InlineDataSource dataSource)
+  @JsonCreator
+  public InlineInputSlice(@JsonProperty("dataSource") InlineDataSource dataSource)
   {
-    this.dataSource = dataSource;
+    this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
   }
 
+  @JsonProperty
   public InlineDataSource getDataSource()
   {
     return dataSource;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSlice.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.query.InlineDataSource;
+
+import java.util.Objects;
+
+/**
+ * Input slice representing inline data. Generated from {@link InlineInputSpec}.
+ */
+public class InlineInputSlice implements InputSlice
+{
+  private final InlineDataSource dataSource;
+
+  public InlineInputSlice(InlineDataSource dataSource)
+  {
+    this.dataSource = dataSource;
+  }
+
+  public InlineDataSource getDataSource()
+  {
+    return dataSource;
+  }
+
+  @Override
+  public int fileCount()
+  {
+    return 1;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    InlineInputSlice that = (InlineInputSlice) o;
+    return Objects.equals(dataSource, that.dataSource);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(dataSource);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "InlineInputSlice{" +
+           "dataSource=" + dataSource +
+           '}';
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSliceReader.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import com.google.common.collect.Iterables;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.msq.counters.CounterTracker;
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.msq.input.InputSliceReader;
+import org.apache.druid.msq.input.ReadableInput;
+import org.apache.druid.msq.input.ReadableInputs;
+import org.apache.druid.msq.input.table.SegmentWithDescriptor;
+import org.apache.druid.msq.querykit.LazyResourceHolder;
+import org.apache.druid.query.InlineDataSource;
+import org.apache.druid.query.SegmentDescriptor;
+import org.apache.druid.segment.SegmentWrangler;
+import org.apache.druid.timeline.SegmentId;
+
+import java.util.function.Consumer;
+
+/**
+ * Reads {@link InlineInputSlice} using {@link SegmentWrangler} (which is expected to contain an
+ * {@link org.apache.druid.segment.InlineSegmentWrangler}).
+ */
+public class InlineInputSliceReader implements InputSliceReader
+{
+  private static final SegmentDescriptor DUMMY_SEGMENT_DESCRIPTOR = SegmentId.dummy("inline").toDescriptor();
+
+  private final SegmentWrangler segmentWrangler;
+
+  public InlineInputSliceReader(SegmentWrangler segmentWrangler)
+  {
+    this.segmentWrangler = segmentWrangler;
+  }
+
+  @Override
+  public int numReadableInputs(InputSlice slice)
+  {
+    return 1;
+  }
+
+  @Override
+  public ReadableInputs attach(
+      final int inputNumber,
+      final InputSlice slice,
+      final CounterTracker counters,
+      final Consumer<Throwable> warningPublisher
+  )
+  {
+    final InlineDataSource dataSource = ((InlineInputSlice) slice).getDataSource();
+
+    return ReadableInputs.segments(
+        Iterables.transform(
+            segmentWrangler.getSegmentsForIntervals(dataSource, Intervals.ONLY_ETERNITY),
+            segment -> ReadableInput.segment(
+                new SegmentWithDescriptor(
+                    new LazyResourceHolder<>(() -> Pair.of(segment, segment)),
+                    DUMMY_SEGMENT_DESCRIPTOR
+                )
+            )
+        )
+    );
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpec.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.query.InlineDataSource;
+
+import java.util.Objects;
+
+/**
+ * Input spec representing inline data. Corresponds to {@link InlineDataSource}.
+ */
+public class InlineInputSpec implements InputSpec
+{
+  private final InlineDataSource dataSource;
+
+  @JsonCreator
+  public InlineInputSpec(@JsonProperty("dataSource") InlineDataSource dataSource)
+  {
+    this.dataSource = dataSource;
+  }
+
+  @JsonProperty
+  public InlineDataSource getDataSource()
+  {
+    return dataSource;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    InlineInputSpec that = (InlineInputSpec) o;
+    return Objects.equals(dataSource, that.dataSource);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(dataSource);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "InlineInputSpec{" +
+           "dataSource=" + dataSource +
+           '}';
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpec.java
@@ -21,6 +21,7 @@ package org.apache.druid.msq.input.inline;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.query.InlineDataSource;
 
@@ -36,7 +37,7 @@ public class InlineInputSpec implements InputSpec
   @JsonCreator
   public InlineInputSpec(@JsonProperty("dataSource") InlineDataSource dataSource)
   {
-    this.dataSource = dataSource;
+    this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
   }
 
   @JsonProperty

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSpecSlicer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.msq.input.InputSpecSlicer;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Slices an {@link InlineInputSpec} into a single {@link InlineInputSlice}.
+ */
+public class InlineInputSpecSlicer implements InputSpecSlicer
+{
+  @Override
+  public boolean canSliceDynamic(InputSpec inputSpec)
+  {
+    return false;
+  }
+
+  @Override
+  public List<InputSlice> sliceStatic(InputSpec inputSpec, int maxNumSlices)
+  {
+    return Collections.singletonList(new InlineInputSlice(((InlineInputSpec) inputSpec).getDataSource()));
+  }
+
+  @Override
+  public List<InputSlice> sliceDynamic(
+      InputSpec inputSpec,
+      int maxNumSlices,
+      int maxFilesPerSlice,
+      long maxBytesPerSlice
+  )
+  {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSlice.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import org.apache.druid.msq.input.InputSlice;
+
+import java.util.Objects;
+
+/**
+ * Represents a lookup table. Generated from {@link LookupInputSpec}.
+ */
+public class LookupInputSlice implements InputSlice
+{
+  private final String lookupName;
+
+  public LookupInputSlice(final String lookupName)
+  {
+    this.lookupName = lookupName;
+  }
+
+  public String getLookupName()
+  {
+    return lookupName;
+  }
+
+  @Override
+  public int fileCount()
+  {
+    return 1;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LookupInputSlice that = (LookupInputSlice) o;
+    return Objects.equals(lookupName, that.lookupName);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(lookupName);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "LookupInputSlice{" +
+           "lookupName='" + lookupName + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSlice.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.msq.input.lookup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import org.apache.druid.msq.input.InputSlice;
 
 import java.util.Objects;
@@ -30,11 +33,13 @@ public class LookupInputSlice implements InputSlice
 {
   private final String lookupName;
 
-  public LookupInputSlice(final String lookupName)
+  @JsonCreator
+  public LookupInputSlice(@JsonProperty("lookupName") final String lookupName)
   {
-    this.lookupName = lookupName;
+    this.lookupName = Preconditions.checkNotNull(lookupName, "lookupName");
   }
 
+  @JsonProperty
   public String getLookupName()
   {
     return lookupName;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import com.google.common.collect.Iterators;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.msq.counters.CounterTracker;
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.msq.input.InputSliceReader;
+import org.apache.druid.msq.input.ReadableInput;
+import org.apache.druid.msq.input.ReadableInputs;
+import org.apache.druid.msq.input.table.SegmentWithDescriptor;
+import org.apache.druid.msq.querykit.LazyResourceHolder;
+import org.apache.druid.query.LookupDataSource;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.SegmentWrangler;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.utils.CloseableUtils;
+
+import java.util.Iterator;
+import java.util.function.Consumer;
+
+/**
+ * Reads {@link LookupInputSlice} using a {@link SegmentWrangler} (which is expected to contain a
+ * {@link org.apache.druid.segment.LookupSegmentWrangler}).
+ */
+public class LookupInputSliceReader implements InputSliceReader
+{
+  private static final Logger log = new Logger(LookupInputSliceReader.class);
+
+  private final SegmentWrangler segmentWrangler;
+
+  public LookupInputSliceReader(SegmentWrangler segmentWrangler)
+  {
+    this.segmentWrangler = segmentWrangler;
+  }
+
+  @Override
+  public int numReadableInputs(InputSlice slice)
+  {
+    return 1;
+  }
+
+  @Override
+  public ReadableInputs attach(
+      final int inputNumber,
+      final InputSlice slice,
+      final CounterTracker counters,
+      final Consumer<Throwable> warningPublisher
+  )
+  {
+    final String lookupName = ((LookupInputSlice) slice).getLookupName();
+
+    return ReadableInputs.segments(
+        () -> Iterators.singletonIterator(
+            ReadableInput.segment(
+                new SegmentWithDescriptor(
+                    new LazyResourceHolder<>(
+                        () -> {
+                          final Iterable<Segment> segments =
+                              segmentWrangler.getSegmentsForIntervals(
+                                  new LookupDataSource(lookupName),
+                                  Intervals.ONLY_ETERNITY
+                              );
+
+                          final Iterator<Segment> segmentIterator = segments.iterator();
+                          if (!segmentIterator.hasNext()) {
+                            throw new ISE("Lookup[%s] is not loaded");
+                          }
+
+                          final Segment segment = segmentIterator.next();
+                          if (segmentIterator.hasNext()) {
+                            // LookupSegmentWrangler always returns zero or one segments, so this code block can't
+                            // happen. That being said: we'll program defensively anyway.
+                            CloseableUtils.closeAndSuppressExceptions(
+                                segment,
+                                e -> log.warn(e, "Failed to close segment for lookup[%s]", lookupName)
+                            );
+                            throw new ISE("Lookup[%s] has multiple segments; cannot read");
+                          }
+
+                          return Pair.of(segment, segment);
+                        }
+                    ),
+                    SegmentId.dummy(lookupName).toDescriptor()
+                )
+            )
+        )
+    );
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
@@ -85,7 +85,7 @@ public class LookupInputSliceReader implements InputSliceReader
 
                           final Iterator<Segment> segmentIterator = segments.iterator();
                           if (!segmentIterator.hasNext()) {
-                            throw new ISE("Lookup[%s] is not loaded");
+                            throw new ISE("Lookup[%s] is not loaded", lookupName);
                           }
 
                           final Segment segment = segmentIterator.next();
@@ -96,7 +96,7 @@ public class LookupInputSliceReader implements InputSliceReader
                                 segment,
                                 e -> log.warn(e, "Failed to close segment for lookup[%s]", lookupName)
                             );
-                            throw new ISE("Lookup[%s] has multiple segments; cannot read");
+                            throw new ISE("Lookup[%s] has multiple segments; cannot read", lookupName);
                           }
 
                           return Pair.of(segment, segment);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpec.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import org.apache.druid.msq.input.InputSpec;
+
+import java.util.Objects;
+
+/**
+ * Represents a lookup table. Corresponds to {@link org.apache.druid.query.LookupDataSource}.
+ */
+public class LookupInputSpec implements InputSpec
+{
+  private final String lookupName;
+
+  public LookupInputSpec(final String lookupName)
+  {
+    this.lookupName = lookupName;
+  }
+
+  public String getLookupName()
+  {
+    return lookupName;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LookupInputSpec that = (LookupInputSpec) o;
+    return Objects.equals(lookupName, that.lookupName);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(lookupName);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "LookupInputSpec{" +
+           "lookupName='" + lookupName + '\'' +
+           '}';
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpec.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.msq.input.lookup;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import org.apache.druid.msq.input.InputSpec;
 
 import java.util.Objects;
@@ -30,11 +33,13 @@ public class LookupInputSpec implements InputSpec
 {
   private final String lookupName;
 
-  public LookupInputSpec(final String lookupName)
+  @JsonCreator
+  public LookupInputSpec(@JsonProperty("lookupName") final String lookupName)
   {
-    this.lookupName = lookupName;
+    this.lookupName = Preconditions.checkNotNull(lookupName, "lookupName");
   }
 
+  @JsonProperty
   public String getLookupName()
   {
     return lookupName;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSpecSlicer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.msq.input.InputSpecSlicer;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Slices a {@link LookupInputSpec} into a single {@link LookupInputSlice}.
+ */
+public class LookupInputSpecSlicer implements InputSpecSlicer
+{
+  @Override
+  public boolean canSliceDynamic(InputSpec inputSpec)
+  {
+    return false;
+  }
+
+  @Override
+  public List<InputSlice> sliceStatic(InputSpec inputSpec, int maxNumSlices)
+  {
+    return Collections.singletonList(new LookupInputSlice(((LookupInputSpec) inputSpec).getLookupName()));
+  }
+
+  @Override
+  public List<InputSlice> sliceDynamic(
+      InputSpec inputSpec,
+      int maxNumSlices,
+      int maxFilesPerSlice,
+      long maxBytesPerSlice
+  )
+  {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/FrameContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/FrameContext.java
@@ -25,8 +25,8 @@ import org.apache.druid.msq.querykit.DataSegmentProvider;
 import org.apache.druid.query.groupby.strategy.GroupByStrategySelector;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMergerV9;
+import org.apache.druid.segment.SegmentWrangler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
-import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.loading.DataSegmentPusher;
 
 import java.io.File;
@@ -36,7 +36,7 @@ import java.io.File;
  */
 public interface FrameContext
 {
-  JoinableFactory joinableFactory();
+  SegmentWrangler segmentWrangler();
 
   GroupByStrategySelector groupByStrategySelector();
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessor.java
@@ -41,7 +41,6 @@ import org.apache.druid.query.Query;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentReference;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,7 +64,6 @@ public abstract class BaseLeafFrameProcessor implements FrameProcessor<Long>
       final Query<?> query,
       final ReadableInput baseInput,
       final Int2ObjectMap<ReadableInput> sideChannels,
-      final JoinableFactoryWrapper joinableFactory,
       final ResourceHolder<WritableFrameChannel> outputChannel,
       final ResourceHolder<FrameWriterFactory> frameWriterFactoryHolder,
       final long memoryReservedForBroadcastJoin
@@ -81,7 +79,6 @@ public abstract class BaseLeafFrameProcessor implements FrameProcessor<Long>
             query.getDataSource(),
             baseInput,
             sideChannels,
-            joinableFactory,
             memoryReservedForBroadcastJoin
         );
 
@@ -96,7 +93,6 @@ public abstract class BaseLeafFrameProcessor implements FrameProcessor<Long>
       final DataSource dataSource,
       final ReadableInput baseInput,
       final Int2ObjectMap<ReadableInput> sideChannels,
-      final JoinableFactoryWrapper joinableFactory,
       final long memoryReservedForBroadcastJoin
   )
   {
@@ -131,7 +127,6 @@ public abstract class BaseLeafFrameProcessor implements FrameProcessor<Long>
           inputNumberToProcessorChannelMap,
           inputChannels,
           channelReaders,
-          joinableFactory,
           memoryReservedForBroadcastJoin
       );
     } else {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafFrameProcessorFactory.java
@@ -31,7 +31,6 @@ import org.apache.druid.frame.processor.OutputChannel;
 import org.apache.druid.frame.processor.OutputChannelFactory;
 import org.apache.druid.frame.processor.OutputChannels;
 import org.apache.druid.frame.write.FrameWriterFactory;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
@@ -128,10 +127,16 @@ public abstract class BaseLeafFrameProcessorFactory extends BaseFrameProcessorFa
 
     final Sequence<FrameProcessor<Long>> processors = processorBaseInputs.map(
         processorBaseInput -> {
-          // For each processor, we are rebuilding the broadcast table again which is wasteful. This can be pushed
-          // up to the factory level
+          // Read broadcast data from earlier stages. Note that for each processor, we are rebuilding the broadcast
+          // table from scratch, which is wasteful. This could be pushed up a level.
           final Int2ObjectMap<ReadableInput> sideChannels =
-              readBroadcastInputs(stageDefinition, inputSlices, inputSliceReader, counters, warningPublisher);
+              readBroadcastInputsFromEarlierStages(
+                  stageDefinition,
+                  inputSlices,
+                  inputSliceReader,
+                  counters,
+                  warningPublisher
+              );
 
           return makeProcessor(
               processorBaseInput,
@@ -201,12 +206,12 @@ public abstract class BaseLeafFrameProcessorFactory extends BaseFrameProcessorFa
   }
 
   /**
-   * Reads all broadcast inputs, which must be {@link StageInputSlice}. The execution framework supports broadcasting
-   * other types of inputs, but QueryKit does not use them at this time.
+   * Reads all broadcast inputs of type {@link StageInputSlice}. Returns a map of input number -> channel containing
+   * all data for that input number.
    *
-   * Returns a map of input number -> channel containing all data for that input number.
+   * Broadcast inputs that are not type {@link StageInputSlice} are ignored.
    */
-  private static Int2ObjectMap<ReadableInput> readBroadcastInputs(
+  private static Int2ObjectMap<ReadableInput> readBroadcastInputsFromEarlierStages(
       final StageDefinition stageDef,
       final List<InputSlice> inputSlices,
       final InputSliceReader inputSliceReader,
@@ -218,17 +223,13 @@ public abstract class BaseLeafFrameProcessorFactory extends BaseFrameProcessorFa
 
     try {
       for (int inputNumber = 0; inputNumber < inputSlices.size(); inputNumber++) {
-        if (stageDef.getBroadcastInputNumbers().contains(inputNumber)) {
-          // QueryKit only uses StageInputSlice at this time.
+        if (stageDef.getBroadcastInputNumbers().contains(inputNumber)
+            && inputSlices.get(inputNumber) instanceof StageInputSlice) {
           final StageInputSlice slice = (StageInputSlice) inputSlices.get(inputNumber);
           final ReadableInputs readableInputs =
               inputSliceReader.attach(inputNumber, slice, counterTracker, warningPublisher);
 
-          if (!readableInputs.isChannelBased()) {
-            // QueryKit limitation: broadcast inputs must be channels.
-            throw new ISE("Broadcast inputs must be channels");
-          }
-
+          // We know ReadableInput::getChannel is OK, because StageInputSlice always uses channels (never segments).
           final ReadableFrameChannel channel = ReadableConcatFrameChannel.open(
               Iterators.transform(readableInputs.iterator(), ReadableInput::getChannel)
           );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BroadcastJoinHelper.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BroadcastJoinHelper.java
@@ -33,7 +33,6 @@ import org.apache.druid.query.DataSource;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +43,6 @@ public class BroadcastJoinHelper
   private final Int2IntMap inputNumberToProcessorChannelMap;
   private final List<ReadableFrameChannel> channels;
   private final List<FrameReader> channelReaders;
-  private final JoinableFactoryWrapper joinableFactory;
   private final List<List<Object[]>> channelData;
   private final IntSet sideChannelNumbers;
   private final long memoryReservedForBroadcastJoin;
@@ -59,7 +57,6 @@ public class BroadcastJoinHelper
    * @param inputNumberToProcessorChannelMap map of input slice number -> channel position in the "channels" list
    * @param channels                         list of input channels
    * @param channelReaders                   list of input channel readers; corresponds one-to-one with "channels"
-   * @param joinableFactory                  joinable factory for this server
    * @param memoryReservedForBroadcastJoin   total bytes of frames we are permitted to use; derived from
    *                                         {@link org.apache.druid.msq.exec.WorkerMemoryParameters#broadcastJoinMemory}
    */
@@ -67,14 +64,12 @@ public class BroadcastJoinHelper
       final Int2IntMap inputNumberToProcessorChannelMap,
       final List<ReadableFrameChannel> channels,
       final List<FrameReader> channelReaders,
-      final JoinableFactoryWrapper joinableFactory,
       final long memoryReservedForBroadcastJoin
   )
   {
     this.inputNumberToProcessorChannelMap = inputNumberToProcessorChannelMap;
     this.channels = channels;
     this.channelReaders = channelReaders;
-    this.joinableFactory = joinableFactory;
     this.channelData = new ArrayList<>();
     this.sideChannelNumbers = new IntOpenHashSet();
     this.sideChannelNumbers.addAll(inputNumberToProcessorChannelMap.values());

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessor.java
@@ -49,7 +49,6 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.spec.SpecificSegmentSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.timeline.SegmentId;
 
 import java.io.IOException;
@@ -75,7 +74,6 @@ public class GroupByPreShuffleFrameProcessor extends BaseLeafFrameProcessor
       final ReadableInput baseInput,
       final Int2ObjectMap<ReadableInput> sideChannels,
       final GroupByStrategySelector strategySelector,
-      final JoinableFactoryWrapper joinableFactory,
       final ResourceHolder<WritableFrameChannel> outputChannel,
       final ResourceHolder<FrameWriterFactory> frameWriterFactoryHolder,
       final long memoryReservedForBroadcastJoin
@@ -85,7 +83,6 @@ public class GroupByPreShuffleFrameProcessor extends BaseLeafFrameProcessor
         query,
         baseInput,
         sideChannels,
-        joinableFactory,
         outputChannel,
         frameWriterFactoryHolder,
         memoryReservedForBroadcastJoin

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessorFactory.java
@@ -34,7 +34,6 @@ import org.apache.druid.msq.kernel.FrameContext;
 import org.apache.druid.msq.querykit.BaseLeafFrameProcessorFactory;
 import org.apache.druid.msq.querykit.LazyResourceHolder;
 import org.apache.druid.query.groupby.GroupByQuery;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 
 @JsonTypeName("groupByPreShuffle")
 public class GroupByPreShuffleFrameProcessorFactory extends BaseLeafFrameProcessorFactory
@@ -67,7 +66,6 @@ public class GroupByPreShuffleFrameProcessorFactory extends BaseLeafFrameProcess
         baseInput,
         sideChannels,
         frameContext.groupByStrategySelector(),
-        new JoinableFactoryWrapper(frameContext.joinableFactory()),
         outputChannelHolder,
         new LazyResourceHolder<>(() -> Pair.of(frameWriterFactoryHolder.get(), frameWriterFactoryHolder)),
         frameContext.memoryParameters().getBroadcastJoinMemory()

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
@@ -58,7 +58,6 @@ import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.filter.Filters;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.Interval;
 
@@ -89,7 +88,6 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
       final ScanQuery query,
       final ReadableInput baseInput,
       final Int2ObjectMap<ReadableInput> sideChannels,
-      final JoinableFactoryWrapper joinableFactory,
       final ResourceHolder<WritableFrameChannel> outputChannel,
       final ResourceHolder<FrameWriterFactory> frameWriterFactoryHolder,
       @Nullable final AtomicLong runningCountForLimit,
@@ -101,7 +99,6 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
         query,
         baseInput,
         sideChannels,
-        joinableFactory,
         outputChannel,
         frameWriterFactoryHolder,
         memoryReservedForBroadcastJoin

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorFactory.java
@@ -34,7 +34,6 @@ import org.apache.druid.msq.kernel.FrameContext;
 import org.apache.druid.msq.querykit.BaseLeafFrameProcessorFactory;
 import org.apache.druid.msq.querykit.LazyResourceHolder;
 import org.apache.druid.query.scan.ScanQuery;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicLong;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorFactory.java
@@ -82,7 +82,6 @@ public class ScanQueryFrameProcessorFactory extends BaseLeafFrameProcessorFactor
         query,
         baseInput,
         sideChannels,
-        new JoinableFactoryWrapper(frameContext.joinableFactory()),
         outputChannelHolder,
         new LazyResourceHolder<>(() -> Pair.of(frameWriterFactoryHolder.get(), frameWriterFactoryHolder)),
         runningCountForLimit,

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -560,7 +560,10 @@ public class MSQSelectTest extends MSQTestBase
                                            new TableDataSource(CalciteTests.DATASOURCE1),
                                            new LookupDataSource("lookyloo"),
                                            "j0.",
-                                           equalsCondition(makeColumnExpression("dim2"), makeColumnExpression("j0.k")),
+                                           equalsCondition(
+                                               DruidExpression.ofColumn(ColumnType.STRING, "dim2"),
+                                               DruidExpression.ofColumn(ColumnType.STRING, "j0.k")
+                                           ),
                                            JoinType.LEFT
                                        )
                                    )

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSliceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSliceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.msq.guice.MSQIndexingModule;
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.query.InlineDataSource;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class InlineInputSliceTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper()
+                                          .registerModules(new MSQIndexingModule().getJacksonModules());
+
+    final InlineDataSource dataSource = InlineDataSource.fromIterable(
+        Collections.singletonList(new Object[]{1}),
+        RowSignature.builder().add("x", ColumnType.LONG).build()
+    );
+
+    final InlineInputSlice slice = new InlineInputSlice(dataSource);
+
+    Assert.assertEquals(
+        slice,
+        mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
+    );
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(InlineInputSlice.class).usingGetClass().verify();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSpecTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/inline/InlineInputSpecTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.inline;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.msq.guice.MSQIndexingModule;
+import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.query.InlineDataSource;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class InlineInputSpecTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper()
+                                          .registerModules(new MSQIndexingModule().getJacksonModules());
+
+    final InlineDataSource dataSource = InlineDataSource.fromIterable(
+        Collections.singletonList(new Object[]{1}),
+        RowSignature.builder().add("x", ColumnType.LONG).build()
+    );
+
+    final InlineInputSpec spec = new InlineInputSpec(dataSource);
+
+    Assert.assertEquals(
+        spec,
+        mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
+    );
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(InlineInputSpec.class).usingGetClass().verify();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSliceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSliceTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.msq.guice.MSQIndexingModule;
+import org.apache.druid.msq.input.InputSlice;
+import org.apache.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LookupInputSliceTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper()
+                                          .registerModules(new MSQIndexingModule().getJacksonModules());
+
+    final LookupInputSlice slice = new LookupInputSlice("myLookup");
+
+    Assert.assertEquals(
+        slice,
+        mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
+    );
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(LookupInputSlice.class).usingGetClass().verify();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSpecTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/lookup/LookupInputSpecTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.lookup;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.msq.guice.MSQIndexingModule;
+import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LookupInputSpecTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper()
+                                          .registerModules(new MSQIndexingModule().getJacksonModules());
+
+    final LookupInputSpec spec = new LookupInputSpec("myLookup");
+
+    Assert.assertEquals(
+        spec,
+        mapper.readValue(mapper.writeValueAsString(spec), InputSpec.class)
+    );
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(LookupInputSpec.class).usingGetClass().verify();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinHelperTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/BroadcastJoinHelperTest.java
@@ -48,7 +48,6 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.segment.join.JoinableFactory;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
@@ -132,7 +131,6 @@ public class BroadcastJoinHelperTest extends InitializedNullHandlingTest
         sideStageChannelNumberMap,
         channels,
         channelReaders,
-        new JoinableFactoryWrapper(joinableFactory),
         25_000_000L // High enough memory limit that we won't hit it
     );
 
@@ -222,7 +220,6 @@ public class BroadcastJoinHelperTest extends InitializedNullHandlingTest
         sideStageChannelNumberMap,
         channels,
         channelReaders,
-        new JoinableFactoryWrapper(joinableFactory),
         100_000 // Low memory limit; we will hit this
     );
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessorTest.java
@@ -52,8 +52,6 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexStorageAdapter;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
-import org.apache.druid.segment.join.NoopJoinableFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.After;
 import org.junit.Assert;
@@ -130,7 +128,6 @@ public class ScanQueryFrameProcessorTest extends InitializedNullHandlingTest
         query,
         ReadableInput.channel(inputChannel.readable(), FrameReader.create(signature), stagePartition),
         Int2ObjectMaps.emptyMap(),
-        new JoinableFactoryWrapper(NoopJoinableFactory.INSTANCE),
         new ResourceHolder<WritableFrameChannel>()
         {
           @Override

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
@@ -55,7 +55,6 @@ import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.query.groupby.strategy.GroupByStrategySelector;
-import org.apache.druid.query.lookup.LookupReferencesManager;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.QueryableIndex;
@@ -83,7 +82,6 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -109,11 +107,6 @@ public class CalciteMSQTestsHelper
 
     Module customBindings =
         binder -> {
-          final LookupReferencesManager lookupReferencesManager =
-              EasyMock.createStrictMock(LookupReferencesManager.class);
-          EasyMock.expect(lookupReferencesManager.getAllLookupNames()).andReturn(Collections.emptySet()).anyTimes();
-          EasyMock.replay(lookupReferencesManager);
-          binder.bind(LookupReferencesManager.class).toInstance(lookupReferencesManager);
           binder.bind(AppenderatorsManager.class).toProvider(() -> null);
 
           // Requirements of JoinableFactoryModule

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -48,6 +48,7 @@ import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.IndexingServiceTuningConfigModule;
 import org.apache.druid.guice.JoinableFactoryModule;
 import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.guice.annotations.EscalatedGlobal;
 import org.apache.druid.guice.annotations.MSQ;
@@ -108,13 +109,10 @@ import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.FloatSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
-import org.apache.druid.query.expression.LookupEnabledTestExprMacroTable;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.query.groupby.strategy.GroupByStrategySelector;
-import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
-import org.apache.druid.query.lookup.LookupReferencesManager;
 import org.apache.druid.rpc.ServiceClientFactory;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.IndexIO;
@@ -152,6 +150,7 @@ import org.apache.druid.sql.calcite.run.SqlEngine;
 import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
 import org.apache.druid.sql.calcite.schema.NoopDruidSchemaManager;
 import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.apache.druid.sql.calcite.util.LookylooModule;
 import org.apache.druid.sql.calcite.util.QueryFrameworkUtils;
 import org.apache.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import org.apache.druid.sql.calcite.util.SqlTestFramework;
@@ -437,22 +436,10 @@ public class MSQTestBase extends BaseCalciteQueryTest
           binder.bind(ExprMacroTable.class).toInstance(CalciteTests.createExprMacroTable());
           binder.bind(DataSegment.PruneSpecsHolder.class).toInstance(DataSegment.PruneSpecsHolder.DEFAULT);
         },
-        binder -> {
-          // Requirements of WorkerMemoryParameters.createProductionInstanceForWorker(injector)
-          final LookupReferencesManager lookupReferencesManager =
-              EasyMock.createStrictMock(LookupReferencesManager.class);
-          EasyMock.expect(lookupReferencesManager.getAllLookupNames()).andReturn(Collections.emptySet());
-          EasyMock.replay(lookupReferencesManager);
-          binder.bind(LookupReferencesManager.class).toInstance(lookupReferencesManager);
-          binder.bind(AppenderatorsManager.class).toProvider(() -> null);
-        },
-        binder -> {
-          // Requirements of JoinableFactoryModule
-          binder.bind(SegmentManager.class).toInstance(EasyMock.createMock(SegmentManager.class));
-          binder.bind(LookupExtractorFactoryContainerProvider.class).toInstance(
-              LookupEnabledTestExprMacroTable.createTestLookupProvider(Collections.emptyMap())
-          );
-        },
+        // Requirement of WorkerMemoryParameters.createProductionInstanceForWorker(injector)
+        binder -> binder.bind(AppenderatorsManager.class).toProvider(() -> null),
+        // Requirement of JoinableFactoryModule
+        binder -> binder.bind(SegmentManager.class).toInstance(EasyMock.createMock(SegmentManager.class)),
         new JoinableFactoryModule(),
         new IndexingServiceTuningConfigModule(),
         new MSQIndexingModule(),
@@ -467,7 +454,9 @@ public class MSQTestBase extends BaseCalciteQueryTest
               binder.bind(MSQTaskSqlEngine.class).toProvider(Providers.of(null));
             }
         ),
-        new MSQExternalDataSourceModule()
+        new MSQExternalDataSourceModule(),
+        new LookylooModule(),
+        new SegmentWranglerModule()
     );
     // adding node role injection to the modules, since CliPeon would also do that through run method
     Injector injector = new CoreInjectorBuilder(new StartupInjectorBuilder().build(), ImmutableSet.of(NodeRole.PEON))

--- a/processing/src/main/java/org/apache/druid/query/DataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/DataSource.java
@@ -87,7 +87,11 @@ public interface DataSource
 
   /**
    * Returns true if this datasource represents concrete data that can be scanned via a
-   * {@link org.apache.druid.segment.Segment} adapter of some kind. True for e.g. 'table' but not for 'query' or 'join'.
+   * {@link org.apache.druid.segment.Segment} adapter of some kind. The adapter may be provided by a
+   * {@link org.apache.druid.segment.SegmentWrangler}, or (as in the case of 'table') may be built into the query stack
+   * itself.
+   *
+   * True for e.g. 'table' and 'lookup' but not for 'query' or 'join'.
    *
    * @see DataSourceAnalysis#isConcreteBased() which uses this
    * @see DataSourceAnalysis#isConcreteTableBased() which uses this

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -50,6 +50,7 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.guice.QueryablePeonModule;
+import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.ServerTypeConfig;
 import org.apache.druid.guice.annotations.AttemptId;
 import org.apache.druid.guice.annotations.Parent;
@@ -123,6 +124,7 @@ public class CliIndexer extends ServerRunnable
         new DruidProcessingModule(),
         new QueryableModule(),
         new QueryRunnerFactoryModule(),
+        new SegmentWranglerModule(),
         new JoinableFactoryModule(),
         new IndexerServiceModule(),
         new Module()

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -58,6 +58,7 @@ import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
 import org.apache.druid.guice.QueryablePeonModule;
+import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.ServerTypeConfig;
 import org.apache.druid.guice.annotations.AttemptId;
 import org.apache.druid.guice.annotations.Json;
@@ -192,6 +193,7 @@ public class CliPeon extends GuiceRunnable
         new DruidProcessingModule(),
         new QueryableModule(),
         new QueryRunnerFactoryModule(),
+        new SegmentWranglerModule(),
         new JoinableFactoryModule(),
         new IndexingServiceTaskLogsModule(),
         new Module()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestInjectorBuilder.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestInjectorBuilder.java
@@ -20,6 +20,7 @@
 package org.apache.druid.sql.calcite.util;
 
 import com.google.inject.Injector;
+import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -38,6 +39,7 @@ public class CalciteTestInjectorBuilder extends CoreInjectorBuilder
         .withEmptyProperties()
         .build());
     add(
+        new SegmentWranglerModule(),
         new LookylooModule(),
         new SqlAggregationModule()
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestInjectorBuilder.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestInjectorBuilder.java
@@ -38,7 +38,7 @@ public class CalciteTestInjectorBuilder extends CoreInjectorBuilder
         .withEmptyProperties()
         .build());
     add(
-        new BasicTestModule(),
+        new LookylooModule(),
         new SqlAggregationModule()
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -184,7 +184,6 @@ public class CalciteTests
   public static final Injector INJECTOR = new CalciteTestInjectorBuilder()
       .withDefaultMacroTable()
       .build();
-  public static final GlobalTableDataSource CUSTOM_TABLE = TestDataBuilder.CUSTOM_TABLE;
 
   private CalciteTests()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -42,7 +42,6 @@ import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.apache.druid.math.expr.ExprMacroTable;
-import org.apache.druid.query.GlobalTableDataSource;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.segment.join.JoinableFactory;
@@ -77,7 +76,6 @@ import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.util.Collection;
 import java.util.HashMap;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/LookylooModule.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/LookylooModule.java
@@ -34,7 +34,11 @@ import org.apache.druid.timeline.DataSegment;
 
 import java.util.List;
 
-class BasicTestModule implements DruidModule
+/**
+ * Provides a lookup called {@link LookupEnabledTestExprMacroTable#LOOKYLOO}, provides the SQL {@code LOOKUP}
+ * function, and provides the native expression function {@code lookup}.
+ */
+public class LookylooModule implements DruidModule
 {
   @Override
   public void configure(Binder binder)
@@ -50,8 +54,6 @@ class BasicTestModule implements DruidModule
         );
 
     binder.bind(DataSegment.PruneSpecsHolder.class).toInstance(DataSegment.PruneSpecsHolder.DEFAULT);
-
-    // This Module is just to get a LookupExtractorFactoryContainerProvider with a usable "lookyloo" lookup.
     binder.bind(LookupExtractorFactoryContainerProvider.class).toInstance(lookupProvider);
     SqlBindings.addOperatorConversion(binder, QueryLookupOperatorConversion.class);
     ExpressionModule.addExprMacro(binder, LookupExprMacro.class);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/SpecificSegmentsQuerySegmentWalker.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/SpecificSegmentsQuerySegmentWalker.java
@@ -95,7 +95,7 @@ public class SpecificSegmentsQuerySegmentWalker implements QuerySegmentWalker, C
    */
   public SpecificSegmentsQuerySegmentWalker(
       final QueryRunnerFactoryConglomerate conglomerate,
-      final LookupExtractorFactoryContainerProvider lookupProvider,
+      final SegmentWrangler segmentWrangler,
       final JoinableFactoryWrapper joinableFactoryWrapper,
       final QueryScheduler scheduler
   )
@@ -108,12 +108,7 @@ public class SpecificSegmentsQuerySegmentWalker implements QuerySegmentWalker, C
         ),
         QueryStackTests.createLocalQuerySegmentWalker(
             conglomerate,
-            new MapSegmentWrangler(
-                ImmutableMap.<Class<? extends DataSource>, SegmentWrangler>builder()
-                            .put(InlineDataSource.class, new InlineSegmentWrangler())
-                            .put(LookupDataSource.class, new LookupSegmentWrangler(lookupProvider))
-                            .build()
-            ),
+            segmentWrangler,
             joinableFactoryWrapper,
             scheduler
         ),
@@ -131,7 +126,15 @@ public class SpecificSegmentsQuerySegmentWalker implements QuerySegmentWalker, C
   {
     this(
         conglomerate,
-        LOOKUP_EXTRACTOR_FACTORY_CONTAINER_PROVIDER,
+        new MapSegmentWrangler(
+            ImmutableMap.<Class<? extends DataSource>, SegmentWrangler>builder()
+                        .put(InlineDataSource.class, new InlineSegmentWrangler())
+                        .put(
+                            LookupDataSource.class,
+                            new LookupSegmentWrangler(LOOKUP_EXTRACTOR_FACTORY_CONTAINER_PROVIDER)
+                        )
+                        .build()
+        ),
         new JoinableFactoryWrapper(QueryStackTests.makeJoinableFactoryForLookup(LOOKUP_EXTRACTOR_FACTORY_CONTAINER_PROVIDER)),
         QueryStackTests.DEFAULT_NOOP_SCHEDULER
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
@@ -28,6 +28,7 @@ import com.google.inject.Provides;
 import org.apache.druid.guice.DruidInjectorBuilder;
 import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.SegmentWranglerModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
@@ -554,7 +555,8 @@ public class SqlTestFramework
         // test pulls in a module, then pull in that module, even though we are
         // not the Druid node to which the module is scoped.
         .ignoreLoadScopes()
-        .addModule(new BasicTestModule())
+        .addModule(new LookylooModule())
+        .addModule(new SegmentWranglerModule())
         .addModule(new SqlAggregationModule())
         .addModule(new ExpressionModule())
         .addModule(new TestSetupModule(builder));

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/TestDataBuilder.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/TestDataBuilder.java
@@ -51,6 +51,7 @@ import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFact
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.SegmentWrangler;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
@@ -776,7 +777,7 @@ public class TestDataBuilder
 
     return new SpecificSegmentsQuerySegmentWalker(
         conglomerate,
-        injector.getInstance(LookupExtractorFactoryContainerProvider.class),
+        injector.getInstance(SegmentWrangler.class),
         joinableFactoryWrapper,
         scheduler
     ).add(


### PR DESCRIPTION
Main changes:

1) Add of LookupInputSpec and DataSourcePlan.forLookup.

2) Add InlineInputSpec, and modify of DataSourcePlan.forInline to use
   this instead of an ExternalInputSpec with JSON. This allows the inline
   data to act as the right-hand side of a join, if needed.

Supporting changes:

1) Modify JoinDataSource's leftFilter validation to be a little less
   strict: it's now OK with leftFilter being attached to any concrete
   leaf (no children) datasource, rather than requiring it be a table.
   This allows MSQ to create JoinDataSource with InputNumberDataSource
   as the base.

2) Add SegmentWranglerModule to CliIndexer, CliPeon. This allows them to
   query lookups and inline data directly.