### PR TITLE
Input source security sql layer can handle input source with multiple types

### DIFF
--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
@@ -345,7 +345,7 @@ public class S3InputSourceDefnTest
         CatalogUtils.stringListToUriList(uris),
         s3InputSource.getUris()
     );
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // But, it fails if there are no columns.
     assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
@@ -366,7 +366,7 @@ public class S3InputSourceDefnTest
         CatalogUtils.stringListToUriList(uris),
         s3InputSource.getUris()
     );
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -399,7 +399,7 @@ public class S3InputSourceDefnTest
         s3InputSource.getUris()
     );
     assertEquals("*.csv", s3InputSource.getObjectGlob());
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -419,7 +419,7 @@ public class S3InputSourceDefnTest
         CatalogUtils.stringListToUriList(prefixes),
         s3InputSource.getPrefixes()
     );
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // But, it fails if there are no columns.
     assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
@@ -442,7 +442,7 @@ public class S3InputSourceDefnTest
         CatalogUtils.stringListToUriList(prefixes),
         s3InputSource.getPrefixes()
     );
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -462,7 +462,7 @@ public class S3InputSourceDefnTest
     CloudObjectLocation obj = s3InputSource.getObjects().get(0);
     assertEquals("foo.com", obj.getBucket());
     assertEquals("bar/file.csv", obj.getPath());
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // But, it fails if there are no columns.
     assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));
@@ -510,7 +510,7 @@ public class S3InputSourceDefnTest
     obj = s3InputSource.getObjects().get(1);
     assertEquals("foo.com", obj.getBucket());
     assertEquals("mumble/file2.csv", obj.getPath());
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -578,7 +578,7 @@ public class S3InputSourceDefnTest
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
     ExternalTableSpec externSpec = externDefn.convert(resolved);
     assertEquals(s3InputSource, externSpec.inputSource);
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
@@ -613,7 +613,7 @@ public class S3InputSourceDefnTest
     ExternalTableDefn externDefn = (ExternalTableDefn) resolved.defn();
     ExternalTableSpec externSpec = externDefn.convert(resolved);
     assertEquals(s3InputSource, externSpec.inputSource);
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // Get the partial table function
     TableFunction fn = externDefn.tableFn(resolved);
@@ -672,7 +672,7 @@ public class S3InputSourceDefnTest
     CloudObjectLocation obj = s3InputSource.getObjects().get(0);
     assertEquals("foo.com", obj.getBucket());
     assertEquals("bar/file.csv", obj.getPath());
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // But, it fails columns are provided since the table already has them.
     assertThrows(IAE.class, () -> fn.apply("x", args, COLUMNS, mapper));
@@ -714,7 +714,7 @@ public class S3InputSourceDefnTest
     assertEquals("foo.com", obj.getBucket());
     assertEquals("bar/file.csv", obj.getPath());
     assertTrue(externSpec.inputFormat instanceof CsvInputFormat);
-    assertEquals(S3InputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(S3InputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
 
     // But, it fails columns are not provided since the table does not have them.
     assertThrows(IAE.class, () -> fn.apply("x", args, Collections.emptyList(), mapper));

--- a/server/src/main/java/org/apache/druid/catalog/model/table/BaseInputSourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/BaseInputSourceDefn.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.CollectionUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,7 +153,7 @@ public abstract class BaseInputSourceDefn implements InputSourceDefn
         convertArgsToSource(args, jsonMapper),
         convertArgsToFormat(args, columns, jsonMapper),
         Columns.convertSignature(columns),
-        typeValue()
+        () -> Collections.singleton(typeValue())
     );
   }
 
@@ -209,7 +210,7 @@ public abstract class BaseInputSourceDefn implements InputSourceDefn
         convertTableToSource(table),
         convertTableToFormat(table),
         Columns.convertSignature(table.resolvedTable().spec().columns()),
-        typeValue()
+        () -> Collections.singleton(typeValue())
     );
   }
 

--- a/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableSpec.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/ExternalTableSpec.java
@@ -19,11 +19,14 @@
 
 package org.apache.druid.catalog.model.table;
 
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.segment.column.RowSignature;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Catalog form of an external table specification used to pass along the three
@@ -36,17 +39,17 @@ public class ExternalTableSpec
   public final InputSource inputSource;
   public final InputFormat inputFormat;
   @Nullable public final RowSignature signature;
-  public final String inputSourceType;
+  public final Supplier<Set<String>> inputSourceTypesSupplier;
 
   public ExternalTableSpec(
       final InputSource inputSource,
       final InputFormat inputFormat,
       final RowSignature signature,
-      final String inputSourceType)
+      final Supplier<Set<String>> inputSourceTypesSupplier)
   {
     this.inputSource = inputSource;
     this.inputFormat = inputFormat;
     this.signature = signature;
-    this.inputSourceType = inputSourceType;
+    this.inputSourceTypesSupplier = inputSourceTypesSupplier;
   }
 }

--- a/server/src/main/java/org/apache/druid/catalog/model/table/FormattedInputSourceDefn.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/table/FormattedInputSourceDefn.java
@@ -33,6 +33,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.utils.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -194,7 +195,7 @@ public abstract class FormattedInputSourceDefn extends BaseInputSourceDefn
         convertSource(sourceMap, jsonMapper),
         inputFormat,
         Columns.convertSignature(completedCols),
-        typeValue()
+        () -> Collections.singleton(typeValue())
     );
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/HttpInputSourceDefnTest.java
@@ -398,7 +398,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/foo.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(HttpInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -442,7 +442,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/my.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(HttpInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -466,7 +466,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         CatalogUtils.stringListToUriList(Arrays.asList("http://foo.com/foo.csv", "http://foo.com/bar.csv")),
         sourceSpec.getUris()
     );
-    assertEquals(HttpInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   @Test
@@ -499,7 +499,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
         "SECRET",
         ((EnvironmentVariablePasswordProvider) sourceSpec.getHttpAuthenticationPasswordProvider()).getVariable()
     );
-    assertEquals(HttpInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   private void validateHappyPath(ExternalTableSpec externSpec, boolean withUser)
@@ -519,7 +519,7 @@ public class HttpInputSourceDefnTest extends BaseExternTableTest
     assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
     assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
     assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
-    assertEquals(HttpInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(HttpInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 
   private Map<String, Object> httpToMap(HttpInputSource source)

--- a/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/InlineInputSourceDefnTest.java
@@ -144,7 +144,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     CsvInputFormat format = (CsvInputFormat) extern.inputFormat;
     assertEquals(Arrays.asList("a", "b"), format.getColumns());
     assertEquals(2, extern.signature.size());
-    assertEquals(InlineInputSourceDefn.TYPE_KEY, extern.inputSourceType);
+    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
 
     // Fails if no columns are provided.
     assertThrows(IAE.class, () -> fn.apply("x", new HashMap<>(), Collections.emptyList(), mapper));
@@ -179,7 +179,7 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     CsvInputFormat actualFormat = (CsvInputFormat) extern.inputFormat;
     assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
     assertEquals(2, extern.signature.size());
-    assertEquals(InlineInputSourceDefn.TYPE_KEY, extern.inputSourceType);
+    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
 
     // Cannot supply columns with the function
     List<ColumnSpec> columns = Arrays.asList(
@@ -215,6 +215,6 @@ public class InlineInputSourceDefnTest extends BaseExternTableTest
     CsvInputFormat actualFormat = (CsvInputFormat) extern.inputFormat;
     assertEquals(Arrays.asList("a", "b"), actualFormat.getColumns());
     assertEquals(2, extern.signature.size());
-    assertEquals(InlineInputSourceDefn.TYPE_KEY, extern.inputSourceType);
+    assertEquals(Collections.singleton(InlineInputSourceDefn.TYPE_KEY), extern.inputSourceTypesSupplier.get());
   }
 }

--- a/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/table/LocalInputSourceDefnTest.java
@@ -536,6 +536,6 @@ public class LocalInputSourceDefnTest extends BaseExternTableTest
     assertEquals(Arrays.asList("x", "y"), sig.getColumnNames());
     assertEquals(ColumnType.STRING, sig.getColumnType(0).get());
     assertEquals(ColumnType.LONG, sig.getColumnType(1).get());
-    assertEquals(LocalInputSourceDefn.TYPE_KEY, externSpec.inputSourceType);
+    assertEquals(Collections.singleton(LocalInputSourceDefn.TYPE_KEY), externSpec.inputSourceTypesSupplier.get());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.NlsString;
+import org.apache.druid.data.input.InputSource;
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
@@ -34,6 +35,7 @@ import org.apache.druid.sql.calcite.table.DruidTable;
 import javax.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Used by {@link ExternalOperatorConversion} to generate a {@link DruidTable}
@@ -55,11 +57,10 @@ public class DruidExternTableMacro extends DruidUserDefinedTableMacro
     String inputSourceStr = getInputSourceArgument(call);
 
     try {
-      JsonNode jsonNode = ((DruidTableMacro) macro).getJsonMapper().readTree(inputSourceStr);
-      return Collections.singleton(new ResourceAction(new Resource(
-          ResourceType.EXTERNAL,
-          jsonNode.get("type").asText()
-      ), Action.READ));
+      InputSource inputSource = ((DruidTableMacro) macro).getJsonMapper().readValue(inputSourceStr, InputSource.class);
+      return inputSource.getTypes().stream()
+          .map(inputSourceType -> new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ))
+          .collect(Collectors.toSet());
     }
     catch (JsonProcessingException e) {
       // this shouldn't happen, the input source paraemeter should have been validated before this

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/ExternalOperatorConversion.java
@@ -34,6 +34,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.segment.column.RowSignature;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -111,12 +112,12 @@ public class ExternalOperatorConversion extends DruidExternTableMacroConversion
         }
 
         String inputSrcStr = CatalogUtils.getString(args, INPUT_SOURCE_PARAM);
-        String inputSrcType = jsonMapper.readTree(inputSrcStr).get("type").asText();
+        InputSource inputSource = jsonMapper.readValue(inputSrcStr, InputSource.class);
         return new ExternalTableSpec(
-            jsonMapper.readValue(inputSrcStr, InputSource.class),
+            inputSource,
             jsonMapper.readValue(CatalogUtils.getString(args, INPUT_FORMAT_PARAM), InputFormat.class),
             rowSignature,
-            inputSrcType
+            inputSource::getTypes
         );
       }
       catch (JsonProcessingException e) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -20,6 +20,7 @@
 package org.apache.druid.sql.calcite.external;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.avatica.SqlType;
 import org.apache.calcite.rel.type.RelDataType;
@@ -55,6 +56,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -297,7 +299,7 @@ public class Externals
                     + "Please change the column name to something other than __time");
     }
 
-    return toExternalTable(spec, jsonMapper, spec.inputSourceType);
+    return toExternalTable(spec, jsonMapper, spec.inputSourceTypesSupplier);
   }
 
   public static ResourceAction externalRead(String name)
@@ -308,7 +310,7 @@ public class Externals
   public static ExternalTable toExternalTable(
       ExternalTableSpec spec,
       ObjectMapper jsonMapper,
-      String inputSourceType
+      Supplier<Set<String>> inputSourceTypesSupplier
   )
   {
     return new ExternalTable(
@@ -319,7 +321,7 @@ public class Externals
           ),
         spec.signature,
         jsonMapper,
-        inputSourceType
+        inputSourceTypesSupplier
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
@@ -48,6 +48,7 @@ import org.apache.druid.sql.calcite.table.ExternalTable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Table macro designed for use with the Druid EXTEND operator. Example:
@@ -172,10 +173,11 @@ public abstract class SchemaAwareUserDefinedTableMacro
     {
       Set<ResourceAction> resourceActions = new HashSet<>();
       if (table instanceof ExternalTable && inputSourceTypeSecurityEnabled) {
-        resourceActions.add(new ResourceAction(new Resource(
-            ResourceType.EXTERNAL,
-            ((ExternalTable) table).getInputSourceType()
-        ), Action.READ));
+        resourceActions.addAll(((ExternalTable) table)
+                                   .getInputSourceTypeSupplier().get().stream()
+                                   .map(inputSourceType ->
+                                 new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ))
+                                   .collect(Collectors.toSet()));
       } else {
         resourceActions.addAll(base.computeResources(call, inputSourceTypeSecurityEnabled));
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
@@ -176,8 +176,9 @@ public abstract class SchemaAwareUserDefinedTableMacro
             ResourceType.EXTERNAL,
             ((ExternalTable) table).getInputSourceType()
         ), Action.READ));
+      } else {
+        resourceActions.addAll(base.computeResources(call, inputSourceTypeSecurityEnabled));
       }
-      resourceActions.addAll(base.computeResources(call, inputSourceTypeSecurityEnabled));
       return resourceActions;
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/table/ExternalTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/table/ExternalTable.java
@@ -21,6 +21,7 @@ package org.apache.druid.sql.calcite.table;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.plan.RelOptTable.ToRelContext;
 import org.apache.calcite.rel.RelNode;
@@ -29,6 +30,8 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.external.ExternalTableScan;
+
+import java.util.Set;
 
 /**
  * Represents an source of data external to Druid: a CSV file, an HTTP request, etc.
@@ -42,7 +45,7 @@ public class ExternalTable extends DruidTable
   private final DataSource dataSource;
   private final ObjectMapper objectMapper;
 
-  private final String inputSourceType;
+  private final Supplier<Set<String>> inputSourceTypeSupplier;
 
   /**
    * Cached row type, to avoid recreating types multiple times.
@@ -53,13 +56,13 @@ public class ExternalTable extends DruidTable
       final DataSource dataSource,
       final RowSignature rowSignature,
       final ObjectMapper objectMapper,
-      final String inputSourceType
+      final Supplier<Set<String>> inputSourceTypesSupplier
   )
   {
     super(rowSignature);
     this.dataSource = Preconditions.checkNotNull(dataSource, "dataSource");
     this.objectMapper = objectMapper;
-    this.inputSourceType = inputSourceType;
+    this.inputSourceTypeSupplier = inputSourceTypesSupplier;
   }
 
   @Override
@@ -93,9 +96,9 @@ public class ExternalTable extends DruidTable
     return rowType;
   }
 
-  public String getInputSourceType()
+  public Supplier<Set<String>> getInputSourceTypeSupplier()
   {
-    return inputSourceType;
+    return inputSourceTypeSupplier;
   }
 
   @Override
@@ -110,7 +113,6 @@ public class ExternalTable extends DruidTable
     return "ExternalTable{" +
            "dataSource=" + dataSource +
            ", rowSignature=" + getRowSignature() +
-           ", inputSourceType=" + getInputSourceType() +
            '}';
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -992,7 +992,7 @@ public class BaseCalciteQueryTest extends CalciteTestBase
    * factory is specific to one test and one planner config. This method can be
    * overridden to control the objects passed to the factory.
    */
-  private SqlStatementFactory getSqlStatementFactory(
+  SqlStatementFactory getSqlStatementFactory(
       PlannerConfig plannerConfig,
       AuthConfig authConfig
   )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.sql.calcite;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,8 +29,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
+import org.apache.druid.data.input.AbstractInputSource;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.InputSplit;
+import org.apache.druid.data.input.SplitHintSpec;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.guice.DruidInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.ISE;
@@ -62,11 +69,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 public class CalciteIngestionDmlTest extends BaseCalciteQueryTest
 {
@@ -144,7 +155,9 @@ public class CalciteIngestionDmlTest extends BaseCalciteQueryTest
       public List<? extends Module> getJacksonModules()
       {
         // We want this module to bring input sources along for the ride.
-        return new InputSourceModule().getJacksonModules();
+        List<Module> modules = new ArrayList<>(new InputSourceModule().getJacksonModules());
+        modules.add(new SimpleModule("test-module").registerSubtypes(TestFileInputSource.class));
+        return modules;
       }
 
       @Override
@@ -366,7 +379,7 @@ public class CalciteIngestionDmlTest extends BaseCalciteQueryTest
       final Throwable e = Assert.assertThrows(
           Throwable.class,
           () -> {
-            getSqlStatementFactory(plannerConfig).directStatement(sqlQuery()).execute();
+            getSqlStatementFactory(plannerConfig, authConfig).directStatement(sqlQuery()).execute();
           }
       );
 
@@ -422,6 +435,66 @@ public class CalciteIngestionDmlTest extends BaseCalciteQueryTest
           .context(queryContext)
           .auth(authenticationResult)
           .build();
+    }
+  }
+
+  static class TestFileInputSource extends AbstractInputSource implements SplittableInputSource<File>
+  {
+    private final List<File> files;
+
+    @JsonCreator
+    TestFileInputSource(@JsonProperty("files") List<File> fileList)
+    {
+      files = fileList;
+    }
+
+    @JsonProperty
+    public List<File> getFiles()
+    {
+      return files;
+    }
+
+    @Override
+    public Stream<InputSplit<File>> createSplits(InputFormat inputFormat, @Nullable SplitHintSpec splitHintSpec)
+    {
+      return files.stream().map(InputSplit::new);
+    }
+
+    @Override
+    public int estimateNumSplits(InputFormat inputFormat, @Nullable SplitHintSpec splitHintSpec)
+    {
+      return files.size();
+    }
+
+    @Override
+    public SplittableInputSource<File> withSplit(InputSplit<File> split)
+    {
+      return new TestFileInputSource(ImmutableList.of(split.get()));
+    }
+
+    @Override
+    public boolean needsFormat()
+    {
+      return true;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TestFileInputSource that = (TestFileInputSource) o;
+      return Objects.equals(files, that.files);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(files);
     }
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteIngestionDmlTest.java
@@ -62,6 +62,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -23,10 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.data.input.InputFormat;
-import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSource;
-import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.impl.CsvInputFormat;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.java.util.common.StringUtils;
@@ -59,7 +56,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -480,7 +476,59 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
   }
 
   @Test
-  public void testInsertFromExternalAnonymousInputSourceFunctionalStyleWithSchemaWithInputsourceSecurity()
+  public void testInsertFromExternalWithoutSecuritySupport()
+  {
+    InputSource inputSource =
+        new TestFileInputSource(ImmutableList.of(new File("testFile.csv").getAbsoluteFile()));
+    final ExternalDataSource externalDataSource = new ExternalDataSource(
+        inputSource,
+        new CsvInputFormat(ImmutableList.of("x", "y", "z"), null, false, false, 0),
+        RowSignature.builder()
+                    .add("x", ColumnType.STRING)
+                    .add("y", ColumnType.STRING)
+                    .add("z", ColumnType.LONG)
+                    .build()
+    );
+    String extern;
+    ObjectMapper queryJsonMapper = queryFramework().queryJsonMapper();
+    try {
+      extern = StringUtils.format(
+          "TABLE(extern("
+          + "inputSource => '%s',"
+          + "inputFormat => '%s'))",
+          queryJsonMapper.writeValueAsString(inputSource),
+          queryJsonMapper.writeValueAsString(
+              new CsvInputFormat(ImmutableList.of("x", "y", "z"), null, false, false, 0)
+          )
+      );
+    }
+    catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT * FROM %s\n" +
+             "  (x VARCHAR, y VARCHAR, z BIGINT)\n" +
+             "PARTITIONED BY ALL TIME",
+             extern
+        )
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .authConfig(AuthConfig.newBuilder().setEnableInputSourceSecurity(false).build())
+        .expectTarget("dst", externalDataSource.getSignature())
+        .expectResources(dataSourceWrite("dst"), Externals.EXTERNAL_RESOURCE_ACTION)
+        .expectQuery(
+            newScanQueryBuilder()
+                .dataSource(externalDataSource)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .columns("x", "y", "z")
+                .context(PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
+                .build()
+        )
+        .expectLogicalPlanFrom("InsertFromExternalWithoutSecuritySupport")
+        .verify();
+  }
+
+  @Test
+  public void testInsertFromExternalWithoutSecuritySupportWithInputsourceSecurityEnabled()
   {
     String extern;
     ObjectMapper queryJsonMapper = queryFramework().queryJsonMapper();
@@ -489,32 +537,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
           "TABLE(extern("
           + "inputSource => '%s',"
           + "inputFormat => '%s'))",
-          queryJsonMapper.writeValueAsString(
-              new InputSource()
-              {
-                @Override
-                public boolean isSplittable()
-                {
-                  return false;
-                }
-
-                @Override
-                public boolean needsFormat()
-                {
-                  return false;
-                }
-
-                @Override
-                public InputSourceReader reader(
-                    InputRowSchema inputRowSchema,
-                    @Nullable InputFormat inputFormat,
-                    File temporaryDirectory
-                )
-                {
-                  return null;
-                }
-              }
-          ),
+          queryJsonMapper.writeValueAsString(new TestFileInputSource(ImmutableList.of(new File("testFile.csv").getAbsoluteFile()))),
           queryJsonMapper.writeValueAsString(
               new CsvInputFormat(ImmutableList.of("x", "y", "z"), null, false, false, 0)
           )
@@ -531,17 +554,14 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
         )
         .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
         .authConfig(AuthConfig.newBuilder().setEnableInputSourceSecurity(true).build())
-        .expectTarget("dst", externalDataSource.getSignature())
-        .expectResources(dataSourceWrite("dst"), externalRead("inline"))
-        .expectQuery(
-            newScanQueryBuilder()
-                .dataSource(externalDataSource)
-                .intervals(querySegmentSpec(Filtration.eternity()))
-                .columns("x", "y", "z")
-                .context(PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
-                .build()
-        )
         .expectLogicalPlanFrom("insertFromExternal")
+        .expectValidationError(
+            CoreMatchers.allOf(
+                CoreMatchers.instanceOf(SqlPlanningException.class),
+                ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
+                    "org.apache.druid.java.util.common.UOE: This inputSource does not support input source based security"))
+            )
+        )
         .verify();
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.sql.calcite.external.ExternalDataSource;
 import org.apache.druid.sql.calcite.external.Externals;
@@ -106,6 +107,65 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
                 .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
                 .build()
          )
+        .expectLogicalPlanFrom("httpExtern")
+        .verify();
+  }
+
+  /**
+   * Http function
+   */
+  @Test
+  public void testHttpFunction()
+  {
+    String extern = "TABLE(http("
+             + "userName => 'bob',"
+             + "password => 'secret',"
+             + "uris => ARRAY['http://foo.com/bar.csv'],"
+             + "format => 'csv'))"
+             + "  (x VARCHAR, y VARCHAR, z BIGINT)";
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT * FROM %s PARTITIONED BY ALL TIME", extern)
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .expectTarget("dst", httpDataSource.getSignature())
+        .expectResources(dataSourceWrite("dst"), Externals.EXTERNAL_RESOURCE_ACTION)
+        .expectQuery(
+            newScanQueryBuilder()
+                .dataSource(httpDataSource)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .columns("x", "y", "z")
+                .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
+                .build()
+        )
+        .expectLogicalPlanFrom("httpExtern")
+        .verify();
+  }
+
+  /**
+   * Http function
+   */
+  @Test
+  public void testHttpFunctionWithInputsourceSecurity()
+  {
+    String extern = "TABLE(http("
+                    + "userName => 'bob',"
+                    + "password => 'secret',"
+                    + "uris => ARRAY['http://foo.com/bar.csv'],"
+                    + "format => 'csv'))"
+                    + "  (x VARCHAR, y VARCHAR, z BIGINT)";
+    testIngestionQuery()
+        .sql("INSERT INTO dst SELECT * FROM %s PARTITIONED BY ALL TIME", extern)
+        .authConfig(AuthConfig.newBuilder().setEnableInputSourceSecurity(true).build())
+        .authentication(CalciteTests.SUPER_USER_AUTH_RESULT)
+        .expectTarget("dst", httpDataSource.getSignature())
+        .expectResources(dataSourceWrite("dst"), externalRead("http"))
+        .expectQuery(
+            newScanQueryBuilder()
+                .dataSource(httpDataSource)
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .columns("x", "y", "z")
+                .context(CalciteIngestionDmlTest.PARTITIONED_BY_ALL_TIME_QUERY_CONTEXT)
+                .build()
+        )
         .expectLogicalPlanFrom("httpExtern")
         .verify();
   }

--- a/sql/src/test/resources/calcite/expected/ingest/InsertFromExternalWithoutSecuritySupport-logicalPlan.txt
+++ b/sql/src/test/resources/calcite/expected/ingest/InsertFromExternalWithoutSecuritySupport-logicalPlan.txt
@@ -1,0 +1,3 @@
+LogicalInsert(target=[dst], partitionedBy=[AllGranularity], clusteredBy=[<none>])
+  LogicalProject(x=[$0], y=[$1], z=[$2])
+    ExternalTableScan(dataSource=[{"type":"external","inputSource":{"type":"CalciteIngestionDmlTest$TestFileInputSource","files":["/Users/zachsherman/projects/opensrc-druid/sql/testFile.csv"]},"inputFormat":{"type":"csv","columns":["x","y","z"]},"signature":[{"name":"x","type":"STRING"},{"name":"y","type":"STRING"},{"name":"z","type":"LONG"}]}])


### PR DESCRIPTION
### Description

This change allows for input sources used during MSQ ingestion to be authorized for multiple input source types, instead of just 1. Such an input source that allows for multiple types is the CombiningInputSource.

Also fixed bug that caused some input source specific functions to be authorized against the permissions

`
[
    new ResourceAction(new Resource(ResourceType.EXTERNAL, ResourceType.EXTERNAL), Action.READ),
    new ResourceAction(new Resource(ResourceType.EXTERNAL, {input_source_type}), Action.READ)
]
`

when the inputSource based authorization feature is enabled, when it should instead be authorized against

`
[
    new ResourceAction(new Resource(ResourceType.EXTERNAL, {input_source_type}), Action.READ)
]
`


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
