### PR TITLE
Fix build failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1531,7 +1531,7 @@
                                 <projectName>Apache Druid</projectName>
                             </properties>
                             <resourceBundles>
-                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
+                                <resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5</resourceBundle>
                             </resourceBundles>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Druid builds are failing with following error
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-remote-resources-plugin:1.5:process (process-resource-bundles) on project druid: Resources archive cannot be found. Could not find artifact org.apache.apache.resources:apache-jar-resource-bundle:jar:1.5-SNAPSHOT in apache.snapshots (https://repository.apache.org/snapshots)
Error:  
Error:  Try downloading the file manually from the project website.
Error:  
Error:  Then, install it using the command: 
Error:      mvn install:install-file -DgroupId=org.apache.apache.resources -DartifactId=apache-jar-resource-bundle -Dversion=1.5-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file
Error:  
Error:  Alternatively, if you host your own repository you can deploy the file there: 
Error:      mvn deploy:deploy-file -DgroupId=org.apache.apache.resources -DartifactId=apache-jar-resource-bundle -Dversion=1.5-SNAPSHOT -Dpackaging=jar -Dfile=/path/to/file -Durl=[url] -DrepositoryId=[id]
Error:  
Error:  
Error:    org.apache.apache.resources:apache-jar-resource-bundle:jar:1.5-SNAPSHOT
Error:  
Error:  from the specified remote repositories:
Error:    maven.org (https://repo1.maven.org/maven2/, releases=true, snapshots=false),
Error:    sigar (https://repository.mulesoft.org/nexus/content/repositories/public, releases=true, snapshots=false),
Error:    apache.snapshots (https://repository.apache.org/snapshots, releases=false, snapshots=true),
Error:    central (https://repo.maven.apache.org/maven2, releases=true, snapshots=false)
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```
Maven is looking for `org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT` in  `https://repository.apache.org/snapshots/org/apache/apache/resources/apache-jar-resource-bundle/1.5-SNAPSHOT/apache-jar-resource-bundle-1.5-SNAPSHOT.jar`. This repository is modified a few days back possibly removing the required jars. Verified `org.apache.apache.resources:apache-jar-resource-bundle:1.5` jar is present in the repo and updated the same in `pom.xml`.