### PR TITLE
Vectorized T-Digest aggregator

### DIFF
--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestNumericVectorizedAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestNumericVectorizedAggregator.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.tdigestsketch;
+
+import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.segment.vector.VectorValueSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class TDigestNumericVectorizedAggregator implements VectorAggregator
+{
+  private final TDigestSketchAggregatorHelper innerAggregator;
+  private final VectorValueSelector selector;
+
+  public TDigestNumericVectorizedAggregator(Integer compression, VectorValueSelector selector)
+  {
+    innerAggregator = new TDigestSketchAggregatorHelper(compression == null
+                                                        ? TDigestSketchAggregatorFactory.DEFAULT_COMPRESSION
+                                                        : compression);
+    this.selector = selector;
+  }
+
+  @Override
+  public void init(ByteBuffer buf, int position)
+  {
+    // after this point the histogram is present in the cache
+    innerAggregator.init(buf, position);
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position, int startRow, int endRow)
+  {
+    double[] vector = selector.getDoubleVector();
+    boolean[] isNull = selector.getNullVector();
+    for (int i = startRow; i < endRow; i++) {
+      double other = toObject(vector, isNull, i);
+      innerAggregator.aggregate(other, buf, position);
+    }
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int numRows, int[] positions, @Nullable int[] rows, int positionOffset)
+  {
+    double[] vector = selector.getDoubleVector();
+    boolean[] isNull = selector.getNullVector();
+    for (int i = 0; i < numRows; i++) {
+      double other = toObject(vector, isNull, i);
+      int position = positions[i] + positionOffset;
+      innerAggregator.aggregate(other, buf, position);
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object get(ByteBuffer buf, int position)
+  {
+    return innerAggregator.get(buf, position);
+  }
+
+  @Override
+  public void close()
+  {
+    innerAggregator.close();
+  }
+
+  @Nullable
+  private Double toObject(double[] vector, @Nullable boolean[] isNull, int index)
+  {
+    return (isNull != null && isNull[index]) ? null : vector[index];
+  }
+}

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestNumericVectorizedAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestNumericVectorizedAggregator.java
@@ -62,8 +62,9 @@ public class TDigestNumericVectorizedAggregator implements VectorAggregator
     double[] vector = selector.getDoubleVector();
     boolean[] isNull = selector.getNullVector();
     for (int i = 0; i < numRows; i++) {
-      double other = toObject(vector, isNull, i);
       int position = positions[i] + positionOffset;
+      int index = rows != null ? rows[i] : i;
+      double other = toObject(vector, isNull, index);
       innerAggregator.aggregate(other, buf, position);
     }
   }

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorHelper.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestSketchAggregatorHelper.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.tdigestsketch;
+
+import com.tdunning.math.stats.MergingDigest;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import org.apache.druid.java.util.common.IAE;
+
+import java.nio.ByteBuffer;
+import java.util.IdentityHashMap;
+
+public class TDigestSketchAggregatorHelper
+{
+  private final int compression;
+  private final IdentityHashMap<ByteBuffer, Int2ObjectMap<MergingDigest>> sketchCache = new IdentityHashMap();
+
+  public TDigestSketchAggregatorHelper(int compression)
+  {
+    this.compression = compression;
+  }
+
+  public void init(ByteBuffer buffer, int position)
+  {
+    MergingDigest emptyDigest = new MergingDigest(compression);
+    addToCache(buffer, position, emptyDigest);
+  }
+
+  public void aggregate(Object x, ByteBuffer buffer, int position)
+  {
+    if (x == null) {
+      return;
+    }
+    merge(x, buffer, position);
+  }
+
+  void merge(Object x, ByteBuffer buffer, int position)
+  {
+    MergingDigest sketch = sketchCache.get(buffer).get(position);
+    if (x instanceof Number) {
+      sketch.add(((Number) x).doubleValue());
+    } else if (x instanceof MergingDigest) {
+      sketch.add((MergingDigest) x);
+    } else {
+      throw new IAE(
+          "Expected a number or an instance of MergingDigest, but received [%s] of type [%s]",
+          x,
+          x.getClass()
+      );
+    }
+  }
+
+  public Object get(final ByteBuffer buffer, final int position)
+  {
+    // sketchCache is an IdentityHashMap where the reference of buffer is used for equality checks.
+    // So the returned object isn't impacted by the changes in the buffer object made by concurrent threads.
+    return sketchCache.get(buffer).get(position);
+  }
+
+  public float getFloat(final ByteBuffer buffer, final int position)
+  {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  public long getLong(final ByteBuffer buffer, final int position)
+  {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  public void close()
+  {
+    sketchCache.clear();
+  }
+
+  public void relocate(int oldPosition, int newPosition, ByteBuffer oldBuffer, ByteBuffer newBuffer)
+  {
+    MergingDigest sketch = sketchCache.get(oldBuffer).get(oldPosition);
+    addToCache(newBuffer, newPosition, sketch);
+    final Int2ObjectMap<MergingDigest> map = sketchCache.get(oldBuffer);
+    map.remove(oldPosition);
+    if (map.isEmpty()) {
+      sketchCache.remove(oldBuffer);
+    }
+  }
+
+  private void addToCache(final ByteBuffer buffer, final int position, final MergingDigest sketch)
+  {
+    Int2ObjectMap<MergingDigest> map = sketchCache.computeIfAbsent(buffer, b -> new Int2ObjectOpenHashMap<>());
+    map.put(position, sketch);
+  }
+
+}

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestVectorizedAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/TDigestVectorizedAggregator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.tdigestsketch;
+
+import org.apache.druid.query.aggregation.VectorAggregator;
+import org.apache.druid.segment.vector.VectorObjectSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class TDigestVectorizedAggregator implements VectorAggregator
+{
+  private final TDigestSketchAggregatorHelper innerAggregator;
+  private final VectorObjectSelector selector;
+
+  public TDigestVectorizedAggregator(Integer compression, VectorObjectSelector selector)
+  {
+    this.selector = selector;
+    this.innerAggregator = new TDigestSketchAggregatorHelper(compression == null
+                                                             ? TDigestSketchAggregatorFactory.DEFAULT_COMPRESSION
+                                                             : compression);
+  }
+
+  @Override
+  public void init(ByteBuffer buf, int position)
+  {
+    // after this point the histogram is present in the cache
+    innerAggregator.init(buf, position);
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int position, int startRow, int endRow)
+  {
+    Object[] vector = selector.getObjectVector();
+    for (int i = startRow; i < endRow; i++) {
+      Object other = vector[i];
+      innerAggregator.aggregate(other, buf, position);
+    }
+  }
+
+  @Override
+  public void aggregate(ByteBuffer buf, int numRows, int[] positions, @Nullable int[] rows, int positionOffset)
+  {
+    Object[] vector = selector.getObjectVector();
+    for (int i = 0; i < numRows; i++) {
+      Object other = vector[i];
+      int position = positions[i] + positionOffset;
+      innerAggregator.aggregate(other, buf, position);
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object get(ByteBuffer buf, int position)
+  {
+    return innerAggregator.get(buf, position);
+  }
+
+  @Override
+  public void close()
+  {
+    innerAggregator.close();
+  }
+}

--- a/extensions-contrib/tdigestsketch/src/test/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchSqlAggregatorTest.java
+++ b/extensions-contrib/tdigestsketch/src/test/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchSqlAggregatorTest.java
@@ -114,8 +114,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testComputingSketchOnNumericValues()
   {
-    cannotVectorize();
-
     testQuery(
         "SELECT\n"
         + "TDIGEST_GENERATE_SKETCH(m1, 200)"
@@ -142,8 +140,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testComputingSketchOnCastedString()
   {
-    cannotVectorize();
-
     testQuery(
         "SELECT\n"
         + "TDIGEST_GENERATE_SKETCH(CAST(dim1 AS DOUBLE), 200)"
@@ -182,8 +178,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testDefaultCompressionForTDigestGenerateSketchAgg()
   {
-    cannotVectorize();
-
     testQuery(
         "SELECT\n"
         + "TDIGEST_GENERATE_SKETCH(m1)"
@@ -208,8 +202,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testComputingQuantileOnPreAggregatedSketch()
   {
-    cannotVectorize();
-
     final List<Object[]> expectedResults = ImmutableList.of(
         new Object[]{
             1.1,
@@ -250,8 +242,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testGeneratingSketchAndComputingQuantileOnFly()
   {
-    cannotVectorize();
-
     final List<Object[]> expectedResults = ImmutableList.of(
         new Object[]{
             1.0,
@@ -305,8 +295,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testQuantileOnNumericValues()
   {
-    cannotVectorize();
-
     final List<Object[]> expectedResults = ImmutableList.of(
         new Object[]{
             1.0,
@@ -342,7 +330,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testCompressionParamForTDigestQuantileAgg()
   {
-    cannotVectorize();
     testQuery(
         "SELECT\n"
         + "TDIGEST_QUANTILE(m1, 0.0), TDIGEST_QUANTILE(m1, 0.5, 200), TDIGEST_QUANTILE(m1, 1.0, 300)\n"
@@ -380,8 +367,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testQuantileOnCastedString()
   {
-    cannotVectorize();
-
     testQuery(
         "SELECT\n"
         + "  TDIGEST_QUANTILE(CAST(dim1 AS DOUBLE), 0.0),\n"
@@ -433,8 +418,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testEmptyTimeseriesResults()
   {
-    cannotVectorize();
-
     testQuery(
         "SELECT\n"
         + "TDIGEST_GENERATE_SKETCH(m1),"
@@ -465,7 +448,6 @@ public class TDigestSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testGroupByAggregatorDefaultValues()
   {
-    cannotVectorize();
     testQuery(
         "SELECT\n"
         + "dim2,\n"


### PR DESCRIPTION
Add a vectorized version of the t-digest aggregator.

This PR has:

- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
