### PR TITLE
Make the tasks run with only a single directory

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1457,6 +1457,7 @@ Middle managers pass their configurations down to their child peons. The MiddleM
 |`druid.worker.ip`|The IP of the worker.|localhost|
 |`druid.worker.version`|Version identifier for the MiddleManager. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accommodate date comparisons.|0|
 |`druid.worker.capacity`|Maximum number of tasks the MiddleManager can accept.|Number of CPUs on the machine - 1|
+|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
 |`druid.worker.category`|A string to name the category that the MiddleManager node belongs to.|`_default_worker_category`|
 
 #### Peon Processing
@@ -1510,8 +1511,7 @@ Additional peon configs include:
 |--------|-----------|-------|
 |`druid.peon.mode`|Choices are "local" and "remote". Setting this to local means you intend to run the peon as a standalone process (Not recommended).|remote|
 |`druid.indexer.task.baseDir`|Base temporary working directory.|`System.getProperty("java.io.tmpdir")`|
-|`druid.indexer.task.baseTaskDir`|Deprecated. Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/task`|
-|`druid.indexer.task.baseTaskDirPaths`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of `${druid.indexer.task.baseTaskDir}`. If a null or empty value is provided, `baseTaskDir` is used. Otherwise, it overrides the value of `baseTaskDir`. Example: `druid.indexer.task.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
+|`druid.indexer.task.baseTaskDir`|Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/task`|
 |`druid.indexer.task.batchProcessingMode`| Batch ingestion tasks have three operating modes to control construction and tracking for intermediary segments: `OPEN_SEGMENTS`, `CLOSED_SEGMENTS`, and `CLOSED_SEGMENT_SINKS`. `OPEN_SEGMENTS` uses the streaming ingestion code path and performs a `mmap` on intermediary segments to build a timeline to make these segments available to realtime queries. Batch ingestion doesn't require intermediary segments, so the default mode, `CLOSED_SEGMENTS`, eliminates `mmap` of intermediary segments. `CLOSED_SEGMENTS` mode still tracks the entire set of segments in heap. The `CLOSED_SEGMENTS_SINKS` mode is the most aggressive configuration and should have the smallest memory footprint. It eliminates in-memory tracking and `mmap` of intermediary segments produced during segment creation. `CLOSED_SEGMENTS_SINKS` mode isn't as well tested as other modes so is currently considered experimental. You can use `OPEN_SEGMENTS` mode if problems occur with the 2 newer modes. |`CLOSED_SEGMENTS`|
 |`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.8.5|
 |`druid.indexer.task.defaultRowFlushBoundary`|Highest row count before persisting to disk. Used for indexing generating tasks.|75000|
@@ -1536,7 +1536,7 @@ If the peon is running in remote mode, there must be an Overlord up and running.
 When new segments are created, Druid temporarily stores some preprocessed data in some buffers. Currently three types of
 *medium* exist for those buffers: *temporary files*, *off-heap memory*, and *on-heap memory*.
 
-*Temporary files* (`tmpFile`) are stored under the task working directory (see `druid.indexer.task.baseTaskDirPaths`
+*Temporary files* (`tmpFile`) are stored under the task working directory (see `druid.worker.baseTaskDirs`
 configuration above) and thus share it's mounting properties, e. g. they could be backed by HDD, SSD or memory (tmpfs).
 This type of medium may do unnecessary disk I/O and requires some disk space to be available.
 
@@ -1577,11 +1577,11 @@ then the value from the configuration below is used:
 |--------|-----------|-------|
 |`druid.worker.version`|Version identifier for the Indexer.|0|
 |`druid.worker.capacity`|Maximum number of tasks the Indexer can accept.|Number of available processors - 1|
+|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
 |`druid.worker.globalIngestionHeapLimitBytes`|Total amount of heap available for ingestion processing. This is applied by automatically setting the `maxBytesInMemory` property on tasks.|60% of configured JVM heap|
 |`druid.worker.numConcurrentMerges`|Maximum number of segment persist or merge operations that can run concurrently across all tasks.|`druid.worker.capacity` / 2, rounded down|
 |`druid.indexer.task.baseDir`|Base temporary working directory.|`System.getProperty("java.io.tmpdir")`|
-|`druid.indexer.task.baseTaskDir`|Deprecated. Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/tasks`|
-|`druid.indexer.task.baseTaskDirPaths`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of `${druid.indexer.task.baseTaskDir}`. If a null or empty value is provided, `baseTaskDir` is used. Otherwise, it overrides the value of `baseTaskDir`. Example: `druid.indexer.task.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
+|`druid.indexer.task.baseTaskDir`|Base temporary working directory for tasks.|`${druid.indexer.task.baseDir}/persistent/tasks`|
 |`druid.indexer.task.defaultHadoopCoordinates`|Hadoop version to use with HadoopIndexTasks that do not request a particular version.|org.apache.hadoop:hadoop-client:2.8.5|
 |`druid.indexer.task.gracefulShutdownTimeout`|Wait this long on Indexer restart for restorable tasks to gracefully exit.|PT5M|
 |`druid.indexer.task.hadoopWorkingPath`|Temporary working directory for Hadoop tasks.|`/tmp/druid-indexing`|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1457,7 +1457,7 @@ Middle managers pass their configurations down to their child peons. The MiddleM
 |`druid.worker.ip`|The IP of the worker.|localhost|
 |`druid.worker.version`|Version identifier for the MiddleManager. The version number is a string. This affects the expected behavior during certain operations like comparison against `druid.indexer.runner.minWorkerVersion`. Specifically, the version comparison follows dictionary order. Use ISO8601 date format for the version to accommodate date comparisons.|0|
 |`druid.worker.capacity`|Maximum number of tasks the MiddleManager can accept.|Number of CPUs on the machine - 1|
-|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
+|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirs=[\"PATH1\",\"PATH2\",...]`.|null|
 |`druid.worker.category`|A string to name the category that the MiddleManager node belongs to.|`_default_worker_category`|
 
 #### Peon Processing
@@ -1577,7 +1577,7 @@ then the value from the configuration below is used:
 |--------|-----------|-------|
 |`druid.worker.version`|Version identifier for the Indexer.|0|
 |`druid.worker.capacity`|Maximum number of tasks the Indexer can accept.|Number of available processors - 1|
-|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirPaths=[\"PATH1\",\"PATH2\",...]`.|null|
+|`druid.worker.baseTaskDirs`|List of base temporary working directories, one of which is assigned per task in a round-robin fashion. This property can be used to allow usage of multiple disks for indexing. This property is recommended in place of and takes precedence over `${druid.indexer.task.baseTaskDir}`.  If this configuration is not set, `${druid.indexer.task.baseTaskDir}` is used.  Example: `druid.worker.baseTaskDirs=[\"PATH1\",\"PATH2\",...]`.|null|
 |`druid.worker.globalIngestionHeapLimitBytes`|Total amount of heap available for ingestion processing. This is applied by automatically setting the `maxBytesInMemory` property on tasks.|60% of configured JVM heap|
 |`druid.worker.numConcurrentMerges`|Maximum number of segment persist or merge operations that can run concurrently across all tasks.|`druid.worker.capacity` / 2, rounded down|
 |`druid.indexer.task.baseDir`|Base temporary working directory.|`System.getProperty("java.io.tmpdir")`|

--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -400,7 +400,7 @@ Logs are created by ingestion tasks as they run.  You can configure Druid to pus
 
 Once the task has been submitted to the Overlord it remains `WAITING` for locks to be acquired.  Worker slot allocation is then `PENDING` until the task can actually start executing.
 
-The task then starts creating logs in a local directory of the middle manager (or indexer) in a `log` directory for the specific `taskId` at [`druid.indexer.task.baseTaskDirPaths`] (../configuration/index.md#additional-peon-configuration).
+The task then starts creating logs in a local directory of the middle manager (or indexer) in a `log` directory for the specific `taskId` at [`druid.worker.baseTaskDirs`] (../configuration/index.md#middlemanager-configuration).
 
 When the task completes - whether it succeeds or fails - the middle manager (or indexer) will push the task log file into the location specified in [`druid.indexer.logs`](../configuration/index.md#task-logging).
 

--- a/examples/conf/druid/auto/indexer/runtime.properties
+++ b/examples/conf/druid/auto/indexer/runtime.properties
@@ -24,7 +24,7 @@ druid.plaintextPort=8091
 # determined based on available processor.
 
 # Task launch parameters
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Processing threads and buffers on Indexer
 # Determined automatically based on available memory. For details on how to manually set parameters:

--- a/examples/conf/druid/auto/middleManager/runtime.properties
+++ b/examples/conf/druid/auto/middleManager/runtime.properties
@@ -26,7 +26,7 @@ druid.plaintextPort=8091
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Processing threads and buffers on Peons
 # Determined automatically based on available memory. For details on how to manually set parameters:

--- a/examples/conf/druid/cluster/data/indexer/runtime.properties
+++ b/examples/conf/druid/cluster/data/indexer/runtime.properties
@@ -24,7 +24,7 @@ druid.plaintextPort=8091
 druid.worker.capacity=4
 
 # Task launch parameters
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=60

--- a/examples/conf/druid/cluster/data/middleManager/runtime.properties
+++ b/examples/conf/druid/cluster/data/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=4
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=60

--- a/examples/conf/druid/single-server/large/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/large/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=8
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=60

--- a/examples/conf/druid/single-server/medium/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/medium/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=4
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=60

--- a/examples/conf/druid/single-server/micro-quickstart/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/micro-quickstart/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=2
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=12

--- a/examples/conf/druid/single-server/nano-quickstart/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/nano-quickstart/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=2
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms256m","-Xmx256m","-XX:MaxDirectMemorySize=300m","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=6

--- a/examples/conf/druid/single-server/small/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/small/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=3
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=50

--- a/examples/conf/druid/single-server/xlarge/middleManager/runtime.properties
+++ b/examples/conf/druid/single-server/xlarge/middleManager/runtime.properties
@@ -22,11 +22,11 @@ druid.plaintextPort=8091
 
 # Number of tasks per middleManager
 druid.worker.capacity=16
+druid.worker.baseTaskDirs=[\"var/druid/task\"]
 
 # Task launch parameters
 druid.indexer.runner.javaCommand=bin/run-java
 druid.indexer.runner.javaOptsArray=["-server","-Xms1g","-Xmx1g","-XX:MaxDirectMemorySize=1g","-Duser.timezone=UTC","-Dfile.encoding=UTF-8","-XX:+ExitOnOutOfMemoryError","-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"]
-druid.indexer.task.baseTaskDirPaths=[\"var/druid/task\"]
 
 # HTTP server threads
 druid.server.http.numThreads=60

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapter.java
@@ -52,7 +52,6 @@ import org.apache.druid.k8s.overlord.KubernetesTaskRunnerConfig;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.StartupLoggingConfig;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,7 +108,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     PeonCommandContext context = new PeonCommandContext(
         generateCommand(task),
         javaOpts(task),
-        new File(taskConfig.getBaseTaskDirPaths().get(0)),
+        taskConfig.getBaseTaskDir(),
         node.isEnableTlsPort()
     );
     PodSpec podSpec = pod.getSpec();
@@ -371,7 +370,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
   {
     final List<String> command = new ArrayList<>();
     command.add("/peon.sh");
-    command.add(new File(taskConfig.getBaseTaskDirPaths().get(0)).getAbsolutePath());
+    command.add(taskConfig.getBaseTaskDir().getAbsolutePath());
     command.add("1"); // the attemptId is always 1, we never run the task twice on the same pod.
 
     String nodeType = task.getNodeType();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapter.java
@@ -209,7 +209,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     return ImmutableList.of(
         new EnvVarBuilder()
             .withName(DruidK8sConstants.TASK_DIR_ENV)
-            .withValue(new File(taskConfig.getBaseTaskDirPaths().get(0)).getAbsolutePath())
+            .withValue(taskConfig.getBaseTaskDir().getAbsolutePath())
             .build(),
         new EnvVarBuilder()
             .withName(DruidK8sConstants.TASK_ID_ENV)

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapter.java
@@ -209,7 +209,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     return ImmutableList.of(
         new EnvVarBuilder()
             .withName(DruidK8sConstants.TASK_DIR_ENV)
-            .withValue(taskConfig.getBaseTaskDir().getAbsolutePath())
+            .withValue(taskConfig.getBaseDir())
             .build(),
         new EnvVarBuilder()
             .withName(DruidK8sConstants.TASK_ID_ENV)

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.k8s.overlord;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.k8s.overlord.common.MultiContainerTaskAdapter;
@@ -71,22 +72,7 @@ public class KubernetesTaskRunnerFactoryTest
         true,
         false
     );
-    taskConfig = new TaskConfig(
-        "/tmp",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("/tmp").build();
     properties = new Properties();
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.k8s.overlord;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
@@ -86,8 +85,7 @@ public class KubernetesTaskRunnerFactoryTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("/tmp")
+        false
     );
     properties = new Properties();
   }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidPeonClientIntegrationTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidPeonClientIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
@@ -92,22 +93,7 @@ public class DruidPeonClientIntegrationTest
         false
     );
     startupLoggingConfig = new StartupLoggingConfig();
-    taskConfig = new TaskConfig(
-        "src/test/resources",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("src/test/resources").build();
   }
 
   @Disabled

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidPeonClientIntegrationTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/DruidPeonClientIntegrationTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.k8s.overlord.common;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
@@ -107,8 +106,7 @@ public class DruidPeonClientIntegrationTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("src/test/resources")
+        false
     );
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.api.client.util.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.fabric8.kubernetes.api.model.Container;
@@ -106,8 +105,7 @@ class K8sTaskAdapterTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("src/test/resources")
+        false
     );
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
@@ -91,22 +92,7 @@ class K8sTaskAdapterTest
         false
     );
     startupLoggingConfig = new StartupLoggingConfig();
-    taskConfig = new TaskConfig(
-        "src/test/resources",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("src/test/resources").build();
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -100,12 +100,14 @@ class K8sTaskAdapterTest
   void testAddingLabelsAndAnnotations() throws IOException
   {
     final PodSpec podSpec = K8sTestUtils.getDummyPodSpec();
-    TestKubernetesClient testClient = new TestKubernetesClient(client){
+    TestKubernetesClient testClient = new TestKubernetesClient(client)
+    {
       @SuppressWarnings("unchecked")
       @Override
       public <T> T executeRequest(KubernetesExecutor<T> executor) throws KubernetesResourceNotFoundException
       {
-        return (T) new Pod(){
+        return (T) new Pod()
+        {
           @Override
           public PodSpec getSpec()
           {

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
@@ -77,22 +78,7 @@ class MultiContainerTaskAdapterTest
         false
     );
     startupLoggingConfig = new StartupLoggingConfig();
-    taskConfig = new TaskConfig(
-        "src/test/resources",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("src/test/resources").build();
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/MultiContainerTaskAdapterTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.k8s.overlord.common;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
@@ -92,8 +91,7 @@ class MultiContainerTaskAdapterTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("src/test/resources")
+        false
     );
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapterTest.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.common.IAE;
@@ -57,22 +58,7 @@ public class PodTemplateTaskAdapterTest
   public void setup()
   {
     taskRunnerConfig = new KubernetesTaskRunnerConfig();
-    taskConfig = new TaskConfig(
-        "/tmp",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("/tmp").build();
     node = new DruidNode(
         "test",
         "",

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateTaskAdapterTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.k8s.overlord.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
@@ -72,8 +71,7 @@ public class PodTemplateTaskAdapterTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("/tmp")
+        false
     );
     node = new DruidNode(
         "test",

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapterTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.k8s.overlord.common;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -90,8 +89,7 @@ class SingleContainerTaskAdapterTest
         false,
         null,
         null,
-        false,
-        ImmutableList.of("src/test/resources")
+        false
     );
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/SingleContainerTaskAdapterTest.java
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.apache.druid.guice.FirehoseModule;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
@@ -75,22 +76,7 @@ class SingleContainerTaskAdapterTest
         false
     );
     startupLoggingConfig = new StartupLoggingConfig();
-    taskConfig = new TaskConfig(
-        "src/test/resources",
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder().setBaseDir("src/test/resources").build();
   }
 
   @Test

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -24,7 +24,6 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.ISE;
 
-import javax.inject.Inject;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +53,6 @@ public class TaskStorageDirTracker
 
   private final Map<String, File> taskToTempDirMap = new HashMap<>();
 
-  @Inject
   public TaskStorageDirTracker(List<File> baseTaskDirs)
   {
     this.baseTaskDirs = baseTaskDirs;
@@ -63,11 +61,6 @@ public class TaskStorageDirTracker
   public File getTaskDir(String taskId)
   {
     return new File(getBaseTaskDir(taskId), taskId);
-  }
-
-  public File getTaskWorkDir(String taskId)
-  {
-    return new File(getTaskDir(taskId), "work");
   }
 
   public File getTaskTempDir(String taskId)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -56,7 +56,7 @@ public class TaskStorageDirTracker
 
   public TaskStorageDirTracker(List<File> baseTaskDirs)
   {
-    this.baseTaskDirs = baseTaskDirs.toArray(new File[]{});
+    this.baseTaskDirs = baseTaskDirs.toArray(new File[0]);
   }
 
   @LifecycleStart

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -78,7 +78,7 @@ public class TaskStorageDirTracker
     }
   }
 
-  public File pickBaseDir(String taskId) throws IOException
+  public File pickBaseDir(String taskId)
   {
     if (baseTaskDirs.length == 1) {
       return baseTaskDirs[0];

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 
@@ -60,13 +61,18 @@ public class TaskStorageDirTracker
   public void ensureDirectories()
   {
     for (File baseTaskDir : baseTaskDirs) {
-      if (baseTaskDir.exists() || baseTaskDir.mkdirs()) {
-        continue;
+      if (!baseTaskDir.exists()) {
+        try {
+          FileUtils.mkdirp(baseTaskDir);
+        }
+        catch (IOException e) {
+          throw new ISE(
+              e,
+              "base task directory [%s] likely does not exist, please ensure it exists and the user has permissions.",
+              baseTaskDir
+          );
+        }
       }
-      throw new ISE(
-          "base task directory [%s] likely does not exist, please ensure it exists and the user has permissions.",
-          baseTaskDir
-      );
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolbox.java
@@ -128,8 +128,6 @@ public class TaskToolbox
 
   private final TaskLogPusher taskLogPusher;
   private final String attemptId;
-  private final TaskStorageDirTracker dirTracker;
-
 
   public TaskToolbox(
       TaskConfig config,
@@ -170,8 +168,7 @@ public class TaskToolbox
       ParallelIndexSupervisorTaskClientProvider supervisorTaskClientProvider,
       ShuffleClient shuffleClient,
       TaskLogPusher taskLogPusher,
-      String attemptId,
-      TaskStorageDirTracker dirTracker
+      String attemptId
   )
   {
     this.config = config;
@@ -214,7 +211,6 @@ public class TaskToolbox
     this.shuffleClient = shuffleClient;
     this.taskLogPusher = taskLogPusher;
     this.attemptId = attemptId;
-    this.dirTracker = dirTracker;
   }
 
   public TaskConfig getConfig()
@@ -472,11 +468,6 @@ public class TaskToolbox
     return attemptId;
   }
 
-  public TaskStorageDirTracker getDirTracker()
-  {
-    return dirTracker;
-  }
-
   /**
    * Get {@link RuntimeInfo} adjusted for this particular task. When running in a task JVM launched by a MiddleManager,
    * this is the same as the baseline {@link RuntimeInfo}. When running in an Indexer, it is adjusted based on
@@ -552,7 +543,6 @@ public class TaskToolbox
     private ShuffleClient shuffleClient;
     private TaskLogPusher taskLogPusher;
     private String attemptId;
-    private TaskStorageDirTracker dirTracker;
 
     public Builder()
     {
@@ -597,7 +587,6 @@ public class TaskToolbox
       this.intermediaryDataManager = other.intermediaryDataManager;
       this.supervisorTaskClientProvider = other.supervisorTaskClientProvider;
       this.shuffleClient = other.shuffleClient;
-      this.dirTracker = other.getDirTracker();
     }
 
     public Builder config(final TaskConfig config)
@@ -834,12 +823,6 @@ public class TaskToolbox
       return this;
     }
 
-    public Builder dirTracker(final TaskStorageDirTracker dirTracker)
-    {
-      this.dirTracker = dirTracker;
-      return this;
-    }
-
     public TaskToolbox build()
     {
       return new TaskToolbox(
@@ -881,8 +864,7 @@ public class TaskToolbox
           supervisorTaskClientProvider,
           shuffleClient,
           taskLogPusher,
-          attemptId,
-          dirTracker
+          attemptId
       );
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolboxFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolboxFactory.java
@@ -195,6 +195,16 @@ public class TaskToolboxFactory
 
   public TaskToolbox build(Task task)
   {
+    return build(config, task);
+  }
+
+  public TaskToolbox build(File baseTaskDir, Task task)
+  {
+    return build(config.withBaseTaskDir(baseTaskDir), task);
+  }
+
+  public TaskToolbox build(TaskConfig config, Task task)
+  {
     final File taskWorkDir = config.getTaskWorkDir(task.getId());
     return new TaskToolbox.Builder()
         .config(config)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolboxFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskToolboxFactory.java
@@ -110,7 +110,6 @@ public class TaskToolboxFactory
   private final ShuffleClient shuffleClient;
   private final TaskLogPusher taskLogPusher;
   private final String attemptId;
-  private final TaskStorageDirTracker dirTracker;
 
   @Inject
   public TaskToolboxFactory(
@@ -151,8 +150,7 @@ public class TaskToolboxFactory
       ParallelIndexSupervisorTaskClientProvider supervisorTaskClientProvider,
       ShuffleClient shuffleClient,
       TaskLogPusher taskLogPusher,
-      @AttemptId String attemptId,
-      TaskStorageDirTracker dirTracker
+      @AttemptId String attemptId
   )
   {
     this.config = config;
@@ -193,12 +191,11 @@ public class TaskToolboxFactory
     this.shuffleClient = shuffleClient;
     this.taskLogPusher = taskLogPusher;
     this.attemptId = attemptId;
-    this.dirTracker = dirTracker;
   }
 
   public TaskToolbox build(Task task)
   {
-    final File taskWorkDir = dirTracker.getTaskWorkDir(task.getId());
+    final File taskWorkDir = config.getTaskWorkDir(task.getId());
     return new TaskToolbox.Builder()
         .config(config)
         .taskExecutorNode(taskExecutorNode)
@@ -243,7 +240,6 @@ public class TaskToolboxFactory
         .shuffleClient(shuffleClient)
         .taskLogPusher(taskLogPusher)
         .attemptId(attemptId)
-        .dirTracker(dirTracker)
         .build();
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -40,7 +40,7 @@ import java.util.List;
 
 /**
  * Configurations for ingestion tasks. These configurations can be applied per middleManager, indexer, or overlord.
- *
+ * <p>
  * See {@link org.apache.druid.indexing.overlord.config.DefaultTaskConfig} if you want to apply the same configuration
  * to all tasks submitted to the overlord.
  */
@@ -133,7 +133,8 @@ public class TaskConfig
       @JsonProperty("directoryLockTimeout") Period directoryLockTimeout,
       @JsonProperty("shuffleDataLocations") List<StorageLocationConfig> shuffleDataLocations,
       @JsonProperty("ignoreTimestampSpecForDruidInputSource") boolean ignoreTimestampSpecForDruidInputSource,
-      @JsonProperty("batchMemoryMappedIndex") boolean batchMemoryMappedIndex, // deprecated, only set to true to fall back to older behavior
+      @JsonProperty("batchMemoryMappedIndex") boolean batchMemoryMappedIndex,
+      // deprecated, only set to true to fall back to older behavior
       @JsonProperty("batchProcessingMode") String batchProcessingMode,
       @JsonProperty("storeEmptyColumns") @Nullable Boolean storeEmptyColumns,
       @JsonProperty("encapsulatedTask") boolean enableTaskLevelLogPush
@@ -182,6 +183,39 @@ public class TaskConfig
     }
     log.debug("Batch processing mode:[%s]", this.batchProcessingMode);
     this.storeEmptyColumns = storeEmptyColumns == null ? DEFAULT_STORE_EMPTY_COLUMNS : storeEmptyColumns;
+  }
+
+  private TaskConfig(
+      String baseDir,
+      File baseTaskDir,
+      String hadoopWorkingPath,
+      int defaultRowFlushBoundary,
+      List<String> defaultHadoopCoordinates,
+      boolean restoreTasksOnRestart,
+      Period gracefulShutdownTimeout,
+      Period directoryLockTimeout,
+      List<StorageLocationConfig> shuffleDataLocations,
+      boolean ignoreTimestampSpecForDruidInputSource,
+      boolean batchMemoryMappedIndex,
+      BatchProcessingMode batchProcessingMode,
+      boolean storeEmptyColumns,
+      boolean encapsulatedTask
+  )
+  {
+    this.baseDir = baseDir;
+    this.baseTaskDir = baseTaskDir;
+    this.hadoopWorkingPath = hadoopWorkingPath;
+    this.defaultRowFlushBoundary = defaultRowFlushBoundary;
+    this.defaultHadoopCoordinates = defaultHadoopCoordinates;
+    this.restoreTasksOnRestart = restoreTasksOnRestart;
+    this.gracefulShutdownTimeout = gracefulShutdownTimeout;
+    this.directoryLockTimeout = directoryLockTimeout;
+    this.shuffleDataLocations = shuffleDataLocations;
+    this.ignoreTimestampSpecForDruidInputSource = ignoreTimestampSpecForDruidInputSource;
+    this.batchMemoryMappedIndex = batchMemoryMappedIndex;
+    this.batchProcessingMode = batchProcessingMode;
+    this.storeEmptyColumns = storeEmptyColumns;
+    this.encapsulatedTask = encapsulatedTask;
   }
 
   @JsonProperty
@@ -299,5 +333,25 @@ public class TaskConfig
     }
 
     return configParameter;
+  }
+
+  public TaskConfig withBaseTaskDir(File baseTaskDir)
+  {
+    return new TaskConfig(
+        baseDir,
+        baseTaskDir,
+        hadoopWorkingPath,
+        defaultRowFlushBoundary,
+        defaultHadoopCoordinates,
+        restoreTasksOnRestart,
+        gracefulShutdownTimeout,
+        directoryLockTimeout,
+        shuffleDataLocations,
+        ignoreTimestampSpecForDruidInputSource,
+        batchMemoryMappedIndex,
+        batchProcessingMode,
+        storeEmptyColumns,
+        encapsulatedTask
+    );
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -142,7 +142,7 @@ public abstract class AbstractTask implements Task
   public String setup(TaskToolbox toolbox) throws Exception
   {
     if (toolbox.getConfig().isEncapsulatedTask()) {
-      File taskDir = toolbox.getDirTracker().getTaskDir(getId());
+      File taskDir = toolbox.getConfig().getTaskDir(getId());
       FileUtils.mkdirp(taskDir);
       File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", toolbox.getAttemptId()).toFile();
       FileUtils.mkdirp(attemptDir);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -48,7 +48,6 @@ import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReportData;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.TaskReport;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TimeChunkLockAcquireAction;
@@ -102,7 +101,6 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   private static final String HADOOP_JOB_ID_FILENAME = "mapReduceJobId.json";
   private static final String TYPE = "index_hadoop";
   private TaskConfig taskConfig = null;
-  private TaskStorageDirTracker dirTracker = null;
 
   private static String getTheDataSource(HadoopIngestionSpec spec)
   {
@@ -295,7 +293,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
 
   private File getHadoopJobIdFile()
   {
-    return new File(dirTracker.getTaskDir(getId()), HADOOP_JOB_ID_FILENAME);
+    return new File(taskConfig.getTaskDir(getId()), HADOOP_JOB_ID_FILENAME);
   }
 
   @Override
@@ -303,7 +301,6 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   {
     try {
       taskConfig = toolbox.getConfig();
-      dirTracker = toolbox.getDirTracker();
       if (chatHandlerProvider.isPresent()) {
         log.info("Found chat handler of class[%s]", chatHandlerProvider.get().getClass().getName());
         chatHandlerProvider.get().register(getId(), this, false);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionParallelIndexTaskRunner.java
@@ -256,7 +256,7 @@ class PartialDimensionDistributionParallelIndexTaskRunner
 
   private File createDistributionsDir()
   {
-    File taskTempDir = getToolbox().getDirTracker().getTaskTempDir(getTaskId());
+    File taskTempDir = getToolbox().getConfig().getTaskTempDir(getTaskId());
     File distributionsDir = new File(taskTempDir, "dimension_distributions");
     try {
       FileUtils.mkdirp(distributionsDir);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
@@ -89,7 +89,7 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
           taskRestoreInfos.put(baseDir, jsonMapper.readValue(restoreFile, TaskRestoreInfo.class));
         }
         catch (Exception e) {
-          LOG.error(e, "Failed to read restorable tasks from file[%s]. Skipping restore.", restoreFile);
+          LOG.warn(e, "Failed to read restorable tasks from file[%s]. Skipping restore.", restoreFile);
         }
       }
     }
@@ -207,28 +207,6 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
       }
       catch (Exception e) {
         LOG.warn(e, "Failed to save tasks to restore file[%s]. Skipping this save.", restoreFile);
-      }
-    }
-  }
-
-  @Override
-  public void stop()
-  {
-    if (!taskConfig.isRestoreTasksOnRestart()) {
-      return;
-    }
-
-    for (File baseDir : dirTracker.getBaseTaskDirs()) {
-      File restoreFile = new File(baseDir, TASK_RESTORE_FILENAME);
-      if (restoreFile.exists()) {
-        try {
-          TaskRestoreInfo taskRestoreInfo = jsonMapper.readValue(restoreFile, TaskRestoreInfo.class);
-          LOG.info("Path[%s] contains restore data for tasks[%s] on restart",
-                   baseDir, taskRestoreInfo.getRunningTasks());
-        }
-        catch (Exception e) {
-          LOG.error(e, "Failed to read task restore info from file[%s].", restoreFile);
-        }
       }
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/BaseRestorableTaskRunner.java
@@ -40,11 +40,8 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -65,61 +62,58 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
   protected final ConcurrentHashMap<String, WorkItemType> tasks = new ConcurrentHashMap<>();
   protected final ObjectMapper jsonMapper;
   protected final TaskConfig taskConfig;
-  protected final TaskStorageDirTracker dirTracker;
+  private final TaskStorageDirTracker tracker;
 
   public BaseRestorableTaskRunner(
       ObjectMapper jsonMapper,
       TaskConfig taskConfig,
-      TaskStorageDirTracker dirTracker
+      TaskStorageDirTracker tracker
   )
   {
     this.jsonMapper = jsonMapper;
     this.taskConfig = taskConfig;
-    this.dirTracker = dirTracker;
+    this.tracker = tracker;
+  }
+
+  protected TaskStorageDirTracker getTracker()
+  {
+    return tracker;
   }
 
   @Override
   public List<Pair<Task, ListenableFuture<TaskStatus>>> restore()
   {
-    final Map<File, TaskRestoreInfo> taskRestoreInfos = new HashMap<>();
-    for (File baseDir : dirTracker.getBaseTaskDirs()) {
-      File restoreFile = new File(baseDir, TASK_RESTORE_FILENAME);
-      if (restoreFile.exists()) {
-        try {
-          taskRestoreInfos.put(baseDir, jsonMapper.readValue(restoreFile, TaskRestoreInfo.class));
-        }
-        catch (Exception e) {
-          LOG.warn(e, "Failed to read restorable tasks from file[%s]. Skipping restore.", restoreFile);
-        }
+    final File restoreFile = getRestoreFile();
+    final TaskRestoreInfo taskRestoreInfo;
+    if (restoreFile.exists()) {
+      try {
+        taskRestoreInfo = jsonMapper.readValue(restoreFile, TaskRestoreInfo.class);
       }
+      catch (Exception e) {
+        LOG.error(e, "Failed to read restorable tasks from file[%s]. Skipping restore.", restoreFile);
+        return ImmutableList.of();
+      }
+    } else {
+      return ImmutableList.of();
     }
 
     final List<Pair<Task, ListenableFuture<TaskStatus>>> retVal = new ArrayList<>();
-    for (Map.Entry<File, TaskRestoreInfo> entry : taskRestoreInfos.entrySet()) {
-      final File baseDir = entry.getKey();
-      final TaskRestoreInfo taskRestoreInfo = entry.getValue();
-      for (final String taskId : taskRestoreInfo.getRunningTasks()) {
-        try {
-          dirTracker.addTask(taskId, baseDir);
-          final File taskFile = new File(dirTracker.getTaskDir(taskId), "task.json");
-          final Task task = jsonMapper.readValue(taskFile, Task.class);
+    for (final String taskId : taskRestoreInfo.getRunningTasks()) {
+      try {
+        final File taskFile = new File(tracker.findExistingTaskDir(taskId), "task.json");
+        final Task task = jsonMapper.readValue(taskFile, Task.class);
 
-          if (!task.getId().equals(taskId)) {
-            throw new ISE("Task[%s] restore file had wrong id[%s]", taskId, task.getId());
-          }
+        if (!task.getId().equals(taskId)) {
+          throw new ISE("Task[%s] restore file had wrong id[%s]", taskId, task.getId());
+        }
 
-          if (taskConfig.isRestoreTasksOnRestart() && task.canRestore()) {
-            LOG.info("Restoring task[%s] from location[%s].", task.getId(), baseDir);
-            retVal.add(Pair.of(task, run(task)));
-          } else {
-            dirTracker.removeTask(taskId);
-          }
+        if (taskConfig.isRestoreTasksOnRestart() && task.canRestore()) {
+          LOG.info("Restoring task[%s].", task.getId());
+          retVal.add(Pair.of(task, run(task)));
         }
-        catch (Exception e) {
-          LOG.warn(e, "Failed to restore task[%s] from path[%s]. Trying to restore other tasks.",
-                   taskId, baseDir);
-          dirTracker.removeTask(taskId);
-        }
+      }
+      catch (Exception e) {
+        LOG.warn(e, "Failed to restore task[%s]. Trying to restore other tasks.", taskId);
       }
     }
 
@@ -188,32 +182,24 @@ public abstract class BaseRestorableTaskRunner<WorkItemType extends TaskRunnerWo
   @GuardedBy("tasks")
   protected void saveRunningTasks()
   {
-    final Map<File, List<String>> theTasks = new HashMap<>();
+    final File restoreFile = getRestoreFile();
+    final List<String> theTasks = new ArrayList<>();
     for (TaskRunnerWorkItem forkingTaskRunnerWorkItem : tasks.values()) {
-      final String taskId = forkingTaskRunnerWorkItem.getTaskId();
-      final File restoreFile = getRestoreFile(taskId);
-      theTasks.computeIfAbsent(restoreFile, k -> new ArrayList<>())
-              .add(taskId);
+      theTasks.add(forkingTaskRunnerWorkItem.getTaskId());
     }
 
-    for (Map.Entry<File, List<String>> entry : theTasks.entrySet()) {
-      final File restoreFile = entry.getKey();
-      final TaskRestoreInfo taskRestoreInfo = new TaskRestoreInfo(entry.getValue());
-      try {
-        Files.createParentDirs(restoreFile);
-        jsonMapper.writeValue(restoreFile, taskRestoreInfo);
-        LOG.debug("Save restore file at [%s] for tasks [%s]",
-                 restoreFile.getAbsoluteFile(), Arrays.toString(theTasks.get(restoreFile).toArray()));
-      }
-      catch (Exception e) {
-        LOG.warn(e, "Failed to save tasks to restore file[%s]. Skipping this save.", restoreFile);
-      }
+    try {
+      Files.createParentDirs(restoreFile);
+      jsonMapper.writeValue(restoreFile, new TaskRestoreInfo(theTasks));
+    }
+    catch (Exception e) {
+      LOG.warn(e, "Failed to save tasks to restore file[%s]. Skipping this save.", restoreFile);
     }
   }
 
-  private File getRestoreFile(String taskId)
+  protected File getRestoreFile()
   {
-    return new File(dirTracker.getBaseTaskDir(taskId), TASK_RESTORE_FILENAME);
+    return new File(taskConfig.getBaseTaskDir(), TASK_RESTORE_FILENAME);
   }
 
   protected static class TaskRestoreInfo

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -159,7 +159,7 @@ public class ForkingTaskRunner
                   try {
                     baseDirForTask = getTracker().pickBaseDir(task.getId());
                   }
-                  catch (IOException e) {
+                  catch (RuntimeException e) {
                     LOG.error(e, "Failed to get directory for task [%s], cannot schedule.", task.getId());
                     return TaskStatus.failure(
                         task.getId(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -156,7 +156,6 @@ public class ForkingTaskRunner
                 {
 
                   final String attemptId = String.valueOf(getNextAttemptID(dirTracker.getTaskDir(task.getId())));
-                  final String baseTaskDir = dirTracker.getBaseTaskDir(task.getId()).getAbsolutePath();
                   final File taskDir = dirTracker.getTaskDir(task.getId());
                   final File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", attemptId).toFile();
 
@@ -368,6 +367,7 @@ public class ForkingTaskRunner
                         // for more information
                         // command.add("-XX:+UseThreadPriorities");
                         // command.add("-XX:ThreadPriorityPolicy=42");
+                        command.add(StringUtils.format("-Ddruid.indexing.task.baseTaskDir=%s", taskDir.getAbsolutePath()));
 
                         command.add("org.apache.druid.cli.Main");
                         command.add("internal");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -155,7 +155,18 @@ public class ForkingTaskRunner
                 public TaskStatus call()
                 {
 
-                  final File baseDirForTask = dirTracker.getBaseTaskDir(task.getId());
+                  final File baseDirForTask;
+                  try {
+                    baseDirForTask = getTracker().pickBaseDir(task.getId());
+                  }
+                  catch (IOException e) {
+                    LOG.error(e, "Failed to get directory for task [%s], cannot schedule.", task.getId());
+                    return TaskStatus.failure(
+                        task.getId(),
+                        StringUtils.format("Could not schedule due to error [%s]", e.getMessage())
+                    );
+                  }
+
                   final File taskDir = new File(baseDirForTask, task.getId());
                   final String attemptId = String.valueOf(getNextAttemptID(taskDir));
                   final File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", attemptId).toFile();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -155,7 +155,7 @@ public class ForkingTaskRunner
                 public TaskStatus call()
                 {
 
-                  final String attemptId = String.valueOf(getNextAttemptID(dirTracker, task.getId()));
+                  final String attemptId = String.valueOf(getNextAttemptID(dirTracker.getTaskDir(task.getId())));
                   final String baseTaskDir = dirTracker.getBaseTaskDir(task.getId()).getAbsolutePath();
                   final File taskDir = dirTracker.getTaskDir(task.getId());
                   final File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", attemptId).toFile();
@@ -372,8 +372,7 @@ public class ForkingTaskRunner
                         command.add("org.apache.druid.cli.Main");
                         command.add("internal");
                         command.add("peon");
-                        command.add(baseTaskDir);
-                        command.add(task.getId());
+                        command.add(taskDir.toString());
                         command.add(attemptId);
                         String nodeType = task.getNodeType();
                         if (nodeType != null) {
@@ -578,7 +577,6 @@ public class ForkingTaskRunner
     } else {
       LOGGER.warn("Ran out of time, not waiting for executor to finish!");
     }
-    super.stop();
   }
 
   @Override
@@ -891,9 +889,8 @@ public class ForkingTaskRunner
   }
 
   @VisibleForTesting
-  static int getNextAttemptID(TaskStorageDirTracker dirTracker, String taskId)
+  static int getNextAttemptID(File taskDir)
   {
-    File taskDir = dirTracker.getTaskDir(taskId);
     File attemptDir = new File(taskDir, "attempt");
     try {
       FileUtils.mkdirp(attemptDir);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -155,8 +155,9 @@ public class ForkingTaskRunner
                 public TaskStatus call()
                 {
 
-                  final String attemptId = String.valueOf(getNextAttemptID(dirTracker.getTaskDir(task.getId())));
-                  final File taskDir = dirTracker.getTaskDir(task.getId());
+                  final File baseDirForTask = dirTracker.getBaseTaskDir(task.getId());
+                  final File taskDir = new File(baseDirForTask, task.getId());
+                  final String attemptId = String.valueOf(getNextAttemptID(taskDir));
                   final File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", attemptId).toFile();
 
                   final ProcessHolder processHolder;
@@ -367,7 +368,7 @@ public class ForkingTaskRunner
                         // for more information
                         // command.add("-XX:+UseThreadPriorities");
                         // command.add("-XX:ThreadPriorityPolicy=42");
-                        command.add(StringUtils.format("-Ddruid.indexing.task.baseTaskDir=%s", taskDir.getAbsolutePath()));
+                        command.add(StringUtils.format("-Ddruid.indexer.task.baseTaskDir=%s", baseDirForTask.getAbsolutePath()));
 
                         command.add("org.apache.druid.cli.Main");
                         command.add("internal");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -199,7 +199,7 @@ public class ThreadingTaskRunner
                                   .setName(StringUtils.format("[%s]-%s", task.getId(), priorThreadName));
 
                             TaskStatus taskStatus;
-                            final TaskToolbox toolbox = toolboxFactory.build(task);
+                            final TaskToolbox toolbox = toolboxFactory.build(taskDir, task);
                             TaskRunnerUtils.notifyLocationChanged(listeners, task.getId(), taskLocation);
                             TaskRunnerUtils.notifyStatusChanged(
                                 listeners,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -61,7 +61,6 @@ import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -160,7 +159,7 @@ public class ThreadingTaskRunner
                           try {
                             baseDirForTask = getTracker().pickBaseDir(task.getId());
                           }
-                          catch (IOException e) {
+                          catch (RuntimeException e) {
                             LOG.error(e, "Failed to get directory for task [%s], cannot schedule.", task.getId());
                             return TaskStatus.failure(
                                 task.getId(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -156,7 +156,8 @@ public class ThreadingTaskRunner
                         public TaskStatus call()
                         {
                           final String attemptUUID = UUID.randomUUID().toString();
-                          final File taskDir = dirTracker.getTaskDir(task.getId());
+                          final File baseDirForTask = dirTracker.getBaseTaskDir(task.getId());
+                          final File taskDir = new File(baseDirForTask, task.getId());
                           final File attemptDir = new File(taskDir, attemptUUID);
 
                           final TaskLocation taskLocation = TaskLocation.create(
@@ -199,7 +200,7 @@ public class ThreadingTaskRunner
                                   .setName(StringUtils.format("[%s]-%s", task.getId(), priorThreadName));
 
                             TaskStatus taskStatus;
-                            final TaskToolbox toolbox = toolboxFactory.build(taskDir, task);
+                            final TaskToolbox toolbox = toolboxFactory.build(baseDirForTask, task);
                             TaskRunnerUtils.notifyLocationChanged(listeners, task.getId(), taskLocation);
                             TaskRunnerUtils.notifyStatusChanged(
                                 listeners,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ThreadingTaskRunner.java
@@ -414,7 +414,6 @@ public class ThreadingTaskRunner
     }
 
     appenderatorsManager.shutdown();
-    super.stop();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -39,7 +39,6 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.indexing.overlord.TaskRunnerListener;
-import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
@@ -111,7 +110,6 @@ public class WorkerTaskManager
       ObjectMapper jsonMapper,
       TaskRunner taskRunner,
       TaskConfig taskConfig,
-      WorkerConfig workerConfig,
       @IndexingService DruidLeaderClient overlordClient
   )
   {
@@ -121,12 +119,7 @@ public class WorkerTaskManager
     this.completedTasksCleanupExecutor = Execs.scheduledSingleThreaded("WorkerTaskManager-CompletedTasksCleaner");
     this.overlordClient = overlordClient;
 
-    final List<String> workerConfigDirs = workerConfig.getBaseTaskDirs();
-    if (workerConfigDirs == null || workerConfigDirs.isEmpty()) {
-      storageDir = taskConfig.getBaseTaskDir();
-    } else {
-      storageDir = new File(workerConfigDirs.get(0));
-    }
+    storageDir = taskConfig.getBaseTaskDir();
   }
 
   @LifecycleStart

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskManager.java
@@ -78,7 +78,6 @@ import java.util.stream.Collectors;
  */
 public class WorkerTaskManager
 {
-
   private static final String TEMP_WORKER = "workerTaskManagerTmp";
   private static final String ASSIGNED = "assignedTasks";
   private static final String COMPLETED = "completedTasks";

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskMonitor.java
@@ -31,9 +31,10 @@ import org.apache.druid.curator.CuratorUtils;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
+import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -63,13 +64,14 @@ public class WorkerTaskMonitor extends WorkerTaskManager
   public WorkerTaskMonitor(
       ObjectMapper jsonMapper,
       TaskRunner taskRunner,
+      TaskConfig taskConfig,
+      WorkerConfig workerConfig,
       CuratorFramework cf,
       WorkerCuratorCoordinator workerCuratorCoordinator,
-      @IndexingService DruidLeaderClient overlordClient,
-      TaskStorageDirTracker dirTracker
+      @IndexingService DruidLeaderClient overlordClient
   )
   {
-    super(jsonMapper, taskRunner, overlordClient, dirTracker);
+    super(jsonMapper, taskRunner, taskConfig, workerConfig, overlordClient);
 
     this.jsonMapper = jsonMapper;
     this.pathChildrenCache = new PathChildrenCache(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskMonitor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/WorkerTaskMonitor.java
@@ -34,7 +34,6 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
-import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
@@ -65,13 +64,12 @@ public class WorkerTaskMonitor extends WorkerTaskManager
       ObjectMapper jsonMapper,
       TaskRunner taskRunner,
       TaskConfig taskConfig,
-      WorkerConfig workerConfig,
       CuratorFramework cf,
       WorkerCuratorCoordinator workerCuratorCoordinator,
       @IndexingService DruidLeaderClient overlordClient
   )
   {
-    super(jsonMapper, taskRunner, taskConfig, workerConfig, overlordClient);
+    super(jsonMapper, taskRunner, taskConfig, overlordClient);
 
     this.jsonMapper = jsonMapper;
     this.pathChildrenCache = new PathChildrenCache(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
@@ -108,7 +108,7 @@ public class ExecutorLifecycle
     // pod twice, no need to lock.
     if (taskExecutorConfig.isParentStreamDefined()) {
       // Avoid running the same task twice on the same machine by locking the task base directory.
-      final File taskLockFile = Preconditions.checkNotNull(taskExecutorConfig.getLockFile(), "lockfile is null");
+      final File taskLockFile = taskConfig.getTaskLockFile(task.getId());
       try {
         synchronized (this) {
           if (taskLockChannel == null && taskLockFileLock == null) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleConfig.java
@@ -40,10 +40,6 @@ public class ExecutorLifecycleConfig
   private File statusFile = null;
 
   @JsonProperty
-  @NotNull
-  private File lockFile = null;
-
-  @JsonProperty
   @Pattern(regexp = "\\{stdin}")
   private String parentStreamName = "stdin";
   @JsonProperty
@@ -76,17 +72,6 @@ public class ExecutorLifecycleConfig
   public ExecutorLifecycleConfig setStatusFile(File statusFile)
   {
     this.statusFile = statusFile;
-    return this;
-  }
-
-  public File getLockFile()
-  {
-    return lockFile;
-  }
-
-  public ExecutorLifecycleConfig setLockFile(File lockFile)
-  {
-    this.lockFile = lockFile;
     return this;
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManager.java
@@ -29,7 +29,6 @@ import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.batch.parallel.GenericPartitionStat;
@@ -91,6 +90,7 @@ public class LocalIntermediaryDataManager implements IntermediaryDataManager
   private final long intermediaryPartitionDiscoveryPeriodSec;
   private final long intermediaryPartitionCleanupPeriodSec;
   private final Period intermediaryPartitionTimeout;
+  private final TaskConfig taskConfig;
   private final List<StorageLocation> shuffleDataLocations;
   private final OverlordClient overlordClient;
 
@@ -109,26 +109,23 @@ public class LocalIntermediaryDataManager implements IntermediaryDataManager
   @MonotonicNonNull
   private ScheduledExecutorService supervisorTaskChecker;
 
-  private final TaskStorageDirTracker dirTracker;
-
   @Inject
   public LocalIntermediaryDataManager(
       WorkerConfig workerConfig,
       TaskConfig taskConfig,
-      OverlordClient overlordClient,
-      TaskStorageDirTracker dirTracker
+      OverlordClient overlordClient
   )
   {
     this.intermediaryPartitionDiscoveryPeriodSec = workerConfig.getIntermediaryPartitionDiscoveryPeriodSec();
     this.intermediaryPartitionCleanupPeriodSec = workerConfig.getIntermediaryPartitionCleanupPeriodSec();
     this.intermediaryPartitionTimeout = workerConfig.getIntermediaryPartitionTimeout();
+    this.taskConfig = taskConfig;
     this.shuffleDataLocations = taskConfig
         .getShuffleDataLocations()
         .stream()
         .map(config -> new StorageLocation(config.getPath(), config.getMaxSize(), config.getFreeSpacePercent()))
         .collect(Collectors.toList());
     this.overlordClient = overlordClient;
-    this.dirTracker = dirTracker;
   }
 
   @Override
@@ -295,7 +292,7 @@ public class LocalIntermediaryDataManager implements IntermediaryDataManager
     );
 
     // Create a zipped segment in a temp directory.
-    final File taskTempDir = dirTracker.getTaskTempDir(subTaskId);
+    final File taskTempDir = taskConfig.getTaskTempDir(subTaskId);
     final Closer closer = Closer.create();
     closer.register(() -> {
       try {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
@@ -35,7 +35,7 @@ public class TaskStorageDirTrackerTest
   @Before
   public void setup()
   {
-    dirTracker = new TaskStorageDirTracker(ImmutableList.of("A", "B", "C"));
+    dirTracker = new TaskStorageDirTracker(ImmutableList.of(new File("A"), new File("B"), new File("C")));
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
@@ -20,59 +20,101 @@
 package org.apache.druid.indexing.common;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
+import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.ISE;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class TaskStorageDirTrackerTest
 {
+  public static final ImmutableList<File> MULTIPLE_FILES = ImmutableList.of(
+      new File("A"),
+      new File("B"),
+      new File("C")
+  );
 
-  private TaskStorageDirTracker dirTracker;
-
-  @Before
-  public void setup()
+  private static TaskStorageDirTracker defaultInstance()
   {
-    dirTracker = new TaskStorageDirTracker(ImmutableList.of(new File("A"), new File("B"), new File("C")));
+    return new TaskStorageDirTracker(MULTIPLE_FILES);
   }
 
   @Test
   public void testGetOrSelectTaskDir()
   {
+    validateRoundRobinAllocation(defaultInstance());
+
+    validateRoundRobinAllocation(TaskStorageDirTracker.fromConfigs(
+        new WorkerConfig()
+        {
+          @Override
+          public List<String> getBaseTaskDirs()
+          {
+            return MULTIPLE_FILES.stream().map(File::toString).collect(Collectors.toList());
+          }
+        },
+        null
+    ));
+  }
+
+  private void validateRoundRobinAllocation(TaskStorageDirTracker dirTracker)
+  {
     // Test round-robin allocation
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task0").getPath(), "A");
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task1").getPath(), "B");
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task2").getPath(), "C");
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task3").getPath(), "A");
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task4").getPath(), "B");
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task5").getPath(), "C");
+    Assert.assertEquals("A", dirTracker.getBaseTaskDir("task0").getPath());
+    Assert.assertEquals("B", dirTracker.getBaseTaskDir("task1").getPath());
+    Assert.assertEquals("C", dirTracker.getBaseTaskDir("task2").getPath());
+    Assert.assertEquals("A", dirTracker.getBaseTaskDir("task3").getPath());
+    Assert.assertEquals("B", dirTracker.getBaseTaskDir("task4").getPath());
+    Assert.assertEquals("C", dirTracker.getBaseTaskDir("task5").getPath());
 
     // Test that the result is always the same
     for (int i = 0; i < 10; i++) {
-      Assert.assertEquals(dirTracker.getBaseTaskDir("task0").getPath(), "A");
+      Assert.assertEquals("A", dirTracker.getBaseTaskDir("task0").getPath());
     }
+  }
+
+  @Test
+  public void testFallBackToTaskConfig()
+  {
+    final TaskStorageDirTracker tracker = TaskStorageDirTracker.fromConfigs(
+        new WorkerConfig(),
+        new TaskConfigBuilder().setBaseDir("A").build()
+    );
+
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task0").getPath());
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task1").getPath());
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task2").getPath());
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task3").getPath());
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task1").getPath());
+    Assert.assertEquals("A/persistent/task", tracker.getBaseTaskDir("task10293721").getPath());
   }
 
   @Test
   public void testAddTask()
   {
+    TaskStorageDirTracker dirTracker = defaultInstance();
+
     // Test add after get. task0 -> "A"
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task0").getPath(), "A");
+    Assert.assertEquals("A", dirTracker.getBaseTaskDir("task0").getPath());
     dirTracker.addTask("task0", new File("A"));
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task0").getPath(), "A");
+    Assert.assertEquals("A", dirTracker.getBaseTaskDir("task0").getPath());
 
     // Assign base path directly
     dirTracker.addTask("task1", new File("C"));
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task1").getPath(), "C");
+    Assert.assertEquals("C", dirTracker.getBaseTaskDir("task1").getPath());
   }
 
   @Test
   public void testAddTaskThrowsISE()
   {
+    TaskStorageDirTracker dirTracker = defaultInstance();
+
     // Test add after get. task0 -> "A"
-    Assert.assertEquals(dirTracker.getBaseTaskDir("task0").getPath(), "A");
+    Assert.assertEquals("A", dirTracker.getBaseTaskDir("task0").getPath());
     Assert.assertThrows(ISE.class, () -> dirTracker.addTask("task0", new File("B")));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
@@ -119,8 +119,7 @@ public class TaskToolboxTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     taskToolbox = new TaskToolboxFactory(
         taskConfig,
@@ -160,8 +159,7 @@ public class TaskToolboxTest
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.client.cache.CachePopulatorStats;
 import org.apache.druid.client.indexing.NoopOverlordClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.NoopTestTaskReportFileWriter;
 import org.apache.druid.indexing.common.task.Task;
@@ -105,22 +106,12 @@ public class TaskToolboxTest
     EasyMock.expect(mockIndexMergerV9.create(true)).andReturn(indexMergerV9).anyTimes();
     EasyMock.replay(task, mockHandoffNotifierFactory, mockIndexMergerV9);
 
-    TaskConfig taskConfig = new TaskConfig(
-        temporaryFolder.newFile().toString(),
-        null,
-        null,
-        50000,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(temporaryFolder.newFile().toString())
+        .setDefaultRowFlushBoundary(50000)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
+
     taskToolbox = new TaskToolboxFactory(
         taskConfig,
         new DruidNode("druid/middlemanager", "localhost", false, 8091, null, true, false),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/config/TaskConfigBuilder.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/config/TaskConfigBuilder.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.config;
+
+import org.apache.druid.segment.loading.StorageLocationConfig;
+import org.joda.time.Period;
+
+import java.util.List;
+
+public class TaskConfigBuilder
+{
+  private String baseDir;
+  private String baseTaskDir;
+  private String hadoopWorkingPath;
+  private Integer defaultRowFlushBoundary;
+  private List<String> defaultHadoopCoordinates;
+  private boolean restoreTasksOnRestart;
+  private Period gracefulShutdownTimeout;
+  private Period directoryLockTimeout;
+  private List<StorageLocationConfig> shuffleDataLocations;
+  private boolean ignoreTimestampSpecForDruidInputSource;
+  private boolean batchMemoryMappedIndex; // deprecated; only set to true to fall back to older behavior
+  private String batchProcessingMode;
+  private Boolean storeEmptyColumns;
+  private boolean enableTaskLevelLogPush;
+
+  public TaskConfigBuilder setBaseDir(String baseDir)
+  {
+    this.baseDir = baseDir;
+    return this;
+  }
+
+  public TaskConfigBuilder setBaseTaskDir(String baseTaskDir)
+  {
+    this.baseTaskDir = baseTaskDir;
+    return this;
+  }
+
+  public TaskConfigBuilder setHadoopWorkingPath(String hadoopWorkingPath)
+  {
+    this.hadoopWorkingPath = hadoopWorkingPath;
+    return this;
+  }
+
+  public TaskConfigBuilder setDefaultRowFlushBoundary(Integer defaultRowFlushBoundary)
+  {
+    this.defaultRowFlushBoundary = defaultRowFlushBoundary;
+    return this;
+  }
+
+  public TaskConfigBuilder setDefaultHadoopCoordinates(List<String> defaultHadoopCoordinates)
+  {
+    this.defaultHadoopCoordinates = defaultHadoopCoordinates;
+    return this;
+  }
+
+  public TaskConfigBuilder setRestoreTasksOnRestart(boolean restoreTasksOnRestart)
+  {
+    this.restoreTasksOnRestart = restoreTasksOnRestart;
+    return this;
+  }
+
+  public TaskConfigBuilder setGracefulShutdownTimeout(Period gracefulShutdownTimeout)
+  {
+    this.gracefulShutdownTimeout = gracefulShutdownTimeout;
+    return this;
+  }
+
+  public TaskConfigBuilder setDirectoryLockTimeout(Period directoryLockTimeout)
+  {
+    this.directoryLockTimeout = directoryLockTimeout;
+    return this;
+  }
+
+  public TaskConfigBuilder setShuffleDataLocations(List<StorageLocationConfig> shuffleDataLocations)
+  {
+    this.shuffleDataLocations = shuffleDataLocations;
+    return this;
+  }
+
+  public TaskConfigBuilder setIgnoreTimestampSpecForDruidInputSource(boolean ignoreTimestampSpecForDruidInputSource)
+  {
+    this.ignoreTimestampSpecForDruidInputSource = ignoreTimestampSpecForDruidInputSource;
+    return this;
+  }
+
+  public TaskConfigBuilder setBatchMemoryMappedIndex(boolean batchMemoryMappedIndex)
+  {
+    this.batchMemoryMappedIndex = batchMemoryMappedIndex;
+    return this;
+  }
+
+  public TaskConfigBuilder setBatchProcessingMode(String batchProcessingMode)
+  {
+    this.batchProcessingMode = batchProcessingMode;
+    return this;
+  }
+
+  public TaskConfigBuilder setStoreEmptyColumns(Boolean storeEmptyColumns)
+  {
+    this.storeEmptyColumns = storeEmptyColumns;
+    return this;
+  }
+
+  public TaskConfigBuilder setEnableTaskLevelLogPush(boolean enableTaskLevelLogPush)
+  {
+    this.enableTaskLevelLogPush = enableTaskLevelLogPush;
+    return this;
+  }
+
+  public TaskConfig build()
+  {
+    return new TaskConfig(
+        baseDir,
+        baseTaskDir,
+        hadoopWorkingPath,
+        defaultRowFlushBoundary,
+        defaultHadoopCoordinates,
+        restoreTasksOnRestart,
+        gracefulShutdownTimeout,
+        directoryLockTimeout,
+        shuffleDataLocations,
+        ignoreTimestampSpecForDruidInputSource,
+        batchMemoryMappedIndex,
+        batchProcessingMode,
+        storeEmptyColumns,
+        enableTaskLevelLogPush
+    );
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -19,10 +19,8 @@
 
 package org.apache.druid.indexing.common.task;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.UpdateStatusAction;
@@ -57,6 +55,10 @@ public class AbstractTaskTest
   @Test
   public void testSetupAndCleanupIsCalledWtihParameter() throws Exception
   {
+    // These tests apparently use Mockito.  Mockito is bad as we've seen it rewrite byte code and effectively cause
+    // impact to other totally unrelated tests.  Mockito needs to be completely erradicated from the codebase.  This
+    // comment is here to either cause me to do it in this commit or just for posterity so that it is clear that it
+    // should happen in the future.
     TaskToolbox toolbox = mock(TaskToolbox.class);
     when(toolbox.getAttemptId()).thenReturn("1");
 
@@ -68,11 +70,9 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
+    File folder = temporaryFolder.newFolder();
+    when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(
-        ImmutableList.of(temporaryFolder.newFolder().getAbsolutePath())
-    );
-    when(toolbox.getDirTracker()).thenReturn(dirTracker);
 
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
@@ -87,10 +87,7 @@ public class AbstractTaskTest
       {
         // create a reports file to test the taskLogPusher pushes task reports
         String result = super.setup(toolbox);
-        File attemptDir = Paths.get(
-            dirTracker.getTaskDir("myID").getAbsolutePath(),
-            "attempt", toolbox.getAttemptId()
-        ).toFile();
+        File attemptDir = Paths.get(folder.getAbsolutePath(), "attempt", toolbox.getAttemptId()).toFile();
         File reportsDir = new File(attemptDir, "report.json");
         FileUtils.write(reportsDir, "foo", StandardCharsets.UTF_8);
         return result;
@@ -118,9 +115,8 @@ public class AbstractTaskTest
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(false);
     File folder = temporaryFolder.newFolder();
+    when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(ImmutableList.of(folder.getAbsolutePath()));
-    when(toolbox.getDirTracker()).thenReturn(dirTracker);
 
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
@@ -163,9 +159,8 @@ public class AbstractTaskTest
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
     File folder = temporaryFolder.newFolder();
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(ImmutableList.of(folder.getAbsolutePath()));
+    when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
-    when(toolbox.getDirTracker()).thenReturn(dirTracker);
 
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -62,6 +62,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionToolbox;
 import org.apache.druid.indexing.common.actions.TaskAuditLogConfig;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.index.RealtimeAppenderatorIngestionSpec;
 import org.apache.druid.indexing.common.index.RealtimeAppenderatorTuningConfig;
@@ -1543,22 +1544,12 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
     };
 
     taskLockbox = new TaskLockbox(taskStorage, mdc);
-    final TaskConfig taskConfig = new TaskConfig(
-        directory.getPath(),
-        null,
-        null,
-        50000,
-        null,
-        true,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(directory.getPath())
+        .setDefaultRowFlushBoundary(50000)
+        .setRestoreTasksOnRestart(true)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
 
     final TaskActionToolbox taskActionToolbox = new TaskActionToolbox(
         taskLockbox,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -54,7 +54,6 @@ import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReportData;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskReport;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestUtils;
@@ -1558,8 +1557,7 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
 
     final TaskActionToolbox taskActionToolbox = new TaskActionToolbox(
@@ -1654,8 +1652,7 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.data.input.impl.JSONParseSpec;
 import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -581,8 +580,7 @@ public class BatchAppenderatorsTest
           false,
           mode.name(),
           null,
-          false,
-          null
+          false
       );
       return new TaskToolbox.Builder()
           .config(config)
@@ -596,7 +594,6 @@ public class BatchAppenderatorsTest
           .appenderatorsManager(new TestAppenderatorsManager())
           .taskLogPusher(null)
           .attemptId("1")
-          .dirTracker(new TaskStorageDirTracker(config))
           .build();
 
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/BatchAppenderatorsTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -566,22 +567,9 @@ public class BatchAppenderatorsTest
         TaskConfig.BatchProcessingMode mode
     )
     {
-      TaskConfig config = new TaskConfig(
-          null,
-          null,
-          null,
-          null,
-          null,
-          false,
-          null,
-          null,
-          null,
-          false,
-          false,
-          mode.name(),
-          null,
-          false
-      );
+      TaskConfig config = new TaskConfigBuilder()
+          .setBatchProcessingMode(mode.name())
+          .build();
       return new TaskToolbox.Builder()
           .config(config)
           .joinableFactory(NoopJoinableFactory.INSTANCE)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -41,7 +41,6 @@ import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
@@ -1603,8 +1602,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     return new TaskToolbox.Builder()
         .config(config)
@@ -1626,7 +1624,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
         .coordinatorClient(coordinatorClient)
         .taskLogPusher(null)
         .attemptId("1")
-        .dirTracker(new TaskStorageDirTracker(config))
         .build();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.indexing.overlord.Segments;
@@ -1588,22 +1589,9 @@ public class CompactionTaskRunTest extends IngestionTestBase
         objectMapper
     );
 
-    final TaskConfig config = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig config = new TaskConfigBuilder()
+            .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+            .build();
     return new TaskToolbox.Builder()
         .config(config)
         .taskActionClient(createActionClient(task))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -63,6 +63,7 @@ import org.apache.druid.indexing.common.actions.RetrieveUsedSegmentsAction;
 import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
 import org.apache.druid.indexing.common.task.CompactionTask.PartitionConfigurationManager;
 import org.apache.druid.indexing.common.task.CompactionTask.SegmentProvider;
@@ -1907,22 +1908,9 @@ public class CompactionTaskTest
       }
     };
 
-    final TaskConfig config = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig config = new TaskConfigBuilder()
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     return new TaskToolbox.Builder()
         .config(config)
         .taskActionClient(taskActionClient)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -57,7 +57,6 @@ import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.RetrieveUsedSegmentsAction;
@@ -1922,8 +1921,7 @@ public class CompactionTaskTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     return new TaskToolbox.Builder()
         .config(config)
@@ -1945,7 +1943,6 @@ public class CompactionTaskTest
         .segmentCacheManager(segmentCacheManager)
         .taskLogPusher(null)
         .attemptId("1")
-        .dirTracker(new TaskStorageDirTracker(config))
         .build();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -120,8 +120,7 @@ public class HadoopTaskTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     )).once();
     EasyMock.replay(toolbox);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.timeline.DataSegment;
@@ -106,22 +107,13 @@ public class HadoopTaskTest
       }
     };
     final TaskToolbox toolbox = EasyMock.createStrictMock(TaskToolbox.class);
-    EasyMock.expect(toolbox.getConfig()).andReturn(new TaskConfig(
-        temporaryFolder.newFolder().toString(),
-        null,
-        null,
-        null,
-        ImmutableList.of("something:hadoop:1"),
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    )).once();
+    EasyMock.expect(toolbox.getConfig()).andReturn(
+        new TaskConfigBuilder()
+            .setBaseDir(temporaryFolder.newFolder().toString())
+            .setDefaultHadoopCoordinates(ImmutableList.of("something:hadoop:1"))
+            .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+            .build()
+    ).once();
     EasyMock.replay(toolbox);
 
     final ClassLoader classLoader = task.buildClassLoader(toolbox);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -47,6 +47,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionToolbox;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -371,22 +372,9 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             StringUtils.format("ingestionTestBase-%s.json", System.currentTimeMillis())
         );
 
-        final TaskConfig config = new TaskConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            false,
-            null,
-            null,
-            null,
-            false,
-            false,
-            TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-            null,
-            false
-        );
+        final TaskConfig config = new TaskConfigBuilder()
+            .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+            .build();
         final TaskToolbox box = new TaskToolbox.Builder()
             .config(config)
             .taskExecutorNode(new DruidNode("druid/middlemanager", "localhost", false, 8091, null, true, false))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -38,7 +38,6 @@ import org.apache.druid.data.input.impl.RegexParseSpec;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.SegmentInsertAction;
@@ -386,8 +385,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             false,
             TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
             null,
-            false,
-            null
+            false
         );
         final TaskToolbox box = new TaskToolbox.Builder()
             .config(config)
@@ -408,7 +406,6 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
             .appenderatorsManager(new TestAppenderatorsManager())
             .taskLogPusher(null)
             .attemptId("1")
-            .dirTracker(new TaskStorageDirTracker(config))
             .build();
 
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -43,7 +43,6 @@ import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestFirehose;
@@ -912,8 +911,7 @@ public class RealtimeIndexTaskTest extends InitializedNullHandlingTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final TaskLockbox taskLockbox = new TaskLockbox(taskStorage, mdc);
     try {
@@ -1026,8 +1024,7 @@ public class RealtimeIndexTaskTest extends InitializedNullHandlingTest
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
 
     return toolboxFactory.build(task);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -52,6 +52,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionToolbox;
 import org.apache.druid.indexing.common.actions.TaskAuditLogConfig;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -897,22 +898,12 @@ public class RealtimeIndexTaskTest extends InitializedNullHandlingTest
       final File directory
   )
   {
-    final TaskConfig taskConfig = new TaskConfig(
-        directory.getPath(),
-        null,
-        null,
-        50000,
-        null,
-        true,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(directory.getPath())
+        .setDefaultRowFlushBoundary(50000)
+        .setRestoreTasksOnRestart(true)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     final TaskLockbox taskLockbox = new TaskLockbox(taskStorage, mdc);
     try {
       taskStorage.insert(task, TaskStatus.running(task.getId()));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -51,11 +51,11 @@ import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.CompactionTask;
 import org.apache.druid.indexing.common.task.IngestionTestBase;
@@ -247,28 +247,11 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     taskRunner = new SimpleThreadingTaskRunner(testName.getMethodName());
     objectMapper = getObjectMapper();
     indexingServiceClient = new LocalOverlordClient(objectMapper, taskRunner);
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
-    intermediaryDataManager = new LocalIntermediaryDataManager(
-        new WorkerConfig(),
-        taskConfig,
-        null,
-        TaskStorageDirTracker.fromConfigs(null, taskConfig)
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)))
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
+    intermediaryDataManager = new LocalIntermediaryDataManager(new WorkerConfig(), taskConfig, null);
     remoteApiExecutor = Execs.singleThreaded("coordinator-api-executor");
     coordinatorClient = new LocalCoordinatorClient(remoteApiExecutor);
     prepareObjectMapper(objectMapper, getIndexIO());
@@ -651,22 +634,9 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   public void prepareObjectMapper(ObjectMapper objectMapper, IndexIO indexIO)
   {
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
 
     objectMapper.setInjectableValues(
         new InjectableValues.Std()
@@ -700,22 +670,9 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   protected TaskToolbox createTaskToolbox(Task task, TaskActionClient actionClient) throws IOException
   {
-    TaskConfig config = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig config = new TaskConfigBuilder()
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     return new TaskToolbox.Builder()
         .config(config)
         .taskExecutorNode(new DruidNode("druid/middlemanager", "localhost", false, 8091, null, true, false))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -261,14 +261,13 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     intermediaryDataManager = new LocalIntermediaryDataManager(
         new WorkerConfig(),
         taskConfig,
         null,
-        new TaskStorageDirTracker(taskConfig)
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     );
     remoteApiExecutor = Execs.singleThreaded("coordinator-api-executor");
     coordinatorClient = new LocalCoordinatorClient(remoteApiExecutor);
@@ -666,8 +665,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
 
     objectMapper.setInjectableValues(
@@ -716,8 +714,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     return new TaskToolbox.Builder()
         .config(config)
@@ -754,7 +751,6 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .shuffleClient(new LocalShuffleClient(intermediaryDataManager))
         .taskLogPusher(null)
         .attemptId("1")
-        .dirTracker(new TaskStorageDirTracker(config))
         .build();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -271,7 +271,7 @@ public class ForkingTaskRunnerTest
 
         for (String param : command) {
           if (param.endsWith(task.getId())) {
-            File resultFile = Paths.get(dirTracker.getTaskDir(task.getId()).getAbsolutePath(), "attempt", "1", "status.json").toFile();
+            File resultFile = Paths.get(getTracker().findExistingTaskDir(task.getId()).getAbsolutePath(), "attempt", "1", "status.json").toFile();
             mapper.writeValue(resultFile, TaskStatus.success(task.getId()));
             break;
           }
@@ -332,7 +332,7 @@ public class ForkingTaskRunnerTest
 
         for (String param : command) {
           if (param.endsWith(task.getId())) {
-            File resultFile = Paths.get(dirTracker.getTaskDir(task.getId()).getAbsolutePath(), "attempt", "1", "status.json").toFile();
+            File resultFile = Paths.get(dirTracker.findExistingTaskDir(task.getId()).getAbsolutePath(), "attempt", "1", "status.json").toFile();
             mapper.writeValue(resultFile, TaskStatus.failure(task.getId(), "task failure test"));
             break;
           }
@@ -363,9 +363,9 @@ public class ForkingTaskRunnerTest
         .build();
     TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     String taskId = "foo";
-    assertEquals(1, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
-    assertEquals(2, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
-    assertEquals(3, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
+    assertEquals(1, ForkingTaskRunner.getNextAttemptID(new File(dirTracker.pickBaseDir(taskId), taskId)));
+    assertEquals(2, ForkingTaskRunner.getNextAttemptID(new File(dirTracker.pickBaseDir(taskId), taskId)));
+    assertEquals(3, ForkingTaskRunner.getNextAttemptID(new File(dirTracker.pickBaseDir(taskId), taskId)));
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.config.ForkingTaskRunnerConfig;
@@ -192,22 +193,8 @@ public class ForkingTaskRunnerTest
   @Test
   public void testTaskStatusWhenTaskProcessFails() throws ExecutionException, InterruptedException
   {
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .build();
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -260,22 +247,9 @@ public class ForkingTaskRunnerTest
     ObjectMapper mapper = new DefaultObjectMapper();
     Task task = NoopTask.create();
     File file = temporaryFolder.newFolder();
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        file.toString(),
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .setBaseTaskDir(file.toString())
+        .build();
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -333,22 +307,9 @@ public class ForkingTaskRunnerTest
     ObjectMapper mapper = new DefaultObjectMapper();
     Task task = NoopTask.create();
     File file = temporaryFolder.newFolder();
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        file.toString(),
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .setBaseTaskDir(file.toString())
+        .build();
     TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
@@ -397,22 +358,9 @@ public class ForkingTaskRunnerTest
   public void testGettingTheNextAttemptDir() throws IOException
   {
     File file = temporaryFolder.newFolder();
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        file.toString(),
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .setBaseTaskDir(file.toString())
+        .build();
     TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     String taskId = "foo";
     assertEquals(1, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
@@ -442,22 +390,8 @@ public class ForkingTaskRunnerTest
     final Task task = OBJECT_MAPPER.readValue(taskContent, NoopTask.class);
     final AtomicInteger xmxJavaOptsIndex = new AtomicInteger(-1);
     final AtomicInteger xmxJavaOptsArrayIndex = new AtomicInteger(-1);
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .build();
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -511,22 +445,8 @@ public class ForkingTaskRunnerTest
                                + "  }\n"
                                + "}";
     final Task task = OBJECT_MAPPER.readValue(taskContent, NoopTask.class);
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .build();
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -570,22 +490,8 @@ public class ForkingTaskRunnerTest
   @Test
   public void testCannotRestoreTasks() throws Exception
   {
-    TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = makeDefaultTaskConfigBuilder()
+        .build();
 
     TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(
         ImmutableList.of(
@@ -620,5 +526,15 @@ public class ForkingTaskRunnerTest
     Task task = NoopTask.create();
     forkingTaskRunner.run(task);
     Assert.assertTrue(forkingTaskRunner.restore().isEmpty());
+  }
+
+  public static TaskConfigBuilder makeDefaultTaskConfigBuilder()
+  {
+    return new TaskConfigBuilder()
+        .setDefaultHadoopCoordinates(ImmutableList.of())
+        .setGracefulShutdownTimeout(new Period("PT0S"))
+        .setDirectoryLockTimeout(new Period("PT10S"))
+        .setShuffleDataLocations(ImmutableList.of())
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -206,10 +206,8 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -219,7 +217,7 @@ public class ForkingTaskRunnerTest
         new DefaultObjectMapper(),
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
         new StartupLoggingConfig(),
-        dirTracker
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     )
     {
       @Override
@@ -276,10 +274,8 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -289,7 +285,7 @@ public class ForkingTaskRunnerTest
         mapper,
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
         new StartupLoggingConfig(),
-        dirTracker
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     )
     {
       @Override
@@ -351,10 +347,9 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -416,14 +411,13 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     String taskId = "foo";
-    assertEquals(1, ForkingTaskRunner.getNextAttemptID(dirTracker, taskId));
-    assertEquals(2, ForkingTaskRunner.getNextAttemptID(dirTracker, taskId));
-    assertEquals(3, ForkingTaskRunner.getNextAttemptID(dirTracker, taskId));
+    assertEquals(1, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
+    assertEquals(2, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
+    assertEquals(3, ForkingTaskRunner.getNextAttemptID(dirTracker.getTaskDir(taskId)));
   }
 
   @Test
@@ -462,10 +456,8 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -475,7 +467,7 @@ public class ForkingTaskRunnerTest
         mapper,
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
         new StartupLoggingConfig(),
-        dirTracker
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     )
     {
       @Override
@@ -533,10 +525,8 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,
@@ -546,7 +536,7 @@ public class ForkingTaskRunnerTest
         mapper,
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
         new StartupLoggingConfig(),
-        dirTracker
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     )
     {
       @Override
@@ -594,13 +584,15 @@ public class ForkingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
+        false
+    );
+
+    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(
         ImmutableList.of(
-            temporaryFolder.newFolder().getAbsolutePath(),
-            temporaryFolder.newFolder().getAbsolutePath()
+            temporaryFolder.newFolder().getAbsoluteFile(),
+            temporaryFolder.newFolder().getAbsoluteFile()
         )
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
     ForkingTaskRunner forkingTaskRunner = new ForkingTaskRunner(
         new ForkingTaskRunnerConfig(),
         taskConfig,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
@@ -26,7 +26,6 @@ import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestUtils;
@@ -101,8 +100,7 @@ public class SingleTaskBackgroundRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final ServiceEmitter emitter = new NoopServiceEmitter();
     EmittingLogger.registerEmitter(emitter);
@@ -144,8 +142,7 @@ public class SingleTaskBackgroundRunnerTest
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
     runner = new SingleTaskBackgroundRunner(
         toolboxFactory,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
@@ -86,22 +87,12 @@ public class SingleTaskBackgroundRunnerTest
   {
     final TestUtils utils = new TestUtils();
     final DruidNode node = new DruidNode("testServer", "testHost", false, 1000, null, true, false);
-    final TaskConfig taskConfig = new TaskConfig(
-        temporaryFolder.newFile().toString(),
-        null,
-        null,
-        50000,
-        null,
-        true,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(temporaryFolder.newFile().toString())
+        .setDefaultRowFlushBoundary(50000)
+        .setRestoreTasksOnRestart(true)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     final ServiceEmitter emitter = new NoopServiceEmitter();
     EmittingLogger.registerEmitter(emitter);
     final TaskToolboxFactory toolboxFactory = new TaskToolboxFactory(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -70,6 +70,7 @@ import org.apache.druid.indexing.common.actions.TaskActionToolbox;
 import org.apache.druid.indexing.common.actions.TaskAuditLogConfig;
 import org.apache.druid.indexing.common.actions.TimeChunkLockTryAcquireAction;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.task.AbstractFixedIntervalTask;
 import org.apache.druid.indexing.common.task.IndexTask;
@@ -606,22 +607,11 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         ),
         new TaskAuditLogConfig(true)
     );
-    taskConfig = new TaskConfig(
-        temporaryFolder.newFolder().toString(),
-        null,
-        null,
-        50000,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    taskConfig = new TaskConfigBuilder()
+        .setBaseDir(temporaryFolder.newFolder().toString())
+        .setDefaultRowFlushBoundary(50000)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
 
     return new TaskToolboxFactory(
         taskConfig,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -59,7 +59,6 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskLockType;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestUtils;
@@ -607,10 +606,8 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         ),
         new TaskAuditLogConfig(true)
     );
-    final String taskDirA = temporaryFolder.newFolder().toString();
-    final String taskDirB = temporaryFolder.newFolder().toString();
     taskConfig = new TaskConfig(
-        null,
+        temporaryFolder.newFolder().toString(),
         null,
         null,
         50000,
@@ -623,11 +620,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        ImmutableList.of(
-            taskDirA,
-            taskDirB
-        )
+        false
     );
 
     return new TaskToolboxFactory(
@@ -713,8 +706,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ThreadingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ThreadingTaskRunnerTest.java
@@ -63,8 +63,7 @@ public class ThreadingTaskRunnerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     ThreadingTaskRunner runner = new ThreadingTaskRunner(
         mockTaskToolboxFactory(),
@@ -75,7 +74,7 @@ public class ThreadingTaskRunnerTest
         new TestAppenderatorsManager(),
         new MultipleFileTaskReportFileWriter(),
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
-        new TaskStorageDirTracker(taskConfig)
+        TaskStorageDirTracker.fromConfigs(null, taskConfig)
     );
 
     Future<TaskStatus> statusFuture = runner.run(new AbstractTask("id", "datasource", null)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ThreadingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ThreadingTaskRunnerTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.indexing.overlord;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.MultipleFileTaskReportFileWriter;
@@ -34,7 +33,6 @@ import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.tasklogs.NoopTaskLogs;
-import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -49,22 +47,7 @@ public class ThreadingTaskRunnerTest
   @Test
   public void testTaskStatusWhenTaskThrowsExceptionWhileRunning() throws ExecutionException, InterruptedException
   {
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        ImmutableList.of(),
-        false,
-        new Period("PT0S"),
-        new Period("PT10S"),
-        ImmutableList.of(),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = ForkingTaskRunnerTest.makeDefaultTaskConfigBuilder().build();
     ThreadingTaskRunner runner = new ThreadingTaskRunner(
         mockTaskToolboxFactory(),
         taskConfig,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -55,7 +55,6 @@ import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskReport;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestUtils;
@@ -578,8 +577,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final TestDerbyConnector derbyConnector = derby.getConnector();
     derbyConnector.createDataSourceTable();
@@ -707,8 +705,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
         null,
         null,
         null,
-        "1",
-        new TaskStorageDirTracker(taskConfig)
+        "1"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -63,6 +63,7 @@ import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionToolbox;
 import org.apache.druid.indexing.common.actions.TaskAuditLogConfig;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
@@ -563,22 +564,14 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
   {
     final ObjectMapper objectMapper = testUtils.getTestObjectMapper();
     directory = tempFolder.newFolder();
-    final TaskConfig taskConfig = new TaskConfig(
-        new File(directory, "baseDir").getPath(),
-        new File(directory, "baseTaskDir").getPath(),
-        null,
-        50000,
-        null,
-        true,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig =
+        new TaskConfigBuilder()
+            .setBaseDir(new File(directory, "baseDir").getPath())
+            .setBaseTaskDir(new File(directory, "baseTaskDir").getPath())
+            .setDefaultRowFlushBoundary(50000)
+            .setRestoreTasksOnRestart(true)
+            .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+            .build();
     final TestDerbyConnector derbyConnector = derby.getConnector();
     derbyConnector.createDataSourceTable();
     derbyConnector.createPendingSegmentsTable();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -109,11 +109,11 @@ public class WorkerTaskManagerTest
 
   private WorkerTaskManager createWorkerTaskManager()
   {
-    List<String> baseTaskDirPaths = null;
+    List<File> baseTaskDirPaths = null;
     if (useMultipleBaseTaskDirPaths) {
       baseTaskDirPaths = ImmutableList.of(
-          FileUtils.createTempDir().toString(),
-          FileUtils.createTempDir().toString()
+          FileUtils.createTempDir(),
+          FileUtils.createTempDir()
       );
     }
     TaskConfig taskConfig = new TaskConfig(
@@ -130,10 +130,16 @@ public class WorkerTaskManagerTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        baseTaskDirPaths
+        false
     );
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+
+    TaskStorageDirTracker dirTracker;
+    if (useMultipleBaseTaskDirPaths) {
+      dirTracker = new TaskStorageDirTracker(baseTaskDirPaths);
+    } else {
+      dirTracker = new TaskStorageDirTracker(ImmutableList.of(taskConfig.getBaseTaskDir()));
+    }
+
     TaskActionClientFactory taskActionClientFactory = EasyMock.createNiceMock(TaskActionClientFactory.class);
     TaskActionClient taskActionClient = EasyMock.createNiceMock(TaskActionClient.class);
     EasyMock.expect(taskActionClientFactory.create(EasyMock.anyObject())).andReturn(taskActionClient).anyTimes();
@@ -181,8 +187,7 @@ public class WorkerTaskManagerTest
                 null,
                 null,
                 null,
-                "1",
-                dirTracker
+                "1"
             ),
             taskConfig,
             location

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.NoopTestTaskReportFileWriter;
 import org.apache.druid.indexing.common.task.Task;
@@ -116,22 +117,12 @@ public class WorkerTaskManagerTest
           FileUtils.createTempDir()
       );
     }
-    TaskConfig taskConfig = new TaskConfig(
-        FileUtils.createTempDir().toString(),
-        null,
-        null,
-        0,
-        null,
-        restoreTasksOnRestart,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(FileUtils.createTempDir().toString())
+        .setDefaultRowFlushBoundary(0)
+        .setRestoreTasksOnRestart(restoreTasksOnRestart)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
 
     TaskStorageDirTracker dirTracker;
     if (useMultipleBaseTaskDirPaths) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexing.common.IndexingServiceCondition;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.TestIndexTask;
 import org.apache.druid.indexing.common.TestTasks;
@@ -160,12 +159,12 @@ public class WorkerTaskMonitorTest
         .setDefaultRowFlushBoundary(0)
         .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
         .build();
+
     TaskActionClientFactory taskActionClientFactory = EasyMock.createNiceMock(TaskActionClientFactory.class);
     TaskActionClient taskActionClient = EasyMock.createNiceMock(TaskActionClient.class);
     EasyMock.expect(taskActionClientFactory.create(EasyMock.anyObject())).andReturn(taskActionClient).anyTimes();
     SegmentHandoffNotifierFactory notifierFactory = EasyMock.createNiceMock(SegmentHandoffNotifierFactory.class);
     EasyMock.replay(taskActionClientFactory, taskActionClient, notifierFactory);
-    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     return new WorkerTaskMonitor(
         jsonMapper,
         new SingleTaskBackgroundRunner(
@@ -214,10 +213,11 @@ public class WorkerTaskMonitorTest
             DUMMY_NODE,
             new ServerConfig()
         ),
+        taskConfig,
+        new WorkerConfig(),
         cf,
         workerCuratorCoordinator,
-        EasyMock.createNiceMock(DruidLeaderClient.class),
-        dirTracker
+        EasyMock.createNiceMock(DruidLeaderClient.class)
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -168,15 +168,14 @@ public class WorkerTaskMonitorTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     TaskActionClientFactory taskActionClientFactory = EasyMock.createNiceMock(TaskActionClientFactory.class);
     TaskActionClient taskActionClient = EasyMock.createNiceMock(TaskActionClient.class);
     EasyMock.expect(taskActionClientFactory.create(EasyMock.anyObject())).andReturn(taskActionClient).anyTimes();
     SegmentHandoffNotifierFactory notifierFactory = EasyMock.createNiceMock(SegmentHandoffNotifierFactory.class);
     EasyMock.replay(taskActionClientFactory, taskActionClient, notifierFactory);
-    final TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     return new WorkerTaskMonitor(
         jsonMapper,
         new SingleTaskBackgroundRunner(
@@ -218,8 +217,7 @@ public class WorkerTaskMonitorTest
                 null,
                 null,
                 null,
-                "1",
-                dirTracker
+                "1"
             ),
             taskConfig,
             new NoopServiceEmitter(),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.NoopTestTaskReportFileWriter;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
@@ -154,22 +155,11 @@ public class WorkerTaskMonitorTest
 
   private WorkerTaskMonitor createTaskMonitor()
   {
-    final TaskConfig taskConfig = new TaskConfig(
-        FileUtils.createTempDir().toString(),
-        null,
-        null,
-        0,
-        null,
-        false,
-        null,
-        null,
-        null,
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setBaseDir(FileUtils.createTempDir().toString())
+        .setDefaultRowFlushBoundary(0)
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     TaskActionClientFactory taskActionClientFactory = EasyMock.createNiceMock(TaskActionClientFactory.class);
     TaskActionClient taskActionClient = EasyMock.createNiceMock(TaskActionClient.class);
     EasyMock.expect(taskActionClientFactory.create(EasyMock.anyObject())).andReturn(taskActionClient).anyTimes();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskMonitorTest.java
@@ -214,7 +214,6 @@ public class WorkerTaskMonitorTest
             new ServerConfig()
         ),
         taskConfig,
-        new WorkerConfig(),
         cf,
         workerCuratorCoordinator,
         EasyMock.createNiceMock(DruidLeaderClient.class)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.druid.client.indexing.NoopOverlordClient;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.rpc.indexing.OverlordClient;
@@ -65,22 +65,10 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
   @Before
   public void setup() throws IOException
   {
-    this.taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    this.taskConfig = new TaskConfigBuilder()
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)))
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     this.overlordClient = new NoopOverlordClient()
     {
       @Override
@@ -138,9 +126,8 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
 
     // Setup data manager with expiry timeout 1s and initial delay of 1 second
     WorkerConfig workerConfig = new TestWorkerConfig(1, 1, timeoutPeriod);
-    TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     LocalIntermediaryDataManager intermediaryDataManager =
-        new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
+        new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     intermediaryDataManager.addSegment(supervisorTaskId, subTaskId, segment, segmentFile);
 
     intermediaryDataManager

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -79,8 +79,7 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     this.overlordClient = new NoopOverlordClient()
     {
@@ -139,7 +138,7 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
 
     // Setup data manager with expiry timeout 1s and initial delay of 1 second
     WorkerConfig workerConfig = new TestWorkerConfig(1, 1, timeoutPeriod);
-    TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     LocalIntermediaryDataManager intermediaryDataManager =
         new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
     intermediaryDataManager.addSegment(supervisorTaskId, subTaskId, segment, segmentFile);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -24,8 +24,8 @@ import com.google.common.io.ByteSource;
 import com.google.common.primitives.Ints;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.client.indexing.NoopOverlordClient;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -69,25 +69,12 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
     final WorkerConfig workerConfig = new WorkerConfig();
     intermediarySegmentsLocation = tempDir.newFolder();
     siblingLocation = tempDir.newFolder();
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        ImmutableList.of(new StorageLocationConfig(intermediarySegmentsLocation, 1200L, null)),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(intermediarySegmentsLocation, 1200L, null)))
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     final OverlordClient overlordClient = new NoopOverlordClient();
-    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
-    intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
+    intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     intermediaryDataManager.start();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -83,11 +83,10 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final OverlordClient overlordClient = new NoopOverlordClient();
-    final TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
     intermediaryDataManager.start();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -113,11 +113,10 @@ public class ShuffleDataSegmentPusherTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final OverlordClient overlordClient = new NoopOverlordClient();
-    final TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     if (LOCAL.equals(intermediateDataStore)) {
       intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
     } else if (DEEPSTORE.equals(intermediateDataStore)) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.client.indexing.NoopOverlordClient;
 import org.apache.druid.guice.GuiceAnnotationIntrospector;
 import org.apache.druid.guice.GuiceInjectableValues;
 import org.apache.druid.guice.GuiceInjectors;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
@@ -99,26 +99,13 @@ public class ShuffleDataSegmentPusherTest
   public void setup() throws IOException
   {
     final WorkerConfig workerConfig = new WorkerConfig();
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)))
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     final OverlordClient overlordClient = new NoopOverlordClient();
-    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     if (LOCAL.equals(intermediateDataStore)) {
-      intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
+      intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     } else if (DEEPSTORE.equals(intermediateDataStore)) {
       localDeepStore = temporaryFolder.newFolder("localStorage");
       intermediaryDataManager = new DeepStorageIntermediaryDataManager(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.druid.client.indexing.NoopOverlordClient;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.indexing.worker.shuffle.ShuffleMetrics.PerDatasourceShuffleMetrics;
 import org.apache.druid.java.util.common.Intervals;
@@ -91,22 +91,10 @@ public class ShuffleResourceTest
       }
 
     };
-    final TaskConfig taskConfig = new TaskConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        null,
-        null,
-        ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)),
-        false,
-        false,
-        TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
-        null,
-        false
-    );
+    final TaskConfig taskConfig = new TaskConfigBuilder()
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)))
+        .setBatchProcessingMode(TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name())
+        .build();
     final OverlordClient overlordClient = new NoopOverlordClient()
     {
       @Override
@@ -119,8 +107,7 @@ public class ShuffleResourceTest
         return Futures.immediateFuture(result);
       }
     };
-    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
-    intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
+    intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     shuffleMetrics = new ShuffleMetrics();
     shuffleResource = new ShuffleResource(intermediaryDataManager, Optional.of(shuffleMetrics));
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
@@ -105,8 +105,7 @@ public class ShuffleResourceTest
         false,
         TaskConfig.BATCH_PROCESSING_MODE_DEFAULT.name(),
         null,
-        false,
-        null
+        false
     );
     final OverlordClient overlordClient = new NoopOverlordClient()
     {
@@ -120,7 +119,7 @@ public class ShuffleResourceTest
         return Futures.immediateFuture(result);
       }
     };
-    final TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(taskConfig);
+    final TaskStorageDirTracker dirTracker = TaskStorageDirTracker.fromConfigs(null, taskConfig);
     intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient, dirTracker);
     shuffleMetrics = new ShuffleMetrics();
     shuffleResource = new ShuffleResource(intermediaryDataManager, Optional.of(shuffleMetrics));

--- a/server/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
+++ b/server/src/main/java/org/apache/druid/indexing/worker/config/WorkerConfig.java
@@ -26,6 +26,7 @@ import org.joda.time.Period;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  */
@@ -42,6 +43,9 @@ public class WorkerConfig
   @JsonProperty
   @Min(1)
   private int capacity = Math.max(1, JvmUtils.getRuntimeInfo().getAvailableProcessors() - 1);
+
+  @JsonProperty
+  private List<String> baseTaskDirs = null;
 
   @JsonProperty
   @NotNull
@@ -74,6 +78,11 @@ public class WorkerConfig
   public int getCapacity()
   {
     return capacity;
+  }
+
+  public List<String> getBaseTaskDirs()
+  {
+    return baseTaskDirs;
   }
 
   public String getCategory()

--- a/services/src/main/java/org/apache/druid/cli/CliIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliIndexer.java
@@ -156,7 +156,7 @@ public class CliIndexer extends ServerRunnable
             CliPeon.bindPeonDataSegmentHandlers(binder);
             CliPeon.bindRealtimeCache(binder);
             CliPeon.bindCoordinatorHandoffNotiferAndClient(binder);
-            CliMiddleManager.bindWorkerManagementClasses(binder, isZkEnabled);
+            binder.install(CliMiddleManager.makeWorkerManagementModule(isZkEnabled));
 
             binder.bind(AppenderatorsManager.class)
                   .to(UnifiedIndexerAppenderatorsManager.class)

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -47,6 +47,7 @@ import org.apache.druid.guice.MiddleManagerServiceModule;
 import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
+import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClientProvider;
@@ -155,7 +156,7 @@ public class CliMiddleManager extends ServerRunnable
                 .in(LazySingleton.class);
             binder.bind(DropwizardRowIngestionMetersFactory.class).in(LazySingleton.class);
 
-            bindWorkerManagementClasses(binder, isZkEnabled);
+            binder.install(makeWorkerManagementModule(isZkEnabled));
 
             binder.bind(JettyServerInitializer.class)
                   .to(MiddleManagerJettyServerInitializer.class)
@@ -230,18 +231,32 @@ public class CliMiddleManager extends ServerRunnable
     );
   }
 
-  public static void bindWorkerManagementClasses(Binder binder, boolean isZkEnabled)
+  public static Module makeWorkerManagementModule(boolean isZkEnabled)
   {
-    if (isZkEnabled) {
-      binder.bind(WorkerTaskManager.class).to(WorkerTaskMonitor.class);
-      binder.bind(WorkerTaskMonitor.class).in(ManageLifecycle.class);
-      binder.bind(WorkerCuratorCoordinator.class).in(ManageLifecycle.class);
-      LifecycleModule.register(binder, WorkerTaskMonitor.class);
-    } else {
-      binder.bind(WorkerTaskManager.class).in(ManageLifecycle.class);
-    }
+    return new Module()
+    {
+      @Override
+      public void configure(Binder binder)
+      {
+        if (isZkEnabled) {
+          binder.bind(WorkerTaskManager.class).to(WorkerTaskMonitor.class);
+          binder.bind(WorkerTaskMonitor.class).in(ManageLifecycle.class);
+          binder.bind(WorkerCuratorCoordinator.class).in(ManageLifecycle.class);
+          LifecycleModule.register(binder, WorkerTaskMonitor.class);
+        } else {
+          binder.bind(WorkerTaskManager.class).in(ManageLifecycle.class);
+        }
 
-    Jerseys.addResource(binder, WorkerResource.class);
-    Jerseys.addResource(binder, TaskManagementResource.class);
+        Jerseys.addResource(binder, WorkerResource.class);
+        Jerseys.addResource(binder, TaskManagementResource.class);
+      }
+
+      @Provides
+      @LazySingleton
+      public TaskStorageDirTracker getTaskStorageDirTracker(WorkerConfig workerConfig, TaskConfig taskConfig)
+      {
+        return TaskStorageDirTracker.fromConfigs(workerConfig, taskConfig);
+      }
+    };
   }
 }

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -252,7 +252,7 @@ public class CliMiddleManager extends ServerRunnable
       }
 
       @Provides
-      @LazySingleton
+      @ManageLifecycle
       public TaskStorageDirTracker getTaskStorageDirTracker(WorkerConfig workerConfig, TaskConfig taskConfig)
       {
         return TaskStorageDirTracker.fromConfigs(workerConfig, taskConfig);

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
@@ -53,6 +54,7 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
+import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.actions.LocalTaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.TaskActionToolbox;
@@ -241,7 +243,7 @@ public class CliOverlord extends ServerRunnable
             configureTaskStorage(binder);
             configureIntermediaryData(binder);
             configureAutoscale(binder);
-            configureRunners(binder);
+            binder.install(runnerConfigModule());
             configureOverlordHelpers(binder);
 
             binder.bind(AuditManager.class)
@@ -314,36 +316,50 @@ public class CliOverlord extends ServerRunnable
             biddy.addBinding("deepstore").to(DeepStorageIntermediaryDataManager.class).in(LazySingleton.class);
           }
 
-          private void configureRunners(Binder binder)
+          private Module runnerConfigModule()
           {
-            JsonConfigProvider.bind(binder, "druid.worker", WorkerConfig.class);
+            return new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bind(binder, "druid.worker", WorkerConfig.class);
 
-            PolyBind.createChoice(
-                binder,
-                "druid.indexer.runner.type",
-                Key.get(TaskRunnerFactory.class),
-                Key.get(HttpRemoteTaskRunnerFactory.class)
-            );
-            final MapBinder<String, TaskRunnerFactory> biddy = PolyBind.optionBinder(
-                binder,
-                Key.get(TaskRunnerFactory.class)
-            );
+                PolyBind.createChoice(
+                    binder,
+                    "druid.indexer.runner.type",
+                    Key.get(TaskRunnerFactory.class),
+                    Key.get(HttpRemoteTaskRunnerFactory.class)
+                );
+                final MapBinder<String, TaskRunnerFactory> biddy = PolyBind.optionBinder(
+                    binder,
+                    Key.get(TaskRunnerFactory.class)
+                );
 
-            IndexingServiceModuleHelper.configureTaskRunnerConfigs(binder);
-            biddy.addBinding("local").to(ForkingTaskRunnerFactory.class);
-            binder.bind(ForkingTaskRunnerFactory.class).in(LazySingleton.class);
+                IndexingServiceModuleHelper.configureTaskRunnerConfigs(binder);
+                biddy.addBinding("local").to(ForkingTaskRunnerFactory.class);
+                binder.bind(ForkingTaskRunnerFactory.class).in(LazySingleton.class);
 
-            biddy.addBinding(RemoteTaskRunnerFactory.TYPE_NAME)
-                 .to(RemoteTaskRunnerFactory.class)
-                 .in(LazySingleton.class);
-            binder.bind(RemoteTaskRunnerFactory.class).in(LazySingleton.class);
+                biddy.addBinding(RemoteTaskRunnerFactory.TYPE_NAME)
+                     .to(RemoteTaskRunnerFactory.class)
+                     .in(LazySingleton.class);
+                binder.bind(RemoteTaskRunnerFactory.class).in(LazySingleton.class);
 
-            biddy.addBinding(HttpRemoteTaskRunnerFactory.TYPE_NAME)
-                 .to(HttpRemoteTaskRunnerFactory.class)
-                 .in(LazySingleton.class);
-            binder.bind(HttpRemoteTaskRunnerFactory.class).in(LazySingleton.class);
+                biddy.addBinding(HttpRemoteTaskRunnerFactory.TYPE_NAME)
+                     .to(HttpRemoteTaskRunnerFactory.class)
+                     .in(LazySingleton.class);
+                binder.bind(HttpRemoteTaskRunnerFactory.class).in(LazySingleton.class);
 
-            JacksonConfigProvider.bind(binder, WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class, null);
+                JacksonConfigProvider.bind(binder, WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class, null);
+              }
+
+              @Provides
+              @LazySingleton
+              public TaskStorageDirTracker getTaskStorageDirTracker(WorkerConfig workerConfig, TaskConfig taskConfig)
+              {
+                return TaskStorageDirTracker.fromConfigs(workerConfig, taskConfig);
+              }
+            };
           }
 
           private void configureAutoscale(Binder binder)

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -354,7 +354,7 @@ public class CliOverlord extends ServerRunnable
               }
 
               @Provides
-              @LazySingleton
+              @ManageLifecycle
               public TaskStorageDirTracker getTaskStorageDirTracker(WorkerConfig workerConfig, TaskConfig taskConfig)
               {
                 return TaskStorageDirTracker.fromConfigs(workerConfig, taskConfig);

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -67,7 +67,6 @@ import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskReportFileWriter;
-import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.actions.LocalTaskActionClientFactory;
 import org.apache.druid.indexing.common.actions.RemoteTaskActionClientFactory;
@@ -144,10 +143,10 @@ public class CliPeon extends GuiceRunnable
 {
   @SuppressWarnings("WeakerAccess")
   @Required
-  @Arguments(description = "baseTaskDirPath taskId attemptId")
+  @Arguments(description = "taskDirPath attemptId")
   public List<String> taskAndStatusFile;
 
-  // path to the base task Directory
+  // path to the task Directory
   private String taskDirPath;
 
   // the attemptId
@@ -200,8 +199,8 @@ public class CliPeon extends GuiceRunnable
           @Override
           public void configure(Binder binder)
           {
-            taskDirPath = Paths.get(taskAndStatusFile.get(0), taskAndStatusFile.get(1)).toAbsolutePath().toString();
-            attemptId = taskAndStatusFile.get(2);
+            taskDirPath = taskAndStatusFile.get(0);
+            attemptId = taskAndStatusFile.get(1);
 
             binder.bindConstant().annotatedWith(Names.named("serviceName")).to("druid/peon");
             binder.bindConstant().annotatedWith(Names.named("servicePort")).to(0);
@@ -221,11 +220,7 @@ public class CliPeon extends GuiceRunnable
             LifecycleModule.register(binder, ExecutorLifecycle.class);
             ExecutorLifecycleConfig executorLifecycleConfig = new ExecutorLifecycleConfig()
                 .setTaskFile(Paths.get(taskDirPath, "task.json").toFile())
-                .setStatusFile(Paths.get(taskDirPath, "attempt", attemptId, "status.json").toFile())
-                .setLockFile(Paths.get(taskDirPath, "lock").toFile());
-
-            TaskStorageDirTracker dirTracker = new TaskStorageDirTracker(ImmutableList.of(taskAndStatusFile.get(0)));
-            binder.bind(TaskStorageDirTracker.class).toInstance(dirTracker);
+                .setStatusFile(Paths.get(taskDirPath, "attempt", attemptId, "status.json").toFile());
 
             if ("k8s".equals(properties.getProperty("druid.indexer.runner.type", null))) {
               log.info("Running peon in k8s mode");

--- a/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
@@ -43,11 +43,9 @@ public class CliPeonTest
   @Test
   public void testCliPeonK8sMode() throws IOException
   {
-    String taskId = "id0";
-    File baseTaskFile = temporaryFolder.newFolder(taskId);
-    File taskFile = new File(baseTaskFile, "task.json");
-    FileUtils.write(taskFile, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
-    GuiceRunnable runnable = new FakeCliPeon(baseTaskFile.getParent(), taskId, true);
+    File file = temporaryFolder.newFile("task.json");
+    FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
+    GuiceRunnable runnable = new FakeCliPeon(file.getParent(), true);
     final Injector injector = GuiceInjectors.makeStartupInjector();
     injector.injectMembers(runnable);
     Assert.assertNotNull(runnable.makeInjector());
@@ -56,11 +54,9 @@ public class CliPeonTest
   @Test
   public void testCliPeonNonK8sMode() throws IOException
   {
-    String taskId = "id0";
-    File baseTaskFile = temporaryFolder.newFolder(taskId);
-    File taskFile = new File(baseTaskFile, "task.json");
-    FileUtils.write(taskFile, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
-    GuiceRunnable runnable = new FakeCliPeon(baseTaskFile.getParent(), taskId, false);
+    File file = temporaryFolder.newFile("task.json");
+    FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
+    GuiceRunnable runnable = new FakeCliPeon(file.getParent(), false);
     final Injector injector = GuiceInjectors.makeStartupInjector();
     injector.injectMembers(runnable);
     Assert.assertNotNull(runnable.makeInjector());
@@ -70,11 +66,10 @@ public class CliPeonTest
   {
     List<String> taskAndStatusFile = new ArrayList<>();
 
-    FakeCliPeon(String baseTaskDirectory, String taskId, boolean runningOnK8s)
+    FakeCliPeon(String taskDirectory, boolean runningOnK8s)
     {
       try {
-        taskAndStatusFile.add(baseTaskDirectory);
-        taskAndStatusFile.add(taskId);
+        taskAndStatusFile.add(taskDirectory);
         taskAndStatusFile.add("1");
 
         Field privateField = CliPeon.class


### PR DESCRIPTION
There was a change that tried to get indexing to run on multiple disks It made a bunch of changes to how tasks run, effectively hiding the "safe" directory for tasks to write files into from the task code itself making it extremely difficult to do anything correctly inside of a task.

This change reverts those changes (https://github.com/apache/druid/pull/13476) inside of the tasks and makes it so that only the task runners are the ones that make decisions about which mount points should be used for storing task-related files.

It adds the config druid.worker.baseTaskDirs which can be used by the task runners to know which directories they should schedule tasks inside of. The TaskConfig remains the authoritative source of configuration for where and how an individual task should be operating.

#### Release note

Tasks can now run using multiple different mount points for temporary storage.  Set `druid.worker.baseTaskDirs` to an array of locations to enable!