### PR TITLE
fix NPE that can happen when merging all null nested v4 format columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
@@ -134,7 +134,7 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
       Supplier<TStringDictionary> stringDictionary,
       Supplier<FixedIndexed<Long>> longDictionarySupplier,
       Supplier<FixedIndexed<Double>> doubleDictionarySupplier,
-      Supplier<FrontCodedIntArrayIndexed> arrayDictionarySupplier,
+      @Nullable Supplier<FrontCodedIntArrayIndexed> arrayDictionarySupplier,
       SmooshedFileMapper fileMapper,
       BitmapSerdeFactory bitmapSerdeFactory,
       ByteOrder byteOrder,
@@ -220,6 +220,9 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
   @Override
   public Indexed<Object[]> getArrayDictionary()
   {
+    if (arrayDictionarySupplier == null) {
+      return Indexed.empty();
+    }
     Iterable<Object[]> arrays = () -> {
       final TStringDictionary stringDictionary = stringDictionarySupplier.get();
       final FixedIndexed<Long> longDictionary = longDictionarySupplier.get();

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -40,6 +40,7 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.IndexSpec;
@@ -92,7 +93,7 @@ public class NestedDataTestUtils
                     .useSchemaDiscovery(true)
                     .build();
 
-  public static final DimensionsSpec TSV_SCHEMA =
+  public static final DimensionsSpec TSV_V4_SCHEMA =
       DimensionsSpec.builder()
                     .setDimensions(
                         Arrays.asList(
@@ -105,15 +106,23 @@ public class NestedDataTestUtils
                         )
                     )
                     .build();
+
+  public static final DimensionsSpec TSV_SCHEMA =
+      DimensionsSpec.builder()
+                    .setDimensions(
+                        Arrays.asList(
+                            new AutoTypeColumnSchema("dim"),
+                            new AutoTypeColumnSchema("nest_json"),
+                            new AutoTypeColumnSchema("nester_json"),
+                            new AutoTypeColumnSchema("variant_json"),
+                            new AutoTypeColumnSchema("list_json"),
+                            new AutoTypeColumnSchema("nonexistent")
+                        )
+                    )
+                    .build();
   public static final InputRowSchema AUTO_SCHEMA = new InputRowSchema(
       TIMESTAMP_SPEC,
       AUTO_DISCOVERY,
-      null
-  );
-
-  public static final InputRowSchema SIMPLE_DATA_TSV_SCHEMA = new InputRowSchema(
-      TIMESTAMP_SPEC,
-      TSV_SCHEMA,
       null
   );
 
@@ -162,6 +171,22 @@ public class NestedDataTestUtils
         tempFolder,
         closer,
         Granularities.NONE,
+        TSV_SCHEMA,
+        true
+    );
+  }
+
+  public static List<Segment> createSimpleSegmentsTsvV4(
+      TemporaryFolder tempFolder,
+      Closer closer
+  )
+      throws Exception
+  {
+    return createSimpleNestedTestDataTsvSegments(
+        tempFolder,
+        closer,
+        Granularities.NONE,
+        TSV_V4_SCHEMA,
         true
     );
   }
@@ -170,6 +195,7 @@ public class NestedDataTestUtils
       TemporaryFolder tempFolder,
       Closer closer,
       Granularity granularity,
+      DimensionsSpec dimensionsSpec,
       boolean rollup
   ) throws Exception
   {
@@ -179,7 +205,7 @@ public class NestedDataTestUtils
         SIMPLE_DATA_TSV_FILE,
         SIMPLE_DATA_TSV_INPUT_FORMAT,
         TIMESTAMP_SPEC,
-        SIMPLE_DATA_TSV_SCHEMA.getDimensionsSpec(),
+        dimensionsSpec,
         SIMPLE_DATA_TSV_TRANSFORM,
         COUNT,
         granularity,

--- a/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/query/NestedDataTestUtils.java
@@ -100,7 +100,8 @@ public class NestedDataTestUtils
                             new NestedDataDimensionSchema("nest_json"),
                             new NestedDataDimensionSchema("nester_json"),
                             new NestedDataDimensionSchema("variant_json"),
-                            new NestedDataDimensionSchema("list_json")
+                            new NestedDataDimensionSchema("list_json"),
+                            new NestedDataDimensionSchema("nonexistent")
                         )
                     )
                     .build();


### PR DESCRIPTION
### Description
Fixes another regression related to #14014, this time when processing all null or nonexistent columns with the 'json' (v4) format. Added a test to ensure that non-existent data is processed correctly, and tests for explicit 'auto' dimension schema with non-existent columns to ensure new common format also doesn't have any issues with non-existent columns.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
