### PR TITLE
Separate web-checks from static-checks to improve build time

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -145,10 +145,18 @@ jobs:
       - name: checkout branch
         uses: actions/checkout@v3
 
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
       - name: setup node
         uses: actions/setup-node@v3
         with:
           node-version: 16.17.0
+          cache: 'npm'
 
       - name: docs
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -156,7 +156,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.17.0
-          cache: 'npm'
 
       - name: docs
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -137,14 +137,19 @@ jobs:
           --levels ERROR \
           --scope JavaInspectionsScope
 
+  web-checks:
+    strategy:
+      fail-fast: false
+    steps:
+      - name: checkout branch
+        uses: actions/checkout@v3
+
       - name: setup node
-        if: ${{ matrix.java == 'jdk8' }}
         uses: actions/setup-node@v3
         with:
           node-version: 16.17.0
 
       - name: docs
-        if: ${{ matrix.java == 'jdk8' }}
         run: |
           (cd website && npm install)
           cd website
@@ -152,14 +157,12 @@ jobs:
           npm run spellcheck
 
       - name: web console
-        if: ${{ matrix.java == 'jdk8' }}
         run: |
           ${MVN} test -pl 'web-console'
           cd web-console
           { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
 
       - name: web console end-to-end test
-        if: ${{ matrix.java == 'jdk8' }}
         run: |
           ./.github/scripts/setup_generate_license.sh
           web-console/script/druid build

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -140,6 +140,7 @@ jobs:
   web-checks:
     strategy:
       fail-fast: false
+    runs-on: ubuntu-latest
     steps:
       - name: checkout branch
         uses: actions/checkout@v3


### PR DESCRIPTION
Currently, all static checks run parallel thereby increasing build time, also web-checks out of these run at the very end. Moving web checks to a separate job to improve builds time and to get quick sights into the website/web-console issues early on.