### PR TITLE
adjust useSchemaDiscovery to also include the behavior of includeAllDimensions

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -872,6 +872,87 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     }
   }
 
+  @Test
+  public void testIngestBothExplicitAndImplicitDimsSchemaDiscovery() throws IOException
+  {
+    final Interval interval = Intervals.of("2017-12/P1M");
+    for (int i = 0; i < 5; i++) {
+      try (final Writer writer =
+               Files.newBufferedWriter(new File(inputDir, "test_" + i + ".json").toPath(), StandardCharsets.UTF_8)) {
+
+        writer.write(
+            getObjectMapper().writeValueAsString(
+                ImmutableMap.of(
+                    "ts",
+                    StringUtils.format("2017-12-%d", 24 + i),
+                    "implicitDim",
+                    "implicit_" + i,
+                    "explicitDim",
+                    "explicit_" + i
+                )
+            )
+        );
+        writer.write(
+            getObjectMapper().writeValueAsString(
+                ImmutableMap.of(
+                    "ts",
+                    StringUtils.format("2017-12-%d", 25 + i),
+                    "implicitDim",
+                    "implicit_" + i,
+                    "explicitDim",
+                    "explicit_" + i
+                )
+            )
+        );
+      }
+    }
+
+    final ParallelIndexSupervisorTask task = new ParallelIndexSupervisorTask(
+        null,
+        null,
+        null,
+        new ParallelIndexIngestionSpec(
+            new DataSchema(
+                "dataSource",
+                DEFAULT_TIMESTAMP_SPEC,
+                DimensionsSpec.builder()
+                              .setDefaultSchemaDimensions(ImmutableList.of("ts", "explicitDim"))
+                              .useSchemaDiscovery(true)
+                              .build(),
+                new AggregatorFactory[]{new CountAggregatorFactory("cnt")},
+                new UniformGranularitySpec(
+                    Granularities.DAY,
+                    Granularities.MINUTE,
+                    Collections.singletonList(interval)
+                ),
+                null
+            ),
+            new ParallelIndexIOConfig(
+                null,
+                new SettableSplittableLocalInputSource(inputDir, "*.json", true),
+                new JsonInputFormat(
+                    new JSONPathSpec(true, null),
+                    null,
+                    null,
+                    null,
+                    null
+                ),
+                false,
+                null
+            ),
+            AbstractParallelIndexSupervisorTaskTest.DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING
+        ),
+        null
+    );
+    task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
+    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+
+    Set<DataSegment> segments = getIndexingServiceClient().getPublishedSegments(task);
+    for (DataSegment segment : segments) {
+      Assert.assertEquals(ImmutableList.of("ts", "explicitDim", "implicitDim"), segment.getDimensions());
+    }
+  }
+
   private ParallelIndexSupervisorTask newTask(
       @Nullable Interval interval,
       boolean appendToExisting,

--- a/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
@@ -88,7 +88,7 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
   {
     final String timestampColumn = timestampSpec.getTimestampColumn();
     final Set<String> exclusions = dimensionsSpec.getDimensionExclusions();
-    if (dimensionsSpec.isIncludeAllDimensions()) {
+    if (dimensionsSpec.isIncludeAllDimensions() || dimensionsSpec.useSchemaDiscovery()) {
       LinkedHashSet<String> dimensions = new LinkedHashSet<>(dimensionsSpec.getDimensionNames());
       for (String field : rawInputRow.keySet()) {
         if (timestampColumn.equals(field) || exclusions.contains(field)) {

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -1315,7 +1315,7 @@ public class IndexMergerV9 implements IndexMerger
       this.explicitDimensions = dimensionsSpec == null
                                 ? ImmutableSet.of()
                                 : new HashSet<>(dimensionsSpec.getDimensionNames());
-      this.includeAllDimensions = dimensionsSpec != null && dimensionsSpec.isIncludeAllDimensions();
+      this.includeAllDimensions = dimensionsSpec != null && (dimensionsSpec.isIncludeAllDimensions() || dimensionsSpec.useSchemaDiscovery());
     }
 
     /**

--- a/processing/src/test/java/org/apache/druid/data/input/impl/MapInputRowParserTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/MapInputRowParserTest.java
@@ -155,4 +155,36 @@ public class MapInputRowParserTest
     Assert.assertEquals(ImmutableList.of("val2"), inputRow.getDimension("dim2"));
     Assert.assertEquals(10, inputRow.getMetric("met"));
   }
+
+  @Test
+  public void testSchemaDiscovery()
+  {
+    final InputRow inputRow = MapInputRowParser.parse(
+        timestampSpec,
+        DimensionsSpec
+            .builder()
+            .setDefaultSchemaDimensions(ImmutableList.of("string"))
+            .setDimensionExclusions(ImmutableList.of("time", "long"))
+            .useSchemaDiscovery(true)
+            .build(),
+        ImmutableMap.<String, Object>builder()
+                    .put("time", "2020-01-01")
+                    .put("array_double", ImmutableList.of(1.1, 2.2, 3.3))
+                    .put("array_long", ImmutableList.of(1, 2, 3))
+                    .put("array_string", ImmutableList.of("a", "b", "c"))
+                    .put("bool", true)
+                    .put("double", 1.0)
+                    .put("float", 1.0f)
+                    .put("long", 1L)
+                    .put("nested", ImmutableMap.of("x", 1, "y", ImmutableList.of("a", "b")))
+                    .put("string", "a")
+                    .build()
+    );
+    // string should appear first as it's explicitly defined in dimensionsSpec.
+    // Discovered dimensions, should be in the parsed row since useSchemaDiscovery is set.
+    Assert.assertEquals(
+        ImmutableList.of("string", "array_double", "array_long", "array_string", "bool", "double", "float", "nested"),
+        inputRow.getDimensions()
+    );
+  }
 }


### PR DESCRIPTION
### Description
This PR adjusts the behavior of `useSchemaDiscovery` to if set also include the behavior of `includeAllDimensions`, meaning that if `useSchemaDiscovery` is set ingestion will use any explicitly defined dimensions and then use the 'auto' schema for any additional dimensions not explicitly specified. This makes the `useSchemaDiscovery` name make a bit more sense, as it means schema discovery will always be enabled even when the schema is partially defined, and avoids the need to set two flags to support partial schema declaration with the new and improved schema discovery mode enabled by `useSchemaDiscovery`.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
