### PR TITLE
Make GCP initialization truly lazy

### DIFF
--- a/cloud/gcp-common/src/test/java/org/apache/druid/common/gcp/GcpMockModule.java
+++ b/cloud/gcp-common/src/test/java/org/apache/druid/common/gcp/GcpMockModule.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.common.gcp;
 
-import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -30,7 +29,7 @@ import com.google.inject.Provides;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.initialization.DruidModule;
 
-public class GcpMockModule implements DruidModule
+public abstract class GcpMockModule implements DruidModule
 {
   @Override
   public void configure(Binder binder)
@@ -39,13 +38,18 @@ public class GcpMockModule implements DruidModule
 
   @Provides
   @LazySingleton
-  public HttpRequestInitializer mockRequestInitializer(
+  public HttpRequestInitializer provideRequestInitializer(
       HttpTransport transport,
       JsonFactory factory
   )
   {
-    return new MockGoogleCredential.Builder().setTransport(transport).setJsonFactory(factory).build();
+    return mockRequestInitializer(transport, factory);
   }
+
+  public abstract HttpRequestInitializer mockRequestInitializer(
+      HttpTransport transport,
+      JsonFactory factory
+  );
 
   @Provides
   @LazySingleton

--- a/cloud/gcp-common/src/test/java/org/apache/druid/common/gcp/GcpModuleTest.java
+++ b/cloud/gcp-common/src/test/java/org/apache/druid/common/gcp/GcpModuleTest.java
@@ -22,12 +22,13 @@ package org.apache.druid.common.gcp;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Scopes;
 import com.google.inject.util.Modules;
+import org.apache.druid.guice.DruidScopes;
 import org.apache.druid.guice.LazySingleton;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +43,16 @@ public class GcpModuleTest
       @Override
       public void configure(Binder binder)
       {
-        binder.bindScope(LazySingleton.class, Scopes.SINGLETON);
+        binder.bindScope(LazySingleton.class, DruidScopes.SINGLETON);
+      }
+
+      @Override
+      public HttpRequestInitializer mockRequestInitializer(
+          HttpTransport transport,
+          JsonFactory factory
+      )
+      {
+        return new MockGoogleCredential.Builder().setTransport(transport).setJsonFactory(factory).build();
       }
     }));
     Assert.assertTrue(injector.getInstance(HttpRequestInitializer.class) instanceof MockGoogleCredential);

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorageDruidModule.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorageDruidModule.java
@@ -27,9 +27,9 @@ import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.storage.Storage;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.druid.data.SearchableVersionedDataFinder;
@@ -97,9 +97,23 @@ public class GoogleStorageDruidModule implements DruidModule
     JsonConfigProvider.bind(binder, "druid.indexer.logs", GoogleTaskLogsConfig.class);
     binder.bind(GoogleTaskLogs.class).in(LazySingleton.class);
     MapBinder.newMapBinder(binder, String.class, SearchableVersionedDataFinder.class)
-        .addBinding(SCHEME_GS)
-        .to(GoogleTimestampVersionedDataFinder.class)
-        .in(LazySingleton.class);
+             .addBinding(SCHEME_GS)
+             .to(GoogleTimestampVersionedDataFinder.class)
+             .in(LazySingleton.class);
+  }
+
+  @Provides
+  @LazySingleton
+  public Storage getGcpStorage(
+      HttpTransport httpTransport,
+      JsonFactory jsonFactory,
+      HttpRequestInitializer requestInitializer
+  )
+  {
+    return new Storage
+        .Builder(httpTransport, jsonFactory, requestInitializer)
+        .setApplicationName(APPLICATION_NAME)
+        .build();
   }
 
   /**
@@ -109,20 +123,10 @@ public class GoogleStorageDruidModule implements DruidModule
   @Provides
   @LazySingleton
   public GoogleStorage getGoogleStorage(
-      HttpTransport httpTransport,
-      JsonFactory jsonFactory,
-      HttpRequestInitializer requestInitializer
+      Provider<Storage> baseStorageProvider
   )
   {
     LOG.info("Building Cloud Storage Client...");
-
-    return new GoogleStorage(
-        Suppliers.memoize(
-            () -> new Storage
-                .Builder(httpTransport, jsonFactory, requestInitializer)
-                .setApplicationName(APPLICATION_NAME)
-                .build()
-        )
-    );
+    return new GoogleStorage(baseStorageProvider::get);
   }
 }


### PR DESCRIPTION
The GCP initialization pulls credentials for
talking to GCP.  We want that to only happen
when fully required and thus want the GCP-related
objects lazily instantiated.
