### PR TITLE
fix web-console tests for release

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
@@ -10,7 +10,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributedg under the License is distributed on an
+ * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations

--- a/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
@@ -10,7 +10,7 @@
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
+ * software distributedg under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations

--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -329,7 +329,7 @@ exports[`HeaderBar matches snapshot 1`] = `
           <Blueprint4.MenuItem
             active={false}
             disabled={false}
-            href="https://druid.apache.org/docs/latest"
+            href="https://druid.apache.org/docs/26.0.0"
             icon="th"
             multiline={false}
             popoverProps={Object {}}

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -62,7 +62,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
         >
           <p>
             Druid uses rules to determine what data should be retained in the cluster. The rules are evaluated in order from top to bottom. For more information please refer to the
-
+             
             <a
               href="https://druid.apache.org/docs/26.0.0/operations/rule-configuration.html"
               rel="noopener noreferrer"

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -62,9 +62,9 @@ exports[`RetentionDialog matches snapshot 1`] = `
         >
           <p>
             Druid uses rules to determine what data should be retained in the cluster. The rules are evaluated in order from top to bottom. For more information please refer to the
-             
+
             <a
-              href="https://druid.apache.org/docs/latest/operations/rule-configuration.html"
+              href="https://druid.apache.org/docs/26.0.0/operations/rule-configuration.html"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -10,21 +10,21 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
   >
     <React.Fragment>
       <Memo(ExternalLink)
-        href="https://druid.apache.org/docs/latest/multi-stage-query/reference.html#error_TooManyWarnings"
+        href="https://druid.apache.org/docs/26.0.0/multi-stage-query/reference.html#error_TooManyWarnings"
       >
         TooManyWarnings
       </Memo(ExternalLink)>
-      : 
+      :
     </React.Fragment>
     Too many warnings of type CannotParseExternalData generated (max = 2)
   </p>
   <div>
-    Failed task ID: 
+    Failed task ID:
     <Memo(ClickToCopy)
       text="query-614dc100-a4b9-40a3-95ce-1227fa7ea765-worker0_0"
     />
     <React.Fragment>
-       (on host: 
+       (on host:
       <Memo(ClickToCopy)
         text="localhost"
       />
@@ -32,7 +32,7 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
     </React.Fragment>
   </div>
   <div>
-    Debug: 
+    Debug:
     <a
       onClick={[Function]}
     >

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -14,17 +14,17 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
       >
         TooManyWarnings
       </Memo(ExternalLink)>
-      :
+      : 
     </React.Fragment>
     Too many warnings of type CannotParseExternalData generated (max = 2)
   </p>
   <div>
-    Failed task ID:
+    Failed task ID: 
     <Memo(ClickToCopy)
       text="query-614dc100-a4b9-40a3-95ce-1227fa7ea765-worker0_0"
     />
     <React.Fragment>
-       (on host:
+       (on host: 
       <Memo(ClickToCopy)
         text="localhost"
       />
@@ -32,7 +32,7 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
     </React.Fragment>
   </div>
   <div>
-    Debug:
+    Debug: 
     <a
       onClick={[Function]}
     >


### PR DESCRIPTION
fix some tests that expect docs links to point to release version instead of 'latest' (fallout from updating the docs version in `links.ts`)

not sure why intellij made the other formatting changes to these files.. was having trouble rolling them back so i just went with it :shrug: