### PR TITLE
Nicer error message for CSV with no properties.

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/impl/FlatTextInputFormat.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/FlatTextInputFormat.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.indexer.Checks;
 import org.apache.druid.indexer.Property;
+import org.apache.druid.java.util.common.IAE;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -54,12 +55,20 @@ public abstract class FlatTextInputFormat implements InputFormat
     this.delimiter = Preconditions.checkNotNull(delimiter, "delimiter");
     //noinspection ConstantConditions
     if (columns == null || columns.isEmpty()) {
-      this.findColumnsFromHeader = Checks.checkOneNotNullOrEmpty(
-          ImmutableList.of(
-              new Property<>("hasHeaderRow", hasHeaderRow),
-              new Property<>("findColumnsFromHeader", findColumnsFromHeader)
-          )
-      ).getValue();
+      final Property<Boolean> property;
+
+      try {
+        property = Checks.checkOneNotNullOrEmpty(
+            ImmutableList.of(
+                new Property<>("hasHeaderRow", hasHeaderRow),
+                new Property<>("findColumnsFromHeader", findColumnsFromHeader)
+            )
+        );
+      } catch (IllegalArgumentException e) {
+        throw new IAE("%s when [columns] is not set", e.getMessage());
+      }
+
+      this.findColumnsFromHeader = property.getValue();
     } else {
       this.findColumnsFromHeader = findColumnsFromHeader == null ? false : findColumnsFromHeader;
     }

--- a/processing/src/main/java/org/apache/druid/indexer/Checks.java
+++ b/processing/src/main/java/org/apache/druid/indexer/Checks.java
@@ -38,7 +38,7 @@ public final class Checks
           nonNullProperty = property;
         } else {
           throw new IAE(
-              "At most one of %s must be present",
+              "At most one of properties[%s] must be present",
               properties.stream().map(Property::getName).collect(Collectors.toList())
           );
         }
@@ -46,7 +46,7 @@ public final class Checks
     }
     if (nonNullProperty == null) {
       throw new IAE(
-          "At least one of %s must be present",
+          "At least one of properties[%s] must be present",
           properties.stream().map(Property::getName).collect(Collectors.toList())
       );
     }

--- a/processing/src/main/java/org/apache/druid/indexer/Checks.java
+++ b/processing/src/main/java/org/apache/druid/indexer/Checks.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexer;
 import org.apache.druid.java.util.common.IAE;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Various helper methods useful for checking the validity of arguments to spec constructors.
@@ -36,12 +37,18 @@ public final class Checks
         if (nonNullProperty == null) {
           nonNullProperty = property;
         } else {
-          throw new IAE("At most one of %s must be present", properties);
+          throw new IAE(
+              "At most one of %s must be present",
+              properties.stream().map(Property::getName).collect(Collectors.toList())
+          );
         }
       }
     }
     if (nonNullProperty == null) {
-      throw new IAE("At least one of %s must be present", properties);
+      throw new IAE(
+          "At least one of %s must be present",
+          properties.stream().map(Property::getName).collect(Collectors.toList())
+      );
     }
     return nonNullProperty;
   }

--- a/processing/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
@@ -19,12 +19,16 @@
 
 package org.apache.druid.data.input.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
@@ -43,6 +47,22 @@ public class CsvInputFormatTest extends InitializedNullHandlingTest
     final byte[] bytes = mapper.writeValueAsBytes(format);
     final CsvInputFormat fromJson = (CsvInputFormat) mapper.readValue(bytes, InputFormat.class);
     Assert.assertEquals(format, fromJson);
+  }
+
+  @Test
+  public void testDeserializeWithoutProperties()
+  {
+    final ObjectMapper mapper = new ObjectMapper();
+    final JsonProcessingException e = Assert.assertThrows(
+        JsonProcessingException.class,
+        () -> mapper.readValue("{\"type\":\"csv\"}", InputFormat.class)
+    );
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith(
+            "Cannot construct instance of `org.apache.druid.data.input.impl.CsvInputFormat`, problem: "
+            + "At least one of [hasHeaderRow, findColumnsFromHeader] must be present when [columns] is not set"))
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/CsvInputFormatTest.java
@@ -72,7 +72,7 @@ public class CsvInputFormatTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testDeserializeWithoutColumnsWithFindColumnsFromHeaderFalse() throws IOException
+  public void testDeserializeWithoutColumnsWithFindColumnsFromHeaderFalse()
   {
     final ObjectMapper mapper = new ObjectMapper();
     final JsonProcessingException e = Assert.assertThrows(

--- a/processing/src/test/java/org/apache/druid/data/input/impl/DelimitedInputFormatTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/DelimitedInputFormatTest.java
@@ -107,7 +107,7 @@ public class DelimitedInputFormatTest
   public void testMissingFindColumnsFromHeaderWithMissingColumnsThrowingError()
   {
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("At least one of [Property{name='hasHeaderRow', value=null}");
+    expectedException.expectMessage("Either [columns] or [findColumnsFromHeader] must be set");
     new DelimitedInputFormat(null, null, "delim", null, null, 0);
   }
 
@@ -129,7 +129,7 @@ public class DelimitedInputFormatTest
   public void testHasHeaderRowWithMissingFindColumnsThrowingError()
   {
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("At most one of [Property{name='hasHeaderRow', value=true}");
+    expectedException.expectMessage("Cannot accept both [findColumnsFromHeader] and [hasHeaderRow]");
     new DelimitedInputFormat(null, null, "delim", true, false, 0);
   }
 

--- a/processing/src/test/java/org/apache/druid/indexer/ChecksTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/ChecksTest.java
@@ -105,10 +105,7 @@ public class ChecksTest
         new Property<>("p4", Collections.emptyList())
     );
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage(
-        "At most one of [Property{name='p1', value=null}, Property{name='p2', value=2}, Property{name='p3', value=3}, "
-        + "Property{name='p4', value=[]}] must be present"
-    );
+    exception.expectMessage("At most one of properties[[p1, p2, p3, p4]] must be present");
     Checks.checkOneNotNullOrEmpty(properties);
   }
 
@@ -122,10 +119,7 @@ public class ChecksTest
         new Property<>("p4", Lists.newArrayList(1, 2))
     );
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage(
-        "At most one of [Property{name='p1', value=null}, Property{name='p2', value=2}, Property{name='p3', value=null}, "
-        + "Property{name='p4', value=[1, 2]}] must be present"
-    );
+    exception.expectMessage("At most one of properties[[p1, p2, p3, p4]] must be present");
     Checks.checkOneNotNullOrEmpty(properties);
   }
 
@@ -139,10 +133,7 @@ public class ChecksTest
         new Property<>("p4", null)
     );
     exception.expect(IllegalArgumentException.class);
-    exception.expectMessage(
-        "At least one of [Property{name='p1', value=null}, Property{name='p2', value=null}, "
-        + "Property{name='p3', value=null}, Property{name='p4', value=null}] must be present"
-    );
+    exception.expectMessage("At least one of properties[[p1, p2, p3, p4]] must be present");
     Checks.checkOneNotNullOrEmpty(properties);
   }
 }


### PR DESCRIPTION
The old message didn't mention that `columns` is an option, which was confusing.