### PR TITLE
fix bug filtering nested columns with expression filters

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumn.java
@@ -136,9 +136,10 @@ public interface NestedCommonFormatColumn extends BaseColumn
                                      .setDictionaryValuesSorted(true)
                                      .setDictionaryValuesUnique(true)
                                      .setHasBitmapIndexes(true)
+                                     .setFilterable(true)
                                      .setHasNulls(hasNulls);
       }
-      return ColumnCapabilitiesImpl.createDefault().setType(logicalType).setHasNulls(hasNulls);
+      return ColumnCapabilitiesImpl.createDefault().setType(logicalType).setHasNulls(hasNulls).setFilterable(true);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataComplexTypeSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataComplexTypeSerde.java
@@ -106,6 +106,7 @@ public class NestedDataComplexTypeSerde extends ComplexMetricSerde
     }
     builder.setComplexColumnSupplier(supplier);
     builder.setColumnFormat(new NestedColumnFormatV4());
+    builder.setFilterable(true);
   }
 
   @Override
@@ -187,7 +188,7 @@ public class NestedDataComplexTypeSerde extends ComplexMetricSerde
     @Override
     public ColumnCapabilities toColumnCapabilities()
     {
-      return ColumnCapabilitiesImpl.createDefault().setType(ColumnType.NESTED_DATA).setHasNulls(true);
+      return ColumnCapabilitiesImpl.createDefault().setType(ColumnType.NESTED_DATA).setHasNulls(true).setFilterable(true);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/serde/NestedCommonFormatColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/NestedCommonFormatColumnPartSerde.java
@@ -121,6 +121,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         builder.setStandardTypeColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
+        builder.setFilterable(true);
       });
     }
     if (logicalType.is(ValueType.LONG)) {
@@ -140,6 +141,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         builder.setStandardTypeColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
+        builder.setFilterable(true);
       });
     }
     if (logicalType.is(ValueType.DOUBLE)) {
@@ -159,6 +161,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         builder.setStandardTypeColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
+        builder.setFilterable(true);
       });
     }
     if (logicalType.isArray()) {
@@ -178,6 +181,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         builder.setType(logicalType);
         builder.setStandardTypeColumnSupplier(supplier);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
+        builder.setFilterable(true);
       });
     }
     return (buffer, builder, columnConfig) -> {
@@ -198,6 +202,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
       builder.setType(logicalType);
       builder.setStandardTypeColumnSupplier(supplier);
       builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, hasNulls));
+      builder.setFilterable(true);
     };
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -48,7 +48,9 @@ import org.apache.druid.segment.ObjectColumnSelector;
 import org.apache.druid.segment.SimpleAscendingOffset;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnConfig;
+import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.DruidPredicateIndex;
@@ -56,6 +58,8 @@ import org.apache.druid.segment.column.NullValueIndex;
 import org.apache.druid.segment.column.StringValueSetIndex;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
+import org.apache.druid.segment.serde.ColumnPartSerde;
+import org.apache.druid.segment.serde.NestedCommonFormatColumnPartSerde;
 import org.apache.druid.segment.vector.BitmapVectorOffset;
 import org.apache.druid.segment.vector.NoFilterVectorOffset;
 import org.apache.druid.segment.vector.VectorObjectSelector;
@@ -245,16 +249,21 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
   public void testBasicFunctionality() throws IOException
   {
     ColumnBuilder bob = new ColumnBuilder();
-    bob.setFileMapper(fileMapper);
-    NestedDataColumnSupplier supplier = NestedDataColumnSupplier.read(
+    NestedCommonFormatColumnPartSerde partSerde = NestedCommonFormatColumnPartSerde.createDeserializer(
+        ColumnType.NESTED_DATA,
         false,
-        baseBuffer,
-        bob,
-        ALWAYS_USE_INDEXES,
-        bitmapSerdeFactory,
-        ByteOrder.nativeOrder()
+        ByteOrder.nativeOrder(),
+        RoaringBitmapSerdeFactory.getInstance()
     );
-    try (NestedDataComplexColumn column = (NestedDataComplexColumn) supplier.get()) {
+    bob.setFileMapper(fileMapper);
+    ColumnPartSerde.Deserializer deserializer = partSerde.getDeserializer();
+    deserializer.read(baseBuffer, bob, ALWAYS_USE_INDEXES);
+    final ColumnHolder holder = bob.build();
+    final ColumnCapabilities capabilities = holder.getCapabilities();
+    Assert.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
+    Assert.assertTrue(capabilities.isFilterable());
+    Assert.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
+    try (NestedDataComplexColumn column = (NestedDataComplexColumn) holder.getColumn()) {
       smokeTest(column);
     }
   }
@@ -263,16 +272,21 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
   public void testArrayFunctionality() throws IOException
   {
     ColumnBuilder bob = new ColumnBuilder();
-    bob.setFileMapper(arrayFileMapper);
-    NestedDataColumnSupplier supplier = NestedDataColumnSupplier.read(
+    NestedCommonFormatColumnPartSerde partSerde = NestedCommonFormatColumnPartSerde.createDeserializer(
+        ColumnType.NESTED_DATA,
         false,
-        arrayBaseBuffer,
-        bob,
-        () -> 0,
-        bitmapSerdeFactory,
-        ByteOrder.nativeOrder()
+        ByteOrder.nativeOrder(),
+        RoaringBitmapSerdeFactory.getInstance()
     );
-    try (NestedDataComplexColumn column = (NestedDataComplexColumn) supplier.get()) {
+    bob.setFileMapper(arrayFileMapper);
+    ColumnPartSerde.Deserializer deserializer = partSerde.getDeserializer();
+    deserializer.read(arrayBaseBuffer, bob, ALWAYS_USE_INDEXES);
+    final ColumnHolder holder = bob.build();
+    final ColumnCapabilities capabilities = holder.getCapabilities();
+    Assert.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
+    Assert.assertTrue(capabilities.isFilterable());
+    Assert.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
+    try (NestedDataComplexColumn column = (NestedDataComplexColumn) holder.getColumn()) {
       smokeTestArrays(column);
     }
   }


### PR DESCRIPTION
### Description
This PR fixes a bug when trying to filter `COMPLEX<json>` columns where omission of setting the `isFilterable` flag of `ColumnCapabilities` when reading the column was incorrectly causing the column to be treated as if it were all null values. The deserializers have been updated to set `isFilterable` to true, allow `COMPLEX<json>` columns to be used in expression filters, which can often be generated by the SQL planner for queries like the added SQL test.

I'm not really certain how useful this behavior is, and it doesn't seem very intuitive, so we might want to consider changing this in the future so that `COMPLEX` columns produce some form of error when used with filters which do not support the type. It might have made sense in the past when there was not really a possible way for complex types to participate in filtering, but since expressions now support complex types it becomes relatively easy to imagine using these columns in filters when used with expressions which can extract meaningful data from the complex types (such as get the estimate from an HLL sketch, or .. extract a value from a json blob as in this case).

#### Release note
Fixed a bug when using expression filters for filtering `COMPLEX<json>` columns or values extracted from them using `JSON_VALUE` or any other nested column function, where the column would be incorrectly treated as all null values.


<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
