### PR TITLE
Fixing null handling in MSQ select test.

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -655,7 +655,7 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(rowSignature)
         .setExpectedResultRows(
             ImmutableList.of(
-                new Object[]{null, 3L},
+                new Object[]{NullHandling.sqlCompatible() ? null : "", 3L},
                 new Object[]{"xabc", 1L}
             )
         )


### PR DESCRIPTION
Fixing null handling in MSQ select test.
Looks like an inflight PR merge issue between : #14046 #14048 