### PR TITLE
Fix MSQSelectTest.

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -655,7 +655,7 @@ public class MSQSelectTest extends MSQTestBase
         .setExpectedRowSignature(rowSignature)
         .setExpectedResultRows(
             ImmutableList.of(
-                new Object[]{null, 3L},
+                new Object[]{NullHandling.defaultStringValue(), 3L},
                 new Object[]{"xabc", 1L}
             )
         )


### PR DESCRIPTION
A logical conflict between #14046 and #14048 caused testJoinWithLookup to fail. This patch fixes it.
