### PR TITLE
fix npe with gs uri having underscores

### DIFF
--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
@@ -83,14 +83,14 @@ public class GoogleDataSegmentPuller implements URIDataPuller
   public InputStream getInputStream(URI uri) throws IOException
   {
     String path = StringUtils.maybeRemoveLeadingSlash(uri.getPath());
-    return storage.get(uri.getHost(), path);
+    return storage.get((uri.getHost() != null ? uri.getHost() : uri.getAuthority(), path);
   }
 
   @Override
   public String getVersion(URI uri) throws IOException
   {
     String path = StringUtils.maybeRemoveLeadingSlash(uri.getPath());
-    return storage.version(uri.getHost(), path);
+    return storage.version(uri.getHost() != null ? uri.getHost() : uri.getAuthority(), path);
   }
 
   @Override

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentPuller.java
@@ -83,7 +83,7 @@ public class GoogleDataSegmentPuller implements URIDataPuller
   public InputStream getInputStream(URI uri) throws IOException
   {
     String path = StringUtils.maybeRemoveLeadingSlash(uri.getPath());
-    return storage.get((uri.getHost() != null ? uri.getHost() : uri.getAuthority(), path);
+    return storage.get(uri.getHost() != null ? uri.getHost() : uri.getAuthority(), path);
   }
 
   @Override


### PR DESCRIPTION
same as [#12445](https://github.com/apache/druid/pull/12445) but this one is for fixing lookups that are hosted on gcs

> GCP allows buckets in GCS to contain underscores in their names. When this location is mapped to java.net.URI, URI#host comes out to be null as URI doesn't allow it to contain underscores which is being translated to bucket name hence mapping URI#authority to bucket name.

<hr>

##### Key changed/added classes in this PR
 * `GoogleDataSegmentPuller `

<hr>

This PR has:
- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.