### PR TITLE
Web console: better lookup 404 detection

### DIFF
--- a/web-console/src/utils/druid-lookup.ts
+++ b/web-console/src/utils/druid-lookup.ts
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import { deepGet } from './object-change';
+
 export function isLookupsUninitialized(error: Error | undefined) {
-  return error && error.message === 'Request failed with status code 404';
+  return deepGet(error || {}, 'response.status') === 404;
 }

--- a/web-console/src/views/lookups-view/lookups-view.tsx
+++ b/web-console/src/views/lookups-view/lookups-view.tsx
@@ -355,11 +355,7 @@ export class LookupsView extends React.PureComponent<LookupsViewProps, LookupsVi
       <ReactTable
         data={lookups}
         loading={lookupEntriesAndTiersState.loading}
-        noDataText={
-          !lookupEntriesAndTiersState.loading && !lookups.length
-            ? 'No lookups'
-            : lookupEntriesAndTiersState.getErrorMessage() || ''
-        }
+        noDataText={lookupEntriesAndTiersState.getErrorMessage() || 'No lookups'}
         filterable
         filtered={lookupFilter}
         onFilteredChange={filtered => {


### PR DESCRIPTION
Change the code to rely on the actual code rather than the stringification of the error message that has no guarantees around it (it can change with locale). Also fix the logic bug where the error message would not actually be shown.