### PR TITLE
KillTask should return empty inputSource resources  - 26.0.0 backport

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -147,7 +147,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<Integer, Long, Kafka
   public Set<ResourceAction> getInputSourceResources()
   {
     return Collections.singleton(new ResourceAction(
-        new Resource(ResourceType.EXTERNAL, INPUT_SOURCE_TYPE),
+        new Resource(INPUT_SOURCE_TYPE, ResourceType.EXTERNAL),
         Action.READ
     ));
   }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -103,10 +103,10 @@ public class KafkaSupervisorSpec extends SeekableStreamSupervisorSpec
   @Nonnull
   @JsonIgnore
   @Override
-  public Set<ResourceAction> getInputSourceTypes()
+  public Set<ResourceAction> getInputSourceResources()
   {
     return Collections.singleton(new ResourceAction(
-        new Resource(ResourceType.EXTERNAL, TASK_TYPE),
+        new Resource(TASK_TYPE, ResourceType.EXTERNAL),
         Action.READ
     ));
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -2707,8 +2707,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                KafkaIndexTask.INPUT_SOURCE_TYPE
+                KafkaIndexTask.INPUT_SOURCE_TYPE,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         task.getInputSourceResources()
     );

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -439,10 +439,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
     Assert.assertEquals(
         Collections.singleton(new ResourceAction(
-            new Resource(ResourceType.EXTERNAL, KafkaSupervisorSpec.TASK_TYPE),
+            new Resource(KafkaSupervisorSpec.TASK_TYPE, ResourceType.EXTERNAL),
             Action.READ
         )),
-        testableSupervisorSpec.getInputSourceTypes()
+        testableSupervisorSpec.getInputSourceResources()
     );
 
     autoscaler.reset();

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -162,7 +162,7 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, By
   public Set<ResourceAction> getInputSourceResources()
   {
     return Collections.singleton(new ResourceAction(
-        new Resource(ResourceType.EXTERNAL, INPUT_SOURCE_TYPE),
+        new Resource(INPUT_SOURCE_TYPE, ResourceType.EXTERNAL),
         Action.READ
     ));
   }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
@@ -125,10 +125,10 @@ public class KinesisSupervisorSpec extends SeekableStreamSupervisorSpec
   @Nonnull
   @JsonIgnore
   @Override
-  public Set<ResourceAction> getInputSourceTypes()
+  public Set<ResourceAction> getInputSourceResources()
   {
     return Collections.singleton(new ResourceAction(
-        new Resource(ResourceType.EXTERNAL, SUPERVISOR_TYPE),
+        new Resource(SUPERVISOR_TYPE, ResourceType.EXTERNAL),
         Action.READ
     ));
   }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -134,8 +134,8 @@ public class KinesisIndexTaskSerdeTest
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                KinesisIndexTask.INPUT_SOURCE_TYPE
+                KinesisIndexTask.INPUT_SOURCE_TYPE,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         target.getInputSourceResources()
     );

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -4130,10 +4130,10 @@ public class KinesisSupervisorTest extends EasyMockSupport
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(
-                new Resource(ResourceType.EXTERNAL, KinesisSupervisorSpec.SUPERVISOR_TYPE),
+                new Resource(KinesisSupervisorSpec.SUPERVISOR_TYPE, ResourceType.EXTERNAL),
                 Action.READ
             )),
-        supervisorSpec.getInputSourceTypes()
+        supervisorSpec.getInputSourceResources()
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -97,6 +97,7 @@ import java.util.stream.Collectors;
 
 public class HadoopIndexTask extends HadoopTask implements ChatHandler
 {
+  public static final String INPUT_SOURCE_TYPE = "hadoop";
   private static final Logger log = new Logger(HadoopIndexTask.class);
   private static final String HADOOP_JOB_ID_FILENAME = "mapReduceJobId.json";
   private static final String TYPE = "index_hadoop";
@@ -202,7 +203,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(new Resource(ResourceType.EXTERNAL, "hadoop"), Action.READ));
+    return Collections.singleton(new ResourceAction(new Resource(INPUT_SOURCE_TYPE, ResourceType.EXTERNAL), Action.READ));
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -305,7 +305,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                .stream()
-               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -20,8 +20,10 @@
 package org.apache.druid.indexing.common.task;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskLock;
@@ -33,16 +35,19 @@ import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskLocks;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -86,6 +91,14 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
   public String getType()
   {
     return "kill";
+  }
+
+  @Nonnull
+  @JsonIgnore
+  @Override
+  public Set<ResourceAction> getInputSourceResources()
+  {
+    return ImmutableSet.of();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/LegacySinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/LegacySinglePhaseSubTask.java
@@ -77,7 +77,7 @@ public class LegacySinglePhaseSubTask extends SinglePhaseSubTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -286,7 +286,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -153,7 +153,7 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
@@ -194,7 +194,7 @@ public class PartialDimensionDistributionTask extends PerfectRollupWorkerTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -149,7 +149,7 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
@@ -167,7 +167,7 @@ public class PartialRangeSegmentGenerateTask extends PartialSegmentGenerateTask<
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -208,7 +208,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(ResourceType.EXTERNAL, i), Action.READ))
+                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
@@ -930,8 +930,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                LocalInputSource.TYPE_KEY
+                LocalInputSource.TYPE_KEY,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         indexTask.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopIndexTaskTest.java
@@ -45,7 +45,7 @@ public class HadoopIndexTaskTest
   private final ObjectMapper jsonMapper = new DefaultObjectMapper();
 
   @Test
-  public void testCorrectInputSourceTypes()
+  public void testCorrectInputSourceResources()
   {
     final HadoopIndexTask task = new HadoopIndexTask(
         null,
@@ -72,8 +72,8 @@ public class HadoopIndexTaskTest
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                "hadoop"
+                HadoopIndexTask.INPUT_SOURCE_TYPE,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         task.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -214,7 +214,7 @@ public class IndexTaskTest extends IngestionTestBase
   }
 
   @Test
-  public void testCorrectInputSourceTypes() throws IOException
+  public void testCorrectInputSourceResources() throws IOException
   {
     File tmpDir = temporaryFolder.newFolder();
     IndexTask indexTask = new IndexTask(
@@ -254,8 +254,8 @@ public class IndexTaskTest extends IngestionTestBase
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                LocalInputSource.TYPE_KEY
+                LocalInputSource.TYPE_KEY,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         indexTask.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -142,6 +142,20 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     );
   }
 
+  @Test
+  public void testGetInputSourceResources()
+  {
+    final KillUnusedSegmentsTask task =
+        new KillUnusedSegmentsTask(
+            null,
+            DATA_SOURCE,
+            Intervals.of("2019-03-01/2019-04-01"),
+            null,
+            true
+        );
+    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+  }
+
   private static DataSegment newSegment(Interval interval, String version)
   {
     return new DataSegment(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -201,7 +201,7 @@ public class RealtimeIndexTaskTest extends InitializedNullHandlingTest
   }
 
   @Test(timeout = 60_000L)
-  public void testInputSourceTypes()
+  public void testInputSourceResources()
   {
     final RealtimeIndexTask task = makeRealtimeTask(null);
     Assert.assertThrows(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
@@ -121,7 +121,7 @@ public class TaskTest
   };
 
   @Test
-  public void testGetInputSourceTypes()
+  public void testGetInputSourceResources()
   {
     Assert.assertThrows(
         UOE.class,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -119,15 +119,15 @@ public class PartialDimensionCardinalityTaskTest
     }
 
     @Test
-    public void hasCorrectInputSourceTypes()
+    public void hasCorrectInputSourceResources()
     {
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .build();
       Assert.assertEquals(
           Collections.singleton(
               new ResourceAction(new Resource(
-                  ResourceType.EXTERNAL,
-                  InlineInputSource.TYPE_KEY
+                  InlineInputSource.TYPE_KEY,
+                  ResourceType.EXTERNAL
               ), Action.READ)),
           task.getInputSourceResources()
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -379,7 +379,7 @@ public class PartialDimensionDistributionTaskTest
       Assert.assertEquals(
           Collections.singleton(
               new ResourceAction(
-                  new Resource(ResourceType.EXTERNAL, InlineInputSource.TYPE_KEY),
+                  new Resource(InlineInputSource.TYPE_KEY, ResourceType.EXTERNAL),
                   Action.READ
               )),
           task.getInputSourceResources()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
@@ -92,13 +92,13 @@ public class PartialHashSegmentGenerateTaskTest
   }
 
   @Test
-  public void hasCorrectInputSourceTypes()
+  public void hasCorrectInputSourceResources()
   {
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                LocalInputSource.TYPE_KEY
+                LocalInputSource.TYPE_KEY,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         target.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
@@ -106,14 +106,14 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   }
 
   @Test
-  public void hasCorrectInputSourceTypes()
+  public void hasCorrectInputSourceResources()
   {
     PartialRangeSegmentGenerateTask task = new PartialRangeSegmentGenerateTaskBuilder().build();
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                InlineInputSource.TYPE_KEY
+                InlineInputSource.TYPE_KEY,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         task.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -179,8 +179,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
       Assert.assertEquals(
           Collections.singleton(
               new ResourceAction(new Resource(
-                  ResourceType.EXTERNAL,
-                  LocalInputSource.TYPE_KEY
+                  LocalInputSource.TYPE_KEY,
+                  ResourceType.EXTERNAL
               ), Action.READ)),
           subTask.getInputSourceResources()
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
@@ -96,8 +96,8 @@ public class SinglePhaseSubTaskSpecTest
     Assert.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
-                ResourceType.EXTERNAL,
-                LocalInputSource.TYPE_KEY
+                LocalInputSource.TYPE_KEY,
+                ResourceType.EXTERNAL
             ), Action.READ)),
         expected.getInputSourceResources()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -1498,7 +1498,7 @@ public class OverlordResourceTest
     EasyMock.expect(task.getDataSource()).andReturn(dataSource);
     EasyMock.expect(task.getInputSourceResources())
             .andReturn(ImmutableSet.of(new ResourceAction(
-                new Resource(ResourceType.EXTERNAL, inputSourceType),
+                new Resource(inputSourceType, ResourceType.EXTERNAL),
                 Action.READ
             )));
 
@@ -1515,7 +1515,7 @@ public class OverlordResourceTest
 
     Set<ResourceAction> expectedResourceActions = ImmutableSet.of(
         new ResourceAction(new Resource(dataSource, ResourceType.DATASOURCE), Action.WRITE),
-        new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ)
+        new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ)
     );
     Set<ResourceAction> resourceActions = overlordResource.getNeededResourceActionsForTask(task);
     Assert.assertEquals(expectedResourceActions, resourceActions);
@@ -1566,7 +1566,7 @@ public class OverlordResourceTest
     EasyMock.expect(task.getDataSource()).andReturn(dataSource);
     EasyMock.expect(task.getInputSourceResources())
             .andReturn(ImmutableSet.of(new ResourceAction(
-                new Resource(ResourceType.EXTERNAL, inputSourceType),
+                new Resource(inputSourceType, ResourceType.EXTERNAL),
                 Action.READ
             )));
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.supervisor;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -30,10 +31,15 @@ import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAu
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Authorizer;
 import org.apache.druid.server.security.AuthorizerMapper;
+import org.apache.druid.server.security.ForbiddenException;
+import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.ResourceAction;
+import org.apache.druid.server.security.ResourceType;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
@@ -44,6 +50,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import java.util.Collections;
@@ -80,6 +87,9 @@ public class SupervisorResourceTest extends EasyMockSupport
   @Mock
   private HttpServletRequest request;
 
+  @Mock
+  private AuthConfig authConfig;
+
   private SupervisorResource supervisorResource;
 
   @Before
@@ -96,16 +106,26 @@ public class SupervisorResourceTest extends EasyMockSupport
               if (authenticationResult.getIdentity().equals("druid")) {
                 return Access.OK;
               } else {
-                if (resource.getName().equals("datasource2")) {
-                  return new Access(false, "not authorized.");
-                } else {
-                  return Access.OK;
+                if (resource.getType().equals(ResourceType.DATASOURCE)) {
+                  if (resource.getName().equals("datasource2")) {
+                    return new Access(false, "not authorized.");
+                  } else {
+                    return Access.OK;
+                  }
+                } else if (resource.getType().equals(ResourceType.EXTERNAL)) {
+                  if (resource.getName().equals("test")) {
+                    return new Access(false, "not authorized.");
+                  } else {
+                    return Access.OK;
+                  }
                 }
+                return Access.OK;
               }
             };
           }
         },
-        OBJECT_MAPPER
+        OBJECT_MAPPER,
+        authConfig
     );
   }
 
@@ -131,6 +151,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     ).atLeastOnce();
     request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
     EasyMock.expectLastCall().anyTimes();
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(false);
     replayAll();
 
     Response response = supervisorResource.specPost(spec, request);
@@ -147,6 +168,75 @@ public class SupervisorResourceTest extends EasyMockSupport
     verifyAll();
 
     Assert.assertEquals(503, response.getStatus());
+  }
+
+  @Test
+  public void testSpecPostWithInputSourceSecurityEnabledAuthorized()
+  {
+    SupervisorSpec spec = new TestSupervisorSpec("my-id", null, null)
+    {
+
+      @Override
+      public List<String> getDataSources()
+      {
+        return Collections.singletonList("datasource1");
+      }
+    };
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
+    EasyMock.expect(supervisorManager.createOrUpdateAndStartSupervisor(spec)).andReturn(true);
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(
+        new AuthenticationResult("druid", "druid", null, null)
+    ).atLeastOnce();
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(true);
+    replayAll();
+
+    Response response = supervisorResource.specPost(spec, request);
+    verifyAll();
+
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    resetAll();
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
+    replayAll();
+
+    response = supervisorResource.specPost(spec, request);
+    verifyAll();
+
+    Assert.assertEquals(503, response.getStatus());
+  }
+
+  @Test
+  public void testSpecPostWithInputSourceSecurityEnabledUnauthorized()
+  {
+    SupervisorSpec spec = new TestSupervisorSpec("my-id", null, null)
+    {
+
+      @Override
+      public List<String> getDataSources()
+      {
+        return Collections.singletonList("datasource1");
+      }
+    };
+
+    EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(request.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT)).andReturn(
+        new AuthenticationResult("notdruid", "druid", null, null)
+    ).atLeastOnce();
+    request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, false);
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(true);
+    replayAll();
+
+    Assert.assertThrows(ForbiddenException.class, () -> supervisorResource.specPost(spec, request));
+    verifyAll();
   }
 
   @Test
@@ -1189,6 +1279,14 @@ public class SupervisorResourceTest extends EasyMockSupport
     public String getType()
     {
       return "test";
+    }
+
+    @JsonIgnore
+    @Nonnull
+    @Override
+    public Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
+    {
+      return Collections.singleton(new ResourceAction(new Resource("test", ResourceType.EXTERNAL), Action.READ));
     }
 
     @Override

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/NoopSupervisorSpec.java
@@ -119,7 +119,7 @@ public class NoopSupervisorSpec implements SupervisorSpec
   @Nonnull
   @JsonIgnore
   @Override
-  public Set<ResourceAction> getInputSourceTypes()
+  public Set<ResourceAction> getInputSourceResources()
   {
     return ImmutableSet.of();
   }

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -85,7 +85,7 @@ public interface SupervisorSpec
    */
   @JsonIgnore
   @Nonnull
-  default Set<ResourceAction> getInputSourceTypes() throws UnsupportedOperationException
+  default Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
   {
     throw new UOE(StringUtils.format(
         "SuperviserSpec type [%s], does not support input source based security",

--- a/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/NoopSupervisorSpecTest.java
@@ -66,9 +66,9 @@ public class NoopSupervisorSpecTest
   }
 
   @Test
-  public void testInputSourceTypes()
+  public void testInputSourceResources()
   {
     NoopSupervisorSpec noopSupervisorSpec = new NoopSupervisorSpec(null, Collections.singletonList("datasource1"));
-    Assert.assertTrue(noopSupervisorSpec.getInputSourceTypes().isEmpty());
+    Assert.assertTrue(noopSupervisorSpec.getInputSourceResources().isEmpty());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
@@ -63,6 +63,6 @@ public class SupervisorSpecTest
   @Test
   public void test()
   {
-    Assert.assertThrows(UOE.class, () -> SUPERVISOR_SPEC.getInputSourceTypes());
+    Assert.assertThrows(UOE.class, () -> SUPERVISOR_SPEC.getInputSourceResources());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
@@ -58,7 +58,7 @@ public class DruidExternTableMacro extends DruidUserDefinedTableMacro
     try {
       InputSource inputSource = ((DruidTableMacro) macro).getJsonMapper().readValue(inputSourceStr, InputSource.class);
       return inputSource.getTypes().stream()
-          .map(inputSourceType -> new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ))
+          .map(inputSourceType -> new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ))
           .collect(Collectors.toSet());
     }
     catch (JsonProcessingException e) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
@@ -176,7 +176,7 @@ public abstract class SchemaAwareUserDefinedTableMacro
         resourceActions.addAll(((ExternalTable) table)
                                    .getInputSourceTypeSupplier().get().stream()
                                    .map(inputSourceType ->
-                                 new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ))
+                                 new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ))
                                    .collect(Collectors.toSet()));
       } else {
         resourceActions.addAll(base.computeResources(call, inputSourceTypeSecurityEnabled));

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTestBase.java
@@ -122,6 +122,6 @@ public abstract class CalciteTestBase
 
   protected static ResourceAction externalRead(final String inputSourceType)
   {
-    return new ResourceAction(new Resource(ResourceType.EXTERNAL, inputSourceType), Action.READ);
+    return new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ);
   }
 }


### PR DESCRIPTION
### Description

This pr fixes a few bugs found with the inputSource security feature.

1. `KillUnusedSegmentsTask` previously had no definition for the `getInputSourceResources`, which caused an unsupportedOperationException to be thrown when this task type was submitted with the inputSource security feature enabled. This task type should not require any input source specific resources, so returning an empty set for this task type now.

2. Fixed a bug where when the input source type security feature is enabled, all of the input source type specific resources used where authenticated against:

`{"resource": {"name": "EXTERNAL", "type": "{INPUT_SOURCE_TYPE}"}, "action": "READ"}`

When they should be instead authenticated against:

`{"resource": {"name": "{INPUT_SOURCE_TYPE}", "type": "EXTERNAL"}, "action": "READ"}`

3. fixed bug where supervisor tasks were not authenticated against the specific input source types used, if input source security feature was enabled.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
