### PR TITLE
Updating segment map function for QueryDataSource to ensure group by …

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryDataSource.java
@@ -98,7 +98,8 @@ public class QueryDataSource implements DataSource
       AtomicLong cpuTime
   )
   {
-    return Function.identity();
+    final Query<?> subQuery = this.getQuery();
+    return subQuery.getDataSource().createSegmentMapFunction(subQuery, cpuTime);
   }
 
   @Override

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -3145,6 +3145,90 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
 
   @Test
   @Parameters(source = QueryContextForJoinProvider.class)
+  public void testGroupByOverGroupByOverInnerJoinOnTwoInlineDataSources(Map<String, Object> queryContext)
+  {
+    skipVectorize();
+    cannotVectorize();
+    testQuery(
+        "with abc as\n"
+        + "(\n"
+        + "  SELECT dim1, \"__time\", m1 from foo WHERE \"dim1\" = '10.1'\n"
+        + ")\n"
+        + "SELECT dim1 from (SELECT dim1,__time FROM (SELECT t1.dim1, t1.\"__time\" from abc as t1 INNER JOIN abc as t2 on t1.dim1 = t2.dim1) GROUP BY 1,2) GROUP BY dim1\n",
+        queryContext,
+        ImmutableList.of(
+            new GroupByQuery.Builder()
+                .setDataSource(
+                    new QueryDataSource(
+                        GroupByQuery.builder()
+                                    .setDataSource(
+                                        join(
+                                            new QueryDataSource(
+                                                newScanQueryBuilder()
+                                                    .dataSource(CalciteTests.DATASOURCE1)
+                                                    .intervals(querySegmentSpec(Filtration.eternity()))
+                                                    .filters(new SelectorDimFilter("dim1", "10.1", null))
+                                                    .virtualColumns(expressionVirtualColumn(
+                                                        "v0",
+                                                        "\'10.1\'",
+                                                        ColumnType.STRING
+                                                    ))
+                                                    .columns(ImmutableList.of("__time", "v0"))
+                                                    .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                                    .context(queryContext)
+                                                    .build()
+                                            ),
+                                            new QueryDataSource(
+                                                newScanQueryBuilder()
+                                                    .dataSource(CalciteTests.DATASOURCE1)
+                                                    .intervals(querySegmentSpec(Filtration.eternity()))
+                                                    .filters(new SelectorDimFilter("dim1", "10.1", null))
+                                                    .columns(ImmutableList.of("dim1"))
+                                                    .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                                    .context(queryContext)
+                                                    .build()
+                                            ),
+                                            "j0.",
+                                            equalsCondition(
+                                                makeColumnExpression("v0"),
+                                                makeColumnExpression("j0.dim1")
+                                            ),
+                                            JoinType.INNER
+                                        ))
+                                    .setInterval(querySegmentSpec(Filtration.eternity()))
+                                    .setVirtualColumns(expressionVirtualColumn("_v0", "\'10.1\'", ColumnType.STRING))
+                                    .setGranularity(Granularities.ALL)
+                                    .setDimensions(new DefaultDimensionSpec(
+                                        "_v0",
+                                        "d0",
+                                        ColumnType.STRING
+                                    ), new DefaultDimensionSpec(
+                                        "__time",
+                                        "d1",
+                                        ColumnType.LONG
+                                    ))
+                                    .setContext(queryContext)
+                                    .build()
+                    )
+                )
+                .setInterval(querySegmentSpec(Filtration.eternity()))
+                .setDimensions(new DefaultDimensionSpec(
+                    "d0",
+                    "_d0",
+                    ColumnType.STRING
+                ))
+                .setContext(queryContext)
+                .setGranularity(Granularities.ALL)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"10.1"}
+        )
+    );
+  }
+
+  @Test
+  @Parameters(source = QueryContextForJoinProvider.class)
   public void testInnerJoinOnTwoInlineDataSources_withLeftDirectAccess(Map<String, Object> queryContext)
   {
     queryContext = withLeftDirectAccessEnabled(queryContext);


### PR DESCRIPTION
…of group by of join data source gets into proper segment map function path

A query such as 
```
{
    "queryType": "groupBy",
    "dimensions": ["related_object_id", "r.category_id"],
    "dataSource":
    {
        "type": "query",
        "query":
        {
            "queryType": "groupBy",
            "dimensions": ["related_object_id","r.category_id"],
            "intervals": "2020-03-20/2020-03-21",
            "dataSource":
            {
                "type": "join",
                "left":
                {
                    "type": "inline",
                    "name": "DRUID_INLINE_DATASOURCE",
                    "columnNames":
                    [
                        "__time",
                        "related_object_id"
                    ],
                    "rows":
                    [
                        [1584662400000,"3229"],
                        [1584662400000,"4510"]
                    ]
                },
                "right":
                {
                    "type": "inline",
                    "columnNames":
                    ["related_object_id","category_id"],
                    "rows":
                    [
                        ["3229", 2985],
                        ["4510", 2985]
                    ]
                },
                "rightPrefix": "r.",
                "condition": "related_object_id == \"r.related_object_id\"",
                "joinType": "LEFT"
            },
            "granularity": "day",
            "filter":
            {
                "type": "in",
                "dimension": "related_object_id",
                "values":
                [
                    "3229",
                    "4510"
                ]
            }
        }
    },
    "intervals": "2020-03-20/2020-03-21",
    "granularity": "all",
}
```

was producing nulls as the Segment map function of Join was not called as the Inner Query Data source's segment map function was returning an identity function. Changed the query data source's segment map function which should delegate to the segment map function of the subquery's datasource. The test now passes.

Fixes https://github.com/apache/druid/issues/14088

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
