### PR TITLE
MSQ: Preserve original ParseException when writing frames.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/write/RowBasedFrameWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/RowBasedFrameWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.frame.write;
 
+import com.google.common.base.Throwables;
 import com.google.common.primitives.Ints;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.memory.WritableMemory;
@@ -125,6 +126,7 @@ public class RowBasedFrameWriter implements FrameWriter
       }
     }
     catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, ParseException.class);
       throw new ParseException("", e, "Unable to add the row to the frame. Type conversion might be required.");
     }
 

--- a/processing/src/main/java/org/apache/druid/frame/write/columnar/ColumnarFrameWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/columnar/ColumnarFrameWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.frame.write.columnar;
 
+import com.google.common.base.Throwables;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
@@ -83,6 +84,7 @@ public class ColumnarFrameWriter implements FrameWriter
       }
     }
     catch (Exception e) {
+      Throwables.propagateIfInstanceOf(e, ParseException.class);
       throw new ParseException("", e, "Unable to add the row to the frame. Type conversion might be required.");
     }
 


### PR DESCRIPTION
Prevents nice ParseExceptions from being shadowed by vague ones.