### PR TITLE
Add retry to opening retrying stream

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -79,6 +79,9 @@ public class S3Utils
         // SdkClientException can be thrown for many reasons and the only way to distinguish it is to look at
         // the message. This is not ideal, since the message may change, so it may need to be adjusted in the future.
         return true;
+      } else if (e instanceof SdkClientException && e.getMessage().contains("Unable to execute HTTP request")) {
+        // This is likely due to a temporary DNS issue and can be retried.
+        return true;
       } else if (e instanceof AmazonClientException) {
         return AWSClientUtil.isClientExceptionRecoverable((AmazonClientException) e);
       } else {

--- a/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStream.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStream.java
@@ -53,7 +53,7 @@ public class RetryingInputStream<T> extends InputStream
   private long startOffset;
 
   // Used in tests to disable waiting.
-  private boolean doWait;
+  private final boolean doWait;
 
   /**
    * @param object             The object entity to open
@@ -70,22 +70,61 @@ public class RetryingInputStream<T> extends InputStream
       @Nullable Integer maxTries
   ) throws IOException
   {
+    this(object, objectOpenFunction, retryCondition, maxTries, true);
+  }
+
+  @VisibleForTesting
+  RetryingInputStream(
+      T object,
+      ObjectOpenFunction<T> objectOpenFunction,
+      Predicate<Throwable> retryCondition,
+      @Nullable Integer maxTries,
+      boolean doWait
+  ) throws IOException
+  {
     this.object = Preconditions.checkNotNull(object, "object");
     this.objectOpenFunction = Preconditions.checkNotNull(objectOpenFunction, "objectOpenFunction");
     this.retryCondition = Preconditions.checkNotNull(retryCondition, "retryCondition");
     this.maxTries = maxTries == null ? RetryUtils.DEFAULT_MAX_TRIES : maxTries;
-    this.delegate = new CountingInputStream(objectOpenFunction.open(object));
-    this.doWait = true;
+    this.doWait = doWait;
+    this.startOffset = 0;
 
     if (this.maxTries <= 1) {
       throw new IAE("maxTries must be greater than 1");
     }
+    openWithRetry();
   }
 
   private void openIfNeeded() throws IOException
   {
     if (delegate == null) {
-      delegate = new CountingInputStream(objectOpenFunction.open(object, startOffset));
+      openWithRetry();
+    }
+  }
+
+  private void openWithRetry() throws IOException
+  {
+    for (int nTry = 0; nTry < maxTries; nTry++) {
+      try {
+        delegate = new CountingInputStream(objectOpenFunction.open(object, startOffset));
+      }
+      catch (Throwable t) {
+        final int nextTry = nTry + 1;
+        if (nextTry < maxTries && retryCondition.apply(t)) {
+          final String message = StringUtils.format("Stream interrupted at position [%d]", startOffset);
+          try {
+            if (doWait) {
+              RetryUtils.awaitNextRetry(t, message, nextTry, maxTries, false);
+            }
+          }
+          catch (InterruptedException e) {
+            t.addSuppressed(e);
+            throwAsIOException(t);
+          }
+        } else {
+          throwAsIOException(t);
+        }
+      }
     }
   }
 
@@ -115,8 +154,7 @@ public class RetryingInputStream<T> extends InputStream
         if (doWait) {
           RetryUtils.awaitNextRetry(t, message, nextTry, maxTries, false);
         }
-
-        delegate = new CountingInputStream(objectOpenFunction.open(object, startOffset));
+        openWithRetry();
       }
       catch (InterruptedException | IOException e) {
         t.addSuppressed(e);
@@ -232,11 +270,5 @@ public class RetryingInputStream<T> extends InputStream
     if (delegate != null) {
       delegate.close();
     }
-  }
-
-  @VisibleForTesting
-  void setNoWait()
-  {
-    this.doWait = false;
   }
 }


### PR DESCRIPTION
When opening an S3Entity using RetryingEntity, the underlying function that is used to open the stream is a simple read using the S3 client. RetryingEntity using the predicate supplied to check if a failing read can be retried and does so. However, we do not check if the exception can be retried while opening the stream. This leads to the opening of the stream failing after a single attempt. Ideally, we should check if the exception can be retried while opening the stream as well using the supplied retryPredicate.

- Add retry to S3Entity for network issues
- Add retry using supplied predicate to opening retrying stream

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
