### PR TITLE
disable broker parallel merge for Java versions greater than 8 and less than 20 due to apparent bug

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -897,7 +897,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
               accumulated.add(in);
               count++;
               if (count % batchSize == 0) {
-                yield();
+                this.yield();
               }
               return accumulated;
             }
@@ -928,6 +928,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         return batchYielder;
       }
       catch (InterruptedException e) {
+        batchYielder = Yielders.done(null, null);
         throw new RuntimeException("Failed to load initial batch of results", e);
       }
     }

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -796,6 +796,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         if (hasTimeout) {
           final long thisTimeoutNanos = timeoutAtNanos - System.nanoTime();
           if (thisTimeoutNanos < 0) {
+            item = null;
             throw new QueryTimeoutException("QueuePusher timed out offering data");
           }
           success = queue.offer(item, thisTimeoutNanos, TimeUnit.NANOSECONDS);
@@ -822,6 +823,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         ForkJoinPool.managedBlock(this);
       }
       catch (InterruptedException e) {
+        this.item = null;
         throw new RuntimeException("Failed to offer result to output queue", e);
       }
     }
@@ -1069,7 +1071,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
     @Override
     public boolean isReleasable()
     {
-      return resultBatch != null && !resultBatch.isDrained();
+      return yielder.isDone() || (resultBatch != null && !resultBatch.isDrained());
     }
 
     @Override
@@ -1140,6 +1142,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
         if (hasTimeout) {
           final long thisTimeoutNanos = timeoutAtNanos - System.nanoTime();
           if (thisTimeoutNanos < 0) {
+            resultBatch = ResultBatch.TERMINAL;
             throw new QueryTimeoutException("BlockingQueue cursor timed out waiting for data");
           }
           resultBatch = queue.poll(thisTimeoutNanos, TimeUnit.NANOSECONDS);

--- a/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
@@ -183,6 +183,9 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
 
   public boolean useParallelMergePool()
   {
+    if (JvmUtils.majorVersion() < 20 && JvmUtils.majorVersion() >= 9) {
+      return false;
+    }
     final boolean useParallelMergePoolConfigured = useParallelMergePoolConfigured();
     final int parallelism = getMergePoolParallelism();
     // need at least 3 to do 2 layer merge

--- a/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidProcessingConfig.java
@@ -178,14 +178,12 @@ public abstract class DruidProcessingConfig extends ExecutorServiceConfig implem
   @Config(value = "${base_path}.merge.useParallelMergePool")
   public boolean useParallelMergePoolConfigured()
   {
-    return true;
+    // some java versions might have some issues with parallel merge, disable by default
+    return JvmUtils.majorVersion() < 9 || JvmUtils.majorVersion() >= 20;
   }
 
   public boolean useParallelMergePool()
   {
-    if (JvmUtils.majorVersion() < 20 && JvmUtils.majorVersion() >= 9) {
-      return false;
-    }
     final boolean useParallelMergePoolConfigured = useParallelMergePoolConfigured();
     final int parallelism = getMergePoolParallelism();
     // need at least 3 to do 2 layer merge

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -441,7 +441,7 @@ public class ParallelMergeCombiningSequenceTest
 
     Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
     Assert.assertEquals("exploded", t.getMessage());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
   }
 
@@ -456,7 +456,7 @@ public class ParallelMergeCombiningSequenceTest
 
     Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
     Assert.assertEquals("exploded", t.getMessage());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
   }
 
@@ -471,7 +471,7 @@ public class ParallelMergeCombiningSequenceTest
 
     Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
     Assert.assertEquals("exploded", t.getMessage());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
   }
 
@@ -488,7 +488,7 @@ public class ParallelMergeCombiningSequenceTest
 
     Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
     Assert.assertEquals("exploded", t.getMessage());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
   }
 
@@ -520,7 +520,7 @@ public class ParallelMergeCombiningSequenceTest
     // java 11, 17 and maybe others in between 8 and 20 don't correctly clean up the pool, however this behavior is
     // flaky and doesn't always happen so we can't definitively assert that the pool is or isn't
     if (JvmUtils.majorVersion() >= 20 || JvmUtils.majorVersion() < 9) {
-      pool.awaitQuiescence(3, TimeUnit.SECONDS);
+      Assert.assertTrue(pool.awaitQuiescence(10, TimeUnit.SECONDS));
       // good result, we want the pool to always be idle if an exception occurred during processing
       Assert.assertTrue(pool.isQuiescent());
     }
@@ -539,7 +539,7 @@ public class ParallelMergeCombiningSequenceTest
     Throwable t = Assert.assertThrows(QueryTimeoutException.class, () -> assertException(input, 8, 64, 1000, 1500));
     Assert.assertEquals("Query did not complete within configured timeout period. " +
                         "You can increase query timeout or tune the performance of query.", t.getMessage());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
   }
 
@@ -634,7 +634,7 @@ public class ParallelMergeCombiningSequenceTest
 
     Assert.assertTrue(combiningYielder.isDone());
     Assert.assertTrue(parallelMergeCombineYielder.isDone());
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
     combiningYielder.close();
     parallelMergeCombineYielder.close();
@@ -707,7 +707,7 @@ public class ParallelMergeCombiningSequenceTest
         parallelMergeCombineSequence.getCancellationGizmo().getRuntimeException().getMessage()
     );
 
-    pool.awaitQuiescence(1, TimeUnit.SECONDS);
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
     Assert.assertTrue(pool.isQuiescent());
 
     Assert.assertFalse(combiningYielder.isDone());

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -695,15 +695,9 @@ public class ParallelMergeCombiningSequenceTest
     // trying to next the yielder creates sadness for you
     final String expectedExceptionMsg = "Already closed";
     Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
-    try {
-      Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
-      parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
-      // this should explode so the contradictory next statement should not be reached
-      Assert.assertTrue(false);
-    }
-    catch (RuntimeException rex) {
-      Assert.assertEquals(expectedExceptionMsg, rex.getMessage());
-    }
+    final Yielder<IntPair> finalYielder = parallelMergeCombineYielder;
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> finalYielder.next(finalYielder.get()));
+    Assert.assertEquals(expectedExceptionMsg, t.getMessage());
 
     // cancellation gizmo of sequence should be cancelled, and also should contain our expected message
     Assert.assertTrue(parallelMergeCombineSequence.getCancellationGizmo().isCancelled());

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -515,11 +515,12 @@ public class ParallelMergeCombiningSequenceTest
     );
     Assert.assertEquals("Query did not complete within configured timeout period. " +
                         "You can increase query timeout or tune the performance of query.", t.getMessage());
-    pool.awaitQuiescence(3, TimeUnit.SECONDS);
-    if (JvmUtils.majorVersion() > 8 && JvmUtils.majorVersion() < 20) {
-      // this is a bug, parallel merge should not be used on these java versions because of this...
-      Assert.assertFalse(pool.isQuiescent());
-    } else {
+
+
+    // java 11, 17 and maybe others in between 8 and 20 don't correctly clean up the pool, however this behavior is
+    // flaky and doesn't always happen so we can't definitively assert that the pool is or isn't
+    if (JvmUtils.majorVersion() >= 20 || JvmUtils.majorVersion() < 9) {
+      pool.awaitQuiescence(3, TimeUnit.SECONDS);
       // good result, we want the pool to always be idle if an exception occurred during processing
       Assert.assertTrue(pool.isQuiescent());
     }

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -520,7 +520,7 @@ public class ParallelMergeCombiningSequenceTest
     // java 11, 17 and maybe others in between 8 and 20 don't correctly clean up the pool, however this behavior is
     // flaky and doesn't always happen so we can't definitively assert that the pool is or isn't
     if (JvmUtils.majorVersion() >= 20 || JvmUtils.majorVersion() < 9) {
-      Assert.assertTrue(pool.awaitQuiescence(10, TimeUnit.SECONDS));
+      Assert.assertTrue(pool.awaitQuiescence(3, TimeUnit.SECONDS));
       // good result, we want the pool to always be idle if an exception occurred during processing
       Assert.assertTrue(pool.isQuiescent());
     }

--- a/processing/src/test/java/org/apache/druid/query/DruidProcessingConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DruidProcessingConfigTest.java
@@ -197,6 +197,18 @@ public class DruidProcessingConfigTest
     config.intermediateComputeSizeBytes();
   }
 
+  @Test
+  public void testParallelMergeDefaultConfig()
+  {
+    Injector injector = makeInjector(NUM_PROCESSORS, DIRECT_SIZE, HEAP_SIZE);
+    DruidProcessingConfig config = injector.getInstance(DruidProcessingConfig.class);
+    if (JvmUtils.majorVersion() < 9 || JvmUtils.majorVersion() >= 20) {
+      Assert.assertTrue(config.useParallelMergePool());
+    } else {
+      Assert.assertFalse(config.useParallelMergePool());
+    }
+  }
+
   public static class MockRuntimeInfo extends RuntimeInfo
   {
     private final int availableProcessors;

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -2843,6 +2843,15 @@ public class CachingClusteredClientTest
             // fixed so same behavior across all test environments
             return 4;
           }
+
+          @Override
+          public boolean useParallelMergePool()
+          {
+            // force it even in java versions that parallel merge is not recommended so that everything uses the same
+            // merge path to ensure the same results across java versions. this test should not run into the issue
+            // that causes those java versions to have parallel merge off by default
+            return true;
+          }
         },
         ForkJoinPool.commonPool(),
         new QueryScheduler(


### PR DESCRIPTION
### Description
Through a bit of luck, stumbled into a possible bug with broker parallel merging on certain java versions which can eventually result in all worker threads becoming completely blocked effectively blocking queries.

I have adjusted the `ParallelMergeCombiningSequenceTest` to check that the pool becomes idle after a short period whenever an exception occurs. The adjust tests fail pretty consistently for me with java 11 and 17, but can repeat indefinitely on java 8 and java 20 on my laptop. Some of these timeout tests are still ever so slightly racy since the exception message can vary slightly depending on which part in the code triggers the timeout exception, but the true important part is that previously missing a check that the pool becomes idle.

I still haven't determined why this happens, perhaps a java bug or at least some issue with how we are trying to configure/use the pool on these versions. It could also just be an artifact of how the test is written, and not a real issue? Im not really sure yet.

#### Release note
Broker parallel merge is now disabled for Java versions greater than 8 and less than 20 due to a bug with how this mechanism operates on these versions that can result in all pool threads becoming blocked effectively halting the ability to process most queries. Java 8 and Java 20 do not appear to exhibit these symptoms and so still have parallel result merging enabled by default.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
