### PR TITLE
Feature: add support for ingesting from rabbitmq super streams

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -456,6 +456,8 @@
                                         <argument>org.apache.druid.extensions.contrib:druid-deltalake-extensions</argument>
                                         <argument>-c</argument>
                                         <argument>org.apache.druid.extensions.contrib:druid-spectator-histogram</argument>
+                                        <argument>-c</argument>
+                                        <argument>org.apache.druid.extensions.contrib:druid-rabbit-indexing-service</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/docs/ingestion/rabbit-stream-ingestion.md
+++ b/docs/ingestion/rabbit-stream-ingestion.md
@@ -1,0 +1,239 @@
+---
+id: rabbit-super-stream-injestion
+title: "RabbitMQ superstream ingestion"
+sidebar_label: "Rabbitmq superstream"
+---
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+When you enable the rabbit stream indexing service, you can configure *supervisors* on the Overlord to manage the creation and lifetime of rabbit indexing tasks. These indexing tasks read events from a rabbit super-stream. The supervisor oversees the state of the indexing tasks to:
+  - coordinate handoffs
+  - manage failures
+  - ensure that scalability and replication requirements are maintained.
+
+  To use the rabbit stream indexing service, load the `druid-rabbit-indexing-service` community druid extension (see
+[Including Extensions](../configuration/extensions.md#loading-extensions)).
+
+
+## Submitting a Supervisor Spec
+
+To use the rabbit stream indexing service, load the `druid-rabbit-indexing-service` extension on both the Overlord and the MiddleManagers. Druid starts a supervisor for a dataSource when you submit a supervisor spec. Submit your supervisor spec to the following endpoint:
+
+
+`http://<OVERLORD_IP>:<OVERLORD_PORT>/druid/indexer/v1/supervisor`
+
+For example:
+
+```
+curl -X POST -H 'Content-Type: application/json' -d @supervisor-spec.json http://localhost:8090/druid/indexer/v1/supervisor
+```
+
+Where the file `supervisor-spec.json` contains a rabbit supervisor spec:
+
+```json
+{
+  "type": "rabbit",
+  "spec": {
+    "dataSchema": {
+      "dataSource": "metrics-rabbit",
+      "timestampSpec": {
+        "column": "timestamp",
+        "format": "auto"
+      },
+     "dimensionsSpec": {
+        "dimensions": [],
+        "dimensionExclusions": [
+         "timestamp",
+         "value"
+       ]
+      },
+     "metricsSpec": [
+        {
+         "name": "count",
+          "type": "count"
+       },
+       {
+          "name": "value_sum",
+          "fieldName": "value",
+          "type": "doubleSum"
+        },
+       {
+         "name": "value_min",
+         "fieldName": "value",
+         "type": "doubleMin"
+       },
+        {
+          "name": "value_max",
+         "fieldName": "value",
+         "type": "doubleMax"
+       }
+     ],
+     "granularitySpec": {
+        "type": "uniform",
+        "segmentGranularity": "HOUR",
+        "queryGranularity": "NONE"
+     }
+   },
+    "ioConfig": {
+     "stream": "metrics",
+     "inputFormat": {
+       "type": "json"
+      },
+      "uri": "rabbitmq-stream://localhost:5552",
+      "taskCount": 1,
+      "replicas": 1,
+      "taskDuration": "PT1H"
+   },
+   "tuningConfig": {
+     "type": "rabbit",
+     "maxRowsPerSegment": 5000000
+   }
+  }
+}
+```
+
+## Supervisor Spec
+
+|Field|Description|Required|
+|--------|-----------|---------|
+|`type`|The supervisor type; this should always be `rabbit`.|yes|
+|`spec`|Container object for the supervisor configuration.|yes|
+|`dataSchema`|The schema that will be used by the rabbit indexing task during ingestion. See [`dataSchema`](ingestion-spec.md#dataschema).|yes|
+|`ioConfig`|An [`ioConfig`](#ioconfig) object for configuring rabbit super stream connection and I/O-related settings for the supervisor and indexing task.|yes|
+|`tuningConfig`|A [`tuningConfig`](#tuningconfig) object for configuring performance-related settings for the supervisor and indexing tasks.|no|
+
+### `ioConfig`
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`stream`|String|The RabbitMQ super stream to read.|yes|
+|`inputFormat`|Object|[`inputFormat`](data-formats.md#input-format) to specify how to parse input data. See [Specifying data format](data-formats.md#input-format) for details about specifying the input format.|yes|
+|`uri`|String|The URI to connect to RabbitMQ with. |yes |
+|`replicas`|Integer|The number of replica sets, where 1 means a single set of tasks (no replication). Replica tasks will always be assigned to different workers to provide resiliency against process failure.|no (default == 1)|
+|`taskCount`|Integer|The maximum number of *reading* tasks in a *replica set*. This means that the maximum number of reading tasks will be `taskCount * replicas` and the total number of tasks (*reading* + *publishing*) will be higher than this. |no (default == 1)|
+|`taskDuration`|ISO8601 Period|The length of time before tasks stop reading and begin publishing their segment.|no (default == PT1H)|
+|`startDelay`|ISO8601 Period|The period to wait before the supervisor starts managing tasks.|no (default == PT5S)|
+|`period`|ISO8601 Period|How often the supervisor will execute its management logic. Note that the supervisor will also run in response to certain events (such as tasks succeeding, failing, and reaching their taskDuration) so this value specifies the maximum time between iterations.|no (default == PT30S)|
+|`useEarliestSequenceNumber`|Boolean|If a supervisor is managing a dataSource for the first time, it will obtain a set of starting sequence numbers from RabbitMQ. This flag determines whether it retrieves the earliest or latest sequence numbers in the stream. Under normal circumstances, subsequent tasks will start from where the previous segments ended so this flag will only be used on first run.|no (default == false)|
+|`completionTimeout`|ISO8601 Period|The length of time to wait before declaring a publishing task as failed and terminating it. If this is set too low, your tasks may never publish. The publishing clock for a task begins roughly after `taskDuration` elapses.|no (default == PT6H)|
+|`lateMessageRejectionPeriod`|ISO8601 Period|Configure tasks to reject messages with timestamps earlier than this period before the task was created; for example if this is set to `PT1H` and the supervisor creates a task at *2016-01-01T12:00Z*, messages with timestamps earlier than *2016-01-01T11:00Z* will be dropped. This may help prevent concurrency issues if your data stream has late messages and you have multiple pipelines that need to operate on the same segments (e.g. a realtime and a nightly batch ingestion pipeline).|no (default == none)|
+|`earlyMessageRejectionPeriod`|ISO8601 Period|Configure tasks to reject messages with timestamps later than this period after the task reached its taskDuration; for example if this is set to `PT1H`, the taskDuration is set to `PT1H` and the supervisor creates a task at *2016-01-01T12:00Z*. Messages with timestamps later than *2016-01-01T14:00Z* will be dropped. **Note:** Tasks sometimes run past their task duration, for example, in cases of supervisor failover. Setting `earlyMessageRejectionPeriod` too low may cause messages to be dropped unexpectedly whenever a task runs past its originally configured task duration.|no (default == none)|
+|`Consumer Properties`|Object| a dynamic map used to provide |no (default == none)|
+
+<a name="tuningconfig"></a>
+
+### `tuningConfig`
+
+The `tuningConfig` is optional. If no `tuningConfig` is specified, default parameters are used.
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`type`| String|The indexing task type, this should always be `rabbit`.|yes|
+|`maxRowsInMemory`|Integer|The number of rows to aggregate before persisting. This number is the post-aggregation rows, so it is not equivalent to the number of input events, but the number of aggregated rows that those events result in. This is used to manage the required JVM heap size. Maximum heap memory usage for indexing scales with `maxRowsInMemory * (2 + maxPendingPersists)`.|no (default == 100000)|
+|`maxBytesInMemory`|Long| The number of bytes to aggregate in heap memory before persisting. This is based on a rough estimate of memory usage and not actual usage. Normally, this is computed internally and user does not need to set it. The maximum heap memory usage for indexing is `maxBytesInMemory * (2 + maxPendingPersists)`.|no (default == One-sixth of max JVM memory)|
+|`maxRowsPerSegment`|Integer|The number of rows to aggregate into a segment; this number is post-aggregation rows. Handoff will happen either if `maxRowsPerSegment` or `maxTotalRows` is hit or every `intermediateHandoffPeriod`, whichever happens earlier.|no (default == 5000000)|
+|`maxTotalRows`|Long|The number of rows to aggregate across all segments; this number is post-aggregation rows. Handoff will happen either if `maxRowsPerSegment` or `maxTotalRows` is hit or every `intermediateHandoffPeriod`, whichever happens earlier.|no (default == unlimited)|
+|`intermediatePersistPeriod`|ISO8601 Period|The period that determines the rate at which intermediate persists occur.|no (default == PT10M)|
+|`maxPendingPersists`|Integer|Maximum number of persists that can be pending but not started. If this limit would be exceeded by a new intermediate persist, ingestion will block until the currently-running persist finishes. Maximum heap memory usage for indexing scales with `maxRowsInMemory * (2 + maxPendingPersists)`.|no (default == 0, meaning one persist can be running concurrently with ingestion, and none can be queued up)|
+|`indexSpec`|Object|Tune how data is indexed. See [IndexSpec](#indexspec) for more information.|no|
+|`indexSpecForIntermediatePersists`|Object|Defines segment storage format options to be used at indexing time for intermediate persisted temporary segments. This can be used to disable dimension/metric compression on intermediate segments to reduce memory required for final merging. However, disabling compression on intermediate segments might increase page cache use while they are used before getting merged into final segment published, see [IndexSpec](#indexspec) for possible values.| no (default = same as `indexSpec`)|
+|`reportParseExceptions`|Boolean|If true, exceptions encountered during parsing will be thrown and will halt ingestion; if false, unparseable rows and fields will be skipped.|no (default == false)|
+|`handoffConditionTimeout`|Long| Milliseconds to wait for segment handoff. It must be >= 0, where 0 means to wait forever.| no (default == 0)|
+|`resetOffsetAutomatically`|Boolean|Controls behavior when Druid needs to read RabbitMQ messages that are no longer available. Not supported.  |no (default == false)|
+|`skipSequenceNumberAvailabilityCheck`|Boolean|Whether to enable checking if the current sequence number is still available in a particular RabbitMQ stream. If set to false, the indexing task will attempt to reset the current sequence number (or not), depending on the value of `resetOffsetAutomatically`.|no (default == false)|
+|`workerThreads`|Integer|The number of threads that the supervisor uses to handle requests/responses for worker tasks, along with any other internal asynchronous operation.|no (default == min(10, taskCount))|
+|`chatAsync`|Boolean| If true, use asynchronous communication with indexing tasks, and ignore the `chatThreads` parameter. If false, use synchronous communication in a thread pool of size `chatThreads`.  | no (default == true) |
+|`chatThreads`|Integer| The number of threads that will be used for communicating with indexing tasks. Ignored if `chatAsync` is `true` (the default).| no (default == min(10, taskCount * replicas))|
+|`chatRetries`|Integer|The number of times HTTP requests to indexing tasks will be retried before considering tasks unresponsive.| no (default == 8)|
+|`httpTimeout`|ISO8601 Period|How long to wait for a HTTP response from an indexing task.|no (default == PT10S)|
+|`shutdownTimeout`|ISO8601 Period|How long to wait for the supervisor to attempt a graceful shutdown of tasks before exiting.|no (default == PT80S)|
+|`recordBufferSize`|Integer|Size of the buffer (number of events) used between the RabbitMQ consumers and the main ingestion thread.|no ( default == 100 MB or an estimated 10% of available heap, whichever is smaller.)|
+|`recordBufferOfferTimeout`|Integer|Length of time in milliseconds to wait for space to become available in the buffer before timing out.| no (default == 5000)|                                                 |
+|`segmentWriteOutMediumFactory`|Object|Segment write-out medium to use when creating segments. See below for more information.|no (not specified by default, the value from `druid.peon.defaultSegmentWriteOutMediumFactory.type` is used)|
+|`intermediateHandoffPeriod`|ISO8601 Period|How often the tasks should hand off segments. Handoff will happen either if `maxRowsPerSegment` or `maxTotalRows` is hit or every `intermediateHandoffPeriod`, whichever happens earlier.| no (default == P2147483647D)|
+|`logParseExceptions`|Boolean|If true, log an error message when a parsing exception occurs, containing information about the row where the error occurred.|no, default == false|
+|`maxParseExceptions`|Integer|The maximum number of parse exceptions that can occur before the task halts ingestion and fails. Overridden if `reportParseExceptions` is set.|no, unlimited default|
+|`maxSavedParseExceptions`|Integer|When a parse exception occurs, Druid can keep track of the most recent parse exceptions. "maxSavedParseExceptions" limits how many exception instances will be saved. These saved exceptions will be made available after the task finishes in the [task completion report](tasks.md#task-reports). Overridden if `reportParseExceptions` is set.|no, default == 0|
+|`maxRecordsPerPoll`|Integer|The maximum number of records/events to be fetched from buffer per poll. The actual maximum will be `Max(maxRecordsPerPoll, Max(bufferSize, 1))`|no, default = 100|
+|`repartitionTransitionDuration`|ISO8601 Period|When shards are split or merged, the supervisor will recompute shard -> task group mappings, and signal any running tasks created under the old mappings to stop early at (current time + `repartitionTransitionDuration`). Stopping the tasks early allows Druid to begin reading from the new shards more quickly. The repartition transition wait time controlled by this property gives the stream additional time to write records to the new shards after the split/merge, which helps avoid the issues with empty shard handling described at https://github.com/apache/druid/issues/7600.|no, (default == PT2M)|
+|`offsetFetchPeriod`|ISO8601 Period|How often the supervisor queries RabbitMQ and the indexing tasks to fetch current offsets and calculate lag. If the user-specified value is below the minimum value (`PT5S`), the supervisor ignores the value and uses the minimum value instead.|no (default == PT30S, min == PT5S)|
+
+
+#### IndexSpec
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|bitmap|Object|Compression format for bitmap indexes. Should be a JSON object. See [Bitmap types](#bitmap-types) below for options.|no (defaults to Roaring)|
+|dimensionCompression|String|Compression format for dimension columns. Choose from `LZ4`, `LZF`, or `uncompressed`.|no (default == `LZ4`)|
+|metricCompression|String|Compression format for primitive type metric columns. Choose from `LZ4`, `LZF`, `uncompressed`, or `none`.|no (default == `LZ4`)|
+|longEncoding|String|Encoding format for metric and dimension columns with type long. Choose from `auto` or `longs`. `auto` encodes the values using sequence number or lookup table depending on column cardinality, and store them with variable size. `longs` stores the value as is with 8 bytes each.|no (default == `longs`)|
+
+##### Bitmap types
+
+For Roaring bitmaps:
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`type`|String|Must be `roaring`.|yes|
+
+For Concise bitmaps:
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`type`|String|Must be `concise`.|yes|
+
+#### SegmentWriteOutMediumFactory
+
+|Field|Type|Description|Required|
+|-----|----|-----------|--------|
+|`type`|String|See [Additional Peon Configuration: SegmentWriteOutMediumFactory](../configuration/index.md#segmentwriteoutmediumfactory) for explanation and available options.|yes|
+
+
+
+## Operations
+
+This section describes how some supervisor APIs work in the Rabbit Stream Indexing Service.
+For all supervisor APIs, check [Supervisor APIs](../api-reference/supervisor-api.md).
+
+### RabbitMQ Authentication
+
+To authenticate with RabbitMQ securely, you must provide a username and password, as well as configure
+a certificate if you aren't using a standard certificate provider.
+
+In order to configure these, use the dynamic configuration provider of the ioConfig
+```
+  "ioConfig": {
+    "type": "rabbit",
+    "stream": "api-audit",
+    "uri": "rabbitmq-stream://localhost:5552",
+    "taskCount": 1,
+    "replicas": 1,
+    "taskDuration": "PT1H",
+    "consumerProperties": {
+        "druid.dynamic.config.provider" : {
+            "type": "environment",
+            "variables": {
+                "username": "RABBIT_USERNAME",
+                "password": "RABBIT_PASSWORD"
+            }
+        }
+    }
+  },
+  ```

--- a/extensions-contrib/rabbit-stream-indexing-service/pom.xml
+++ b/extensions-contrib/rabbit-stream-indexing-service/pom.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRA NTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.druid.extensions.contrib</groupId>
+  <artifactId>druid-rabbit-indexing-service</artifactId>
+  <name>druid-rabbit-indexing-service</name>
+  <description>druid-rabbit-indexing-service</description>
+
+  <parent>
+    <groupId>org.apache.druid</groupId>
+    <artifactId>druid</artifactId>
+    <version>30.0.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty</artifactId>
+      <version>3.10.6.Final</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rabbitmq</groupId>
+      <artifactId>stream-client</artifactId>
+      <version>0.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>2.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-processing</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-server</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.druid</groupId>
+      <artifactId>druid-indexing-service</artifactId>
+      <version>${project.parent.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/IncrementalPublishingRabbitStreamIndexTaskRunner.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/IncrementalPublishingRabbitStreamIndexTaskRunner.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.data.input.impl.InputRowParser;
+import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.seekablestream.SeekableStreamDataSourceMetadata;
+import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
+import org.apache.druid.indexing.seekablestream.SeekableStreamSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SequenceMetadata;
+import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
+import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
+import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
+import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.server.security.AuthorizerMapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * RabbitStream indexing task runner supporting incremental segments publishing
+ */
+public class IncrementalPublishingRabbitStreamIndexTaskRunner
+    extends SeekableStreamIndexTaskRunner<String, Long, ByteEntity>
+{
+  private static final EmittingLogger log = new EmittingLogger(IncrementalPublishingRabbitStreamIndexTaskRunner.class);
+  private final RabbitStreamIndexTask task;
+
+  IncrementalPublishingRabbitStreamIndexTaskRunner(
+      RabbitStreamIndexTask task,
+      @Nullable InputRowParser<ByteBuffer> parser,
+      AuthorizerMapper authorizerMapper,
+      LockGranularity lockGranularityToUse)
+  {
+    super(
+        task,
+        parser,
+        authorizerMapper,
+        lockGranularityToUse);
+    this.task = task;
+  }
+
+  @Override
+  protected Long getNextStartOffset(@NotNull Long sequenceNumber)
+  {
+    return sequenceNumber + 1;
+  }
+
+  @Nonnull
+  @Override
+  protected List<OrderedPartitionableRecord<String, Long, ByteEntity>> getRecords(
+      RecordSupplier<String, Long, ByteEntity> recordSupplier,
+      TaskToolbox toolbox)
+  {
+    return recordSupplier.poll(task.getIOConfig().getPollTimeout());
+  }
+
+  @Override
+  protected SeekableStreamEndSequenceNumbers<String, Long> deserializePartitionsFromMetadata(
+      ObjectMapper mapper,
+      Object object)
+  {
+    return mapper.convertValue(object, mapper.getTypeFactory().constructParametrizedType(
+        SeekableStreamEndSequenceNumbers.class,
+        SeekableStreamEndSequenceNumbers.class,
+        String.class,
+        Long.class));
+  }
+
+  @Override
+  protected SeekableStreamDataSourceMetadata<String, Long> createDataSourceMetadata(
+      SeekableStreamSequenceNumbers<String, Long> partitions)
+  {
+    return new RabbitStreamDataSourceMetadata(partitions);
+  }
+
+  @Override
+  protected OrderedSequenceNumber<Long> createSequenceNumber(Long sequenceNumber)
+  {
+    return RabbitSequenceNumber.of(sequenceNumber);
+  }
+
+  @Override
+  protected void possiblyResetDataSourceMetadata(
+      TaskToolbox toolbox,
+      RecordSupplier<String, Long, ByteEntity> recordSupplier,
+      Set<StreamPartition<String>> assignment)
+  {
+    // do nothing
+  }
+
+  @Override
+  protected boolean isEndOffsetExclusive()
+  {
+    return true;
+  }
+
+  @Override
+  protected boolean isEndOfShard(Long seqNum)
+  {
+    return false;
+  }
+
+  @Override
+  public TypeReference<List<SequenceMetadata<String, Long>>> getSequenceMetadataTypeReference()
+  {
+    return new TypeReference<List<SequenceMetadata<String, Long>>>() {
+    };
+  }
+
+  @Nullable
+  @Override
+  protected TreeMap<Integer, Map<String, Long>> getCheckPointsFromContext(
+      TaskToolbox toolbox,
+      String checkpointsString) throws IOException
+  {
+    if (checkpointsString != null) {
+      log.debug("Got checkpoints from task context[%s].", checkpointsString);
+      return toolbox.getJsonMapper().readValue(
+          checkpointsString,
+          new TypeReference<TreeMap<Integer, Map<String, Long>>>() {
+          });
+    } else {
+      return null;
+    }
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitSequenceNumber.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitSequenceNumber.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
+
+import javax.validation.constraints.NotNull;
+
+// OrderedSequenceNumber.equals() should be used instead.
+@SuppressWarnings("ComparableImplementedButEqualsNotOverridden")
+public class RabbitSequenceNumber extends OrderedSequenceNumber<Long>
+{
+  private RabbitSequenceNumber(Long sequenceNumber)
+  {
+    super(sequenceNumber, false);
+  }
+
+  public static RabbitSequenceNumber of(Long sequenceNumber)
+  {
+    return new RabbitSequenceNumber(sequenceNumber);
+  }
+
+  @Override
+  public int compareTo(
+      @NotNull OrderedSequenceNumber<Long> o)
+  {
+    return this.get().compareTo(o.get());
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamDataSourceMetadata.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamDataSourceMetadata.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.overlord.DataSourceMetadata;
+import org.apache.druid.indexing.seekablestream.SeekableStreamDataSourceMetadata;
+import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamSequenceNumbers;
+
+public class RabbitStreamDataSourceMetadata extends SeekableStreamDataSourceMetadata<String, Long>
+{
+
+  @JsonCreator
+  public RabbitStreamDataSourceMetadata(
+      @JsonProperty("partitions") SeekableStreamSequenceNumbers<String, Long> partitions)
+  {
+    super(partitions);
+  }
+
+  @Override
+  public DataSourceMetadata asStartMetadata()
+  {
+    final SeekableStreamSequenceNumbers<String, Long> sequenceNumbers = getSeekableStreamSequenceNumbers();
+    if (sequenceNumbers instanceof SeekableStreamEndSequenceNumbers) {
+      return createConcreteDataSourceMetaData(
+          ((SeekableStreamEndSequenceNumbers<String, Long>) sequenceNumbers).asStartPartitions(true));
+    } else {
+      return this;
+    }
+  }
+
+  @Override
+  protected SeekableStreamDataSourceMetadata<String, Long> createConcreteDataSourceMetaData(
+      SeekableStreamSequenceNumbers<String, Long> seekableStreamSequenceNumbers)
+  {
+    return new RabbitStreamDataSourceMetadata(seekableStreamSequenceNumbers);
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTask.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.utils.RuntimeInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RabbitStreamIndexTask extends SeekableStreamIndexTask<String, Long, ByteEntity>
+{
+  private static final String TYPE = "index_rabbit";
+  private final ObjectMapper configMapper;
+  // This value can be tuned in some tests
+  private long pollRetryMs = 30000;
+  private RuntimeInfo runtimeInfo;
+
+  @JsonCreator
+  public RabbitStreamIndexTask(
+      @JsonProperty("id") String id,
+      @JsonProperty("resource") TaskResource taskResource,
+      @JsonProperty("dataSchema") DataSchema dataSchema,
+      @JsonProperty("tuningConfig") RabbitStreamIndexTaskTuningConfig tuningConfig,
+      @JsonProperty("ioConfig") RabbitStreamIndexTaskIOConfig ioConfig,
+      @JsonProperty("context") Map<String, Object> context,
+      @JacksonInject ObjectMapper configMapper)
+  {
+    super(
+        getOrMakeId(id, dataSchema.getDataSource(), TYPE),
+        taskResource,
+        dataSchema,
+        tuningConfig,
+        ioConfig,
+        context,
+        getFormattedGroupId(dataSchema.getDataSource(), TYPE));
+    this.configMapper = configMapper;
+
+    Preconditions.checkArgument(
+        ioConfig.getStartSequenceNumbers().getExclusivePartitions().isEmpty(),
+        "All startSequenceNumbers must be inclusive");
+  }
+
+  long getPollRetryMs()
+  {
+    return pollRetryMs;
+  }
+
+  @Override
+  public TaskStatus runTask(TaskToolbox toolbox)
+  {
+    this.runtimeInfo = toolbox.getAdjustedRuntimeInfo();
+    return super.runTask(toolbox);
+  }
+
+  @Override
+  protected SeekableStreamIndexTaskRunner<String, Long, ByteEntity> createTaskRunner()
+  {
+    // noinspection unchecked
+    return new IncrementalPublishingRabbitStreamIndexTaskRunner(
+        this,
+        dataSchema.getParser(),
+        authorizerMapper,
+        lockGranularityToUse);
+  }
+
+  @Override
+  protected RabbitStreamRecordSupplier newTaskRecordSupplier()
+  {
+
+    RabbitStreamIndexTaskIOConfig ioConfig = ((RabbitStreamIndexTaskIOConfig) super.ioConfig);
+    RabbitStreamIndexTaskTuningConfig tuningConfig = ((RabbitStreamIndexTaskTuningConfig) super.tuningConfig);
+    final Map<String, Object> props = new HashMap<>(ioConfig.getConsumerProperties());
+
+    final int recordBufferSize =
+        tuningConfig.getRecordBufferSizeOrDefault(runtimeInfo.getMaxHeapSizeBytes());
+    final int maxRecordsPerPoll = tuningConfig.getMaxRecordsPerPollOrDefault();
+
+
+    return new RabbitStreamRecordSupplier(
+      props,
+      configMapper,
+      ioConfig.getUri(),
+      recordBufferSize,
+      tuningConfig.getRecordBufferOfferTimeout(),
+      maxRecordsPerPoll
+      );
+  }
+
+  @Override
+  @JsonProperty
+  public RabbitStreamIndexTaskTuningConfig getTuningConfig()
+  {
+    return (RabbitStreamIndexTaskTuningConfig) super.getTuningConfig();
+  }
+
+  @VisibleForTesting
+  void setPollRetryMs(long retryMs)
+  {
+    this.pollRetryMs = retryMs;
+  }
+
+  @Override
+  @JsonProperty("ioConfig")
+  public RabbitStreamIndexTaskIOConfig getIOConfig()
+  {
+    return (RabbitStreamIndexTaskIOConfig) super.getIOConfig();
+  }
+
+  @Override
+  public String getType()
+  {
+    return TYPE;
+  }
+
+  @Override
+  public boolean supportsQueries()
+  {
+    return true;
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskClientFactory.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskClientFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.annotations.EscalatedGlobal;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClientFactory;
+import org.apache.druid.rpc.ServiceClientFactory;
+
+@LazySingleton
+public class RabbitStreamIndexTaskClientFactory extends SeekableStreamIndexTaskClientFactory<String, Long>
+{
+  @Inject
+  public RabbitStreamIndexTaskClientFactory(
+      @EscalatedGlobal ServiceClientFactory serviceClientFactory,
+      @Json ObjectMapper mapper)
+  {
+    super(serviceClientFactory, mapper);
+  }
+
+  @Override
+  public Class<String> getPartitionType()
+  {
+    return String.class;
+  }
+
+  @Override
+  public Class<Long> getSequenceType()
+  {
+    return Long.class;
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfig.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfig.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorIOConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class RabbitStreamIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<String, Long>
+{
+  private final long pollTimeout;
+  private final String uri;
+  private final Map<String, Object> consumerProperties;
+
+  @JsonCreator
+  public RabbitStreamIndexTaskIOConfig(
+      @JsonProperty("taskGroupId") @Nullable Integer taskGroupId, // can be null
+                                                                  // for
+                                                                  // backward
+                                                                  // compabitility
+      @JsonProperty("baseSequenceName") String baseSequenceName,
+      @JsonProperty("startSequenceNumbers") SeekableStreamStartSequenceNumbers<String, Long> startSequenceNumbers,
+      @JsonProperty("endSequenceNumbers") SeekableStreamEndSequenceNumbers<String, Long> endSequenceNumbers,
+      @JsonProperty("consumerProperties") Map<String, Object> consumerProperties,
+      @JsonProperty("pollTimeout") Long pollTimeout,
+      @JsonProperty("useTransaction") Boolean useTransaction,
+      @JsonProperty("minimumMessageTime") DateTime minimumMessageTime,
+      @JsonProperty("maximumMessageTime") DateTime maximumMessageTime,
+      @JsonProperty("inputFormat") @Nullable InputFormat inputFormat,
+      @JsonProperty("uri") String uri)
+  {
+    super(
+        taskGroupId,
+        baseSequenceName,
+        startSequenceNumbers,
+        endSequenceNumbers,
+        useTransaction,
+        minimumMessageTime,
+        maximumMessageTime,
+        inputFormat);
+
+    this.pollTimeout = pollTimeout != null ? pollTimeout : RabbitStreamSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS;
+    this.uri = uri;
+
+    this.consumerProperties = consumerProperties;
+
+    final SeekableStreamEndSequenceNumbers<String, Long> myEndSequenceNumbers = getEndSequenceNumbers();
+    for (String partition : myEndSequenceNumbers.getPartitionSequenceNumberMap().keySet()) {
+      Preconditions.checkArgument(
+          myEndSequenceNumbers.getPartitionSequenceNumberMap()
+              .get(partition)
+              .compareTo(getStartSequenceNumbers().getPartitionSequenceNumberMap().get(partition)) >= 0,
+          "end offset must be >= start offset for partition[%s]",
+          partition);
+    }
+  }
+
+  @JsonProperty
+  public Map<String, Object> getConsumerProperties()
+  {
+    return consumerProperties;
+  }
+
+  @JsonProperty
+  public long getPollTimeout()
+  {
+    return pollTimeout;
+  }
+
+  @JsonProperty
+  public String getUri()
+  {
+    return this.uri;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamIndexTaskIOConfig{" +
+        "taskGroupId=" + getTaskGroupId() +
+        ", baseSequenceName='" + getBaseSequenceName() + '\'' +
+        ", startSequenceNumbers=" + getStartSequenceNumbers() +
+        ", endSequenceNumbers=" + getEndSequenceNumbers() +
+        ", consumerProperties=" + consumerProperties +
+        ", pollTimeout=" + pollTimeout +
+        ", useTransaction=" + isUseTransaction() +
+        ", minimumMessageTime=" + getMinimumMessageTime() +
+        ", maximumMessageTime=" + getMaximumMessageTime() +
+        ", uri=" + getUri() +
+        '}';
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskModule.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskModule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorSpec;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorTuningConfig;
+import org.apache.druid.initialization.DruidModule;
+
+import java.util.List;
+
+public class RabbitStreamIndexTaskModule implements DruidModule
+{
+
+  static final String PROPERTY_BASE = "druid.rabbit";
+
+  @Override
+  public List<? extends Module> getJacksonModules()
+  {
+    return ImmutableList.of(
+        new SimpleModule(getClass().getSimpleName())
+            .registerSubtypes(
+                new NamedType(RabbitStreamIndexTask.class, "index_rabbit"),
+                new NamedType(RabbitStreamDataSourceMetadata.class, "rabbit"),
+                new NamedType(RabbitStreamIndexTaskIOConfig.class, "rabbit"),
+                new NamedType(RabbitStreamIndexTaskTuningConfig.class, "RabbitTuningConfig"),
+                new NamedType(RabbitStreamSupervisorTuningConfig.class, "rabbit"),
+                new NamedType(RabbitStreamSupervisorSpec.class, "rabbit"),
+                new NamedType(RabbitStreamSamplerSpec.class, "rabbit")));
+  }
+
+  @Override
+  public void configure(Binder binder)
+  {
+    // Nothing to do.
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfig.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfig.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.primitives.Ints;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.incremental.AppendableIndexSpec;
+import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+
+public class RabbitStreamIndexTaskTuningConfig extends SeekableStreamIndexTaskTuningConfig
+{
+  private static final int DEFAULT_RECORD_BUFFER_OFFER_TIMEOUT = 5000;
+  private static final int DEFAULT_MAX_RECORDS_PER_POLL = 100;
+
+
+  static final int ASSUMED_RECORD_SIZE = 10_000;
+
+  private static final double RECORD_BUFFER_MEMORY_MAX_HEAP_FRACTION = 0.1;
+
+  private static final int MAX_RECORD_BUFFER_MEMORY = 100_000_000;
+
+
+  private final Integer recordBufferSize;
+  private final int recordBufferOfferTimeout;
+
+  private final Integer maxRecordsPerPoll;
+
+  public RabbitStreamIndexTaskTuningConfig(
+      @Nullable AppendableIndexSpec appendableIndexSpec,
+      @Nullable Integer maxRowsInMemory,
+      @Nullable Long maxBytesInMemory,
+      @Nullable Boolean skipBytesInMemoryOverheadCheck,
+      @Nullable Integer maxRowsPerSegment,
+      @Nullable Long maxTotalRows,
+      @Nullable Period intermediatePersistPeriod,
+      @Nullable File basePersistDirectory,
+      @Nullable Integer maxPendingPersists,
+      @Nullable IndexSpec indexSpec,
+      @Nullable IndexSpec indexSpecForIntermediatePersists,
+      @Nullable Boolean reportParseExceptions,
+      @Nullable Long handoffConditionTimeout,
+      @Nullable Boolean resetOffsetAutomatically,
+      @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      @Nullable Period intermediateHandoffPeriod,
+      @Nullable Boolean logParseExceptions,
+      @Nullable Integer maxParseExceptions,
+      @Nullable Integer maxSavedParseExceptions,
+      @Nullable Integer numPersistThreads,
+      @Nullable Integer recordBufferSize,
+      @Nullable Integer recordBufferOfferTimeout,
+      @Nullable Integer maxRecordsPerPoll)
+  {
+    super(
+        appendableIndexSpec,
+        maxRowsInMemory,
+        maxBytesInMemory,
+        skipBytesInMemoryOverheadCheck,
+        maxRowsPerSegment,
+        maxTotalRows,
+        intermediatePersistPeriod,
+        basePersistDirectory,
+        maxPendingPersists,
+        indexSpec,
+        indexSpecForIntermediatePersists,
+        reportParseExceptions,
+        handoffConditionTimeout,
+        resetOffsetAutomatically,
+        false,
+        segmentWriteOutMediumFactory,
+        intermediateHandoffPeriod,
+        logParseExceptions,
+        maxParseExceptions,
+        maxSavedParseExceptions,
+        numPersistThreads
+    );
+
+    this.recordBufferSize = recordBufferSize;
+    this.recordBufferOfferTimeout = recordBufferOfferTimeout == null
+                                    ? DEFAULT_RECORD_BUFFER_OFFER_TIMEOUT
+                                    : recordBufferOfferTimeout;
+    this.maxRecordsPerPoll = maxRecordsPerPoll;
+  }
+
+  @JsonCreator
+  private RabbitStreamIndexTaskTuningConfig(
+      @JsonProperty("appendableIndexSpec") @Nullable AppendableIndexSpec appendableIndexSpec,
+      @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
+      @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
+      @JsonProperty("skipBytesInMemoryOverheadCheck") @Nullable Boolean skipBytesInMemoryOverheadCheck,
+      @JsonProperty("maxRowsPerSegment") @Nullable Integer maxRowsPerSegment,
+      @JsonProperty("maxTotalRows") @Nullable Long maxTotalRows,
+      @JsonProperty("intermediatePersistPeriod") @Nullable Period intermediatePersistPeriod,
+      @JsonProperty("maxPendingPersists") @Nullable Integer maxPendingPersists,
+      @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
+      @JsonProperty("indexSpecForIntermediatePersists") @Nullable IndexSpec indexSpecForIntermediatePersists,
+      @Deprecated @JsonProperty("reportParseExceptions") @Nullable Boolean reportParseExceptions,
+      @JsonProperty("handoffConditionTimeout") @Nullable Long handoffConditionTimeout,
+      @JsonProperty("recordBufferSize") Integer recordBufferSize,
+      @JsonProperty("recordBufferOfferTimeout") Integer recordBufferOfferTimeout,
+      @JsonProperty("resetOffsetAutomatically") @Nullable Boolean resetOffsetAutomatically,
+      @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      @JsonProperty("intermediateHandoffPeriod") @Nullable Period intermediateHandoffPeriod,
+      @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
+      @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
+      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("numPersistThreads") @Nullable Integer numPersistThreads,
+      @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll
+  )
+  {
+    this(
+        appendableIndexSpec,
+        maxRowsInMemory,
+        maxBytesInMemory,
+        skipBytesInMemoryOverheadCheck,
+        maxRowsPerSegment,
+        maxTotalRows,
+        intermediatePersistPeriod,
+        null,
+        maxPendingPersists,
+        indexSpec,
+        indexSpecForIntermediatePersists,
+        reportParseExceptions,
+        handoffConditionTimeout,
+        resetOffsetAutomatically,
+        segmentWriteOutMediumFactory,
+        intermediateHandoffPeriod,
+        logParseExceptions,
+        maxParseExceptions,
+        maxSavedParseExceptions,
+        numPersistThreads,
+        recordBufferSize,
+        recordBufferOfferTimeout,
+        maxRecordsPerPoll);
+  }
+
+  @Nullable
+  @JsonProperty("recordBufferSize")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Integer getRecordBufferSizeConfigured()
+  {
+    return recordBufferSize;
+  }
+
+  @JsonProperty
+  public int getRecordBufferOfferTimeout()
+  {
+    return recordBufferOfferTimeout;
+  }
+
+  @Nullable
+  @JsonProperty("maxRecordsPerPoll")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Integer getMaxRecordsPerPollConfigured()
+  {
+    return maxRecordsPerPoll;
+  }
+
+  public int getRecordBufferSizeOrDefault(final long maxHeapSize)
+  {
+    if (recordBufferSize != null) {
+      return recordBufferSize;
+    } else {
+      final long memoryToUse = Math.min(
+          MAX_RECORD_BUFFER_MEMORY,
+          (long) (maxHeapSize * RECORD_BUFFER_MEMORY_MAX_HEAP_FRACTION)
+      );
+
+      return Ints.checkedCast(Math.max(1, memoryToUse / ASSUMED_RECORD_SIZE));
+    }
+  }
+
+  public int getMaxRecordsPerPollOrDefault()
+  {
+    return (this.maxRecordsPerPoll != null) ? this.maxRecordsPerPoll : DEFAULT_MAX_RECORDS_PER_POLL;
+  }
+
+  @Override
+  public RabbitStreamIndexTaskTuningConfig withBasePersistDirectory(File dir)
+  {
+    return new RabbitStreamIndexTaskTuningConfig(
+        getAppendableIndexSpec(),
+        getMaxRowsInMemory(),
+        getMaxBytesInMemory(),
+        isSkipBytesInMemoryOverheadCheck(),
+        getMaxRowsPerSegment(),
+        getMaxTotalRows(),
+        getIntermediatePersistPeriod(),
+        dir,
+        getMaxPendingPersists(),
+        getIndexSpec(),
+        getIndexSpecForIntermediatePersists(),
+        isReportParseExceptions(),
+        getHandoffConditionTimeout(),
+        isResetOffsetAutomatically(),
+        getSegmentWriteOutMediumFactory(),
+        getIntermediateHandoffPeriod(),
+        isLogParseExceptions(),
+        getMaxParseExceptions(),
+        getMaxSavedParseExceptions(),
+        getNumPersistThreads(),
+        getRecordBufferSizeConfigured(),
+        getRecordBufferOfferTimeout(),
+        getMaxRecordsPerPollConfigured()
+        );
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamIndexTaskTuningConfig{" +
+        "maxRowsInMemory=" + getMaxRowsInMemory() +
+        ", maxRowsPerSegment=" + getMaxRowsPerSegment() +
+        ", maxTotalRows=" + getMaxTotalRows() +
+        ", maxBytesInMemory=" + getMaxBytesInMemory() +
+        ", skipBytesInMemoryOverheadCheck=" + isSkipBytesInMemoryOverheadCheck() +
+        ", intermediatePersistPeriod=" + getIntermediatePersistPeriod() +
+        ", maxPendingPersists=" + getMaxPendingPersists() +
+        ", indexSpec=" + getIndexSpec() +
+        ", indexSpecForIntermediatePersists=" + getIndexSpecForIntermediatePersists() +
+        ", reportParseExceptions=" + isReportParseExceptions() +
+        ", handoffConditionTimeout=" + getHandoffConditionTimeout() +
+        ", resetOffsetAutomatically=" + isResetOffsetAutomatically() +
+        ", segmentWriteOutMediumFactory=" + getSegmentWriteOutMediumFactory() +
+        ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
+        ", logParseExceptions=" + isLogParseExceptions() +
+        ", maxParseExceptions=" + getMaxParseExceptions() +
+        ", maxSavedParseExceptions=" + getMaxSavedParseExceptions() +
+        ", numPersistThreads=" + getNumPersistThreads() +
+        ", maxRecordsPerPole=" + getMaxRecordsPerPollConfigured() +
+        '}';
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplier.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplier.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Queues;
+import com.rabbitmq.stream.Consumer;
+import com.rabbitmq.stream.ConsumerBuilder;
+import com.rabbitmq.stream.Environment;
+import com.rabbitmq.stream.EnvironmentBuilder;
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.MessageHandler;
+import com.rabbitmq.stream.OffsetSpecification;
+import com.rabbitmq.stream.impl.Client;
+import com.rabbitmq.stream.impl.Client.ClientParameters;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorIOConfig;
+import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
+import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
+import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
+import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.metadata.DynamicConfigProvider;
+
+import javax.annotation.Nonnull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class RabbitStreamRecordSupplier implements RecordSupplier<String, Long, ByteEntity>, MessageHandler
+{
+
+  private static final EmittingLogger log = new EmittingLogger(RabbitStreamRecordSupplier.class);
+  private Environment env;
+  private Map<String, ConsumerBuilder> streamBuilders;
+  private boolean closed;
+  private BlockingQueue<OrderedPartitionableRecord<String, Long, ByteEntity>> queue;
+  private String superStream;
+  private String uri;
+  private ObjectMapper mapper;
+
+  private final int recordBufferOfferTimeout;
+  private final int maxRecordsPerPoll;
+  private final int recordBufferSize;
+
+  private final Map<String, OffsetSpecification> offsetMap;
+
+  private List<Consumer> consumers;
+  private boolean isRunning;
+  private Semaphore stateSemaphore;
+
+  private String password;
+  private String username;
+
+  public RabbitStreamRecordSupplier(
+      Map<String, Object> consumerProperties,
+      ObjectMapper mapper,
+      String uri,
+      int recordBufferSize,
+      int recordBufferOfferTimeout,
+      int maxRecordsPerPoll
+  )
+  {
+    this.uri = uri;
+    this.mapper = mapper;
+
+    this.recordBufferSize = recordBufferSize;
+    this.maxRecordsPerPoll = maxRecordsPerPoll;
+
+    this.recordBufferOfferTimeout = recordBufferOfferTimeout;
+
+    // Messages will be added to this queue from multiple threads
+    queue = new LinkedBlockingQueue<>(recordBufferSize);
+
+    offsetMap = new ConcurrentHashMap<>();
+    streamBuilders = new ConcurrentHashMap<>();
+
+    // stateSemaphore protects isRunning and consumers
+    stateSemaphore = new Semaphore(1, true);
+    isRunning = false;
+    consumers = new ArrayList<Consumer>();
+
+    this.password = null;
+    this.username = null;
+    this.env = null;
+
+    if (consumerProperties != null) {
+
+      // Additional DynamicConfigProvider based extensible support for all consumer
+      // properties
+      Object dynamicConfigProviderJson = consumerProperties
+          .get(RabbitStreamSupervisorIOConfig.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY);
+      if (dynamicConfigProviderJson != null) {
+        DynamicConfigProvider dynamicConfigProvider = this.mapper.convertValue(dynamicConfigProviderJson,
+            DynamicConfigProvider.class);
+        Map<String, String> dynamicConfig = dynamicConfigProvider.getConfig();
+        for (Map.Entry<String, String> e : dynamicConfig.entrySet()) {
+          if (e.getKey().equals("password")) {
+            this.password = e.getValue();
+          }
+          if (e.getKey().equals("username")) {
+            this.username = e.getValue();
+          }
+        }
+      }
+    }
+  }
+
+  private void startBackgroundFetch()
+  {
+    try {
+      // aquire uninteruptibly to prevent state corruption issues
+      // on consumers and isRunning
+      stateSemaphore.acquireUninterruptibly();
+      if (this.isRunning != false) {
+        return;
+      }
+      for (Map.Entry<String, ConsumerBuilder> entry : streamBuilders.entrySet()) {
+        consumers.add(
+            entry.getValue().offset(
+                offsetMap.get(entry.getKey())).build());
+      }
+      this.isRunning = true;
+    }
+    finally {
+      stateSemaphore.release();
+    }
+  }
+
+  @VisibleForTesting
+  public int bufferSize()
+  {
+    return queue.size();
+  }
+
+  @VisibleForTesting
+  public boolean isRunning()
+  {
+    return this.isRunning;
+  }
+
+  @VisibleForTesting
+  public OffsetSpecification getOffset(StreamPartition<String> partition)
+  {
+    return this.offsetMap.get(partition.getPartitionId());
+  }
+
+  public void stopBackgroundFetch()
+  {
+    try {
+      stateSemaphore.acquire();
+      try {
+        if (this.isRunning != true) {
+          return;
+        }
+        for (Consumer consumer : consumers) {
+          consumer.close();
+        }
+        this.consumers.clear();
+        this.isRunning = false;
+      }
+      finally {
+        stateSemaphore.release();
+      }
+    }
+    catch (InterruptedException exc) {
+    }
+
+  }
+
+  public EnvironmentBuilder getEnvBuilder()
+  {
+    return Environment.builder();
+  }
+
+  public Environment getRabbitEnvironment()
+  {
+    if (this.env != null) {
+      return this.env;
+    }
+
+    EnvironmentBuilder envBuilder = this.getEnvBuilder().uri(this.uri);
+
+    if (this.password != null) {
+      envBuilder = envBuilder.password(this.password);
+    }
+    if (this.username != null) {
+      envBuilder = envBuilder.username(this.username);
+    }
+
+    this.env = envBuilder.build();
+    return this.env;
+  }
+
+  public static String getStreamFromSubstream(String partionID)
+  {
+    String[] res = partionID.split("-");
+    res = Arrays.copyOf(res, res.length - 1);
+    return String.join("-", res);
+  }
+
+  private void removeOldAssignments(Set<StreamPartition<String>> streamPartitionstoKeep)
+  {
+    Iterator<Map.Entry<String, ConsumerBuilder>> streamBuilderIterator = streamBuilders.entrySet().iterator();
+    while (streamBuilderIterator.hasNext()) {
+      Map.Entry<String, ConsumerBuilder> entry = streamBuilderIterator.next();
+      StreamPartition<String> comparitor = new StreamPartition<String>(getStreamFromSubstream(entry.getKey()), entry.getKey());
+      if (!streamPartitionstoKeep.contains(comparitor)) {
+        streamBuilderIterator.remove();
+      }
+    }
+
+    Iterator<Map.Entry<String, OffsetSpecification>> offsetIterator = offsetMap.entrySet().iterator();
+    while (offsetIterator.hasNext()) {
+      Map.Entry<String, OffsetSpecification> entry = offsetIterator.next();
+      StreamPartition<String> comparitor = new StreamPartition<String>(getStreamFromSubstream(entry.getKey()), entry.getKey());
+      if (!streamPartitionstoKeep.contains(comparitor)) {
+        offsetIterator.remove();
+      }
+    }
+  }
+
+  @Override
+  public void assign(Set<StreamPartition<String>> streamPartitions)
+  {
+    this.stopBackgroundFetch();
+
+    for (StreamPartition<String> part : streamPartitions) {
+      ConsumerBuilder builder = this.getRabbitEnvironment().consumerBuilder().noTrackingStrategy();
+      builder = builder.stream(part.getPartitionId());
+      builder = builder.messageHandler(this);
+      streamBuilders.put(part.getPartitionId(), builder);
+      this.superStream = part.getStream();
+    }
+
+    removeOldAssignments(streamPartitions);
+
+
+  }
+
+  private void filterBufferAndResetBackgroundFetch(Set<StreamPartition<String>> partitions)
+  {
+    this.stopBackgroundFetch();
+    // filter records in buffer and only retain ones whose partition was not seeked
+    BlockingQueue<OrderedPartitionableRecord<String, Long, ByteEntity>> newQ = new LinkedBlockingQueue<>(
+        recordBufferSize);
+
+    queue.stream()
+        .filter(x -> !streamBuilders.containsKey(x.getPartitionId()))
+        .forEachOrdered(newQ::offer);
+
+    queue = newQ;
+  }
+
+  @Override
+  public void seek(StreamPartition<String> partition, Long sequenceNumber)
+  {
+    filterBufferAndResetBackgroundFetch(ImmutableSet.of(partition));
+    offsetMap.put(partition.getPartitionId(), OffsetSpecification.offset(sequenceNumber));
+  }
+
+  @Override
+  public void seekToEarliest(Set<StreamPartition<String>> partitions)
+  {
+    filterBufferAndResetBackgroundFetch(partitions);
+    for (StreamPartition<String> part : partitions) {
+      offsetMap.put(part.getPartitionId(), OffsetSpecification.first());
+    }
+  }
+
+  @Override
+  public void seekToLatest(Set<StreamPartition<String>> partitions)
+  {
+    filterBufferAndResetBackgroundFetch(partitions);
+    for (StreamPartition<String> part : partitions) {
+      offsetMap.put(part.getPartitionId(), OffsetSpecification.last());
+    }
+  }
+
+  @Override
+  public Set<StreamPartition<String>> getAssignment()
+  {
+    return streamBuilders.keySet().stream().map(e -> StreamPartition.of(this.superStream, e))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * handle can be called from any consumer, so it must be
+   * as short as possible and thread safe
+   */
+  @Override
+  public void handle(MessageHandler.Context context, Message message)
+  {
+
+    OrderedPartitionableRecord<String, Long, ByteEntity> currRecord;
+    currRecord = new OrderedPartitionableRecord<>(
+        this.superStream,
+        context.stream(),
+        context.offset(),
+        ImmutableList.of(new ByteEntity(message.getBodyAsBinary())));
+
+    try {
+      if (!queue.offer(
+          currRecord,
+          this.recordBufferOfferTimeout,
+          TimeUnit.MILLISECONDS)) {
+        log.warn("Message not accepted, message buffer full");
+        stopBackgroundFetch();
+      } else {
+        this.offsetMap.put(context.stream(), OffsetSpecification.offset(context.offset() + 1));
+      }
+    }
+    catch (InterruptedException e) {
+      // may happen if interrupted while BlockingQueue.offer() is waiting
+      log.warn(
+          e,
+          "Interrupted while waiting to add record to buffer");
+      stopBackgroundFetch();
+    }
+
+  }
+
+  /**
+   * optionalStartBackgroundFetch ensures that a background fetch is running
+   * if this.queue is running low on records. We want to minimize thrashing
+   * around starting/stopping the consumers.
+   */
+  public void optionalStartBackgroundFetch()
+  {
+    if (this.queue.size() < Math.min(this.maxRecordsPerPoll * 2, recordBufferSize / 2)) {
+      this.startBackgroundFetch();
+    }
+  }
+
+  @Nonnull
+  @Override
+  public List<OrderedPartitionableRecord<String, Long, ByteEntity>> poll(long timeout)
+  {
+    this.optionalStartBackgroundFetch();
+
+    try {
+      int expectedSize = Math.min(Math.max(queue.size(), 1), maxRecordsPerPoll);
+
+      List<OrderedPartitionableRecord<String, Long, ByteEntity>> polledRecords = new ArrayList<>(expectedSize);
+
+      Queues.drain(
+          queue,
+          polledRecords,
+          expectedSize,
+          timeout,
+          TimeUnit.MILLISECONDS);
+
+      polledRecords = polledRecords.stream()
+          .filter(x -> streamBuilders.containsKey(x.getPartitionId()))
+          .collect(Collectors.toList());
+
+      return polledRecords;
+    }
+    catch (InterruptedException e) {
+      log.warn(e, "Interrupted while polling");
+
+      return Collections.emptyList();
+    }
+  }
+
+  @Override
+  public Long getEarliestSequenceNumber(StreamPartition<String> partition)
+  {
+    return this.getRabbitEnvironment().queryStreamStats(partition.getPartitionId()).firstOffset();
+  }
+
+  @Override
+  public Long getLatestSequenceNumber(StreamPartition<String> partition)
+  {
+    return this.getRabbitEnvironment().queryStreamStats(partition.getPartitionId()).committedChunkId();
+  }
+
+  @Override
+  public boolean isOffsetAvailable(StreamPartition<String> partition, OrderedSequenceNumber<Long> offset)
+  {
+    final Long earliestOffset = getEarliestSequenceNumber(partition);
+    return earliestOffset != null
+        && offset.isAvailableWithEarliest(RabbitSequenceNumber.of(earliestOffset));
+  }
+
+  @Override
+  public Long getPosition(StreamPartition<String> partition)
+  {
+    throw new UnsupportedOperationException("getPosition() is not supported in RabbitMQ streams");
+  }
+
+
+  public ClientParameters getParameters()
+  {
+    return new ClientParameters();
+  }
+
+  public Client getClient(ClientParameters parameters)
+  {
+    return new Client(parameters);
+  }
+
+  @Override
+  public Set<String> getPartitionIds(String stream)
+  {
+    ClientParameters parameters = getParameters();
+
+    try {
+      URI parsedURI = new URI(uri);
+      parameters.host(parsedURI.getHost());
+
+      if (parsedURI.getPort() != -1) {
+        parameters.port(parsedURI.getPort());
+      }
+
+      if (this.password != null) {
+        parameters.password(password);
+      }
+
+      if (this.username != null) {
+        parameters.username(username);
+      }
+
+      Client client = getClient(parameters);
+
+      List<String> partitions = client.partitions(stream);
+      client.close();
+      return new HashSet<>(partitions);
+    }
+    catch (URISyntaxException e) {
+      throw new IllegalArgumentException("error on uri" + uri);
+    }
+    catch (Exception e) {
+      throw e;
+    }
+  }
+
+  @Override
+  public void close()
+  {
+    if (closed) {
+      return;
+    }
+    this.stopBackgroundFetch();
+    closed = true;
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamSamplerSpec.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/RabbitStreamSamplerSpec.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.overlord.sampler.InputSourceSampler;
+import org.apache.druid.indexing.overlord.sampler.SamplerConfig;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorIOConfig;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorSpec;
+import org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisorTuningConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamSamplerSpec;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RabbitStreamSamplerSpec extends SeekableStreamSamplerSpec<String, Long, ByteEntity>
+{
+  private final ObjectMapper objectMapper;
+
+  @JsonCreator
+  public RabbitStreamSamplerSpec(
+      @JsonProperty("spec") final RabbitStreamSupervisorSpec ingestionSpec,
+      @JsonProperty("samplerConfig") @Nullable final SamplerConfig samplerConfig,
+      @JacksonInject InputSourceSampler inputSourceSampler,
+      @JacksonInject ObjectMapper objectMapper)
+  {
+    super(ingestionSpec, samplerConfig, inputSourceSampler);
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected RabbitStreamRecordSupplier createRecordSupplier()
+  {
+    RabbitStreamSupervisorIOConfig ioConfig = (RabbitStreamSupervisorIOConfig) RabbitStreamSamplerSpec.this.ioConfig;
+    final Map<String, Object> props = new HashMap<>(((RabbitStreamSupervisorIOConfig) ioConfig).getConsumerProperties());
+
+    RabbitStreamSupervisorTuningConfig tuningConfig = ((RabbitStreamSupervisorTuningConfig) RabbitStreamSamplerSpec.this.tuningConfig);
+
+
+    return new RabbitStreamRecordSupplier(
+      props,
+      objectMapper,
+      ioConfig.getUri(),
+      tuningConfig.getRecordBufferSizeOrDefault(Runtime.getRuntime().maxMemory()),
+      tuningConfig.getRecordBufferOfferTimeout(),
+      tuningConfig.getMaxRecordsPerPollOrDefault()
+    );
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.druid.common.utils.IdUtils;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.overlord.DataSourceMetadata;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
+import org.apache.druid.indexing.rabbitstream.RabbitSequenceNumber;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamDataSourceMetadata;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTask;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskClientFactory;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskIOConfig;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskTuningConfig;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamRecordSupplier;
+import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningConfig;
+import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
+import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
+import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
+import org.apache.druid.indexing.seekablestream.common.StreamException;
+import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
+import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Supervisor responsible for managing the RabbitStreamIndexTasks for a single
+ * dataSource. At a high level, the class accepts a
+ * {@link RabbitStreamSupervisorSpec} which includes the rabbit super stream and
+ * configuration as well as an ingestion spec which will be used to generate the
+ * indexing tasks. The run loop periodically refreshes its view of the super stream's
+ * partitions and the list of running indexing tasks and ensures that
+ * all partitions are being read from and that there are enough tasks to satisfy
+ * the desired number of replicas. As tasks complete, new tasks are queued to
+ * process the next range of rabbit stream offsets.
+ */
+public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Long, ByteEntity>
+{
+  public static final TypeReference<TreeMap<Integer, Map<String, Long>>> CHECKPOINTS_TYPE_REF = new TypeReference<TreeMap<Integer, Map<String, Long>>>() {
+  };
+
+  private static final EmittingLogger log = new EmittingLogger(RabbitStreamSupervisor.class);
+  private static final Long NOT_SET = -1L;
+  private static final Long END_OF_PARTITION = Long.MAX_VALUE;
+
+  private final ServiceEmitter emitter;
+  private final DruidMonitorSchedulerConfig monitorSchedulerConfig;
+  private volatile Map<String, Long> latestSequenceFromStream;
+
+  private final RabbitStreamSupervisorSpec spec;
+
+  public RabbitStreamSupervisor(
+      final TaskStorage taskStorage,
+      final TaskMaster taskMaster,
+      final IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator,
+      final RabbitStreamIndexTaskClientFactory taskClientFactory,
+      final ObjectMapper mapper,
+      final RabbitStreamSupervisorSpec spec,
+      final RowIngestionMetersFactory rowIngestionMetersFactory)
+  {
+    super(
+        StringUtils.format("RabbitSupervisor-%s", spec.getDataSchema().getDataSource()),
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        taskClientFactory,
+        mapper,
+        spec,
+        rowIngestionMetersFactory,
+        false);
+
+    this.spec = spec;
+    this.emitter = spec.getEmitter();
+    this.monitorSchedulerConfig = spec.getMonitorSchedulerConfig();
+  }
+
+  @Override
+  protected RecordSupplier<String, Long, ByteEntity> setupRecordSupplier()
+  {
+    RabbitStreamIndexTaskTuningConfig taskTuningConfig = spec.getTuningConfig();
+
+    return new RabbitStreamRecordSupplier(
+      spec.getIoConfig().getConsumerProperties(),
+      sortingMapper,
+      spec.getIoConfig().getUri(),
+      taskTuningConfig.getRecordBufferSizeOrDefault(Runtime.getRuntime().maxMemory()),
+      taskTuningConfig.getRecordBufferOfferTimeout(),
+      taskTuningConfig.getMaxRecordsPerPollOrDefault()      
+      );
+  }
+
+  @Override
+  protected int getTaskGroupIdForPartition(String partitionId)
+  {
+    return partitionId.hashCode() % spec.getIoConfig().getTaskCount();
+  }
+
+  @Override
+  protected boolean checkSourceMetadataMatch(DataSourceMetadata metadata)
+  {
+    return metadata instanceof RabbitStreamDataSourceMetadata;
+  }
+
+  @Override
+  protected boolean doesTaskTypeMatchSupervisor(Task task)
+  {
+    return task instanceof RabbitStreamIndexTask;
+  }
+
+  @Override
+  protected SeekableStreamSupervisorReportPayload<String, Long> createReportPayload(
+      int numPartitions,
+      boolean includeOffsets)
+  {
+    RabbitStreamSupervisorIOConfig ioConfig = spec.getIoConfig();
+    Map<String, Long> partitionLag = getRecordLagPerPartitionInLatestSequences(getHighestCurrentOffsets());
+    return new RabbitStreamSupervisorReportPayload(
+        spec.getDataSchema().getDataSource(),
+        ioConfig.getStream(),
+        numPartitions,
+        ioConfig.getReplicas(),
+        ioConfig.getTaskDuration().getMillis() / 1000,
+        includeOffsets ? latestSequenceFromStream : null,
+        includeOffsets ? partitionLag : null,
+        includeOffsets ? partitionLag.values().stream().mapToLong(x -> Math.max(x, 0)).sum() : null,
+        includeOffsets ? sequenceLastUpdated : null,
+        spec.isSuspended(),
+        stateManager.isHealthy(),
+        stateManager.getSupervisorState().getBasicState(),
+        stateManager.getSupervisorState(),
+        stateManager.getExceptionEvents());
+  }
+
+  @Override
+  protected SeekableStreamIndexTaskIOConfig createTaskIoConfig(
+      int groupId,
+      Map<String, Long> startPartitions,
+      Map<String, Long> endPartitions,
+      String baseSequenceName,
+      DateTime minimumMessageTime,
+      DateTime maximumMessageTime,
+      Set<String> exclusiveStartSequenceNumberPartitions,
+      SeekableStreamSupervisorIOConfig ioConfig)
+  {
+    RabbitStreamSupervisorIOConfig rabbitConfig = (RabbitStreamSupervisorIOConfig) ioConfig;
+    return new RabbitStreamIndexTaskIOConfig(
+        groupId,
+        baseSequenceName,
+        new SeekableStreamStartSequenceNumbers<>(ioConfig.getStream(), startPartitions, Collections.emptySet()),
+        new SeekableStreamEndSequenceNumbers<>(ioConfig.getStream(), endPartitions),
+        rabbitConfig.getConsumerProperties(),
+        rabbitConfig.getPollTimeout(),
+        true,
+        minimumMessageTime,
+        maximumMessageTime,
+        ioConfig.getInputFormat(),
+        rabbitConfig.getUri());
+  }
+
+  @Override
+  protected List<SeekableStreamIndexTask<String, Long, ByteEntity>> createIndexTasks(
+      int replicas,
+      String baseSequenceName,
+      ObjectMapper sortingMapper,
+      TreeMap<Integer, Map<String, Long>> sequenceOffsets,
+      SeekableStreamIndexTaskIOConfig taskIoConfig,
+      SeekableStreamIndexTaskTuningConfig taskTuningConfig,
+      RowIngestionMetersFactory rowIngestionMetersFactory) throws JsonProcessingException
+  {
+    final String checkpoints = sortingMapper.writerFor(CHECKPOINTS_TYPE_REF).writeValueAsString(sequenceOffsets);
+    final Map<String, Object> context = createBaseTaskContexts();
+    context.put(CHECKPOINTS_CTX_KEY, checkpoints);
+
+    List<SeekableStreamIndexTask<String, Long, ByteEntity>> taskList = new ArrayList<>();
+    for (int i = 0; i < replicas; i++) {
+      String taskId = IdUtils.getRandomIdWithPrefix(baseSequenceName);
+      taskList.add(new RabbitStreamIndexTask(
+          taskId,
+          new TaskResource(baseSequenceName, 1),
+          spec.getDataSchema(),
+          (RabbitStreamIndexTaskTuningConfig) taskTuningConfig,
+          (RabbitStreamIndexTaskIOConfig) taskIoConfig,
+          context,
+          sortingMapper));
+    }
+    return taskList;
+  }
+
+  @Override
+  protected Map<String, Long> getPartitionRecordLag()
+  {
+    Map<String, Long> highestCurrentOffsets = getHighestCurrentOffsets();
+
+    if (latestSequenceFromStream == null) {
+      return null;
+    }
+
+    if (!latestSequenceFromStream.keySet().equals(highestCurrentOffsets.keySet())) {
+      log.warn(
+          "Lag metric: rabbit partitions %s do not match task partitions %s",
+          latestSequenceFromStream.keySet(),
+          highestCurrentOffsets.keySet());
+    }
+
+    return getRecordLagPerPartitionInLatestSequences(highestCurrentOffsets);
+  }
+
+  @Nullable
+  @Override
+  protected Map<String, Long> getPartitionTimeLag()
+  {
+    // time lag not currently support with rabbit
+    return null;
+  }
+
+  // suppress use of CollectionUtils.mapValues() since the valueMapper function
+  // is
+  // dependent on map key here
+  @SuppressWarnings("SSBasedInspection")
+  // Used while calculating cummulative lag for entire stream
+  private Map<String, Long> getRecordLagPerPartitionInLatestSequences(Map<String, Long> currentOffsets)
+  {
+    if (latestSequenceFromStream == null) {
+      return Collections.emptyMap();
+    }
+
+    return latestSequenceFromStream
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                Entry::getKey,
+                e -> e.getValue() != null
+                    ? e.getValue() + 1 - Optional.ofNullable(currentOffsets.get(e.getKey())).orElse(0L)
+                    : 0));
+  }
+
+  @Override
+  // suppress use of CollectionUtils.mapValues() since the valueMapper function
+  // is
+  // dependent on map key here
+  @SuppressWarnings("SSBasedInspection")
+  // Used while generating Supervisor lag reports per task
+  protected Map<String, Long> getRecordLagPerPartition(Map<String, Long> currentOffsets)
+  {
+    if (latestSequenceFromStream == null || currentOffsets == null) {
+      return Collections.emptyMap();
+    }
+
+    return currentOffsets
+        .entrySet()
+        .stream()
+        .filter(e -> latestSequenceFromStream.get(e.getKey()) != null)
+        .collect(
+            Collectors.toMap(
+                Entry::getKey,
+                e -> e.getValue() != null
+                    ? latestSequenceFromStream.get(e.getKey()) + 1 - e.getValue()
+                    : 0));
+  }
+
+  @Override
+  protected Map<String, Long> getTimeLagPerPartition(Map<String, Long> currentOffsets)
+  {
+    return null;
+  }
+
+  @Override
+  protected RabbitStreamDataSourceMetadata createDataSourceMetaDataForReset(String topic, Map<String, Long> map)
+  {
+    return new RabbitStreamDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, map));
+  }
+
+  @Override
+  protected OrderedSequenceNumber<Long> makeSequenceNumber(Long seq, boolean isExclusive)
+  {
+    return RabbitSequenceNumber.of(seq);
+  }
+
+  @Override
+  protected Long getNotSetMarker()
+  {
+    return NOT_SET;
+  }
+
+  @Override
+  protected Long getEndOfPartitionMarker()
+  {
+    return END_OF_PARTITION;
+  }
+
+  @Override
+  protected boolean isEndOfShard(Long seqNum)
+  {
+    return false;
+  }
+
+  @Override
+  protected boolean isShardExpirationMarker(Long seqNum)
+  {
+    return false;
+  }
+
+  @Override
+  protected boolean useExclusiveStartSequenceNumberForNonFirstSequence()
+  {
+    return false;
+  }
+
+  @Override
+  public LagStats computeLagStats()
+  {
+    Map<String, Long> partitionRecordLag = getPartitionRecordLag();
+    if (partitionRecordLag == null) {
+      return new LagStats(0, 0, 0);
+    }
+
+    return computeLags(partitionRecordLag);
+  }
+
+  @Override
+  protected void updatePartitionLagFromStream()
+  {
+    getRecordSupplierLock().lock();
+
+    Set<String> partitionIds;
+    try {
+      partitionIds = recordSupplier.getPartitionIds(getIoConfig().getStream());
+    }
+    catch (Exception e) {
+      log.warn("Could not fetch partitions for topic/stream [%s]", getIoConfig().getStream());
+      getRecordSupplierLock().unlock();
+      throw new StreamException(e);
+    }
+
+    Set<StreamPartition<String>> partitions = partitionIds
+        .stream()
+        .map(e -> new StreamPartition<>(getIoConfig().getStream(), e))
+        .collect(Collectors.toSet());
+
+    latestSequenceFromStream = partitions.stream()
+        .collect(Collectors.toMap(StreamPartition::getPartitionId, recordSupplier::getLatestSequenceNumber));
+
+    getRecordSupplierLock().unlock();
+
+  }
+
+  @Override
+  protected Map<String, Long> getLatestSequencesFromStream()
+  {
+    return latestSequenceFromStream != null ? latestSequenceFromStream : new HashMap<>();
+  }
+
+  @Override
+  protected String baseTaskName()
+  {
+    return "index_rabbit";
+  }
+
+  @Override
+  @VisibleForTesting
+  public RabbitStreamSupervisorIOConfig getIoConfig()
+  {
+    return spec.getIoConfig();
+  }
+
+  @VisibleForTesting
+  public RabbitStreamSupervisorTuningConfig getTuningConfig()
+  {
+    return spec.getTuningConfig();
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfig.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.indexing.seekablestream.supervisor.IdleConfig;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
+import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+public class RabbitStreamSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
+{
+  public static final String DRUID_DYNAMIC_CONFIG_PROVIDER_KEY = "druid.dynamic.config.provider";
+  
+  public static final String USERNAME_KEY = "username";
+  public static final String PASSWORD_KEY = "password";
+
+  private final Map<String, Object> consumerProperties;
+
+  public static final long DEFAULT_POLL_TIMEOUT_MILLIS = 100;
+
+  private final String uri;
+  private final long pollTimeout;
+
+  @JsonCreator
+  public RabbitStreamSupervisorIOConfig(
+      @JsonProperty("stream") String stream,
+      @JsonProperty("uri") String uri,
+      @JsonProperty("inputFormat") InputFormat inputFormat,
+      @JsonProperty("replicas") Integer replicas,
+      @JsonProperty("taskCount") Integer taskCount,
+      @JsonProperty("taskDuration") Period taskDuration,
+      @JsonProperty("consumerProperties") Map<String, Object> consumerProperties,
+      @Nullable @JsonProperty("autoScalerConfig") AutoScalerConfig autoScalerConfig,
+      @JsonProperty("pollTimeout") Long pollTimeout,
+      @JsonProperty("startDelay") Period startDelay,
+      @JsonProperty("period") Period period,
+      @JsonProperty("completionTimeout") Period completionTimeout,
+      @JsonProperty("useEarliestOffset") Boolean useEarliestOffset,
+      @JsonProperty("lateMessageRejectionPeriod") Period lateMessageRejectionPeriod,
+      @JsonProperty("earlyMessageRejectionPeriod") Period earlyMessageRejectionPeriod,
+      @JsonProperty("lateMessageRejectionStartDateTime") DateTime lateMessageRejectionStartDateTime,
+      @JsonProperty("stopTaskCount") Integer stopTaskCount
+  )
+  {
+    super(
+        Preconditions.checkNotNull(stream, "stream"),
+        inputFormat,
+        replicas,
+        taskCount,
+        taskDuration,
+        startDelay,
+        period,
+        useEarliestOffset,
+        completionTimeout,
+        lateMessageRejectionPeriod,
+        earlyMessageRejectionPeriod,
+        autoScalerConfig,
+        lateMessageRejectionStartDateTime,
+        new IdleConfig(null, null),
+        stopTaskCount
+    );
+
+    this.consumerProperties = consumerProperties;
+    Preconditions.checkNotNull(uri, "uri");
+    this.uri = uri;
+
+    this.pollTimeout = pollTimeout != null ? pollTimeout : DEFAULT_POLL_TIMEOUT_MILLIS;
+  }
+
+  @JsonProperty
+  public String getUri()
+  {
+    return this.uri;
+  }
+
+  @JsonProperty
+  public Map<String, Object> getConsumerProperties()
+  {
+    return consumerProperties;
+  }
+
+  @JsonProperty
+  public long getPollTimeout()
+  {
+    return pollTimeout;
+  }
+
+  @JsonProperty
+  public boolean isUseEarliestOffset()
+  {
+    return isUseEarliestSequenceNumber();
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamSupervisorIOConfig{" +
+        "stream='" + getStream() + '\'' +
+        ", replicas=" + getReplicas() +
+        ", uri=" + getUri() +
+        ", taskCount=" + getTaskCount() +
+        ", taskDuration=" + getTaskDuration() +
+        ", autoScalerConfig=" + getAutoScalerConfig() +
+        ", pollTimeout=" + pollTimeout +
+        ", startDelay=" + getStartDelay() +
+        ", period=" + getPeriod() +
+        ", useEarliestOffset=" + isUseEarliestOffset() +
+        ", completionTimeout=" + getCompletionTimeout() +
+        ", earlyMessageRejectionPeriod=" + getEarlyMessageRejectionPeriod() +
+        ", lateMessageRejectionPeriod=" + getLateMessageRejectionPeriod() +
+        ", lateMessageRejectionStartDateTime=" + getLateMessageRejectionStartDateTime() +
+        ", idleConfig=" + getIdleConfig() +
+        '}';
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIngestionSpec.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIngestionSpec.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIngestionSpec;
+import org.apache.druid.segment.indexing.DataSchema;
+
+public class RabbitStreamSupervisorIngestionSpec extends SeekableStreamSupervisorIngestionSpec
+{
+  private final DataSchema dataSchema;
+  private final RabbitStreamSupervisorIOConfig ioConfig;
+  private final RabbitStreamSupervisorTuningConfig tuningConfig;
+
+  @JsonCreator
+  public RabbitStreamSupervisorIngestionSpec(
+      @JsonProperty("dataSchema") DataSchema dataSchema,
+      @JsonProperty("ioConfig") RabbitStreamSupervisorIOConfig ioConfig,
+      @JsonProperty("tuningConfig") RabbitStreamSupervisorTuningConfig tuningConfig)
+  {
+    super(dataSchema, ioConfig, tuningConfig);
+    this.dataSchema = dataSchema;
+    this.ioConfig = ioConfig;
+    this.tuningConfig = tuningConfig == null ? RabbitStreamSupervisorTuningConfig.defaultConfig() : tuningConfig;
+  }
+
+  @Override
+  @JsonProperty("dataSchema")
+  public DataSchema getDataSchema()
+  {
+    return dataSchema;
+  }
+
+  @Override
+  @JsonProperty("ioConfig")
+  public RabbitStreamSupervisorIOConfig getIOConfig()
+  {
+    return ioConfig;
+  }
+
+  @Override
+  @JsonProperty("tuningConfig")
+  public RabbitStreamSupervisorTuningConfig getTuningConfig()
+  {
+    return tuningConfig;
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorReportPayload.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorReportPayload.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManager;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+public class RabbitStreamSupervisorReportPayload extends SeekableStreamSupervisorReportPayload<String, Long>
+{
+  public RabbitStreamSupervisorReportPayload(
+      String dataSource,
+      String stream,
+      int partitions,
+      int replicas,
+      long durationSeconds,
+      @Nullable Map<String, Long> latestOffsets,
+      @Nullable Map<String, Long> minimumLag,
+      @Nullable Long aggregateLag,
+      @Nullable DateTime offsetsLastUpdated,
+      boolean suspended,
+      boolean healthy,
+      SupervisorStateManager.State state,
+      SupervisorStateManager.State detailedState,
+      List<SupervisorStateManager.ExceptionEvent> recentErrors)
+  {
+    super(
+        dataSource,
+        stream,
+        partitions,
+        replicas,
+        durationSeconds,
+        latestOffsets,
+        minimumLag,
+        aggregateLag,
+        null,
+        null,
+        offsetsLastUpdated,
+        suspended,
+        healthy,
+        state,
+        detailedState,
+        recentErrors);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamSupervisorReportPayload{" +
+        "dataSource='" + getDataSource() + '\'' +
+        ", stream='" + getStream() + '\'' +
+        ", partitions=" + getPartitions() +
+        ", replicas=" + getReplicas() +
+        ", durationSeconds=" + getDurationSeconds() +
+        ", active=" + getActiveTasks() +
+        ", publishing=" + getPublishingTasks() +
+        (getLatestOffsets() != null ? ", latestOffsets=" + getLatestOffsets() : "") +
+        (getMinimumLag() != null ? ", minimumLag=" + getMinimumLag() : "") +
+        (getAggregateLag() != null ? ", aggregateLag=" + getAggregateLag() : "") +
+        (getOffsetsLastUpdated() != null ? ", sequenceLastUpdated=" + getOffsetsLastUpdated() : "") +
+        ", suspended=" + isSuspended() +
+        ", healthy=" + isHealthy() +
+        ", state=" + getState() +
+        ", detailedState=" + getDetailedState() +
+        ", recentErrors=" + getRecentErrors() +
+        '}';
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorSpec.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorSpec.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.supervisor.Supervisor;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskClientFactory;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorSpec;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
+import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
+import org.apache.druid.segment.indexing.DataSchema;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+public class RabbitStreamSupervisorSpec extends SeekableStreamSupervisorSpec
+{
+  private static final String TASK_TYPE = "rabbit";
+
+  @JsonCreator
+  public RabbitStreamSupervisorSpec(
+      @JsonProperty("spec") @Nullable RabbitStreamSupervisorIngestionSpec ingestionSchema,
+      @JsonProperty("dataSchema") @Nullable DataSchema dataSchema,
+      @JsonProperty("tuningConfig") @Nullable RabbitStreamSupervisorTuningConfig tuningConfig,
+      @JsonProperty("ioConfig") @Nullable RabbitStreamSupervisorIOConfig ioConfig,
+      @JsonProperty("context") Map<String, Object> context,
+      @JsonProperty("suspended") Boolean suspended,
+      @JacksonInject TaskStorage taskStorage,
+      @JacksonInject TaskMaster taskMaster,
+      @JacksonInject IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator,
+      @JacksonInject RabbitStreamIndexTaskClientFactory rabbitStreamIndexTaskClientFactory,
+      @JacksonInject @Json ObjectMapper mapper,
+      @JacksonInject ServiceEmitter emitter,
+      @JacksonInject DruidMonitorSchedulerConfig monitorSchedulerConfig,
+      @JacksonInject RowIngestionMetersFactory rowIngestionMetersFactory,
+      @JacksonInject SupervisorStateManagerConfig supervisorStateManagerConfig)
+  {
+    super(
+        ingestionSchema != null
+            ? ingestionSchema
+            : new RabbitStreamSupervisorIngestionSpec(
+                dataSchema,
+                ioConfig,
+                tuningConfig != null
+                    ? tuningConfig
+                    : RabbitStreamSupervisorTuningConfig.defaultConfig()),
+        context,
+        suspended,
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        rabbitStreamIndexTaskClientFactory,
+        mapper,
+        emitter,
+        monitorSchedulerConfig,
+        rowIngestionMetersFactory,
+        supervisorStateManagerConfig);
+  }
+
+  @Override
+  public String getType()
+  {
+    return TASK_TYPE;
+  }
+
+  @Override
+  public String getSource()
+  {
+    return getIoConfig() != null ? getIoConfig().getStream() : null;
+  }
+
+  @Override
+  public Supervisor createSupervisor()
+  {
+    return new RabbitStreamSupervisor(
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        (RabbitStreamIndexTaskClientFactory) indexTaskClientFactory,
+        mapper,
+        this,
+        rowIngestionMetersFactory);
+  }
+
+  @Override
+  @Deprecated
+  @JsonProperty
+  public RabbitStreamSupervisorTuningConfig getTuningConfig()
+  {
+    return (RabbitStreamSupervisorTuningConfig) super.getTuningConfig();
+  }
+
+  @Override
+  @Deprecated
+  @JsonProperty
+  public RabbitStreamSupervisorIOConfig getIoConfig()
+  {
+    return (RabbitStreamSupervisorIOConfig) super.getIoConfig();
+  }
+
+  @Override
+  @JsonProperty
+  public RabbitStreamSupervisorIngestionSpec getSpec()
+  {
+    return (RabbitStreamSupervisorIngestionSpec) super.getSpec();
+  }
+
+  @Override
+  protected RabbitStreamSupervisorSpec toggleSuspend(boolean suspend)
+  {
+    return new RabbitStreamSupervisorSpec(
+        getSpec(),
+        getDataSchema(),
+        getTuningConfig(),
+        getIoConfig(),
+        getContext(),
+        suspend,
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        (RabbitStreamIndexTaskClientFactory) indexTaskClientFactory,
+        mapper,
+        emitter,
+        monitorSchedulerConfig,
+        rowIngestionMetersFactory,
+        supervisorStateManagerConfig);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamSupervisorSpec{" +
+        "dataSchema=" + getDataSchema() +
+        ", tuningConfig=" + getTuningConfig() +
+        ", ioConfig=" + getIoConfig() +
+        ", context=" + getContext() +
+        ", suspend=" + isSuspended() +
+        '}';
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfig.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfig.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskTuningConfig;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorTuningConfig;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.incremental.AppendableIndexSpec;
+import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+
+import javax.annotation.Nullable;
+
+public class RabbitStreamSupervisorTuningConfig extends RabbitStreamIndexTaskTuningConfig
+    implements SeekableStreamSupervisorTuningConfig
+{
+  private final Integer workerThreads;
+  private final Boolean chatAsync;
+  private final Integer chatThreads;
+  private final Long chatRetries;
+  private final Duration httpTimeout;
+  private final Duration shutdownTimeout;
+  private final Duration offsetFetchPeriod;
+
+  public static RabbitStreamSupervisorTuningConfig defaultConfig()
+  {
+    return new RabbitStreamSupervisorTuningConfig(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+        );
+  }
+
+  public RabbitStreamSupervisorTuningConfig(
+      @JsonProperty("appendableIndexSpec") @Nullable AppendableIndexSpec appendableIndexSpec,
+      @JsonProperty("maxRowsInMemory") Integer maxRowsInMemory,
+      @JsonProperty("maxBytesInMemory") Long maxBytesInMemory,
+      @JsonProperty("skipBytesInMemoryOverheadCheck") @Nullable Boolean skipBytesInMemoryOverheadCheck,
+      @JsonProperty("maxRowsPerSegment") Integer maxRowsPerSegment,
+      @JsonProperty("maxTotalRows") Long maxTotalRows,
+      @JsonProperty("intermediatePersistPeriod") Period intermediatePersistPeriod,
+      @JsonProperty("maxPendingPersists") Integer maxPendingPersists,
+      @JsonProperty("indexSpec") IndexSpec indexSpec,
+      @JsonProperty("indexSpecForIntermediatePersists") @Nullable IndexSpec indexSpecForIntermediatePersists,
+      @JsonProperty("reportParseExceptions") Boolean reportParseExceptions,
+      @JsonProperty("handoffConditionTimeout") Long handoffConditionTimeout,
+      @JsonProperty("resetOffsetAutomatically") Boolean resetOffsetAutomatically,
+      @JsonProperty("segmentWriteOutMediumFactory") @Nullable SegmentWriteOutMediumFactory segmentWriteOutMediumFactory,
+      @JsonProperty("workerThreads") Integer workerThreads,
+      @JsonProperty("chatAsync") Boolean chatAsync,
+      @JsonProperty("chatThreads") Integer chatThreads,
+      @JsonProperty("chatRetries") Long chatRetries,
+      @JsonProperty("httpTimeout") Period httpTimeout,
+      @JsonProperty("shutdownTimeout") Period shutdownTimeout,
+      @JsonProperty("recordBufferSize") Integer recordBufferSize,
+      @JsonProperty("recordBufferOfferTimeout") Integer recordBufferOfferTimeout,
+      @JsonProperty("offsetFetchPeriod") Period offsetFetchPeriod,
+      @JsonProperty("intermediateHandoffPeriod") Period intermediateHandoffPeriod,
+      @JsonProperty("logParseExceptions") @Nullable Boolean logParseExceptions,
+      @JsonProperty("maxParseExceptions") @Nullable Integer maxParseExceptions,
+      @JsonProperty("numPersistThreads") @Nullable Integer numPersistThreads,
+      @JsonProperty("maxSavedParseExceptions") @Nullable Integer maxSavedParseExceptions,
+      @JsonProperty("maxRecordsPerPoll") @Nullable Integer maxRecordsPerPoll)
+  {
+    super(
+        appendableIndexSpec,
+        maxRowsInMemory,
+        maxBytesInMemory,
+        skipBytesInMemoryOverheadCheck,
+        maxRowsPerSegment,
+        maxTotalRows,
+        intermediatePersistPeriod,
+        null,
+        maxPendingPersists,
+        indexSpec,
+        indexSpecForIntermediatePersists,
+        reportParseExceptions,
+        handoffConditionTimeout,
+        resetOffsetAutomatically,
+        segmentWriteOutMediumFactory,
+        intermediateHandoffPeriod,
+        logParseExceptions,
+        maxParseExceptions,
+        maxSavedParseExceptions,
+        numPersistThreads,
+        recordBufferSize,
+        recordBufferOfferTimeout,
+        maxRecordsPerPoll
+    );
+    this.workerThreads = workerThreads;
+    this.chatAsync = chatAsync;
+    this.chatThreads = chatThreads;
+    this.chatRetries = (chatRetries != null ? chatRetries : DEFAULT_CHAT_RETRIES);
+    this.httpTimeout = SeekableStreamSupervisorTuningConfig.defaultDuration(httpTimeout, DEFAULT_HTTP_TIMEOUT);
+    this.shutdownTimeout = SeekableStreamSupervisorTuningConfig.defaultDuration(
+        shutdownTimeout,
+        DEFAULT_SHUTDOWN_TIMEOUT);
+    this.offsetFetchPeriod = SeekableStreamSupervisorTuningConfig.defaultDuration(
+        offsetFetchPeriod,
+        DEFAULT_OFFSET_FETCH_PERIOD);
+  }
+
+  @Override
+  @JsonProperty
+  public Integer getWorkerThreads()
+  {
+    return workerThreads;
+  }
+
+  @Override
+  @JsonProperty
+  public Long getChatRetries()
+  {
+    return chatRetries;
+  }
+
+  @Override
+  @JsonProperty
+  public Duration getHttpTimeout()
+  {
+    return httpTimeout;
+  }
+
+  @Override
+  @JsonProperty
+  public Duration getShutdownTimeout()
+  {
+    return shutdownTimeout;
+  }
+
+  @Override
+  public Duration getRepartitionTransitionDuration()
+  {
+    // just return a default for now.
+    return SeekableStreamSupervisorTuningConfig.defaultDuration(
+        null,
+        SeekableStreamSupervisorTuningConfig.DEFAULT_REPARTITION_TRANSITION_DURATION);
+  }
+
+  @Override
+  @JsonProperty
+  public Duration getOffsetFetchPeriod()
+  {
+    return offsetFetchPeriod;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RabbitStreamSupervisorTuningConfig{" +
+        "maxRowsInMemory=" + getMaxRowsInMemory() +
+        ", maxRowsPerSegment=" + getMaxRowsPerSegment() +
+        ", maxTotalRows=" + getMaxTotalRows() +
+        ", maxBytesInMemory=" + getMaxBytesInMemoryOrDefault() +
+        ", skipBytesInMemoryOverheadCheck=" + isSkipBytesInMemoryOverheadCheck() +
+        ", intermediatePersistPeriod=" + getIntermediatePersistPeriod() +
+        ", maxPendingPersists=" + getMaxPendingPersists() +
+        ", indexSpec=" + getIndexSpec() +
+        ", reportParseExceptions=" + isReportParseExceptions() +
+        ", handoffConditionTimeout=" + getHandoffConditionTimeout() +
+        ", resetOffsetAutomatically=" + isResetOffsetAutomatically() +
+        ", segmentWriteOutMediumFactory=" + getSegmentWriteOutMediumFactory() +
+        ", workerThreads=" + workerThreads +
+        ", chatThreads=" + chatThreads +
+        ", chatRetries=" + chatRetries +
+        ", httpTimeout=" + httpTimeout +
+        ", shutdownTimeout=" + shutdownTimeout +
+        ", recordBufferSize=" + getRecordBufferSizeConfigured() +
+        ", recordBufferOfferTimeout=" + getRecordBufferOfferTimeout() +
+        ", offsetFetchPeriod=" + offsetFetchPeriod +
+        ", intermediateHandoffPeriod=" + getIntermediateHandoffPeriod() +
+        ", logParseExceptions=" + isLogParseExceptions() +
+        ", maxParseExceptions=" + getMaxParseExceptions() +
+        ", maxSavedParseExceptions=" + getMaxSavedParseExceptions() +
+        ", numPersistThreads=" + getNumPersistThreads() +
+        ", maxRecordsPerPoll=" + getMaxRecordsPerPollConfigured() +
+        '}';
+  }
+
+  @Override
+  public RabbitStreamIndexTaskTuningConfig convertToTaskTuningConfig()
+  {
+    return new RabbitStreamIndexTaskTuningConfig(
+        getAppendableIndexSpec(),
+        getMaxRowsInMemory(),
+        getMaxBytesInMemory(),
+        isSkipBytesInMemoryOverheadCheck(),
+        getMaxRowsPerSegment(),
+        getMaxTotalRows(),
+        getIntermediatePersistPeriod(),
+        null,
+        getMaxPendingPersists(),
+        getIndexSpec(),
+        getIndexSpecForIntermediatePersists(),
+        isReportParseExceptions(),
+        getHandoffConditionTimeout(),
+        isResetOffsetAutomatically(),
+        getSegmentWriteOutMediumFactory(),
+        getIntermediateHandoffPeriod(),
+        isLogParseExceptions(),
+        getMaxParseExceptions(),
+        getMaxSavedParseExceptions(),
+        getRecordBufferSizeConfigured(),
+        getRecordBufferOfferTimeout(),
+        getMaxRecordsPerPollConfigured(),
+        getNumPersistThreads()
+        );
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskModule

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfigTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.segment.indexing.IOConfig;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+
+public class RabbitStreamIndexTaskIOConfigTest
+{
+  private final ObjectMapper mapper;
+
+  public RabbitStreamIndexTaskIOConfigTest()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
+  }
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"baseSequenceName\": \"my-sequence-name\",\n"
+        + "  \"uri\": \"rabbitmq-stream://localhost:5552\",\n"
+        + "  \"startSequenceNumbers\": {\"type\":\"start\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"stream-0\":1, \"stream-1\":10}},\n"
+        + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"stream-0\":15, \"stream-1\":200}}\n"
+        + "}";
+
+    RabbitStreamIndexTaskIOConfig config = (RabbitStreamIndexTaskIOConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                IOConfig.class)),
+        IOConfig.class);
+
+    Assert.assertNull(config.getTaskGroupId());
+    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
+
+    Assert.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
+
+    Assert.assertEquals(Long.class,
+        config.getStartSequenceNumbers().getPartitionSequenceNumberMap().get("stream-1").getClass());
+    Assert.assertEquals(
+        ImmutableMap.of("stream-0", Long.valueOf(1), "stream-1", Long.valueOf(10)),
+        config.getStartSequenceNumbers().getPartitionSequenceNumberMap());
+
+    Assert.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
+
+    Assert.assertEquals(
+        ImmutableMap.of("stream-0", Long.valueOf(15L), "stream-1", Long.valueOf(200L)),
+        config.getEndSequenceNumbers().getPartitionSequenceNumberMap());
+
+    Assert.assertTrue(config.isUseTransaction());
+    Assert.assertFalse("minimumMessageTime", config.getMinimumMessageTime().isPresent());
+    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfigTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
+import org.apache.druid.segment.indexing.TuningConfig;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.Duration;
+
+public class RabbitStreamIndexTaskTuningConfigTest
+{
+  private final ObjectMapper mapper;
+
+  public RabbitStreamIndexTaskTuningConfigTest()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
+  }
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\"type\": \"rabbit\"}";
+
+    RabbitStreamIndexTaskTuningConfig config = (RabbitStreamIndexTaskTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class)),
+        TuningConfig.class);
+
+    Assert.assertNull(config.getBasePersistDirectory());
+    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assert.assertEquals(150000, config.getMaxRowsInMemory());
+    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(0, config.getMaxPendingPersists());
+    // Assert.assertEquals(IndexSpec.DEFAULT, config.getIndexSpec());
+    Assert.assertEquals(false, config.isReportParseExceptions());
+    Assert.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+
+    Assert.assertNull(config.getRecordBufferSizeConfigured());
+    Assert.assertEquals(10000, config.getRecordBufferSizeOrDefault(1_000_000_000));
+    Assert.assertEquals(5000, config.getRecordBufferOfferTimeout());
+
+    Assert.assertFalse(config.isSkipSequenceNumberAvailabilityCheck());
+    Assert.assertFalse(config.isResetOffsetAutomatically());
+  }
+
+  @Test
+  public void testSerdeWithNonDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"basePersistDirectory\": \"/tmp/xxx\",\n"
+        + "  \"maxRowsInMemory\": 100,\n"
+        + "  \"maxRowsPerSegment\": 100,\n"
+        + "  \"intermediatePersistPeriod\": \"PT1H\",\n"
+        + "  \"maxPendingPersists\": 100,\n"
+        + "  \"reportParseExceptions\": true,\n"
+        + "  \"handoffConditionTimeout\": 100,\n"
+        + "  \"recordBufferSize\": 1000,\n"
+        + "  \"recordBufferOfferTimeout\": 500,\n"
+        + "  \"resetOffsetAutomatically\": false,\n"
+        + "  \"appendableIndexSpec\": { \"type\" : \"onheap\" }\n"
+        + "}";
+
+    RabbitStreamIndexTaskTuningConfig config = (RabbitStreamIndexTaskTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class)),
+        TuningConfig.class);
+
+    Assert.assertNull(config.getBasePersistDirectory());
+    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assert.assertEquals(100, config.getMaxRowsInMemory());
+    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(100, config.getMaxPendingPersists());
+    Assert.assertTrue(config.isReportParseExceptions());
+    Assert.assertEquals(100, config.getHandoffConditionTimeout());
+    Assert.assertEquals(1000, (int) config.getRecordBufferSizeConfigured());
+    Assert.assertEquals(1000, config.getRecordBufferSizeOrDefault(1_000_000_000));
+    Assert.assertEquals(500, config.getRecordBufferOfferTimeout());
+    Assert.assertFalse(config.isResetOffsetAutomatically());
+  }
+
+
+  @Test
+  public void testtoString() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"basePersistDirectory\": \"/tmp/xxx\",\n"
+        + "  \"maxRowsInMemory\": 100,\n"
+        + "  \"maxRowsPerSegment\": 100,\n"
+        + "  \"intermediatePersistPeriod\": \"PT1H\",\n"
+        + "  \"maxPendingPersists\": 100,\n"
+        + "  \"reportParseExceptions\": true,\n"
+        + "  \"handoffConditionTimeout\": 100,\n"
+        + "  \"recordBufferSize\": 1000,\n"
+        + "  \"recordBufferOfferTimeout\": 500,\n"
+        + "  \"resetOffsetAutomatically\": false,\n"
+        + "  \"appendableIndexSpec\": { \"type\" : \"onheap\" }\n"
+        + "}";
+
+    RabbitStreamIndexTaskTuningConfig config = (RabbitStreamIndexTaskTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class)),
+        TuningConfig.class);
+
+    String resStr = "RabbitStreamSupervisorTuningConfig{" +
+        "maxRowsInMemory=100, " +
+        "maxRowsPerSegment=100, " +
+        "maxTotalRows=null, " +
+        "maxBytesInMemory=" + config.getMaxBytesInMemoryOrDefault() + ", " +
+        "skipBytesInMemoryOverheadCheck=false, " +
+        "intermediatePersistPeriod=PT1H, " +
+        "maxPendingPersists=100, " +
+        "indexSpec=IndexSpec{" +
+        "bitmapSerdeFactory=RoaringBitmapSerdeFactory{}, " +
+        "dimensionCompression=lz4, " +
+        "stringDictionaryEncoding=Utf8{}, " +
+        "metricCompression=lz4, " +
+        "longEncoding=longs, " +
+        "jsonCompression=null, " +
+        "segmentLoader=null" +
+        "}, " +
+        "reportParseExceptions=true, " +
+        "handoffConditionTimeout=100, " +
+        "resetOffsetAutomatically=false, " +
+        "segmentWriteOutMediumFactory=null, " +
+        "workerThreads=null, " +
+        "chatThreads=null, " +
+        "chatRetries=8, " +
+        "httpTimeout=PT10S, " +
+        "shutdownTimeout=PT80S, " +
+        "recordBufferSize=1000, " +
+        "recordBufferOfferTimeout=500, " +
+        "offsetFetchPeriod=PT30S, " +
+        "intermediateHandoffPeriod=" + config.getIntermediateHandoffPeriod() + ", " +
+        "logParseExceptions=false, " +
+        "maxParseExceptions=0, " +
+        "maxSavedParseExceptions=0, " +
+        "numPersistThreads=1, " +
+        "maxRecordsPerPoll=null}";
+  
+
+    Assert.assertEquals(resStr, config.toString());
+  }
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplierTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplierTest.java
@@ -1,0 +1,597 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.rabbitmq.stream.Consumer;
+import com.rabbitmq.stream.ConsumerBuilder;
+import com.rabbitmq.stream.Environment;
+import com.rabbitmq.stream.EnvironmentBuilder;
+import com.rabbitmq.stream.MessageHandler;
+import com.rabbitmq.stream.OffsetSpecification;
+import com.rabbitmq.stream.codec.WrapperMessageBuilder;
+import com.rabbitmq.stream.impl.Client;
+import com.rabbitmq.stream.impl.Client.ClientParameters;
+import org.apache.druid.data.input.impl.ByteEntity;
+import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecord;
+import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.metadata.MapStringDynamicConfigProvider;
+import org.apache.druid.segment.TestHelper;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class RabbitStreamRecordSupplierTest extends EasyMockSupport
+{
+
+  private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
+  private static String uri = "rabbitmq-stream://localhost:5552";
+  private static Environment environment;
+  private static EnvironmentBuilder environmentBuilder;
+  private static ClientParameters clientParameters;
+  private static Client client;
+  
+  private static final String STREAM = "stream";
+  private static final String PARTITION_ID1 = "stream-1";
+  private static final String PARTITION_ID0 = "stream-0";
+  private static final List<String> ALL_PARTITIONS = ImmutableList.of(PARTITION_ID0, PARTITION_ID1);
+
+  private static class MockedRabbitStreamRecordSupplier extends RabbitStreamRecordSupplier
+  {
+
+    public ClientParameters sentParameters = null;
+
+    public MockedRabbitStreamRecordSupplier(String uri, Map<String, Object> consumerProperties)
+    {
+      super(
+          consumerProperties,
+          OBJECT_MAPPER,
+          uri,
+          100,
+          1000,
+          100);
+
+    }
+
+    @Override
+    public EnvironmentBuilder getEnvBuilder()
+    {
+      return environmentBuilder;
+    }
+
+    @Override
+    public ClientParameters getParameters()
+    {
+      return clientParameters;
+    }
+
+    @Override
+    public Client getClient(ClientParameters paramaters)
+    {
+      this.sentParameters = paramaters;
+      return client;
+    }
+
+  }
+
+  public MockedRabbitStreamRecordSupplier makeRecordSupplierWithMockedEnvironment(String uri, Map<String, Object> consumerProperties)
+  {
+    EasyMock.expect(environmentBuilder.uri(uri)).andReturn(environmentBuilder);
+    EasyMock.expect(environmentBuilder.build()).andReturn(environment);
+    replayAll();
+    MockedRabbitStreamRecordSupplier res = new MockedRabbitStreamRecordSupplier(uri, consumerProperties);
+    resetAll();
+    return res;
+  }
+
+  private class MessageHandlerContext implements MessageHandler.Context
+  {
+
+    private final long offset;
+    private final long timestamp;
+    private final long committedOffset;
+    private final String stream;
+
+    private MessageHandlerContext(
+        long offset,
+        long timestamp,
+        long committedOffset,
+        String stream)
+    {
+      this.offset = offset;
+      this.timestamp = timestamp;
+      this.committedOffset = committedOffset;
+      this.stream = stream;
+    }
+
+    @Override
+    public long offset()
+    {
+      return this.offset;
+    }
+
+    @Override
+    public void storeOffset()
+    {
+    }
+
+    @Override
+    public long timestamp()
+    {
+      return this.timestamp;
+    }
+
+    @Override
+    public long committedChunkId()
+    {
+      return this.committedOffset;
+    }
+
+    @Override
+    public String stream()
+    {
+      return this.stream;
+    }
+
+    @Override
+    public Consumer consumer()
+    {
+      return createMock(Consumer.class);
+    }
+
+    @Override
+    public void processed()
+    {
+
+    }
+  }
+
+  @Before
+  public void setupTest()
+  {
+    environment = createMock(Environment.class);
+    environmentBuilder = createMock(EnvironmentBuilder.class);
+    client = createMock(Client.class);
+    clientParameters = createMock(ClientParameters.class);
+    
+  }
+
+  @Test
+  public void testGetStreamFromSubstream()
+  {
+    String test = "stream-0";
+    String res = RabbitStreamRecordSupplier.getStreamFromSubstream(test);
+    Assert.assertEquals("stream", res);
+
+    test = "test-stream-0";
+    res = RabbitStreamRecordSupplier.getStreamFromSubstream(test);
+    Assert.assertEquals("test-stream", res);
+
+  }
+
+  @Test
+  public void testAssign()
+  {
+    Set<StreamPartition<String>> partitions = ImmutableSet.of(
+        StreamPartition.of(STREAM, PARTITION_ID0),
+        StreamPartition.of(STREAM, PARTITION_ID1));
+
+    Set<StreamPartition<String>> res;
+
+    RabbitStreamRecordSupplier recordSupplier = makeRecordSupplierWithMockedEnvironment(
+        uri,
+        null
+    );
+
+
+    res = recordSupplier.getAssignment();
+
+    Assert.assertTrue(res.isEmpty());
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
+
+    ConsumerBuilder consumerBuilderMock1 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.noTrackingStrategy()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.stream(PARTITION_ID0)).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.messageHandler(recordSupplier)).andReturn(consumerBuilderMock1).once();
+
+    ConsumerBuilder consumerBuilderMock2 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.noTrackingStrategy()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.stream(PARTITION_ID1)).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.messageHandler(recordSupplier)).andReturn(consumerBuilderMock2).once();
+
+    replayAll();
+
+    recordSupplier.assign(partitions);
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+
+    verifyAll();
+  }
+
+  @Test
+  public void testAssignClears()
+  {
+    StreamPartition<String> partition0 = StreamPartition.of(STREAM, PARTITION_ID0);
+    StreamPartition<String> partition1 = StreamPartition.of(STREAM, PARTITION_ID1);
+    long offset1 = 1;
+    long offset2 = 2;
+
+    Set<StreamPartition<String>> partitions = ImmutableSet.of(
+        StreamPartition.of(STREAM, PARTITION_ID0),
+        StreamPartition.of(STREAM, PARTITION_ID1));
+
+    Set<StreamPartition<String>> res;
+
+    RabbitStreamRecordSupplier recordSupplier = makeRecordSupplierWithMockedEnvironment(
+        uri,
+        null
+    );
+
+
+    res = recordSupplier.getAssignment();
+
+    Assert.assertTrue(res.isEmpty());
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
+
+    ConsumerBuilder consumerBuilderMock1 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock1).once();
+
+    EasyMock.expect(consumerBuilderMock1.noTrackingStrategy()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.stream(PARTITION_ID0)).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.messageHandler(recordSupplier)).andReturn(consumerBuilderMock1).once();
+
+    ConsumerBuilder consumerBuilderMock2 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.noTrackingStrategy()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.stream(PARTITION_ID1)).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.messageHandler(recordSupplier)).andReturn(consumerBuilderMock2).once();
+
+    replayAll();
+
+    recordSupplier.assign(partitions);
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+
+    verifyAll();
+
+    try {
+      recordSupplier.seek(partition0, offset1);
+      recordSupplier.seek(partition1, offset2);
+    }
+    catch (Exception exc) {
+      Assert.fail("Exception seeking:" + exc.getMessage());
+    }
+
+    resetAll();
+
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.noTrackingStrategy()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.stream(PARTITION_ID0)).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.messageHandler(recordSupplier)).andReturn(consumerBuilderMock1).once();
+    replayAll();
+
+    recordSupplier.assign(ImmutableSet.of(partition0));
+    Assert.assertEquals(ImmutableSet.of(partition0), recordSupplier.getAssignment());
+  
+    Assert.assertNotNull(recordSupplier.getOffset(partition0));
+    Assert.assertNull(recordSupplier.getOffset(partition1));
+
+  }
+
+  @Test
+  public void testSeek()
+  {
+    StreamPartition<String> partition0 = StreamPartition.of(STREAM, PARTITION_ID0);
+    StreamPartition<String> partition1 = StreamPartition.of(STREAM, PARTITION_ID1);
+
+    Set<StreamPartition<String>> partitions = ImmutableSet.of(
+        partition0,
+        partition1);
+
+    long offset1 = 1;
+    long offset2 = 2;
+
+
+    RabbitStreamRecordSupplier recordSupplier = makeRecordSupplierWithMockedEnvironment(
+        uri,
+        null
+    );
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
+
+    ConsumerBuilder consumerBuilderMock1 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock1).once();
+
+    EasyMock.expect(consumerBuilderMock1.noTrackingStrategy()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.stream(PARTITION_ID0)).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.messageHandler(recordSupplier)).andReturn(consumerBuilderMock1).once();
+
+    ConsumerBuilder consumerBuilderMock2 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.noTrackingStrategy()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.stream(PARTITION_ID1)).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.messageHandler(recordSupplier)).andReturn(consumerBuilderMock2).once();
+
+    replayAll();
+
+    recordSupplier.assign(partitions);
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+
+    verifyAll();
+
+    try {
+      recordSupplier.seek(partition0, offset1);
+      recordSupplier.seek(partition1, offset2);
+    }
+    catch (Exception exc) {
+      Assert.fail("Exception seeking:" + exc.getMessage());
+    }
+
+
+    Assert.assertEquals(recordSupplier.getOffset(partition0).getOffset(), offset1);
+    Assert.assertEquals(recordSupplier.getOffset(partition1).getOffset(), offset2);
+
+    try {
+      recordSupplier.seekToEarliest(partitions);
+    }
+    catch (Exception exc) {
+      Assert.fail("Exception seeking:" + exc.getMessage());
+    }
+    Assert.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.first());
+    Assert.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.first());
+
+    try {
+      recordSupplier.seekToLatest(partitions);
+    }
+    catch (Exception exc) {
+      Assert.fail("Exception seeking:" + exc.getMessage());
+    }
+
+    Assert.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.last());
+    Assert.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.last());
+
+  }
+
+
+
+  @Test
+  public void testPollBothPartitions()
+  {
+
+    StreamPartition<String> partition1 = StreamPartition.of(STREAM, PARTITION_ID0);
+    StreamPartition<String> partition2 = StreamPartition.of(STREAM, PARTITION_ID1);
+
+    Set<StreamPartition<String>> partitions = ImmutableSet.of(
+        partition1,
+        partition2);
+
+    long offset1 = 1;
+    long offset2 = 2;
+
+    RabbitStreamRecordSupplier recordSupplier = makeRecordSupplierWithMockedEnvironment(
+        uri,
+        null
+    );
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
+
+    ConsumerBuilder consumerBuilderMock1 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.noTrackingStrategy()).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.stream(PARTITION_ID0)).andReturn(consumerBuilderMock1).once();
+    EasyMock.expect(consumerBuilderMock1.messageHandler(recordSupplier)).andReturn(consumerBuilderMock1).once();
+
+    EasyMock.expect(consumerBuilderMock1.offset(OffsetSpecification.offset(offset1))).andReturn(consumerBuilderMock1)
+        .once();
+
+    Consumer consumer1 = createMock(Consumer.class);
+    consumer1.close();
+
+    MessageHandler.Context mockMessageContext1 = new MessageHandlerContext(0, 0, 0, PARTITION_ID0);
+    WrapperMessageBuilder mockMessageBuilder = new WrapperMessageBuilder();
+    mockMessageBuilder.addData("Hello shard0".getBytes(StandardCharsets.UTF_8));
+
+    // when the consumerbuilder is turned into a consumer, call the handler method
+    // to test round trip and ensure messages come back
+    EasyMock.expect(consumerBuilderMock1.build()).andAnswer(() -> {
+      recordSupplier.handle(
+          mockMessageContext1,
+          mockMessageBuilder.build());
+      return consumer1;
+    }).once();
+
+    ConsumerBuilder consumerBuilderMock2 = createMock(ConsumerBuilder.class);
+    EasyMock.expect(environment.consumerBuilder()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.noTrackingStrategy()).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.stream(PARTITION_ID1)).andReturn(consumerBuilderMock2).once();
+    EasyMock.expect(consumerBuilderMock2.messageHandler(recordSupplier)).andReturn(consumerBuilderMock2).once();
+
+    EasyMock.expect(consumerBuilderMock2.offset(OffsetSpecification.offset(offset2))).andReturn(consumerBuilderMock2)
+        .once();
+
+    Consumer consumer2 = createMock(Consumer.class);
+    consumer2.close();
+
+    MessageHandler.Context mockMessageContext2 = new MessageHandlerContext(0, 0, 0, PARTITION_ID1);
+    WrapperMessageBuilder mockMessageBuilder2 = new WrapperMessageBuilder();
+    mockMessageBuilder2.addData("Hello shard1".getBytes(StandardCharsets.UTF_8));
+
+    EasyMock.expect(consumerBuilderMock2.build()).andAnswer(() -> {
+      recordSupplier.handle(
+          mockMessageContext2,
+          mockMessageBuilder2.build());
+      return consumer2;
+    }).once();
+
+    replayAll();
+
+    recordSupplier.assign(partitions);
+
+    try {
+      recordSupplier.seek(partition1, offset1);
+      recordSupplier.seek(partition2, offset2);
+    }
+    catch (Exception exc) {
+      Assert.fail("Exception seeking:" + exc.getMessage());
+    }
+
+    List<OrderedPartitionableRecord<String, Long, ByteEntity>> messages = recordSupplier.poll(0);
+    Assert.assertEquals(2, messages.size());
+
+    recordSupplier.close();
+
+    // test double close
+    recordSupplier.close();
+
+    verifyAll();
+  }
+
+
+  @Test
+  public void testConsumerProperties()
+  {
+
+    DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+        ImmutableMap.of(
+            "username", "RABBIT_USERNAME",
+            "password", "RABBIT_PASSWORD"
+        )
+    );
+    Map<String, Object> consumerProperties = ImmutableMap.of(
+        "druid.dynamic.config.provider", OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+    );
+    
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.password("RABBIT_PASSWORD")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.username("RABBIT_USERNAME")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andReturn(environment).once();
+    replayAll();
+
+    MockedRabbitStreamRecordSupplier supplier = new MockedRabbitStreamRecordSupplier("rabbitmq-stream://localhost:5552", consumerProperties);
+    supplier.getRabbitEnvironment();
+    verifyAll();
+    supplier.close();
+   
+
+    
+  }
+
+
+  @Test
+  public void testGetPartitionIDs()
+  {
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andReturn(environment).once();
+    replayAll();
+
+    MockedRabbitStreamRecordSupplier supplier = new MockedRabbitStreamRecordSupplier("rabbitmq-stream://localhost:5552", null);
+    supplier.getRabbitEnvironment();
+    verifyAll();
+    resetAll();
+
+    EasyMock.expect(clientParameters.host("localhost")).andReturn(clientParameters);
+    EasyMock.expect(clientParameters.port(5552)).andReturn(clientParameters);
+
+    
+    EasyMock.expect(client.partitions(STREAM)).andReturn(ALL_PARTITIONS);
+    
+    client.close();
+    replayAll();
+
+    Set<String> partitions = supplier.getPartitionIds(STREAM);
+    verifyAll();
+
+    Assert.assertTrue(clientParameters == supplier.sentParameters);
+
+    Assert.assertEquals(2, partitions.size());
+    Assert.assertTrue(partitions.containsAll(ALL_PARTITIONS));
+   
+    supplier.close();
+    
+  }
+
+  @Test
+  public void testGetPartitionIDsWithConfig()
+  {
+
+    DynamicConfigProvider dynamicConfigProvider = new MapStringDynamicConfigProvider(
+        ImmutableMap.of(
+        "username", "RABBIT_USERNAME",
+        "password", "RABBIT_PASSWORD"
+        )
+    );
+    Map<String, Object> consumerProperties = ImmutableMap.of(
+          "druid.dynamic.config.provider", OBJECT_MAPPER.convertValue(dynamicConfigProvider, Map.class)
+    );
+    
+
+    EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.password("RABBIT_PASSWORD")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.username("RABBIT_USERNAME")).andReturn(environmentBuilder).once();
+    EasyMock.expect(environmentBuilder.build()).andReturn(environment).once();
+    replayAll();
+
+    MockedRabbitStreamRecordSupplier supplier = new MockedRabbitStreamRecordSupplier("rabbitmq-stream://localhost:5552", consumerProperties);
+    supplier.getRabbitEnvironment();
+    verifyAll();
+    resetAll();
+
+    
+    EasyMock.expect(clientParameters.host("localhost")).andReturn(clientParameters);
+    EasyMock.expect(clientParameters.port(5552)).andReturn(clientParameters);
+    EasyMock.expect(clientParameters.password("RABBIT_PASSWORD")).andReturn(clientParameters);
+    EasyMock.expect(clientParameters.username("RABBIT_USERNAME")).andReturn(clientParameters);
+    
+    EasyMock.expect(client.partitions(STREAM)).andReturn(ALL_PARTITIONS);
+    
+    client.close();
+    replayAll();
+
+    Set<String> partitions = supplier.getPartitionIds(STREAM);
+    verifyAll();
+
+    Assert.assertTrue(clientParameters == supplier.sentParameters);
+
+    Assert.assertEquals(2, partitions.size());
+    Assert.assertTrue(partitions.containsAll(ALL_PARTITIONS));
+   
+    supplier.close();
+    
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfigTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskModule;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.hamcrest.CoreMatchers;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RabbitStreamSupervisorIOConfigTest
+{
+  private final ObjectMapper mapper;
+
+  public RabbitStreamSupervisorIOConfigTest()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
+  }
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"stream\": \"my-stream\",\n"
+        + "  \"uri\": \"rabbitmq-stream://localhost:5552\"\n"
+        + "}";
+
+    RabbitStreamSupervisorIOConfig config = mapper.readValue(
+        jsonStr,
+        RabbitStreamSupervisorIOConfig.class);
+
+    Assert.assertEquals("my-stream", config.getStream());
+    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assert.assertEquals(1, (int) config.getReplicas());
+    Assert.assertEquals(1, (int) config.getTaskCount());
+    Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
+    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assert.assertFalse(config.isUseEarliestSequenceNumber());
+    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assert.assertFalse("lateMessageRejectionPeriod", config.getLateMessageRejectionPeriod().isPresent());
+    Assert.assertFalse("earlyMessageRejectionPeriod", config.getEarlyMessageRejectionPeriod().isPresent());
+    Assert.assertFalse("lateMessageRejectionStartDateTime", config.getLateMessageRejectionStartDateTime().isPresent());
+  }
+
+  @Test
+  public void testSerdeWithNonDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"stream\": \"my-stream\",\n"
+        + "  \"uri\": \"rabbitmq-stream://localhost:5552\",\n"
+        + "  \"replicas\": 3,\n"
+        + "  \"taskCount\": 9,\n"
+        + "  \"taskDuration\": \"PT30M\",\n"
+        + "  \"startDelay\": \"PT1M\",\n"
+        + "  \"period\": \"PT10S\",\n"
+        + "  \"useEarliestOffset\": true,\n"
+        + "  \"completionTimeout\": \"PT45M\",\n"
+        + "  \"lateMessageRejectionPeriod\": \"PT1H\",\n"
+        + "  \"earlyMessageRejectionPeriod\": \"PT1H\",\n"
+        + "  \"recordsPerFetch\": 4000\n"
+        + "}";
+
+    RabbitStreamSupervisorIOConfig config = mapper.readValue(
+        jsonStr,
+        RabbitStreamSupervisorIOConfig.class);
+
+    Assert.assertEquals("my-stream", config.getStream());
+    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assert.assertEquals(3, (int) config.getReplicas());
+    Assert.assertEquals(9, (int) config.getTaskCount());
+    Assert.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
+    Assert.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
+    Assert.assertEquals(Duration.standardSeconds(10), config.getPeriod());
+    Assert.assertTrue(config.isUseEarliestSequenceNumber());
+    Assert.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
+    Assert.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().get());
+    Assert.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().get());
+    // Assert.assertEquals((Integer) 4000, config.getRecordsPerFetch());
+    // Assert.assertEquals(1000, config.getFetchDelayMillis());
+  }
+
+  @Test
+  public void testStreamRequired() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\"\n"
+        + "}";
+
+    exception.expect(JsonMappingException.class);
+    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
+    exception.expectMessage(CoreMatchers.containsString("stream"));
+    mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
+  }
+
+  @Test
+  public void testURIRequired() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"stream\": \"my-stream\"\n"
+        + "}";
+
+    exception.expect(JsonMappingException.class);
+    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
+    exception.expectMessage(CoreMatchers.containsString("uri"));
+    mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.data.input.impl.DimensionSchema;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.indexing.common.TestUtils;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.indexing.overlord.TaskQueue;
+import org.apache.druid.indexing.overlord.TaskRunner;
+import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorStateManagerConfig;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskClientFactory;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamRecordSupplier;
+import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskClient;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.emitter.EmittingLogger;
+import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
+import org.easymock.EasyMockSupport;
+import org.joda.time.Period;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RabbitStreamSupervisorTest extends EasyMockSupport
+{
+  private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
+  private static final InputFormat INPUT_FORMAT = new JsonInputFormat(
+      new JSONPathSpec(true, ImmutableList.of()),
+      ImmutableMap.of(),
+      false,
+      false,
+      false,
+      false);
+  private static final String DATASOURCE = "testDS";
+  private static final int TEST_CHAT_THREADS = 3;
+  private static final long TEST_CHAT_RETRIES = 9L;
+  private static final Period TEST_HTTP_TIMEOUT = new Period("PT10S");
+  private static final Period TEST_SHUTDOWN_TIMEOUT = new Period("PT80S");
+  private static final String STREAM = "stream";
+  private static final String URI = "rabbitmq-stream://localhost:5552";
+
+  private static DataSchema dataSchema;
+  private RabbitStreamRecordSupplier supervisorRecordSupplier;
+
+  private final int numThreads = 1;
+  private RabbitStreamSupervisor supervisor;
+  private RabbitStreamSupervisorTuningConfig tuningConfig;
+  private TaskStorage taskStorage;
+  private TaskMaster taskMaster;
+  private TaskRunner taskRunner;
+  private IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator;
+  private SeekableStreamIndexTaskClient<String, String> taskClient;
+  private TaskQueue taskQueue;
+  private RowIngestionMetersFactory rowIngestionMetersFactory;
+  private StubServiceEmitter serviceEmitter;
+  private SupervisorStateManagerConfig supervisorConfig;
+
+  private static DataSchema getDataSchema(String dataSource)
+  {
+    List<DimensionSchema> dimensions = new ArrayList<>();
+    dimensions.add(StringDimensionSchema.create("dim1"));
+    dimensions.add(StringDimensionSchema.create("dim2"));
+
+    return new DataSchema(
+        dataSource,
+        new TimestampSpec("timestamp", "iso", null),
+        new DimensionsSpec(dimensions),
+        new AggregatorFactory[] {new CountAggregatorFactory("rows")},
+        new UniformGranularitySpec(
+            Granularities.HOUR,
+            Granularities.NONE,
+            ImmutableList.of()),
+        null);
+  }
+
+  @BeforeClass
+  public static void setupClass()
+  {
+    dataSchema = getDataSchema(DATASOURCE);
+  }
+
+  @Before
+  public void setupTest()
+  {
+    taskStorage = createMock(TaskStorage.class);
+    taskMaster = createMock(TaskMaster.class);
+    taskRunner = createMock(TaskRunner.class);
+    indexerMetadataStorageCoordinator = createMock(IndexerMetadataStorageCoordinator.class);
+    taskClient = createMock(SeekableStreamIndexTaskClient.class);
+    taskQueue = createMock(TaskQueue.class);
+    supervisorRecordSupplier = createMock(RabbitStreamRecordSupplier.class);
+
+    tuningConfig = new RabbitStreamSupervisorTuningConfig(
+        null,
+        1000, // max rows in memory
+        null, // max bytes
+        null, // skipBytes
+        50000, // max rows per seg
+        null, // max total rows
+        new Period("P1Y"), // intermediatepersistPeriod
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        numThreads, // worker threads
+        null,
+        TEST_CHAT_THREADS,
+        TEST_CHAT_RETRIES,
+        TEST_HTTP_TIMEOUT,
+        TEST_SHUTDOWN_TIMEOUT,
+        1000,
+        100,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        100);
+    rowIngestionMetersFactory = new TestUtils().getRowIngestionMetersFactory();
+    serviceEmitter = new StubServiceEmitter("RabbitStreamSupervisorTest", "localhost");
+    EmittingLogger.registerEmitter(serviceEmitter);
+    supervisorConfig = new SupervisorStateManagerConfig();
+  }
+
+  @After
+  public void tearDownTest()
+  {
+    supervisor = null;
+  }
+
+  /**
+   * Use for tests where you don't want generateSequenceName to be overridden out
+   */
+  private RabbitStreamSupervisor getSupervisor(
+      int replicas,
+      int taskCount,
+      boolean useEarliestOffset,
+      String duration,
+      Period lateMessageRejectionPeriod,
+      Period earlyMessageRejectionPeriod,
+      DataSchema dataSchema,
+      RabbitStreamSupervisorTuningConfig tuningConfig)
+  {
+    RabbitStreamSupervisorIOConfig rabbitStreamSupervisorIOConfig = new RabbitStreamSupervisorIOConfig(
+        STREAM, // stream
+        URI, // uri
+        INPUT_FORMAT, // inputFormat
+        replicas, // replicas
+        taskCount, // taskCount
+        new Period(duration), // taskDuration
+        null, // consumerProperties
+        null, // autoscalerConfig
+        400L, // poll timeout
+        new Period("P1D"), // start delat
+        new Period("PT30M"), // period
+        new Period("PT30S"), // completiontimeout
+        false, // useearliest
+        lateMessageRejectionPeriod, // latemessagerejection
+        earlyMessageRejectionPeriod, // early message rejection
+        null, // latemessagerejectionstartdatetime
+        1
+    );
+    RabbitStreamIndexTaskClientFactory clientFactory = new RabbitStreamIndexTaskClientFactory(null,
+        OBJECT_MAPPER);
+    RabbitStreamSupervisor supervisor = new RabbitStreamSupervisor(
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        clientFactory,
+        OBJECT_MAPPER,
+        new RabbitStreamSupervisorSpec(
+            null,
+            dataSchema,
+            tuningConfig,
+            rabbitStreamSupervisorIOConfig,
+            null,
+            false,
+            taskStorage,
+            taskMaster,
+            indexerMetadataStorageCoordinator,
+            clientFactory,
+            OBJECT_MAPPER,
+            new NoopServiceEmitter(),
+            new DruidMonitorSchedulerConfig(),
+            rowIngestionMetersFactory,
+            new SupervisorStateManagerConfig()),
+        rowIngestionMetersFactory);
+    return supervisor;
+  }
+
+  public RabbitStreamSupervisor getDefaultSupervisor()
+  {
+    return getSupervisor(
+        1,
+        1,
+        false,
+        "PT30M",
+        null,
+        null,
+        RabbitStreamSupervisorTest.dataSchema,
+        tuningConfig);
+  }
+
+  @Test
+  public void testRecordSupplier()
+  {
+    RabbitStreamSupervisorIOConfig rabbitStreamSupervisorIOConfig = new RabbitStreamSupervisorIOConfig(
+        STREAM, // stream
+        URI, // uri
+        INPUT_FORMAT, // inputFormat
+        1, // replicas
+        1, // taskCount
+        new Period("PT30M"), // taskDuration
+        null, // consumerProperties
+        null, // autoscalerConfig
+        400L, // poll timeout
+        new Period("P1D"), // start delat
+        new Period("PT30M"), // period
+        new Period("PT30S"), // completiontimeout
+        false, // useearliest
+        null, // latemessagerejection
+        null, // early message rejection
+        null, // latemessagerejectionstartdatetime
+        1
+    );
+    RabbitStreamIndexTaskClientFactory clientFactory = new RabbitStreamIndexTaskClientFactory(null,
+        OBJECT_MAPPER);
+    RabbitStreamSupervisor supervisor = new RabbitStreamSupervisor(
+        taskStorage,
+        taskMaster,
+        indexerMetadataStorageCoordinator,
+        clientFactory,
+        OBJECT_MAPPER,
+        new RabbitStreamSupervisorSpec(
+            null,
+            dataSchema,
+            tuningConfig,
+            rabbitStreamSupervisorIOConfig,
+            null,
+            false,
+            taskStorage,
+            taskMaster,
+            indexerMetadataStorageCoordinator,
+            clientFactory,
+            OBJECT_MAPPER,
+            new NoopServiceEmitter(),
+            new DruidMonitorSchedulerConfig(),
+            rowIngestionMetersFactory,
+            new SupervisorStateManagerConfig()),
+        rowIngestionMetersFactory);
+
+    RabbitStreamRecordSupplier supplier = (RabbitStreamRecordSupplier) supervisor.setupRecordSupplier();
+    Assert.assertNotNull(supplier);
+    Assert.assertEquals(0, supplier.bufferSize());
+    Assert.assertEquals(Collections.emptySet(), supplier.getAssignment());
+    Assert.assertEquals(false, supplier.isRunning());
+  }
+
+  @Test
+  public void testGetters()
+  {
+    supervisor = getDefaultSupervisor();
+    Assert.assertNull(supervisor.getPartitionTimeLag());
+
+    Assert.assertNull(supervisor.getTimeLagPerPartition(null));
+    Assert.assertFalse(supervisor.isEndOfShard(null));
+    Assert.assertFalse(supervisor.isShardExpirationMarker(null));
+
+    Assert.assertEquals(Long.valueOf(Long.MAX_VALUE), supervisor.getEndOfPartitionMarker());
+
+    Assert.assertEquals("index_rabbit", supervisor.baseTaskName());
+
+    Assert.assertEquals(Long.valueOf(-1L), supervisor.getNotSetMarker());
+    Assert.assertEquals(false, supervisor.useExclusiveStartSequenceNumberForNonFirstSequence());
+
+  }
+
+  @Test
+  public void testTaskGroupID()
+  {
+
+    List<Integer> taskCounts = ImmutableList.of(1, 2, 3, 4);
+    List<String> partitions = ImmutableList.of("a", "b", "c");
+
+    for (Integer taskCount : taskCounts) {
+      supervisor = getSupervisor(
+          1,
+          taskCount,
+          false,
+          "PT30M",
+          null,
+          null,
+          RabbitStreamSupervisorTest.dataSchema,
+          tuningConfig);
+      for (String partition : partitions) {
+        Assert.assertEquals(partition.hashCode() % taskCount, supervisor.getTaskGroupIdForPartition(partition));
+      }
+    }
+  }
+
+  @Test
+  public void testReportPayload()
+  {
+    supervisor = getSupervisor(
+        1,
+        1,
+        false,
+        "PT30M",
+        null,
+        null,
+        RabbitStreamSupervisorTest.dataSchema,
+        tuningConfig);
+
+    SeekableStreamSupervisorReportPayload<String, Long> payload = supervisor.createReportPayload(1, false);
+    Assert.assertEquals(STREAM, payload.getStream());
+    Assert.assertEquals(1, payload.getPartitions());
+    Assert.assertEquals(1, payload.getReplicas());
+    Assert.assertEquals(false, payload.isSuspended());
+    Assert.assertEquals(true, payload.isHealthy());
+    Assert.assertEquals(30 * 60, payload.getDurationSeconds());
+  }
+
+}

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.rabbitstream.supervisor;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskModule;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
+import org.apache.druid.segment.indexing.TuningConfig;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RabbitStreamSupervisorTuningConfigTest
+{
+  private final ObjectMapper mapper;
+
+  public RabbitStreamSupervisorTuningConfigTest()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
+  }
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\"type\": \"rabbit\"}";
+
+    RabbitStreamSupervisorTuningConfig config = (RabbitStreamSupervisorTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class)),
+        TuningConfig.class);
+
+    Assert.assertNull(config.getBasePersistDirectory());
+    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assert.assertEquals(150000, config.getMaxRowsInMemory());
+    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(0, config.getMaxPendingPersists());
+    // Assert.assertEquals(IndexSpec.DEFAULT, config.getIndexSpec());
+    Assert.assertEquals(false, config.isReportParseExceptions());
+    Assert.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assert.assertNull(config.getWorkerThreads());
+    Assert.assertEquals(8L, (long) config.getChatRetries());
+    Assert.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
+    Assert.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
+    Assert.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
+    Assert.assertEquals(100, config.getMaxRecordsPerPollOrDefault());
+  }
+
+  @Test
+  public void testSerdeWithNonDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+        + "  \"type\": \"rabbit\",\n"
+        + "  \"basePersistDirectory\": \"/tmp/xxx\",\n"
+        + "  \"maxRowsInMemory\": 100,\n"
+        + "  \"maxRowsPerSegment\": 100,\n"
+        + "  \"intermediatePersistPeriod\": \"PT1H\",\n"
+        + "  \"maxPendingPersists\": 100,\n"
+        + "  \"reportParseExceptions\": true,\n"
+        + "  \"handoffConditionTimeout\": 100,\n"
+        + "  \"workerThreads\": 12,\n"
+        + "  \"chatThreads\": 13,\n"
+        + "  \"chatRetries\": 14,\n"
+        + "  \"httpTimeout\": \"PT15S\",\n"
+        + "  \"shutdownTimeout\": \"PT95S\",\n"
+        + "  \"repartitionTransitionDuration\": \"PT500S\",\n"
+        + "  \"appendableIndexSpec\": { \"type\" : \"onheap\" },\n"
+        + "  \"recordBufferSize\": 15,\n"
+        + "  \"recordBufferOfferTimeout\": 16,\n"
+        + "  \"maxRecordsPerPoll\": 17\n"
+        + "}";
+
+    RabbitStreamSupervisorTuningConfig config = (RabbitStreamSupervisorTuningConfig) mapper.readValue(
+        mapper.writeValueAsString(
+            mapper.readValue(
+                jsonStr,
+                TuningConfig.class)),
+        TuningConfig.class);
+
+    Assert.assertNull(config.getBasePersistDirectory());
+    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assert.assertEquals(100, config.getMaxRowsInMemory());
+    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assert.assertEquals(100, config.getMaxPendingPersists());
+    Assert.assertEquals(true, config.isReportParseExceptions());
+    Assert.assertEquals(100, config.getHandoffConditionTimeout());
+    Assert.assertEquals(12, (int) config.getWorkerThreads());
+    Assert.assertEquals(14L, (long) config.getChatRetries());
+    Assert.assertEquals(15, (int) config.getRecordBufferSizeConfigured());
+    Assert.assertEquals(16, (int) config.getRecordBufferOfferTimeout());
+    Assert.assertEquals(17, (int) config.getMaxRecordsPerPollConfigured());
+    Assert.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
+    Assert.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
+    Assert.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
+  }
+
+}

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2812,6 +2812,16 @@ libraries:
 
 ---
 
+name: com.rabbitmq stream-client
+license_category: binary
+version: 0.9
+module: extensions-contrib/rabbit-stream-indexing-service
+license_name: Apache License version 2.0
+libraries:
+  - com.rabbitmq: stream-client
+
+---
+
 name: swagger-annotations
 version: 1.6.0
 license_category: binary

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
         <module>extensions-contrib/druid-iceberg-extensions</module>
         <module>extensions-contrib/druid-deltalake-extensions</module>
         <module>extensions-contrib/spectator-histogram</module>
+        <module>extensions-contrib/rabbit-stream-indexing-service</module>
 
         <!-- distribution packaging -->
         <module>distribution</module>

--- a/website/.spelling
+++ b/website/.spelling
@@ -1130,6 +1130,7 @@ taskDuration
 9.2dist
 KinesisSupervisorIOConfig
 KinesisSupervisorTuningConfig
+RabbitMQ
 Resharding
 resharding
 LZ4LZFuncompressedLZ4LZ4LZFuncompressednoneLZ4autolongsautolongslongstypeconcisetyperoaringtypestreamendpointreplicastaskCounttaskCount


### PR DESCRIPTION
This PR aims to add support for ingesting logs from a rabbitmq [superstream](https://blog.rabbitmq.com/posts/2022/07/rabbitmq-3-11-feature-preview-super-streams), as a peer to Kafka or Kinesis. Since this supports scalable exactly once delivery, this provides a good gasket between RabbitMQ and Druid.

Currently, this is a WIP for a few reasons:

1) No support for username/password and some other features, I welcome suggestions here as I'm not exactly sure how those work yet and could use some guidance on how that plumbing works

2) The algorithm is pretty poor here, simply making a new rabbit consumer for each poll, it should be doing something similar to Kinesis where it fetches in the background, occasionally backing off if it gets too far ahead.

3) Testing is extremely bare bones, primarily because the design of the record supplier could change here, and design layout could change test layout here.

4) Documentation on how exactly to use it is missing. I've been testing it with the below supervisor spec, the primary configuration mechanism is the 'uri' which is used to configure how it connects to rabbitmq for reading metadata and for getting messages

The meat of the change is in RabbitStreamRecordSupplier, which has the components that interface with rabbitmq.
 It uses two interfaces, one being the low level 'Client' interface to read the partitions from a super stream so that druid can distribute work, and the other being the 'Consumer' interface, the conventional interface which creates a thread that listens for messages for you, and calls back on the handler which puts the messages in queue.
 
The current interface simply manages a map of ConsumerBuilders as partitions are assigned, and then when it is polled for messages it will create consumers and wait for the timeout. Once the timeout has elapsed, it will close all the consumers, then collect any messages from the queue and return them. This should ensure no messages are lost, but probably isn't very efficient as it could be reconnecting more than necessary.


#### Release note

New: You can now ingest logs from RabbitMQ via super streams

This feature gives the ability to read directly from rabbitmq using the new super-streams feature. As super streams allows exactly-once delivery with full support for partitioning, it is now compatible with Druid's modern ingestion algorithm, without the downsides that the prior RabbitMQ firehose.

Note that this uses the RabbitMQ streams feature, and not a conventional exchange. You will need to make sure that your messages are in a super stream before consumption. For more information, see https://www.rabbitmq.com/streams.html.

In order to configure, create a new index task using the 'rabbit' type, and configure it's stream and URI to connect to the rabbitmq host.
```
{
  "type": "rabbit",
  "dataSchema": {
    "dataSource": <your super-stream>,
    }
  },
  "ioConfig": {
    "type": "rabbit",
    "stream": "api-audit",
    "uri": "rabbitmq-stream://localhost:5552",
    "taskCount": 1,
    "replicas": 1,
    "taskDuration": "PT1H"
  },
  "tuningConfig": {
    "type": "rabbit",
    "resetOffsetAutomatically": true
  }
}
```
<hr>

##### Key changed/added classes in this PR
The following classes have been added to druid in this PR:
 * `RabbitStreamSamplerSpec`
 * `RabbitStreamRecordSupplier`
 * `RabbitStreamIndexTaskTuningConfig`
 * `RabbitStreamIndexTaskModule`
 * `RabbitStreamIndexTaskIOConfig`
 * `RabbitStreamIndexTaskClientFactory`
 * `RabbitStreamIndexTask`
 * `RabbitStreamDataSourceMetadata`
 * `IncrementalPublishingRabbitStreamIndexTaskRunner`
 * `RabbitSupervisorTuningConfig`
 * `RabbitStreamSupervisorSpec`
 * `RabbitStreamSupervisorReportPayload`
 * `RabbitStreamSupervisorIOConfig`
 * `RabbitStreamSupervisorIngestionSpec`
 * `RabbitStreamSupervisor`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
