### PR TITLE
fix issues with filtering nulls on values coerced to numeric types

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/vector/VectorProcessors.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/VectorProcessors.java
@@ -116,8 +116,12 @@ public class VectorProcessors
     final double[] doubles = new double[maxVectorSize];
     final boolean[] nulls;
     if (constant == null) {
-      nulls = new boolean[maxVectorSize];
-      Arrays.fill(nulls, NullHandling.sqlCompatible());
+      if (NullHandling.sqlCompatible()) {
+        nulls = new boolean[maxVectorSize];
+        Arrays.fill(nulls, true);
+      } else {
+        nulls = null;
+      }
     } else {
       nulls = null;
       Arrays.fill(doubles, constant);
@@ -149,8 +153,12 @@ public class VectorProcessors
     final long[] longs = new long[maxVectorSize];
     final boolean[] nulls;
     if (constant == null) {
-      nulls = new boolean[maxVectorSize];
-      Arrays.fill(nulls, NullHandling.sqlCompatible());
+      if (NullHandling.sqlCompatible()) {
+        nulls = new boolean[maxVectorSize];
+        Arrays.fill(nulls, true);
+      } else {
+        nulls = null;
+      }
     } else {
       nulls = null;
       Arrays.fill(longs, constant);
@@ -721,7 +729,7 @@ public class VectorProcessors
               if (leftNull) {
                 if (rightNull) {
                   output[i] = 0L;
-                  outputNulls[i] = NullHandling.sqlCompatible();
+                  outputNulls[i] = true;
                   return;
                 }
                 final boolean bool = Evals.asBoolean(rightInput[i]);
@@ -770,7 +778,7 @@ public class VectorProcessors
               if (leftNull) {
                 if (rightNull) {
                   output[i] = 0;
-                  outputNulls[i] = NullHandling.sqlCompatible();
+                  outputNulls[i] = true;
                   return;
                 }
                 final boolean bool = Evals.asBoolean(rightInput[i]);
@@ -884,7 +892,7 @@ public class VectorProcessors
               if (leftNull) {
                 if (rightNull) {
                   output[i] = 0L;
-                  outputNulls[i] = NullHandling.sqlCompatible();
+                  outputNulls[i] = true;
                   return;
                 }
                 final boolean bool = Evals.asBoolean(rightInput[i]);
@@ -933,7 +941,7 @@ public class VectorProcessors
               if (leftNull) {
                 if (rightNull) {
                   output[i] = 0L;
-                  outputNulls[i] = NullHandling.sqlCompatible();
+                  outputNulls[i] = true;
                   return;
                 }
                 final boolean bool = Evals.asBoolean(rightInput[i]);
@@ -980,7 +988,7 @@ public class VectorProcessors
             final boolean rightNull = rightInput[i] == null;
             if (leftNull) {
               if (rightNull) {
-                outputNulls[i] = NullHandling.sqlCompatible();
+                outputNulls[i] = true;
                 return;
               }
               final boolean bool = Evals.asBoolean((String) rightInput[i]);

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnBuilder.java
@@ -117,7 +117,7 @@ public class ColumnBuilder
     return this;
   }
 
-  public ColumnBuilder setStandardTypeColumnSupplier(Supplier<? extends NestedCommonFormatColumn> columnSupplier)
+  public ColumnBuilder setNestedCommonFormatColumnSupplier(Supplier<? extends NestedCommonFormatColumn> columnSupplier)
   {
     checkColumnSupplierNotSet();
     this.columnSupplier = columnSupplier;

--- a/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/RowSignature.java
@@ -138,6 +138,15 @@ public class RowSignature implements ColumnInspector
   }
 
   /**
+   * Returns true if the column is a numeric type ({@link ColumnType#isNumeric()}), otherwise false if the column
+   * is not a numeric type or is not present in the row signature.
+   */
+  public boolean isNumeric(final String columnName)
+  {
+    return getColumnType(columnName).map(ColumnType::isNumeric).orElse(false);
+  }
+
+  /**
    * Returns a list of column names in the order they appear in this signature.
    */
   public List<String> getColumnNames()

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldDictionaryEncodedColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedFieldDictionaryEncodedColumn.java
@@ -25,6 +25,7 @@ import com.google.common.base.Predicates;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
@@ -320,6 +321,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
       @Override
       public boolean isNull()
       {
+        if (NullHandling.replaceWithDefault()) {
+          return false;
+        }
         if (dictionary.get(getRowValue()) == 0) {
           return true;
         }
@@ -491,6 +495,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
           @Override
           public boolean isNull()
           {
+            if (NullHandling.replaceWithDefault()) {
+              return false;
+            }
             final int i = offset.getOffset();
             if (i < offsetMark) {
               // offset was reset, reset iterator state
@@ -530,6 +537,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
           @Override
           public boolean isNull()
           {
+            if (NullHandling.replaceWithDefault()) {
+              return false;
+            }
             final int i = offset.getOffset();
             if (i < offsetMark) {
               // offset was reset, reset iterator state
@@ -637,6 +647,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
         @Override
         public boolean isNull()
         {
+          if (NullHandling.replaceWithDefault()) {
+            return false;
+          }
           final int i = offset.getOffset();
           if (i < offsetMark) {
             // offset was reset, reset iterator state
@@ -831,6 +844,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
           @Override
           public boolean[] getNullVector()
           {
+            if (NullHandling.replaceWithDefault()) {
+              return null;
+            }
             computeVectorsIfNeeded();
             return nullVector;
           }
@@ -884,6 +900,9 @@ public class NestedFieldDictionaryEncodedColumn<TStringDictionary extends Indexe
           @Override
           public boolean[] getNullVector()
           {
+            if (NullHandling.replaceWithDefault()) {
+              return null;
+            }
             computeVectorsIfNeeded();
             return nullVector;
           }

--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantArrayColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantArrayColumn.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.nested;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -287,7 +288,7 @@ public class VariantArrayColumn<TStringDictionary extends Indexed<ByteBuffer>> i
         if (nullMark == offsetMark) {
           return true;
         }
-        return DimensionHandlerUtils.isNumericNull(getObject());
+        return NullHandling.sqlCompatible() && DimensionHandlerUtils.isNumericNull(getObject());
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/segment/serde/NestedCommonFormatColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/NestedCommonFormatColumnPartSerde.java
@@ -118,7 +118,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         capabilitiesBuilder.setDictionaryValuesSorted(true);
         capabilitiesBuilder.setDictionaryValuesUnique(true);
         builder.setType(logicalType);
-        builder.setStandardTypeColumnSupplier(supplier);
+        builder.setNestedCommonFormatColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
         builder.setFilterable(true);
@@ -138,7 +138,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         capabilitiesBuilder.setDictionaryValuesSorted(true);
         capabilitiesBuilder.setDictionaryValuesUnique(true);
         builder.setType(logicalType);
-        builder.setStandardTypeColumnSupplier(supplier);
+        builder.setNestedCommonFormatColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
         builder.setFilterable(true);
@@ -158,7 +158,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         capabilitiesBuilder.setDictionaryValuesSorted(true);
         capabilitiesBuilder.setDictionaryValuesUnique(true);
         builder.setType(logicalType);
-        builder.setStandardTypeColumnSupplier(supplier);
+        builder.setNestedCommonFormatColumnSupplier(supplier);
         builder.setIndexSupplier(supplier, true, false);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
         builder.setFilterable(true);
@@ -179,7 +179,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
         capabilitiesBuilder.setDictionaryValuesSorted(true);
         capabilitiesBuilder.setDictionaryValuesUnique(true);
         builder.setType(logicalType);
-        builder.setStandardTypeColumnSupplier(supplier);
+        builder.setNestedCommonFormatColumnSupplier(supplier);
         builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, capabilitiesBuilder.hasNulls().isTrue()));
         builder.setFilterable(true);
       });
@@ -200,7 +200,7 @@ public class NestedCommonFormatColumnPartSerde implements ColumnPartSerde
       ColumnType simpleType = supplier.getLogicalType();
       ColumnType logicalType = simpleType == null ? ColumnType.NESTED_DATA : simpleType;
       builder.setType(logicalType);
-      builder.setStandardTypeColumnSupplier(supplier);
+      builder.setNestedCommonFormatColumnSupplier(supplier);
       builder.setColumnFormat(new NestedCommonFormatColumn.Format(logicalType, hasNulls));
       builder.setFilterable(true);
     };

--- a/processing/src/main/java/org/apache/druid/segment/virtual/CastToTypeVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/CastToTypeVirtualColumn.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.virtual;
+
+import org.apache.druid.query.dimension.DimensionSpec;
+import org.apache.druid.segment.ColumnInspector;
+import org.apache.druid.segment.ColumnSelector;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.VirtualColumn;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnIndexSupplier;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.data.ReadableOffset;
+import org.apache.druid.segment.vector.ReadableVectorOffset;
+import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
+import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
+import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+public class CastToTypeVirtualColumn implements VirtualColumn
+{
+  private final String columnName;
+  private final String outputName;
+  private final ColumnType castToType;
+
+  public CastToTypeVirtualColumn(String columnName, String outputName, ColumnType castToType)
+  {
+    this.columnName = columnName;
+    this.outputName = outputName;
+    this.castToType = castToType;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return new byte[0];
+  }
+
+  @Override
+  public String getOutputName()
+  {
+    return outputName;
+  }
+
+  @Override
+  public DimensionSelector makeDimensionSelector(DimensionSpec dimensionSpec, ColumnSelectorFactory factory)
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public DimensionSelector makeDimensionSelector(
+      DimensionSpec dimensionSpec,
+      ColumnSelector columnSelector,
+      ReadableOffset offset
+  )
+  {
+    return VirtualColumn.super.makeDimensionSelector(dimensionSpec, columnSelector, offset);
+  }
+
+  @Override
+  public ColumnValueSelector<?> makeColumnValueSelector(String columnName, ColumnSelectorFactory factory)
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ColumnValueSelector<?> makeColumnValueSelector(
+      String columnName,
+      ColumnSelector columnSelector,
+      ReadableOffset offset
+  )
+  {
+    return VirtualColumn.super.makeColumnValueSelector(columnName, columnSelector, offset);
+  }
+
+  @Override
+  public boolean canVectorize(ColumnInspector inspector)
+  {
+    return VirtualColumn.super.canVectorize(inspector);
+  }
+
+  @Override
+  public SingleValueDimensionVectorSelector makeSingleValueVectorDimensionSelector(
+      DimensionSpec dimensionSpec,
+      VectorColumnSelectorFactory factory
+  )
+  {
+    return VirtualColumn.super.makeSingleValueVectorDimensionSelector(dimensionSpec, factory);
+  }
+
+  @Nullable
+  @Override
+  public SingleValueDimensionVectorSelector makeSingleValueVectorDimensionSelector(
+      DimensionSpec dimensionSpec,
+      ColumnSelector columnSelector,
+      ReadableVectorOffset offset
+  )
+  {
+    return VirtualColumn.super.makeSingleValueVectorDimensionSelector(dimensionSpec, columnSelector, offset);
+  }
+
+  @Override
+  public VectorValueSelector makeVectorValueSelector(String columnName, VectorColumnSelectorFactory factory)
+  {
+    return VirtualColumn.super.makeVectorValueSelector(columnName, factory);
+  }
+
+  @Nullable
+  @Override
+  public VectorValueSelector makeVectorValueSelector(
+      String columnName,
+      ColumnSelector columnSelector,
+      ReadableVectorOffset offset
+  )
+  {
+    return VirtualColumn.super.makeVectorValueSelector(columnName, columnSelector, offset);
+  }
+
+  @Override
+  public VectorObjectSelector makeVectorObjectSelector(String columnName, VectorColumnSelectorFactory factory)
+  {
+    return VirtualColumn.super.makeVectorObjectSelector(columnName, factory);
+  }
+
+  @Nullable
+  @Override
+  public VectorObjectSelector makeVectorObjectSelector(
+      String columnName,
+      ColumnSelector columnSelector,
+      ReadableVectorOffset offset
+  )
+  {
+    return VirtualColumn.super.makeVectorObjectSelector(columnName, columnSelector, offset);
+  }
+
+  @Override
+  public ColumnCapabilities capabilities(String columnName)
+  {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ColumnCapabilities capabilities(ColumnInspector inspector, String columnName)
+  {
+    return ColumnCapabilitiesImpl.createDefault().setType(castToType);
+  }
+
+  @Override
+  public List<String> requiredColumns()
+  {
+    return Collections.singletonList(columnName);
+  }
+
+  @Override
+  public boolean usesDotNotation()
+  {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public ColumnIndexSupplier getIndexSupplier(String columnName, ColumnSelector columnSelector)
+  {
+    return VirtualColumn.super.getIndexSupplier(columnName, columnSelector);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/NestedDataScanQueryTest.java
@@ -188,7 +188,9 @@ public class NestedDataScanQueryTest extends InitializedNullHandlingTest
     logResults(resultsRealtime);
     Assert.assertEquals(1, resultsRealtime.size());
     Assert.assertEquals(resultsRealtime.size(), resultsSegments.size());
-    Assert.assertEquals(resultsSegments.get(0).getEvents().toString(), resultsRealtime.get(0).getEvents().toString());
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertEquals(resultsSegments.get(0).getEvents().toString(), resultsRealtime.get(0).getEvents().toString());
+    }
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -726,8 +726,14 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       Assert.assertTrue(dimSelector.makeValueMatcher(x -> Objects.equals(x, theString)).matches());
       Assert.assertFalse(dimSelector.makeValueMatcher(x -> Objects.equals(x, NO_MATCH)).matches());
     } else {
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(path, valueSelector.isNull());
+      if (ColumnType.LONG.equals(singleType)) {
+        Assert.assertEquals(NullHandling.defaultLongValue(), valueSelector.getObject());
+      } else if (ColumnType.DOUBLE.equals(singleType)) {
+        Assert.assertEquals(NullHandling.defaultDoubleValue(), valueSelector.getObject());
+      } else {
+        Assert.assertNull(valueSelector.getObject());
+      }
+      Assert.assertEquals(path, NullHandling.sqlCompatible(), valueSelector.isNull());
 
       Assert.assertEquals(0, dimSelector.getRow().get(0));
       Assert.assertNull(dimSelector.getObject());

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4Test.java
@@ -507,8 +507,14 @@ public class NestedDataColumnSupplierV4Test extends InitializedNullHandlingTest
       Assert.assertTrue(dimSelector.makeValueMatcher(x -> Objects.equals(x, theString)).matches());
       Assert.assertFalse(dimSelector.makeValueMatcher(x -> Objects.equals(x, NO_MATCH)).matches());
     } else {
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(path, valueSelector.isNull());
+      if (ColumnType.LONG.equals(singleType)) {
+        Assert.assertEquals(NullHandling.defaultLongValue(), valueSelector.getObject());
+      } else if (ColumnType.DOUBLE.equals(singleType)) {
+        Assert.assertEquals(NullHandling.defaultDoubleValue(), valueSelector.getObject());
+      } else {
+        Assert.assertNull(valueSelector.getObject());
+      }
+      Assert.assertEquals(path, NullHandling.sqlCompatible(), valueSelector.isNull());
 
       Assert.assertEquals(0, dimSelector.getRow().get(0));
       Assert.assertNull(dimSelector.getObject());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/DruidExpression.java
@@ -437,6 +437,22 @@ public class DruidExpression
     );
   }
 
+  public DruidExpression map(
+      final Function<SimpleExtraction, SimpleExtraction> extractionMap,
+      final Function<String, String> expressionMap,
+      final ColumnType newType
+  )
+  {
+    return new DruidExpression(
+        nodeType,
+        newType,
+        simpleExtraction == null ? null : extractionMap.apply(simpleExtraction),
+        (args) -> expressionMap.apply(expressionGenerator.compile(args)),
+        arguments,
+        virtualColumnCreator
+    );
+  }
+
   public DruidExpression withArguments(List<DruidExpression> newArgs)
   {
     return new DruidExpression(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -108,7 +108,8 @@ public class CastOperatorConversion implements SqlOperatorConversion
         // Ignore casts for simple extractions (use Function.identity) since it is ok in many cases.
         typeCastExpression = operandExpression.map(
             Function.identity(),
-            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExpressionType.asTypeString())
+            expression -> StringUtils.format("CAST(%s, '%s')", expression, toExpressionType.asTypeString()),
+            toDruidType
         );
       }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -109,6 +109,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
       ImmutableMap.<String, Object>builder()
                   .put("t", "2000-01-01")
                   .put("string", "ccc")
+                  .put("string_sparse", "10")
                   .put("nest", ImmutableMap.of("x", 200L, "y", 3.03, "z", "abcdef", "mixed", 1.1, "mixed2", 1L))
                   .put("long", 3L)
                   .build(),
@@ -705,7 +706,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{NullHandling.defaultStringValue(), 10L},
+            new Object[]{NullHandling.defaultStringValue(), 8L},
+            new Object[]{"10", 2L},
             new Object[]{"yyy", 2L},
             new Object[]{"zzz", 2L}
         ),
@@ -811,7 +813,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{NullHandling.defaultStringValue(), 10L},
+            new Object[]{NullHandling.defaultStringValue(), 8L},
+            new Object[]{"10", 2L},
             new Object[]{"yyy", 2L},
             new Object[]{"zzz", 2L}
         ),
@@ -4559,6 +4562,258 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
               "Unsupported JSON_VALUE parameter 'ON EMPTY' defined - please re-issue this query without this argument"
           );
         }
+    );
+  }
+
+  @Test
+  public void testGroupByPathSelectorFilterVariantNull()
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(nest, '$.x'), "
+        + "JSON_VALUE(nester, '$.n.x' RETURNING BIGINT), "
+        + "SUM(cnt) "
+        + "FROM druid.nested WHERE JSON_VALUE(nester, '$.n.x' RETURNING BIGINT) IS NULL GROUP BY 1, 2",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            new NestedFieldVirtualColumn("nester", "$.n.x", "v0", ColumnType.LONG),
+                            new NestedFieldVirtualColumn("nest", "$.x", "v1", ColumnType.STRING)
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v1", "d0"),
+                                new DefaultDimensionSpec("v0", "d1", ColumnType.LONG)
+                            )
+                        )
+                        .setDimFilter(selector("v0", null, null))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        NullHandling.sqlCompatible() ?
+        ImmutableList.of(
+            new Object[]{NullHandling.defaultStringValue(), NullHandling.defaultLongValue(), 4L},
+            new Object[]{"200", NullHandling.defaultLongValue(), 1L}
+        ) : Collections.emptyList(),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .add("EXPR$2", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testGroupByPathSelectorFilterVariantNotNull()
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(nest, '$.x'), "
+        + "JSON_VALUE(nester, '$.n.x' RETURNING BIGINT), "
+        + "SUM(cnt) "
+        + "FROM druid.nested WHERE JSON_VALUE(nester, '$.n.x' RETURNING BIGINT) IS NOT NULL GROUP BY 1, 2",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setVirtualColumns(
+                            new NestedFieldVirtualColumn("nester", "$.n.x", "v0", ColumnType.LONG),
+                            new NestedFieldVirtualColumn("nest", "$.x", "v1", ColumnType.STRING)
+                        )
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v1", "d0"),
+                                new DefaultDimensionSpec("v0", "d1", ColumnType.LONG)
+                            )
+                        )
+                        .setDimFilter(not(selector("v0", null, null)))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        NullHandling.sqlCompatible() ?
+        ImmutableList.of(
+            new Object[]{"100", 1L, 1L}
+        ) :
+        ImmutableList.of(
+            new Object[]{"", 0L, 4L},
+            new Object[]{"100", 0L, 1L},
+            new Object[]{"100", 1L, 1L},
+            new Object[]{"200", 0L, 1L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.STRING)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .add("EXPR$2", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testGroupByRegularLongLongMixed1FilterNotNull()
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(long, '$' RETURNING BIGINT), "
+        + "SUM(cnt) "
+        + "FROM druid.nested_mix WHERE JSON_VALUE(long, '$' RETURNING BIGINT) IS NOT NULL GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE_MIXED)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)
+                            )
+                        )
+                        .setVirtualColumns(new NestedFieldVirtualColumn("long", "$", "v0", ColumnType.LONG))
+                        .setDimFilter(not(selector("v0", null, null)))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1L, 2L},
+            new Object[]{2L, 4L},
+            new Object[]{3L, 2L},
+            new Object[]{4L, 2L},
+            new Object[]{5L, 4L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testGroupByRootSingleTypeStringMixed1SparseNotNull()
+  {
+    testQuery(
+        "SELECT "
+        + "JSON_VALUE(string_sparse, '$' RETURNING BIGINT), "
+        + "SUM(cnt) "
+        + "FROM druid.nested_mix_2 WHERE JSON_VALUE(string_sparse, '$' RETURNING BIGINT) IS NOT NULL GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE_MIXED_2)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)
+                            )
+                        )
+                        .setVirtualColumns(new NestedFieldVirtualColumn("string_sparse", "$", "v0", ColumnType.LONG))
+                        .setDimFilter(not(selector("v0", null, null)))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        NullHandling.sqlCompatible() ? ImmutableList.of(
+            new Object[]{10L, 2L}
+        ) :
+        ImmutableList.of(
+            new Object[]{0L, 12L},
+            new Object[]{10L, 2L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testScanStringNotNullCast()
+  {
+    skipVectorize();
+    testQuery(
+        "SELECT "
+        + "CAST(string_sparse as BIGINT)"
+        + "FROM druid.nested_mix WHERE CAST(string_sparse as BIGINT) IS NOT NULL",
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(DATA_SOURCE_MIXED)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .virtualColumns(
+                      expressionVirtualColumn("v0", "CAST(\"string_sparse\", 'LONG')", ColumnType.LONG)
+                  )
+                  .filters(not(selector("v0", null, null)))
+                  .columns("v0")
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .legacy(false)
+                  .build()
+        ),
+        NullHandling.sqlCompatible() ?
+        ImmutableList.of(
+            new Object[]{10L},
+            new Object[]{10L}
+        ) :
+        ImmutableList.of(
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{10L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{10L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .build()
+    );
+  }
+
+  @Test
+  public void testGroupByRootSingleTypeStringMixed1SparseNotNullCast2()
+  {
+    testQuery(
+        "SELECT "
+        + "CAST(string_sparse as BIGINT), "
+        + "SUM(cnt) "
+        + "FROM druid.nested_mix WHERE CAST(string_sparse as BIGINT) IS NOT NULL GROUP BY 1",
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(DATA_SOURCE_MIXED)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("string_sparse", "d0", ColumnType.LONG)
+                            )
+                        )
+                        .setVirtualColumns(expressionVirtualColumn("v0", "CAST(\"string_sparse\", 'LONG')", ColumnType.LONG))
+                        .setDimFilter(not(selector("v0", null, null)))
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setContext(QUERY_CONTEXT_DEFAULT)
+                        .build()
+        ),
+        NullHandling.sqlCompatible() ?
+        ImmutableList.of(
+            new Object[]{10L, 2L}
+        ) :
+        ImmutableList.of(
+            new Object[]{0L, 12L},
+            new Object[]{10L, 2L}
+        ),
+        RowSignature.builder()
+                    .add("EXPR$0", ColumnType.LONG)
+                    .add("EXPR$1", ColumnType.LONG)
+                    .build()
     );
   }
 }


### PR DESCRIPTION
### Description
This PR fixes some bugs in both SQL compatible and 'default' value modes when filtering `IS NULL`/`IS NOT NULL` on values which are coerced to a numeric type, such as `CAST(x AS BIGINT)` or `JSON_VALUE(nested, '$.x' RETURNING BIGINT)`. While these expressions had different causes, the underlying effect was more or less the same and involved the query engine using the null value index for the underlying column to build the cursor, which only counts the null string values, and misses out on values which might become null after coercion.

For example given the following source data:
<img width="516" alt="Screenshot 2023-04-18 at 4 43 30 PM" src="https://user-images.githubusercontent.com/1577461/233599768-1944500d-efe5-42e4-898f-8e3e18f31b92.png">

trying to filter out nulls in default value mode would produce the following results:

<img width="625" alt="Screenshot 2023-04-18 at 4 43 18 PM" src="https://user-images.githubusercontent.com/1577461/233599907-fba40829-49db-41be-8fa6-04a78b49f17f.png">

and the same data ingested in SQL compatible mode also incorrect:

<img width="823" alt="Screenshot 2023-04-18 at 4 48 30 PM" src="https://user-images.githubusercontent.com/1577461/233600103-89404513-b388-4a2f-8649-8cb5478a847b.png">

However the "correct" results in "default" value mode should match all of the rows because there are no null numbers, and in SQL compatible mode, should only match a single row, since that is the only truly non-null number.

`JSON_VALUE` suffered from the same problem when using the `RETURNING` syntax to cast to a numeric type for string or mixed type fields.

The fix for `JSON_VALUE` is to adjust `NestedFieldVirtualColumn` to wrap the `ColumnIndexSupplier` when the expected type does not match the actual type of the path to return `NullValueIndex` which create indexes with `ColumnIndexCapabilities` that have `isExact()` return false. This allows queries to still use the underlying `NullValueIndex` as a partial index, and then a `ValueMatcher` or `VectorValueMatcher` to match any remaining values which become null after coercion.

The fix for `CAST` for now is that I have updated the cast coercion to set the output type to the cast type when creating a `DruidExpression` (we setup cast expressions as a simple extraction rather than an expression because many native parts can handle it themselves), and `Expressions.toSimpleLeafFilter` now checks for a simple extraction where the output type does not match the direct column type on the `RowSignature` and use an expression virtual column instead. Unfortunately this means that unlike `JSON_VALUE`, `CAST` cannot currently use the partial index. I want to change this in the future to either add a specialized casting virtual column that operates similar to how `NestedFieldVirtualColumn` is doing things, or perhaps just allow `ExpressionVirtualColumns` to allow expressions to opt into using indexes, though I'm not sure what this should look like quite yet.

This is such a giant mess, it seems wrong to me that like every selector `isNull` implementation is basically forced to check the value of `NullHandling.sqlCompatible`, not to mention how completely insane and unintuitive the default value mode results actually are due to there not being null values for numeric types. I want to prioritize switching to SQL compatible null handling by default... it is far past time for this I think.

#### Release note
Fixed issues involving filtering `NULL` values when using `CAST` expressions and `JSON_VALUE` expressions using the `RETURNING` syntax to coerce non-numeric types into numeric types, such as `CAST(x AS BIGINT) IS NOT NULL` or `JSON_VALUE(nested, '$.x' RETURNING BIGINT) IS NULL`. These expressions were incorrectly using the null value index of the underlying column, which produced results matching the values which were `NULL` string values, but not values which could not be converted into a numeric value and so were effectively `NULL`.

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
