### PR TITLE
fix(avro-json-path-expressions): allow more complex jsonpath expressions

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/GenericAvroJsonProvider.java
@@ -163,4 +163,14 @@ public class GenericAvroJsonProvider extends FlattenerJsonProvider
     }
     return ImmutableMap.of();
   }
+
+  @Override
+  public Object unwrap(final Object o)
+  {
+    if (o instanceof Utf8) {
+      return o.toString();
+    }
+
+    return o;
+  }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -102,10 +102,12 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
   private static final String EVENT_TYPE = "eventType";
   private static final String ID = "id";
   private static final String SOME_OTHER_ID = "someOtherId";
+  private static final String NESTED_ARRAY_VAL = "nestedArrayVal";
   private static final String IS_VALID = "isValid";
   private static final String TOPIC = "aTopic";
-  static final List<String> DIMENSIONS = Arrays.asList(EVENT_TYPE, ID, SOME_OTHER_ID, IS_VALID);
+  static final List<String> DIMENSIONS = Arrays.asList(EVENT_TYPE, ID, SOME_OTHER_ID, IS_VALID, NESTED_ARRAY_VAL);
   private static final List<String> DIMENSIONS_SCHEMALESS = Arrays.asList(
+      NESTED_ARRAY_VAL,
       SOME_OTHER_ID,
       "someIntArray",
       "someFloat",
@@ -135,7 +137,9 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
     flattenSpec = new JSONPathSpec(
       true,
       ImmutableList.of(
-          new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong")
+          new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong"),
+          new JSONPathFieldSpec(JSONPathFieldType.PATH, "nestedArrayVal", "someRecordArray[?(@.nestedString=='string in record')].nestedString")
+
       )
   );
     for (Module jacksonModule : new AvroExtensionsModule().getJacksonModules()) {

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -76,6 +76,7 @@ public class AvroStreamInputRowParserTest
   private static final String ID = "id";
   private static final String SOME_OTHER_ID = "someOtherId";
   private static final String IS_VALID = "isValid";
+  private static final String NESTED_ARRAY_VAL = "nestedArrayVal";
   private static final String TOPIC = "aTopic";
   private static final String EVENT_TYPE_VALUE = "type-a";
   private static final long ID_VALUE = 1976491L;
@@ -84,8 +85,9 @@ public class AvroStreamInputRowParserTest
   private static final int SOME_INT_VALUE = 1;
   private static final long SOME_LONG_VALUE = 679865987569912369L;
   private static final ZonedDateTime DATE_TIME = ZonedDateTime.of(2015, 10, 25, 19, 30, 0, 0, ZoneOffset.UTC);
-  static final List<String> DIMENSIONS = Arrays.asList(EVENT_TYPE, ID, SOME_OTHER_ID, IS_VALID);
+  static final List<String> DIMENSIONS = Arrays.asList(EVENT_TYPE, ID, SOME_OTHER_ID, IS_VALID, NESTED_ARRAY_VAL);
   private static final List<String> DIMENSIONS_SCHEMALESS = Arrays.asList(
+      NESTED_ARRAY_VAL,
       SOME_OTHER_ID,
       "someIntArray",
       "someFloat",
@@ -105,7 +107,8 @@ public class AvroStreamInputRowParserTest
       new JSONPathSpec(
           true,
           ImmutableList.of(
-              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong")
+              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong"),
+              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nestedArrayVal", "someRecordArray[?(@.nestedString=='string in record')].nestedString")
           )
       )
   );
@@ -115,7 +118,9 @@ public class AvroStreamInputRowParserTest
       new JSONPathSpec(
           true,
           ImmutableList.of(
-              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong")
+              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nested", "someRecord.subLong"),
+              new JSONPathFieldSpec(JSONPathFieldType.PATH, "nestedArrayVal", "someRecordArray[?(@.nestedString=='string in record')].nestedString")
+
           )
       )
   );
@@ -364,6 +369,14 @@ public class AvroStreamInputRowParserTest
     LinkedHashMap someRecord = (LinkedHashMap) someRecordObj;
     Assert.assertEquals(4892, someRecord.get("subInt"));
     Assert.assertEquals(1543698L, someRecord.get("subLong"));
+
+    final Object someList = inputRow.getDimension("nestedArrayVal");
+    Assert.assertNotNull(someList);
+    Assert.assertTrue(someList instanceof List);
+    List someRecordObj3List = (List) someList;
+    Assert.assertEquals(1, someRecordObj3List.size());
+    Assert.assertEquals("string in record", someRecordObj3List.get(0));
+
 
     // towards Map avro field as druid dimension, need to convert its toString() back to HashMap to check equality
     Assert.assertEquals(1, inputRow.getDimension("someIntValueMap").size());


### PR DESCRIPTION
### Description
When using the avro extension druid does not ingest dimensions that have been flattened  using the below jsonpath expression

```
someRecordArray[?(@.nestedString=='string in record')].nestedString
```

The purpose of the above expression is to capture all elements within a record array which have their `nestedString` field set to 'string in record'. This was not working in druid because the jayway jsonpath library was throwing an exception with the message `com.jayway.jsonpath.JsonPathException: Could not convert string in record to a ValueNode`. Exceptions are suppressed for this library so end users would not see this error appear in the logs (I believe). 

The exception would have been thrown here https://github.com/json-path/JsonPath/blob/master/json-path/src/main/java/com/jayway/jsonpath/internal/filter/ValueNodes.java#L705 This is because the `res` is of type `org.apache.avro.util.Utf8`. The idea with my fix is to return a type which the jayway json path can understand.

I think this would allow end users to create more complex jsonpath expressions 
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
