### PR TITLE
Persist supervisor spec only after successful start

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -55,10 +55,6 @@ jobs:
       - name: setup ${{ matrix.java }}
         run: export JAVA_HOME=$JAVA_HOME_${{ env.java_version }}_X64
 
-      - name: checkstyle
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} checkstyle:checkstyle --fail-at-end
-
       - name: packaging check
         run: |
           ./.github/scripts/setup_generate_license.sh
@@ -84,6 +80,10 @@ jobs:
           echo 'Running Maven install...' &&
           ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
           ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+
+      - name: checkstyle
+        if: ${{ matrix.java == 'jdk8' }}
+        run: ${MVN} checkstyle:checkstyle --fail-at-end
 
       - name: license checks
         if: ${{ matrix.java == 'jdk8' }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -55,6 +55,10 @@ jobs:
       - name: setup ${{ matrix.java }}
         run: export JAVA_HOME=$JAVA_HOME_${{ env.java_version }}_X64
 
+      - name: checkstyle
+        if: ${{ matrix.java == 'jdk8' }}
+        run: ${MVN} checkstyle:checkstyle --fail-at-end
+
       - name: packaging check
         run: |
           ./.github/scripts/setup_generate_license.sh
@@ -106,10 +110,6 @@ jobs:
       - name: animal sniffer checks
         if: ${{ matrix.java == 'jdk8' }}
         run: ${MVN} animal-sniffer:check --fail-at-end
-
-      - name: checkstyle
-        if: ${{ matrix.java == 'jdk8' }}
-        run: ${MVN} checkstyle:checkstyle --fail-at-end
 
       - name: enforcer checks
         if: ${{ matrix.java == 'jdk8' }}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -258,6 +259,36 @@ public class SupervisorManagerTest extends EasyMockSupport
     manager.start();
 
     // if we get here, we are properly insulated from exploding supervisors
+  }
+
+  @Test
+  public void testNoPersistOnFailedStart()
+  {
+    exception.expect(RuntimeException.class);
+
+    Capture<TestSupervisorSpec> capturedInsert = Capture.newInstance();
+
+    EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(Collections.emptyMap());
+    metadataSupervisorManager.insert(EasyMock.eq("id1"), EasyMock.capture(capturedInsert));
+    supervisor1.start();
+    supervisor1.stop(true);
+    supervisor2.start();
+    EasyMock.expectLastCall().andThrow(new RuntimeException("supervisor failed to start"));
+    replayAll();
+
+    final SupervisorSpec testSpecOld = new TestSupervisorSpec("id1", supervisor1);
+    final SupervisorSpec testSpecNew = new TestSupervisorSpec("id1", supervisor2);
+
+    manager.start();
+    try {
+      manager.createOrUpdateAndStartSupervisor(testSpecOld);
+      manager.createOrUpdateAndStartSupervisor(testSpecNew);
+    }
+    catch (Exception e)
+    {
+      Assert.assertEquals(testSpecOld, capturedInsert.getValue());
+      throw e;
+    }
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -284,8 +284,7 @@ public class SupervisorManagerTest extends EasyMockSupport
       manager.createOrUpdateAndStartSupervisor(testSpecOld);
       manager.createOrUpdateAndStartSupervisor(testSpecNew);
     }
-    catch (Exception e)
-    {
+    catch (Exception e) {
       Assert.assertEquals(testSpecOld, capturedInsert.getValue());
       throw e;
     }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes unneeded creation of a NoopSupervisorSpec as a tombstone

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

If a supervisor fails to start, it may create a NoopSupervisorSpec as a tombstone instead of remaining in its old state. This could lead to the "disappearance" of a supervisor

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
A simple fix could be to persist the spec only after it has successfully started

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `SupervisorManager`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
