### PR TITLE
MSQ: Slightly quieter fault tolerance logging.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernel.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernel.java
@@ -669,7 +669,7 @@ public class ControllerQueryKernel
       errorCode = msqFault.getErrorCode();
     }
 
-    log.info("Parsed out errorCode[%s] to check eligibility for retry", errorCode);
+    log.debug("Parsed out errorCode[%s] to check eligibility for retry for workerNumber[%s]", errorCode, workerNumber);
 
     if (RETRIABLE_ERROR_CODES.contains(errorCode)) {
       return getWorkInCaseWorkerEligibleForRetry(workerNumber);


### PR DESCRIPTION
There's a bunch of messages logged when a worker fails. IMO this one isn't as useful as the others.