### PR TITLE
Web console: set count on rule history api

### DIFF
--- a/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
@@ -81,7 +81,7 @@ ORDER BY 1`,
     initQuery: props.datasource,
     processQuery: async datasource => {
       const historyResp = await Api.instance.get(
-        `/druid/coordinator/v1/rules/${Api.encodePath(datasource)}/history`,
+        `/druid/coordinator/v1/rules/${Api.encodePath(datasource)}/history?count=200`,
       );
       return historyResp.data;
     },


### PR DESCRIPTION
By not setting the `count` it default to fetching results by interval and uses only the latest 1 week as the default interval. Set the count instead.