### PR TITLE
Web console: allow __time in MSQ

### DIFF
--- a/web-console/src/druid-models/dimension-spec/dimension-spec.ts
+++ b/web-console/src/druid-models/dimension-spec/dimension-spec.ts
@@ -85,7 +85,7 @@ export function getDimensionSpecs(
   guessNumericStringsAsNumbers: boolean,
   hasRollup: boolean,
 ): (string | DimensionSpec)[] {
-  return filterMap(getHeaderNamesFromSampleResponse(sampleResponse, true), h => {
+  return filterMap(getHeaderNamesFromSampleResponse(sampleResponse, 'ignore'), h => {
     const dimensionType =
       typeHints[h] ||
       guessColumnTypeFromSampleResponse(sampleResponse, h, guessNumericStringsAsNumbers);

--- a/web-console/src/druid-models/timestamp-spec/timestamp-spec.tsx
+++ b/web-console/src/druid-models/timestamp-spec/timestamp-spec.tsx
@@ -39,6 +39,12 @@ export const PLACEHOLDER_TIMESTAMP_SPEC: TimestampSpec = {
   missingValue: '1970-01-01T00:00:00Z',
 };
 
+export const DETECTION_TIMESTAMP_SPEC: TimestampSpec = {
+  column: TIME_COLUMN,
+  format: 'millis',
+  missingValue: '1970-01-01T00:00:00Z',
+};
+
 export const REINDEX_TIMESTAMP_SPEC: TimestampSpec = {
   column: TIME_COLUMN,
   format: 'millis',

--- a/web-console/src/helpers/__snapshots__/spec-conversion.spec.ts.snap
+++ b/web-console/src/helpers/__snapshots__/spec-conversion.spec.ts.snap
@@ -10,7 +10,7 @@ WITH "source" AS (SELECT * FROM TABLE(
   )
 ) EXTEND ("event_ts" VARCHAR, "col1" VARCHAR, "col2" VARCHAR, "col3" VARCHAR, "col4" VARCHAR, "field1" DOUBLE, "field2" DOUBLE, "field3" DOUBLE, "field4" VARCHAR, "field5" VARCHAR, "field6" BIGINT, "field7" DOUBLE))
 SELECT
-  TIME_FLOOR(CASE WHEN CAST("event_ts" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("event_ts" AS BIGINT)) ELSE TIME_PARSE("event_ts") END, 'PT1H') AS __time,
+  TIME_FLOOR(CASE WHEN CAST("event_ts" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("event_ts" AS BIGINT)) ELSE TIME_PARSE("event_ts") END, 'PT1H') AS "__time",
   "col1",
   "col2",
   "col3",
@@ -38,7 +38,7 @@ WITH "source" AS (SELECT * FROM TABLE(
   )
 ) EXTEND ("timestamp" VARCHAR, "isRobot" VARCHAR, "channel" VARCHAR, "flags" VARCHAR, "isUnpatrolled" VARCHAR, "comment" VARCHAR, "isNew" VARCHAR, "isMinor" VARCHAR, "isAnonymous" VARCHAR, "user" VARCHAR, "namespace" VARCHAR, "cityName" VARCHAR, "countryName" VARCHAR, "regionIsoCode" VARCHAR, "metroCode" VARCHAR, "countryIsoCode" VARCHAR, "regionName" VARCHAR, "added" BIGINT, "commentLength" BIGINT, "delta" BIGINT, "deltaBucket" BIGINT, "deleted" BIGINT, "page" VARCHAR))
 SELECT
-  TIME_FLOOR(TIME_PARSE("timestamp"), 'PT1H') AS __time,
+  TIME_FLOOR(TIME_PARSE("timestamp"), 'PT1H') AS "__time",
   "isRobot",
   "channel",
   "flags",
@@ -77,7 +77,7 @@ WITH "source" AS (SELECT * FROM TABLE(
   )
 ) EXTEND ("timestamp" VARCHAR, "isRobot" VARCHAR, "channel" VARCHAR, "flags" VARCHAR, "isUnpatrolled" VARCHAR, "page" VARCHAR, "diffUrl" VARCHAR, "added" BIGINT, "comment" VARCHAR, "commentLength" BIGINT, "isNew" VARCHAR, "isMinor" VARCHAR, "delta" BIGINT, "isAnonymous" VARCHAR, "user" VARCHAR, "deltaBucket" BIGINT, "deleted" BIGINT, "namespace" VARCHAR, "cityName" VARCHAR, "countryName" VARCHAR, "regionIsoCode" VARCHAR, "metroCode" VARCHAR, "countryIsoCode" VARCHAR, "regionName" VARCHAR, "event" TYPE('COMPLEX<json>')))
 SELECT
-  CASE WHEN CAST("timestamp" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("timestamp" AS BIGINT)) ELSE TIME_PARSE("timestamp") END AS __time,
+  CASE WHEN CAST("timestamp" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("timestamp" AS BIGINT)) ELSE TIME_PARSE("timestamp") END AS "__time",
   "isRobot",
   "channel",
   "flags",
@@ -119,7 +119,7 @@ WITH "source" AS (SELECT * FROM TABLE(
 ) EXTEND ("isRobot" VARCHAR, "channel" VARCHAR, "flags" VARCHAR, "isUnpatrolled" VARCHAR, "page" VARCHAR, "diffUrl" VARCHAR, "added" BIGINT, "comment" VARCHAR, "commentLength" BIGINT, "isNew" VARCHAR, "isMinor" VARCHAR, "delta" BIGINT, "isAnonymous" VARCHAR, "user" VARCHAR, "deltaBucket" BIGINT, "deleted" BIGINT, "namespace" VARCHAR, "cityName" VARCHAR, "countryName" VARCHAR, "regionIsoCode" VARCHAR, "metroCode" VARCHAR, "countryIsoCode" VARCHAR, "regionName" VARCHAR))
 SELECT
   --:ISSUE: The spec contained transforms that could not be automatically converted.
-  REWRITE_[_some_time_parse_expression_]_TO_SQL AS __time, --:ISSUE: Transform for __time could not be converted
+  REWRITE_[_some_time_parse_expression_]_TO_SQL AS "__time", --:ISSUE: Transform for __time could not be converted
   "isRobot",
   "channel",
   "flags",
@@ -159,7 +159,7 @@ WITH "source" AS (SELECT * FROM TABLE(
 ) EXTEND ("timestamp" VARCHAR, "isRobot" VARCHAR, "channel" VARCHAR, "flags" VARCHAR, "isUnpatrolled" VARCHAR, "page" VARCHAR, "diffUrl" VARCHAR, "added" BIGINT, "comment" VARCHAR, "commentLength" BIGINT, "isNew" VARCHAR, "isMinor" VARCHAR, "delta" BIGINT, "isAnonymous" VARCHAR, "user" VARCHAR, "deltaBucket" BIGINT, "deleted" BIGINT, "namespace" VARCHAR, "cityName" VARCHAR, "countryName" VARCHAR, "regionIsoCode" VARCHAR, "metroCode" VARCHAR, "countryIsoCode" VARCHAR, "regionName" VARCHAR))
 SELECT
   --:ISSUE: The spec contained transforms that could not be automatically converted.
-  CASE WHEN CAST("timestamp" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("timestamp" AS BIGINT)) ELSE TIME_PARSE("timestamp") END AS __time,
+  CASE WHEN CAST("timestamp" AS BIGINT) > 0 THEN MILLIS_TO_TIMESTAMP(CAST("timestamp" AS BIGINT)) ELSE TIME_PARSE("timestamp") END AS "__time",
   "isRobot",
   "channel",
   "flags",
@@ -185,6 +185,25 @@ SELECT
   "regionName"
 FROM "source"
 WHERE REWRITE_[{"type":"strange"}]_TO_SQL --:ISSUE: The spec contained a filter that could not be automatically converted, please convert it manually
+PARTITIONED BY HOUR
+CLUSTERED BY "isRobot"
+`;
+
+exports[`spec conversion converts with when the __time column is used as the __time column 1`] = `
+-- This SQL query was auto generated from an ingestion spec
+REPLACE INTO "wikipedia" OVERWRITE ALL
+WITH "source" AS (SELECT * FROM TABLE(
+  EXTERN(
+    '{"type":"http","uris":["https://druid.apache.org/data/wikipedia.json.gz"]}',
+    '{"type":"json"}'
+  )
+) EXTEND ("__time" BIGINT, "isRobot" VARCHAR, "channel" VARCHAR, "flags" VARCHAR))
+SELECT
+  "__time" AS "__time",
+  "isRobot",
+  "channel",
+  "flags"
+FROM "source"
 PARTITIONED BY HOUR
 CLUSTERED BY "isRobot"
 `;

--- a/web-console/src/helpers/spec-conversion.spec.ts
+++ b/web-console/src/helpers/spec-conversion.spec.ts
@@ -444,6 +444,52 @@ describe('spec conversion', () => {
     expect(converted.queryString).toMatchSnapshot();
   });
 
+  it('converts with when the __time column is used as the __time column', () => {
+    const converted = convertSpecToSql({
+      type: 'index_parallel',
+      spec: {
+        ioConfig: {
+          type: 'index_parallel',
+          inputSource: {
+            type: 'http',
+            uris: ['https://druid.apache.org/data/wikipedia.json.gz'],
+          },
+          inputFormat: {
+            type: 'json',
+          },
+        },
+        dataSchema: {
+          granularitySpec: {
+            segmentGranularity: 'hour',
+            queryGranularity: 'none',
+            rollup: false,
+          },
+          dataSource: 'wikipedia',
+          timestampSpec: {
+            column: '__time',
+            format: 'millis',
+          },
+          dimensionsSpec: {
+            dimensions: ['isRobot', 'channel', 'flags'],
+          },
+        },
+        tuningConfig: {
+          type: 'index_parallel',
+          partitionsSpec: {
+            type: 'single_dim',
+            partitionDimension: 'isRobot',
+            targetRowsPerSegment: 150000,
+          },
+          forceGuaranteedRollup: true,
+          maxNumConcurrentSubTasks: 4,
+          maxParseExceptions: 3,
+        },
+      },
+    });
+
+    expect(converted.queryString).toMatchSnapshot();
+  });
+
   it('converts with issue when there is a dimension transform and strange filter', () => {
     const converted = convertSpecToSql({
       type: 'index_parallel',

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -32,6 +32,7 @@ import type {
   TransformSpec,
 } from '../druid-models';
 import {
+  DETECTION_TIMESTAMP_SPEC,
   getDimensionNamesFromTransforms,
   getDimensionSpecName,
   getSpecType,
@@ -343,7 +344,7 @@ export async function sampleForParser(
       ioConfig,
       dataSchema: {
         dataSource: 'sample',
-        timestampSpec: reingestMode ? REINDEX_TIMESTAMP_SPEC : PLACEHOLDER_TIMESTAMP_SPEC,
+        timestampSpec: reingestMode ? REINDEX_TIMESTAMP_SPEC : DETECTION_TIMESTAMP_SPEC,
         dimensionsSpec: {
           useSchemaDiscovery: true,
         },

--- a/web-console/src/views/load-data-view/parse-data-table/__snapshots__/parse-data-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/parse-data-table/__snapshots__/parse-data-table.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`ParseDataTable matches snapshot 1`] = `
   >
     <div
       class="rt-thead -header"
-      style="min-width: 875px;"
+      style="min-width: 1015px;"
     >
       <div
         class="rt-tr"
@@ -24,6 +24,35 @@ exports[`ParseDataTable matches snapshot 1`] = `
         >
           <div
             class=""
+          />
+        </div>
+        <div
+          class="rt-th rt-resizable-header"
+          role="columnheader"
+          style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          tabindex="-1"
+        >
+          <div
+            class="rt-resizable-header-content"
+          >
+            <div
+              class=""
+            >
+              <div
+                class="column-name"
+              >
+                __time
+              </div>
+              <div
+                class="column-detail"
+              >
+                
+                 
+              </div>
+            </div>
+          </div>
+          <div
+            class="rt-resizer"
           />
         </div>
         <div
@@ -204,7 +233,7 @@ exports[`ParseDataTable matches snapshot 1`] = `
     </div>
     <div
       class="rt-tbody"
-      style="min-width: 875px;"
+      style="min-width: 1015px;"
     >
       <div
         class="rt-tr-group"
@@ -223,6 +252,17 @@ exports[`ParseDataTable matches snapshot 1`] = `
               class="rt-expander"
             >
               •
+            </div>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <div
+              class="table-cell plain"
+            >
+              1460366400000
             </div>
           </div>
           <div
@@ -320,6 +360,17 @@ exports[`ParseDataTable matches snapshot 1`] = `
             <div
               class="table-cell plain"
             >
+              1460366460000
+            </div>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <div
+              class="table-cell plain"
+            >
               Bob
             </div>
           </div>
@@ -397,6 +448,17 @@ exports[`ParseDataTable matches snapshot 1`] = `
               class="rt-expander"
             >
               •
+            </div>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <div
+              class="table-cell plain"
+            >
+              1460366520000
             </div>
           </div>
           <div
@@ -538,6 +600,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -552,6 +623,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -684,6 +764,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -698,6 +787,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -830,6 +928,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -844,6 +951,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -976,6 +1092,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -990,6 +1115,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1122,6 +1256,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1136,6 +1279,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1268,6 +1420,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1282,6 +1443,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1414,6 +1584,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1428,6 +1607,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1560,6 +1748,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1574,6 +1771,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1706,6 +1912,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1720,6 +1935,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1852,6 +2076,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -1866,6 +2099,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -1998,6 +2240,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2012,6 +2263,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2144,6 +2404,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2158,6 +2427,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2290,6 +2568,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2304,6 +2591,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2436,6 +2732,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2450,6 +2755,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2582,6 +2896,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2596,6 +2919,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2728,6 +3060,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2742,6 +3083,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -2874,6 +3224,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -2888,6 +3247,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3020,6 +3388,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3034,6 +3411,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3166,6 +3552,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3180,6 +3575,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3312,6 +3716,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3326,6 +3739,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3458,6 +3880,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3472,6 +3903,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3604,6 +4044,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3618,6 +4067,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                
@@ -3750,6 +4208,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3823,6 +4290,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
                
             </span>
           </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
+          >
+            <span>
+               
+            </span>
+          </div>
         </div>
       </div>
       <div
@@ -3837,6 +4313,15 @@ exports[`ParseDataTable matches snapshot 1`] = `
             class="rt-td"
             role="gridcell"
             style="flex: 35 0 auto; width: 35px; max-width: 35px;"
+          >
+            <span>
+               
+            </span>
+          </div>
+          <div
+            class="rt-td"
+            role="gridcell"
+            style="flex: 140 0 auto; width: 140px; max-width: 140px;"
           >
             <span>
                

--- a/web-console/src/views/load-data-view/parse-data-table/parse-data-table.tsx
+++ b/web-console/src/views/load-data-view/parse-data-table/parse-data-table.tsx
@@ -41,8 +41,7 @@ export interface ParseDataTableProps {
   canFlatten: boolean;
   flattenedColumnsOnly: boolean;
   flattenFields: FlattenField[];
-  onFlattenFieldSelect: (field: FlattenField, index: number) => void;
-  useInput?: boolean;
+  onFlattenFieldSelect?: (field: FlattenField, index: number) => void;
 }
 
 export const ParseDataTable = React.memo(function ParseDataTable(props: ParseDataTableProps) {
@@ -53,10 +52,8 @@ export const ParseDataTable = React.memo(function ParseDataTable(props: ParseDat
     flattenedColumnsOnly,
     flattenFields,
     onFlattenFieldSelect,
-    useInput,
   } = props;
 
-  const key = useInput ? 'input' : 'parsed';
   return (
     <ReactTable
       className={classNames('parse-data-table', DEFAULT_TABLE_CLASS_NAME)}
@@ -66,7 +63,7 @@ export const ParseDataTable = React.memo(function ParseDataTable(props: ParseDat
       pageSizeOptions={STANDARD_TABLE_PAGE_SIZE_OPTIONS}
       showPagination={sampleResponse.data.length > STANDARD_TABLE_PAGE_SIZE}
       columns={filterMap(
-        getHeaderNamesFromSampleResponse(sampleResponse, true),
+        getHeaderNamesFromSampleResponse(sampleResponse, 'ignoreIfZero'),
         (columnName, i) => {
           if (!caseInsensitiveContains(columnName, columnFilter)) return;
           const flattenFieldIndex = flattenFields.findIndex(f => f.name === columnName);
@@ -78,7 +75,7 @@ export const ParseDataTable = React.memo(function ParseDataTable(props: ParseDat
                 className={classNames({ clickable: flattenField })}
                 onClick={() => {
                   if (!flattenField) return;
-                  onFlattenFieldSelect(flattenField, flattenFieldIndex);
+                  onFlattenFieldSelect?.(flattenField, flattenFieldIndex);
                 }}
               >
                 <div className="column-name">{columnName}</div>
@@ -88,7 +85,7 @@ export const ParseDataTable = React.memo(function ParseDataTable(props: ParseDat
               </div>
             ),
             id: String(i),
-            accessor: (row: SampleEntry) => (row[key] ? row[key]![columnName] : null),
+            accessor: (row: SampleEntry) => row.parsed?.[columnName] ?? null,
             width: 140,
             Cell: function ParseDataTableCell(row: RowRenderProps) {
               if (row.original.unparseable) {

--- a/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
+++ b/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
@@ -49,12 +49,12 @@ import { AsyncActionDialog } from '../../../dialogs';
 import type { Execution, ExternalConfig, IngestQueryPattern } from '../../../druid-models';
 import {
   changeQueryPatternExpression,
+  DETECTION_TIMESTAMP_SPEC,
   fitIngestQueryPattern,
   getDestinationMode,
   getQueryPatternExpression,
   getQueryPatternExpressionType,
   ingestQueryPatternToQuery,
-  PLACEHOLDER_TIMESTAMP_SPEC,
   possibleDruidFormatForValues,
   TIME_COLUMN,
   WorkbenchQueryPart,
@@ -84,7 +84,7 @@ import {
   wait,
   without,
 } from '../../../utils';
-import { postToSampler } from '../../../utils/sampler';
+import { getHeaderFromSampleResponse, postToSampler } from '../../../utils/sampler';
 import { FlexibleQueryInput } from '../../workbench-view/flexible-query-input/flexible-query-input';
 import { ColumnActions } from '../column-actions/column-actions';
 import { ColumnEditor } from '../column-editor/column-editor';
@@ -406,12 +406,14 @@ export const SchemaStep = function SchemaStep(props: SchemaStepProps) {
             },
             dataSchema: {
               dataSource: 'sample',
-              timestampSpec: PLACEHOLDER_TIMESTAMP_SPEC,
+              timestampSpec: DETECTION_TIMESTAMP_SPEC,
               dimensionsSpec: {
-                dimensions: sampleExternalConfig.signature.map(s => {
+                dimensions: filterMap(sampleExternalConfig.signature, s => {
+                  const columnName = s.getColumnName();
+                  if (columnName === TIME_COLUMN) return;
                   const t = s.columnType.getNativeType();
                   return {
-                    name: s.getColumnName(),
+                    name: columnName,
                     type: t === 'COMPLEX<json>' ? 'json' : t,
                   };
                 }),
@@ -429,12 +431,11 @@ export const SchemaStep = function SchemaStep(props: SchemaStepProps) {
         'sample',
       );
 
-      const columns = filterMap(sampleResponse.logicalSegmentSchema, ({ name, type }) => {
-        if (name === '__time') return;
+      const columns = getHeaderFromSampleResponse(sampleResponse).map(({ name, type }) => {
         return new Column({
           name,
           nativeType: type,
-          sqlType: SqlType.fromNativeType(type).toString(),
+          sqlType: name === TIME_COLUMN ? 'TIMESTAMP' : SqlType.fromNativeType(type).toString(),
         });
       });
 


### PR DESCRIPTION
This is the web console follow up to utilize the functionality enabled in the PR: https://github.com/apache/druid/pull/14148

This changes:
- The sampling for "Connect input source"
- The SQL data loader
- The native batch data loader
- The native-to-SQL spec converter

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/177816/234475575-1bc97c5b-d7ca-4669-9948-6bb063eb7cab.png">

Note: Here is some data I used for testing:

```json
{"__time": 1681794225551, "str_dim": "day1", "double_measure1": 5, "double_measure2": 15.5}
{"__time": 1681794225558, "str_dim": "day1", "double_measure1": 5, "double_measure2": 15.5}
```