### PR TITLE
Adding EitherException to prevent nested error in Either usage.

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/Either.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Either.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 /**
  * Encapsulates either an "error" or a "value".
- *
+ * <br/>
  * Similar to the Either class in Scala or Haskell, except the possibilities are named "error" and "value" instead of
  * "left" and "right".
  */
@@ -77,11 +77,26 @@ public class Either<L, R>
   }
 
   /**
-   * If this Either represents a value, returns it. If this Either represents an error, throw an error.
-   *
-   * If the error is a {@link Throwable}, it is wrapped in a RuntimeException and thrown. If it is not a throwable,
-   * a generic error is thrown containing the string representation of the error object.
-   *
+   * <ul>
+   *  <li>
+   *  If this Either represents a value, returns it.
+   *  </li>
+   *  <li>
+   *  If this Either represents an error, throw an error.
+   *  <ul>
+   *    <li>
+   *    If the error is an {@link EitherException}, the original exception is thrown.
+   *    </li>
+   *    <li>
+   *    If the error is a {@link Throwable}, it is wrapped in an {@link EitherException} and thrown.
+   *    </li>
+   *    <li>
+   *    If it is not a throwable, a generic {@link EitherException} is thrown containing the string representation of the error object.
+   *    </li>
+   *    </li>
+   *  </ul>
+   * </ul>
+   * <br/>
    * To retrieve the error as-is, use {@link #isError()} and {@link #error()} instead.
    */
   @Nullable
@@ -89,21 +104,23 @@ public class Either<L, R>
   {
     if (isValue()) {
       return value;
+    } else if (error instanceof EitherException) {
+      throw (EitherException) error;
     } else if (error instanceof Throwable) {
       // Always wrap Throwable, even if we could throw it directly, to provide additional context
       // about where the exception happened (we want the current stack frame in the trace).
-      throw new RuntimeException((Throwable) error);
+      throw new EitherException((Throwable) error);
     } else {
-      throw new RuntimeException(error.toString());
+      throw new EitherException(error.toString());
     }
   }
 
   /**
    * Applies a function to this value, if present.
-   *
+   * <br/>
    * If the mapping function throws an exception, it is thrown by this method instead of being packed up into
    * the returned Either.
-   *
+   * <br/>
    * If this Either represents an error, the mapping function is not applied.
    *
    * @throws NullPointerException if the mapping function returns null

--- a/processing/src/main/java/org/apache/druid/java/util/common/EitherException.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/EitherException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.common;
+
+public class EitherException extends RuntimeException
+{
+  public EitherException(Throwable error)
+  {
+    super(error);
+  }
+
+  public EitherException(String errorMessage)
+  {
+    super(errorMessage);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/common/EitherTest.java
+++ b/processing/src/test/java/org/apache/druid/common/EitherTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.common;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.Either;
+import org.apache.druid.java.util.common.EitherException;
 import org.apache.druid.java.util.common.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -29,6 +30,9 @@ import org.junit.Test;
 
 public class EitherTest
 {
+
+  public static final String ERROR_MESSAGE = "oh no";
+
   @Test
   public void testValueString()
   {
@@ -70,17 +74,17 @@ public class EitherTest
   @Test
   public void testErrorString()
   {
-    final Either<String, Object> either = Either.error("oh no");
+    final Either<String, Object> either = Either.error(ERROR_MESSAGE);
 
     Assert.assertTrue(either.isError());
     Assert.assertFalse(either.isValue());
-    Assert.assertEquals("oh no", either.error());
+    Assert.assertEquals(ERROR_MESSAGE, either.error());
 
     final RuntimeException e = Assert.assertThrows(RuntimeException.class, either::valueOrThrow);
-    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo("oh no"));
+    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.equalTo(ERROR_MESSAGE));
 
     // Test toString.
-    Assert.assertEquals("Error[oh no]", either.toString());
+    Assert.assertEquals("Error[" + ERROR_MESSAGE + "]", either.toString());
 
     // Test map.
     Assert.assertEquals(either, either.map(o -> "this does nothing because the Either is an error"));
@@ -89,20 +93,60 @@ public class EitherTest
   @Test
   public void testErrorThrowable()
   {
-    final Either<Throwable, Object> either = Either.error(new AssertionError("oh no"));
+    final Either<Throwable, Object> either = Either.error(new AssertionError(ERROR_MESSAGE));
 
     Assert.assertTrue(either.isError());
     Assert.assertFalse(either.isValue());
     MatcherAssert.assertThat(either.error(), CoreMatchers.instanceOf(AssertionError.class));
-    MatcherAssert.assertThat(either.error().getMessage(), CoreMatchers.equalTo("oh no"));
+    MatcherAssert.assertThat(either.error().getMessage(), CoreMatchers.equalTo(ERROR_MESSAGE));
 
     final RuntimeException e = Assert.assertThrows(RuntimeException.class, either::valueOrThrow);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(AssertionError.class));
-    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.equalTo("oh no"));
+    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.equalTo(ERROR_MESSAGE));
 
     // Test toString.
-    Assert.assertEquals("Error[java.lang.AssertionError: oh no]", either.toString());
+    Assert.assertEquals("Error[java.lang.AssertionError: " + ERROR_MESSAGE + "]", either.toString());
   }
+
+
+  @Test
+  public void testNestedExceptions()
+  {
+    final Either<Throwable, Object> either = Either.error(new AssertionError(ERROR_MESSAGE));
+    Assert.assertTrue(either.isError());
+    Assert.assertFalse(either.isValue());
+    MatcherAssert.assertThat(either.error(), CoreMatchers.instanceOf(AssertionError.class));
+    MatcherAssert.assertThat(either.error().getMessage(), CoreMatchers.equalTo(ERROR_MESSAGE));
+
+    final EitherException e1 = Assert.assertThrows(EitherException.class, either::valueOrThrow);
+    MatcherAssert.assertThat(e1.getCause(), CoreMatchers.instanceOf(AssertionError.class));
+    MatcherAssert.assertThat(e1.getCause().getMessage(), CoreMatchers.equalTo(ERROR_MESSAGE));
+
+    // Test toString.
+    Assert.assertEquals("Error[java.lang.AssertionError: " + ERROR_MESSAGE + "]", either.toString());
+
+    final Exception e2 = Assert.assertThrows(EitherException.class, Either.error(e1)::valueOrThrow);
+    Assert.assertEquals(e1, e2);
+  }
+
+  @Test
+  public void testNestedErrors()
+  {
+    final Either<String, Object> either = Either.error(ERROR_MESSAGE);
+    Assert.assertTrue(either.isError());
+    Assert.assertFalse(either.isValue());
+    Assert.assertEquals(ERROR_MESSAGE, either.error());
+
+    final EitherException e1 = Assert.assertThrows(EitherException.class, either::valueOrThrow);
+    Assert.assertNull(e1.getCause());
+
+    // Test toString.
+    Assert.assertEquals("Error[" + ERROR_MESSAGE + "]", either.toString());
+
+    final Exception e2 = Assert.assertThrows(EitherException.class, Either.error(e1)::valueOrThrow);
+    Assert.assertEquals(e1, e2);
+  }
+
 
   @Test
   public void testEqualsAndHashCode()


### PR DESCRIPTION
If Either exception was fed into another either nested exceptions were thrown which becomes hard to debug. 
Added a new `EitherException` to break the nesting. 

This change resulted in much cleaner logs on the MSQ side
Logs went from :

```
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: org.apache.druid.query.groupby.epinephelinae.UnexpectedMultiValueDimensionException: Encountered multi-value dimension [tags] that cannot be processed with 'gro
```
to  

```
org.apache.druid.java.util.common.EitherException: org.apache.druid.query.groupby.epinephelinae.UnexpectedMultiValueDimensionException: Encountered multi-valu
``` 
