### PR TITLE
Web console: fix task query error decode

### DIFF
--- a/web-console/src/utils/druid-query.spec.ts
+++ b/web-console/src/utils/druid-query.spec.ts
@@ -18,7 +18,7 @@
 
 import { sane } from 'druid-query-toolkit';
 
-import { DruidError, getDruidErrorMessage, parseHtmlError } from './druid-query';
+import { DruidError, getDruidErrorMessage } from './druid-query';
 
 describe('DruidQuery', () => {
   describe('DruidError.parsePosition', () => {
@@ -198,13 +198,41 @@ describe('DruidQuery', () => {
     });
   });
 
-  describe('misc', () => {
-    it('parseHtmlError', () => {
-      expect(parseHtmlError('<div></div>')).toMatchInlineSnapshot(`undefined`);
+  describe('getDruidErrorMessage', () => {
+    it('works with regular error response', () => {
+      expect(
+        getDruidErrorMessage({
+          response: {
+            data: {
+              error: 'SQL parse failed',
+              errorMessage: 'Encountered "<EOF>" at line 1, column 26.\nWas expecting one of:...',
+              errorClass: 'org.apache.calcite.sql.parser.SqlParseException',
+              host: null,
+            },
+          },
+        }),
+      ).toEqual(`SQL parse failed / Encountered "<EOF>" at line 1, column 26.
+Was expecting one of:... / org.apache.calcite.sql.parser.SqlParseException`);
     });
 
-    it('parseHtmlError', () => {
-      expect(getDruidErrorMessage({})).toMatchInlineSnapshot(`undefined`);
+    it('works with task error response', () => {
+      expect(
+        getDruidErrorMessage({
+          response: {
+            data: {
+              taskId: '60a761ee-1ef5-437f-ae4c-adcc78c8a94c',
+              state: 'FAILED',
+              error: {
+                error: 'SQL parse failed',
+                errorMessage: 'Encountered "<EOF>" at line 1, column 26.\nWas expecting one of:...',
+                errorClass: 'org.apache.calcite.sql.parser.SqlParseException',
+                host: null,
+              },
+            },
+          },
+        }),
+      ).toEqual(`SQL parse failed / Encountered "<EOF>" at line 1, column 26.
+Was expecting one of:... / org.apache.calcite.sql.parser.SqlParseException`);
     });
   });
 });

--- a/web-console/src/utils/druid-query.ts
+++ b/web-console/src/utils/druid-query.ts
@@ -54,7 +54,10 @@ export function parseHtmlError(htmlStr: string): string | undefined {
 function getDruidErrorObject(e: any): DruidErrorResponse | string {
   if (e.response) {
     // This is a direct axios response error
-    return e.response.data || {};
+    let data = e.response.data || {};
+    // MSQ errors nest their error objects inside the error key. Yo dawg, I heard you like errors...
+    if (typeof data.error?.error === 'string') data = data.error;
+    return data;
   } else {
     return e; // Assume the error was passed in directly
   }


### PR DESCRIPTION
Fix decoding of task errors which are nested an extra level

Right now if you open the explain dialog on an MSQ query that has a syntax error you get:

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/177816/234732127-650d9354-898b-4ce5-a362-3a76a3fd05e4.png">
