### PR TITLE
Fix NPE when sampling Avro streams.

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroStreamInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.druid.data.input.InputEntity;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.NestedInputFormat;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 
 import javax.annotation.Nullable;
@@ -48,6 +49,9 @@ public class AvroStreamInputFormat extends NestedInputFormat
   )
   {
     super(flattenSpec);
+    if (avroBytesDecoder == null) {
+      throw new IAE("avroBytesDecoder is required to decode Avro records");
+    }
     this.avroBytesDecoder = avroBytesDecoder;
     this.binaryAsString = binaryAsString != null && binaryAsString;
     this.extractUnionsByType = extractUnionsByType != null && extractUnionsByType;

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.data.input.schemarepo.Avro1124RESTRepositoryClientWrapper;
 import org.apache.druid.data.input.schemarepo.Avro1124SubjectAndIdConverter;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
@@ -200,6 +201,21 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
         NestedInputFormat.class
     );
     Assert.assertEquals(inputFormat, inputFormat2);
+  }
+
+  @Test
+  public void testMissingAvroBytesDecoderRaisesIAE()
+  {
+    Assert.assertThrows(
+        "avroBytesDecoder is required to decode Avro records",
+        IAE.class,
+        () -> new AvroStreamInputFormat(
+            flattenSpec,
+            null,
+            true,
+            true
+        )
+    );
   }
 
   @Test


### PR DESCRIPTION
This PR fixes an NPE that occurs when `avroBytesDecoder` is missing in the sampling spec. This is the default behavior from the Druid web console when sampling Avro Kafka streams, unless you manually edit the spec to add in the required property.
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't 
reference the issue in the title of this pull-request. -->

The NPE stacktrace:

```
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.druid.data.input.avro.AvroBytesDecoder.parse(java.nio.ByteBuffer)" because "this.avroBytesDecoder" is null
	at org.apache.druid.data.input.avro.AvroStreamReader.intermediateRowIterator(AvroStreamReader.java:78) ~[?:?]
	at org.apache.druid.data.input.IntermediateRowParsingReader.intermediateRowIteratorWithMetadata(IntermediateRowParsingReader.java:231) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.data.input.IntermediateRowParsingReader.sample(IntermediateRowParsingReader.java:124) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.data.input.impl.InputEntityIteratingReader.lambda$sample$1(InputEntityIteratingReader.java:98) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.common.parsers.CloseableIterator$2.findNextIteratorIfNecessary(CloseableIterator.java:84) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.common.parsers.CloseableIterator$2.<init>(CloseableIterator.java:69) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.java.util.common.parsers.CloseableIterator.flatMap(CloseableIterator.java:67) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.data.input.impl.InputEntityIteratingReader.createIterator(InputEntityIteratingReader.java:108) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.data.input.impl.InputEntityIteratingReader.sample(InputEntityIteratingReader.java:94) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.data.input.impl.TimedShutoffInputSourceReader.sample(TimedShutoffInputSourceReader.java:62) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.segment.transform.TransformingInputSourceReader.sample(TransformingInputSourceReader.java:50) ~[druid-processing-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.overlord.sampler.InputSourceSampler.sample(InputSourceSampler.java:129) ~[druid-indexing-service-2023.05.0-iap-SNAPSHOT.jar:2023.05.0-iap-SNAPSHOT]
```
Screenshot before the fix:
<img width="1722" alt="CleanShot 2023-04-26 at 13 42 47@2x" src="https://user-images.githubusercontent.com/8687261/234964002-1e2a5403-346e-421c-a6d5-8cf265cfd56b.png">



This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
