### PR TITLE
Register emitter to logger to avoid unit test failures

### DIFF
--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
@@ -45,6 +46,7 @@ import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.SegmentChangeRequestDrop;
 import org.apache.druid.server.coordination.SegmentChangeRequestLoad;
 import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.easymock.EasyMock;
@@ -55,6 +57,7 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.Duration;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -72,6 +75,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class HttpServerInventoryViewTest
 {
+
+  @BeforeClass
+  public static void setup()
+  {
+    EmittingLogger.registerEmitter(new NoopServiceEmitter());
+  }
+
   @Test(timeout = 60_000L)
   public void testSimple() throws Exception
   {


### PR DESCRIPTION
There are some build failures (https://github.com/apache/druid/actions/runs/4815370013/jobs/8580557362?pr=14175) due to HttpServerInventoryViewTest.testSyncMonitoring. This PR will hopefully fix those flakey test issues.

**Description**
The test fails occasionally because the test calls serverAdded on three servers and then immediately calls syncMonitoring, assuming that the three recently added servers will be newly synced and the logic in syncMonitoring will skip them.

Calling serverAdded on a server will create a DruidServerHolder for the server and then call start() on the underlying ChangeRequestHttpSyncer object. The start() call will schedule a execution of the sync() method but not guarantee execution before the serverAdded returns. Because of this the unit test can sometimes call syncMonitoring before sync() has been called on all of the ChangeRequestHttpSyncer objects.

This causes serverHolder.syncer.isOK() to return false and eventually leads to the emit call that is failing in the tests.

**Release notes**
Fix to flaky unit test

**Key changed/added classes in this PR**
Register a noop emitter so the emit call doesn't fail
