### PR TITLE
modify QueryScheduler to lazily acquire lanes when executing queries to avoid leaks

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -228,6 +228,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         return GroupByStrategySelector.STRATEGY_V1;
       }
     };
+
     final GroupByQueryConfig v1SingleThreadedConfig = new GroupByQueryConfig()
     {
       @Override
@@ -361,6 +362,20 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
   }
 
+  public static GroupByQueryRunnerFactory makeQueryRunnerFactory(
+      final GroupByQueryConfig config
+  )
+  {
+    return makeQueryRunnerFactory(
+        DEFAULT_MAPPER,
+        config,
+        new TestGroupByBuffers(
+            DEFAULT_PROCESSING_CONFIG.intermediateComputeSizeBytes(),
+            DEFAULT_PROCESSING_CONFIG.getNumMergeBuffers()
+        ),
+        DEFAULT_PROCESSING_CONFIG
+    );
+  }
   public static GroupByQueryRunnerFactory makeQueryRunnerFactory(
       final GroupByQueryConfig config,
       final TestGroupByBuffers bufferPools

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -896,9 +896,7 @@ public class QueryResourceTest
     assertAsyncResponseAndCountdownOrBlockForever(
         SIMPLE_TIMESERIES_QUERY,
         waitAllFinished,
-        response -> {
-          Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-        }
+        response -> Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus())
     );
     waitTwoScheduled.await();
     assertSynchronousResponseAndCountdownOrBlockForever(

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -60,9 +60,7 @@ import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -80,9 +78,6 @@ public class QuerySchedulerTest
   private static final int NUM_ROWS = 10000;
   private static final int TEST_HI_CAPACITY = 5;
   private static final int TEST_LO_CAPACITY = 2;
-
-  @Rule
-  public ExpectedException expected = ExpectedException.none();
 
   private ListeningExecutorService executorService;
   private ObservableQueryScheduler scheduler;
@@ -230,11 +225,15 @@ public class QuerySchedulerTest
         QueryCapacityExceededException.class,
         () -> Yielders.each(
             scheduler.run(
-                scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of()), Sequences.empty()
+                scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeReportQuery()), ImmutableSet.of()),
+                Sequences.empty()
             )
         )
     );
-    Assert.assertEquals("Too many concurrent queries for lane 'low', query capacity of 2 exceeded. Please try your query again later.", t.getMessage());
+    Assert.assertEquals(
+        "Too many concurrent queries for lane 'low', query capacity of 2 exceeded. Please try your query again later.",
+        t.getMessage()
+    );
   }
 
   @Test
@@ -275,10 +274,14 @@ public class QuerySchedulerTest
     Throwable t = Assert.assertThrows(
         QueryCapacityExceededException.class,
         () -> Yielders.each(scheduler.run(
-            scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of()), Sequences.empty()
+            scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(makeInteractiveQuery()), ImmutableSet.of()),
+            Sequences.empty()
         ))
     );
-    Assert.assertEquals("Too many concurrent queries, total query capacity of 5 exceeded. Please try your query again later.", t.getMessage());
+    Assert.assertEquals(
+        "Too many concurrent queries, total query capacity of 5 exceeded. Please try your query again later.",
+        t.getMessage()
+    );
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -171,7 +171,7 @@ public class QuerySchedulerTest
   }
 
   @Test
-  public void testHiLoReleaseLaneWhenSequenceExplodes() throws Exception
+  public void testHiLoReleaseLaneWhenSequenceExplodes()
   {
     TopNQuery interactive = makeInteractiveQuery();
     ListenableFuture<?> future = executorService.submit(() -> {

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -366,6 +366,7 @@ public class QuerySchedulerTest
           {
             return GroupByStrategySelector.STRATEGY_V2;
           }
+
           @Override
           public String toString()
           {
@@ -743,34 +744,34 @@ public class QuerySchedulerTest
   }
 
   private ListenableFuture<?> makeMergingQueryFuture(
-    ListeningExecutorService executorService,
-    QueryScheduler scheduler,
-    Query<?> query,
-    QueryToolChest toolChest,
-    int numRows
-)
-{
-  return executorService.submit(() -> {
-    try {
-      Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(query), ImmutableSet.of());
+      ListeningExecutorService executorService,
+      QueryScheduler scheduler,
+      Query<?> query,
+      QueryToolChest toolChest,
+      int numRows
+  )
+  {
+    return executorService.submit(() -> {
+      try {
+        Query<?> scheduled = scheduler.prioritizeAndLaneQuery(QueryPlus.wrap(query), ImmutableSet.of());
 
-      Assert.assertNotNull(scheduled);
+        Assert.assertNotNull(scheduled);
 
-      FluentQueryRunnerBuilder fluentQueryRunnerBuilder = new FluentQueryRunnerBuilder(toolChest);
-      FluentQueryRunnerBuilder.FluentQueryRunner runner = fluentQueryRunnerBuilder.create((queryPlus, responseContext) -> {
-        Sequence<Integer> underlyingSequence = makeSequence(numRows);
-        Sequence<Integer> results = scheduler.run(scheduled, underlyingSequence);
-        return results;
-      });
+        FluentQueryRunnerBuilder fluentQueryRunnerBuilder = new FluentQueryRunnerBuilder(toolChest);
+        FluentQueryRunnerBuilder.FluentQueryRunner runner = fluentQueryRunnerBuilder.create((queryPlus, responseContext) -> {
+          Sequence<Integer> underlyingSequence = makeSequence(numRows);
+          Sequence<Integer> results = scheduler.run(scheduled, underlyingSequence);
+          return results;
+        });
 
-      final int actualNumRows = consumeAndCloseSequence(runner.mergeResults().run(QueryPlus.wrap(query)));
-      Assert.assertEquals(actualNumRows, numRows);
-    }
-    catch (IOException ex) {
-      throw new RuntimeException(ex);
-    }
-  });
-}
+        final int actualNumRows = consumeAndCloseSequence(runner.mergeResults().run(QueryPlus.wrap(query)));
+        Assert.assertEquals(actualNumRows, numRows);
+      }
+      catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    });
+  }
 
 
   private void getFuturesAndAssertAftermathIsChill(

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -198,6 +198,7 @@ public class QuerySchedulerTest
       }
     });
     Throwable t = Assert.assertThrows(ExecutionException.class, future::get);
+    Assert.assertEquals("java.lang.RuntimeException: exploded", t.getMessage());
     Assert.assertEquals(5, scheduler.getTotalAvailableCapacity());
   }
 


### PR DESCRIPTION
### Description
This PR fixes an issue that could occur if `druid.query.scheduler.numThreads` is configured and any exception occurs after `QueryScheduler.run` has been called to create a `Sequence`. This would result in total and/or lane specific locks being acquired, but because the sequence was not actually being evaluated, the "baggage" which typically releases these locks was not being executed. An example of how this can happen is if a group-by having filter, which wraps and transforms this sequence happens to explode while wrapping the sequence. The end result is that the locks are acquired, but never released, eventually halting the ability to execute any queries.

I've modified `QueryScheduler.run` to now use `Sequence.wrap` with a full `SequenceWrapper` implementation that acquire the locks in the `before` and releases them in the `after` to better ensure that we always release what we take, no matter what. I'm not really sure why I wasn't doing it like this before...

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
