### PR TITLE
Web console: allow marking segments as used when the whole datasource is unused

### DIFF
--- a/web-console/src/components/action-cell/action-cell.tsx
+++ b/web-console/src/components/action-cell/action-cell.tsx
@@ -33,16 +33,19 @@ export const ACTION_COLUMN_WIDTH = 70;
 
 export interface ActionCellProps {
   onDetail?: () => void;
+  disableDetail?: boolean;
   actions?: BasicAction[];
 }
 
 export const ActionCell = React.memo(function ActionCell(props: ActionCellProps) {
-  const { onDetail, actions } = props;
+  const { onDetail, disableDetail, actions } = props;
   const actionsMenu = actions ? basicActionsToMenu(actions) : null;
 
   return (
     <div className="action-cell">
-      {onDetail && <ActionIcon icon={IconNames.SEARCH_TEMPLATE} onClick={onDetail} />}
+      {onDetail && (
+        <ActionIcon icon={IconNames.SEARCH_TEMPLATE} onClick={onDetail} disabled={disableDetail} />
+      )}
       {actionsMenu && (
         <Popover2 content={actionsMenu} position={Position.BOTTOM_RIGHT}>
           <ActionIcon icon={IconNames.MORE} />

--- a/web-console/src/components/action-icon/action-icon.scss
+++ b/web-console/src/components/action-icon/action-icon.scss
@@ -23,4 +23,9 @@
   &:hover {
     color: #4891d2;
   }
+
+  &.disabled {
+    pointer-events: none;
+    opacity: 0.25;
+  }
 }

--- a/web-console/src/components/action-icon/action-icon.tsx
+++ b/web-console/src/components/action-icon/action-icon.tsx
@@ -27,10 +27,17 @@ export interface ActionIconProps {
   className?: string;
   icon: IconName;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
 export const ActionIcon = React.memo(function ActionIcon(props: ActionIconProps) {
-  const { className, icon, onClick } = props;
+  const { className, icon, onClick, disabled } = props;
 
-  return <Icon className={classNames('action-icon', className)} icon={icon} onClick={onClick} />;
+  return (
+    <Icon
+      className={classNames('action-icon', className, { disabled })}
+      icon={icon}
+      onClick={onClick}
+    />
+  );
 });

--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -852,10 +852,18 @@ ORDER BY 1`;
         {
           icon: IconNames.EXPORT,
           title: 'Mark as used all segments',
-
           onAction: () =>
             this.setState({
               datasourceToMarkAllNonOvershadowedSegmentsAsUsedIn: datasource,
+            }),
+        },
+        {
+          icon: IconNames.EXPORT,
+          title: 'Mark as used segments by interval',
+          onAction: () =>
+            this.setState({
+              datasourceToMarkSegmentsByIntervalIn: datasource,
+              useUnuseAction: 'use',
             }),
         },
         {
@@ -905,7 +913,6 @@ ORDER BY 1`;
           {
             icon: IconNames.EXPORT,
             title: 'Mark as used segments by interval',
-
             onAction: () =>
               this.setState({
                 datasourceToMarkSegmentsByIntervalIn: datasource,
@@ -915,7 +922,6 @@ ORDER BY 1`;
           {
             icon: IconNames.IMPORT,
             title: 'Mark as unused segments by interval',
-
             onAction: () =>
               this.setState({
                 datasourceToMarkSegmentsByIntervalIn: datasource,
@@ -1474,6 +1480,7 @@ ORDER BY 1`;
                   onDetail={() => {
                     this.onDetail(original);
                   }}
+                  disableDetail={unused}
                   actions={datasourceActions}
                 />
               );


### PR DESCRIPTION
It was an oversight that it was not added before (thus the bug label). Also disable the detail view for the unused datasources as you can not see anything in it anyway.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/177816/235273932-f1516803-a579-4865-b49f-fdceebf61295.png">
