### PR TITLE
Web console: allow stringly schemas in the data loader

### DIFF
--- a/web-console/src/druid-models/execution/execution.ts
+++ b/web-console/src/druid-models/execution/execution.ts
@@ -140,10 +140,11 @@ function formatPendingMessage(
 
   // If there are not enough slots free then there are two cases:
   if (totalNeeded <= totalTaskSlots) {
-    // (1) not enough free, but enough total: "Launched 2/4 tasks. Cluster is currently using 5/6 task slots. Waiting for 1 other task to finish."
+    // (1) not enough free, but enough total: "Launched 2/4 tasks. Cluster is currently using 5/6 task slots. Waiting for 1 task slot to become available."
     const tasksThatNeedToFinish = pendingTasks - availableTaskSlots;
     return (
-      baseMessage + ` Waiting for ${pluralIfNeeded(tasksThatNeedToFinish, 'other task')} to finish.`
+      baseMessage +
+      ` Waiting for ${pluralIfNeeded(tasksThatNeedToFinish, 'task slot')} to become available.`
     );
   } else {
     // (2) not enough total: "Launched 2/4 tasks. Cluster is currently using 2/2 task slots. Add more capacity or reduce maxNumTasks to 2 or lower."

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.spec.ts
@@ -757,7 +757,7 @@ describe('spec utils', () => {
   });
 
   it('updateSchemaWithSample', () => {
-    const withRollup = updateSchemaWithSample(ingestionSpec, JSON_SAMPLE, 'specific', true);
+    const withRollup = updateSchemaWithSample(ingestionSpec, JSON_SAMPLE, 'fixed', true);
 
     expect(withRollup).toMatchInlineSnapshot(`
       Object {
@@ -822,7 +822,7 @@ describe('spec utils', () => {
       }
     `);
 
-    const noRollup = updateSchemaWithSample(ingestionSpec, JSON_SAMPLE, 'specific', false);
+    const noRollup = updateSchemaWithSample(ingestionSpec, JSON_SAMPLE, 'fixed', false);
 
     expect(noRollup).toMatchInlineSnapshot(`
       Object {

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -273,6 +273,9 @@ export function getSchemaMode(spec: Partial<IngestionSpec>): SchemaMode {
   if (deepGet(spec, 'spec.dataSchema.dimensionsSpec.useSchemaDiscovery') === true) {
     return 'flexible';
   }
+  if (deepGet(spec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions') === true) {
+    return 'stringly';
+  }
   const dimensions = deepGet(spec, 'spec.dataSchema.dimensionsSpec.dimensions') || EMPTY_ARRAY;
   return Array.isArray(dimensions) && dimensions.length === 0 ? 'stringly' : 'fixed';
 }
@@ -2432,7 +2435,7 @@ export function updateSchemaWithSample(
   switch (schemaMode) {
     case 'flexible':
       newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.useSchemaDiscovery', true);
-      newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions', true);
+      newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions');
       newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.dimensionExclusions', []);
       newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.dimensions');
       break;

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -267,17 +267,17 @@ export interface DataSchema {
   metricsSpec?: MetricSpec[];
 }
 
-export type SchemaMode = 'fixed' | 'stringly' | 'flexible';
+export type SchemaMode = 'fixed' | 'string-only-discovery' | 'type-aware-discovery';
 
 export function getSchemaMode(spec: Partial<IngestionSpec>): SchemaMode {
   if (deepGet(spec, 'spec.dataSchema.dimensionsSpec.useSchemaDiscovery') === true) {
-    return 'flexible';
+    return 'type-aware-discovery';
   }
   if (deepGet(spec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions') === true) {
-    return 'stringly';
+    return 'string-only-discovery';
   }
   const dimensions = deepGet(spec, 'spec.dataSchema.dimensionsSpec.dimensions') || EMPTY_ARRAY;
-  return Array.isArray(dimensions) && dimensions.length === 0 ? 'stringly' : 'fixed';
+  return Array.isArray(dimensions) && dimensions.length === 0 ? 'string-only-discovery' : 'fixed';
 }
 
 export function getRollup(spec: Partial<IngestionSpec>): boolean {
@@ -2433,14 +2433,14 @@ export function updateSchemaWithSample(
   let newSpec = spec;
 
   switch (schemaMode) {
-    case 'flexible':
+    case 'type-aware-discovery':
       newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.useSchemaDiscovery', true);
       newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions');
       newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.dimensionExclusions', []);
       newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.dimensions');
       break;
 
-    case 'stringly':
+    case 'string-only-discovery':
       newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.useSchemaDiscovery');
       newSpec = deepDelete(newSpec, 'spec.dataSchema.dimensionsSpec.includeAllDimensions');
       newSpec = deepSet(newSpec, 'spec.dataSchema.dimensionsSpec.dimensionExclusions', []);

--- a/web-console/src/views/load-data-view/info-messages.tsx
+++ b/web-console/src/views/load-data-view/info-messages.tsx
@@ -20,7 +20,7 @@ import { Button, Callout, Code, FormGroup, Intent } from '@blueprintjs/core';
 import React from 'react';
 
 import { ExternalLink, LearnMore } from '../../components';
-import type { DimensionMode, IngestionSpec } from '../../druid-models';
+import type { IngestionSpec, SchemaMode } from '../../druid-models';
 import { getIngestionDocLink } from '../../druid-models';
 import { getLink } from '../../links';
 import { deepGet, deepSet } from '../../utils';
@@ -129,11 +129,11 @@ export const FilterMessage = React.memo(function FilterMessage() {
 });
 
 export interface SchemaMessageProps {
-  dimensionMode: DimensionMode;
+  schemaMode: SchemaMode;
 }
 
 export const SchemaMessage = React.memo(function SchemaMessage(props: SchemaMessageProps) {
-  const { dimensionMode } = props;
+  const { schemaMode } = props;
 
   return (
     <FormGroup>
@@ -142,7 +142,7 @@ export const SchemaMessage = React.memo(function SchemaMessage(props: SchemaMess
           Each column in Druid must have an assigned type (string, long, float, double, complex,
           etc).
         </p>
-        {dimensionMode === 'specific' && (
+        {schemaMode === 'fixed' && (
           <p>
             Default primitive types have been automatically assigned to your columns. If you want to
             change the type, click on the column header.

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2378,7 +2378,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   checked={schemaMode === 'fixed'}
                   onChange={() =>
                     this.setState({
-                      newSchemaMode: schemaMode === 'fixed' ? 'flexible' : 'fixed',
+                      newSchemaMode: schemaMode === 'fixed' ? 'stringly' : 'fixed',
                     })
                   }
                   label="Explicitly specify schema"
@@ -2634,11 +2634,11 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             updateSchemaWithSample(spec, sampleResponse, newSchemaMode, getRollup(spec)),
           );
         }}
-        confirmButtonText={`Yes - ${autoDetect ? 'auto detect' : 'explicitly set'} columns`}
+        confirmButtonText={`Yes - ${autoDetect ? 'auto detect' : 'explicitly define'} schema`}
         successText={`Dimension mode changes to ${
           autoDetect ? 'auto detect' : 'specific list'
         }. Schema has been updated.`}
-        failText="Could change dimension mode"
+        failText="Could not change schema mode"
         intent={Intent.WARNING}
         onClose={() => this.setState({ newSchemaMode: undefined })}
       >
@@ -2654,7 +2654,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             label="Use the new schema discovery capability. De-select this if are appending to a datasource created with a previous version of Druid and want to preserve schema compatibility."
             onChange={() => {
               this.setState({
-                newSchemaMode: newSchemaMode === 'stringly' ? 'fixed' : 'stringly',
+                newSchemaMode: newSchemaMode === 'stringly' ? 'flexible' : 'stringly',
               });
             }}
           />

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2638,9 +2638,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
           );
         }}
         confirmButtonText={`Yes - ${autoDetect ? 'auto detect' : 'explicitly define'} schema`}
-        successText={`Dimension mode changes to ${
-          autoDetect ? 'auto detect' : 'specific list'
-        }. Schema has been updated.`}
+        successText={`Schema mode changed to ${autoDetect ? 'auto detect' : 'explicitly defined'}.`}
         failText="Could not change schema mode"
         intent={Intent.WARNING}
         onClose={() => this.setState({ newSchemaMode: undefined })}
@@ -2650,7 +2648,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             ? `Are you sure you want Druid to auto detect the data schema?`
             : `Are you sure you want to explicitly specify a schema?`}
         </p>
-        <p>Making this change will reset any work you have done in this section.</p>
+        <p>Making this change will reset all schema configuration done so far.</p>
         {autoDetect && (
           <Switch
             checked={newSchemaMode === 'type-aware-discovery'}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3347,7 +3347,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             />
           )}
           <Button
-            text="Submit"
+            text={submitting ? 'Submitting...' : 'Submit'}
             rightIcon={IconNames.CLOUD_UPLOAD}
             intent={Intent.PRIMARY}
             disabled={submitting || Boolean(issueWithSpec)}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2663,7 +2663,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               });
             }}
           >
-            Use the new type-aware schema discovery capability. Avoid this if are appending to a
+            Use the new type-aware schema discovery capability. Avoid this if you are appending to a
             datasource created with string-only schema discovery of Druid and want to preserve
             schema compatibility. For more information see the{' '}
             <ExternalLink

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3313,13 +3313,16 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               <FormGroup>
                 <Callout intent={Intent.WARNING}>
                   <p>
-                    It appears that you are using type-aware schema discovery (
-                    <Code>useSchemaDiscovery: true</Code>) while ingesting data into a datasource (
-                    <Code>{datasource}</Code>) that already exists.
+                    You have enabled type-aware schema discovery (
+                    <Code>useSchemaDiscovery: true</Code>) to ingest data into the existing
+                    datasource <Code>{datasource}</Code>.
                   </p>
                   <p>
-                    If the original datasource was ingested string-based schema discovery this can
-                    potentially cause problems with how multi-value string values will be recorded.
+                    If you used string-based schema discovery when first ingesting data to{' '}
+                    <Code>{datasource}</Code>, using type-aware schema discovery now can cause
+                    problems with the values multi-value string dimensions.
+                  </p>
+                  <p>
                     For more information see the{' '}
                     <ExternalLink
                       href={`${getLink(

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2644,8 +2644,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
       >
         <p>
           {autoDetect
-            ? `Are you sure you don't want to explicitly specify a dimension list?`
-            : `Are you sure you want to explicitly specify a dimension list?`}
+            ? `Are you sure you want Druid to auto detect the data schema?`
+            : `Are you sure you want to explicitly specify a schema?`}
         </p>
         <p>Making this change will reset any work you have done in this section.</p>
         {autoDetect && (

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2378,7 +2378,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   checked={schemaMode === 'fixed'}
                   onChange={() =>
                     this.setState({
-                      newSchemaMode: schemaMode === 'fixed' ? 'stringly' : 'fixed',
+                      newSchemaMode: schemaMode === 'fixed' ? 'string-only-discovery' : 'fixed',
                     })
                   }
                   label="Explicitly specify schema"
@@ -2650,14 +2650,28 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         <p>Making this change will reset any work you have done in this section.</p>
         {autoDetect && (
           <Switch
-            checked={newSchemaMode === 'flexible'}
-            label="Use the new schema discovery capability. De-select this if are appending to a datasource created with a previous version of Druid and want to preserve schema compatibility."
+            checked={newSchemaMode === 'type-aware-discovery'}
             onChange={() => {
               this.setState({
-                newSchemaMode: newSchemaMode === 'stringly' ? 'flexible' : 'stringly',
+                newSchemaMode:
+                  newSchemaMode === 'string-only-discovery'
+                    ? 'type-aware-discovery'
+                    : 'string-only-discovery',
               });
             }}
-          />
+          >
+            Use the new type-aware schema discovery capability. Avoid this if are appending to a
+            datasource created with string-only schema discovery of Druid and want to preserve
+            schema compatibility. For more information see the{' '}
+            <ExternalLink
+              href={`${getLink(
+                'DOCS',
+              )}/ingestion/schema-design.html#schema-auto-discovery-for-dimensions`}
+            >
+              documentation
+            </ExternalLink>
+            .
+          </Switch>
         )}
       </AsyncActionDialog>
     );


### PR DESCRIPTION
This is a change to retain the ability to specify no dimensions without setting `useSchemaDiscovery: true` in the data loader.

This is needed if someone wants to ingest data in schemaless mode into a datasource made with Druid < 26 and retain the same dimension types.

Internally in the code there is an internal representation of how dimensions are read it used to have values: `specific` and `auto-detect` it now has values:

- `fixed` (renamed from `specific`)
- `string-only-discovery` - represents non `useSchemaDiscovery: true` schema-less where everything is string typed
- `type-aware-discovery` - represents `useSchemaDiscovery: true`

Here is how the user selects it:

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/177816/235832135-26a93bd5-0d8f-4673-8339-b21e261460b1.png">

There is also a warning:

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/177816/235832095-4db1e08b-0b88-4a77-abda-f371625d1964.png">
