### PR TITLE
update documentation about multiValueHandling

### DIFF
--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -226,7 +226,7 @@ Dimension objects can have the following components:
 | type | Either `string`, `long`, `float`, `double`, or `json`. | `string` |
 | name | The name of the dimension. This will be used as the field name to read from input records, as well as the column name stored in generated segments.<br /><br />Note that you can use a [`transformSpec`](#transformspec) if you want to rename columns during ingestion time. | none (required) |
 | createBitmapIndex | For `string` typed dimensions, whether or not bitmap indexes should be created for the column in generated segments. Creating a bitmap index requires more storage, but speeds up certain kinds of filtering (especially equality and prefix filtering). Only supported for `string` typed dimensions. | `true` |
-| multiValueHandling | For `string` typed dimensions, specifies the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `array` (ingest string arrays as-is), `sorted_array` (sort string arrays during ingestion), and `sorted_set` (sort and deduplicate string arrays during ingestion). This parameter is ignored for types other than `string`. | `sorted_array` |
+| multiValueHandling | For `string` typed dimensions, specifies the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `array` (ingest string arrays as-is), `sorted_array` (sort string arrays during ingestion), and `sorted_set` (sort and de-duplicate string arrays during ingestion). This parameter is ignored for types other than `string`. | `sorted_array` |
 
 #### Inclusions and exclusions
 

--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -226,7 +226,7 @@ Dimension objects can have the following components:
 | type | Either `string`, `long`, `float`, `double`, or `json`. | `string` |
 | name | The name of the dimension. This will be used as the field name to read from input records, as well as the column name stored in generated segments.<br /><br />Note that you can use a [`transformSpec`](#transformspec) if you want to rename columns during ingestion time. | none (required) |
 | createBitmapIndex | For `string` typed dimensions, whether or not bitmap indexes should be created for the column in generated segments. Creating a bitmap index requires more storage, but speeds up certain kinds of filtering (especially equality and prefix filtering). Only supported for `string` typed dimensions. | `true` |
-| multiValueHandling | Specify the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `sorted_array`, `sorted_set`, and `array`. Both `sorted_array` and `sorted_set` order the array upon ingestion. For string typed dimensions, `sorted_set` removes duplicates. For string typed dimensions, `array` ingests data as is. | `sorted_array` |
+| multiValueHandling | For `string` typed dimensions, specifies the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `array` (ingest string arrays as-is), `sorted_array` (sort string arrays during ingestion), and `sorted_set` (sort and deduplicate string arrays during ingestion). This parameter is ignored for types other than `string`. | `sorted_array` |
 
 #### Inclusions and exclusions
 

--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -226,7 +226,7 @@ Dimension objects can have the following components:
 | type | Either `string`, `long`, `float`, `double`, or `json`. | `string` |
 | name | The name of the dimension. This will be used as the field name to read from input records, as well as the column name stored in generated segments.<br /><br />Note that you can use a [`transformSpec`](#transformspec) if you want to rename columns during ingestion time. | none (required) |
 | createBitmapIndex | For `string` typed dimensions, whether or not bitmap indexes should be created for the column in generated segments. Creating a bitmap index requires more storage, but speeds up certain kinds of filtering (especially equality and prefix filtering). Only supported for `string` typed dimensions. | `true` |
-| multiValueHandling | Specify the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `sorted_array`, `sorted_set`, and `array`. `sorted_array` and `sorted_set` order the array upon ingestion. For `string` typed dimensions, `sorted_set` removes duplicates. For `string` typed dimensions, `array` ingests data as-is. | `sorted_array` |
+| multiValueHandling | Specify the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `sorted_array`, `sorted_set`, and `array`. Both `sorted_array` and `sorted_set` order the array upon ingestion. For string typed dimensions, `sorted_set` removes duplicates. For string typed dimensions, `array` ingests data as is. | `sorted_array` |
 
 #### Inclusions and exclusions
 

--- a/docs/ingestion/ingestion-spec.md
+++ b/docs/ingestion/ingestion-spec.md
@@ -226,7 +226,7 @@ Dimension objects can have the following components:
 | type | Either `string`, `long`, `float`, `double`, or `json`. | `string` |
 | name | The name of the dimension. This will be used as the field name to read from input records, as well as the column name stored in generated segments.<br /><br />Note that you can use a [`transformSpec`](#transformspec) if you want to rename columns during ingestion time. | none (required) |
 | createBitmapIndex | For `string` typed dimensions, whether or not bitmap indexes should be created for the column in generated segments. Creating a bitmap index requires more storage, but speeds up certain kinds of filtering (especially equality and prefix filtering). Only supported for `string` typed dimensions. | `true` |
-| multiValueHandling | Specify the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `sorted_array`, `sorted_set`, and `array`. `sorted_array` and `sorted_set` order the array upon ingestion. `sorted_set` removes duplicates. `array` ingests data as-is | `sorted_array` |
+| multiValueHandling | Specify the type of handling for [multi-value fields](../querying/multi-value-dimensions.md). Possible values are `sorted_array`, `sorted_set`, and `array`. `sorted_array` and `sorted_set` order the array upon ingestion. For `string` typed dimensions, `sorted_set` removes duplicates. For `string` typed dimensions, `array` ingests data as-is. | `sorted_array` |
 
 #### Inclusions and exclusions
 


### PR DESCRIPTION
Update documentation about `multiValueHandling`

### Description

I'm a druid beginner, so I'm not super sure, but `multiValueHandling` param has only effects on `string` type dimension.
I read source codes and PRs below, and it seems the `multiValueHandling` sorts only string value.
So I update the doc to add the information about it.
https://github.com/apache/druid/pull/2541
https://github.com/apache/druid/pull/10695

I tried to create supervisor with `long` data with `multiValueHandling` as `ARRAY`, but druid always override `multiValueHandling` as `SORTED_ARRAY`.
I though it is weird and I read the doc, but doc seems that we can set the value for all types.
I spent long time for this survey, so I want to clarify it in the documents.

<hr>

##### Key changed/added classes in this PR
* `docs`

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.