### PR TITLE
Add wait for worker shutdown to MSQ task cancel

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -355,6 +355,8 @@ public class ControllerImpl implements Controller
           throw new MSQException(CanceledFault.INSTANCE);
         }
     );
+
+    workerTaskLauncher.waitForWorkerShutdown();
   }
 
   public TaskStatus runTask(final Closer closer)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -202,12 +202,7 @@ public class MSQWorkerTaskLauncher
     }
 
     // Block until stopped.
-    try {
-      FutureUtils.getUnchecked(stopFuture, false);
-    }
-    catch (Throwable ignored) {
-      // Suppress.
-    }
+    waitForWorkerShutdown();
   }
 
   /**
@@ -306,6 +301,14 @@ public class MSQWorkerTaskLauncher
     }
   }
 
+  public void waitForWorkerShutdown() {
+    try {
+      FutureUtils.getUnchecked(stopFuture, false);
+    }
+    catch (Throwable ignored) {
+      // Suppress.
+    }
+  }
 
   /**
    * Checks if the controller has canceled the input taskId. This method is used in {@link ControllerImpl}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTaskLauncher.java
@@ -301,7 +301,8 @@ public class MSQWorkerTaskLauncher
     }
   }
 
-  public void waitForWorkerShutdown() {
+  public void waitForWorkerShutdown()
+  {
     try {
       FutureUtils.getUnchecked(stopFuture, false);
     }


### PR DESCRIPTION
Currently, when cancelling an MSQ task, the stopGracefully method isn't blocking. It just adds the request to the kernel queue. The lifecycle close thread continues to shutdown other lifecycle objects. This leads to a bug where other classes like DiscoveryServiceLocator is closed before the controller has time to send cancel requests to all the workers (noticeable more when using MM than indexer, though the issue is present in both).

stopGracefully should be a blocking call so that this does not occur.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
