### PR TITLE
Ability to optionally bind extra service dimensions to ServiceEvents

### DIFF
--- a/server/src/main/java/org/apache/druid/server/emitter/EmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/EmitterModule.java
@@ -125,7 +125,7 @@ public class EmitterModule implements Module
         config.getServiceName(),
         config.getHostAndPortToUse(),
         emitter,
-        ImmutableMap.copyOf(serviceDimensions.build())
+        serviceDimensions.build()
     );
     EmittingLogger.registerEmitter(retVal);
     return retVal;

--- a/server/src/main/java/org/apache/druid/server/emitter/ExtraServiceDimensions.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/ExtraServiceDimensions.java
@@ -29,12 +29,25 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to inject extra dimensions, added to all events, emitted via {@link EmitterModule#getServiceEmitter}.
- *
+ * <p/>
  * For example, write this in a body of {@link com.google.inject.Module#configure} of your extension module):
- *
+ * <p/>
  * MapBinder<String, String> extraDims =
  *     MapBinder.newMapBinder(binder, String.class, String.class, ExtraServiceDimensions.class);
  * extraDims.addBinding("foo").toInstance("bar");
+ * <p/>
+ * If a module wishes to optionally bind service dimensions they may do so by using the binding to
+ * Map<String, Optional<String>. The key is only added to the service dimensions that are emitted if the Optional is
+ * present.
+ * <p/>
+ * MapBinder<String, String> extraDims =
+ *     MapBinder.newMapBinder(
+ *        binder,
+ *        new TypeLiteral<String>() {},
+ *        new TypeLiteral<Optionl<String>>() {},
+ *        ExtraServiceDimensions.class
+ * );
+ * extraDims.addBinding("foo").toInstance(Optional.fromNullable(bar));
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)

--- a/server/src/main/java/org/apache/druid/server/emitter/ExtraServiceDimensions.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/ExtraServiceDimensions.java
@@ -40,11 +40,11 @@ import java.lang.annotation.Target;
  * Map<String, Optional<String>. The key is only added to the service dimensions that are emitted if the Optional is
  * present.
  * <p/>
- * MapBinder<String, String> extraDims =
+ * MapBinder<String, Optional<String>> extraDims =
  *     MapBinder.newMapBinder(
  *        binder,
  *        new TypeLiteral<String>() {},
- *        new TypeLiteral<Optionl<String>>() {},
+ *        new TypeLiteral<Optional<String>>() {},
  *        ExtraServiceDimensions.class
  * );
  * extraDims.addBinding("foo").toInstance(Optional.fromNullable(bar));

--- a/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/emitter/EmitterModuleTest.java
@@ -19,20 +19,34 @@
 
 package org.apache.druid.server.emitter;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Named;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
+import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.ServerModule;
+import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.core.ParametrizedUriEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
+import org.apache.druid.server.DruidNode;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -41,6 +55,9 @@ import org.junit.rules.ExpectedException;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 public class EmitterModuleTest
@@ -87,26 +104,89 @@ public class EmitterModuleTest
     makeInjectorWithProperties(props).getInstance(Emitter.class);
   }
 
+  @Test
+  public void testGetServiceEmitterWithExtraServiceDimensionsHasAllDimensions()
+  {
+    final Properties props = new Properties();
+    props.setProperty("druid.emitter", "noop");
+    props.setProperty("druid.service", "druid/test");
+    props.setProperty("druid.host", "localhost");
+
+    ServiceEmitter emitter = makeInjectorWithProperties(props).getInstance(ServiceEmitter.class);
+    ServiceEventBuilder<TestEvent> eventBuilder = new ServiceEventBuilder<TestEvent>()
+    {
+      @Override
+      public TestEvent build(ImmutableMap<String, String> serviceDimensions)
+      {
+        Assert.assertFalse(serviceDimensions.containsKey("extraButEmpty"));
+        Assert.assertEquals("extraVal", serviceDimensions.get("extra"));
+        Assert.assertEquals("bar", serviceDimensions.get("foo"));
+        return new TestEvent(serviceDimensions);
+      }
+    };
+    emitter.emit(eventBuilder);
+  }
+
   private Injector makeInjectorWithProperties(final Properties props)
   {
     return Guice.createInjector(
         ImmutableList.of(
             new DruidGuiceExtensions(),
             new LifecycleModule(),
-            new ServerModule(),
+            binder -> binder.bind(new TypeLiteral<Supplier<DruidNode>>()
+                            {
+                            })
+                            .annotatedWith(Self.class)
+                            .toInstance(
+                                Suppliers.ofInstance(new DruidNode("test", "host", false, 8091, null, true, false))
+                            ),
             new JacksonModule(),
-            new Module()
-            {
-              @Override
-              public void configure(Binder binder)
-              {
-                binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
-                binder.bind(JsonConfigurator.class).in(LazySingleton.class);
-                binder.bind(Properties.class).toInstance(props);
-              }
+            binder -> {
+              binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+              binder.bind(JsonConfigurator.class).in(LazySingleton.class);
+              binder.bind(Properties.class).toInstance(props);
+            },
+            binder -> {
+              MapBinder<String, Optional<String>> extraDims = MapBinder.newMapBinder(
+                  binder,
+                  new TypeLiteral<String>()
+                  {
+                  },
+                  new TypeLiteral<Optional<String>>()
+                  {
+                  },
+                  ExtraServiceDimensions.class
+              );
+              extraDims.addBinding("extra").toInstance(Optional.of("extraVal"));
+              extraDims.addBinding("extraButEmpty").toInstance(Optional.empty());
+              MapBinder.newMapBinder(binder, String.class, String.class, ExtraServiceDimensions.class)
+                       .addBinding("foo").toInstance("bar");
             },
             new EmitterModule(props)
         )
     );
+  }
+
+  public static class TestEvent implements Event
+  {
+
+    private final Map<String, String> dimensions;
+
+    public TestEvent(Map<String, String> dimensions)
+    {
+      this.dimensions = dimensions;
+    }
+
+    @Override
+    public EventMap toMap()
+    {
+      return EventMap.builder().putAll(dimensions).build();
+    }
+
+    @Override
+    public String getFeed()
+    {
+      return "test";
+    }
   }
 }


### PR DESCRIPTION
### Description

This change makes it so that extension writers can now optionally bind extra service dimensions. This is useful if an extension wants to bind service dimensions that are only relevant to one node type, but not the others. This will allow the extension to be listed in the extension load list in the common runtime properties without needing to inject invalid properties for all the other services where the dimensions are not relevant.

Developer facing docs are added to the `ExtraServiceDimensions` class.

#### Release note
NEW: Extension developers can optionally bind extra service dimensions to be emitted by the service emitter.

<hr>


This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
