### PR TITLE
Ephemeral storage is respected from the overlod for peon tasks

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskAdapterTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.api.client.util.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.fabric8.kubernetes.api.model.Container;
@@ -32,6 +33,8 @@ import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -42,6 +45,7 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.IndexTask;
+import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.java.util.common.HumanReadableBytes;
@@ -321,5 +325,92 @@ class K8sTaskAdapterTest
                    .findFirst()
                    .get();
     assertEquals(jsonMapper.writeValueAsString(config.peonMonitors), env.getValue());
+  }
+
+  @Test
+  void testEphemeralStorageIsRespected() throws IOException
+  {
+    TestKubernetesClient testClient = new TestKubernetesClient(client);
+    Pod pod = K8sTestUtils.fileToResource("ephemeralPodSpec.yaml", Pod.class);
+    KubernetesTaskRunnerConfig config = new KubernetesTaskRunnerConfig();
+    config.namespace = "test";
+    SingleContainerTaskAdapter adapter =
+        new SingleContainerTaskAdapter(testClient,
+                                       config, taskConfig,
+                                       startupLoggingConfig,
+                                       node,
+                                       jsonMapper
+        );
+    NoopTask task = NoopTask.create("id", 1);
+    Job actual = adapter.createJobFromPodSpec(
+        pod.getSpec(),
+        task,
+        new PeonCommandContext(
+            Collections.singletonList("foo && bar"),
+            new ArrayList<>(),
+            new File("/tmp")
+        )
+    );
+    Job expected = K8sTestUtils.fileToResource("expectedEphemeralOutput.yaml", Job.class);
+    // something is up with jdk 17, where if you compress with jdk < 17 and try and decompress you get different results,
+    // this would never happen in real life, but for the jdk 17 tests this is a problem
+    // could be related to: https://bugs.openjdk.org/browse/JDK-8081450
+    actual.getSpec()
+          .getTemplate()
+          .getSpec()
+          .getContainers()
+          .get(0)
+          .getEnv()
+          .removeIf(x -> x.getName().equals("TASK_JSON"));
+    expected.getSpec()
+            .getTemplate()
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getEnv()
+            .removeIf(x -> x.getName().equals("TASK_JSON"));
+    Assertions.assertEquals(expected, actual);
+  }
+
+  @Test
+  void testEphemeralStorage()
+  {
+    // no resources set.
+    Container container = new ContainerBuilder().build();
+    ResourceRequirements result = K8sTaskAdapter.getResourceRequirements(
+        container.getResources(),
+        100
+    );
+    // requests and limits will only have 2 items, cpu / memory
+    assertEquals(2, result.getLimits().size());
+    assertEquals(2, result.getRequests().size());
+
+    // test with ephemeral storage
+    ImmutableMap<String, Quantity> requestMap = ImmutableMap.of("ephemeral-storage", new Quantity("1Gi"));
+    ImmutableMap<String, Quantity> limitMap = ImmutableMap.of("ephemeral-storage", new Quantity("10Gi"));
+    container.setResources(new ResourceRequirementsBuilder().withRequests(requestMap).withLimits(limitMap).build());
+    ResourceRequirements ephemeralResult = K8sTaskAdapter.getResourceRequirements(
+        container.getResources(),
+        100
+    );
+    // you will have ephemeral storage as well.
+    assertEquals(3, ephemeralResult.getLimits().size());
+    assertEquals(3, ephemeralResult.getRequests().size());
+    // cpu and memory should be fixed
+    assertEquals(result.getRequests().get("cpu"), ephemeralResult.getRequests().get("cpu"));
+    assertEquals(result.getRequests().get("memory"), ephemeralResult.getRequests().get("memory"));
+    assertEquals("1Gi", ephemeralResult.getRequests().get("ephemeral-storage").toString());
+
+    assertEquals(result.getLimits().get("cpu"), ephemeralResult.getLimits().get("cpu"));
+    assertEquals(result.getLimits().get("memory"), ephemeralResult.getLimits().get("memory"));
+    assertEquals("10Gi", ephemeralResult.getLimits().get("ephemeral-storage").toString());
+
+    // we should also preserve additional properties
+    container.getResources().setAdditionalProperty("additional", "some-value");
+    ResourceRequirements additionalProperties = K8sTaskAdapter.getResourceRequirements(
+        container.getResources(),
+        100
+    );
+    assertEquals(1, additionalProperties.getAdditionalProperties().size());
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/ephemeralPodSpec.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/ephemeralPodSpec.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+spec:
+  containers:
+    - command:
+        - sleep
+        - "3600"
+      image: one
+      name: primary
+      resources:
+        limits:
+          cpu: "1m"
+          memory: "1"
+          ephemeral-storage: "10Gi"
+        requests:
+          cpu: "1m"
+          memory: "1"
+          ephemeral-storage: "1Gi"
+      env:
+        - name: "druid_monitoring_monitors"
+          value: '["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.TaskCountStatsMonitor"]'
+    - command:
+        - "tail -f /dev/null"
+      image: two
+      name: sidecar

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedEphemeralOutput.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedEphemeralOutput.yaml
@@ -1,0 +1,65 @@
+apiVersion: "batch/v1"
+kind: "Job"
+metadata:
+  annotations:
+    task.id: "id"
+    tls.enabled: "false"
+  labels:
+    druid.k8s.peons: "true"
+  name: "id"
+spec:
+  activeDeadlineSeconds: 14400
+  backoffLimit: 0
+  template:
+    metadata:
+      annotations:
+        task.id: "id"
+        tls.enabled: "false"
+      labels:
+        druid.k8s.peons: "true"
+    spec:
+      containers:
+        - args:
+            - "foo && bar"
+          command:
+            - "sh"
+            - "-c"
+          env:
+            - name: "druid_monitoring_monitors"
+              value: "[\"org.apache.druid.java.util.metrics.JvmMonitor\", \"org.apache.druid.server.metrics.TaskCountStatsMonitor\"\
+            ]"
+            - name: "TASK_DIR"
+              value: "/tmp"
+            - name: "TASK_JSON"
+              value: "H4sIAAAAAAAAAEVOOw7CMAy9i+cOBYmlK0KItWVhNI0BSyEOToKoqt4doxZYLPv9/EbIQyRoIIhEqICd7TYquKqUePidDjN2UrSfxYEM0xKOfDdgvalr86aW0A0z9L9bSsVnc512nZkurHSTZJJQvK+gl5DpZfwIUVmU8wDNarJ0Ssu/EfCJ7PHM3tj9p9i3ltKjWKDbYsR+sU5vP86oMNUAAAA="
+            - name: "JAVA_OPTS"
+              value: ""
+            - name: "druid_host"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "status.podIP"
+            - name: "HOSTNAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.name"
+          image: "one"
+          name: "main"
+          ports:
+            - containerPort: 8091
+              name: "druid-tls-port"
+              protocol: "TCP"
+            - containerPort: 8100
+              name: "druid-port"
+              protocol: "TCP"
+          resources:
+            limits:
+              memory: "2400000000"
+              cpu: "1000m"
+              ephemeral-storage: 10Gi
+            requests:
+              memory: "2400000000"
+              cpu: "1000m"
+              ephemeral-storage: 1Gi
+      hostname: "id"
+      restartPolicy: "Never"
+  ttlSecondsAfterFinished: 172800


### PR DESCRIPTION
I noticed during testing that the ephemeral storage resource was not inherited from the overlord.  We should only be overriding the specific "cpu" and "memory" resources, currently we are calculating cpu/memory and only setting those.  We should inherit all the other resources and only override `cpu` and `memory`