### PR TITLE
Add more logging for query timeouts and errors during broker parallel merge

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -158,7 +158,8 @@ public class ParallelMergeCombiningSequenceTest
         outputQueue,
         true,
         System.nanoTime() + TimeUnit.NANOSECONDS.convert(10_000, TimeUnit.MILLISECONDS),
-        new ParallelMergeCombiningSequence.CancellationGizmo()
+        new ParallelMergeCombiningSequence.CancellationGizmo(),
+        new ParallelMergeCombiningSequence.MergeCombineMetricsAccumulator(1)
     );
 
     Yielder<IntPair> queueYielder = Yielders.each(queueAsSequence);


### PR DESCRIPTION
This change adds a couple of changes : 
1. Prefers to throw any cancellations or execution errors in the parallel merge over the query timeout exception
2. Adds some state logging of the parallel merge incase a timeout occurs - this is helpful in debugging which state the merge was stuck in
