### PR TITLE
Fix NPE in parse exception test report and add a couple of UTs with `maxSavedParseExceptions = 0`

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ParseExceptionReport.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ParseExceptionReport.java
@@ -47,13 +47,14 @@ public class ParseExceptionReport
   {
     List<LinkedHashMap<String, Object>> events =
         (List<LinkedHashMap<String, Object>>) reportData.getUnparseableEvents().get(phase);
-
     final List<String> inputs = new ArrayList<>();
     final List<String> errorMessages = new ArrayList<>();
-    events.forEach(event -> {
-      inputs.add((String) event.get("input"));
-      errorMessages.add(((List<String>) event.get("details")).get(0));
-    });
+    if (events != null) {
+      events.forEach(event -> {
+        inputs.add((String) event.get("input"));
+        errorMessages.add(((List<String>) event.get("details")).get(0));
+      });
+    }
 
     return new ParseExceptionReport(inputs, errorMessages);
   }


### PR DESCRIPTION
This PR is a test-only change that fixes an NPE when `maxSavedParseExceptions` is set to 0. Currently, none of the unit tests in `KafkaIndexTaskTest` have it set as 0, so adding a couple of unit tests for coverage.

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

