### PR TITLE
Remove the redundant ISO-8601 text in the readme.

### DIFF
--- a/docs/operations/rule-configuration.md
+++ b/docs/operations/rule-configuration.md
@@ -151,7 +151,7 @@ Period load rules have type `loadByPeriod`. The following example places one rep
 
 Set the following properties:
 
-- `period`: a JSON object representing [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the present, or into the future if `includeFuture` is set to `true`.
+- `period`: a JSON object representing [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the present, or into the future if `includeFuture` is set to `true`.
 - `includeFuture`: a boolean flag to instruct Druid to match a segment if:
   - the segment interval overlaps the rule interval, or
   - the segment interval starts any time after the rule interval starts.
@@ -178,7 +178,7 @@ Interval load rules have type `loadByInterval`. The following example places one
 
 Set the following properties:
 
-- `interval`: the load interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the load interval specified as an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 - `tieredReplicants`: a map of tier names to the number of segment replicas for that tier.
 
 ## Drop rules
@@ -215,7 +215,7 @@ Period drop rules have type `dropByPeriod` and the following JSON structure:
 
 Set the following properties:
 
-- `period`: a JSON object representing [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the future or to the current time, depending on the `includeFuture` flag.
+- `period`: a JSON object representing [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the future or to the current time, depending on the `includeFuture` flag.
 - `includeFuture`: a boolean flag to instruct Druid to match a segment if one of the following conditions apply:
 
   - the segment interval overlaps the rule interval
@@ -240,7 +240,7 @@ Period drop rules have type `dropBeforeByPeriod` and the following JSON structur
 
 Set the following property:
 
-- `period`: a JSON object representing [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) periods.
+- `period`: a JSON object representing [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) periods.
 
 ### Interval drop rule
 
@@ -257,7 +257,7 @@ Interval drop rules have type `dropByInterval` and the following JSON structure:
 
 Set the following property:
 
-- `interval`: the drop interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the drop interval specified as an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 
 ## Broadcast rules
 
@@ -291,7 +291,7 @@ Period broadcast rules have type `broadcastByPeriod` and the following JSON stru
 
 Set the following properties:
 
-- `period`: a JSON object representing [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the future or to the current time, depending on the `includeFuture` flag.
+- `period`: a JSON object representing [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) periods. The period is from some time in the past to the future or to the current time, depending on the `includeFuture` flag.
 - `includeFuture`: a boolean flag to instruct Druid to match a segment if one of the following conditions apply:
   - the segment interval overlaps the rule interval
   - the segment interval starts any time after the rule interval starts.
@@ -313,7 +313,7 @@ Interval broadcast rules have type `broadcastByInterval` and the following JSON 
 
 Set the following property:
 
-- `interval`: the broadcast interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the broadcast interval specified as an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 
 ## Permanently delete data
 

--- a/docs/operations/rule-configuration.md
+++ b/docs/operations/rule-configuration.md
@@ -178,7 +178,7 @@ Interval load rules have type `loadByInterval`. The following example places one
 
 Set the following properties:
 
-- `interval`: the load interval specified as an ISO-8601 [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the load interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 - `tieredReplicants`: a map of tier names to the number of segment replicas for that tier.
 
 ## Drop rules
@@ -257,7 +257,7 @@ Interval drop rules have type `dropByInterval` and the following JSON structure:
 
 Set the following property:
 
-- `interval`: the drop interval specified as an ISO-8601 [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the drop interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 
 ## Broadcast rules
 
@@ -313,7 +313,7 @@ Interval broadcast rules have type `broadcastByInterval` and the following JSON 
 
 Set the following property:
 
-- `interval`: the broadcast interval specified as an ISO-8601 [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
+- `interval`: the broadcast interval specified as an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) range encoded as a string.
 
 ## Permanently delete data
 


### PR DESCRIPTION
Fixes the redundant "ISO-8601" text in the README.

This PR has:

- [x] been self-reviewed.