### PR TITLE
Update heap size of services in docker IT environment

### DIFF
--- a/integration-tests/docker/environment-configs/coordinator
+++ b/integration-tests/docker/environment-configs/coordinator
@@ -21,7 +21,7 @@ DRUID_SERVICE=coordinator
 DRUID_LOG_PATH=/shared/logs/coordinator.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006
 
 # Druid configs
 druid_host=druid-coordinator

--- a/integration-tests/docker/environment-configs/overlord
+++ b/integration-tests/docker/environment-configs/overlord
@@ -21,7 +21,7 @@ DRUID_SERVICE=overlord
 DRUID_LOG_PATH=/shared/logs/overlord.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5009
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5009
 
 # Druid configs
 druid_host=druid-overlord


### PR DESCRIPTION
Deep storage tests in standard ITs are failing with the below error.

```
[2023-05-12T08:43:10.122Z] 2023-05-12T08:43:09,781 WARN [HttpClient-Netty-Worker-6] org.apache.druid.java.util.http.client.pool.ResourcePool - Resource at key[http://127.0.0.1:8090] was returned multiple times?
[2023-05-12T08:43:10.122Z] 2023-05-12T08:43:09,781 ERROR [main] org.apache.druid.testing.clients.OverlordResourceTestClient - Exception while sending request
[2023-05-12T08:43:10.122Z] java.util.concurrent.ExecutionException: org.jboss.netty.channel.ChannelException: Channel disconnected
[2023-05-12T08:43:10.122Z] 	at com.google.common.util.concurrent.AbstractFuture$Sync.getValue(AbstractFuture.java:299) ~[guava-16.0.1.jar:?]
[2023-05-12T08:43:10.122Z] 	at com.google.common.util.concurrent.AbstractFuture$Sync.get(AbstractFuture.java:286) ~[guava-16.0.1.jar:?]
[2023-05-12T08:43:10.122Z] 	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:116) ~[guava-16.0.1.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.testing.clients.OverlordResourceTestClient.makeRequest(OverlordResourceTestClient.java:727) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.testing.clients.OverlordResourceTestClient.getTasks(OverlordResourceTestClient.java:184) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.testing.clients.OverlordResourceTestClient.getUncompletedTasksForDataSource(OverlordResourceTestClient.java:175) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractIndexerTest.lambda$waitForAllTasksToCompleteForDataSource$3(AbstractIndexerTest.java:157) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.testing.utils.ITRetryUtil.retryUntil(ITRetryUtil.java:61) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.testing.utils.ITRetryUtil.retryUntilTrue(ITRetryUtil.java:39) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractIndexerTest.waitForAllTasksToCompleteForDataSource(AbstractIndexerTest.java:156) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractITBatchIndexTest.submitTaskAndWait(AbstractITBatchIndexTest.java:345) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractITBatchIndexTest.doIndexTest(AbstractITBatchIndexTest.java:171) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractITBatchIndexTest.doIndexTest(AbstractITBatchIndexTest.java:137) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.AbstractAzureInputSourceParallelIndexTest.doTest(AbstractAzureInputSourceParallelIndexTest.java:124) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.tests.indexer.ITAzureToAzureParallelIndexTest.testAzureIndexData(ITAzureToAzureParallelIndexTest.java:47) ~[test-classes/:?]
[2023-05-12T08:43:10.122Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_282]
[2023-05-12T08:43:10.122Z] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_282]
[2023-05-12T08:43:10.122Z] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_282]
[2023-05-12T08:43:10.122Z] 	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_282]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46) ~[testng-7.3.0.jar:?]\
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at java.util.ArrayList.forEach(ArrayList.java:1259) ~[?:1.8.0_282]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestRunner.privateRun(TestRunner.java:764) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestRunner.run(TestRunner.java:585) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.DruidTestRunnerFactory$DruidTestRunner.runTests(DruidTestRunnerFactory.java:99) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.DruidTestRunnerFactory$DruidTestRunner.run(DruidTestRunnerFactory.java:86) ~[druid-integration-tests-27.0.0-SNAPSHOT.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunner.runTest(SuiteRunner.java:384) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:378) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:337) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunner.run(SuiteRunner.java:286) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:53) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:96) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1218) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestNG.runSuitesLocally(TestNG.java:1140) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestNG.runSuites(TestNG.java:1069) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.testng.TestNG.run(TestNG.java:1037) ~[testng-7.3.0.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:283) ~[surefire-testng-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:75) ~[surefire-testng-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:120) ~[surefire-testng-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:383) ~[surefire-booter-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:344) ~[surefire-booter-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125) ~[surefire-booter-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:417) ~[surefire-booter-2.22.0.jar:2.22.0]
[2023-05-12T08:43:10.122Z] Caused by: org.jboss.netty.channel.ChannelException: Channel disconnected
[2023-05-12T08:43:10.122Z] 	at org.apache.druid.java.util.http.client.NettyHttpClient$1.channelDisconnected(NettyHttpClient.java:334) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
[2023-05-12T08:43:10.122Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:102) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.122Z] 	at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.channelDisconnected(SimpleChannelUpstreamHandler.java:208) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:102) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.channelDisconnected(SimpleChannelUpstreamHandler.java:208) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:102) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.handler.codec.replay.ReplayingDecoder.cleanup(ReplayingDecoder.java:570) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.handler.codec.frame.FrameDecoder.channelDisconnected(FrameDecoder.java:365) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:102) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.handler.codec.http.HttpClientCodec.handleUpstream(HttpClientCodec.java:92) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:559) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.Channels.fireChannelDisconnected(Channels.java:396) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.AbstractNioWorker.close(AbstractNioWorker.java:360) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.NioWorker.read(NioWorker.java:93) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.AbstractNioWorker.process(AbstractNioWorker.java:108) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:337) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.AbstractNioWorker.run(AbstractNioWorker.java:89) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.channel.socket.nio.NioWorker.run(NioWorker.java:178) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.util.ThreadRenamingRunnable.run(ThreadRenamingRunnable.java:108) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at org.jboss.netty.util.internal.DeadLockProofWorker$1.run(DeadLockProofWorker.java:42) ~[netty-3.10.6.Final-iap3.jar:?]
[2023-05-12T08:43:10.123Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_282]
[2023-05-12T08:43:10.123Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_282]
[2023-05-12T08:43:10.123Z] 	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_282]
```

Upon debugging, it's understood that Overlord & coordinator services are failing due to OOM errors. This PR increases the heap pool size of these services from 64M to 128M.