### PR TITLE
Fix planning in CASE expressions with complex WHEN and ELSE expressions

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -14642,4 +14642,36 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         )
     );
   }
+
+  @Test
+  public void testFilterWithNVLAndNotIn()
+  {
+    testQuery(
+        "select __time, dim1 from druid.foo where nvl(dim1, '') NOT IN ('a' , '')",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .dataSource(new TableDataSource(CalciteTests.DATASOURCE1))
+                .context(QUERY_CONTEXT_DEFAULT)
+                .intervals(querySegmentSpec(Intervals.of(
+                    "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z")))
+                .columns(ImmutableList.of("__time", "dim1"))
+                .filters(and(
+                    or(
+                        not(selector("dim1", "a", null)),
+                        selector("dim1", null, null)
+                    ),
+                    not(selector("dim1", NullHandling.sqlCompatible() ? "" : null, null))
+                ))
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{946771200000L, "10.1"},
+            new Object[]{946857600000L, "2"},
+            new Object[]{978307200000L, "1"},
+            new Object[]{978393600000L, "def"},
+            new Object[]{978480000000L, "abc"}
+        )
+    );
+  }
 }


### PR DESCRIPTION
Using expressions like `NVL(x, '') NOT IN ('y', '')` in filters produce an incorrect filter currently. Calcite converts this expression into a `CASE` expression. This changes fixes that bug by using better planning mechanisms for planning the `WHEN` and `ELSE` clauses of the case expression.