### PR TITLE
Do not allow retention rules to be null

### DIFF
--- a/processing/src/main/java/org/apache/druid/audit/AuditInfo.java
+++ b/processing/src/main/java/org/apache/druid/audit/AuditInfo.java
@@ -22,6 +22,8 @@ package org.apache.druid.audit;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class AuditInfo
 {
   private final String author;
@@ -67,29 +69,16 @@ public class AuditInfo
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    AuditInfo that = (AuditInfo) o;
-
-    if (!author.equals(that.author)) {
-      return false;
-    }
-    if (!comment.equals(that.comment)) {
-      return false;
-    }
-    if (!ip.equals(that.ip)) {
-      return false;
-    }
-
-    return true;
+    AuditInfo auditInfo = (AuditInfo) o;
+    return Objects.equals(author, auditInfo.author)
+           && Objects.equals(comment, auditInfo.comment)
+           && Objects.equals(ip, auditInfo.ip);
   }
 
   @Override
   public int hashCode()
   {
-    int result = author.hashCode();
-    result = 31 * result + comment.hashCode();
-    result = 31 * result + ip.hashCode();
-    return result;
+    return Objects.hash(author, comment, ip);
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/audit/AuditInfoTest.java
+++ b/processing/src/test/java/org/apache/druid/audit/AuditInfoTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.DateTimes;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class AuditInfoTest
+{
+  @Test
+  public void testAuditInfoEquality()
+  {
+    final AuditInfo auditInfo1 = new AuditInfo("druid", "test equality", "127.0.0.1");
+    final AuditInfo auditInfo2 = new AuditInfo("druid", "test equality", "127.0.0.1");
+    Assert.assertEquals(auditInfo1, auditInfo2);
+    Assert.assertEquals(auditInfo1.hashCode(), auditInfo2.hashCode());
+  }
+
+  @Test(timeout = 60_000L)
+  public void testAuditEntrySerde() throws IOException
+  {
+    AuditEntry entry = new AuditEntry(
+        "testKey",
+        "testType",
+        new AuditInfo(
+            "testAuthor",
+            "testComment",
+            "127.0.0.1"
+        ),
+        "testPayload",
+        DateTimes.of("2013-01-01T00:00:00Z")
+    );
+    ObjectMapper mapper = new DefaultObjectMapper();
+    AuditEntry serde = mapper.readValue(mapper.writeValueAsString(entry), AuditEntry.class);
+    Assert.assertEquals(entry, serde);
+  }
+
+}

--- a/server/src/main/java/org/apache/druid/metadata/MetadataRuleManagerConfig.java
+++ b/server/src/main/java/org/apache/druid/metadata/MetadataRuleManagerConfig.java
@@ -35,6 +35,10 @@ public class MetadataRuleManagerConfig
   @JsonProperty
   private Period alertThreshold = new Period("PT10M");
 
+  /**
+   * Datasource name against which the cluster-level default rules are stored
+   * in the metadata store.
+   */
   public String getDefaultRule()
   {
     return defaultRule;

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataRuleManager.java
@@ -42,20 +42,12 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordinator.rules.ForeverLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.joda.time.DateTime;
-import org.skife.jdbi.v2.FoldController;
-import org.skife.jdbi.v2.Folder3;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.IDBI;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.TransactionCallback;
-import org.skife.jdbi.v2.TransactionStatus;
 import org.skife.jdbi.v2.Update;
 import org.skife.jdbi.v2.tweak.HandleCallback;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -351,7 +343,7 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
     synchronized (lock) {
       try {
         dbi.inTransaction(
-            (TransactionCallback<Void>) (handle, transactionStatus) -> {
+            (handle, transactionStatus) -> {
               final DateTime auditTime = DateTimes.nowUtc();
               auditManager.doAudit(
                   AuditEntry.builder()

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataRuleManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataRuleManager.java
@@ -32,6 +32,7 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -174,6 +175,12 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
     Preconditions.checkNotNull(config.getAlertThreshold().toStandardDuration());
     Preconditions.checkNotNull(config.getPollDuration().toStandardDuration());
 
+    String defaultRule = config.getDefaultRule();
+    Preconditions.checkState(
+        defaultRule != null && !defaultRule.isEmpty(),
+        "If specified, 'druid.manager.rules.defaultRule' must have a non-empty value."
+    );
+
     this.rules = new AtomicReference<>(ImmutableMap.of());
   }
 
@@ -194,26 +201,18 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
 
       createDefaultRule(dbi, getRulesTable(), config.getDefaultRule(), jsonMapper);
       exec.scheduleWithFixedDelay(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              try {
-                // poll() is synchronized together with start() and stop() to ensure that when stop() exits, poll()
-                // won't actually run anymore after that (it could only enter the synchronized section and exit
-                // immediately because the localStartedOrder doesn't match the new currentStartOrder). It's needed
-                // to avoid flakiness in SQLMetadataRuleManagerTest.
-                // See https://github.com/apache/druid/issues/6028
-                synchronized (lock) {
-                  if (localStartedOrder == currentStartOrder) {
-                    poll();
-                  }
+          () -> {
+            try {
+              // Do not poll if already stopped
+              // See https://github.com/apache/druid/issues/6028
+              synchronized (lock) {
+                if (localStartedOrder == currentStartOrder) {
+                  poll();
                 }
               }
-              catch (Exception e) {
-                log.error(e, "uncaught exception in rule manager polling thread");
-              }
+            }
+            catch (Exception e) {
+              log.error(e, "uncaught exception in rule manager polling thread");
             }
           },
           0,
@@ -246,73 +245,45 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
     
       ImmutableMap<String, List<Rule>> newRules = ImmutableMap.copyOf(
           dbi.withHandle(
-              new HandleCallback<Map<String, List<Rule>>>()
-              {
-                @Override
-                public Map<String, List<Rule>> withHandle(Handle handle)
-                {
-                  return handle.createQuery(
-                      // Return latest version rule by dataSource
-                      StringUtils.format(
-                          "SELECT r.dataSource, r.payload "
-                          + "FROM %1$s r "
-                          + "INNER JOIN(SELECT dataSource, max(version) as version FROM %1$s GROUP BY dataSource) ds "
-                          + "ON r.datasource = ds.datasource and r.version = ds.version",
-                          getRulesTable()
-                      )
-                  ).map(
-                      new ResultSetMapper<Pair<String, List<Rule>>>()
-                      {
-                        @Override
-                        public Pair<String, List<Rule>> map(int index, ResultSet r, StatementContext ctx)
-                            throws SQLException
-                        {
-                          try {
-                            return Pair.of(
-                                r.getString("dataSource"),
-                                jsonMapper.readValue(
-                                    r.getBytes("payload"), new TypeReference<List<Rule>>()
-                                    {
-                                    }
-                                )
-                            );
-                          }
-                          catch (IOException e) {
-                            throw new RuntimeException(e);
-                          }
-                        }
-                      }
+              handle -> handle.createQuery(
+                  // Return latest version rule by dataSource
+                  StringUtils.format(
+                      "SELECT r.dataSource, r.payload "
+                      + "FROM %1$s r "
+                      + "INNER JOIN(SELECT dataSource, max(version) as version FROM %1$s GROUP BY dataSource) ds "
+                      + "ON r.datasource = ds.datasource and r.version = ds.version",
+                      getRulesTable()
                   )
-                               .fold(
-                                   new HashMap<>(),
-                                   new Folder3<Map<String, List<Rule>>, Pair<String, List<Rule>>>()
-                                   {
-                                     @Override
-                                     public Map<String, List<Rule>> fold(
-                                         Map<String, List<Rule>> retVal,
-                                         Pair<String, List<Rule>> stringObjectMap,
-                                         FoldController foldController,
-                                         StatementContext statementContext
-                                     )
-                                     {
-                                       try {
-                                         String dataSource = stringObjectMap.lhs;
-                                         retVal.put(dataSource, stringObjectMap.rhs);
-                                         return retVal;
-                                       }
-                                       catch (Exception e) {
-                                         throw new RuntimeException(e);
-                                       }
-                                     }
-                                   }
-                               );
-                }
-              }
+              ).map(
+                  (index, r, ctx) -> {
+                    try {
+                      return Pair.of(
+                          r.getString("dataSource"),
+                          jsonMapper.readValue(r.getBytes("payload"), new TypeReference<List<Rule>>() {})
+                      );
+                    }
+                    catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
+                  }
+              ).fold(
+                  new HashMap<>(),
+                  (retVal, stringObjectMap, foldController, statementContext) -> {
+                    try {
+                      String dataSource = stringObjectMap.lhs;
+                      retVal.put(dataSource, stringObjectMap.rhs);
+                      return retVal;
+                    }
+                    catch (Exception e) {
+                      throw new RuntimeException(e);
+                    }
+                  }
+              )
           )
       );
 
       final int newRuleCount = newRules.values().stream().mapToInt(List::size).sum();
-      log.info("Polled and found %,d rule(s) for %,d datasource(s)", newRuleCount, newRules.size());
+      log.info("Polled and found [%d] rule(s) for [%d] datasource(s).", newRuleCount, newRules.size());
 
       rules.set(newRules);
       failStartTimeMs = 0;
@@ -322,9 +293,9 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
         failStartTimeMs = System.currentTimeMillis();
       }
 
-      if (System.currentTimeMillis() - failStartTimeMs > config.getAlertThreshold().toStandardDuration().getMillis()) {
-        log.makeAlert(e, "Exception while polling for rules")
-           .emit();
+      final long alertPeriodMillis = config.getAlertThreshold().toStandardDuration().getMillis();
+      if (System.currentTimeMillis() - failStartTimeMs > alertPeriodMillis) {
+        log.makeAlert(e, "Exception while polling for rules").emit();
         failStartTimeMs = 0;
       } else {
         log.error(e, "Exception while polling for rules");
@@ -362,6 +333,12 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
   @Override
   public boolean overrideRule(final String dataSource, final List<Rule> newRules, final AuditInfo auditInfo)
   {
+    if (newRules == null) {
+      throw new IAE("Rules cannot be null.");
+    } else if (newRules.isEmpty() && config.getDefaultRule().equals(dataSource)) {
+      throw new IAE("Cluster-level rules cannot be empty.");
+    }
+
     final String ruleString;
     try {
       ruleString = jsonMapper.writeValueAsString(newRules);
@@ -374,39 +351,35 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
     synchronized (lock) {
       try {
         dbi.inTransaction(
-            new TransactionCallback<Void>()
-            {
-              @Override
-              public Void inTransaction(Handle handle, TransactionStatus transactionStatus) throws Exception
-              {
-                final DateTime auditTime = DateTimes.nowUtc();
-                auditManager.doAudit(
-                    AuditEntry.builder()
-                              .key(dataSource)
-                              .type("rules")
-                              .auditInfo(auditInfo)
-                              .payload(ruleString)
-                              .auditTime(auditTime)
-                              .build(),
-                    handle
-                );
-                // Note that the method removeRulesForEmptyDatasourcesOlderThan depends on the version field
-                // to be a timestamp
-                String version = auditTime.toString();
-                handle.createStatement(
-                    StringUtils.format(
-                        "INSERT INTO %s (id, dataSource, version, payload) VALUES (:id, :dataSource, :version, :payload)",
-                        getRulesTable()
-                    )
-                )
-                      .bind("id", StringUtils.format("%s_%s", dataSource, version))
-                      .bind("dataSource", dataSource)
-                      .bind("version", version)
-                      .bind("payload", jsonMapper.writeValueAsBytes(newRules))
-                      .execute();
+            (TransactionCallback<Void>) (handle, transactionStatus) -> {
+              final DateTime auditTime = DateTimes.nowUtc();
+              auditManager.doAudit(
+                  AuditEntry.builder()
+                            .key(dataSource)
+                            .type("rules")
+                            .auditInfo(auditInfo)
+                            .payload(ruleString)
+                            .auditTime(auditTime)
+                            .build(),
+                  handle
+              );
+              // Note that the method removeRulesForEmptyDatasourcesOlderThan
+              // depends on the version field to be a timestamp
+              String version = auditTime.toString();
+              handle.createStatement(
+                  StringUtils.format(
+                      "INSERT INTO %s (id, dataSource, version, payload)"
+                      + " VALUES (:id, :dataSource, :version, :payload)",
+                      getRulesTable()
+                  )
+              )
+                    .bind("id", StringUtils.format("%s_%s", dataSource, version))
+                    .bind("dataSource", dataSource)
+                    .bind("version", version)
+                    .bind("payload", jsonMapper.writeValueAsBytes(newRules))
+                    .execute();
 
-                return null;
-              }
+              return null;
             }
         );
       }
@@ -438,7 +411,8 @@ public class SQLMetadataRuleManager implements MetadataRuleManager
                 // However, since currently this query is run very infrequent (by default once a day by the KillRules Coordinator duty)
                 // and the inner query on segment table is a READ (no locking), it is keep this way.
                 StringUtils.format(
-                    "DELETE FROM %1$s WHERE datasource NOT IN (SELECT DISTINCT datasource from %2$s) and datasource!=:default_rule and version < :date_time",
+                    "DELETE FROM %1$s WHERE datasource NOT IN (SELECT DISTINCT datasource from %2$s)"
+                    + " and datasource!=:default_rule and version < :date_time",
                     getRulesTable(),
                     getSegmentsTable()
                 )

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -114,11 +114,11 @@ public class RulesResource
       } else {
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
       }
-    } catch (IllegalArgumentException e)
-    {
+    }
+    catch (IllegalArgumentException e) {
       return Response.status(Response.Status.BAD_REQUEST)
-          .entity(ImmutableMap.of("error", e.getMessage()))
-          .build();
+                     .entity(ImmutableMap.of("error", e.getMessage()))
+                     .build();
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -54,6 +54,8 @@ public class RulesResource
 {
   public static final String RULES_ENDPOINT = "/druid/coordinator/v1/rules";
 
+  private static final String AUDIT_HISTORY_TYPE = "rules";
+
   private final MetadataRuleManager databaseRuleManager;
   private final AuditManager auditManager;
 
@@ -105,14 +107,19 @@ public class RulesResource
       @Context HttpServletRequest req
   )
   {
-    if (databaseRuleManager.overrideRule(
-        dataSourceName,
-        rules,
-        new AuditInfo(author, comment, req.getRemoteAddr())
-    )) {
-      return Response.ok().build();
+    try {
+      final AuditInfo auditInfo = new AuditInfo(author, comment, req.getRemoteAddr());
+      if (databaseRuleManager.overrideRule(dataSourceName, rules, auditInfo)) {
+        return Response.ok().build();
+      } else {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+      }
+    } catch (IllegalArgumentException e)
+    {
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity(ImmutableMap.of("error", e.getMessage()))
+          .build();
     }
-    return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
   }
 
   @GET
@@ -162,16 +169,16 @@ public class RulesResource
   {
     if (interval == null && count != null) {
       if (dataSourceName != null) {
-        return auditManager.fetchAuditHistory(dataSourceName, "rules", count);
+        return auditManager.fetchAuditHistory(dataSourceName, AUDIT_HISTORY_TYPE, count);
       }
-      return auditManager.fetchAuditHistory("rules", count);
+      return auditManager.fetchAuditHistory(AUDIT_HISTORY_TYPE, count);
     }
 
     Interval theInterval = interval == null ? null : Intervals.of(interval);
     if (dataSourceName != null) {
-      return auditManager.fetchAuditHistory(dataSourceName, "rules", theInterval);
+      return auditManager.fetchAuditHistory(dataSourceName, AUDIT_HISTORY_TYPE, theInterval);
     }
-    return auditManager.fetchAuditHistory("rules", theInterval);
+    return auditManager.fetchAuditHistory(AUDIT_HISTORY_TYPE, theInterval);
   }
 
 }

--- a/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SQLMetadataRuleManagerTest.java
@@ -261,7 +261,7 @@ public class SQLMetadataRuleManagerTest
             ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS)
         )
     );
-    ruleManager.overrideRule(DATASOURCE, rules, createAuditInfo("udpate rules"));
+    ruleManager.overrideRule(DATASOURCE, rules, createAuditInfo("update rules"));
 
     // Verify that rule was added
     ruleManager.poll();
@@ -289,7 +289,7 @@ public class SQLMetadataRuleManagerTest
             ImmutableMap.of(DruidServer.DEFAULT_TIER, DruidServer.DEFAULT_NUM_REPLICANTS)
         )
     );
-    ruleManager.overrideRule(DATASOURCE, rules, createAuditInfo("udpate rules"));
+    ruleManager.overrideRule(DATASOURCE, rules, createAuditInfo("update rules"));
 
     // Verify that rule was added
     ruleManager.poll();

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -42,8 +42,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.tweak.HandleCallback;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -521,6 +519,14 @@ public class SQLAuditManagerTest
     Mockito.verify(mockConfigSerde).serializeToString(ArgumentMatchers.eq(entryPayload1WithNull), ArgumentMatchers.eq(true));
   }
 
+  @Test
+  public void testAuditInfoEquality()
+  {
+    final AuditInfo auditInfo = new AuditInfo("druid", "test equality", "127.0.0.1");
+    Assert.assertEquals(auditInfo, auditInfo);
+    Assert.assertEquals(auditInfo.hashCode(), auditInfo.hashCode());
+  }
+
   @After
   public void cleanup()
   {
@@ -530,16 +536,8 @@ public class SQLAuditManagerTest
   private void dropTable(final String tableName)
   {
     Assert.assertNull(connector.getDBI().withHandle(
-        new HandleCallback<Void>()
-        {
-          @Override
-          public Void withHandle(Handle handle)
-          {
-            handle.createStatement(StringUtils.format("DROP TABLE %s", tableName))
-                  .execute();
-            return null;
-          }
-        }
+        handle -> handle.createStatement(StringUtils.format("DROP TABLE %s", tableName))
+                        .execute()
     ));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -522,9 +522,10 @@ public class SQLAuditManagerTest
   @Test
   public void testAuditInfoEquality()
   {
-    final AuditInfo auditInfo = new AuditInfo("druid", "test equality", "127.0.0.1");
-    Assert.assertEquals(auditInfo, auditInfo);
-    Assert.assertEquals(auditInfo.hashCode(), auditInfo.hashCode());
+    final AuditInfo auditInfo1 = new AuditInfo("druid", "test equality", "127.0.0.1");
+    final AuditInfo auditInfo2 = new AuditInfo("druid", "test equality", "127.0.0.1");
+    Assert.assertEquals(auditInfo1, auditInfo2);
+    Assert.assertEquals(auditInfo1.hashCode(), auditInfo2.hashCode());
   }
 
   @After
@@ -535,9 +536,12 @@ public class SQLAuditManagerTest
 
   private void dropTable(final String tableName)
   {
-    Assert.assertNull(connector.getDBI().withHandle(
-        handle -> handle.createStatement(StringUtils.format("DROP TABLE %s", tableName))
+    Assert.assertEquals(
+        0,
+        connector.getDBI().withHandle(
+            handle -> handle.createStatement(StringUtils.format("DROP TABLE %s", tableName))
                         .execute()
-    ));
+        ).intValue()
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/audit/SQLAuditManagerTest.java
@@ -56,9 +56,7 @@ public class SQLAuditManagerTest
 
   private TestDerbyConnector connector;
   private AuditManager auditManager;
-  private final String PAYLOAD_DIMENSION_KEY = "payload";
   private ConfigSerde<String> stringConfigSerde;
-
 
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
@@ -103,36 +101,13 @@ public class SQLAuditManagerTest
     };
   }
 
-  @Test(timeout = 60_000L)
-  public void testAuditEntrySerde() throws IOException
-  {
-    AuditEntry entry = new AuditEntry(
-        "testKey",
-        "testType",
-        new AuditInfo(
-            "testAuthor",
-            "testComment",
-            "127.0.0.1"
-        ),
-        "testPayload",
-        DateTimes.of("2013-01-01T00:00:00Z")
-    );
-    ObjectMapper mapper = new DefaultObjectMapper();
-    AuditEntry serde = mapper.readValue(mapper.writeValueAsString(entry), AuditEntry.class);
-    Assert.assertEquals(entry, serde);
-  }
-
   @Test
   public void testAuditMetricEventBuilderConfig()
   {
     AuditEntry entry = new AuditEntry(
         "testKey",
         "testType",
-        new AuditInfo(
-            "testAuthor",
-            "testComment",
-            "127.0.0.1"
-        ),
+        new AuditInfo("testAuthor", "testComment", "127.0.0.1"),
         "testPayload",
         DateTimes.of("2013-01-01T00:00:00Z")
     );
@@ -153,10 +128,11 @@ public class SQLAuditManagerTest
     );
 
     ServiceMetricEvent.Builder auditEntryBuilder = ((SQLAuditManager) auditManager).getAuditMetricEventBuilder(entry);
-    Assert.assertEquals(null, auditEntryBuilder.getDimension(PAYLOAD_DIMENSION_KEY));
+    final String payloadDimensionKey = "payload";
+    Assert.assertNull(auditEntryBuilder.getDimension(payloadDimensionKey));
 
     ServiceMetricEvent.Builder auditEntryBuilderWithPayload = auditManagerWithPayloadAsDimension.getAuditMetricEventBuilder(entry);
-    Assert.assertEquals("testPayload", auditEntryBuilderWithPayload.getDimension(PAYLOAD_DIMENSION_KEY));
+    Assert.assertEquals("testPayload", auditEntryBuilderWithPayload.getDimension(payloadDimensionKey));
   }
 
   @Test(timeout = 60_000L)
@@ -164,11 +140,7 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
@@ -191,11 +163,7 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
@@ -224,29 +192,17 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey1";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload";
 
     String entry2Key = "testKey2";
     String entry2Type = "testType";
-    AuditInfo entry2AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry2AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry2Payload = "testPayload";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
     auditManager.doAudit(entry2Key, entry2Type, entry2AuditInfo, entry2Payload, stringConfigSerde);
-    List<AuditEntry> auditEntries = auditManager.fetchAuditHistory(
-        "testKey1",
-        "testType",
-        1
-    );
+    List<AuditEntry> auditEntries = auditManager.fetchAuditHistory("testKey1", "testType", 1);
     Assert.assertEquals(1, auditEntries.size());
     Assert.assertEquals(entry1Key, auditEntries.get(0).getKey());
     Assert.assertEquals(entry1Payload, auditEntries.get(0).getPayload());
@@ -259,11 +215,7 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
@@ -296,11 +248,7 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
@@ -336,39 +284,24 @@ public class SQLAuditManagerTest
   {
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "testPayload1";
 
     String entry2Key = "testKey";
     String entry2Type = "testType";
-    AuditInfo entry2AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry2AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry2Payload = "testPayload2";
 
     String entry3Key = "testKey";
     String entry3Type = "testType";
-    AuditInfo entry3AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry3AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry3Payload = "testPayload3";
 
     auditManager.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload, stringConfigSerde);
     auditManager.doAudit(entry2Key, entry2Type, entry2AuditInfo, entry2Payload, stringConfigSerde);
     auditManager.doAudit(entry3Key, entry3Type, entry3AuditInfo, entry3Payload, stringConfigSerde);
 
-    List<AuditEntry> auditEntries = auditManager.fetchAuditHistory(
-        "testType",
-        2
-    );
+    List<AuditEntry> auditEntries = auditManager.fetchAuditHistory("testType", 2);
     Assert.assertEquals(2, auditEntries.size());
     Assert.assertEquals(entry3Key, auditEntries.get(0).getKey());
     Assert.assertEquals(entry3Payload, auditEntries.get(0).getPayload());
@@ -414,15 +347,15 @@ public class SQLAuditManagerTest
 
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "payload audit to store";
 
-    auditManagerWithMaxPayloadSizeBytes.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload,
-                                                stringConfigSerde
+    auditManagerWithMaxPayloadSizeBytes.doAudit(
+        entry1Key,
+        entry1Type,
+        entry1AuditInfo,
+        entry1Payload,
+        stringConfigSerde
     );
 
     byte[] payload = connector.lookup(
@@ -459,15 +392,15 @@ public class SQLAuditManagerTest
     );
     String entry1Key = "testKey";
     String entry1Type = "testType";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     String entry1Payload = "payload audit to store";
 
-    auditManagerWithMaxPayloadSizeBytes.doAudit(entry1Key, entry1Type, entry1AuditInfo, entry1Payload,
-                                                stringConfigSerde
+    auditManagerWithMaxPayloadSizeBytes.doAudit(
+        entry1Key,
+        entry1Type,
+        entry1AuditInfo,
+        entry1Payload,
+        stringConfigSerde
     );
 
     byte[] payload = connector.lookup(
@@ -505,11 +438,7 @@ public class SQLAuditManagerTest
 
     String entry1Key = "test1Key";
     String entry1Type = "test1Type";
-    AuditInfo entry1AuditInfo = new AuditInfo(
-        "testAuthor",
-        "testComment",
-        "127.0.0.1"
-    );
+    AuditInfo entry1AuditInfo = new AuditInfo("testAuthor", "testComment", "127.0.0.1");
     // Entry 1 payload has a null field for one of the property
     Map<String, String> entryPayload1WithNull = new HashMap<>();
     entryPayload1WithNull.put("version", "x");
@@ -517,15 +446,6 @@ public class SQLAuditManagerTest
 
     auditManagerWithSkipNull.doAudit(entry1Key, entry1Type, entry1AuditInfo, entryPayload1WithNull, mockConfigSerde);
     Mockito.verify(mockConfigSerde).serializeToString(ArgumentMatchers.eq(entryPayload1WithNull), ArgumentMatchers.eq(true));
-  }
-
-  @Test
-  public void testAuditInfoEquality()
-  {
-    final AuditInfo auditInfo1 = new AuditInfo("druid", "test equality", "127.0.0.1");
-    final AuditInfo auditInfo2 = new AuditInfo("druid", "test equality", "127.0.0.1");
-    Assert.assertEquals(auditInfo1, auditInfo2);
-    Assert.assertEquals(auditInfo1.hashCode(), auditInfo2.hashCode());
   }
 
   @After


### PR DESCRIPTION
### Changes

- Give a proper error message when retention rules are passed as null/empty to the `POST coordinator/v1/rules` API
- Empty rules are allowed at the datasource level but not at the cluster level
- Add validation to ensure that `druid.manager.rules.defaultRule` is always set correctly
- Minor style refactors

### Changed classes
- Update `RulesResource`: Handle `IllegalArgumentException` and send back appropriate response with error message
- Update `SqlMetadataRuleManager`
  - Throw an exception when rules are null/empty
  - Minor style refactor using lambdas
- Refactor `AuditInfo`: Clean equals and hashCode methods
- Add `AuditInfoTest`
- Refactor `SqlMetadataRuleManagerTest`

### Screenshots

<img width="788" alt="empty_cluster_rules" src="https://user-images.githubusercontent.com/18635897/236813908-9657dde1-b611-41ef-b387-6043655a49e4.png">
<img width="208" alt="null_rules" src="https://user-images.githubusercontent.com/18635897/236813919-bc22fc83-272b-4163-b1b9-f85439ee1b5e.png">


#### Release note
- Rules defined at the datasource level cannot be null
- Rules defined at the cluster level cannot be null or empty

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
