### PR TITLE
add array_to_mv function to convert arrays into mvds to assist with migration from mvds to arrays

### DIFF
--- a/docs/querying/sql-array-functions.md
+++ b/docs/querying/sql-array-functions.md
@@ -36,8 +36,11 @@ sidebar_label: "Array functions"
 
 This page describes the operations you can perform on arrays using [Druid SQL](./sql.md). See [`ARRAY` data type documentation](./sql-data-types.md#arrays) for additional details.
 
-All array references in the array function documentation can refer to multi-value string columns or `ARRAY` literals. These functions are largely
-identical to the [multi-value string functions](sql-multivalue-string-functions.md), but use `ARRAY` types and behavior.
+All array references in the array function documentation can refer to multi-value string columns or `ARRAY` literals.
+These functions are largely identical to the [multi-value string functions](sql-multivalue-string-functions.md), but
+use `ARRAY` types and behavior. Multi-value string `VARCHAR` columns can be converted to `VARCHAR ARRAY` to use with
+these functions using `MV_TO_ARRAY`, and `ARRAY` types can be converted to multi-value string `VARCHAR` with
+`ARRAY_TO_MV`.
 
 |Function|Description|
 |--------|-----|
@@ -55,3 +58,4 @@ identical to the [multi-value string functions](sql-multivalue-string-functions.
 |`ARRAY_SLICE(arr, start, end)`|Returns the subarray of `arr` from the 0-based index `start` (inclusive) to `end` (exclusive). Returns `null`, if `start` is less than 0, greater than length of `arr`, or greater than `end`.|
 |`ARRAY_TO_STRING(arr, str)`|Joins all elements of `arr` by the delimiter specified by `str`.|
 |`STRING_TO_ARRAY(str1, str2)`|Splits `str1` into an array on the delimiter specified by `str2`.|
+|`ARRAY_TO_MV(arr)`|Converts an `ARRAY` of any type into a multi-value string `VARCHAR`.|

--- a/docs/querying/sql-multivalue-string-functions.md
+++ b/docs/querying/sql-multivalue-string-functions.md
@@ -40,8 +40,9 @@ See [SQL multi-value strings](./sql-data-types.md#multi-value-strings) and nativ
 
 All array references in the multi-value string function documentation can refer to multi-value string columns or
 `ARRAY` types. These functions are largely identical to the [array functions](./sql-array-functions.md), but use
-`VARCHAR` types and behavior. Multi-value strings can also be converted to `ARRAY` types using `MV_TO_ARRAY`. For
-additional details about `ARRAY` types, see [`ARRAY` data type documentation](./sql-data-types.md#arrays).
+`VARCHAR` types and behavior. Multi-value strings can also be converted to `ARRAY` types using `MV_TO_ARRAY`, and
+`ARRAY` into multi-value strings via `ARRAY_TO_MV`. For additional details about `ARRAY` types, see
+[`ARRAY` data type documentation](./sql-data-types.md#arrays).
 
 |Function|Description|
 |--------|-----|

--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -224,7 +224,7 @@ public interface Expr extends Cacheable
         if (argType == null) {
           continue;
         }
-        numeric &= argType.isNumeric();
+        numeric = numeric && argType.isNumeric();
       }
       return numeric;
     }
@@ -265,7 +265,7 @@ public interface Expr extends Cacheable
         if (currentType == null) {
           currentType = argType;
         }
-        allSame &= Objects.equals(argType, currentType);
+        allSame = allSame && Objects.equals(argType, currentType);
       }
       return allSame;
     }
@@ -302,7 +302,7 @@ public interface Expr extends Cacheable
         if (argType == null) {
           continue;
         }
-        scalar &= argType.isPrimitive();
+        scalar = scalar && argType.isPrimitive();
       }
       return scalar;
     }
@@ -330,7 +330,7 @@ public interface Expr extends Cacheable
     {
       boolean canVectorize = true;
       for (Expr arg : args) {
-        canVectorize &= arg.canVectorize(this);
+        canVectorize = canVectorize && arg.canVectorize(this);
       }
       return canVectorize;
     }

--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -2922,7 +2922,7 @@ public interface Function extends NamedFunction
     }
   }
 
-  class MVToArrayFunction implements Function
+  class MultiValueStringToArrayFunction implements Function
   {
     @Override
     public String name()
@@ -2981,6 +2981,67 @@ public interface Function extends NamedFunction
       return ImmutableSet.copyOf(args);
     }
   }
+
+  class ArrayToMultiValueStringFunction implements Function
+  {
+    @Override
+    public String name()
+    {
+      return "array_to_mv";
+    }
+
+    @Override
+    public ExprEval apply(List<Expr> args, Expr.ObjectBinding bindings)
+    {
+      return args.get(0).eval(bindings).castTo(ExpressionType.STRING_ARRAY);
+    }
+
+    @Override
+    public void validateArguments(List<Expr> args)
+    {
+      validationHelperCheckArgumentCount(args, 1);
+      IdentifierExpr expr = args.get(0).getIdentifierExprIfIdentifierExpr();
+
+      if (expr == null) {
+        throw validationFailed(
+            "argument %s should be an identifier expression. Use array() instead",
+            args.get(0).toString()
+        );
+      }
+    }
+
+    @Nullable
+    @Override
+    public ExpressionType getOutputType(Expr.InputBindingInspector inspector, List<Expr> args)
+    {
+      return ExpressionType.STRING_ARRAY;
+    }
+
+    @Override
+    public boolean hasArrayInputs()
+    {
+      return true;
+    }
+
+    @Override
+    public boolean hasArrayOutput()
+    {
+      return true;
+    }
+
+    @Override
+    public Set<Expr> getScalarInputs(List<Expr> args)
+    {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<Expr> getArrayInputs(List<Expr> args)
+    {
+      return ImmutableSet.copyOf(args);
+    }
+  }
+
   class ArrayConstructorFunction implements Function
   {
     @Override

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnType.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnType.java
@@ -135,6 +135,23 @@ public class ColumnType extends BaseTypeSignature<ValueType>
     return ColumnTypeFactory.getInstance().ofComplex(complexTypeName);
   }
 
+  /**
+   * Finds the type that can best represent both types, or none if there is no type information.
+   * If either type is null, the other type is returned. If both types are null, this method returns null as we cannot
+   * determine any useful type information. If the types are {@link ValueType#COMPLEX}, they must be the same complex
+   * type, else this function throws a {@link IllegalArgumentException} as the types are truly incompatible, with the
+   * exception of {@link ColumnType#NESTED_DATA} which is complex and represents nested AND mixed type data so is
+   * instead treated as the 'least restrictive type' if present. If both types are {@link ValueType#ARRAY}, the result
+   * is an array of the result of calling this method again on {@link ColumnType#elementType}. If only one type is an
+   * array, the result is an array type of calling this method on the non-array type and the array element type. After
+   * arrays, if either type is {@link ValueType#STRING}, the result is {@link ValueType#STRING}. If both types are
+   * numeric, then the result will be {@link ValueType#LONG} if both are longs, {@link ValueType#FLOAT} if both are
+   * floats, else {@link ValueType#DOUBLE}.
+   *
+   * @see org.apache.druid.math.expr.ExpressionTypeConversion#function for a similar method used for expression type
+   *                                                                   inference
+   */
+  @Nullable
   public static ColumnType leastRestrictiveType(@Nullable ColumnType type, @Nullable ColumnType other)
   {
     if (type == null) {

--- a/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -1007,14 +1007,16 @@ public class FunctionTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testMVToArrayWithValidInputs()
+  public void testMultiValueStringToArrayWithValidInputs()
   {
     assertArrayExpr("mv_to_array(x)", new String[]{"foo"});
     assertArrayExpr("mv_to_array(a)", new String[]{"foo", "bar", "baz", "foobar"});
+    assertArrayExpr("mv_to_array(b)", new String[]{"1", "2", "3", "4", "5"});
+    assertArrayExpr("mv_to_array(c)", new String[]{"3.1", "4.2", "5.3"});
   }
 
   @Test
-  public void testMVToArrayWithConstantLiteral()
+  public void testMultiValueStringToArrayWithInvalidInputs()
   {
     Throwable t = Assert.assertThrows(
         ExpressionValidationException.class,
@@ -1024,12 +1026,8 @@ public class FunctionTest extends InitializedNullHandlingTest
         "Function[mv_to_array] argument 1 should be an identifier expression. Use array() instead",
         t.getMessage()
     );
-  }
 
-  @Test
-  public void testMVToArrayWithFunction()
-  {
-    Throwable t = Assert.assertThrows(
+    t = Assert.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(repeat('hello', 2))", null)
     );
@@ -1037,14 +1035,19 @@ public class FunctionTest extends InitializedNullHandlingTest
         "Function[mv_to_array] argument (repeat [hello, 2]) should be an identifier expression. Use array() instead",
         t.getMessage()
     );
-  }
 
-  @Test
-  public void testMVToArrayWithMoreArgs()
-  {
-    Throwable t = Assert.assertThrows(
+    t = Assert.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(x,y)", null)
+    );
+    Assert.assertEquals(
+        "Function[mv_to_array] requires 1 argument",
+        t.getMessage()
+    );
+
+    t = Assert.assertThrows(
+        ExpressionValidationException.class,
+        () -> assertArrayExpr("mv_to_array()", null)
     );
     Assert.assertEquals(
         "Function[mv_to_array] requires 1 argument",
@@ -1053,9 +1056,42 @@ public class FunctionTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testMVToArrayWithNoArgs()
+  public void testArrayToMultiValueStringWithValidInputs()
+  {
+    assertArrayExpr("array_to_mv(x)", new String[]{"foo"});
+    assertArrayExpr("array_to_mv(a)", new String[]{"foo", "bar", "baz", "foobar"});
+    assertArrayExpr("array_to_mv(b)", new String[]{"1", "2", "3", "4", "5"});
+    assertArrayExpr("array_to_mv(c)", new String[]{"3.1", "4.2", "5.3"});
+  }
+
+  @Test
+  public void testArrayToMultiValueStringWithInvalidInputs()
   {
     Throwable t = Assert.assertThrows(
+        ExpressionValidationException.class,
+        () -> assertArrayExpr("mv_to_array('1')", null)
+    );
+    Assert.assertEquals(
+        "Function[mv_to_array] argument 1 should be an identifier expression. Use array() instead",
+        t.getMessage()
+    );
+    t = Assert.assertThrows(
+        ExpressionValidationException.class,
+        () -> assertArrayExpr("mv_to_array(repeat('hello', 2))", null)
+    );
+    Assert.assertEquals(
+        "Function[mv_to_array] argument (repeat [hello, 2]) should be an identifier expression. Use array() instead",
+        t.getMessage()
+    );
+    t = Assert.assertThrows(
+        ExpressionValidationException.class,
+        () -> assertArrayExpr("mv_to_array(x,y)", null)
+    );
+    Assert.assertEquals(
+        "Function[mv_to_array] requires 1 argument",
+        t.getMessage()
+    );
+    t = Assert.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array()", null)
     );

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.sql.calcite.expression.builtin;
 
 import org.apache.calcite.sql.SqlFunction;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
@@ -1,0 +1,31 @@
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.sql.calcite.expression.DirectOperatorConversion;
+import org.apache.druid.sql.calcite.expression.OperatorConversions;
+
+public class ArrayToMultiValueStringOperatorConversion extends DirectOperatorConversion
+{
+  public static final SqlFunction SQL_FUNCTION = OperatorConversions
+      .operatorBuilder("ARRAY_TO_MV")
+      .operandTypeChecker(
+          OperandTypes.or(
+              OperandTypes.family(SqlTypeFamily.STRING),
+              OperandTypes.family(SqlTypeFamily.ARRAY)
+          )
+      )
+      .functionCategory(SqlFunctionCategory.STRING)
+      .returnTypeNullable(SqlTypeName.VARCHAR)
+      .build();
+
+  public ArrayToMultiValueStringOperatorConversion()
+  {
+    super(SQL_FUNCTION, "array_to_mv");
+  }
+
+
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringToArrayOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringToArrayOperatorConversion.java
@@ -36,7 +36,13 @@ public class MultiValueStringToArrayOperatorConversion extends DirectOperatorCon
 {
   public static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder("MV_TO_ARRAY")
-      .operandTypeChecker(OperandTypes.family(SqlTypeFamily.STRING))
+      // allow using arrays as inputs to MV_TO_ARRAY to assist with migration of MVDs to ARRAY types
+      .operandTypeChecker(
+          OperandTypes.or(
+              OperandTypes.family(SqlTypeFamily.STRING),
+              OperandTypes.family(SqlTypeFamily.ARRAY)
+          )
+      )
       .functionCategory(SqlFunctionCategory.STRING)
       .returnTypeNullableArrayWithNullableElements(SqlTypeName.VARCHAR)
       .build();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -68,6 +68,7 @@ import org.apache.druid.sql.calcite.expression.builtin.ArrayOverlapOperatorConve
 import org.apache.druid.sql.calcite.expression.builtin.ArrayPrependOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ArrayQuantileOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ArraySliceOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.ArrayToMultiValueStringOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ArrayToStringOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.BTrimOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.CaseOperatorConversion;
@@ -244,6 +245,7 @@ public class DruidOperatorTable implements SqlOperatorTable
                    .add(new ArraySliceOperatorConversion())
                    .add(new ArrayToStringOperatorConversion())
                    .add(new StringToArrayOperatorConversion())
+                   .add(new ArrayToMultiValueStringOperatorConversion())
                    .build();
 
   private static final List<SqlOperatorConversion> MULTIVALUE_STRING_OPERATOR_CONVERSIONS =


### PR DESCRIPTION
### Description
This function adds a new `ARRAY_TO_MV` function which provides the opposite behavior of `MV_TO_ARRAY` to allow coercing any type of `ARRAY` into a plain `VARCHAR`. The intention of this function is to assist in the process of migrating tables that currently use native multi-value `STRING` columns to `ARRAY<STRING>`. 

`ARRAY_TO_MV` allows cluster operators to begin ingesting true native `ARRAY` type columns, but can use this function to wrap these array types to use as a crutch to make them exhibit classic multi-value dimension (implicit unnest when grouping, etc) so that applications using Druid can continue with their current behavior. As the apps are updated to properly begin querying these columns with `ARRAY` semantics, existing MVD columns can instead be switched to use `MV_TO_ARRAY`, which has been modified to now accept `ARRAY` types to pass through as `ARRAY<STRING>`. Note that I didn't change the `MV_TO_ARRAY` of casting to `ARRAY<STRING>`, so only MVDs and the `ARRAY<STRING>` type they have become should be wrapped with this function. Other types of `ARRAY` when used with `MV_TO_ARRAY` will be coerced to `ARRAY<STRING>`, which likely isn't desirable behavior.

Right now `ARRAY_TO_MV` exists purely as an expression virtual column, as a follow-up I will be adding a dedicated virtual column for both `ARRAY_TO_MV` and `MV_TO_ARRAY` so that coercing in either direction can be nearly as performant as the native column usage, including supporting indexes for fast filtering. Making migration not come with a penalty which is very important longer term.

Deferring release notes specifically for this in favor of this being part of a larger section on mvd -> array migration in 27 release.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
