### PR TITLE
suppress some cves and fix javadoc build when using java 17

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,7 +31,6 @@
       <writeAnnotation name="org.powermock.api.easymock.annotation.Mock" />
     </writeAnnotations>
   </component>
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
@@ -85,7 +84,8 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,6 +31,7 @@
       <writeAnnotation name="org.powermock.api.easymock.annotation.Mock" />
     </writeAnnotations>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
@@ -84,8 +85,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>
-

--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/BucketingAccumulator.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/BucketingAccumulator.java
@@ -55,7 +55,7 @@ public class BucketingAccumulator extends YieldingAccumulator<RowBucket, Row>
       rows.add(in);
       RowBucket nextBucket = new RowBucket(in.getTimestamp(), rows);
       accumulated.setNextBucket(nextBucket);
-      yield();
+      this.yield();
     } else {
       // still on the same day
       rows = accumulated.getRows();

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -247,6 +247,7 @@
     <cve>CVE-2022-40150</cve>
     <cve>CVE-2022-45685</cve>
     <cve>CVE-2022-45693</cve>
+    <cve>CVE-2023-1436</cve>
   </suppress>
   <suppress>
     <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
@@ -256,6 +257,8 @@
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@1.6$</packageUrl>
     <cve>CVE-2017-18640</cve>
     <cve>CVE-2022-25857</cve>
+    <cve>CVE-2023-2251</cve>
+    <cve>CVE-2022-3064</cve>
   </suppress>
   <suppress>
     <!-- We need to wait for 17.0.0 of https://github.com/kubernetes-client/java/releases -->
@@ -264,6 +267,9 @@
     ]]></notes>
     <cve>CVE-2022-25857</cve>
     <cve>CVE-2022-1471</cve>
+    <!-- false positive -->
+    <cve>CVE-2023-2251</cve>
+    <cve>CVE-2022-3064</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -343,6 +349,7 @@
     <packageUrl regex="true">^pkg:maven/org\.apache\.kafka/kafka-clients@2.0.0$</packageUrl>
     <cve>CVE-2019-12399</cve>
     <cve>CVE-2018-17196</cve>
+    <cve>CVE-2023-25194</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -353,7 +360,7 @@
   </suppress>
   <suppress>
     <!--
-      ~ TODO: Fix when Apache Ranger is released with updated log4j
+      ~ ambari-metrics-emitter, druid-ranger-security
       -->
     <notes><![CDATA[
     file name: log4j-1.2.17.jar
@@ -365,6 +372,7 @@
     <cve>CVE-2022-23307</cve>
     <cve>CVE-2022-23305</cve>
     <cve>CVE-2022-23302</cve>
+    <cve>CVE-2023-26464</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -392,6 +400,7 @@
     <cve>CVE-2022-23305</cve>
     <cve>CVE-2022-23302</cve>
     <cve>CVE-2022-41881</cve>
+    <cve>CVE-2020-11612</cve>
   </suppress>
   <suppress>
        <!--
@@ -789,4 +798,12 @@
      <vulnerabilityName>1070209</vulnerabilityName>
      <cve>CVE-2020-7774</cve>
    </suppress>
+  <suppress>
+    <!-- druid-ranger-security -->
+    <notes><![CDATA[
+     file name: ranger-plugins-common-2.0.0.jar
+     ]]></notes>
+    <!-- seems not applicable to plugin -->
+    <cve>CVE-2022-45048</cve>
+  </suppress>
 </suppressions>

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/ConcatSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/ConcatSequence.java
@@ -55,7 +55,7 @@ public class ConcatSequence<T> implements Sequence<T>
           @Override
           public Sequence<T> accumulate(Sequence<T> accumulated, Sequence<T> in)
           {
-            yield();
+            this.yield();
             return in;
           }
         }

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/LimitedSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/LimitedSequence.java
@@ -132,7 +132,7 @@ final class LimitedSequence<T> extends YieldingSequenceBase<T>
         interruptYield = false;
       }
       if (interruptYield) {
-        yield();
+        this.yield();
       }
 
       return retVal;

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/MergeSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/MergeSequence.java
@@ -55,7 +55,7 @@ public class MergeSequence<T> extends YieldingSequenceBase<T>
     PriorityQueue<Yielder<T>> pQueue = new PriorityQueue<>(
         32,
         ordering.onResultOf(
-            (Function<Yielder<T>, T>) input -> input.get()
+            (Function<Yielder<T>, T>) Yielder::get
         )
     );
 
@@ -70,7 +70,7 @@ public class MergeSequence<T> extends YieldingSequenceBase<T>
                   @Override
                   public T accumulate(T accumulated, T in)
                   {
-                    yield();
+                    this.yield();
                     return in;
                   }
                 }

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java
@@ -895,7 +895,7 @@ public class ParallelMergeCombiningSequence<T> extends YieldingSequenceBase<T>
               accumulated.add(in);
               count++;
               if (count % batchSize == 0) {
-                yield();
+                this.yield();
               }
               return accumulated;
             }

--- a/processing/src/main/java/org/apache/druid/java/util/common/guava/Yielders.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/guava/Yielders.java
@@ -36,7 +36,7 @@ public class Yielders
           @Override
           public T accumulate(T accumulated, T in)
           {
-            yield();
+            this.yield();
             return in;
           }
         }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
@@ -76,7 +76,7 @@ public class ScanQueryLimitRowIterator implements CloseableIterator<ScanResultVa
           @Override
           public ScanResultValue accumulate(ScanResultValue accumulated, ScanResultValue in)
           {
-            yield();
+            this.yield();
             return in;
           }
         }


### PR DESCRIPTION
### Description
Suppress some CVEs that I think are false positives, not applicable, or that are unable to be resolved (like ambari stuff).

Also fixes some errors that happen with the javadoc plugin build and java 17, which complains about our `yield()` method

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.1:jar (attach-javadocs) on project druid-processing: MavenReportException: Error while creating archive: 
[ERROR] Exit code: 1 - Loading source files for package org.apache.druid.crypto...
[ERROR] Loading source files for package org.apache.druid.hll...

...

[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/java/util/common/guava/Yielders.java:39: error: invalid use of a restricted identifier 'yield'
[ERROR]             yield();
[ERROR]             ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/java/util/common/guava/ConcatSequence.java:58: error: invalid use of a restricted identifier 'yield'
[ERROR]             yield();
[ERROR]             ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/java/util/common/guava/MergeSequence.java:73: error: invalid use of a restricted identifier 'yield'
[ERROR]                     yield();
[ERROR]                     ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequence.java:898: error: invalid use of a restricted identifier 'yield'
[ERROR]                 yield();
[ERROR]                 ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/java/util/common/guava/LimitedSequence.java:135: error: invalid use of a restricted identifier 'yield'
[ERROR]         yield();
[ERROR]         ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] /Users/clint/workspace/apache/druid/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java:79: error: invalid use of a restricted identifier 'yield'
[ERROR]             yield();
[ERROR]             ^
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
[ERROR] 6 errors
[ERROR] 
[ERROR] Command line was: /Library/Java/JavaVirtualMachines/amazon-corretto-17.jdk/Contents/Home/bin/javadoc @options @packages
[ERROR] 
[ERROR] Refer to the generated Javadoc files in '/Users/clint/workspace/apache/druid/processing/target/apidocs' dir.
[ERROR] 
```