### PR TITLE
Define DruidInputSource getTypes() method 

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -92,6 +92,8 @@ import java.util.stream.Stream;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class DruidInputSource extends AbstractInputSource implements SplittableInputSource<List<WindowedSegmentId>>
 {
+
+  public static final String TYPE_KEY = "druid";
   private static final Logger LOG = new Logger(DruidInputSource.class);
 
   /**
@@ -188,7 +190,7 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
   @Override
   public Set<String> getTypes()
   {
-    return ImmutableSet.of();
+    return ImmutableSet.of(TYPE_KEY);
   }
 
   @JsonProperty

--- a/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/input/DruidInputSource.java
@@ -21,12 +21,14 @@ package org.apache.druid.indexing.input;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.data.input.AbstractInputSource;
@@ -64,6 +66,7 @@ import org.apache.druid.utils.Streams;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
@@ -75,6 +78,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -177,6 +181,14 @@ public class DruidInputSource extends AbstractInputSource implements SplittableI
     this.segmentCacheManagerFactory = Preconditions.checkNotNull(segmentCacheManagerFactory, "null segmentCacheManagerFactory");
     this.retryPolicyFactory = Preconditions.checkNotNull(retryPolicyFactory, "null RetryPolicyFactory");
     this.taskConfig = Preconditions.checkNotNull(taskConfig, "null taskConfig");
+  }
+
+  @JsonIgnore
+  @Nonnull
+  @Override
+  public Set<String> getTypes()
+  {
+    return ImmutableSet.of();
   }
 
   @JsonProperty

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
@@ -299,4 +299,36 @@ public class DruidInputSourceTest
     Assert.assertTrue(columnsFilter.apply(column));
     Assert.assertFalse(columnsFilter.apply(metricName));
   }
+
+  @Test
+  public void testGetTypesEmpty()
+  {
+    String datasource = "foo";
+    Interval interval = Intervals.of("2000/2001");
+    String column = "c1";
+    String metricName = "m1";
+    ColumnsFilter originalColumnsFilter = ColumnsFilter.inclusionBased(ImmutableSet.of(column));
+    InputRowSchema inputRowSchema = new InputRowSchema(
+        new TimestampSpec("timestamp", "auto", null),
+        new DimensionsSpec(
+            DimensionsSpec.getDefaultSchemas(Arrays.asList("timestamp", "a", "b"))
+        ),
+        originalColumnsFilter,
+        ImmutableSet.of(metricName)
+    );
+    DruidInputSource druidInputSource = new DruidInputSource(
+        datasource,
+        interval,
+        null,
+        null,
+        ImmutableList.of("a"),
+        ImmutableList.of("b"),
+        indexIO,
+        coordinatorClient,
+        segmentCacheManagerFactory,
+        retryPolicyFactory,
+        taskConfig
+    );
+    Assert.assertTrue(druidInputSource.getTypes().isEmpty());
+  }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
@@ -305,17 +305,6 @@ public class DruidInputSourceTest
   {
     String datasource = "foo";
     Interval interval = Intervals.of("2000/2001");
-    String column = "c1";
-    String metricName = "m1";
-    ColumnsFilter originalColumnsFilter = ColumnsFilter.inclusionBased(ImmutableSet.of(column));
-    InputRowSchema inputRowSchema = new InputRowSchema(
-        new TimestampSpec("timestamp", "auto", null),
-        new DimensionsSpec(
-            DimensionsSpec.getDefaultSchemas(Arrays.asList("timestamp", "a", "b"))
-        ),
-        originalColumnsFilter,
-        ImmutableSet.of(metricName)
-    );
     DruidInputSource druidInputSource = new DruidInputSource(
         datasource,
         interval,
@@ -329,6 +318,6 @@ public class DruidInputSourceTest
         retryPolicyFactory,
         taskConfig
     );
-    Assert.assertTrue(druidInputSource.getTypes().isEmpty());
+    Assert.assertEquals(ImmutableSet.of(DruidInputSource.TYPE_KEY), druidInputSource.getTypes());
   }
 }


### PR DESCRIPTION
This method being undefined on the `DruidInputSource` class causes compaction tasks and datasource reindexing tasks to fail, when the input source security feature is enabled, as the the interface default is to throw an `UnsupportedOperationException`, when input source security feature is enabled. Define the types to be `ImmutableSet.of("druid")`

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
