### PR TITLE
suppress hadoop3 cve that seem not applicable to us

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/config/TaskConfig.java
@@ -54,8 +54,7 @@ public class TaskConfig
     try {
       DEFAULT_DEFAULT_HADOOP_COORDINATES =
           ImmutableList.copyOf(Lists.newArrayList(IOUtils.toString(
-              TaskConfig.class.getResourceAsStream("/"
-                                                   + HADOOP_LIB_VERSIONS),
+              TaskConfig.class.getResourceAsStream("/" + HADOOP_LIB_VERSIONS),
               StandardCharsets.UTF_8
           ).split(",")));
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -105,14 +105,23 @@
   </suppress>
   <suppress>
     <!--
-      Suppressing for patch release 24.0.1
+      the suppressions here aren't currently applicable, but can be resolved once we update the version
       -->
     <notes><![CDATA[
    file name: jackson-databind-2.10.5.1.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <!-- CVE-2022-42003 and CVE-2022-42004 are related to UNWRAP_SINGLE_VALUE_ARRAYS which we do not use
+    https://nvd.nist.gov/vuln/detail/CVE-2022-42003
+    https://nvd.nist.gov/vuln/detail/CVE-2022-42004
+     -->
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
+    <!-- CVE-2021-46877 only applies to jdk serialization which we do not use
+    https://nvd.nist.gov/vuln/detail/CVE-2021-46877
+    https://github.com/FasterXML/jackson-databind/issues/3328
+    -->
+    <cve>CVE-2021-46877</cve>
   </suppress>
 
 
@@ -807,12 +816,13 @@
     <cve>CVE-2022-45048</cve>
   </suppress>
   <suppress>
+    <!-- from extensions using hadoop-client-runtime, these dependencies are shaded in the jar -->
     <notes><![CDATA[
      file name: hadoop-client-runtime-3.3.5.jar
      ]]></notes>
-    <!-- this one is windows only? https://nvd.nist.gov/vuln/detail/CVE-2022-26612 -->
+    <!-- this one is windows only - https://nvd.nist.gov/vuln/detail/CVE-2022-26612 -->
     <cve>CVE-2022-26612</cve>
-    <!-- this one seems to apply to backend server? https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
+    <!-- this one seems to apply to backend server - https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
     <cve>CVE-2023-25613</cve>
   </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -806,4 +806,13 @@
     <!-- seems not applicable to plugin -->
     <cve>CVE-2022-45048</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+     file name: hadoop-client-runtime-3.3.5.jar
+     ]]></notes>
+    <!-- this one is windows only? https://nvd.nist.gov/vuln/detail/CVE-2023-25612 -->
+    <cve>CVE-2022-26612</cve>
+    <!-- this one seems to apply to backend server? https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
+    <cve>CVE-2023-25613</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -810,7 +810,7 @@
     <notes><![CDATA[
      file name: hadoop-client-runtime-3.3.5.jar
      ]]></notes>
-    <!-- this one is windows only? https://nvd.nist.gov/vuln/detail/CVE-2023-25612 -->
+    <!-- this one is windows only? https://nvd.nist.gov/vuln/detail/CVE-2022-26612 -->
     <cve>CVE-2022-26612</cve>
     <!-- this one seems to apply to backend server? https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
     <cve>CVE-2023-25613</cve>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
         <protobuf.version>3.21.7</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <!-- If compiling with different hadoop version also modify default hadoop coordinates in TaskConfig.java -->
         <hadoop.compile.version>3.3.5</hadoop.compile.version>
         <mockito.version>4.3.1</mockito.version>
         <aws.sdk.version>1.12.317</aws.sdk.version>


### PR DESCRIPTION
follow-up to #14241

https://nvd.nist.gov/vuln/detail/CVE-2022-26612 - seems windows only?
https://nvd.nist.gov/vuln/detail/CVE-2023-25613 - seems like not a problem on druid side?