### PR TITLE
Add new lock types: APPEND and REPLACE

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
@@ -19,10 +19,33 @@
 
 package org.apache.druid.indexing.common;
 
+/**
+ *
+ * There can be at most one active EXCLUSIVE lock for a given interval.
+ * It cannot co-exist with any other active locks with overlapping intervals.
+ *
+ * There can be any number of active SHARED locks for a given interval.
+ * They can coexist only with other SHARED locks, but not with active locks of other types.
+ *
+ * There can be at most one active REPLACE lock for a given interval.
+ * It can co-exist only with APPEND locks whose intervals are enclosed within its interval,
+ * and is incompatible with all other active locks with overlapping intervals.
+ *
+ * There can be any number of active APPEND locks for a given interval.
+ * They can coexist with other APPEND locks,
+ * and with at most one REPLACE lock whose interval encloses that of the APPEND lock.
+ * They are incompatible with all other active locks.
+ *
+ * Please note that
+ * 1) A revoked lock is compatible with every lock.
+ * 2) An appending task may use only EXCLUSIVE, SHARED or APPEND locks
+ * 3) A replacing task may use only EXCLUSIVE or REPLACE locks
+ * 4) REPLACE and APPEND locks can only be used with timechunk locking
+ */
 public enum TaskLockType
 {
-  REPLACE, // Meant to be used only with Replacing jobs and timechunk locking
-  APPEND, // Meant to be used only with Appending jobs and timechunk locking
+  EXCLUSIVE,
   SHARED,
-  EXCLUSIVE // taskLocks of this type can be shared by tasks of the same groupId.
+  REPLACE,
+  APPEND
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
@@ -21,6 +21,8 @@ package org.apache.druid.indexing.common;
 
 public enum TaskLockType
 {
+  REPLACE, // Meant to be used only with Replacing jobs and timechunk locking
+  APPEND, // Meant to be used only with Appending jobs and timechunk locking
   SHARED,
   EXCLUSIVE // taskLocks of this type can be shared by tasks of the same groupId.
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskLockType.java
@@ -20,23 +20,6 @@
 package org.apache.druid.indexing.common;
 
 /**
- *
- * There can be at most one active EXCLUSIVE lock for a given interval.
- * It cannot co-exist with any other active locks with overlapping intervals.
- *
- * There can be any number of active SHARED locks for a given interval.
- * They can coexist only with other SHARED locks, but not with active locks of other types.
- *
- * There can be at most one active REPLACE lock for a given interval.
- * It can co-exist only with APPEND locks whose intervals are enclosed within its interval,
- * and is incompatible with all other active locks with overlapping intervals.
- *
- * There can be any number of active APPEND locks for a given interval.
- * They can coexist with other APPEND locks,
- * and with at most one REPLACE lock whose interval encloses that of the APPEND lock.
- * They are incompatible with all other active locks.
- *
- * Please note that
  * 1) A revoked lock is compatible with every lock.
  * 2) An appending task may use only EXCLUSIVE, SHARED or APPEND locks
  * 3) A replacing task may use only EXCLUSIVE or REPLACE locks
@@ -44,8 +27,27 @@ package org.apache.druid.indexing.common;
  */
 public enum TaskLockType
 {
+  /**
+   * There can be at most one active EXCLUSIVE lock for a given interval.
+   * It cannot co-exist with any other active locks with overlapping intervals.
+   */
   EXCLUSIVE,
+  /**
+   * There can be any number of active SHARED locks for a given interval.
+   * They can coexist only with other SHARED locks, but not with active locks of other types.
+   */
   SHARED,
+  /**
+   * There can be at most one active REPLACE lock for a given interval.
+   * It can co-exist only with APPEND locks whose intervals are enclosed within its interval,
+   * and is incompatible with all other active locks with overlapping intervals.
+   */
   REPLACE,
+  /**
+   * There can be any number of active APPEND locks for a given interval.
+   * They can coexist with other APPEND locks,
+   * and with at most one REPLACE lock whose interval encloses that of the APPEND lock.
+   * They are incompatible with all other active locks.
+   */
   APPEND
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -1258,7 +1258,7 @@ public class TaskLockbox
       case EXCLUSIVE:
         return canExclusiveLockCoexist(conflictPosses);
       default:
-        throw new UOE("Unsupposted lock type: " + request.getType());
+        throw new UOE("Unsupported lock type: " + request.getType());
     }
   }
 
@@ -1418,7 +1418,7 @@ public class TaskLockbox
           }
           break;
         default:
-          throw new UOE("Unsupposted lock type: " + type);
+          throw new UOE("Unsupported lock type: " + type);
       }
     }
     for (TaskLockPosse revokablePosse : possesToRevoke) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -1275,9 +1275,9 @@ public class TaskLockbox
       case REPLACE:
         return canReplaceLockCoexist(conflictPosses, request);
       case SHARED:
-        return canSharedLockCoexist(conflictPosses, request);
+        return canSharedLockCoexist(conflictPosses);
       case EXCLUSIVE:
-        return canExclusiveLockCoexist(conflictPosses, request);
+        return canExclusiveLockCoexist(conflictPosses);
       default:
         return false;
     }
@@ -1322,7 +1322,7 @@ public class TaskLockbox
    * @param replaceLock replace lock request
    * @return true iff replace lock can coexist with all its conflicting locks
    */
-  private static boolean canReplaceLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest replaceLock)
+  private boolean canReplaceLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest replaceLock)
   {
     for (TaskLockPosse posse : conflictPosses) {
       if (posse.getTaskLock().isRevoked()) {
@@ -1345,10 +1345,9 @@ public class TaskLockbox
    * Check if a SHARED lock can coexist with a given set of conflicting posses.
    * A SHARED lock can coexist with any number of other active SHARED locks
    * @param conflictPosses conflicting lock posses
-   * @param sharedLock replace lock request
    * @return true iff shared lock can coexist with all its conflicting locks
    */
-  private static boolean canSharedLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest sharedLock)
+  private boolean canSharedLockCoexist(List<TaskLockPosse> conflictPosses)
   {
     for (TaskLockPosse posse : conflictPosses) {
       if (posse.getTaskLock().isRevoked()) {
@@ -1367,10 +1366,9 @@ public class TaskLockbox
    * Check if an EXCLUSIVE lock can coexist with a given set of conflicting posses.
    * An EXCLUSIVE lock cannot coexist with any other overlapping active locks
    * @param conflictPosses conflicting lock posses
-   * @param exclusiveLock exclusive lock request
    * @return true iff the exclusive lock can coexist with all its conflicting locks
    */
-  private static boolean canExclusiveLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest exclusiveLock)
+  private boolean canExclusiveLockCoexist(List<TaskLockPosse> conflictPosses)
   {
     for (TaskLockPosse posse : conflictPosses) {
       if (posse.getTaskLock().isRevoked()) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -24,7 +24,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
@@ -1093,27 +1092,6 @@ public class TaskLockbox
       finally {
         activeTasks.remove(task.getId());
       }
-    }
-    finally {
-      giant.unlock();
-    }
-  }
-
-  public Set<TaskLock> getAllExclusiveLocksForDatasource(final String datasource)
-  {
-    giant.lock();
-    try {
-      final NavigableMap<DateTime, SortedMap<Interval, List<TaskLockPosse>>> dsRunning = running.get(datasource);
-      if (dsRunning == null) {
-        return ImmutableSet.of();
-      }
-      return dsRunning.values()
-                      .stream()
-                      .flatMap(map -> map.values().stream())
-                      .flatMap(Collection::stream)
-                      .map(TaskLockPosse::getTaskLock)
-                      .filter(taskLock -> taskLock.getType().equals(TaskLockType.EXCLUSIVE))
-                      .collect(Collectors.toSet());
     }
     finally {
       giant.unlock();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -39,6 +39,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
@@ -1257,7 +1258,7 @@ public class TaskLockbox
       case EXCLUSIVE:
         return canExclusiveLockCoexist(conflictPosses);
       default:
-        return false;
+        throw new UOE("Unsupposted lock type: " + request.getType());
     }
   }
 
@@ -1359,7 +1360,7 @@ public class TaskLockbox
 
 
   /**
-   * Verify if each incompatible active lock is revokable. If yes, revoke all of them.
+   * Verify if every incompatible active lock is revokable. If yes, revoke all of them.
    * - EXCLUSIVE locks are incompatible with every other conflicting lock
    * - SHARED locks are incompatible with conflicting locks of every other type
    * - REPLACE locks are incompatible with every conflicting lock which is not (APPEND and enclosed) within its interval
@@ -1417,7 +1418,7 @@ public class TaskLockbox
           }
           break;
         default:
-          return false;
+          throw new UOE("Unsupposted lock type: " + type);
       }
     }
     for (TaskLockPosse revokablePosse : possesToRevoke) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -24,6 +24,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
@@ -614,13 +615,21 @@ public class TaskLockbox
         if (reusablePosses.size() == 0) {
           // case 1) this task doesn't have any lock, but others do
 
-          if (request.getType().equals(TaskLockType.SHARED)
-              && areAllEqualOrHigherPriorityLocksSharedOrRevoked(conflictPosses, request.getPriority())) {
-            // Any number of shared locks can be acquired for the same dataSource and interval
-            // Exclusive locks of equal or greater priority, if present, must already be revoked
-            // Exclusive locks of lower priority can be revoked
-            revokeAllLowerPriorityNonSharedLocks(conflictPosses, request.getPriority());
+          if ((request.getType().equals(TaskLockType.APPEND) || request.getType().equals(TaskLockType.REPLACE))
+              && !request.getGranularity().equals(LockGranularity.TIME_CHUNK)) {
+            // APPEND and REPLACE locks are specific to time chunk locks
+            return null;
+          }
+
+          // First, check if the lock can coexist with its conflicting posses
+          if (canLockCoexist(conflictPosses, request)) {
             return createNewTaskLockPosse(request);
+          }
+
+          // If not, revoke all lower priority locks of different types if the request has a greater priority
+          if (revokeAllIncompatibleActiveLocksIfPossible(conflictPosses, request)) {
+            return createNewTaskLockPosse(request);
+
           } else {
             // During a rolling update, tasks of mixed versions can be run at the same time. Old tasks would request
             // timeChunkLocks while new tasks would ask segmentLocks. The below check is to allow for old and new tasks
@@ -637,19 +646,12 @@ public class TaskLockbox
               // We can add a new taskLockPosse.
               return createNewTaskLockPosse(request);
             } else {
-              if (isAllRevocable(conflictPosses, request.getPriority())) {
-                // Revoke all existing locks
-                conflictPosses.forEach(this::revokeLock);
-
-                return createNewTaskLockPosse(request);
-              } else {
-                log.info(
-                    "Cannot create a new taskLockPosse for request[%s] because existing locks[%s] have same or higher priorities",
-                    request,
-                    conflictPosses
-                );
-                return null;
-              }
+              log.info(
+                  "Cannot create a new taskLockPosse for request[%s] because existing locks[%s] have same or higher priorities",
+                  request,
+                  conflictPosses
+              );
+              return null;
             }
           }
         } else if (reusablePosses.size() == 1) {
@@ -1097,6 +1099,27 @@ public class TaskLockbox
     }
   }
 
+  public Set<TaskLock> getAllExclusiveLocksForDatasource(final String datasource)
+  {
+    giant.lock();
+    try {
+      final NavigableMap<DateTime, SortedMap<Interval, List<TaskLockPosse>>> dsRunning = running.get(datasource);
+      if (dsRunning == null) {
+        return ImmutableSet.of();
+      }
+      return dsRunning.values()
+                      .stream()
+                      .flatMap(map -> map.values().stream())
+                      .flatMap(Collection::stream)
+                      .map(TaskLockPosse::getTaskLock)
+                      .filter(taskLock -> taskLock.getType().equals(TaskLockType.EXCLUSIVE))
+                      .collect(Collectors.toSet());
+    }
+    finally {
+      giant.unlock();
+    }
+  }
+
   /**
    * Return the currently-active lock posses for some task.
    *
@@ -1239,43 +1262,192 @@ public class TaskLockbox
   }
 
   /**
-   * Check if all lockPosses are either shared
-   * OR of lower priority
-   * OR are revoked non-shared locks if their priorities are greater than or equal to the provided priority
-   * @param lockPosses conflicting task lock posses to be checked
-   * @param priority priority of the lock to be acquired
-   * @return true if the condititons are met
+   * Check if the lock for a given request can coexist with a given set of conflicting posses without any revocation.
+   * @param conflictPosses conflict lock posses
+   * @param request lock request
+   * @return true iff the lock can coexist with all its conflicting locks
    */
-  private static boolean areAllEqualOrHigherPriorityLocksSharedOrRevoked(List<TaskLockPosse> lockPosses, int priority)
+  private boolean canLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest request)
   {
-    return lockPosses.stream()
-                     .filter(taskLockPosse -> taskLockPosse.getTaskLock().getNonNullPriority() >= priority)
-                     .allMatch(taskLockPosse -> taskLockPosse.getTaskLock().getType().equals(TaskLockType.SHARED)
-                                                || taskLockPosse.getTaskLock().isRevoked());
+    switch (request.getType()) {
+      case APPEND:
+        return canAppendLockCoexist(conflictPosses, request);
+      case REPLACE:
+        return canReplaceLockCoexist(conflictPosses, request);
+      case SHARED:
+        return canSharedLockCoexist(conflictPosses, request);
+      case EXCLUSIVE:
+        return canExclusiveLockCoexist(conflictPosses, request);
+      default:
+        return false;
+    }
   }
 
   /**
-   * Revokes all non-shared locks with priorities lower than the provided priority
-   * @param lockPosses conflicting task lock posses which may be revoked
-   * @param priority priority of the lock to be acquired
+   * Check if an APPEND lock can coexist with a given set of conflicting posses.
+   * An APPEND lock can coexist with any number of other APPEND locks
+   *    OR with at most one REPLACE lock over an interval which encloes this request.
+   * @param conflictPosses conflicting lock posses
+   * @param appendRequest append lock request
+   * @return true iff append lock can coexist with all its conflicting locks
    */
-  private void revokeAllLowerPriorityNonSharedLocks(List<TaskLockPosse> lockPosses, int priority)
+  private boolean canAppendLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest appendRequest)
   {
-    lockPosses.stream()
-              .filter(taskLockPosse -> !TaskLockType.SHARED.equals(taskLockPosse.getTaskLock().getType()))
-              .filter(taskLockPosse -> taskLockPosse.getTaskLock().getNonNullPriority() < priority)
-              .forEach(this::revokeLock);
+    TaskLock replaceLock = null;
+    for (TaskLockPosse posse : conflictPosses) {
+      if (posse.getTaskLock().isRevoked()) {
+        continue;
+      }
+      if (posse.getTaskLock().getType().equals(TaskLockType.EXCLUSIVE)
+          || posse.getTaskLock().getType().equals(TaskLockType.SHARED)) {
+        return false;
+      }
+      if (posse.getTaskLock().getType().equals(TaskLockType.REPLACE)) {
+        if (replaceLock != null) {
+          return false;
+        }
+        replaceLock = posse.getTaskLock();
+        if (!replaceLock.getInterval().contains(appendRequest.getInterval())) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
-  private static boolean isAllRevocable(List<TaskLockPosse> lockPosses, int tryLockPriority)
+  /**
+   * Check if a REPLACE lock can coexist with a given set of conflicting posses.
+   * A REPLACE lock can coexist with any number of other APPEND locks and revoked locks
+   * @param conflictPosses conflicting lock posses
+   * @param replaceLock replace lock request
+   * @return true iff replace lock can coexist with all its conflicting locks
+   */
+  private static boolean canReplaceLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest replaceLock)
   {
-    return lockPosses.stream().allMatch(taskLockPosse -> isRevocable(taskLockPosse, tryLockPriority));
+    for (TaskLockPosse posse : conflictPosses) {
+      if (posse.getTaskLock().isRevoked()) {
+        continue;
+      }
+      if (posse.getTaskLock().getType().equals(TaskLockType.EXCLUSIVE)
+          || posse.getTaskLock().getType().equals(TaskLockType.SHARED)
+          || posse.getTaskLock().getType().equals(TaskLockType.REPLACE)) {
+        return false;
+      }
+      if (posse.getTaskLock().getType().equals(TaskLockType.APPEND)
+          && !replaceLock.getInterval().contains(posse.getTaskLock().getInterval())) {
+        return false;
+      }
+    }
+    return true;
   }
 
-  private static boolean isRevocable(TaskLockPosse lockPosse, int tryLockPriority)
+  /**
+   * Check if a SHARED lock can coexist with a given set of conflicting posses.
+   * A SHARED lock can coexist with any number of other active SHARED locks
+   * @param conflictPosses conflicting lock posses
+   * @param sharedLock replace lock request
+   * @return true iff shared lock can coexist with all its conflicting locks
+   */
+  private static boolean canSharedLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest sharedLock)
   {
-    final TaskLock existingLock = lockPosse.getTaskLock();
-    return existingLock.isRevoked() || existingLock.getNonNullPriority() < tryLockPriority;
+    for (TaskLockPosse posse : conflictPosses) {
+      if (posse.getTaskLock().isRevoked()) {
+        continue;
+      }
+      if (posse.getTaskLock().getType().equals(TaskLockType.EXCLUSIVE)
+          || posse.getTaskLock().getType().equals(TaskLockType.APPEND)
+          || posse.getTaskLock().getType().equals(TaskLockType.REPLACE)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Check if an EXCLUSIVE lock can coexist with a given set of conflicting posses.
+   * An EXCLUSIVE lock cannot coexist with any other overlapping active locks
+   * @param conflictPosses conflicting lock posses
+   * @param exclusiveLock exclusive lock request
+   * @return true iff the exclusive lock can coexist with all its conflicting locks
+   */
+  private static boolean canExclusiveLockCoexist(List<TaskLockPosse> conflictPosses, LockRequest exclusiveLock)
+  {
+    for (TaskLockPosse posse : conflictPosses) {
+      if (posse.getTaskLock().isRevoked()) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  }
+
+
+  /**
+   * Verify if each incompatible active lock is revokable. If yes, revoke all of them.
+   * - EXCLUSIVE locks are incompatible with every other conflicting lock
+   * - SHARED locks are incompatible with conflicting locks of every other type
+   * - REPLACE locks are incompatible with every conflicting lock which is not (APPEND and enclosed) within its interval
+   * - APPEND locks are incompatible with every EXCLUSIVE and SHARED lock.
+   *   Conflicting REPLACE locks which don't enclose its interval are also incompatible.
+   * @param conflictPosses conflicting lock posses
+   * @param request lock request
+   * @return true iff every incompatible lock is revocable.
+   */
+  private boolean revokeAllIncompatibleActiveLocksIfPossible(
+      List<TaskLockPosse> conflictPosses,
+      LockRequest request
+  )
+  {
+    final int priority = request.getPriority();
+    final TaskLockType type = request.getType();
+    final List<TaskLockPosse> possesToRevoke = new ArrayList<>();
+
+    for (TaskLockPosse posse : conflictPosses) {
+      if (posse.getTaskLock().isRevoked()) {
+        continue;
+      }
+      switch (type) {
+        case EXCLUSIVE:
+          if (posse.getTaskLock().getPriority() >= priority) {
+            return false;
+          }
+          possesToRevoke.add(posse);
+          break;
+        case SHARED:
+          if (!posse.getTaskLock().getType().equals(TaskLockType.SHARED)) {
+            if (posse.getTaskLock().getPriority() >= priority) {
+              return false;
+            }
+            possesToRevoke.add(posse);
+          }
+          break;
+        case REPLACE:
+          if (!(posse.getTaskLock().getType().equals(TaskLockType.APPEND)
+                && request.getInterval().contains(posse.getTaskLock().getInterval()))) {
+            if (posse.getTaskLock().getPriority() >= priority) {
+              return false;
+            }
+            possesToRevoke.add(posse);
+          }
+          break;
+        case APPEND:
+          if (!(posse.getTaskLock().getType().equals(TaskLockType.APPEND)
+                || (posse.getTaskLock().getType().equals(TaskLockType.REPLACE)
+                    && posse.getTaskLock().getInterval().contains(request.getInterval())))) {
+            if (posse.getTaskLock().getPriority() >= priority) {
+              return false;
+            }
+            possesToRevoke.add(posse);
+          }
+          break;
+        default:
+          return false;
+      }
+    }
+    for (TaskLockPosse revokablePosse : possesToRevoke) {
+      revokeLock(revokablePosse);
+    }
+    return true;
   }
 
   /**
@@ -1350,6 +1522,8 @@ public class TaskLockbox
     {
       if (taskLock.getType() == request.getType() && taskLock.getGranularity() == request.getGranularity()) {
         switch (taskLock.getType()) {
+          case REPLACE:
+          case APPEND:
           case SHARED:
             if (request instanceof TimeChunkLockRequest) {
               return taskLock.getInterval().contains(request.getInterval())

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -1454,6 +1454,8 @@ public class TaskLockboxTest
     );
 
 
+    // Any append lock can be created, provided that it lies within the interval of the previously created replace lock
+    // This should not revoke any of the existing locks even with a higher priority
     final TaskLock appendLock0 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2017-06-01"),
@@ -1545,6 +1547,8 @@ public class TaskLockboxTest
         MEDIUM_PRIORITY
     );
 
+    // An append lock can be created for an interval enclosed within the replace lock's.
+    // Also note that the append lock has a higher priority but doesn't revoke the replace lock as it can coexist.
     final TaskLock appendLock = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2017-06-01"),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -180,32 +180,27 @@ public class TaskLockboxTest
   {
     final Interval interval = Intervals.of("2017-01/2017-02");
 
-    // Add an exclusive lock entry of the highest priority
     final TaskLock exclusiveRevokedLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         interval,
         HIGH_PRIORITY
     );
 
-    // Any equal or lower priority shared lock must fail
     validator.expectLockNotGranted(
         TaskLockType.SHARED,
         interval,
         HIGH_PRIORITY
     );
 
-    // Revoke existing active exclusive lock
     validator.revokeLock(exclusiveRevokedLock);
     validator.expectRevokedLocks(exclusiveRevokedLock);
 
-    // test creating a new low priority shared lock
     final TaskLock lowPrioritySharedLock = validator.expectLockCreated(
         TaskLockType.SHARED,
         interval,
         LOW_PRIORITY
     );
 
-    // Adding an exclusive task lock of medium priority should revoke all existing active locks
     final TaskLock mediumPriorityExclusiveLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         interval,
@@ -214,7 +209,6 @@ public class TaskLockboxTest
     validator.expectActiveLocks(mediumPriorityExclusiveLock);
     validator.expectRevokedLocks(exclusiveRevokedLock, lowPrioritySharedLock);
 
-    // Add new shared lock which revokes the active exclusive task lock
     final TaskLock highPrioritySharedLock = validator.expectLockCreated(
         TaskLockType.SHARED,
         interval,
@@ -1259,28 +1253,24 @@ public class TaskLockboxTest
         MEDIUM_PRIORITY
     );
 
-    // Another exclusive lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-05-01/2017-06-01"),
         MEDIUM_PRIORITY
     );
 
-    // A shared lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
         MEDIUM_PRIORITY
     );
 
-    // A replace lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.REPLACE,
         Intervals.of("2017/2018"),
         MEDIUM_PRIORITY
     );
 
-    // An append lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2018-05-01"),
@@ -1296,7 +1286,6 @@ public class TaskLockboxTest
   {
     final TaskLockboxValidator validator = new TaskLockboxValidator(lockbox, taskStorage);
 
-    // Revoked shared lock of higher priority -> revoked locks are compatible
     final TaskLock sharedLock = validator.tryTaskLock(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
@@ -1304,21 +1293,18 @@ public class TaskLockboxTest
     );
     validator.revokeLock(sharedLock);
 
-    // Active Exclusive lock of lower priority -> will be revoked
     final TaskLock exclusiveLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-01-01/2017-02-01"),
         LOW_PRIORITY
     );
 
-    // Active replace lock of lower priority -> will be revoked
     final TaskLock replaceLock = validator.expectLockCreated(
         TaskLockType.REPLACE,
         Intervals.of("2017-07-01/2018-01-01"),
         LOW_PRIORITY
     );
 
-    // Active append lock of lower priority -> will be revoked
     final TaskLock appendLock = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-09-01/2017-10-01"),
@@ -1347,42 +1333,36 @@ public class TaskLockboxTest
         MEDIUM_PRIORITY
     );
 
-    // No overlapping exclusive lock is compatible
     validator.expectLockNotGranted(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-05-01/2017-06-01"),
         MEDIUM_PRIORITY
     );
 
-    // Enclosing shared lock of lower priority - compatible
     final TaskLock sharedLock0 = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
         LOW_PRIORITY
     );
 
-    // Enclosed shared lock of higher priority - compatible
     final TaskLock sharedLock1 = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2017-06-01/2017-07-01"),
         LOW_PRIORITY
     );
 
-    // Partially Overlapping shared lock of equal priority - compatible
     final TaskLock sharedLock2 = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2017-05-01/2018-05-01"),
         MEDIUM_PRIORITY
     );
 
-    // Conficting replace locks are incompatible
     validator.expectLockNotGranted(
         TaskLockType.REPLACE,
         Intervals.of("2017/2018"),
         MEDIUM_PRIORITY
     );
 
-    // Conflicting append locks are incompatible
     validator.expectLockNotGranted(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2018-05-01"),
@@ -1396,7 +1376,6 @@ public class TaskLockboxTest
   @Test
   public void testSharedLockCanRevokeAllIncompatible() throws Exception
   {
-    // Revoked Exclusive lock of higher priority -> revoked locks are compatible
     final TaskLock exclusiveLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2016/2019"),
@@ -1404,21 +1383,18 @@ public class TaskLockboxTest
     );
     validator.revokeLock(exclusiveLock);
 
-    // Active Shared lock of same priority -> will not be affected
     final TaskLock sharedLock = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2017-01-01/2017-02-01"),
         MEDIUM_PRIORITY
     );
 
-    // Active replace lock of lower priority -> will be revoked
     final TaskLock replaceLock = validator.expectLockCreated(
         TaskLockType.REPLACE,
         Intervals.of("2017-07-01/2018-07-01"),
         LOW_PRIORITY
     );
 
-    // Active append lock of lower priority -> will be revoked
     final TaskLock appendLock = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-02-01/2017-03-01"),
@@ -1447,35 +1423,30 @@ public class TaskLockboxTest
         MEDIUM_PRIORITY
     );
 
-    // An exclusive lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-05-01/2017-06-01"),
         MEDIUM_PRIORITY
     );
 
-    // A shared lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
         MEDIUM_PRIORITY
     );
 
-    // A replace lock cannot be created for a non-enclosing interval
     validator.expectLockNotGranted(
         TaskLockType.REPLACE,
         Intervals.of("2017-05-01/2018-01-01"),
         MEDIUM_PRIORITY
     );
 
-    // A replace lock can be created for an enclosing interval
     final TaskLock replaceLock = validator.expectLockCreated(
         TaskLockType.REPLACE,
         Intervals.of("2017/2018"),
         MEDIUM_PRIORITY
     );
 
-    // Another replace lock cannot be created
     validator.expectLockNotGranted(
         TaskLockType.REPLACE,
         Intervals.of("2016/2019"),
@@ -1483,15 +1454,12 @@ public class TaskLockboxTest
     );
 
 
-    // Any append lock can be created, provided that it lies within the interval of the previously created replace lock
-    // This should not revoke any of the existing locks even with a higher priority
     final TaskLock appendLock0 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2017-06-01"),
         HIGH_PRIORITY
     );
 
-    // Append lock with a lower priority can be created as well
     final TaskLock appendLock1 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2017-06-01"),
@@ -1505,7 +1473,6 @@ public class TaskLockboxTest
   @Test
   public void testAppendLockCanRevokeAllIncompatible() throws Exception
   {
-    // Revoked Shared lock of higher priority -> revoked locks are compatible
     final TaskLock sharedLock = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
@@ -1513,28 +1480,24 @@ public class TaskLockboxTest
     );
     validator.revokeLock(sharedLock);
 
-    // Active Exclusive lock of lower priority -> will be revoked
     final TaskLock exclusiveLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-01-01/2017-02-01"),
         LOW_PRIORITY
     );
 
-    // Active replace lock of lower priority which doesn't enclose the interval -> will be revoked
     final TaskLock replaceLock = validator.expectLockCreated(
         TaskLockType.REPLACE,
         Intervals.of("2017-07-01/2018-07-01"),
         LOW_PRIORITY
     );
 
-    // Active append lock of lower priority -> will not be revoked
     final TaskLock appendLock0 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-02-01/2017-03-01"),
         LOW_PRIORITY
     );
 
-    // Active append lock of higher priority -> will not revoke or be revoked
     final TaskLock appendLock1 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-02-01/2017-05-01"),
@@ -1564,36 +1527,30 @@ public class TaskLockboxTest
         MEDIUM_PRIORITY
     );
 
-    // An exclusive lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-05-01/2017-06-01"),
         MEDIUM_PRIORITY
     );
 
-    // A shared lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.SHARED,
         Intervals.of("2016/2019"),
         MEDIUM_PRIORITY
     );
 
-    // A replace lock cannot be created for an overlapping interval
     validator.expectLockNotGranted(
         TaskLockType.REPLACE,
         Intervals.of("2017/2018"),
         MEDIUM_PRIORITY
     );
 
-    // An append lock can be created for an interval enclosed within the replace lock's.
-    // Also note that the append lock has a higher priority but doesn't revoke the replace lock as it can coexist.
     final TaskLock appendLock = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-05-01/2017-06-01"),
         HIGH_PRIORITY
     );
 
-    // An append lock cannot coexist when its interval is not enclosed within the replace lock's.
     validator.expectLockNotGranted(
         TaskLockType.APPEND,
         Intervals.of("2016-05-01/2017-06-01"),
@@ -1607,7 +1564,6 @@ public class TaskLockboxTest
   @Test
   public void testReplaceLockCanRevokeAllIncompatible() throws Exception
   {
-    // Revoked Append lock of higher priority -> revoked locks are compatible
     final TaskLock appendLock0 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2016/2019"),
@@ -1615,35 +1571,30 @@ public class TaskLockboxTest
     );
     validator.revokeLock(appendLock0);
 
-    // Active append lock of higher priority within replace interval -> unaffected
     final TaskLock appendLock1 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-02-01/2017-03-01"),
         HIGH_PRIORITY
     );
 
-    // Active Append lock of lower priority which is not enclosed -> will be revoked
     final TaskLock appendLock2 = validator.expectLockCreated(
         TaskLockType.APPEND,
         Intervals.of("2017-09-01/2018-03-01"),
         LOW_PRIORITY
     );
 
-    // Active Exclusive lock of lower priority -> will be revoked
     final TaskLock exclusiveLock = validator.expectLockCreated(
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-05-01/2017-06-01"),
         LOW_PRIORITY
     );
 
-    // Active replace lock of lower priority which doesn't enclose the interval -> will be revoked
     final TaskLock replaceLock = validator.expectLockCreated(
         TaskLockType.REPLACE,
         Intervals.of("2016-09-01/2017-03-01"),
         LOW_PRIORITY
     );
 
-    // Active shared lock of lower priority -> will be revoked
     final TaskLock sharedLock = validator.expectLockCreated(
         TaskLockType.SHARED,
         Intervals.of("2017-04-01/2017-05-01"),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->


<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Introduce two new lock types: APPEND and REPLACE

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
- An interval may have at most one EXCLUSIVE lock and no other locks may coexist with it. -> This is useful when replacing -the data within an interval
- An interval may have any number of SHARED locks of different priorities, with any overlap. No other types of locks may coexist with such intervals. This facilitates several appending jobs to run concurrently on the same interval.

This means that we can only replace or append to an interval, but not both, with timechunk locking.


<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
We introduce two new lock types in this PR to lay the foundation for a replace job to run concurrently with multiple appending jobs for an interval. These locks are called REPLACE and APPEND and are meant to be used for replacing and appending jobs respectively, and may only be used with TIMECHUNK locking.
`Please note that this PR doesn't enable the usage of these locks.`

- An interval may have at most one REPLACE lock and any number of APPEND locks with intervals completely enclosed by that of the REPLACE lock's.
- An interval may have any number of APPEND locks and each of these may be coexist with at most one REPLACE lock, whose interval completely encloses the APPEND lock's.

### Algorithm
We now have 4 types of locks, with different compatibility criteria described above.
- When a lock is requested, we first see if it can peacefully exist with other conflicting locks in which case we grant the lock immediately.
- When the request is incompatible with one or more of the existing locks, we try to see if each of the incompatible locks can be revoked. If yes, we grant the requested lock after revoking all of them.
- Otherwise, the request fails without affecting any of the existing locks.



<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `TaskLockbox`
 * `TaskLockType`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
