### PR TITLE
suppress CVE-2021-40331 since it applies to ranger-hive-plugin which afaict we do not use

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -825,4 +825,12 @@
     <!-- this one seems to apply to backend server - https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
     <cve>CVE-2023-25613</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+     file name: ranger-plugins-cred-2.0.0.jar
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-plugins\-cred@2.0.0$</packageUrl>
+    <!-- applies to ranger-hive-plugin which afaict we do not use https://nvd.nist.gov/vuln/detail/CVE-2021-40331 -->
+    <cve>CVE-2021-40331</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -827,9 +827,9 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-     file name: ranger-plugins-cred-2.0.0.jar
+     file name: ranger-plugins-*-2.0.0.jar
      ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-plugins\-cred@2.0.0$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-plugins\-.*@2.0.0$</packageUrl>
     <!-- applies to ranger-hive-plugin which afaict we do not use https://nvd.nist.gov/vuln/detail/CVE-2021-40331 -->
     <cve>CVE-2021-40331</cve>
   </suppress>


### PR DESCRIPTION
This one got updated today (because trying to make Druid releases has long been cursed).

https://nvd.nist.gov/vuln/detail/CVE-2021-40331