### PR TITLE
fix segment metadata queries for auto ingested columns that had all null values

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -344,7 +344,8 @@ public class SegmentAnalyzer
     final TypeSignature<ValueType> typeSignature = capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities;
     final String typeName = typeSignature.getComplexTypeName();
 
-    try (final ComplexColumn complexColumn = columnHolder != null ? (ComplexColumn) columnHolder.getColumn() : null) {
+    try (final BaseColumn theColumn = columnHolder != null ? columnHolder.getColumn() : null) {
+      final ComplexColumn complexColumn = (ComplexColumn) theColumn;
       final boolean hasMultipleValues = capabilities != null && capabilities.hasMultipleValues().isTrue();
       final boolean hasNulls = capabilities != null && capabilities.hasNulls().isMaybeTrue();
       long size = 0;
@@ -386,6 +387,9 @@ public class SegmentAnalyzer
           null,
           null
       );
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnIndexer.java
@@ -282,6 +282,10 @@ public class AutoTypeColumnIndexer implements DimensionIndexer<StructuredData, S
 
   private ColumnType getLogicalType()
   {
+    if (fieldIndexers.isEmpty()) {
+      // we didn't see anything, so we can be anything, so why not a string?
+      return ColumnType.STRING;
+    }
     if (fieldIndexers.size() == 1 && fieldIndexers.containsKey(NestedPathFinder.JSON_PATH_ROOT)) {
       FieldIndexer rootField = fieldIndexers.get(NestedPathFinder.JSON_PATH_ROOT);
       ColumnType singleType = rootField.getTypes().getSingleType();

--- a/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
@@ -129,6 +129,12 @@ public class IndexBuilder
     return this;
   }
 
+  public IndexBuilder writeNullColumns(boolean shouldWriteNullColumns)
+  {
+    this.indexMerger = new IndexMergerV9(jsonMapper, indexIO, segmentWriteOutMediumFactory, shouldWriteNullColumns);
+    return this;
+  }
+
   public IndexBuilder indexSpec(IndexSpec indexSpec)
   {
     this.indexSpec = indexSpec;

--- a/processing/src/test/java/org/apache/druid/segment/TestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestHelper.java
@@ -484,6 +484,17 @@ public class TestHelper
     return theVals;
   }
 
+  public static Map<String, Object> makeMapWithExplicitNull(Object... vals)
+  {
+    Preconditions.checkArgument(vals.length % 2 == 0);
+
+    Map<String, Object> theVals = new HashMap<>();
+    for (int i = 0; i < vals.length; i += 2) {
+      theVals.put(vals[i].toString(), vals[i + 1]);
+    }
+    return theVals;
+  }
+
   public static void testSerializesDeserializes(Object object)
   {
     testSerializesDeserializes(JSON_MAPPER, object);


### PR DESCRIPTION
### Description
Fixes an oversight whenever `storeEmptyColumns` is enabled on the task config when using 'auto' type columns which would result in a class cast exception when issuing segment metadata queries to build the SQL schema like:

```
java.lang.ClassCastException: org.apache.druid.segment.serde.NullColumnPartSerde$NullDictionaryEncodedColumn cannot be cast to org.apache.druid.segment.column.ComplexColumn
```

This was happening because the 'null' column serde relies on `ValueType` being set correctly in the column descriptor, which for totally empty auto columns were defaulting to `Complex<JSON>` which ends up with `ValueType.COMPLEX` which when coming back from reading a segment ends up with "unknown" complex, pushing it into the 'complex' analysis. I've changed the 'auto' indexer to treat empty columns logical type as 'STRING' so that the value type is set accordingly when writing out the 'null' column.

Added test coverage to ensure null auto type columns dont explode the SQL schema when this flag is set.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
