### PR TITLE
[Backport] suppress CVE-2021-40331 since it applies to ranger-hive-plugin which afaict we do not use (#14261)

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -825,4 +825,12 @@
     <!-- this one seems to apply to backend server - https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
     <cve>CVE-2023-25613</cve>
   </suppress>
+  <suppress>g
+    <notes><![CDATA[
+     file name: ranger-plugins-*-2.0.0.jar
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.ranger/ranger\-plugins\-.*@2.0.0$</packageUrl>
+    <!-- applies to ranger-hive-plugin which afaict we do not use https://nvd.nist.gov/vuln/detail/CVE-2021-40331 -->
+    <cve>CVE-2021-40331</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Backport #14261 to 26.0.0.