### PR TITLE
doc: fix unnest datasource syntax

### DIFF
--- a/docs/querying/datasource.md
+++ b/docs/querying/datasource.md
@@ -413,7 +413,7 @@ The `unnest` datasource uses the following syntax:
       "name": "output_column",
       "expression": "\"column_reference\""
     },
-    "outputName": "unnested_target_column"
+    "unnestFilter": "optional_filter"
   }
 ```
 
@@ -421,5 +421,6 @@ The `unnest` datasource uses the following syntax:
 * `dataSource.base`: Defines the datasource you want to unnest.
   * `dataSource.base.type`: The type of datasource you want to unnest, such as a table.
 * `dataSource.virtualColumn`: [Virtual column](virtual-columns.md) that references the nested values. The output name of this column is reused as the name of the column that contains unnested values. You can replace the source column with the unnested column by specifying the source column's name or a new column by specifying a different name. Outputting it to a new column can help you verify that you get the results that you expect but isn't required.
+* `unnestFilter`: A filter only on the output column. You can omit this or set it to null if there are no filters.
 
 To learn more about how to use the `unnest` datasource, see the [unnest tutorial](../tutorials/tutorial-unnest-arrays.md).


### PR DESCRIPTION
The unnest datasource syntax was outdated. Updated to include the filter and remove output name

#### Release note
n/a

<hr>


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
