### PR TITLE
fix hdfs initialization issue

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageAvailabilityChecker.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageAvailabilityChecker.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.storage.hdfs;
+
+
+import com.google.inject.Inject;
+import org.apache.druid.guice.Hdfs;
+import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+@ManageLifecycle
+public class HdfsStorageAvailabilityChecker
+{
+  private final Configuration hadoopConf;
+
+  @Inject
+  public HdfsStorageAvailabilityChecker(@Hdfs Configuration hadoopConf)
+  {
+    this.hadoopConf = hadoopConf;
+  }
+
+  @LifecycleStart
+  public void checkHdfsAvailability()
+  {
+    try {
+      // If cache is enabled, need to check the FileSystem object by access hdfs because FileSystem object will be used later, like in push stage.
+      // If FileSystem is invalid, the peon task should stop immediately.
+      boolean disableCache = hadoopConf.getBoolean("fs.hdfs.impl.disable.cache", false);
+      if (!disableCache) {
+        FileSystem fs = FileSystem.get(hadoopConf);
+        fs.exists(new Path("/"));
+      }
+    }
+    catch (IOException ex) {
+      throw new ISE(ex, "Failed to access hdfs.");
+    }
+  }
+
+  @LifecycleStop
+  public void stop()
+  {
+    //noop
+  }
+}

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -100,7 +100,7 @@ public class HdfsStorageDruidModule implements DruidModule
 
       // If cache is enabled, need to check the FileSystem object by access hdfs because FileSystem object will be used later.
       // Like in push stage. If FileSystem is invalid, the peon task should stop immediately.
-      // See
+      // See https://github.com/apache/druid/pull/14276
       boolean enabledCache = !conf.getBoolean("fs.hdfs.impl.disable.cache", false);
       if (enabledCache) {
         fs.exists(new Path("/"));

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -92,17 +92,13 @@ public class HdfsStorageDruidModule implements DruidModule
     ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-
-      // Not make the initialization take too long if HDFS can't be reached
-      conf.setInt("dfs.client.failover.max.attempts", 3);
-      conf.setInt("dfs.http.client.failover.max.attempts", 3);
       FileSystem fs = FileSystem.get(conf);
 
       // If cache is enabled, need to check the FileSystem object by access hdfs because FileSystem object will be used later.
       // Like in push stage. If FileSystem is invalid, the peon task should stop immediately.
       // See https://github.com/apache/druid/pull/14276
-      boolean enabledCache = !conf.getBoolean("fs.hdfs.impl.disable.cache", false);
-      if (enabledCache) {
+      boolean disableCache = conf.getBoolean("fs.hdfs.impl.disable.cache", false);
+      if (!disableCache) {
         fs.exists(new Path("/"));
       }
     }

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -35,7 +35,6 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.inputsource.hdfs.HdfsInputSource;
 import org.apache.druid.inputsource.hdfs.HdfsInputSourceConfig;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import org.apache.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
 import org.apache.hadoop.conf.Configuration;
@@ -95,7 +94,7 @@ public class HdfsStorageDruidModule implements DruidModule
       FileSystem.get(conf);
     }
     catch (IOException ex) {
-      throw new ISE(ex, "Failed to access hdfs.");
+      throw new RuntimeException(ex);
     }
     finally {
       Thread.currentThread().setContextClassLoader(currCtxCl);

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModule.java
@@ -94,8 +94,8 @@ public class HdfsStorageDruidModule implements DruidModule
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
       FileSystem fs = FileSystem.get(conf);
 
-      // If cache is enabled, need to check the FileSystem object by access hdfs because FileSystem object will be used later.
-      // Like in push stage. If FileSystem is invalid, the peon task should stop immediately.
+      // If cache is enabled, need to check the FileSystem object by access hdfs because FileSystem object will be used later, like in push stage.
+      // If FileSystem is invalid, the peon task should stop immediately.
       // See https://github.com/apache/druid/pull/14276
       boolean disableCache = conf.getBoolean("fs.hdfs.impl.disable.cache", false);
       if (!disableCache) {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

In our production, we met an issue due to the unstable DNS resolving (very low chance): The FileSystem object is invalid with UnknownHostException, but this object will be used during the `push` stage(`fs.hdfs.impl.disable.cache` is not set, default value is `false`). The `taskDuration` of index_kafka ingestion task is about PT1H, so if failed in `push` stage, data will be re-consumed, it will cause big data delay in realtime scenario.
1) During the peon task initialization, there was error:
`
WARN [main] org.apache.hadoop.hdfs.DFSUtilClient - Namenode for nameservice-XXX remains unresolved for ID namenodeXXX. Check your hdfs-site.xml file to ensure namenodes are configured properly.
`
2) During the `push` stage, there was NameNode failover for 15 times. Finally peon task was failed.


Except for the DNS issue in my company, I think we need to make improvement in Druid: we need to validate the FileSystem object completely if `fs.hdfs.impl.disable.cache` is `false`. If FileSystem is invalid, we should stop the task immediately, not let it go and then finally become failed during the `push` stage.  
Source code locates in: `HdfsStorageDruidModule::configure`
```
    final Configuration conf = new Configuration();

    conf.setClassLoader(getClass().getClassLoader());

    ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
    try {
      Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
      FileSystem.get(conf);  // Get a FileSystem object is not complete
    }
    catch (IOException ex) {
      throw new RuntimeException(ex);
    }
    finally {
      Thread.currentThread().setContextClassLoader(currCtxCl);
    }
```


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.storage.hdfs.HdfsStorageDruidModule`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
