### PR TITLE
Fixing an issue with filtering on a single dimension by converting In…

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/JoinableFactoryWrapper.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.segment.filter.FalseFilter;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.utils.CollectionUtils;
 
 import javax.annotation.Nullable;
@@ -177,7 +178,10 @@ public class JoinableFactoryWrapper
         }
         return new JoinClauseToFilterConversion(null, false);
       }
-      final Filter onlyFilter = new InDimFilter(leftColumn, columnValuesWithUniqueFlag.getColumnValues());
+      final Filter onlyFilter = Filters.toFilter(new InDimFilter(
+          leftColumn,
+          columnValuesWithUniqueFlag.getColumnValues()
+      ));
       if (!columnValuesWithUniqueFlag.isAllUnique()) {
         joinClauseFullyConverted = false;
       }

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -271,9 +271,9 @@ public class JoinableFactoryWrapperTest extends NullHandlingTest
         Integer.MAX_VALUE
     );
 
-    // Although the filter created was an In Filter in equijoin
-    // We should receive a SelectorFilter for Filters.toFilter
-    // as there is a single value
+    // Although the filter created was an In Filter in equijoin (here inFilter = IN (Mexico))
+    // We should receive a SelectorFilter for Filters.toFilter(inFilter) call
+    // and should receive a SelectorFilter with x = Mexico
     Assert.assertEquals(
         Pair.of(
             ImmutableList.of(new SelectorFilter("x", "Mexico", null)),


### PR DESCRIPTION
… filter to a selector filter as needed with Filters.toFilter


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
