### PR TITLE
Do not cancel old GHA workflows triggered on branch commits

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,7 +27,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}' # group workflows only on pull_requests and not on branch commits
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -22,7 +22,6 @@ on:
       - 'helm/**'
       - 'web-console/**'
       - '**/*.md'
-      - 'test-branch'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -22,6 +22,7 @@ on:
       - 'helm/**'
       - 'web-console/**'
       - '**/*.md'
+      - 'test-branch'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches
@@ -39,7 +40,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}' # group workflows only on pull_requests and not on branch commits
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Since Concurrency is configured on `Static checks CI` and `Unit & Integration tests CI`, only a single workflow (latest) runs per PR and per branch. We would like to not cancel already running workflows on a branch even when a new commit is pushed. This PR limits concurrency setup to PRs and doesn't automatically cancel workflows triggered on branch push events.