### PR TITLE
Expr getCacheKey now delegates to children

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -187,9 +187,11 @@ public interface Expr extends Cacheable
 
 
   /**
-   * Decorates the cache key builder by adding extra elements if stringify alone is not sufficient
-   * to create the cache key. Override this method in such cases then, for e.g. {@link org.apache.druid.query.expression.LookupExprMacro}}
-   * @param builder
+   * Decorates the {@link CacheKeyBuilder} for the default implementation of {@link #getCacheKey()}. The default cache
+   * key implementation includes the output of {@link #stringify()} and then uses a {@link Shuttle} to call this method
+   * on all children. The stringified representation is sufficient for most expressions, but for any which rely on
+   * external state that might change, this method allows the cache key to change when the state does, even if the
+   * expression itself is otherwise the same.
    */
   default void decorateCacheKeyBuilder(CacheKeyBuilder builder)
   {

--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -185,7 +185,12 @@ public interface Expr extends Cacheable
     throw Exprs.cannotVectorize(this);
   }
 
-  // This will be overridden for lookup exprs
+
+  /**
+   * Decorates the cache key builder by adding extra elements if stringify alone is not sufficient
+   * to create the cache key. Override this method in such cases then, for e.g. {@link org.apache.druid.query.expression.LookupExprMacro}}
+   * @param builder
+   */
   default void decorateCacheKeyBuilder(CacheKeyBuilder builder)
   {
     // no op

--- a/processing/src/main/java/org/apache/druid/math/expr/Exprs.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Exprs.java
@@ -30,7 +30,6 @@ import java.util.Stack;
 public class Exprs
 {
   public static final byte EXPR_CACHE_KEY = 0x00;
-  public static final byte LOOKUP_EXPR_CACHE_KEY = 0x01;
 
   public static UnsupportedOperationException cannotVectorize(Expr expr)
   {

--- a/processing/src/main/java/org/apache/druid/query/expression/LookupExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LookupExprMacro.java
@@ -26,7 +26,6 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
-import org.apache.druid.math.expr.Exprs;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.RegisteredLookupExtractionFn;
@@ -112,19 +111,6 @@ public class LookupExprMacro implements ExprMacroTable.ExprMacro
       public void decorateCacheKeyBuilder(CacheKeyBuilder builder)
       {
         builder.appendCacheable(extractionFn);
-      }
-
-      @Override
-      public byte[] getCacheKey()
-      {
-        CacheKeyBuilder builder = new CacheKeyBuilder(Exprs.LOOKUP_EXPR_CACHE_KEY).appendString(stringify());
-        // delegate to the child expressions through shuttle
-        Shuttle keyShuttle = expr -> {
-          expr.decorateCacheKeyBuilder(builder);
-          return expr;
-        };
-        this.visit(keyShuttle);
-        return builder.build();
       }
     }
 

--- a/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -81,6 +81,30 @@ public class LookupExprMacroTest extends InitializedNullHandlingTest
     }
   }
 
+  @Test
+  public void testCacheKeyChangesWhenLookupChangesSubExpr()
+  {
+    final String expression = "concat(lookup(x, 'lookyloo'))";
+    final Expr expr = Parser.parse(expression, LookupEnabledTestExprMacroTable.INSTANCE);
+    final Expr exprSameLookup = Parser.parse(expression, LookupEnabledTestExprMacroTable.INSTANCE);
+    final Expr exprChangedLookup = Parser.parse(
+        expression,
+        new ExprMacroTable(LookupEnabledTestExprMacroTable.makeTestMacros(ImmutableMap.of("x", "y", "a", "b")))
+    );
+    // same should have same cache key
+    Assert.assertArrayEquals(expr.getCacheKey(), exprSameLookup.getCacheKey());
+    // different should not have same key
+    final byte[] exprBytes = expr.getCacheKey();
+    final byte[] expr2Bytes = exprChangedLookup.getCacheKey();
+    if (exprBytes.length == expr2Bytes.length) {
+      // only check for equality if lengths are equal
+      boolean allEqual = true;
+      for (int i = 0; i < exprBytes.length; i++) {
+        allEqual = allEqual && (exprBytes[i] == expr2Bytes[i]);
+      }
+      Assert.assertFalse(allEqual);
+    }
+  }
 
   private void assertExpr(final String expression, final Object expectedResult)
   {


### PR DESCRIPTION

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
