### PR TITLE
more resilient segment metadata, dont parallel merge internal segment metadata queries

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,7 +31,6 @@
       <writeAnnotation name="org.powermock.api.easymock.annotation.Mock" />
     </writeAnnotations>
   </component>
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
@@ -85,7 +84,8 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -31,6 +31,7 @@
       <writeAnnotation name="org.powermock.api.easymock.annotation.Mock" />
     </writeAnnotations>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
@@ -84,8 +85,7 @@
     <resource url="http://maven.apache.org/ASSEMBLY/2.0.0" location="$PROJECT_DIR$/.idea/xml-schemas/assembly-2.0.0.xsd" />
     <resource url="http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" location="$PROJECT_DIR$/.idea/xml-schemas/svg11.dtd" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>
-

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentAnalyzer.java
@@ -112,38 +112,47 @@ public class SegmentAnalyzer
         capabilities = storageAdapter.getColumnCapabilities(columnName);
       }
 
-      final ColumnAnalysis analysis;
+      ColumnAnalysis analysis;
 
-      switch (capabilities.getType()) {
-        case LONG:
-          final int bytesPerRow =
-              ColumnHolder.TIME_COLUMN_NAME.equals(columnName) ? NUM_BYTES_IN_TIMESTAMP : Long.BYTES;
+      try {
+        switch (capabilities.getType()) {
+          case LONG:
+            final int bytesPerRow =
+                ColumnHolder.TIME_COLUMN_NAME.equals(columnName) ? NUM_BYTES_IN_TIMESTAMP : Long.BYTES;
 
-          analysis = analyzeNumericColumn(capabilities, numRows, bytesPerRow);
-          break;
-        case FLOAT:
-          analysis = analyzeNumericColumn(capabilities, numRows, NUM_BYTES_IN_TEXT_FLOAT);
-          break;
-        case DOUBLE:
-          analysis = analyzeNumericColumn(capabilities, numRows, Double.BYTES);
-          break;
-        case STRING:
-          if (index != null) {
-            analysis = analyzeStringColumn(capabilities, index.getColumnHolder(columnName));
-          } else {
-            analysis = analyzeStringColumn(capabilities, storageAdapter, columnName);
-          }
-          break;
-        case ARRAY:
-          analysis = analyzeArrayColumn(capabilities);
-          break;
-        case COMPLEX:
-          final ColumnHolder columnHolder = index != null ? index.getColumnHolder(columnName) : null;
-          analysis = analyzeComplexColumn(capabilities, numRows, columnHolder);
-          break;
-        default:
-          log.warn("Unknown column type[%s].", capabilities.asTypeString());
-          analysis = ColumnAnalysis.error(StringUtils.format("unknown_type_%s", capabilities.asTypeString()));
+            analysis = analyzeNumericColumn(capabilities, numRows, bytesPerRow);
+            break;
+          case FLOAT:
+            analysis = analyzeNumericColumn(capabilities, numRows, NUM_BYTES_IN_TEXT_FLOAT);
+            break;
+          case DOUBLE:
+            analysis = analyzeNumericColumn(capabilities, numRows, Double.BYTES);
+            break;
+          case STRING:
+            if (index != null) {
+              analysis = analyzeStringColumn(capabilities, index.getColumnHolder(columnName));
+            } else {
+              analysis = analyzeStringColumn(capabilities, storageAdapter, columnName);
+            }
+            break;
+          case ARRAY:
+            analysis = analyzeArrayColumn(capabilities);
+            break;
+          case COMPLEX:
+            final ColumnHolder columnHolder = index != null ? index.getColumnHolder(columnName) : null;
+            analysis = analyzeComplexColumn(capabilities, numRows, columnHolder);
+            break;
+          default:
+            log.warn("Unknown column type[%s].", capabilities.asTypeString());
+            analysis = ColumnAnalysis.error(StringUtils.format("unknown_type_%s", capabilities.asTypeString()));
+        }
+      }
+      catch (Throwable throwable) {
+        // eat the exception and add error analysis, this is preferrable to exploding since exploding results in
+        // the broker downstream SQL metadata cache left in a state where it is unable to completely finish
+        // the SQL schema relies on this stuff functioning, and so will continuously retry when it faces a failure
+        log.warn(throwable, "Error analyzing column");
+        analysis = ColumnAnalysis.error(throwable.getMessage());
       }
 
       columns.put(columnName, analysis);
@@ -174,26 +183,16 @@ public class SegmentAnalyzer
   )
   {
     long size = 0;
+    final ColumnAnalysis.Builder bob = ColumnAnalysis.builder().withCapabilities(capabilities);
 
     if (analyzingSize()) {
       if (capabilities.hasMultipleValues().isTrue()) {
-        return ColumnAnalysis.error("multi_value");
+        return bob.withErrorMessage("multi_value").build();
       }
 
       size = ((long) length) * sizePerRow;
     }
-
-    return new ColumnAnalysis(
-        capabilities.toColumnType(),
-        capabilities.getType().name(),
-        capabilities.hasMultipleValues().isTrue(),
-        capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
-        size,
-        null,
-        null,
-        null,
-        null
-    );
+    return bob.withSize(size).build();
   }
 
   private ColumnAnalysis analyzeStringColumn(
@@ -237,23 +236,20 @@ public class SegmentAnalyzer
         }
       }
       catch (IOException e) {
-        throw new RuntimeException(e);
+        return ColumnAnalysis.builder().withCapabilities(capabilities).withErrorMessage(e.getMessage()).build();
       }
     } else {
       cardinality = 0;
     }
 
-    return new ColumnAnalysis(
-        capabilities.toColumnType(),
-        capabilities.getType().name(),
-        capabilities.hasMultipleValues().isTrue(),
-        capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
-        size,
-        analyzingCardinality() ? cardinality : 0,
-        min,
-        max,
-        null
-    );
+    return ColumnAnalysis.builder()
+                         .withCapabilities(capabilities)
+                         .withSize(size)
+                         .withCardinality(analyzingCardinality() ? cardinality : 0)
+                         .withMinValue(min)
+                         .withMaxValue(max)
+                         .build();
+
   }
 
   private ColumnAnalysis analyzeStringColumn(
@@ -322,17 +318,13 @@ public class SegmentAnalyzer
       max = storageAdapter.getMaxValue(columnName);
     }
 
-    return new ColumnAnalysis(
-        capabilities.toColumnType(),
-        capabilities.getType().name(),
-        capabilities.hasMultipleValues().isTrue(),
-        capabilities.hasNulls().isMaybeTrue(), // if we don't know for sure, then we should plan to check for nulls
-        size,
-        cardinality,
-        min,
-        max,
-        null
-    );
+    return ColumnAnalysis.builder()
+                         .withCapabilities(capabilities)
+                         .withSize(size)
+                         .withCardinality(cardinality)
+                         .withMinValue(min)
+                         .withMaxValue(max)
+                         .build();
   }
 
   private ColumnAnalysis analyzeComplexColumn(
@@ -344,67 +336,51 @@ public class SegmentAnalyzer
     final TypeSignature<ValueType> typeSignature = capabilities == null ? ColumnType.UNKNOWN_COMPLEX : capabilities;
     final String typeName = typeSignature.getComplexTypeName();
 
-    try (final BaseColumn theColumn = columnHolder != null ? columnHolder.getColumn() : null) {
-      final ComplexColumn complexColumn = (ComplexColumn) theColumn;
-      final boolean hasMultipleValues = capabilities != null && capabilities.hasMultipleValues().isTrue();
-      final boolean hasNulls = capabilities != null && capabilities.hasNulls().isMaybeTrue();
-      long size = 0;
+    final ColumnAnalysis.Builder bob = ColumnAnalysis.builder()
+                                                     .withType(ColumnTypeFactory.ofType(typeSignature))
+                                                     .withTypeName(typeName);
 
+    try (final BaseColumn theColumn = columnHolder != null ? columnHolder.getColumn() : null) {
+      if (theColumn != null && !(theColumn instanceof ComplexColumn)) {
+        return bob.withErrorMessage(
+                    StringUtils.format(
+                        "[%s] is not a [%s]",
+                        theColumn == null ? null : theColumn.getClass().getName(),
+                        ComplexColumn.class.getName()
+                    )
+                  )
+                  .build();
+      }
+      final ComplexColumn complexColumn = (ComplexColumn) theColumn;
+
+      bob.hasMultipleValues(capabilities != null && capabilities.hasMultipleValues().isTrue())
+         .hasNulls(capabilities != null && capabilities.hasNulls().isMaybeTrue());
+
+      long size = 0;
       if (analyzingSize() && complexColumn != null) {
+
         final ComplexMetricSerde serde = typeName == null ? null : ComplexMetrics.getSerdeForType(typeName);
         if (serde == null) {
-          return ColumnAnalysis.error(StringUtils.format("unknown_complex_%s", typeName));
+          return bob.withErrorMessage(StringUtils.format("unknown_complex_%s", typeName)).build();
         }
 
         final Function<Object, Long> inputSizeFn = serde.inputSizeFn();
-        if (inputSizeFn == null) {
-          return new ColumnAnalysis(
-              ColumnTypeFactory.ofType(typeSignature),
-              typeName,
-              hasMultipleValues,
-              hasNulls,
-              0,
-              null,
-              null,
-              null,
-              null
-          );
-        }
+        if (inputSizeFn != null) {
 
-        for (int i = 0; i < numCells; ++i) {
-          size += inputSizeFn.apply(complexColumn.getRowValue(i));
+          for (int i = 0; i < numCells; ++i) {
+            size += inputSizeFn.apply(complexColumn.getRowValue(i));
+          }
         }
       }
-
-      return new ColumnAnalysis(
-          ColumnTypeFactory.ofType(typeSignature),
-          typeName,
-          hasMultipleValues,
-          hasNulls,
-          size,
-          null,
-          null,
-          null,
-          null
-      );
+      return bob.withSize(size).build();
     }
     catch (IOException e) {
-      throw new RuntimeException(e);
+      return bob.withErrorMessage(e.getMessage()).build();
     }
   }
 
   private ColumnAnalysis analyzeArrayColumn(final ColumnCapabilities capabilities)
   {
-    return new ColumnAnalysis(
-        capabilities.toColumnType(),
-        capabilities.getType().name(),
-        false,
-        capabilities.hasNulls().isTrue(),
-        0L,
-        null,
-        null,
-        null,
-        null
-    );
+    return ColumnAnalysis.builder().withCapabilities(capabilities).build();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -53,9 +53,12 @@ import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.ColumnBuilder;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.StringDictionaryEncodedColumn;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.data.ListIndexed;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
@@ -65,6 +68,7 @@ import org.apache.druid.segment.serde.ComplexMetricSerde;
 import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
+import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -356,7 +360,7 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testComplexAnalysisNullColumn() throws IOException
+  public void testAnalysisNullAutoDiscoveredColumn() throws IOException
   {
     IndexBuilder bob = IndexBuilder.create();
     bob.tmpDir(temporaryFolder.newFolder());
@@ -382,6 +386,72 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     Assert.assertEquals(ColumnType.STRING, analysis.get("x").getTypeSignature());
     Assert.assertFalse(analysis.get("x").isError());
   }
+
+  @Test
+  public void testAnalysisAutoNullColumn() throws IOException
+  {
+    IndexBuilder bob = IndexBuilder.create();
+    bob.tmpDir(temporaryFolder.newFolder());
+    bob.writeNullColumns(true);
+    InputRowSchema schema = new InputRowSchema(
+        new TimestampSpec("time", null, null),
+        DimensionsSpec.builder().useSchemaDiscovery(true).build(),
+        null
+    );
+    bob.schema(IncrementalIndexSchema.builder()
+                                     .withTimestampSpec(schema.getTimestampSpec())
+                                     .withDimensionsSpec(schema.getDimensionsSpec())
+                                     .build());
+    bob.rows(ImmutableList.of(
+        MapInputRowParser.parse(schema, TestHelper.makeMapWithExplicitNull("time", 1234L, "x", null)))
+    );
+
+    QueryableIndex queryableIndex = bob.buildMMappedIndex();
+    Segment s = new QueryableIndexSegment(queryableIndex, SegmentId.dummy("test"));
+
+    SegmentAnalyzer analyzer = new SegmentAnalyzer(EMPTY_ANALYSES);
+    Map<String, ColumnAnalysis> analysis = analyzer.analyze(s);
+    Assert.assertEquals(ColumnType.STRING, analysis.get("x").getTypeSignature());
+    Assert.assertFalse(analysis.get("x").isError());
+  }
+
+  @Test
+  public void testAnalysisImproperComplex() throws IOException
+  {
+    QueryableIndex mockIndex = EasyMock.createMock(QueryableIndex.class);
+    EasyMock.expect(mockIndex.getNumRows()).andReturn(100).atLeastOnce();
+    EasyMock.expect(mockIndex.getColumnNames()).andReturn(Collections.singletonList("x")).atLeastOnce();
+    EasyMock.expect(mockIndex.getAvailableDimensions())
+            .andReturn(new ListIndexed<>(Collections.singletonList("x")))
+            .atLeastOnce();
+    EasyMock.expect(mockIndex.getColumnCapabilities(ColumnHolder.TIME_COLUMN_NAME))
+            .andReturn(ColumnCapabilitiesImpl.createDefault().setType(ColumnType.LONG))
+            .atLeastOnce();
+    EasyMock.expect(mockIndex.getColumnCapabilities("x"))
+            .andReturn(ColumnCapabilitiesImpl.createDefault().setType(ColumnType.UNKNOWN_COMPLEX))
+            .atLeastOnce();
+
+    ColumnHolder holder = EasyMock.createMock(ColumnHolder.class);
+    EasyMock.expect(mockIndex.getColumnHolder("x")).andReturn(holder).atLeastOnce();
+
+    StringDictionaryEncodedColumn dictionaryEncodedColumn = EasyMock.createMock(StringDictionaryEncodedColumn.class);
+    EasyMock.expect(holder.getColumn()).andReturn(dictionaryEncodedColumn).atLeastOnce();
+
+    dictionaryEncodedColumn.close();
+    EasyMock.expectLastCall();
+    EasyMock.replay(mockIndex, holder, dictionaryEncodedColumn);
+
+    Segment s = new QueryableIndexSegment(mockIndex, SegmentId.dummy("test"));
+
+    SegmentAnalyzer analyzer = new SegmentAnalyzer(EMPTY_ANALYSES);
+    Map<String, ColumnAnalysis> analysis = analyzer.analyze(s);
+    Assert.assertEquals(ColumnType.UNKNOWN_COMPLEX, analysis.get("x").getTypeSignature());
+    Assert.assertTrue(analysis.get("x").isError());
+    Assert.assertTrue(analysis.get("x").getErrorMessage().contains("is not a [org.apache.druid.segment.column.ComplexColumn]"));
+
+    EasyMock.verify(mockIndex, holder, dictionaryEncodedColumn);
+  }
+
 
   private static final class DummyObjectStrategy implements ObjectStrategy
   {
@@ -529,5 +599,4 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
       return getIntermediateType();
     }
   }
-
 }

--- a/processing/src/test/java/org/apache/druid/query/metadata/metadata/ColumnAnalysisTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/metadata/ColumnAnalysisTest.java
@@ -22,10 +22,11 @@ package org.apache.druid.query.metadata.metadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ColumnAnalysisTest
+public class ColumnAnalysisTest extends InitializedNullHandlingTest
 {
   private final ObjectMapper MAPPER = TestHelper.makeJsonMapper();
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
@@ -47,6 +47,7 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.GlobalTableDataSource;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.metadata.metadata.AllColumnIncluderator;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
@@ -920,7 +921,12 @@ public class SegmentMetadataCache
         querySegmentSpec,
         new AllColumnIncluderator(),
         false,
-        brokerInternalQueryConfig.getContext(),
+        // we are not merging segment metadata query result, why use parallel merge pool
+        QueryContexts.override(
+            brokerInternalQueryConfig.getContext(),
+            QueryContexts.BROKER_PARALLEL_MERGE_KEY,
+            false
+        ),
         EnumSet.noneOf(SegmentMetadataQuery.AnalysisType.class),
         false,
         false

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
@@ -921,7 +921,7 @@ public class SegmentMetadataCache
         querySegmentSpec,
         new AllColumnIncluderator(),
         false,
-        // we are not merging segment metadata query result, why use parallel merge pool
+        // disable the parallel merge because we don't care about the merge and don't want to consume its resources
         QueryContexts.override(
             brokerInternalQueryConfig.getContext(),
             QueryContexts.BROKER_PARALLEL_MERGE_KEY,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.query.GlobalTableDataSource;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -1130,7 +1131,10 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
   @Test
   public void testRunSegmentMetadataQueryWithContext() throws Exception
   {
-    Map<String, Object> queryContext = ImmutableMap.of("priority", 5);
+    Map<String, Object> queryContext = ImmutableMap.of(
+        QueryContexts.PRIORITY_KEY, 5,
+        QueryContexts.BROKER_PARALLEL_MERGE_KEY, false
+    );
 
     String brokerInternalQueryConfigJson = "{\"context\": { \"priority\": 5} }";
 


### PR DESCRIPTION
### Description
Fixes `SegmentAnalyzer` to be more resilient and prefer to use 'error' flag and messages on `ColumnAnalysis` rather than exploding, which protects the downstream broker SQL metadata cache from getting stuck if any segments run into bugs or other unexpected errors during column analysis.

This was uncovered bug a bug in 'auto' column schema which was incorrectly calling an 'all null' `DictionaryEncodedColumn` a `COMPLEX` type resulting in a class cast exception while doing complex analysis since it did not implement `ComplexColumn`. However, there were a handful of other places which might have thrown exceptions while processing columns, so I've updated things to more aggressively handle any errors that might be thrown and turn them into ColumnAnalysis with the 'error' state set.

I made a builder for `ColumnAnalysis` while I was here to clean up a few things, and also made these internal segment metadata queries no longer utilize the broker parallel merge pool, both to reserve capacity for actual user queries, and also because we aren't actually merging these segment metadata results, so it is rather pointless to use anyway.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
