### PR TITLE
[Backport] update NOTICE year, update kafka notice in licenses.yaml

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Druid
-Copyright 2018-2022 The Apache Software Foundation
+Copyright 2018-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3808,10 +3808,28 @@ libraries:
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2022 The Apache Software Foundation.
-
+      Copyright 2023 The Apache Software Foundation.
+      
+      This product includes software developed at
+      The Apache Software Foundation (https://www.apache.org/).
+      
       This distribution has a binary dependency on jersey, which is available under the CDDL
       License. The source code of jersey can be found at https://github.com/jersey/jersey/.
+      
+      This distribution has a binary test dependency on jqwik, which is available under
+      the Eclipse Public License 2.0. The source code can be found at
+      https://github.com/jlink/jqwik.
+    
+      The streams-scala (streams/streams-scala) module was donated by Lightbend and the original code was copyrighted by them:
+        Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+        Copyright (C) 2017-2018 Alexis Seigneurin.
+      
+      This project contains the following code copied from Apache Hadoop:
+        clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java
+        Some portions of this file Copyright (c) 2004-2006 Intel Corporation and licensed under the BSD license.
+      
+      This project contains the following code copied from Apache Hive:
+        streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
 
 ---
 
@@ -4722,12 +4740,30 @@ version: 3.4.0
 libraries:
   - org.apache.kafka: kafka-clients
 notices:
-  - kafka-clients:
+  - kafka-clients: |
       Apache Kafka
-      Copyright 2022 The Apache Software Foundation.
-
+      Copyright 2023 The Apache Software Foundation.
+      
+      This product includes software developed at
+      The Apache Software Foundation (https://www.apache.org/).
+      
       This distribution has a binary dependency on jersey, which is available under the CDDL
       License. The source code of jersey can be found at https://github.com/jersey/jersey/.
+      
+      This distribution has a binary test dependency on jqwik, which is available under
+      the Eclipse Public License 2.0. The source code can be found at
+      https://github.com/jlink/jqwik.
+      
+      The streams-scala (streams/streams-scala) module was donated by Lightbend and the original code was copyrighted by them:
+        Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+        Copyright (C) 2017-2018 Alexis Seigneurin.
+      
+      This project contains the following code copied from Apache Hadoop:
+        clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java
+        Some portions of this file Copyright (c) 2004-2006 Intel Corporation and licensed under the BSD license.
+      
+      This project contains the following code copied from Apache Hive:
+        streams/src/main/java/org/apache/kafka/streams/state/internals/Murmur3.java
 
 ---
 


### PR DESCRIPTION
Backport of #14299 to 26.0.0.