### PR TITLE
Web console: don't show merged stats until needed

### DIFF
--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -604,13 +604,14 @@ ${title} uncompressed size: ${formatBytesCompact(
                     {dataProcessedShuffle(stage)}
                   </>
                 )}
-                {stages.hasCounterForStage(stage, 'segmentGenerationProgress') && (
-                  <>
-                    <div className="counter-spacer extend-left" />
-                    {dataProcessedSegmentGeneration(stage, 'rowsMerged')}
-                    {dataProcessedSegmentGeneration(stage, 'rowsPushed')}
-                  </>
-                )}
+                {stages.hasCounterForStage(stage, 'segmentGenerationProgress') &&
+                  stages.getTotalSegmentGenerationProgressForStage(stage, 'rowsMerged') > 0 && (
+                    <>
+                      <div className="counter-spacer extend-left" />
+                      {dataProcessedSegmentGeneration(stage, 'rowsMerged')}
+                      {dataProcessedSegmentGeneration(stage, 'rowsPushed')}
+                    </>
+                  )}
               </>
             );
           },


### PR DESCRIPTION
Only show the merged counters when the are non-zero otherwise the UI looks buggy:

![image](https://github.com/apache/druid/assets/177816/7663cbc4-e685-4d16-bed9-85d5aa692642)

(noticed this while testing Druid 26 RC2)