### PR TITLE
Doc: List supported values for Kafka `headerFormat`

### DIFF
--- a/docs/development/extensions-core/kafka-ingestion.md
+++ b/docs/development/extensions-core/kafka-ingestion.md
@@ -153,7 +153,13 @@ You would configure it as follows:
 
 - `valueFormat`: Define how to parse the payload value. Set this to the payload parsing input format (`{ "type": "json" }`).
 - `timestampColumnName`: Supply a custom name for the Kafka timestamp in the Druid schema to avoid conflicts with columns from the payload. The default is `kafka.timestamp`.
-- `headerFormat`: The default "string" decodes UTF8-encoded strings from the Kafka header. If you need another format, you can implement your own parser.
+- `headerFormat`: The default value `string` decodes strings in UTF-8 encoding from the Kafka header.
+   Other supported encoding formats include the following:
+   - `ISO-8859-1`: ISO Latin Alphabet No. 1, that is, ISO-LATIN-1.
+   - `US-ASCII`: Seven-bit ASCII. Also known as ISO646-US. The Basic Latin block of the Unicode character set.
+   - `UTF-16`: Sixteen-bit UCS Transformation Format, byte order identified by an optional byte-order mark.
+   - `UTF-16BE`: Sixteen-bit UCS Transformation Format, big-endian byte order.
+   - `UTF-16LE`: Sixteen-bit UCS Transformation Format, little-endian byte order.
 - `headerColumnPrefix`: Supply a prefix to the Kafka headers to avoid any conflicts with columns from the payload. The default is `kafka.header.`.
   Considering the header from the example, Druid maps the headers to the following columns: `kafka.header.env`, `kafka.header.zone`.
 - `keyFormat`: Supply an input format to parse the key. Only the first value will be used.

--- a/website/.spelling
+++ b/website/.spelling
@@ -2263,3 +2263,5 @@ druid-tdigestsketch
 gce-extensions
 prometheus-emitter
 kubernetes-overlord-extensions
+UCS
+ISO646-US


### PR DESCRIPTION
Updates https://druid.apache.org/docs/latest/development/extensions-core/kafka-ingestion.html#kafka-input-format-supervisor-spec-example

When using the Kafka format, you can ingest data associated with the Kafka record headers. The headers are decoded from the format supplied in `headerFormat`. This docs change includes the encoding formats supported for `headerFormat`.

