### PR TITLE
Update operations per run for Stale bot GHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -95,4 +95,4 @@ jobs:
           exempt-milestones: true
           exempt-assignees: true
           ascending: true
-          operations-per-run: 50 
+          operations-per-run: 200


### PR DESCRIPTION
Given the number of active issues, 50 `operations-per-run` is too low and is only analyzing 25 issues in a run. Increasing this number to 200 to cover more issues in a run.