### PR TITLE
write factory.json use utf-8

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -251,12 +251,13 @@ public class IndexMergerV9 implements IndexMerger
 
       progress.progress();
       startTime = System.currentTimeMillis();
-      try (FileOutputStream fos = new FileOutputStream(new File(outDir, "factory.json"))) {
+      try (FileOutputStream fos = new FileOutputStream(new File(outDir, "factory.json"));
+          OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8)) {
         SegmentizerFactory customSegmentLoader = indexSpec.getSegmentLoader();
         if (customSegmentLoader != null) {
-          mapper.writeValue(fos, customSegmentLoader);
+          mapper.writeValue(osw, customSegmentLoader);
         } else {
-          mapper.writeValue(fos, new MMappedQueryableSegmentizerFactory(indexIO));
+          mapper.writeValue(osw, new MMappedQueryableSegmentizerFactory(indexIO));
         }
       }
       log.debug("Completed factory.json in %,d millis", System.currentTimeMillis() - startTime);


### PR DESCRIPTION
### Description
when I use Hadoop ingestion, some hadoop cluster node did not set system encoding as utf-8, resulting in the following content for factory.json:
 :)
^Eú<83>typeQmMapSegmentFactoryû

Historical Node SegmentLoadDropHandler.loadSegment throw JsonParseException, fix this issue by setting write encoding of file.

This PR has:

- [x] been self-reviewed.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
