### PR TITLE
Fix regression in batch segment allocation

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateRequest.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocateRequest.java
@@ -74,4 +74,17 @@ public class SegmentAllocateRequest
   {
     return rowInterval;
   }
+
+  @Override
+  public String toString()
+  {
+    return "SegmentAllocateRequest{" +
+           "taskId=" + task.getId() +
+           ", queryGranularity=" + action.getQueryGranularity() +
+           ", segmentGranularity=" + action.getPreferredSegmentGranularity() +
+           ", maxAttempts=" + maxAttempts +
+           ", rowInterval=" + rowInterval +
+           ", attempts=" + attempts +
+           '}';
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -338,9 +338,7 @@ public class SegmentAllocationQueue
 
     log.debug(
         "Processing [%d] requests for batch [%s], queue time [%s].",
-        requestBatch.size(),
-        requestKey,
-        requestKey.getQueueTime()
+        requestBatch.size(), requestKey, requestKey.getQueueTime()
     );
 
     final long startTimeMillis = System.currentTimeMillis();
@@ -368,7 +366,7 @@ public class SegmentAllocationQueue
           "Completing [%d] failed requests in batch [%s] with null value as there"
           + " are conflicting segments. Cannot retry allocation until the set of"
           + " used segments overlapping the allocation interval [%s] changes.",
-          size(), requestBatch, requestBatch.key.preferredAllocationInterval
+          size(), requestKey, requestKey.preferredAllocationInterval
       );
 
       requestBatch.completePendingRequestsWithNull();
@@ -486,9 +484,7 @@ public class SegmentAllocationQueue
     final AllocateRequestKey requestKey = requestBatch.key;
     log.debug(
         "Trying allocation for [%d] requests, interval [%s] in batch [%s]",
-        requests.size(),
-        tryInterval,
-        requestKey
+        requests.size(), tryInterval, requestKey
     );
 
     final List<SegmentAllocateResult> results = taskLockbox.allocateSegments(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
@@ -64,7 +64,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -983,9 +982,6 @@ public class SegmentAllocateActionTest
       } else {
         return action.perform(task, taskActionTestKit.getTaskActionToolbox());
       }
-    }
-    catch (ExecutionException e) {
-      return null;
     }
     catch (Exception e) {
       throw new RuntimeException(e);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueueTest.java
@@ -223,8 +223,7 @@ public class SegmentAllocationQueueTest
     executor.finishNextPendingTask();
 
     Assert.assertNotNull(getSegmentId(hourSegmentFuture));
-    Throwable t = Assert.assertThrows(ISE.class, () -> getSegmentId(halfHourSegmentFuture));
-    Assert.assertEquals("Storage coordinator could not allocate segment.", t.getMessage());
+    Assert.assertNull(getSegmentId(halfHourSegmentFuture));
   }
 
   @Test
@@ -309,7 +308,7 @@ public class SegmentAllocationQueueTest
 
     for (Future<SegmentIdWithShardSpec> future : segmentFutures) {
       Throwable t = Assert.assertThrows(ISE.class, () -> getSegmentId(future));
-      Assert.assertEquals("Cannot allocate segment if not leader", t.getMessage());
+      Assert.assertEquals("Not leader anymore", t.getMessage());
     }
   }
 


### PR DESCRIPTION
Non-batch segment allocation completes in one of three ways:
1. allocation success: return the allocated `SegmentIdWithShardSpec`
2. allocation failed due to conflicting segments and cannot retry: return `null`
3. sleep interrupted or other unknown error: throw a `RuntimeException`

Batch segment allocation had diverged from this in item (2) by throwing an exception. This PR fixes that bug and cleans up some of the logs.