### PR TITLE
fixes dataSourceName varaible ref

### DIFF
--- a/examples/quickstart/jupyter-notebooks/sql-tutorial.ipynb
+++ b/examples/quickstart/jupyter-notebooks/sql-tutorial.ipynb
@@ -156,7 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sql_client.wait_until_ready(dataSourceName)"
+    "sql_client.wait_until_ready('wikipedia-sql-tutorial')"
    ]
   },
   {
@@ -169,7 +169,7 @@
     "Druid supports a variety of datasources, with the table datasource being the most common. In Druid documentation, the word \"datasource\" often implicitly refers to the table datasource.\n",
     "The [Datasources](https://druid.apache.org/docs/latest/querying/datasource.html) topic provides a comprehensive overview of datasources supported by Druid SQL.\n",
     "\n",
-    "In Druid SQL, table datasources reside in the `druid` schema. This is the default schema, so table datasources can be referenced as either `druid.dataSourceName` or `dataSourceName`.\n",
+    "In Druid SQL, table datasources reside in the `druid` schema. This is the default schema, so table datasources can be referenced as either `druid.DATASOURCE_NAME` or `DATASOURCE_NAME`.\n",
     "\n",
     "For example, run the next cell to return the rows of the column named `channel` from the `wikipedia-sql-tutorial` table. Because this tutorial is running in Jupyter, the cells use the LIMIT clause to limit the size of the query results for display purposes. The cell uses the built-in table formatting feature of the Python API. You can also retrieve the values as a Python object if you wish to perform additional processing."
    ]
@@ -242,7 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display.table(dataSourceName)"
+    "display.table('wikipedia-sql-tutorial')"
    ]
   },
   {


### PR DESCRIPTION
Fixes a reference to the undeclared variable `dataSourceName`

### Description

In a couple spots the tutorial was using `dataSourceName` when it was previously undeclared which caused an error.

Changed the documentation from `dataSourceName` to `DATASOURCE_NAME` to indicate that the developer can change the  value to their own datasource name.

This PR has:

- [ x] been self-reviewed.
- [x ] been tested in a test Druid cluster.
