### PR TITLE
MSQ should ignore tombstone segments while querying over them.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/TableInputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/TableInputSpecSlicer.java
@@ -103,6 +103,7 @@ public class TableInputSpecSlicer implements InputSpecSlicer
                         .flatMap(
                             holder ->
                                 StreamSupport.stream(holder.getObject().spliterator(), false)
+                                             .filter(chunk -> !chunk.getObject().isTombstone())
                                              .map(
                                                  chunk ->
                                                      new DataSegmentWithInterval(

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecSlicerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/TableInputSpecSlicerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
+import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,13 +80,25 @@ public class TableInputSpecSlicerTest extends InitializedNullHandlingTest
       BYTES_PER_SEGMENT
   );
 
+  private static final DataSegment SEGMENT3 = new DataSegment(
+      DATASOURCE,
+      Intervals.of("2001/2002"),
+      "1",
+      Collections.emptyMap(),
+      Collections.emptyList(),
+      Collections.emptyList(),
+      TombstoneShardSpec.INSTANCE,
+      null,
+      null,
+      BYTES_PER_SEGMENT
+  );
   private SegmentTimeline timeline;
   private TableInputSpecSlicer slicer;
 
   @Before
   public void setUp()
   {
-    timeline = SegmentTimeline.forSegments(ImmutableList.of(SEGMENT1, SEGMENT2));
+    timeline = SegmentTimeline.forSegments(ImmutableList.of(SEGMENT1, SEGMENT2, SEGMENT3));
     DataSegmentTimelineView timelineView = (dataSource, intervals) -> {
       if (DATASOURCE.equals(dataSource)) {
         return Optional.of(timeline);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

MSQ should ignore Tombstone segments while querying over them. If the data source interval has a tombstone segment, the job fails with 
```

va.lang.RuntimeException: org.apache.druid.java.util.common.RE: Failed to download segment [wikipedia_2016-06-27T22:00:00.000Z_2016-06-28T00:00:00.000Z_2023-03-27T10:50:54.563Z]
	at org.apache.druid.java.util.common.Either.valueOrThrow(Either.java:95)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.runProcessorNow(FrameProcessorExecutor.java:258)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.run(FrameProcessorExecutor.java:137)
	at org.apache.druid.msq.exec.WorkerImpl$1$2.run(WorkerImpl.java:820)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.apache.druid.query.PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:251)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.druid.java.util.common.RE: Failed to download segment [wikipedia_2016-06-27T22:00:00.000Z_2016-06-28T00:00:00.000Z_2023-03-27T10:50:54.563Z]
	at org.apache.druid.msq.exec.TaskDataSegmentProvider.fetchSegmentInternal(TaskDataSegmentProvider.java:136)
	at org.apache.druid.msq.exec.TaskDataSegmentProvider.lambda$fetchSegment$0(TaskDataSegmentProvider.java:87)
	at org.apache.druid.msq.exec.TaskDataSegmentProvider$SegmentHolder.get(TaskDataSegmentProvider.java:183)
	at org.apache.druid.msq.exec.TaskDataSegmentProvider.lambda$fetchSegment$3(TaskDataSegmentProvider.java:90)
	at org.apache.druid.msq.input.table.SegmentWithDescriptor.getOrLoad(SegmentWithDescriptor.java:65)
	at org.apache.druid.msq.querykit.groupby.GroupByPreShuffleFrameProcessor.runWithSegment(GroupByPreShuffleFrameProcessor.java:104)
	at org.apache.druid.msq.querykit.BaseLeafFrameProcessor.runIncrementally(BaseLeafFrameProcessor.java:159)
	at org.apache.druid.frame.processor.FrameProcessors$1FrameProcessorWithBaggage.runIncrementally(FrameProcessors.java:75)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.runProcessorNow(FrameProcessorExecutor.java:229)
	... 8 more
Caused by: org.apache.druid.java.util.common.IOE: Invalid segment dir [/var/folders/sx/n0v16tnj6mvf6hd14l6j6dth0000gn/T/persistent/task/slot2/query-1127076b-44d4-43a3-bfed-71ebad35f1a2-worker3_0/work/indexing-tmp/segment-fetch/wikipedia/2016-06-27T22:00:00.000Z_2016-06-28T00:00:00.000Z/2023-03-27T10:50:54.563Z/0]. Can't find either of version.bin or index.drd.
	at org.apache.druid.segment.SegmentUtils.getVersionFromDir(SegmentUtils.java:82)
	at org.apache.druid.segment.IndexIO.loadIndex(IndexIO.java:199)
	at org.apache.druid.segment.IndexIO.loadIndex(IndexIO.java:194)
	at org.apache.druid.msq.exec.TaskDataSegmentProvider.fetchSegmentInternal(TaskDataSegmentProvider.java:128)
	... 16 more

```



<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Fixed a bug where msq jobs were failing when tombstone segments were encountered in the underlying datasource. 


<hr>

##### Key changed/added classes in this PR
 * `TableInputSpecSlicer`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
