### PR TITLE
docs: k8s-jobs role needs batch apigroup

### DIFF
--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -125,6 +125,7 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - batch
   resources:
   - pods
   - configmaps


### PR DESCRIPTION
### Description
Following [documentation](https://github.com/apache/druid/blob/1873fca6c73f816db45482eda3e59abc6fd4e8f5/docs/development/extensions-contrib/k8s-jobs.md?plain=1#L126-L127) of `druid-kubernetes-overlord-extensions` and applying suggested `Role` results in an error in Overlord container:
```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://172.20.0.1:443/apis/batch/v1/namespaces/druid-test/jobs?labelSelector=druid.k8s.peons. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. jobs.batch is forbidden: User "system:serviceaccount:druid-test:druid" cannot list resource "jobs" in API group "batch" in the namespace "druid-test".
```

This issue is solved when `Role` includes `batch` in `ApiGroups` - this PR improves docs to include this information.

<hr>

- [x] been self-reviewed
 
- [x] been tested in a test Druid cluster.
