### PR TITLE
Update heap size of MiddleManager service in docker IT environment

### DIFF
--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -21,7 +21,7 @@ DRUID_SERVICE=middleManager
 DRUID_LOG_PATH=/shared/logs/middlemanager.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx64m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5008
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5008
 
 # Druid configs
 druid_host=druid-middlemanager


### PR DESCRIPTION
Cloud deep storage tests are flaky and failing with following error

**Overlord logs:**
```
2023-05-19T04:16:41,012 INFO [qtp999685353-107] org.apache.druid.indexing.overlord.RemoteTaskRunner - Shutdown [single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z] because: [Shutdown request from user]
2023-05-19T04:16:41,021 WARN [qtp999685353-107] org.apache.druid.indexing.overlord.TaskQueue - TaskRunner failed to cleanup task after completion: single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z
org.apache.druid.java.util.common.RE: Error in handling post to [druid-middlemanager:8291] for task [single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z]
2023-05-19T04:16:41,038 INFO [qtp999685353-107] org.apache.druid.indexing.overlord.TaskLockbox - Removing task[single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z] from activeTasks
2023-05-19T04:16:41,072 INFO [TaskQueue-Manager] org.apache.druid.indexing.overlord.RemoteTaskRunner - Shutdown [single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z] because: [Task is not in knownTaskIds]
```

**MiddleManager logs:**
```
output to: /tmp/persistent/task/slot0/single_phase_sub_task_wikipedia_index_test_f73ffed5-459a-497a-bdf0-db045f9b43a5 %?????? ?? ??!?_nnbhooje_2023-05-19T04:16:12.774Z/log
java.lang.OutOfMemoryError: Java heap space
Dumping heap to /tmp/java_pid660.hprof ...
Heap dump file created [85041468 bytes in 6.807 secs]
Terminating due to java.lang.OutOfMemoryError: Java heap space
```

Since 64M size is too small and observed no erratic object creation on the heap profile, incrementing the size of the middleManager to 128M.