### PR TITLE
Fix `EARLIEST_BY`/`LATEST_BY` signature and include function name in signature.

### DIFF
--- a/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalSqlAggregatorBase.java
+++ b/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalSqlAggregatorBase.java
@@ -178,7 +178,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
               OperandTypes.and(OperandTypes.ANY, OperandTypes.family(SqlTypeFamily.ANY)),
               OperandTypes.and(
                   OperandTypes.sequence(
-                      "'" + name + "'(column, size)",
+                      "'" + name + "(column, size)'",
                       OperandTypes.ANY,
                       OperandTypes.POSITIVE_INTEGER_LITERAL
                   ),
@@ -186,7 +186,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
               ),
               OperandTypes.and(
                   OperandTypes.sequence(
-                      "'" + name + "'(column, size, scale)",
+                      "'" + name + "(column, size, scale)'",
                       OperandTypes.ANY,
                       OperandTypes.POSITIVE_INTEGER_LITERAL,
                       OperandTypes.POSITIVE_INTEGER_LITERAL
@@ -195,7 +195,7 @@ public abstract class CompressedBigDecimalSqlAggregatorBase implements SqlAggreg
               ),
               OperandTypes.and(
                   OperandTypes.sequence(
-                      "'" + name + "'(column, size, scale, strictNumberParsing)",
+                      "'" + name + "(column, size, scale, strictNumberParsing)'",
                       OperandTypes.ANY,
                       OperandTypes.POSITIVE_INTEGER_LITERAL,
                       OperandTypes.POSITIVE_INTEGER_LITERAL,

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestGenerateSketchSqlAggregator.java
@@ -148,7 +148,7 @@ public class TDigestGenerateSketchSqlAggregator implements SqlAggregator
 
   private static class TDigestGenerateSketchSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE_WITH_COMPRESSION = "'" + NAME + "(column, compression)'\n";
+    private static final String SIGNATURE_WITH_COMPRESSION = "'" + NAME + "(column, compression)'";
 
     TDigestGenerateSketchSqlAggFunction()
     {

--- a/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
+++ b/extensions-contrib/tdigestsketch/src/main/java/org/apache/druid/query/aggregation/tdigestsketch/sql/TDigestSketchQuantileSqlAggregator.java
@@ -178,8 +178,8 @@ public class TDigestSketchQuantileSqlAggregator implements SqlAggregator
 
   private static class TDigestSketchQuantileSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE1 = "'" + NAME + "(column, quantile)'\n";
-    private static final String SIGNATURE2 = "'" + NAME + "(column, quantile, compression)'\n";
+    private static final String SIGNATURE1 = "'" + NAME + "(column, quantile)'";
+    private static final String SIGNATURE2 = "'" + NAME + "(column, quantile, compression)'";
 
     TDigestSketchQuantileSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
@@ -69,7 +69,7 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
 
   private static class HllSketchApproxCountDistinctSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE = "'" + NAME + "(column, lgK, tgtHllType)'\n";
+    private static final String SIGNATURE = "'" + NAME + "(column, lgK, tgtHllType)'";
 
     HllSketchApproxCountDistinctSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchObjectSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchObjectSqlAggregator.java
@@ -64,7 +64,7 @@ public class HllSketchObjectSqlAggregator extends HllSketchBaseSqlAggregator imp
 
   private static class HllSketchSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE = "'" + NAME + "(column, lgK, tgtHllType)'\n";
+    private static final String SIGNATURE = "'" + NAME + "(column, lgK, tgtHllType)'";
 
     HllSketchSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchApproxQuantileSqlAggregator.java
@@ -215,8 +215,8 @@ public class DoublesSketchApproxQuantileSqlAggregator implements SqlAggregator
 
   private static class DoublesSketchApproxQuantileSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE1 = "'" + NAME + "(column, probability)'\n";
-    private static final String SIGNATURE2 = "'" + NAME + "(column, probability, k)'\n";
+    private static final String SIGNATURE1 = "'" + NAME + "(column, probability)'";
+    private static final String SIGNATURE2 = "'" + NAME + "(column, probability, k)'";
 
     DoublesSketchApproxQuantileSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchObjectSqlAggregator.java
@@ -142,7 +142,7 @@ public class DoublesSketchObjectSqlAggregator implements SqlAggregator
 
   private static class DoublesSketchSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE2 = "'" + NAME + "(column, k)'\n";
+    private static final String SIGNATURE2 = "'" + NAME + "(column, k)'";
 
     DoublesSketchSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
@@ -69,7 +69,7 @@ public class ThetaSketchApproxCountDistinctSqlAggregator extends ThetaSketchBase
 
   private static class ThetaSketchSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE = "'" + NAME + "(column, size)'\n";
+    private static final String SIGNATURE = "'" + NAME + "(column, size)'";
 
     ThetaSketchSqlAggFunction()
     {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchObjectSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchObjectSqlAggregator.java
@@ -62,7 +62,7 @@ public class ThetaSketchObjectSqlAggregator extends ThetaSketchBaseSqlAggregator
 
   private static class ThetaSketchObjectSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE = "'" + NAME + "(column, size)'\n";
+    private static final String SIGNATURE = "'" + NAME + "(column, size)'";
 
     ThetaSketchObjectSqlAggFunction()
     {

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/sql/BloomFilterSqlAggregator.java
@@ -182,7 +182,7 @@ public class BloomFilterSqlAggregator implements SqlAggregator
 
   private static class BloomFilterSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE1 = "'" + NAME + "(column, maxNumEntries)'\n";
+    private static final String SIGNATURE1 = "'" + NAME + "(column, maxNumEntries)'";
 
     BloomFilterSqlAggFunction()
     {

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/FixedBucketsHistogramQuantileSqlAggregator.java
@@ -259,11 +259,11 @@ public class FixedBucketsHistogramQuantileSqlAggregator implements SqlAggregator
     private static final String SIGNATURE1 =
         "'"
         + NAME
-        + "(column, probability, numBuckets, lowerLimit, upperLimit)'\n";
+        + "(column, probability, numBuckets, lowerLimit, upperLimit)'";
     private static final String SIGNATURE2 =
         "'"
         + NAME
-        + "(column, probability, numBuckets, lowerLimit, upperLimit, outlierHandlingMode)'\n";
+        + "(column, probability, numBuckets, lowerLimit, upperLimit, outlierHandlingMode)'";
 
     FixedBucketsHistogramQuantileSqlAggFunction()
     {

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/sql/QuantileSqlAggregator.java
@@ -213,8 +213,8 @@ public class QuantileSqlAggregator implements SqlAggregator
 
   private static class QuantileSqlAggFunction extends SqlAggFunction
   {
-    private static final String SIGNATURE1 = "'" + NAME + "(column, probability)'\n";
-    private static final String SIGNATURE2 = "'" + NAME + "(column, probability, resolution)'\n";
+    private static final String SIGNATURE1 = "'" + NAME + "(column, probability)'";
+    private static final String SIGNATURE2 = "'" + NAME + "(column, probability, resolution)'";
 
     QuantileSqlAggFunction()
     {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArrayConcatSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArrayConcatSqlAggregator.java
@@ -163,7 +163,7 @@ public class ArrayConcatSqlAggregator implements SqlAggregator
           OperandTypes.or(
               OperandTypes.ARRAY,
               OperandTypes.sequence(
-                  StringUtils.format("'%s'(expr, maxSizeBytes)", NAME),
+                  StringUtils.format("'%s(expr, maxSizeBytes)'", NAME),
                   OperandTypes.ARRAY,
                   OperandTypes.POSITIVE_INTEGER_LITERAL
               )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/ArraySqlAggregator.java
@@ -187,7 +187,7 @@ public class ArraySqlAggregator implements SqlAggregator
           OperandTypes.or(
             OperandTypes.ANY,
             OperandTypes.and(
-                OperandTypes.sequence(StringUtils.format("%s(expr, maxSizeBytes)", NAME), OperandTypes.ANY, OperandTypes.POSITIVE_INTEGER_LITERAL),
+                OperandTypes.sequence(StringUtils.format("'%s(expr, maxSizeBytes)'", NAME), OperandTypes.ANY, OperandTypes.POSITIVE_INTEGER_LITERAL),
                 OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.NUMERIC)
             )
           ),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestAnySqlAggregator.java
@@ -301,7 +301,7 @@ public class EarliestLatestAnySqlAggregator implements SqlAggregator
               OperandTypes.NUMERIC,
               OperandTypes.BOOLEAN,
               OperandTypes.sequence(
-                  "'" + aggregatorType.name() + "(expr, maxBytesPerString)'\n",
+                  "'" + aggregatorType.name() + "(expr, maxBytesPerString)'",
                   OperandTypes.ANY,
                   OperandTypes.and(OperandTypes.NUMERIC, OperandTypes.LITERAL)
               )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
@@ -168,12 +168,12 @@ public class EarliestLatestBySqlAggregator implements SqlAggregator
           InferTypes.RETURN_TYPE,
           OperandTypes.or(
               OperandTypes.sequence(
-                  "'" + aggregatorType.name() + "(expr, timeColumn)'\n",
+                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn)'\n",
                   OperandTypes.ANY,
                   OperandTypes.family(SqlTypeFamily.TIMESTAMP)
               ),
               OperandTypes.sequence(
-                  "'" + aggregatorType.name() + "(expr, timeColumn, maxBytesPerString)'\n",
+                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn, maxBytesPerString)'\n",
                   OperandTypes.ANY,
                   OperandTypes.family(SqlTypeFamily.TIMESTAMP),
                   OperandTypes.and(OperandTypes.NUMERIC, OperandTypes.LITERAL)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/EarliestLatestBySqlAggregator.java
@@ -168,12 +168,12 @@ public class EarliestLatestBySqlAggregator implements SqlAggregator
           InferTypes.RETURN_TYPE,
           OperandTypes.or(
               OperandTypes.sequence(
-                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn)'\n",
+                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn)'",
                   OperandTypes.ANY,
                   OperandTypes.family(SqlTypeFamily.TIMESTAMP)
               ),
               OperandTypes.sequence(
-                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn, maxBytesPerString)'\n",
+                  "'" + StringUtils.format("%s_BY", aggregatorType.name()) + "(expr, timeColumn, maxBytesPerString)'",
                   OperandTypes.ANY,
                   OperandTypes.family(SqlTypeFamily.TIMESTAMP),
                   OperandTypes.and(OperandTypes.NUMERIC, OperandTypes.LITERAL)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/StringSqlAggregator.java
@@ -222,7 +222,7 @@ public class StringSqlAggregator implements SqlAggregator
           OperandTypes.or(
               OperandTypes.and(
                   OperandTypes.sequence(
-                      StringUtils.format("'%s'(expr, separator)", NAME),
+                      StringUtils.format("'%s(expr, separator)'", NAME),
                       OperandTypes.ANY,
                       OperandTypes.STRING
                   ),
@@ -230,7 +230,7 @@ public class StringSqlAggregator implements SqlAggregator
               ),
               OperandTypes.and(
                   OperandTypes.sequence(
-                      StringUtils.format("'%s'(expr, separator, maxSizeBytes)", NAME),
+                      StringUtils.format("'%s(expr, separator, maxSizeBytes)'", NAME),
                       OperandTypes.ANY,
                       OperandTypes.STRING,
                       OperandTypes.POSITIVE_INTEGER_LITERAL

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayAppendOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_APPEND")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_APPEND(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayAppendOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayAppendOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_APPEND")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_APPEND(array,expr)",
+              "'ARRAY_APPEND(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayConcatOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_CONCAT")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,array)",
+              "ARRAY_CONCAT(array,array)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayConcatOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayConcatOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_CONCAT")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_CONCAT(array,array)",
+              "'ARRAY_CONCAT(array, array)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
@@ -52,7 +52,7 @@ public class ArrayContainsOperatorConversion extends BaseExpressionDimFilterOper
       .operatorBuilder("ARRAY_CONTAINS")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,array)",
+              "ARRAY_CONTAINS(array,array)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
@@ -52,7 +52,7 @@ public class ArrayContainsOperatorConversion extends BaseExpressionDimFilterOper
       .operatorBuilder("ARRAY_CONTAINS")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_CONTAINS(array,array)",
+              "'ARRAY_CONTAINS(array, array)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayOffsetOfOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_OFFSET_OF")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_OFFSET_OF(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOfOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayOffsetOfOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_OFFSET_OF")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_OFFSET_OF(array,expr)",
+              "'ARRAY_OFFSET_OF(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
@@ -32,7 +32,7 @@ public class ArrayOffsetOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_OFFSET")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_OFFSET(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOffsetOperatorConversion.java
@@ -32,7 +32,7 @@ public class ArrayOffsetOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_OFFSET")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_OFFSET(array,expr)",
+              "'ARRAY_OFFSET(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayOrdinalOfOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_ORDINAL_OF")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_ORDINAL_OF(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOfOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayOrdinalOfOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_ORDINAL_OF")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_ORDINAL_OF(array,expr)",
+              "'ARRAY_ORDINAL_OF(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
@@ -38,7 +38,7 @@ public class ArrayOrdinalOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_ORDINAL")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_ORDINAL(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOrdinalOperatorConversion.java
@@ -38,7 +38,7 @@ public class ArrayOrdinalOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_ORDINAL")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_ORDINAL(array,expr)",
+              "'ARRAY_ORDINAL(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
@@ -52,7 +52,7 @@ public class ArrayOverlapOperatorConversion extends BaseExpressionDimFilterOpera
       .operatorBuilder("ARRAY_OVERLAP")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,array)",
+              "ARRAY_OVERLAP(array,array)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
@@ -52,7 +52,7 @@ public class ArrayOverlapOperatorConversion extends BaseExpressionDimFilterOpera
       .operatorBuilder("ARRAY_OVERLAP")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_OVERLAP(array,array)",
+              "'ARRAY_OVERLAP(array, array)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayPrependOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_PREPEND")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(expr,array)",
+              "ARRAY_PREPEND(expr,array)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.STRING),
                   OperandTypes.family(SqlTypeFamily.NUMERIC)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayPrependOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayPrependOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_PREPEND")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_PREPEND(expr,array)",
+              "'ARRAY_PREPEND(expr, array)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.STRING),
                   OperandTypes.family(SqlTypeFamily.NUMERIC)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
@@ -34,7 +34,7 @@ public class ArraySliceOperatorConversion extends DirectOperatorConversion
       .operandTypeChecker(
           OperandTypes.or(
             OperandTypes.sequence(
-                "(expr,start)",
+                "ARRAY_SLICE(expr,start)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -42,7 +42,7 @@ public class ArraySliceOperatorConversion extends DirectOperatorConversion
                 OperandTypes.family(SqlTypeFamily.NUMERIC)
             ),
             OperandTypes.sequence(
-                "(expr,start,end)",
+                "ARRAY_SLICE(expr,start,end)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArraySliceOperatorConversion.java
@@ -34,7 +34,7 @@ public class ArraySliceOperatorConversion extends DirectOperatorConversion
       .operandTypeChecker(
           OperandTypes.or(
             OperandTypes.sequence(
-                "ARRAY_SLICE(expr,start)",
+                "'ARRAY_SLICE(expr, start)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -42,7 +42,7 @@ public class ArraySliceOperatorConversion extends DirectOperatorConversion
                 OperandTypes.family(SqlTypeFamily.NUMERIC)
             ),
             OperandTypes.sequence(
-                "ARRAY_SLICE(expr,start,end)",
+                "'ARRAY_SLICE(expr, start, end)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayToStringOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_TO_STRING")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(array,expr)",
+              "ARRAY_TO_STRING(array,expr)",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToStringOperatorConversion.java
@@ -33,7 +33,7 @@ public class ArrayToStringOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("ARRAY_TO_STRING")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "ARRAY_TO_STRING(array,expr)",
+              "'ARRAY_TO_STRING(array, expr)'",
               OperandTypes.or(
                   OperandTypes.family(SqlTypeFamily.ARRAY),
                   OperandTypes.family(SqlTypeFamily.STRING)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
@@ -54,7 +54,7 @@ public class ComplexDecodeBase64OperatorConversion implements SqlOperatorConvers
       .operatorBuilder(StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME))
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(typeName,base64)",
+              StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME) + "(typeName,base64)",
               OperandTypes.and(OperandTypes.family(SqlTypeFamily.STRING), OperandTypes.LITERAL),
               OperandTypes.ANY
           )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ComplexDecodeBase64OperatorConversion.java
@@ -54,7 +54,7 @@ public class ComplexDecodeBase64OperatorConversion implements SqlOperatorConvers
       .operatorBuilder(StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME))
       .operandTypeChecker(
           OperandTypes.sequence(
-              StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME) + "(typeName,base64)",
+              "'" + StringUtils.toUpperCase(BuiltInExprMacros.ComplexDecodeBase64ExprMacro.NAME) + "(typeName, base64)'",
               OperandTypes.and(OperandTypes.family(SqlTypeFamily.STRING), OperandTypes.LITERAL),
               OperandTypes.ANY
           )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
@@ -44,7 +44,7 @@ public class IPv4AddressMatchOperatorConversion extends DirectOperatorConversion
       .operatorBuilder(StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME))
       .operandTypeChecker(
           OperandTypes.sequence(
-              StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME) + "(expr,string)",
+              "'" + StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME) + "(expr, string)'",
               ADDRESS_OPERAND,
               SUBNET_OPERAND
           )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressMatchOperatorConversion.java
@@ -42,7 +42,13 @@ public class IPv4AddressMatchOperatorConversion extends DirectOperatorConversion
 
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder(StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME))
-      .operandTypeChecker(OperandTypes.sequence("(expr,string)", ADDRESS_OPERAND, SUBNET_OPERAND))
+      .operandTypeChecker(
+          OperandTypes.sequence(
+              StringUtils.toUpperCase(IPv4AddressMatchExprMacro.FN_NAME) + "(expr,string)",
+              ADDRESS_OPERAND,
+              SUBNET_OPERAND
+          )
+      )
       .returnTypeInference(ReturnTypes.BOOLEAN_NULLABLE)
       .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
       .build();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -61,7 +61,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_APPEND")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(array,expr)",
+                "MV_APPEND(array,expr)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -86,7 +86,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_PREPEND")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(expr,array)",
+                "MV_PREPEND(expr,array)",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
@@ -111,7 +111,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_CONCAT")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(array,array)",
+                "MV_CONCAT(array,array)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -139,7 +139,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_CONTAINS")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(array,array)",
+                "MV_CONTAINS(array,array)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -167,7 +167,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_OFFSET")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(array,expr)",
+                "MV_OFFSET(array,expr)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -192,7 +192,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_ORDINAL")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(array,expr)",
+                "MV_ORDINAL(array,expr)",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -218,7 +218,7 @@ public class MultiValueStringOperatorConversions
         .operandTypeChecker(
             OperandTypes.or(
                 OperandTypes.sequence(
-                    "(expr,start)",
+                    "MV_SLICE(expr,start)",
                     OperandTypes.or(
                         OperandTypes.family(SqlTypeFamily.ARRAY),
                         OperandTypes.family(SqlTypeFamily.STRING)
@@ -253,7 +253,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("STRING_TO_MV")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(string,expr)",
+                "STRING_TO_MV(string,expr)",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.STRING)
             )
@@ -398,7 +398,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_FILTER_ONLY")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(string,array)",
+                "MV_FILTER_ONLY(string,array)",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.ARRAY)
             )
@@ -427,7 +427,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_FILTER_NONE")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(string,array)",
+                "MV_FILTER_NONE(string,array)",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.ARRAY)
             )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -61,7 +61,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_APPEND")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_APPEND(array,expr)",
+                "'MV_APPEND(array, expr)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -86,7 +86,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_PREPEND")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_PREPEND(expr,array)",
+                "'MV_PREPEND(expr, array)'",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
@@ -111,7 +111,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_CONCAT")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_CONCAT(array,array)",
+                "'MV_CONCAT(array, array)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -139,7 +139,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_CONTAINS")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_CONTAINS(array,array)",
+                "'MV_CONTAINS(array, array)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -167,7 +167,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_OFFSET")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_OFFSET(array,expr)",
+                "'MV_OFFSET(array, expr)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -192,7 +192,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_ORDINAL")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_ORDINAL(array,expr)",
+                "'MV_ORDINAL(array, expr)'",
                 OperandTypes.or(
                     OperandTypes.family(SqlTypeFamily.ARRAY),
                     OperandTypes.family(SqlTypeFamily.STRING)
@@ -218,7 +218,7 @@ public class MultiValueStringOperatorConversions
         .operandTypeChecker(
             OperandTypes.or(
                 OperandTypes.sequence(
-                    "MV_SLICE(expr,start)",
+                    "'MV_SLICE(expr, start)'",
                     OperandTypes.or(
                         OperandTypes.family(SqlTypeFamily.ARRAY),
                         OperandTypes.family(SqlTypeFamily.STRING)
@@ -226,7 +226,7 @@ public class MultiValueStringOperatorConversions
                     OperandTypes.family(SqlTypeFamily.NUMERIC)
                 ),
                 OperandTypes.sequence(
-                    "(expr,start,end)",
+                    "'MV_SLICE(expr, start, end)'",
                     OperandTypes.or(
                         OperandTypes.family(SqlTypeFamily.ARRAY),
                         OperandTypes.family(SqlTypeFamily.STRING)
@@ -253,7 +253,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("STRING_TO_MV")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "STRING_TO_MV(string,expr)",
+                "'STRING_TO_MV(string, expr)'",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.STRING)
             )
@@ -398,7 +398,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_FILTER_ONLY")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_FILTER_ONLY(string,array)",
+                "'MV_FILTER_ONLY(string, array)'",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.ARRAY)
             )
@@ -427,7 +427,7 @@ public class MultiValueStringOperatorConversions
         .operatorBuilder("MV_FILTER_NONE")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "MV_FILTER_NONE(string,array)",
+                "'MV_FILTER_NONE(string, array)'",
                 OperandTypes.family(SqlTypeFamily.STRING),
                 OperandTypes.family(SqlTypeFamily.ARRAY)
             )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -117,7 +117,7 @@ public class NestedDataOperatorConversions
         .operatorBuilder("JSON_KEYS")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "JSON_KEYS(expr,path)",
+                "'JSON_KEYS(expr, path)'",
                 OperandTypes.ANY,
                 OperandTypes.and(OperandTypes.family(SqlTypeFamily.STRING), OperandTypes.LITERAL)
             )
@@ -428,7 +428,7 @@ public class NestedDataOperatorConversions
       return OperatorConversions.operatorBuilder(functionName)
                                 .operandTypeChecker(
                                     OperandTypes.sequence(
-                                        functionName + "(expr,path)",
+                                        "'" + functionName + "(expr, path)'",
                                         OperandTypes.family(SqlTypeFamily.ANY),
                                         OperandTypes.family(SqlTypeFamily.STRING)
                                     )
@@ -558,7 +558,7 @@ public class NestedDataOperatorConversions
       return OperatorConversions.operatorBuilder(functionName)
                                 .operandTypeChecker(
                                     OperandTypes.sequence(
-                                        functionName + "(expr,path)",
+                                        "'" + functionName + "(expr, path)'",
                                         OperandTypes.family(SqlTypeFamily.ANY),
                                         OperandTypes.family(SqlTypeFamily.STRING)
                                     )
@@ -610,7 +610,7 @@ public class NestedDataOperatorConversions
                            .operandTypeChecker(
                                OperandTypes.or(
                                    OperandTypes.sequence(
-                                       "JSON_VALUE_ANY(expr,path)",
+                                       "'JSON_VALUE_ANY(expr, path)'",
                                        OperandTypes.family(SqlTypeFamily.ANY),
                                        OperandTypes.family(SqlTypeFamily.STRING)
                                    ),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -117,7 +117,7 @@ public class NestedDataOperatorConversions
         .operatorBuilder("JSON_KEYS")
         .operandTypeChecker(
             OperandTypes.sequence(
-                "(expr,path)",
+                "JSON_KEYS(expr,path)",
                 OperandTypes.ANY,
                 OperandTypes.and(OperandTypes.family(SqlTypeFamily.STRING), OperandTypes.LITERAL)
             )
@@ -428,7 +428,7 @@ public class NestedDataOperatorConversions
       return OperatorConversions.operatorBuilder(functionName)
                                 .operandTypeChecker(
                                     OperandTypes.sequence(
-                                        "(expr,path)",
+                                        functionName + "(expr,path)",
                                         OperandTypes.family(SqlTypeFamily.ANY),
                                         OperandTypes.family(SqlTypeFamily.STRING)
                                     )
@@ -558,7 +558,7 @@ public class NestedDataOperatorConversions
       return OperatorConversions.operatorBuilder(functionName)
                                 .operandTypeChecker(
                                     OperandTypes.sequence(
-                                        "(expr,path)",
+                                        functionName + "(expr,path)",
                                         OperandTypes.family(SqlTypeFamily.ANY),
                                         OperandTypes.family(SqlTypeFamily.STRING)
                                     )
@@ -610,7 +610,7 @@ public class NestedDataOperatorConversions
                            .operandTypeChecker(
                                OperandTypes.or(
                                    OperandTypes.sequence(
-                                       "(expr,path)",
+                                       "JSON_VALUE_ANY(expr,path)",
                                        OperandTypes.family(SqlTypeFamily.ANY),
                                        OperandTypes.family(SqlTypeFamily.STRING)
                                    ),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
@@ -34,7 +34,7 @@ public class StringToArrayOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("STRING_TO_ARRAY")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "(string,expr)",
+              "STRING_TO_ARRAY(string,expr)",
               OperandTypes.family(SqlTypeFamily.STRING),
               OperandTypes.family(SqlTypeFamily.STRING)
           )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/StringToArrayOperatorConversion.java
@@ -34,7 +34,7 @@ public class StringToArrayOperatorConversion extends DirectOperatorConversion
       .operatorBuilder("STRING_TO_ARRAY")
       .operandTypeChecker(
           OperandTypes.sequence(
-              "STRING_TO_ARRAY(string,expr)",
+              "'STRING_TO_ARRAY(string, expr)'",
               OperandTypes.family(SqlTypeFamily.STRING),
               OperandTypes.family(SqlTypeFamily.STRING)
           )

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/TimeInIntervalConvertletFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/TimeInIntervalConvertletFactory.java
@@ -55,7 +55,7 @@ public class TimeInIntervalConvertletFactory implements DruidConvertletFactory
       .operatorBuilder(NAME)
       .operandTypeChecker(
           OperandTypes.sequence(
-              NAME + "(<TIMESTAMP>, <LITERAL ISO8601 INTERVAL>)",
+              "'" + NAME + "(<TIMESTAMP>, <LITERAL ISO8601 INTERVAL>)'",
               OperandTypes.family(SqlTypeFamily.TIMESTAMP),
               OperandTypes.and(OperandTypes.family(SqlTypeFamily.CHARACTER), OperandTypes.LITERAL)
           )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -5866,7 +5866,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
           expected.expect(ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
               "From line 1, column 38 to line 1, column 67: "
               + "Cannot apply 'TIME_IN_INTERVAL' to arguments of type 'TIME_IN_INTERVAL(<TIMESTAMP(3)>, <VARCHAR>)'. "
-              + "Supported form(s): TIME_IN_INTERVAL(<TIMESTAMP>, <LITERAL ISO8601 INTERVAL>)")));
+              + "Supported form(s): 'TIME_IN_INTERVAL(<TIMESTAMP>, <LITERAL ISO8601 INTERVAL>)'")));
         }
     );
   }


### PR DESCRIPTION
This PR:
- Fixes the `EARLIEST_BY` and `LATEST_BY` signatures  -- should be `EARLIEST_BY(expr, timeColumn)` instead of `EARLIEST(expr, timeColumn)`; similarly for `LATEST_BY` signature.
- Fixes inconsistent usages of customized function signatures, including:
  - No or incorrect single quotes around function names
  - No space between args
  - Additional `\n`


This change is precursor to https://github.com/apache/druid/issues/14346.

This PR has:
- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
