### PR TITLE
Remove context params from class component ctors

### DIFF
--- a/web-console/src/components/show-log/show-log.tsx
+++ b/web-console/src/components/show-log/show-log.tsx
@@ -54,8 +54,8 @@ export class ShowLog extends React.PureComponent<ShowLogProps, ShowLogState> {
   private readonly log = React.createRef<HTMLTextAreaElement>();
   private interval: number | undefined;
 
-  constructor(props: ShowLogProps, context: any) {
-    super(props, context);
+  constructor(props: ShowLogProps) {
+    super(props);
     this.state = {
       logState: QueryState.INIT,
       tail: true,

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -83,8 +83,8 @@ export class ConsoleApplication extends React.PureComponent<
   private onlyUnavailable?: boolean;
   private queryWithContext?: QueryWithContext;
 
-  constructor(props: ConsoleApplicationProps, context: any) {
-    super(props, context);
+  constructor(props: ConsoleApplicationProps) {
+    super(props);
     this.state = {
       capabilities: Capabilities.FULL,
       capabilitiesLoading: true,

--- a/web-console/src/dialogs/doctor-dialog/doctor-dialog.tsx
+++ b/web-console/src/dialogs/doctor-dialog/doctor-dialog.tsx
@@ -45,8 +45,8 @@ export interface DoctorDialogState {
 export class DoctorDialog extends React.PureComponent<DoctorDialogProps, DoctorDialogState> {
   private mounted = false;
 
-  constructor(props: DoctorDialogProps, context: any) {
-    super(props, context);
+  constructor(props: DoctorDialogProps) {
+    super(props);
     this.state = {};
   }
 

--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -347,8 +347,8 @@ ORDER BY 1`;
     DatasourcesAndDefaultRules
   >;
 
-  constructor(props: DatasourcesViewProps, context: any) {
-    super(props, context);
+  constructor(props: DatasourcesViewProps) {
+    super(props);
 
     const datasourceFilter: Filter[] = [];
     if (props.initDatasource) {

--- a/web-console/src/views/ingestion-view/ingestion-view.tsx
+++ b/web-console/src/views/ingestion-view/ingestion-view.tsx
@@ -228,8 +228,8 @@ ORDER BY
   ) DESC,
   "created_time" DESC`;
 
-  constructor(props: IngestionViewProps, context: any) {
-    super(props, context);
+  constructor(props: IngestionViewProps) {
+    super(props);
 
     const taskFilter: Filter[] = [];
     if (props.taskId) taskFilter.push({ id: 'task_id', value: `=${props.taskId}` });

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -253,8 +253,8 @@ END AS "time_span"`,
 
   private lastTableState: TableState | undefined;
 
-  constructor(props: SegmentsViewProps, context: any) {
-    super(props, context);
+  constructor(props: SegmentsViewProps) {
+    super(props);
 
     const segmentFilter: Filter[] = [];
     if (props.datasource) segmentFilter.push({ id: 'datasource', value: `=${props.datasource}` });

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -235,8 +235,8 @@ ORDER BY
     });
   }
 
-  constructor(props: ServicesViewProps, context: any) {
-    super(props, context);
+  constructor(props: ServicesViewProps) {
+    super(props);
     this.state = {
       servicesState: QueryState.INIT,
       serviceFilter: [],

--- a/web-console/src/views/workbench-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/workbench-view/column-tree/column-tree.tsx
@@ -518,8 +518,8 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
     return null;
   }
 
-  constructor(props: ColumnTreeProps, context: any) {
-    super(props, context);
+  constructor(props: ColumnTreeProps) {
+    super(props);
     this.state = {
       selectedTreeIndex: -1,
     };

--- a/web-console/src/views/workbench-view/flexible-query-input/flexible-query-input.tsx
+++ b/web-console/src/views/workbench-view/flexible-query-input/flexible-query-input.tsx
@@ -230,8 +230,8 @@ export class FlexibleQueryInput extends React.PureComponent<
     return null;
   }
 
-  constructor(props: FlexibleQueryInputProps, context: any) {
-    super(props, context);
+  constructor(props: FlexibleQueryInputProps) {
+    super(props);
     this.state = {
       editorHeight: 200,
       quotedCompletions: [],


### PR DESCRIPTION
### Description

Removes `context` constructor parameters from React components. These have been deprecated since React 16.3 and [were only relevant if you defined `contextTypes` on the class itself](https://legacy.reactjs.org/docs/legacy-context.html#referencing-context-in-lifecycle-methods). Including these parameters will actually cause TypeScript errors with future React/TS versions.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
