### PR TITLE
Reduce the spam in broker logs when native queries are issued

### DIFF
--- a/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
+++ b/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
@@ -235,12 +235,14 @@ public class TieredBrokerHostSelector
     }
 
     if (brokerServiceName == null) {
-      log.error(
-          "No brokerServiceName found for datasource[%s], intervals[%s]. Using default[%s].",
-          query.getDataSource(),
-          query.getIntervals(),
-          tierConfig.getDefaultBrokerServiceName()
-      );
+      if (query.context().isDebug()) {
+        log.info(
+            "Using default broker service[%s] for query with datasource [%s] and intervals[%s].",
+            tierConfig.getDefaultBrokerServiceName(),
+            query.getDataSource(),
+            query.getIntervals()
+        );
+      }
       brokerServiceName = tierConfig.getDefaultBrokerServiceName();
     }
 


### PR DESCRIPTION
It's not really an error condition if the router cannot find a tiered broker for a given native query. 