### PR TITLE
NullPointerException fix in MSQ Controller

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -356,7 +356,9 @@ public class ControllerImpl implements Controller
         }
     );
 
-    workerTaskLauncher.waitForWorkerShutdown();
+    if (workerTaskLauncher != null) {
+      workerTaskLauncher.waitForWorkerShutdown();
+    }
   }
 
   public TaskStatus runTask(final Closer closer)


### PR DESCRIPTION
### Description

This PR fixes an NPE in the controller which occurs when the controller awaits for the workers to stop even before the `workerTaskLauncher` is initialized. This would be a common occurrence in cases where the controller fails while initializing the query, for example, when the MSQ is unable to generate a query definition for the submitted query.

<hr>

##### Key changed/added classes in this PR
 * `ControllerImpl`

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
