### PR TITLE
Switch to @blueprint/datetime2

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5221,7 +5221,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Palantir Technologies
-version: 4.1.19
+version: 4.2.1
 
 ---
 
@@ -5230,7 +5230,16 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Palantir Technologies
-version: 4.17.6
+version: 4.20.1
+
+---
+
+name: "@blueprintjs/datetime2"
+license_category: binary
+module: web-console
+license_name: Apache License version 2.0
+copyright: Palantir Technologies
+version: 0.9.35
 
 ---
 
@@ -5239,7 +5248,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Palantir Technologies
-version: 4.4.25
+version: 4.4.36
 
 ---
 
@@ -5248,7 +5257,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Palantir Technologies
-version: 4.14.3
+version: 4.16.0
 
 ---
 
@@ -5257,7 +5266,16 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Palantir Technologies
-version: 1.13.10
+version: 1.14.9
+
+---
+
+name: "@blueprintjs/select"
+license_category: binary
+module: web-console
+license_name: Apache License version 2.0
+copyright: Palantir Technologies
+version: 4.9.22
 
 ---
 
@@ -5375,7 +5393,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Federico Zivolo
-version: 2.11.6
+version: 2.11.8
 license_file_path: licenses/bin/@popperjs-core.MIT
 
 ---
@@ -5737,6 +5755,26 @@ license_name: BSD-3-Clause License
 copyright: Mike Bostock
 version: 1.1.0
 license_file_path: licenses/bin/d3-time.BSD3
+
+---
+
+name: "date-fns-tz"
+license_category: binary
+module: web-console
+license_name: MIT License
+copyright: Marnus Weststrate
+version: 1.3.8
+license_file_path: licenses/bin/date-fns-tz.MIT
+
+---
+
+name: "date-fns"
+license_category: binary
+module: web-console
+license_name: MIT License
+copyright: Sasha Koss and Lesha Koss https://kossnocorp.mit-license.org
+version: 2.30.0
+license_file_path: licenses/bin/date-fns.MIT
 
 ---
 
@@ -6185,6 +6223,16 @@ license_name: MIT License
 copyright: John-David Dalton
 version: 4.5.0
 license_file_path: licenses/bin/lodash.isequal.MIT
+
+---
+
+name: "lodash"
+license_category: binary
+module: web-console
+license_name: MIT License
+copyright: John-David Dalton
+version: 4.17.21
+license_file_path: licenses/bin/lodash.MIT
 
 ---
 
@@ -6692,7 +6740,7 @@ license_category: binary
 module: web-console
 license_name: Zero-Clause BSD
 copyright: Microsoft Corp.
-version: 2.3.1
+version: 2.5.3
 license_file_path: licenses/bin/tslib.0BSD
 
 ---

--- a/licenses/bin/date-fns-tz.MIT
+++ b/licenses/bin/date-fns-tz.MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2018 Marnus Weststrate
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/licenses/bin/date-fns.MIT
+++ b/licenses/bin/date-fns.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Sasha Koss and Lesha Koss https://kossnocorp.mit-license.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/bin/lodash.MIT
+++ b/licenses/bin/lodash.MIT
@@ -1,0 +1,47 @@
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -9,10 +9,10 @@
       "version": "27.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@blueprintjs/core": "^4.17.6",
-        "@blueprintjs/datetime": "^4.4.25",
-        "@blueprintjs/icons": "^4.14.3",
-        "@blueprintjs/popover2": "^1.13.10",
+        "@blueprintjs/core": "^4.20.1",
+        "@blueprintjs/datetime2": "^0.9.35",
+        "@blueprintjs/icons": "^4.16.0",
+        "@blueprintjs/popover2": "^1.14.9",
         "ace-builds": "^1.4.13",
         "axios": "^0.26.1",
         "classnames": "^2.2.6",
@@ -2389,17 +2389,20 @@
       "dev": true
     },
     "node_modules/@blueprintjs/colors": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.19.tgz",
-      "integrity": "sha512-x5mDo4Ue9rAdbMHvOm0dNru9MSZqgs9Dd/l/2rgjzottthjsq1XjkiVae6evX4EGNM0I/bZKjTT8ccvqCqn4yw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.2.1.tgz",
+      "integrity": "sha512-Cx7J2YnUuxn+fi+y5XtXnBB7+cFHN4xBrRkaAetp78i3VTCXjUk+d1omrOr8TqbRucUXTdrhbZOUHpzRLFcJpQ==",
+      "dependencies": {
+        "tslib": "~2.5.0"
+      }
     },
     "node_modules/@blueprintjs/core": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.17.6.tgz",
-      "integrity": "sha512-hZBIYfOUsgeeKeFeYCW6qcCTOxwA6EJTXJyjTv+QK34245Lms/rW4sKn+t8Z3z/b0AK5cTH0/S3a1umjshDhLA==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.20.1.tgz",
+      "integrity": "sha512-nKFXfWj8PQrkweLrCr6VazYd4JJHCwiAxcgT9zzoxbEs0mSJF4yI7Qjoh5QkomtWugXrVLCDSzs4uJdaO1reAA==",
       "dependencies": {
-        "@blueprintjs/colors": "^4.1.19",
-        "@blueprintjs/icons": "^4.14.3",
+        "@blueprintjs/colors": "^4.2.1",
+        "@blueprintjs/icons": "^4.16.0",
         "@juggle/resize-observer": "^3.4.0",
         "@types/dom4": "^2.0.2",
         "classnames": "^2.3.1",
@@ -2408,7 +2411,7 @@
         "popper.js": "^1.16.1",
         "react-popper": "^1.3.11",
         "react-transition-group": "^4.4.5",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       },
       "bin": {
         "upgrade-blueprint-2.0.0-rename": "scripts/upgrade-blueprint-2.0.0-rename.sh",
@@ -2426,14 +2429,40 @@
       }
     },
     "node_modules/@blueprintjs/datetime": {
-      "version": "4.4.25",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-4.4.25.tgz",
-      "integrity": "sha512-2Q818yMKqfUbU53fxh1XmkDLP9DMGDxe7t4LrrdKZBPM/m3qs2pyI5ficwDak1Rr9cHbe7Bq8ICwieCrudBeYw==",
+      "version": "4.4.36",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-4.4.36.tgz",
+      "integrity": "sha512-+0zMGorGNjR/5lEB2t7sjVX0jWPVgmFkHTIezhAIQgJAj0upcxF3SuvnrpVjJKA3Ug6/0wZ+76eLPbpNz9CVzA==",
       "dependencies": {
-        "@blueprintjs/core": "^4.17.6",
+        "@blueprintjs/core": "^4.20.1",
         "classnames": "^2.3.1",
         "react-day-picker": "7.4.9",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.14.32 || 17",
+        "react": "^16.8 || 17",
+        "react-dom": "^16.8 || 17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@blueprintjs/datetime2": {
+      "version": "0.9.35",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime2/-/datetime2-0.9.35.tgz",
+      "integrity": "sha512-9vuhKtVj8GwtB3fx4xnzQWc1g4kH6NB3QqotDI1azJrzTOVVEqzYs+RVGwLw60/WAR2PD+L/WJkthRIS6/wKAw==",
+      "dependencies": {
+        "@blueprintjs/core": "^4.20.1",
+        "@blueprintjs/datetime": "^4.4.36",
+        "@blueprintjs/popover2": "^1.14.9",
+        "@blueprintjs/select": "^4.9.22",
+        "classnames": "^2.3.1",
+        "date-fns": "^2.28.0",
+        "date-fns-tz": "^1.3.7",
+        "lodash": "^4.17.21",
+        "tslib": "~2.5.0"
       },
       "peerDependencies": {
         "@types/react": "^16.14.32 || 17",
@@ -2447,27 +2476,27 @@
       }
     },
     "node_modules/@blueprintjs/icons": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.14.3.tgz",
-      "integrity": "sha512-2X5VXYCfybcax+tPVFl6WDngdxEk6AS7gflRjI9iuiJvkgjnkYeHBXZGRMhCzZb/B6+cBuMyvvAxmD2WVtlQsg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.16.0.tgz",
+      "integrity": "sha512-cyfgjUZcZCtQrXWUV8FwqYTFEzduV4a0N7yhOU38jY+cBRCLu/sDrD0Osvfk4DGRvNe4YjY7pohVLFSxpg68Uw==",
       "dependencies": {
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       }
     },
     "node_modules/@blueprintjs/popover2": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.13.10.tgz",
-      "integrity": "sha512-ohdO3F9MUZXDaBNYFi+xrlhDWl6GWg9/zl8VQTzhk5ny5kuGJsU7cPAeTGNyrXkR8PMRbTWKfFFc/R/H4qUo/g==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.14.9.tgz",
+      "integrity": "sha512-46gesoxeEbp1owKDGz7JwurXmVqSLq9ALes5etHqtjwdCpenBQc7GM+sFuJoLlEU7twcIlzwE6xaSU2+vnYVCQ==",
       "dependencies": {
-        "@blueprintjs/core": "^4.17.6",
+        "@blueprintjs/core": "^4.20.1",
         "@juggle/resize-observer": "^3.4.0",
-        "@popperjs/core": "^2.11.6",
+        "@popperjs/core": "^2.11.7",
         "classnames": "^2.3.1",
         "dom4": "^2.1.5",
         "react-popper": "^2.3.0",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       },
       "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -2492,6 +2521,27 @@
         "@popperjs/core": "^2.0.0",
         "react": "^16.8.0 || ^17 || ^18",
         "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@blueprintjs/select": {
+      "version": "4.9.22",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-4.9.22.tgz",
+      "integrity": "sha512-T5ofz571kPfycbxAuXlTrE7ndXIiHPCDMjADYJpb5HVOk0SYwwzDvnWjsYbyAj1SONbxOAKh4/wmFTDjZv7G2g==",
+      "dependencies": {
+        "@blueprintjs/core": "^4.20.1",
+        "@blueprintjs/popover2": "^1.14.9",
+        "classnames": "^2.3.1",
+        "tslib": "~2.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.14.32 || 17 || 18",
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -4263,9 +4313,9 @@
       "dev": true
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -7812,6 +7862,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/debug": {
@@ -16484,8 +16557,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -24230,9 +24302,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -27984,17 +28056,20 @@
       "dev": true
     },
     "@blueprintjs/colors": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.1.19.tgz",
-      "integrity": "sha512-x5mDo4Ue9rAdbMHvOm0dNru9MSZqgs9Dd/l/2rgjzottthjsq1XjkiVae6evX4EGNM0I/bZKjTT8ccvqCqn4yw=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/colors/-/colors-4.2.1.tgz",
+      "integrity": "sha512-Cx7J2YnUuxn+fi+y5XtXnBB7+cFHN4xBrRkaAetp78i3VTCXjUk+d1omrOr8TqbRucUXTdrhbZOUHpzRLFcJpQ==",
+      "requires": {
+        "tslib": "~2.5.0"
+      }
     },
     "@blueprintjs/core": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.17.6.tgz",
-      "integrity": "sha512-hZBIYfOUsgeeKeFeYCW6qcCTOxwA6EJTXJyjTv+QK34245Lms/rW4sKn+t8Z3z/b0AK5cTH0/S3a1umjshDhLA==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-4.20.1.tgz",
+      "integrity": "sha512-nKFXfWj8PQrkweLrCr6VazYd4JJHCwiAxcgT9zzoxbEs0mSJF4yI7Qjoh5QkomtWugXrVLCDSzs4uJdaO1reAA==",
       "requires": {
-        "@blueprintjs/colors": "^4.1.19",
-        "@blueprintjs/icons": "^4.14.3",
+        "@blueprintjs/colors": "^4.2.1",
+        "@blueprintjs/icons": "^4.16.0",
         "@juggle/resize-observer": "^3.4.0",
         "@types/dom4": "^2.0.2",
         "classnames": "^2.3.1",
@@ -28003,42 +28078,58 @@
         "popper.js": "^1.16.1",
         "react-popper": "^1.3.11",
         "react-transition-group": "^4.4.5",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       }
     },
     "@blueprintjs/datetime": {
-      "version": "4.4.25",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-4.4.25.tgz",
-      "integrity": "sha512-2Q818yMKqfUbU53fxh1XmkDLP9DMGDxe7t4LrrdKZBPM/m3qs2pyI5ficwDak1Rr9cHbe7Bq8ICwieCrudBeYw==",
+      "version": "4.4.36",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime/-/datetime-4.4.36.tgz",
+      "integrity": "sha512-+0zMGorGNjR/5lEB2t7sjVX0jWPVgmFkHTIezhAIQgJAj0upcxF3SuvnrpVjJKA3Ug6/0wZ+76eLPbpNz9CVzA==",
       "requires": {
-        "@blueprintjs/core": "^4.17.6",
+        "@blueprintjs/core": "^4.20.1",
         "classnames": "^2.3.1",
         "react-day-picker": "7.4.9",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
+      }
+    },
+    "@blueprintjs/datetime2": {
+      "version": "0.9.35",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/datetime2/-/datetime2-0.9.35.tgz",
+      "integrity": "sha512-9vuhKtVj8GwtB3fx4xnzQWc1g4kH6NB3QqotDI1azJrzTOVVEqzYs+RVGwLw60/WAR2PD+L/WJkthRIS6/wKAw==",
+      "requires": {
+        "@blueprintjs/core": "^4.20.1",
+        "@blueprintjs/datetime": "^4.4.36",
+        "@blueprintjs/popover2": "^1.14.9",
+        "@blueprintjs/select": "^4.9.22",
+        "classnames": "^2.3.1",
+        "date-fns": "^2.28.0",
+        "date-fns-tz": "^1.3.7",
+        "lodash": "^4.17.21",
+        "tslib": "~2.5.0"
       }
     },
     "@blueprintjs/icons": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.14.3.tgz",
-      "integrity": "sha512-2X5VXYCfybcax+tPVFl6WDngdxEk6AS7gflRjI9iuiJvkgjnkYeHBXZGRMhCzZb/B6+cBuMyvvAxmD2WVtlQsg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-4.16.0.tgz",
+      "integrity": "sha512-cyfgjUZcZCtQrXWUV8FwqYTFEzduV4a0N7yhOU38jY+cBRCLu/sDrD0Osvfk4DGRvNe4YjY7pohVLFSxpg68Uw==",
       "requires": {
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       }
     },
     "@blueprintjs/popover2": {
-      "version": "1.13.10",
-      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.13.10.tgz",
-      "integrity": "sha512-ohdO3F9MUZXDaBNYFi+xrlhDWl6GWg9/zl8VQTzhk5ny5kuGJsU7cPAeTGNyrXkR8PMRbTWKfFFc/R/H4qUo/g==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/popover2/-/popover2-1.14.9.tgz",
+      "integrity": "sha512-46gesoxeEbp1owKDGz7JwurXmVqSLq9ALes5etHqtjwdCpenBQc7GM+sFuJoLlEU7twcIlzwE6xaSU2+vnYVCQ==",
       "requires": {
-        "@blueprintjs/core": "^4.17.6",
+        "@blueprintjs/core": "^4.20.1",
         "@juggle/resize-observer": "^3.4.0",
-        "@popperjs/core": "^2.11.6",
+        "@popperjs/core": "^2.11.7",
         "classnames": "^2.3.1",
         "dom4": "^2.1.5",
         "react-popper": "^2.3.0",
-        "tslib": "~2.3.1"
+        "tslib": "~2.5.0"
       },
       "dependencies": {
         "react-popper": {
@@ -28050,6 +28141,17 @@
             "warning": "^4.0.2"
           }
         }
+      }
+    },
+    "@blueprintjs/select": {
+      "version": "4.9.22",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-4.9.22.tgz",
+      "integrity": "sha512-T5ofz571kPfycbxAuXlTrE7ndXIiHPCDMjADYJpb5HVOk0SYwwzDvnWjsYbyAj1SONbxOAKh4/wmFTDjZv7G2g==",
+      "requires": {
+        "@blueprintjs/core": "^4.20.1",
+        "@blueprintjs/popover2": "^1.14.9",
+        "classnames": "^2.3.1",
+        "tslib": "~2.5.0"
       }
     },
     "@bufbuild/protobuf": {
@@ -29434,9 +29536,9 @@
       "dev": true
     },
     "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.2",
@@ -32292,6 +32394,20 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "date-fns-tz": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+      "requires": {}
     },
     "debug": {
       "version": "3.1.0",
@@ -38981,8 +39097,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -44836,9 +44951,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -63,10 +63,10 @@
     "not ie 11"
   ],
   "dependencies": {
-    "@blueprintjs/core": "^4.17.6",
-    "@blueprintjs/datetime": "^4.4.25",
-    "@blueprintjs/icons": "^4.14.3",
-    "@blueprintjs/popover2": "^1.13.10",
+    "@blueprintjs/core": "^4.20.1",
+    "@blueprintjs/datetime2": "^0.9.35",
+    "@blueprintjs/icons": "^4.16.0",
+    "@blueprintjs/popover2": "^1.14.9",
     "ace-builds": "^1.4.13",
     "axios": "^0.26.1",
     "classnames": "^2.2.6",

--- a/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
+++ b/web-console/src/components/auto-form/__snapshots__/auto-form.spec.tsx.snap
@@ -34,6 +34,7 @@ exports[`AutoForm matches snapshot 1`] = `
       onValueChange={[Function]}
       selectAllOnFocus={false}
       selectAllOnIncrement={false}
+      small={false}
       stepSize={1000}
     />
   </Memo(FormGroupWithInfo)>

--- a/web-console/src/components/date-range-selector/date-range-selector.tsx
+++ b/web-console/src/components/date-range-selector/date-range-selector.tsx
@@ -16,15 +16,18 @@
  * limitations under the License.
  */
 
-import { Button, InputGroup, Popover, Position } from '@blueprintjs/core';
-import type { DateRange } from '@blueprintjs/datetime';
-import { DateRangePicker } from '@blueprintjs/datetime';
+import { Button, InputGroup, Position } from '@blueprintjs/core';
+import type { DateRange } from '@blueprintjs/datetime2';
+import { DateRangeInput2 } from '@blueprintjs/datetime2';
 import { IconNames } from '@blueprintjs/icons';
+import { Popover2 } from '@blueprintjs/popover2';
 import React, { useState } from 'react';
 
 import { dateToIsoDateString, localToUtcDate, utcToLocalDate } from '../../utils';
 
 import './date-range-selector.scss';
+
+const BASIC_DATE_PARSER = (str: string) => new Date(str);
 
 interface DateRangeSelectorProps {
   startDate: Date;
@@ -39,10 +42,12 @@ export const DateRangeSelector = React.memo(function DateRangeSelector(
   const [intermediateDateRange, setIntermediateDateRange] = useState<DateRange | undefined>();
 
   return (
-    <Popover
+    <Popover2
       className="date-range-selector"
       content={
-        <DateRangePicker
+        <DateRangeInput2
+          formatDate={dateToIsoDateString}
+          parseDate={BASIC_DATE_PARSER}
           value={intermediateDateRange || [utcToLocalDate(startDate), utcToLocalDate(endDate)]}
           contiguousCalendarMonths={false}
           reverseMonthAndYearMenus
@@ -64,6 +69,6 @@ export const DateRangeSelector = React.memo(function DateRangeSelector(
         readOnly
         rightElement={<Button rightIcon={IconNames.CALENDAR} minimal />}
       />
-    </Popover>
+    </Popover2>
   );
 });

--- a/web-console/src/components/interval-input/interval-input.tsx
+++ b/web-console/src/components/interval-input/interval-input.tsx
@@ -18,13 +18,19 @@
 
 import type { Intent } from '@blueprintjs/core';
 import { Button, InputGroup, Position } from '@blueprintjs/core';
-import type { DateRange } from '@blueprintjs/datetime';
-import { DateRangePicker, TimePrecision } from '@blueprintjs/datetime';
+import type { DateRange } from '@blueprintjs/datetime2';
+import { DateRangeInput2 } from '@blueprintjs/datetime2';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
 import React from 'react';
 
-import { intervalToLocalDateRange, localDateRangeToInterval } from '../../utils';
+import {
+  dateToIsoDateString,
+  intervalToLocalDateRange,
+  localDateRangeToInterval,
+} from '../../utils';
+
+const BASIC_DATE_PARSER = (str: string) => new Date(str);
 
 export interface IntervalInputProps {
   interval: string;
@@ -45,14 +51,16 @@ export const IntervalInput = React.memo(function IntervalInput(props: IntervalIn
           <Popover2
             popoverClassName="calendar"
             content={
-              <DateRangePicker
-                timePrecision={TimePrecision.SECOND}
+              <DateRangeInput2
+                timePrecision="second"
                 value={intervalToLocalDateRange(interval)}
                 contiguousCalendarMonths={false}
                 reverseMonthAndYearMenus
                 onChange={(selectedRange: DateRange) => {
                   onValueChange(localDateRangeToInterval(selectedRange));
                 }}
+                formatDate={dateToIsoDateString}
+                parseDate={BASIC_DATE_PARSER}
               />
             }
             position={Position.BOTTOM_RIGHT}

--- a/web-console/src/components/menu-tristate/__snapshots__/menu-tristate.spec.tsx.snap
+++ b/web-console/src/components/menu-tristate/__snapshots__/menu-tristate.spec.tsx.snap
@@ -11,12 +11,14 @@ exports[`MenuTristate matches snapshot false 1`] = `
     <span
       aria-haspopup="true"
       class="bp4-popover-target"
+      role="menuitem"
+      tabindex="0"
     >
       <a
         class="bp4-menu-item menu-tristate"
         label="false"
-        role="menuitem"
-        tabindex="0"
+        role="none"
+        tabindex="-1"
       >
         <div
           class="bp4-fill bp4-text-overflow-ellipsis"
@@ -63,12 +65,14 @@ exports[`MenuTristate matches snapshot undefined 1`] = `
     <span
       aria-haspopup="true"
       class="bp4-popover-target"
+      role="menuitem"
+      tabindex="0"
     >
       <a
         class="bp4-menu-item menu-tristate"
         label="auto (true)"
-        role="menuitem"
-        tabindex="0"
+        role="none"
+        tabindex="-1"
       >
         <div
           class="bp4-fill bp4-text-overflow-ellipsis"

--- a/web-console/src/components/numeric-input-with-default/__snapshots__/numeric-input-with-default.spec.tsx.snap
+++ b/web-console/src/components/numeric-input-with-default/__snapshots__/numeric-input-with-default.spec.tsx.snap
@@ -13,6 +13,7 @@ exports[`NumericInputWithDefault matches snapshot 1`] = `
   onValueChange={[Function]}
   selectAllOnFocus={false}
   selectAllOnIncrement={false}
+  small={false}
   stepSize={1}
   value={5}
 />

--- a/web-console/src/components/segment-timeline/__snapshots__/segment-timeline.spec.tsx.snap
+++ b/web-console/src/components/segment-timeline/__snapshots__/segment-timeline.spec.tsx.snap
@@ -146,51 +146,47 @@ exports[`SegmentTimeline matches snapshot 1`] = `
         class="bp4-form-content"
       >
         <span
-          class="bp4-popover-wrapper date-range-selector"
+          aria-haspopup="true"
+          class="date-range-selector bp4-popover2-target"
         >
-          <span
-            aria-haspopup="true"
-            class="bp4-popover-target"
+          <div
+            class="bp4-input-group bp4-read-only"
           >
-            <div
-              class="bp4-input-group bp4-read-only"
+            <input
+              class="bp4-input"
+              readonly=""
+              style="padding-right: 0px;"
+              type="text"
+              value="2021-03-09 ➔ 2021-06-09"
+            />
+            <span
+              class="bp4-input-action"
             >
-              <input
-                class="bp4-input"
-                readonly=""
-                style="padding-right: 0px;"
-                type="text"
-                value="2021-03-09 ➔ 2021-06-09"
-              />
-              <span
-                class="bp4-input-action"
+              <button
+                class="bp4-button bp4-minimal"
+                type="button"
               >
-                <button
-                  class="bp4-button bp4-minimal"
-                  type="button"
+                <span
+                  aria-hidden="true"
+                  class="bp4-icon bp4-icon-calendar"
+                  icon="calendar"
                 >
-                  <span
-                    aria-hidden="true"
-                    class="bp4-icon bp4-icon-calendar"
-                    icon="calendar"
+                  <svg
+                    data-icon="calendar"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
                   >
-                    <svg
-                      data-icon="calendar"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                    >
-                      <path
-                        d="M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </span>
-            </div>
-          </span>
+                    <path
+                      d="M11 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1s-1 .4-1 1v1c0 .5.4 1 1 1zm3-2h-1v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H6v1c0 1.1-.9 2-2 2s-2-.9-2-2V1H1c-.6 0-1 .5-1 1v12c0 .6.4 1 1 1h13c.6 0 1-.4 1-1V2c0-.6-.5-1-1-1zM5 13H2v-3h3v3zm0-4H2V6h3v3zm4 4H6v-3h3v3zm0-4H6V6h3v3zm4 4h-3v-3h3v3zm0-4h-3V6h3v3zM4 3c.6 0 1-.5 1-1V1c0-.6-.4-1-1-1S3 .4 3 1v1c0 .5.4 1 1 1z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </span>
+          </div>
         </span>
       </div>
     </div>

--- a/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
+++ b/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
@@ -63,11 +63,13 @@ exports[`SuggestionMenu matches snapshot 1`] = `
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <div
             class="bp4-fill bp4-text-overflow-ellipsis"

--- a/web-console/src/entry.scss
+++ b/web-console/src/entry.scss
@@ -22,6 +22,7 @@
 @import '@blueprintjs/core/src/blueprint';
 @import '@blueprintjs/datetime/src/blueprint-datetime';
 @import '@blueprintjs/popover2/src/blueprint-popover2';
+@import '@blueprintjs/select/src/blueprint-select';
 @import 'react-splitter-layout/lib/index';
 @import './react-table/react-table-base-styles';
 @import './react-table/react-table-extra';

--- a/web-console/src/utils/date.ts
+++ b/web-console/src/utils/date.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import type { DateRange } from '@blueprintjs/datetime';
+import type { DateRange } from '@blueprintjs/datetime2';
 
 const CURRENT_YEAR = new Date().getUTCFullYear();
 

--- a/web-console/src/views/workbench-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/column-tree/column-tree-menu/number-menu-items/__snapshots__/number-menu-items.spec.tsx.snap
@@ -12,11 +12,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -78,11 +80,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -183,11 +187,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -254,11 +260,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -320,11 +328,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -386,11 +396,13 @@ exports[`NumberMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"

--- a/web-console/src/views/workbench-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/column-tree/column-tree-menu/string-menu-items/__snapshots__/string-menu-items.spec.tsx.snap
@@ -12,11 +12,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -78,11 +80,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -183,11 +187,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column inside 
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -254,11 +260,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -320,11 +328,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -386,11 +396,13 @@ exports[`StringMenuItems matches snapshot when menu is opened for column not ins
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"

--- a/web-console/src/views/workbench-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/column-tree/column-tree-menu/time-menu-items/__snapshots__/time-menu-items.spec.tsx.snap
@@ -12,11 +12,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column inside gr
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -78,11 +80,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column inside gr
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -183,11 +187,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column inside gr
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -254,11 +260,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column not insid
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -320,11 +328,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column not insid
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"
@@ -386,11 +396,13 @@ exports[`TimeMenuItems matches snapshot when menu is opened for column not insid
       <span
         aria-haspopup="true"
         class="bp4-popover-target"
+        role="menuitem"
+        tabindex="0"
       >
         <a
           class="bp4-menu-item"
-          role="menuitem"
-          tabindex="0"
+          role="none"
+          tabindex="-1"
         >
           <span
             class="bp4-menu-item-icon"


### PR DESCRIPTION
### Description

Pre-requisite for upgrading to React 18. This switches to the `@blueprint/datetime2` package for date inputs.

It seems like `formatDate` and `parseDate` are required props on DateRangeInput2, though it doesn't appear that they're actually being used.

This PR has:

- [x] been self-reviewed.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] been tested in a test Druid cluster.
