### PR TITLE
Prevent coordinator from getting stuck if leadership changes during coordinator run

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class CostBalancerStrategy implements BalancerStrategy
@@ -226,7 +227,7 @@ public class CostBalancerStrategy implements BalancerStrategy
 
     try {
       // results is an un-ordered list of a pair consisting of the 'cost' of a segment being on a server and the server
-      List<Pair<Double, ServerHolder>> results = resultsFuture.get();
+      List<Pair<Double, ServerHolder>> results = resultsFuture.get(5, TimeUnit.MINUTES);
       return results.stream()
                     // Comparator.comapringDouble will order by lowest cost...
                     // reverse it because we want to drop from the highest cost servers first
@@ -373,7 +374,7 @@ public class CostBalancerStrategy implements BalancerStrategy
     final List<Pair<Double, ServerHolder>> bestServers = new ArrayList<>();
     bestServers.add(bestServer);
     try {
-      for (Pair<Double, ServerHolder> server : resultsFuture.get()) {
+      for (Pair<Double, ServerHolder> server : resultsFuture.get(5, TimeUnit.MINUTES)) {
         if (server.lhs <= bestServers.get(0).lhs) {
           if (server.lhs < bestServers.get(0).lhs) {
             bestServers.clear();

--- a/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CostBalancerStrategy.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.commons.math3.util.FastMath;
 import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.NavigableSet;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 public class CostBalancerStrategy implements BalancerStrategy
@@ -227,7 +229,7 @@ public class CostBalancerStrategy implements BalancerStrategy
 
     try {
       // results is an un-ordered list of a pair consisting of the 'cost' of a segment being on a server and the server
-      List<Pair<Double, ServerHolder>> results = resultsFuture.get(5, TimeUnit.MINUTES);
+      List<Pair<Double, ServerHolder>> results = resultsFuture.get(1, TimeUnit.MINUTES);
       return results.stream()
                     // Comparator.comapringDouble will order by lowest cost...
                     // reverse it because we want to drop from the highest cost servers first
@@ -236,7 +238,7 @@ public class CostBalancerStrategy implements BalancerStrategy
                     .iterator();
     }
     catch (Exception e) {
-      log.makeAlert(e, "Cost Balancer Multithread strategy wasn't able to complete cost computation.").emit();
+      alertOnFailure(e, "pick drop server");
     }
     return Collections.emptyIterator();
   }
@@ -299,10 +301,7 @@ public class CostBalancerStrategy implements BalancerStrategy
 
     log.info(
         "[%s]: Initial Total Cost: [%f], Normalization: [%f], Initial Normalized Cost: [%f]",
-        tier,
-        initialTotalCost,
-        normalization,
-        normalizedInitialCost
+        tier, initialTotalCost, normalization, normalizedInitialCost
     );
   }
 
@@ -374,7 +373,7 @@ public class CostBalancerStrategy implements BalancerStrategy
     final List<Pair<Double, ServerHolder>> bestServers = new ArrayList<>();
     bestServers.add(bestServer);
     try {
-      for (Pair<Double, ServerHolder> server : resultsFuture.get(5, TimeUnit.MINUTES)) {
+      for (Pair<Double, ServerHolder> server : resultsFuture.get(1, TimeUnit.MINUTES)) {
         if (server.lhs <= bestServers.get(0).lhs) {
           if (server.lhs < bestServers.get(0).lhs) {
             bestServers.clear();
@@ -391,9 +390,28 @@ public class CostBalancerStrategy implements BalancerStrategy
       bestServer = bestServers.get(ThreadLocalRandom.current().nextInt(bestServers.size()));
     }
     catch (Exception e) {
-      log.makeAlert(e, "Cost Balancer Multithread strategy wasn't able to complete cost computation.").emit();
+      alertOnFailure(e, "choose best load server");
     }
     return bestServer;
   }
+
+  private void alertOnFailure(Exception e, String action)
+  {
+    // Do not alert if the executor has been shutdown
+    if (exec.isShutdown()) {
+      log.noStackTrace().info("Balancer executor was terminated. Failing action [%s].", action);
+      return;
+    }
+
+    final boolean hasTimedOut = e instanceof TimeoutException;
+
+    final String message = StringUtils.format(
+        "Cost balancer strategy %s in action [%s].%s",
+        hasTimedOut ? "timed out" : "failed", action,
+        hasTimedOut ? " Try setting a higher value of 'balancerComputeThreads'." : ""
+    );
+    log.makeAlert(e, message).emit();
+  }
+
 }
 


### PR DESCRIPTION
### Description

If the current leader coordinator is asked to stop being leader, the following happens:
- The `DruidCoordinator.balancerExec` (used for strategy cost computations) is shutdown
- The currently running duty finishes execution normally and no more duties are executed
- An exception to this is the `BalanceSegments` duty, which can exit abnormally or even get stuck in the race conditions explained below.

#### ✅ Case 1: `balancerExec.submit()` after `balancerExec.shutdown()`, `BalanceSegments` exits abnormally

Typical sequence of events:
- Current coordinator stops being leader and `balancerExec` is shutdown
- `CostBalancerStrategy.findNewSegmentHomeBalancer()` or any other strategy method is invoked
- `balancerExec.submit()` is invoked with `computeCost()` tasks
- Since the executor has already been shutdown, submission of new tasks throws a `RejectedExecutionException` and ends the coordinator run as desired

#### ❌ Case 2: `balancerExec.submit()` before `balancerExec.shutdown()`, `BalanceSegments` gets stuck

Typical sequence of events:
- `BalanceSegments` duty is in progress
- `CostBalancerStrategy.findNewSegmentHomeBalancer()` is invoked for some segment
- `computeCost()` tasks for, say 5 servers, are submitted to the executor
- Executor picks up 3 of these tasks and starts executing them
- Coordinator stops being leader and `balancerExec` is shutdown
- Since the `computeCost()` tasks do not handle interrupts, the 3 picked up tasks finish execution normally
- But the 2 remaining tasks are never picked up by the executor as it is already shutdown
- The method `findNewSegmentHomeBalancer` waits indefinitely for the futures to finish

#### ✅ Case 3: Change in `balancerComputeThreads` dynamic config

A change in this config also results in a shutdown of the `balancerExec`. But this shutdown is never done concurrently with the coordinator duties and thus doesn't cause the coordinator to get stuck.

### Changes
- Add a timeout of 1 minute to the `resultFuture.get()`. 1 minute is the typical time for a full coordinator run and is more than enough time for cost computations of a single segment.
- Raise an alert if an exception is encountered while computing costs and if the executor has not been shutdown. This is because a shutdown is intentional and does not require an alert.
