### PR TITLE
Add NullHandling module initialization for `LookupDimensionSpecTest`

### DIFF
--- a/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
+++ b/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
@@ -54,6 +54,7 @@ public class LookupDimensionSpecTest
       EasyMock.createMock(LookupExtractorFactoryContainerProvider.class);
 
   static {
+    NullHandling.initializeForTests();
     EasyMock
         .expect(LOOKUP_REF_MANAGER.get(EasyMock.eq("lookupName")))
         .andReturn(

--- a/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
+++ b/server/src/test/java/org/apache/druid/query/dimension/LookupDimensionSpecTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.MapLookupExtractorFactory;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,7 +46,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @RunWith(JUnitParamsRunner.class)
-public class LookupDimensionSpecTest
+public class LookupDimensionSpecTest extends InitializedNullHandlingTest
 {
   private static final Map<String, String> STRING_MAP = ImmutableMap.of("key", "value", "key2", "value2");
   private static LookupExtractor MAP_LOOKUP_EXTRACTOR = new MapLookupExtractor(STRING_MAP, true);
@@ -54,7 +55,6 @@ public class LookupDimensionSpecTest
       EasyMock.createMock(LookupExtractorFactoryContainerProvider.class);
 
   static {
-    NullHandling.initializeForTests();
     EasyMock
         .expect(LOOKUP_REF_MANAGER.get(EasyMock.eq("lookupName")))
         .andReturn(


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/14392.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
