### PR TITLE
Add 'Flaky test' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,10 @@
+---
+name: Flaky Test
+about: A template for Druid CI flaky test reports
+title: "Flaky Test: test name"
+labels: Flaky Test
+assignees: ''
+
+---
+
+Please replace 'test name' in the title with the actual test name. Also include a link to a failing test run, along with any investigation you might have done to triage the issue.

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -7,4 +7,4 @@ assignees: ''
 
 ---
 
-Please replace 'test name' in the title with the actual test name. Also include a link to a failing test run, along with any investigation you might have done to triage the issue.
+Please replace 'test name' in the title with the actual test name. Also include a stack trace as well as link to a failing test run, along with any investigation you might have done to triage the issue.


### PR DESCRIPTION
Streamline flaky test reporting to automatically assign the label and provide light instructions