### PR TITLE
Reset `RuntimeInfo` to fix flaky test `ParametrizedUriEmitterConfigTest`.

### DIFF
--- a/processing/src/main/java/org/apache/druid/utils/JvmUtils.java
+++ b/processing/src/main/java/org/apache/druid/utils/JvmUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 
@@ -144,6 +145,7 @@ public class JvmUtils
   /**
    * Only for testing.
    */
+  @VisibleForTesting
   public static void resetTestsToDefaultRuntimeInfo()
   {
     RUNTIME_INFO = new RuntimeInfo();

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterConfigTest.java
@@ -68,7 +68,7 @@ public class ParametrizedUriEmitterConfigTest
     final HttpEmitterConfig config = injector.getInstance(HttpEmitterConfig.class);
 
     Pair<Integer, Integer> batchConfigPair = BaseHttpEmittingConfig.getDefaultBatchSizeAndLimit(
-         JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes()
+        JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes()
     );
     Assert.assertEquals(batchConfigPair.lhs.intValue(), config.getMaxBatchSize());
     Assert.assertEquals(batchConfigPair.rhs.intValue(), config.getBatchQueueSizeLimit());

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterConfigTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterConfigTest.java
@@ -20,8 +20,12 @@
 package org.apache.druid.java.util.emitter.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.utils.JvmUtils;
+import org.apache.druid.utils.RuntimeInfo;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,22 +33,42 @@ import java.util.Properties;
 
 public class ParametrizedUriEmitterConfigTest
 {
+  /**
+   * The JVM RuntimeInfo is static, and the default settings that depend on it such
+   * as {@link BaseHttpEmittingConfig#DEFAULT_BATCH_QUEUE_SIZE_LIMIT} are static as well. So bind the runtime info
+   * for this test, so it doesn't get pawned by other tests setting the runtime to different values.
+   */
+  private static Injector makeInjector(Properties props)
+  {
+    return Guice.createInjector(
+        binder -> {
+          JvmUtils.resetTestsToDefaultRuntimeInfo();
+          binder.bind(RuntimeInfo.class)
+                .toInstance(JvmUtils.getRuntimeInfo());
+          binder.requestStaticInjection(JvmUtils.class);
+
+          final ParametrizedUriEmitterConfig paramConfig = new ObjectMapper().convertValue(
+              Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);
+          final HttpEmitterConfig httpEmitterConfig = paramConfig.buildHttpEmitterConfig("http://example.com/topic");
+          binder.bind(HttpEmitterConfig.class).toInstance(httpEmitterConfig);
+        }
+    );
+  }
+
+  @AfterClass
+  public static void teardown()
+  {
+    JvmUtils.resetTestsToDefaultRuntimeInfo();
+  }
+
   @Test
   public void testDefaults()
   {
-    final Properties props = new Properties();
+    final Injector injector = makeInjector(new Properties());
+    final HttpEmitterConfig config = injector.getInstance(HttpEmitterConfig.class);
 
-    final ObjectMapper objectMapper = new ObjectMapper();
-    final ParametrizedUriEmitterConfig paramConfig = objectMapper.convertValue(Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);
-    final HttpEmitterConfig config = paramConfig.buildHttpEmitterConfig("http://example.com/topic");
-
-    Assert.assertEquals(60000, config.getFlushMillis());
-    Assert.assertEquals(500, config.getFlushCount());
-    Assert.assertEquals("http://example.com/topic", config.getRecipientBaseUrl());
-    Assert.assertNull(config.getBasicAuthentication());
-    Assert.assertEquals(BatchingStrategy.ARRAY, config.getBatchingStrategy());
     Pair<Integer, Integer> batchConfigPair = BaseHttpEmittingConfig.getDefaultBatchSizeAndLimit(
-        JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes()
+         JvmUtils.getRuntimeInfo().getMaxHeapSizeBytes()
     );
     Assert.assertEquals(batchConfigPair.lhs.intValue(), config.getMaxBatchSize());
     Assert.assertEquals(batchConfigPair.rhs.intValue(), config.getBatchQueueSizeLimit());
@@ -62,9 +86,8 @@ public class ParametrizedUriEmitterConfigTest
     props.setProperty("org.apache.druid.java.util.emitter.httpEmitting.maxBatchSize", "4");
     props.setProperty("org.apache.druid.java.util.emitter.httpEmitting.flushTimeOut", "1000");
 
-    final ObjectMapper objectMapper = new ObjectMapper();
-    final ParametrizedUriEmitterConfig paramConfig = objectMapper.convertValue(Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);
-    final HttpEmitterConfig config = paramConfig.buildHttpEmitterConfig("http://example.com/topic");
+    final Injector injector = makeInjector(props);
+    final HttpEmitterConfig config = injector.getInstance(HttpEmitterConfig.class);
 
     Assert.assertEquals(1, config.getFlushMillis());
     Assert.assertEquals(2, config.getFlushCount());


### PR DESCRIPTION
This change should fix https://github.com/apache/druid/issues/14373.

`RuntimeInfo` can statically be injected from other tests via mocks. It's unclear what test is leaving the runtime info in a dirty state - I went through a few that statically inject `RuntimeInfo` mock (for example, `DruidProcessingConfigTest`)  and couldn't spot something obvious. Regardless, I think it's OK to for a test start with a clean state until we find all the bad candidates. An alternative to what's being done in this PR could be to use static mocks, but resetting any shared mocked state from other test runs is cleaner, IMO. Also, add `@VisibleForTesting` method annotation to the test-only method.


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
