### PR TITLE
fix kafka input format reader schema discovery and partial schema discovery

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -58,30 +58,36 @@ public class KafkaInputFormatTest
 {
   private KafkaRecordEntity inputEntity;
   private long timestamp = DateTimes.of("2021-06-24").getMillis();
-  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header() {
-      @Override
-      public String key()
+  private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(
+      new Header()
       {
-        return "encoding";
-      }
-      @Override
-      public byte[] value()
+        @Override
+        public String key()
+        {
+          return "encoding";
+        }
+
+        @Override
+        public byte[] value()
+        {
+          return "application/json".getBytes(StandardCharsets.UTF_8);
+        }
+      },
+      new Header()
       {
-        return "application/json".getBytes(StandardCharsets.UTF_8);
+        @Override
+        public String key()
+        {
+          return "kafkapkc";
+        }
+
+        @Override
+        public byte[] value()
+        {
+          return "pkc-bar".getBytes(StandardCharsets.UTF_8);
+        }
       }
-    },
-      new Header() {
-      @Override
-      public String key()
-      {
-        return "kafkapkc";
-      }
-      @Override
-      public byte[] value()
-      {
-        return "pkc-bar".getBytes(StandardCharsets.UTF_8);
-      }
-    });
+  );
   private KafkaInputFormat format;
 
   @Before
@@ -92,8 +98,11 @@ public class KafkaInputFormatTest
         // Key Format
         new JsonInputFormat(
             new JSONPathSpec(true, ImmutableList.of()),
-            null, null, false, //make sure JsonReader is used
-            false, false
+            null,
+            null,
+            false, //make sure JsonReader is used
+            false,
+            false
         ),
         // Value Format
         new JsonInputFormat(
@@ -108,10 +117,15 @@ public class KafkaInputFormatTest
                     new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
                 )
             ),
-            null, null, false, //make sure JsonReader is used
-            false, false
+            null,
+            null,
+            false, //make sure JsonReader is used
+            false,
+            false
         ),
-        "kafka.newheader.", "kafka.newkey.key", "kafka.newts.timestamp"
+        "kafka.newheader.",
+        "kafka.newkey.key",
+        "kafka.newts.timestamp"
     );
   }
 
@@ -124,8 +138,11 @@ public class KafkaInputFormatTest
         // Key Format
         new JsonInputFormat(
             new JSONPathSpec(true, ImmutableList.of()),
-            null, null, false, //make sure JsonReader is used
-            false, false
+            null,
+            null,
+            false, //make sure JsonReader is used
+            false,
+            false
         ),
         // Value Format
         new JsonInputFormat(
@@ -140,10 +157,15 @@ public class KafkaInputFormatTest
                     new JSONPathFieldSpec(JSONPathFieldType.JQ, "jq_omg2", ".o.mg2")
                 )
             ),
-            null, null, false, //make sure JsonReader is used
-            false, false
+            null,
+            null,
+            false, //make sure JsonReader is used
+            false,
+            false
         ),
-        "kafka.newheader.", "kafka.newkey.key", "kafka.newts.timestamp"
+        "kafka.newheader.",
+        "kafka.newkey.key",
+        "kafka.newts.timestamp"
     );
     Assert.assertEquals(format, kif);
 
@@ -158,7 +180,8 @@ public class KafkaInputFormatTest
     final byte[] key = StringUtils.toUtf8(
         "{\n"
         + "    \"key\": \"sampleKey\"\n"
-        + "}");
+        + "}"
+    );
 
     final byte[] payload = StringUtils.toUtf8(
         "{\n"
@@ -169,23 +192,40 @@ public class KafkaInputFormatTest
         + "    \"o\": {\n"
         + "        \"mg\": 1\n"
         + "    }\n"
-        + "}");
+        + "}"
+    );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
-        "sample", 0, 0, timestamp,
-        null, null, 0, 0,
-        key, payload, headers));
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers
+        )
+    );
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newheader.encoding",
-                "kafka.newheader.kafkapkc",
-                "kafka.newts.timestamp"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newheader.encoding",
+                        "kafka.newheader.kafkapkc",
+                        "kafka.newts.timestamp"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         newSettableByteEntity(inputEntity),
@@ -198,8 +238,20 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-
+        Assert.assertEquals(
+            Arrays.asList(
+                "bar",
+                "foo",
+                "kafka.newheader.encoding",
+                "kafka.newheader.kafkapkc",
+                "kafka.newts.timestamp"
+            ),
+            row.getDimensions()
+        );
         // Payload verifications
+        // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
+        // but test reading them anyway since it isn't technically illegal
+        
         Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
@@ -211,10 +263,14 @@ public class KafkaInputFormatTest
         // Header verification
         Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
         Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
-        Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
-                            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
-        Assert.assertEquals("2021-06-25",
-                            Iterables.getOnlyElement(row.getDimension("timestamp")));
+        Assert.assertEquals(
+            String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            "2021-06-25",
+            Iterables.getOnlyElement(row.getDimension("timestamp"))
+        );
 
         // Key verification
         Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
@@ -246,20 +302,36 @@ public class KafkaInputFormatTest
         + "}");
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
-        "sample", 0, 0, timestamp,
-        null, null, 0, 0,
-        null, payload, headers));
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            null,
+            payload,
+            headers
+        )
+    );
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newheader.encoding",
-                "kafka.newheader.kafkapkc",
-                "kafka.newts.timestamp"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newheader.encoding",
+                        "kafka.newheader.kafkapkc",
+                        "kafka.newts.timestamp"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         newSettableByteEntity(inputEntity),
@@ -289,23 +361,28 @@ public class KafkaInputFormatTest
     Iterable<Header> sample_header_with_ts = Iterables.unmodifiableIterable(
         Iterables.concat(
             SAMPLE_HEADERS,
-            ImmutableList.of(new Header() {
-              @Override
-              public String key()
-              {
-                return "headerTs";
-              }
-              @Override
-              public byte[] value()
-              {
-                return "2021-06-24".getBytes(StandardCharsets.UTF_8);
-              }
-            }
-    )));
+            ImmutableList.of(
+                new Header()
+                {
+                  @Override
+                  public String key()
+                  {
+                    return "headerTs";
+                  }
+
+                  @Override
+                  public byte[] value()
+                  {
+                    return "2021-06-24".getBytes(StandardCharsets.UTF_8);
+                  }
+                }
+            )
+        ));
     final byte[] key = StringUtils.toUtf8(
         "{\n"
         + "    \"key\": \"sampleKey\"\n"
-        + "}");
+        + "}"
+    );
 
     final byte[] payload = StringUtils.toUtf8(
         "{\n"
@@ -316,22 +393,39 @@ public class KafkaInputFormatTest
         + "    \"o\": {\n"
         + "        \"mg\": 1\n"
         + "    }\n"
-        + "}");
+        + "}"
+    );
 
     Headers headers = new RecordHeaders(sample_header_with_ts);
-    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
-        "sample", 0, 0, timestamp,
-        null, null, 0, 0,
-        key, payload, headers));
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers
+        )
+    );
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
             new TimestampSpec("kafka.newheader.headerTs", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newheader.encoding",
-                "kafka.newheader.kafkapkc"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newheader.encoding",
+                        "kafka.newheader.kafkapkc"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         newSettableByteEntity(inputEntity),
@@ -345,6 +439,9 @@ public class KafkaInputFormatTest
 
         final InputRow row = iterator.next();
         // Payload verifications
+        // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
+        // but test reading them anyway since it isn't technically illegal
+
         Assert.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
@@ -356,12 +453,18 @@ public class KafkaInputFormatTest
         // Header verification
         Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
         Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
-        Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
-                            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
-        Assert.assertEquals("2021-06-24",
-                            Iterables.getOnlyElement(row.getDimension("kafka.newheader.headerTs")));
-        Assert.assertEquals("2021-06-24",
-                            Iterables.getOnlyElement(row.getDimension("timestamp")));
+        Assert.assertEquals(
+            String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            "2021-06-24",
+            Iterables.getOnlyElement(row.getDimension("kafka.newheader.headerTs"))
+        );
+        Assert.assertEquals(
+            "2021-06-24",
+            Iterables.getOnlyElement(row.getDimension("timestamp"))
+        );
 
         // Key verification
         Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
@@ -389,13 +492,25 @@ public class KafkaInputFormatTest
         + "    \"o\": {\n"
         + "        \"mg\": 1\n"
         + "    }\n"
-        + "}");
+        + "}"
+    );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(new ConsumerRecord<byte[], byte[]>(
-        "sample", 0, 0, timestamp,
-        null, null, 0, 0,
-        null, payload, headers));
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            null,
+            payload,
+            headers
+        )
+    );
 
     KafkaInputFormat localFormat = new KafkaInputFormat(
         null,
@@ -422,10 +537,15 @@ public class KafkaInputFormatTest
     final InputEntityReader reader = localFormat.createReader(
         new InputRowSchema(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newts.timestamp"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newts.timestamp"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         newSettableByteEntity(inputEntity),
@@ -440,6 +560,8 @@ public class KafkaInputFormatTest
         final InputRow row = iterator.next();
 
         // Key verification
+        // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
+        // but test reading them anyway since it isn't technically illegal
         Assert.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
         Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
         Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
@@ -464,23 +586,25 @@ public class KafkaInputFormatTest
     for (int i = 0; i < keys.length; i++) {
       keys[i] = StringUtils.toUtf8(
           "{\n"
-              + "    \"key\": \"sampleKey-" + i + "\"\n"
-              + "}");
+          + "    \"key\": \"sampleKey-" + i + "\"\n"
+          + "}"
+      );
     }
     keys[2] = null;
 
     for (int i = 0; i < values.length; i++) {
       values[i] = StringUtils.toUtf8(
           "{\n"
-              + "    \"timestamp\": \"2021-06-2" + i + "\",\n"
-              + "    \"bar\": null,\n"
-              + "    \"foo\": \"x\",\n"
-              + "    \"baz\": 4,\n"
-              + "    \"index\": " + i + ",\n"
-              + "    \"o\": {\n"
-              + "        \"mg\": 1\n"
-              + "    }\n"
-              + "}");
+          + "    \"timestamp\": \"2021-06-2" + i + "\",\n"
+          + "    \"bar\": null,\n"
+          + "    \"foo\": \"x\",\n"
+          + "    \"baz\": 4,\n"
+          + "    \"index\": " + i + ",\n"
+          + "    \"o\": {\n"
+          + "        \"mg\": 1\n"
+          + "    }\n"
+          + "}"
+      );
     }
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
@@ -489,12 +613,17 @@ public class KafkaInputFormatTest
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
             new TimestampSpec("timestamp", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newheader.encoding",
-                "kafka.newheader.kafkapkc",
-                "kafka.newts.timestamp"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newheader.encoding",
+                        "kafka.newheader.kafkapkc",
+                        "kafka.newts.timestamp"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         settableByteEntity,
@@ -504,10 +633,21 @@ public class KafkaInputFormatTest
     for (int i = 0; i < keys.length; i++) {
       headers = headers.add(new RecordHeader("indexH", String.valueOf(i).getBytes(StandardCharsets.UTF_8)));
 
-      inputEntity = new KafkaRecordEntity(new ConsumerRecord<>(
-          "sample", 0, 0, timestamp,
-          null, null, 0, 0,
-          keys[i], values[i], headers));
+      inputEntity = new KafkaRecordEntity(
+          new ConsumerRecord<>(
+              "sample",
+              0,
+              0,
+              timestamp,
+              null,
+              null,
+              0,
+              0,
+              keys[i],
+              values[i],
+              headers
+          )
+      );
       settableByteEntity.setEntity(inputEntity);
 
       final int numExpectedIterations = 1;
@@ -518,6 +658,8 @@ public class KafkaInputFormatTest
           final InputRow row = iterator.next();
 
           // Payload verification
+          // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
+          // but test reading them anyway since it isn't technically illegal
           Assert.assertEquals(DateTimes.of("2021-06-2" + i), row.getTimestamp());
           Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
           Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
@@ -529,10 +671,15 @@ public class KafkaInputFormatTest
 
 
           // Header verification
-          Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+          Assert.assertEquals(
+              "application/json",
+              Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding"))
+          );
           Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
-          Assert.assertEquals(String.valueOf(DateTimes.of("2021-06-24").getMillis()),
-              Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp")));
+          Assert.assertEquals(
+              String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+              Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+          );
           Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("kafka.newheader.indexH")));
 
 
@@ -561,7 +708,8 @@ public class KafkaInputFormatTest
     final byte[] key = StringUtils.toUtf8(
         "{\n"
         + "    \"key\": \"sampleKey\"\n"
-        + "}");
+        + "}"
+    );
 
     final byte[] payload = StringUtils.toUtf8(
         "{\n"
@@ -572,34 +720,40 @@ public class KafkaInputFormatTest
         + "    \"o\": {\n"
         + "        \"mg\": 1\n"
         + "    }\n"
-        + "}");
+        + "}"
+    );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
     inputEntity = new KafkaRecordEntity(
         new ConsumerRecord<>(
-        "sample",
-        0,
-        0,
-        timestamp,
-        null,
-        null,
-        0,
-        0,
-        key,
-        payload,
-        headers
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers
         )
     );
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
             new TimestampSpec("time", "iso", null),
-            new DimensionsSpec(DimensionsSpec.getDefaultSchemas(ImmutableList.of(
-                "bar", "foo",
-                "kafka.newheader.encoding",
-                "kafka.newheader.kafkapkc",
-                "kafka.newts.timestamp"
-            ))),
+            new DimensionsSpec(
+                DimensionsSpec.getDefaultSchemas(
+                    ImmutableList.of(
+                        "bar",
+                        "foo",
+                        "kafka.newheader.encoding",
+                        "kafka.newheader.kafkapkc",
+                        "kafka.newts.timestamp"
+                    )
+                )
+            ),
             ColumnsFilter.all()
         ),
         newSettableByteEntity(inputEntity),
@@ -616,6 +770,230 @@ public class KafkaInputFormatTest
       }
     }
   }
+
+  @Test
+  public void testWithSchemaDiscovery() throws IOException
+  {
+    // testWithHeaderKeyAndValue + schemaless
+    final byte[] key = StringUtils.toUtf8(
+        "{\n"
+        + "    \"key\": \"sampleKey\"\n"
+        + "}"
+    );
+
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2021-06-25\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}"
+    );
+
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers
+        )
+    );
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("timestamp", "iso", null),
+            DimensionsSpec.builder().useSchemaDiscovery(true).build(),
+            ColumnsFilter.all()
+        ),
+        newSettableByteEntity(inputEntity),
+        null
+    );
+
+    final int numExpectedIterations = 1;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+        Assert.assertEquals(
+            Arrays.asList(
+                "foo",
+                "kafka.newts.timestamp",
+                "kafka.newkey.key",
+                "root_baz",
+                "o",
+                "bar",
+                "kafka.newheader.kafkapkc",
+                "path_omg",
+                "jq_omg",
+                "jq_omg2",
+                "baz",
+                "root_baz2",
+                "kafka.newheader.encoding",
+                "path_omg2"
+            ),
+            row.getDimensions()
+        );
+
+        // Payload verifications
+        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+
+        // Header verification
+        Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+        Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+        Assert.assertEquals(
+            String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            "2021-06-25",
+            Iterables.getOnlyElement(row.getDimension("timestamp"))
+        );
+
+        // Key verification
+        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+
+        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+
+        numActualIterations++;
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+  }
+
+  @Test
+  public void testWithPartialDeclarationSchemaDiscovery() throws IOException
+  {
+    // testWithHeaderKeyAndValue + partial-schema + schema discovery
+    final byte[] key = StringUtils.toUtf8(
+        "{\n"
+        + "    \"key\": \"sampleKey\"\n"
+        + "}"
+    );
+
+    final byte[] payload = StringUtils.toUtf8(
+        "{\n"
+        + "    \"timestamp\": \"2021-06-25\",\n"
+        + "    \"bar\": null,\n"
+        + "    \"foo\": \"x\",\n"
+        + "    \"baz\": 4,\n"
+        + "    \"o\": {\n"
+        + "        \"mg\": 1\n"
+        + "    }\n"
+        + "}"
+    );
+
+    Headers headers = new RecordHeaders(SAMPLE_HEADERS);
+    inputEntity = new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers
+        )
+    );
+
+    final InputEntityReader reader = format.createReader(
+        new InputRowSchema(
+            new TimestampSpec("timestamp", "iso", null),
+            DimensionsSpec.builder().setDimensions(
+                DimensionsSpec.getDefaultSchemas(ImmutableList.of("bar", "kafka.newheader.kafkapkc"))
+            ).useSchemaDiscovery(true).build(),
+            ColumnsFilter.all()
+        ),
+        newSettableByteEntity(inputEntity),
+        null
+    );
+
+    final int numExpectedIterations = 1;
+    try (CloseableIterator<InputRow> iterator = reader.read()) {
+      int numActualIterations = 0;
+      while (iterator.hasNext()) {
+
+        final InputRow row = iterator.next();
+
+        Assert.assertEquals(
+            Arrays.asList(
+                "bar",
+                "kafka.newheader.kafkapkc",
+                "foo",
+                "kafka.newts.timestamp",
+                "kafka.newkey.key",
+                "root_baz",
+                "o",
+                "path_omg",
+                "jq_omg",
+                "jq_omg2",
+                "baz",
+                "root_baz2",
+                "kafka.newheader.encoding",
+                "path_omg2"
+            ),
+            row.getDimensions()
+        );
+
+        // Payload verifications
+        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+
+        // Header verification
+        Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+        Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+        Assert.assertEquals(
+            String.valueOf(DateTimes.of("2021-06-24").getMillis()),
+            Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            "2021-06-25",
+            Iterables.getOnlyElement(row.getDimension("timestamp"))
+        );
+
+        // Key verification
+        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+
+        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+
+        numActualIterations++;
+      }
+
+      Assert.assertEquals(numExpectedIterations, numActualIterations);
+    }
+  }
+
 
   private SettableByteEntity<KafkaRecordEntity> newSettableByteEntity(KafkaRecordEntity kafkaRecordEntity)
   {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -53,11 +53,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
 public class KafkaInputFormatTest
 {
   private KafkaRecordEntity inputEntity;
-  private long timestamp = DateTimes.of("2021-06-24").getMillis();
+  private final long timestamp = DateTimes.of("2021-06-24").getMillis();
   private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(
       new Header()
       {
@@ -171,7 +172,7 @@ public class KafkaInputFormatTest
 
     final byte[] formatBytes = mapper.writeValueAsBytes(format);
     final byte[] kifBytes = mapper.writeValueAsBytes(kif);
-    Assert.assertTrue(Arrays.equals(formatBytes, kifBytes));
+    Assert.assertArrayEquals(formatBytes, kifBytes);
   }
 
   @Test
@@ -196,21 +197,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            key,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(key, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -299,24 +286,11 @@ public class KafkaInputFormatTest
         + "    \"o\": {\n"
         + "        \"mg\": 1\n"
         + "    }\n"
-        + "}");
+        + "}"
+    );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            null,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(null, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -377,7 +351,8 @@ public class KafkaInputFormatTest
                   }
                 }
             )
-        ));
+        )
+    );
     final byte[] key = StringUtils.toUtf8(
         "{\n"
         + "    \"key\": \"sampleKey\"\n"
@@ -397,21 +372,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(sample_header_with_ts);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            key,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(key, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -496,21 +457,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            null,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(null, payload, headers);
 
     KafkaInputFormat localFormat = new KafkaInputFormat(
         null,
@@ -633,21 +580,7 @@ public class KafkaInputFormatTest
     for (int i = 0; i < keys.length; i++) {
       headers = headers.add(new RecordHeader("indexH", String.valueOf(i).getBytes(StandardCharsets.UTF_8)));
 
-      inputEntity = new KafkaRecordEntity(
-          new ConsumerRecord<>(
-              "sample",
-              0,
-              0,
-              timestamp,
-              null,
-              null,
-              0,
-              0,
-              keys[i],
-              values[i],
-              headers
-          )
-      );
+      inputEntity = makeInputEntity(keys[i], values[i], headers);
       settableByteEntity.setEntity(inputEntity);
 
       final int numExpectedIterations = 1;
@@ -724,21 +657,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            key,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(key, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -794,21 +713,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            key,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(key, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -904,21 +809,7 @@ public class KafkaInputFormatTest
     );
 
     Headers headers = new RecordHeaders(SAMPLE_HEADERS);
-    inputEntity = new KafkaRecordEntity(
-        new ConsumerRecord<>(
-            "sample",
-            0,
-            0,
-            timestamp,
-            null,
-            null,
-            0,
-            0,
-            key,
-            payload,
-            headers
-        )
-    );
+    inputEntity = makeInputEntity(key, payload, headers);
 
     final InputEntityReader reader = format.createReader(
         new InputRowSchema(
@@ -992,6 +883,25 @@ public class KafkaInputFormatTest
 
       Assert.assertEquals(numExpectedIterations, numActualIterations);
     }
+  }
+
+  private KafkaRecordEntity makeInputEntity(byte[] key, byte[] payload, Headers headers)
+  {
+    return new KafkaRecordEntity(
+        new ConsumerRecord<>(
+            "sample",
+            0,
+            0,
+            timestamp,
+            null,
+            0,
+            0,
+            key,
+            payload,
+            headers,
+            Optional.empty()
+        )
+    );
   }
 
 

--- a/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
@@ -66,6 +66,19 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
     return parse(inputRowSchema.getTimestampSpec(), inputRowSchema.getDimensionsSpec(), theMap);
   }
 
+  @VisibleForTesting
+  static InputRow parse(
+      TimestampSpec timestampSpec,
+      DimensionsSpec dimensionsSpec,
+      Map<String, Object> theMap
+  ) throws ParseException
+  {
+    final List<String> dimensionsToUse = findDimensions(timestampSpec, dimensionsSpec, theMap.keySet());
+
+    final DateTime timestamp = parseTimestamp(timestampSpec, theMap);
+    return new MapBasedInputRow(timestamp, dimensionsToUse, theMap);
+  }
+
   /**
    * Finds the final set of dimension names to use for {@link InputRow}.
    * There are 3 cases here.
@@ -80,17 +93,17 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
    * In any case, the returned list does not include any dimensions in {@link DimensionsSpec#getDimensionExclusions()}
    * or {@link TimestampSpec#getTimestampColumn()}.
    */
-  private static List<String> findDimensions(
+  public static List<String> findDimensions(
       TimestampSpec timestampSpec,
       DimensionsSpec dimensionsSpec,
-      Map<String, Object> rawInputRow
+      Set<String> fields
   )
   {
     final String timestampColumn = timestampSpec.getTimestampColumn();
     final Set<String> exclusions = dimensionsSpec.getDimensionExclusions();
     if (dimensionsSpec.isIncludeAllDimensions() || dimensionsSpec.useSchemaDiscovery()) {
       LinkedHashSet<String> dimensions = new LinkedHashSet<>(dimensionsSpec.getDimensionNames());
-      for (String field : rawInputRow.keySet()) {
+      for (String field : fields) {
         if (timestampColumn.equals(field) || exclusions.contains(field)) {
           continue;
         }
@@ -102,7 +115,7 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
         return dimensionsSpec.getDimensionNames();
       } else {
         List<String> dimensions = new ArrayList<>();
-        for (String field : rawInputRow.keySet()) {
+        for (String field : fields) {
           if (timestampColumn.equals(field) || exclusions.contains(field)) {
             continue;
           }
@@ -111,19 +124,6 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
         return dimensions;
       }
     }
-  }
-
-  @VisibleForTesting
-  static InputRow parse(
-      TimestampSpec timestampSpec,
-      DimensionsSpec dimensionsSpec,
-      Map<String, Object> theMap
-  ) throws ParseException
-  {
-    final List<String> dimensionsToUse = findDimensions(timestampSpec, dimensionsSpec, theMap);
-
-    final DateTime timestamp = parseTimestamp(timestampSpec, theMap);
-    return new MapBasedInputRow(timestamp, dimensionsToUse, theMap);
   }
 
   public static DateTime parseTimestamp(TimestampSpec timestampSpec, Map<String, Object> theMap)

--- a/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/MapInputRowParser.java
@@ -32,6 +32,7 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,11 @@ public class MapInputRowParser implements InputRowParser<Map<String, Object>>
       Map<String, Object> theMap
   ) throws ParseException
   {
-    final List<String> dimensionsToUse = findDimensions(timestampSpec, dimensionsSpec, theMap.keySet());
+    final List<String> dimensionsToUse = findDimensions(
+        timestampSpec,
+        dimensionsSpec,
+        theMap == null ? Collections.emptySet() : theMap.keySet()
+    );
 
     final DateTime timestamp = parseTimestamp(timestampSpec, theMap);
     return new MapBasedInputRow(timestamp, dimensionsToUse, theMap);


### PR DESCRIPTION
### Description
Fixes some bugs when using the Kafka input format with schema discovery and partial schema discovery, the former would incorrectly not exclude the column chosen as __time from the timestampSpec (resulting in an extra time column of whatever the source type was), and the latter which just only include the explicit dimensions list if `dimensionSpec` had a non-empty list of dimensions, even if `includeAllDimensions` or `useSchemaDiscovery` was set.

To avoid this happening in the future, it now shares the same logic used by `MapInputRowParser` to create the dimensions list.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
