### PR TITLE
Fix issues when startup timeout is hit

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -124,6 +124,11 @@ public class KubernetesPeonLifecycle
 
       return join(timeout);
     }
+    catch (Exception e) {
+      log.info("Failed to run task: %s", taskId.getOriginalTaskId());
+      shutdown();
+      throw e;
+    }
     finally {
       state.set(State.STOPPED);
     }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -163,7 +163,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         EasyMock.anyLong(),
         EasyMock.eq(TimeUnit.MILLISECONDS)
     )).andReturn(null);
-
+    EasyMock.expect(kubernetesClient.deletePeonJob(
+      new K8sTaskId(ID)
+    )).andReturn(true);
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
     replayAll();


### PR DESCRIPTION
### Description
Fixes a bug in the K8s Task Runner when k8sjobLaunchTimeout is hit during launchPeonJobAndWaitForStart  in KubernetesPeonLifecycle.run without the task pod successfully coming up, e.g. when there is no available node.

Currently if a task pod fails to come up in time, the overlord marks the task as failed and logs the timeout error message, but doesn't actually cleanup the job. Eventually the cleanupExecutor will cleanup the job, but it's possible for the job to fail to come up in k8sjobLaunchTimeout, then succeed afterwards and actually run even though the overlord has marked it as failed.

#### Release note
Fix a bug with the K8s overlord extension

##### Key changed/added classes in this PR
Update KubernetesPeonsLifecycle to cleanup jobs it has tried to start and that haven't come up.

This PR has:

- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X ] been tested in a test Druid cluster.
