### PR TITLE
adjust broker parallel merge to help managed blocking be more well behaved

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ParallelMergeCombiningSequenceTest.java
@@ -24,12 +24,11 @@ import org.apache.druid.common.guava.CombiningSequence;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.QueryTimeoutException;
+import org.apache.druid.utils.JvmUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -62,9 +61,6 @@ public class ParallelMergeCombiningSequenceTest
   };
 
   private ForkJoinPool pool;
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setup()
@@ -443,12 +439,10 @@ public class ParallelMergeCombiningSequenceTest
     input.add(explodingSequence(15));
     input.add(nonBlockingSequence(25));
 
-
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(
-        "exploded"
-    );
-    assertException(input);
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
+    Assert.assertEquals("exploded", t.getMessage());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
   }
 
   @Test
@@ -460,11 +454,10 @@ public class ParallelMergeCombiningSequenceTest
     input.add(explodingSequence(11));
     input.add(nonBlockingSequence(12));
 
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(
-        "exploded"
-    );
-    assertException(input);
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
+    Assert.assertEquals("exploded", t.getMessage());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
   }
 
   @Test
@@ -476,11 +469,10 @@ public class ParallelMergeCombiningSequenceTest
     input.add(nonBlockingSequence(2));
     input.add(nonBlockingSequence(2));
 
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(
-        "exploded"
-    );
-    assertException(input);
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
+    Assert.assertEquals("exploded", t.getMessage());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
   }
 
   @Test
@@ -494,12 +486,12 @@ public class ParallelMergeCombiningSequenceTest
     input.add(nonBlockingSequence(2));
     input.add(nonBlockingSequence(2));
 
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(
-        "exploded"
-    );
-    assertException(input);
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> assertException(input));
+    Assert.assertEquals("exploded", t.getMessage());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
   }
+
 
   @Test
   public void testTimeoutExceptionDueToStalledInput() throws Exception
@@ -510,17 +502,29 @@ public class ParallelMergeCombiningSequenceTest
     input.add(nonBlockingSequence(someSize));
     input.add(nonBlockingSequence(someSize));
     input.add(blockingSequence(someSize, 400, 500, 1, 500, true));
-    expectedException.expect(QueryTimeoutException.class);
-    expectedException.expectMessage("Query did not complete within configured timeout period. " +
-        "You can increase query timeout or tune the performance of query");
 
-    assertException(
-        input,
-        ParallelMergeCombiningSequence.DEFAULT_TASK_SMALL_BATCH_NUM_ROWS,
-        ParallelMergeCombiningSequence.DEFAULT_TASK_INITIAL_YIELD_NUM_ROWS,
-        1000L,
-        0
+    Throwable t = Assert.assertThrows(
+        QueryTimeoutException.class,
+        () -> assertException(
+            input,
+            ParallelMergeCombiningSequence.DEFAULT_TASK_SMALL_BATCH_NUM_ROWS,
+            ParallelMergeCombiningSequence.DEFAULT_TASK_INITIAL_YIELD_NUM_ROWS,
+            1000L,
+            0
+        )
     );
+    Assert.assertEquals("Query did not complete within configured timeout period. " +
+                        "You can increase query timeout or tune the performance of query.", t.getMessage());
+
+
+    // these tests when run in java 11, 17 and maybe others in between 8 and 20 don't seem to correctly clean up the
+    // pool, however this behavior is flaky and doesn't always happen so we can't definitively assert that the pool is
+    // or isn't
+    if (JvmUtils.majorVersion() >= 20 || JvmUtils.majorVersion() < 9) {
+      Assert.assertTrue(pool.awaitQuiescence(3, TimeUnit.SECONDS));
+      // good result, we want the pool to always be idle if an exception occurred during processing
+      Assert.assertTrue(pool.isQuiescent());
+    }
   }
 
   @Test
@@ -533,10 +537,11 @@ public class ParallelMergeCombiningSequenceTest
     input.add(nonBlockingSequence(someSize));
     input.add(nonBlockingSequence(someSize));
 
-    expectedException.expect(QueryTimeoutException.class);
-    expectedException.expectMessage("Query did not complete within configured timeout period. " +
-        "You can increase query timeout or tune the performance of query");
-    assertException(input, 8, 64, 1000, 500);
+    Throwable t = Assert.assertThrows(QueryTimeoutException.class, () -> assertException(input, 8, 64, 1000, 1500));
+    Assert.assertEquals("Query did not complete within configured timeout period. " +
+                        "You can increase query timeout or tune the performance of query.", t.getMessage());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
   }
 
   @Test
@@ -630,10 +635,8 @@ public class ParallelMergeCombiningSequenceTest
 
     Assert.assertTrue(combiningYielder.isDone());
     Assert.assertTrue(parallelMergeCombineYielder.isDone());
-    while (pool.getRunningThreadCount() > 0) {
-      Thread.sleep(100);
-    }
-    Assert.assertEquals(0, pool.getRunningThreadCount());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
     combiningYielder.close();
     parallelMergeCombineYielder.close();
     // cancellation trigger should not be set if sequence was fully yielded and close is called
@@ -693,15 +696,10 @@ public class ParallelMergeCombiningSequenceTest
     }
     // trying to next the yielder creates sadness for you
     final String expectedExceptionMsg = "Already closed";
-    try {
-      Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
-      parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
-      // this should explode so the contradictory next statement should not be reached
-      Assert.assertTrue(false);
-    }
-    catch (RuntimeException rex) {
-      Assert.assertEquals(expectedExceptionMsg, rex.getMessage());
-    }
+    Assert.assertEquals(combiningYielder.get(), parallelMergeCombineYielder.get());
+    final Yielder<IntPair> finalYielder = parallelMergeCombineYielder;
+    Throwable t = Assert.assertThrows(RuntimeException.class, () -> finalYielder.next(finalYielder.get()));
+    Assert.assertEquals(expectedExceptionMsg, t.getMessage());
 
     // cancellation gizmo of sequence should be cancelled, and also should contain our expected message
     Assert.assertTrue(parallelMergeCombineSequence.getCancellationGizmo().isCancelled());
@@ -710,16 +708,14 @@ public class ParallelMergeCombiningSequenceTest
         parallelMergeCombineSequence.getCancellationGizmo().getRuntimeException().getMessage()
     );
 
-    while (pool.getRunningThreadCount() > 0) {
-      Thread.sleep(100);
-    }
-    Assert.assertEquals(0, pool.getRunningThreadCount());
+    Assert.assertTrue(pool.awaitQuiescence(1, TimeUnit.SECONDS));
+    Assert.assertTrue(pool.isQuiescent());
 
     Assert.assertFalse(combiningYielder.isDone());
     Assert.assertFalse(parallelMergeCombineYielder.isDone());
   }
 
-  private void assertException(List<Sequence<IntPair>> sequences) throws Exception
+  private void assertException(List<Sequence<IntPair>> sequences) throws Throwable
   {
     assertException(
         sequences,
@@ -737,9 +733,9 @@ public class ParallelMergeCombiningSequenceTest
       long timeout,
       int readDelayMillis
   )
-      throws Exception
+      throws Throwable
   {
-    try {
+    Throwable t = Assert.assertThrows(Exception.class, () -> {
       final ParallelMergeCombiningSequence<IntPair> parallelMergeCombineSequence = new ParallelMergeCombiningSequence<>(
           pool,
           sequences,
@@ -768,17 +764,16 @@ public class ParallelMergeCombiningSequenceTest
         parallelMergeCombineYielder = parallelMergeCombineYielder.next(parallelMergeCombineYielder.get());
       }
       parallelMergeCombineYielder.close();
-    }
-    catch (Exception ex) {
-      sequences.forEach(sequence -> {
-        if (sequence instanceof ExplodingSequence) {
-          ExplodingSequence exploder = (ExplodingSequence) sequence;
-          Assert.assertEquals(1, exploder.getCloseCount());
-        }
-      });
-      LOG.warn(ex, "exception:");
-      throw ex;
-    }
+    });
+
+    sequences.forEach(sequence -> {
+      if (sequence instanceof ExplodingSequence) {
+        ExplodingSequence exploder = (ExplodingSequence) sequence;
+        Assert.assertEquals(1, exploder.getCloseCount());
+      }
+    });
+    LOG.warn(t, "exception:");
+    throw t;
   }
 
   public static class IntPair extends Pair<Integer, Integer>


### PR DESCRIPTION
### Description
Splits out the `ParallelMergeCombiningSequence` changes and test improvements of #14130 since they seem like improvements, but without changing the default config until we can definitively prove that java version is the cause.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
