### PR TITLE
Handle native arrays when coercing results back

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlResults.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlResults.java
@@ -40,6 +40,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,6 +78,18 @@ public class SqlResults
                                    .map(v -> (String) coerce(jsonMapper, context, v, sqlTypeName))
                                    .collect(Collectors.toList());
 
+        try {
+          coercedValue = jsonMapper.writeValueAsString(valueStrings);
+        }
+        catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      } else if (value.getClass().isArray()) {
+        List<String> valueStrings = new ArrayList<>();
+        for (int i = 0; i < Array.getLength(value); ++i) {
+          String coercedElement = (String) coerce(jsonMapper, context, Array.get(value, i), sqlTypeName);
+          valueStrings.add(coercedElement);
+        }
         try {
           coercedValue = jsonMapper.writeValueAsString(valueStrings);
         }


### PR DESCRIPTION
Fixes #14006

### Description
`SqlResults.coerce` cannot coerce native Java arrays in the results. This PR updates the method to account for them as well. Attached the reported issue above which contains the repro for the bug, and added unit test for the same.

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
