### PR TITLE
use the latest datasketches-java-4.1.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3784,7 +3784,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.0.0
+version: 4.1.0
 libraries:
   - org.apache.datasketches: datasketches-java
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
           Also, CalcitePlanner is a clone of Calcite's PlannerImpl and may require updates when
           Calcite is upgrade. -->
         <calcite.version>1.21.0</calcite.version>
-        <datasketches.version>4.0.0</datasketches.version>
+        <datasketches.version>4.1.0</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.0.0</dropwizard.metrics.version>


### PR DESCRIPTION
This is to update the dependency on datasketches-java to the latest version 4.1.0 that has just been released. This version fixed a bug that made impossible reading KllDoubleSketch serialized by C++ version of the library.