### PR TITLE
Fix segment/deleted/count metric not being emitted 

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -283,7 +283,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`segment/moved/count`|Number of segments moved in the cluster.|`tier`|Varies|
 |`segment/unmoved/count`|Number of segments which were chosen for balancing but were found to be already optimally placed.|`tier`|Varies|
 |`segment/dropped/count`|Number of segments chosen to be dropped from the cluster due to being over-replicated.|`tier`|Varies|
-|`segment/deleted/count`|Number of segments marked as unused due to drop rules.|`tier`|Varies|
+|`segment/deleted/count`|Number of segments marked as unused due to drop rules.| |Varies|
 |`segment/unneeded/count`|Number of segments dropped due to being marked as unused.|`tier`|Varies|
 |`segment/cost/raw`|Used in cost balancing. The raw cost of hosting segments.|`tier`|Varies|
 |`segment/cost/normalization`|Used in cost balancing. The normalization of hosting segments.|`tier`|Varies|

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetrics.java
@@ -190,7 +190,13 @@ public class EmitClusterStatsAndMetrics implements CoordinatorDuty
     emitTieredStats(emitter, "segment/moved/count", stats, "movedCount");
     emitTieredStats(emitter, "segment/unmoved/count", stats, "unmovedCount");
 
-    emitTieredStats(emitter, "segment/deleted/count", stats, "deletedCount");
+    emitter.emit(
+        new ServiceMetricEvent.Builder()
+            .build(
+                "segment/deleted/count",
+                stats.getGlobalStat("deletedCount")
+            )
+    );
 
     stats.forEachTieredStat(
         "normalizedInitialCostTimesOneThousand",

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/EmitClusterStatsAndMetricsTest.java
@@ -71,6 +71,7 @@ public class EmitClusterStatsAndMetricsTest
     List<ServiceEventBuilder> emittedEvents = argumentCaptor.getAllValues();
     boolean foundCompactMetric = false;
     boolean foundHistoricalDutyMetric = false;
+    boolean foundSegmentDeletedCount = false;
     for (ServiceEventBuilder eventBuilder : emittedEvents) {
       ServiceMetricEvent serviceMetricEvent = ((ServiceMetricEvent) eventBuilder.build("x", "x"));
       String metric = serviceMetricEvent.getMetric();
@@ -78,6 +79,9 @@ public class EmitClusterStatsAndMetricsTest
         foundHistoricalDutyMetric = true;
       } else if ("compact/task/count".equals(metric)) {
         foundCompactMetric = true;
+      } else if ("segment/deleted/count".equals(metric)) {
+        foundSegmentDeletedCount = true;
+        continue;
       }
       String dutyGroup = (String) serviceMetricEvent.getUserDims().get("dutyGroup");
       Assert.assertNotNull(dutyGroup);
@@ -85,6 +89,7 @@ public class EmitClusterStatsAndMetricsTest
     }
     Assert.assertTrue(foundHistoricalDutyMetric);
     Assert.assertFalse(foundCompactMetric);
+    Assert.assertTrue(foundSegmentDeletedCount);
   }
 
   @Test


### PR DESCRIPTION
Fix segment/deleted/count metric not being emitted 

### Description

The `segment/deleted/count` metric is being stored as GlobalStat in DropRule but being emitted as TieredStat in EmitClusterStatsAndMetrics. The GlobalStat and TieredStat are separate data structures. Hence, when we try to emit `segment/deleted/count` metric, the metric values are not found and nothing is emitted. 

Looking at the code in DropRule, the tier information for the segment being dropped is not available. Hence I kept the `segment/deleted/count` metric as GlobalStat and modify the emit code in EmitClusterStatsAndMetrics to use GlobalStat for `segment/deleted/count` metric instead.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
