### PR TITLE
Don't need to double synchronize on simple map operations

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -134,18 +134,16 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   @Override
   public ListenableFuture<TaskStatus> run(Task task)
   {
-    synchronized (tasks) {
-      tasks.computeIfAbsent(task.getId(), k -> new KubernetesWorkItem(task, exec.submit(() -> runTask(task))));
-      return tasks.get(task.getId()).getResult();
-    }
+    return tasks.computeIfAbsent(
+        task.getId(), k -> new KubernetesWorkItem(task, exec.submit(() -> runTask(task)))
+    ).getResult();
   }
 
   protected ListenableFuture<TaskStatus> joinAsync(Task task)
   {
-    synchronized (tasks) {
-      tasks.computeIfAbsent(task.getId(), k -> new KubernetesWorkItem(task, exec.submit(() -> joinTask(task))));
-      return tasks.get(task.getId()).getResult();
-    }
+    return tasks.computeIfAbsent(
+        task.getId(), k -> new KubernetesWorkItem(task, exec.submit(() -> joinTask(task)))
+    ).getResult();
   }
 
   private TaskStatus runTask(Task task)
@@ -202,9 +200,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
     }
 
     finally {
-      synchronized (tasks) {
-        tasks.remove(task.getId());
-      }
+      tasks.remove(task.getId());
     }
   }
 
@@ -322,9 +318,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   @Override
   public Collection<? extends TaskRunnerWorkItem> getKnownTasks()
   {
-    synchronized (tasks) {
-      return Lists.newArrayList(tasks.values());
-    }
+    return Lists.newArrayList(tasks.values());
   }
 
 
@@ -393,23 +387,19 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   @Override
   public Collection<TaskRunnerWorkItem> getRunningTasks()
   {
-    synchronized (tasks) {
-      return tasks.values()
-          .stream()
-          .filter(KubernetesWorkItem::isRunning)
-          .collect(Collectors.toList());
-    }
+    return tasks.values()
+        .stream()
+        .filter(KubernetesWorkItem::isRunning)
+        .collect(Collectors.toList());
   }
 
   @Override
   public Collection<TaskRunnerWorkItem> getPendingTasks()
   {
-    synchronized (tasks) {
-      return tasks.values()
-          .stream()
-          .filter(KubernetesWorkItem::isPending)
-          .collect(Collectors.toList());
-    }
+    return tasks.values()
+        .stream()
+        .filter(KubernetesWorkItem::isPending)
+        .collect(Collectors.toList());
   }
 
   @Nullable

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -161,19 +161,17 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   {
     KubernetesPeonLifecycle peonLifecycle = peonLifecycleFactory.build(task);
 
-    synchronized (tasks) {
-      KubernetesWorkItem workItem = tasks.get(task.getId());
+    KubernetesWorkItem workItem = tasks.get(task.getId());
 
-      if (workItem == null) {
-        throw new ISE("Task [%s] disappeared", task.getId());
-      }
-
-      if (workItem.isShutdownRequested()) {
-        throw new ISE("Task [%s] has been shut down", task.getId());
-      }
-
-      workItem.setKubernetesPeonLifecycle(peonLifecycle);
+    if (workItem == null) {
+      throw new ISE("Task [%s] disappeared", task.getId());
     }
+
+    if (workItem.isShutdownRequested()) {
+      throw new ISE("Task [%s] has been shut down", task.getId());
+    }
+
+    workItem.setKubernetesPeonLifecycle(peonLifecycle);
 
     try {
       TaskStatus taskStatus;


### PR DESCRIPTION
### Description
We are using a lock around a concurrentHashMap for simple one line get/insert operations into the map

The concurrentHashMap guarantees that computeIfAbsent will only call the operation once if multiple threads attempt to call it concurrently, so this shouldn't be necessary.

We don't need the lock inside doTask either because doTask is called as a part of the operation in computeIfAbsent from either joinAsync or run for a single taskId. Because the map is concurrent, there will be one thread running doTask per taskId.

#### Release note
- remove unnecessary synchronization in K8s task runner.

This PR has:

- [X ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ X] been tested in a test Druid cluster.
