### PR TITLE
MSQ: Load broadcast tables on workers.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
@@ -155,6 +155,14 @@ public class MSQWorkerTask extends AbstractTask
   }
 
   @Override
+  public boolean supportsQueries()
+  {
+    // Even though we don't have a QueryResource, we do embed a query stack, and so we need preloaded resources
+    // such as broadcast tables.
+    return true;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -182,7 +182,12 @@ public interface Task
   <T> QueryRunner<T> getQueryRunner(Query<T> query);
 
   /**
-   * @return true if this Task type is queryable, such as streaming ingestion tasks
+   * True if this task type embeds a query stack, and therefore should preload resources (like broadcast tables)
+   * that may be needed by queries.
+   *
+   * If true, {@link #getQueryRunner(Query)} does not necessarily return nonnull query runners. For example,
+   * MSQWorkerTask returns true from this method (because it embeds a query stack for running multi-stage queries)
+   * even though it is not directly queryable via HTTP.
    */
   boolean supportsQueries();
 


### PR DESCRIPTION
They were not previously loaded because supportsQueries was false. This patch sets supportsQueries to true, and clarifies in Task javadocs that supportsQueries can be true for tasks that aren't directly queryable over HTTP.