### PR TITLE
Upgrade Avro to latest version

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -24,7 +24,6 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JsonProvider;
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -142,9 +141,9 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
   @Override
   public Object getRootField(final GenericRecord record, final String key)
   {
-    try {
+    if (record.getSchema().getField(key) != null) {
       return transformValue(record.get(key));
-    } catch (AvroRuntimeException e) {
+    } else {
       return null;
     }
   }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/AvroFlattenerMaker.java
@@ -24,6 +24,7 @@ import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JsonProvider;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -141,7 +142,11 @@ public class AvroFlattenerMaker implements ObjectFlatteners.FlattenerMaker<Gener
   @Override
   public Object getRootField(final GenericRecord record, final String key)
   {
-    return transformValue(record.get(key));
+    try {
+      return transformValue(record.get(key));
+    } catch (AvroRuntimeException e) {
+      return null;
+    }
   }
 
   @Override

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -349,6 +349,10 @@ public class AvroFlattenerMakerTest
         list,
         flattener.getRootField(record, "someRecordArray")
     );
+    Assert.assertEquals(
+        null,
+        flattener.getRootField(record, "invalidField")
+    );
   }
 
   private void makeJsonPathExtractor_common(final SomeAvroDatum record, final AvroFlattenerMaker flattener)

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3634,7 +3634,7 @@ libraries:
 ---
 
 name: Apache Velocity Engine
-version: 2.2
+version: 2.3
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3652,7 +3652,7 @@ name: Apache Avro
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
-version: 1.9.2
+version: 1.11.1
 libraries:
   - org.apache.avro: avro
   - org.apache.avro: avro-mapred

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -473,14 +473,6 @@
   </suppress>
 
   <suppress>
-    <!-- (avro, parquet, integration-tests) we don't allow velocity templates to be uploaded by untrusted users -->
-    <notes><![CDATA[
-     file name: velocity-engine-core-2.2.jar:
-     ]]></notes>
-    <cve>CVE-2020-13936</cve>
-  </suppress>
-
-  <suppress>
      <!-- (ranger, ambari, and aliyun-oss) these vulnerabilities are legit, but their latest releases still use the vulnerable jackson version -->
      <notes><![CDATA[
      file name: jackson-xc-1.9.x.jar or jackson-jaxrs-1.9.x.jar

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <scala.library.version>2.13.9</scala.library.version>
         <avatica.version>1.17.0</avatica.version>
-        <avro.version>1.9.2</avro.version>
+        <avro.version>1.11.1</avro.version>
         <!-- sql/src/main/codegen/config.fmpp is based on a file from calcite-core, and needs to be
           updated when upgrading Calcite. Refer to the top-level comments in that file for details.
           Also, CalcitePlanner is a clone of Calcite's PlannerImpl and may require updates when


### PR DESCRIPTION
Currently Druid is using Avro 1.9.2 version. Following are CVEs flagged. 

- One of the transitive dependencies `velocity-engine-core-2.2.jar` is bringing in CVE-2020-13936 - An attacker that is able to modify Velocity templates may execute arbitrary Java code or run arbitrary system commands with the same privileges as the account running the Servlet container. This applies to applications that allow untrusted users to upload/modify velocity templates running Apache Velocity Engine versions up to 2.2.
- Direct vulnerability CVE-2021-43045 (Allocation of Resources Without Limits or Throttling in Apache Avro - Only applicable to .NET SDK)

Despite being false positive as we don't allow untrusted users to upload velocity templates, they're causing red security scans on Druid distribution. Hence updating the version to latest version 1.11.1 which uses `velocity-engine-core-2.3.jar`.