### PR TITLE
Skip tests based on files changed in the PR

### DIFF
--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -21,6 +21,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      # run everything if not a PR
+      core: ${{ steps.filter.outputs.core || github.event_name != 'pull_request'}}
+      # the common extension in revised ITs is different from the one in standard ITs
+      common-extensions: ${{ steps.filter.outputs.common-extensions }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            common-extensions:
+              - 'extension-core/(mysql-metadata-storage|druid-it-tools|druid-lookups-cached-global|druid-histogram|druid-datasketches|druid-parquet-extensions|druid-avro-extensions|druid-protobuf-extensions|druid-orc-extensions|druid-kafka-indexing-service|druid-s3-extensions|druid-multi-stage-query|druid-catalog)/**'
+            core:
+              - '!extension*/**'
+
   it:
     strategy:
       fail-fast: false
@@ -31,6 +53,7 @@ jobs:
         #indexer: [indexer, middleManager]
         indexer: [middleManager]
     uses: ./.github/workflows/reusable-revised-its.yml
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: ${{ matrix.jdk }}
       runtime_jdk: ${{ matrix.jdk }}
@@ -41,6 +64,7 @@ jobs:
 
   s3-deep-storage-minio:
     uses: ./.github/workflows/reusable-revised-its.yml
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 11

--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -44,6 +44,7 @@ jobs:
               - '!extension*/**'
 
   it:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +64,7 @@ jobs:
       mysql_driver: com.mysql.jdbc.Driver
 
   s3-deep-storage-minio:
+    needs: changes
     uses: ./.github/workflows/reusable-revised-its.yml
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -21,12 +21,38 @@ on:
   workflow_dispatch:
 
 jobs:
+  # unlike unit tests, we skip ITs if changes are only in certain extensions. Since it's hard to tell what
+  # extensions a particular IT is affected by right now
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      non-msq: ${{ steps.filter.outputs.non-msq }}
+      non-contrib: ${{ steps.filter.outputs.non-contrib }}
+      # run everything if not a PR
+      run-all: ${{ github.event_name != 'pull_request'}}
+    steps:
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            non-msq:
+              - '!extension-core/multi-stage-query/**'
+            non-contrib:
+              - '!extensions-contrib/**'
+
   integration-index-tests-middleManager:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
         testing_group: [batch-index, input-format, input-source, perfect-rollup-parallel-batch-index, kafka-index, kafka-index-slow, kafka-transactional-index, kafka-transactional-index-slow, kafka-data-format, ldap-security, realtime-index, append-ingestion, compaction]
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -40,6 +66,7 @@ jobs:
       matrix:
         testing_group: [input-source, perfect-rollup-parallel-batch-index, kafka-index, kafka-transactional-index, kafka-index-slow, kafka-transactional-index-slow, kafka-data-format, append-ingestion, compaction]
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -53,6 +80,7 @@ jobs:
       matrix:
         testing_group: [query, query-retry, query-error, security, high-availability]
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -67,6 +95,7 @@ jobs:
       matrix:
         jdk: [8, 11]
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: ${{ matrix.jdk }}
@@ -92,6 +121,7 @@ jobs:
 
   integration-custom-coordinator-duties-tests:
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -102,6 +132,7 @@ jobs:
 
   integration-k8s-leadership-tests:
     name: (Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test
+    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     runs-on: ubuntu-22.04
     env:
       MVN: mvn --no-snapshot-updates

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -106,6 +106,7 @@ jobs:
       group: query
 
   integration-shuffle-deep-store-tests:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        testing_group: [input-source, perfect-rollup-parallel-batch-index, kafka-index, kafka-transactional-index, kafka-index-slow, kafka-transactional-index-slow, kafka-data-format, append-ingestion, compaction]
+        testing_group: [input-source, perfect-rollup-parallel-batch-index, kafka-index, append-ingestion, compaction]
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -61,6 +61,7 @@ jobs:
       group: ${{ matrix.testing_group }}
 
   integration-index-tests-indexer:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +76,7 @@ jobs:
       group: ${{ matrix.testing_group }}
 
   integration-query-tests-middleManager:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +92,7 @@ jobs:
       group: ${{ matrix.testing_group }}
 
   integration-query-tests-middleManager-mariaDB:
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +123,7 @@ jobs:
       group: shuffle deep store
 
   integration-custom-coordinator-duties-tests:
+    needs: changes
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     with:
@@ -131,6 +135,7 @@ jobs:
       group: custom coordinator duties
 
   integration-k8s-leadership-tests:
+    needs: changes
     name: (Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test
     if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -21,8 +21,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # unlike unit tests, we skip ITs if changes are only in certain extensions. Since it's hard to tell what
-  # extensions a particular IT is affected by right now
   changes:
     runs-on: ubuntu-latest
     # Required permissions
@@ -30,20 +28,19 @@ jobs:
       pull-requests: read
     # Set job outputs to values from filter step
     outputs:
-      non-msq: ${{ steps.filter.outputs.non-msq }}
-      non-contrib: ${{ steps.filter.outputs.non-contrib }}
       # run everything if not a PR
-      run-all: ${{ github.event_name != 'pull_request'}}
+      core: ${{ steps.filter.outputs.core || github.event_name != 'pull_request'}}
+      common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
       - uses: dorny/paths-filter@v2
         if: github.event_name == 'pull_request'
         id: filter
         with:
           filters: |
-            non-msq:
-              - '!extension-core/multi-stage-query/**'
-            non-contrib:
-              - '!extensions-contrib/**'
+            common-extensions:
+              - 'extension-core/(mysql-metadata-storage|druid-basic-security|simple-client-sslcontext|druid-testing-tools|druid-lookups-cached-global|druid-histogram|druid-datasketches|druid-parquet-extensions|druid-avro-extensions|druid-protobuf-extensions|druid-orc-extensions|druid-kafka-indexing-service|druid-s3-extensions)/**'
+            core:
+              - '!extension*/**'
 
   integration-index-tests-middleManager:
     needs: changes
@@ -52,7 +49,7 @@ jobs:
       matrix:
         testing_group: [batch-index, input-format, input-source, perfect-rollup-parallel-batch-index, kafka-index, kafka-index-slow, kafka-transactional-index, kafka-transactional-index-slow, kafka-data-format, ldap-security, realtime-index, append-ingestion, compaction]
     uses: ./.github/workflows/reusable-standard-its.yml
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -67,7 +64,7 @@ jobs:
       matrix:
         testing_group: [input-source, perfect-rollup-parallel-batch-index, kafka-index, append-ingestion, compaction]
     uses: ./.github/workflows/reusable-standard-its.yml
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -82,7 +79,7 @@ jobs:
       matrix:
         testing_group: [query, query-retry, query-error, security, high-availability]
     uses: ./.github/workflows/reusable-standard-its.yml
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -98,7 +95,7 @@ jobs:
       matrix:
         jdk: [8, 11]
     uses: ./.github/workflows/reusable-standard-its.yml
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: ${{ matrix.jdk }}
@@ -114,6 +111,7 @@ jobs:
       matrix:
         indexer: [indexer, middleManager]
     uses: ./.github/workflows/reusable-standard-its.yml
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -125,7 +123,7 @@ jobs:
   integration-custom-coordinator-duties-tests:
     needs: changes
     uses: ./.github/workflows/reusable-standard-its.yml
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
       build_jdk: 8
       runtime_jdk: 8
@@ -137,7 +135,7 @@ jobs:
   integration-k8s-leadership-tests:
     needs: changes
     name: (Compile=openjdk8, Run=openjdk8, Cluster Build On K8s) ITNestedQueryPushDownTest integration test
-    if: ${{ (needs.changes.outputs.non-msq == 'true' && needs.changes.outputs.non-contrib == 'true') || needs.changes.outputs.run-all == 'true' }}
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     runs-on: ubuntu-22.04
     env:
       MVN: mvn --no-snapshot-updates

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,10 +31,14 @@ on:
         description: 'Flag to decide if next tests need to run incase coverage issue failures'
         value: |
           ${{
-            (jobs.indexing_modules_test.result == 'success' || fromJson(jobs.indexing_modules_test.outputs.coverage_failure)) &&
-            (jobs.processing_modules_test.result == 'success' || fromJson(jobs.processing_modules_test.outputs.coverage_failure)) &&
-            (jobs.server_modules_test.result == 'success' || fromJson(jobs.server_modules_test.outputs.coverage_failure)) &&
-            (jobs.other_modules_test.result == 'success' || fromJson(jobs.other_modules_test.outputs.coverage_failure))
+            (jobs.indexing_modules_test.result == 'success' || jobs.indexing_modules_test.result == 'skipped' || 
+          fromJson(jobs.indexing_modules_test.outputs.coverage_failure)) &&
+            (jobs.processing_modules_test.result == 'success' || jobs.processing_modules_test.result == 'skipped' || 
+          fromJson(jobs.processing_modules_test.outputs.coverage_failure)) &&
+            (jobs.server_modules_test.result == 'success' || jobs.server_modules_test.result == 'skipped' || fromJson
+          (jobs.server_modules_test.outputs.coverage_failure)) &&
+            (jobs.other_modules_test.result == 'success' || jobs.other_modules_test.result == 'skipped' || fromJson(jobs
+          .other_modules_test.outputs.coverage_failure))
           }}
 
 jobs:
@@ -45,7 +49,8 @@ jobs:
       pull-requests: read
     # Set job outputs to values from filter step
     outputs:
-      extensions: ${{ steps.filter.outputs.extensions }}
+      kafka: ${{ steps.filter.outputs.kafka }}
+      kinesis: ${{ steps.filter.outputs.kinesis }}
       # run everything if not a PR
       core: ${{ steps.filter.outputs.core  || github.event_name != 'pull_request'}}
     steps:
@@ -54,8 +59,6 @@ jobs:
         id: filter
         with:
           filters: |
-            extensions:
-              - 'extension*/**'
             core:
               - '!extension*/**'
             kafka:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,32 @@ on:
           }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Required permissions
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      extensions: ${{ steps.filter.outputs.extensions }}
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            extensions:
+              - 'extension*/**'
+            core:
+              - '!extension*/**'
+            kafka:
+              - 'extensions-core/kafka-indexing-service/**'
+            kinesis:
+              - 'extensions-core/kinesis-indexing-service/**'
+
   indexing_modules_test:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.kafka == 'true' || needs.changes.outputs.kinesis == 'true'}}
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
@@ -47,6 +72,8 @@ jobs:
       maven_projects: 'indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
 
   processing_modules_test:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' }}
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
@@ -55,6 +82,8 @@ jobs:
       maven_projects: 'processing'
 
   server_modules_test:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' }}
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,9 +46,11 @@ jobs:
     # Set job outputs to values from filter step
     outputs:
       extensions: ${{ steps.filter.outputs.extensions }}
-      core: ${{ steps.filter.outputs.core }}
+      # run everything if not a PR
+      core: ${{ steps.filter.outputs.core  || github.event_name != 'pull_request'}}
     steps:
       - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
         id: filter
         with:
           filters: |

--- a/integration-tests-ex/cases/cluster/Common/environment-configs/common.env
+++ b/integration-tests-ex/cases/cluster/Common/environment-configs/common.env
@@ -49,6 +49,7 @@ DRUID_INSTANCE=
 # variables: druid_standard_loadList defined here, and druid_test_loadList, defined
 # in a docker-compose.yaml file, for any test-specific extensions.
 # See compose.md for more details.
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_standard_loadList=mysql-metadata-storage,druid-it-tools,druid-lookups-cached-global,druid-histogram,druid-datasketches,druid-parquet-extensions,druid-avro-extensions,druid-protobuf-extensions,druid-orc-extensions,druid-kafka-indexing-service,druid-s3-extensions,druid-multi-stage-query,druid-catalog
 
 # Location of Hadoop dependencies provided at runtime in the shared directory.

--- a/integration-tests/docker/environment-configs/common
+++ b/integration-tests/docker/environment-configs/common
@@ -26,6 +26,7 @@ COMMON_DRUID_JAVA_OPTS=-Duser.timezone=UTC -Dfile.encoding=UTF-8 -Dlog4j.configu
 DRUID_DEP_LIB_DIR=/shared/hadoop_xml:/shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
 
 # Druid configs
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_extensions_loadList=["mysql-metadata-storage","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-parquet-extensions","druid-avro-extensions","druid-protobuf-extensions","druid-orc-extensions","druid-kafka-indexing-service","druid-s3-extensions"]
 druid_startup_logging_logProperties=true
 druid_extensions_directory=/shared/docker/extensions

--- a/integration-tests/docker/environment-configs/common-ldap
+++ b/integration-tests/docker/environment-configs/common-ldap
@@ -27,6 +27,7 @@ COMMON_DRUID_JAVA_OPTS=-Duser.timezone=UTC -Dfile.encoding=UTF-8 -Dlog4j.configu
 DRUID_DEP_LIB_DIR=/shared/hadoop_xml:/shared/docker/lib/*:/usr/local/druid/lib/mysql-connector-java.jar
 
 # Druid configs
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches"]
 druid_extensions_directory=/shared/docker/extensions
 druid_auth_authenticator_ldap_authorizerName=ldapauth

--- a/integration-tests/docker/environment-configs/test-groups/custom-coordinator-duties
+++ b/integration-tests/docker/environment-configs/test-groups/custom-coordinator-duties
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_extensions_loadList=["druid-kafka-indexing-service","mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches"]
 
 druid_coordinator_period_metadataStoreManagementPeriod=PT1H

--- a/integration-tests/docker/environment-configs/test-groups/prepopulated-data
+++ b/integration-tests/docker/environment-configs/test-groups/prepopulated-data
@@ -19,6 +19,7 @@
 
 AWS_REGION=us-east-1
 
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-integration-tests"]
 
 # Setting s3 credentials and region to use pre-populated data for testing.

--- a/integration-tests/docker/environment-configs/test-groups/shuffle-deep-store
+++ b/integration-tests/docker/environment-configs/test-groups/shuffle-deep-store
@@ -19,5 +19,6 @@
 
 # Test with deep storage as intermediate location to store shuffle data
 # Local deep storage will be used here
+# If you are making a change in load list below, make the necessary changes in github actions too
 druid_extensions_loadList=["mysql-metadata-storage","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches"]
 druid_processing_intermediaryData_storage_type=deepstore


### PR DESCRIPTION
Our CI system has a lot of tests. And much of this testing is really unnecessary for most of the PRs. This PR adds some checks so we can skip these expensive tests when we know they are not necessary. 

I have ensured that
- All the tests always run on the feature branch
- In unit tests, we skip jobs when we know that there are no changes outside extensions
- In standard ITs, we skip jobs if common extensions and core are not changed. Core includes everything outside extensions. 

Tested it here - https://github.com/abhishekagarwal87/druid/pull/53

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
