### PR TITLE
Fix exception if replicant information is not available

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -302,11 +302,11 @@ public class DruidCoordinator
   @Nullable
   public Integer getReplicationFactor(SegmentId segmentId)
   {
-    if (segmentReplicationStatus != null) {
-      return segmentReplicationStatus.getReplicaCountsInCluster(segmentId).required();
-    } else {
+    if (segmentReplicationStatus == null) {
       return null;
     }
+    SegmentReplicaCount replicaCountsInCluster = segmentReplicationStatus.getReplicaCountsInCluster(segmentId);
+    return replicaCountsInCluster == null ? null : replicaCountsInCluster.required();
   }
 
   @Nullable

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -249,6 +249,9 @@ public class DruidCoordinatorTest extends CuratorTestBase
     EasyMock.replay(serverInventoryView, loadQueueTaskMaster);
 
     coordinator.start();
+
+    Assert.assertNull(coordinator.getReplicationFactor(dataSegment.getId()));
+
     // Wait for this coordinator to become leader
     leaderAnnouncerLatch.await();
 
@@ -306,6 +309,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     // the segments are replicated as many times as they can be given state of cluster, therefore should not be
     // under-replicated.
     Assert.assertEquals(0L, underRepliicationCountsPerDataSourceUsingClusterView.getLong(dataSource));
+    Assert.assertEquals(Integer.valueOf(2), coordinator.getReplicationFactor(dataSegment.getId()));
 
     coordinator.stop();
     leaderUnannouncerLatch.await();
@@ -397,6 +401,8 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertEquals(2, underReplicationCountsPerDataSourcePerTierUsingClusterView.size());
     Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(hotTierName).getLong(dataSource));
     Assert.assertEquals(0L, underReplicationCountsPerDataSourcePerTierUsingClusterView.get(coldTierName).getLong(dataSource));
+
+    dataSegments.values().forEach(dataSegment -> Assert.assertEquals(Integer.valueOf(1), coordinator.getReplicationFactor(dataSegment.getId())));
 
     coordinator.stop();
     leaderUnannouncerLatch.await();


### PR DESCRIPTION
This resolves an issue in master, which was caused due to the collision of some PRs. A null pointer exception occurs if the replicant information was not available in `SegmentReplicationStatus` in the Coordinator.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
