### PR TITLE
Add log statements for tmpStorageBytes in MSQ

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
@@ -32,10 +32,10 @@ import java.util.Objects;
 /**
  * Class for determining the amount of temporary disk space to allocate to various purposes, given the per-worker limit.
  * Similar to {@link WorkerMemoryParameters}, but for temporary disk space.
- *
+ * <br>
  * Currently only used to allocate disk space for intermediate output from super sorter storage, if intermediate super
  * sorter storage is enabled.
- *
+ * <br>
  * If it is enabled, keeps {@link #MINIMUM_BASIC_OPERATIONS_BYTES} for miscellaneous operations and
  * configures the super sorter to use {@link #SUPER_SORTER_TMP_STORAGE_USABLE_FRACTION} of the remaining space for
  * intermediate files. If this value is less than {@link #MINIMUM_SUPER_SORTER_TMP_STORAGE_BYTES},
@@ -100,6 +100,8 @@ public class WorkerStorageParameters
 
     Preconditions.checkArgument(tmpStorageBytesPerTask > 0, "Temporary storage bytes passed: [%s] should be > 0", tmpStorageBytesPerTask);
     long intermediateSuperSorterStorageMaxLocalBytes = computeUsableStorage(tmpStorageBytesPerTask);
+
+    log.info("Useable storage: [%s]", intermediateSuperSorterStorageMaxLocalBytes);
 
     if (intermediateSuperSorterStorageMaxLocalBytes < MINIMUM_SUPER_SORTER_TMP_STORAGE_BYTES) {
       throw new MSQException(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.Injector;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.NotEnoughTemporaryStorageFault;
 
@@ -42,6 +43,8 @@ import java.util.Objects;
  */
 public class WorkerStorageParameters
 {
+  private static final Logger log = new Logger(WorkerStorageParameters.class);
+
   /**
    * Fraction of temporary worker storage that can be allocated to super sorter intermediate files.
    */
@@ -71,6 +74,7 @@ public class WorkerStorageParameters
   )
   {
     long tmpStorageBytesPerTask = injector.getInstance(TaskConfig.class).getTmpStorageBytesPerTask();
+    log.info("Creating WorkerStorageParameters with value of tmpStorageBytesPerTask: [%s]", tmpStorageBytesPerTask);
     return createInstance(tmpStorageBytesPerTask, isIntermediateSuperSorterStorageEnabled);
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerStorageParameters.java
@@ -74,7 +74,6 @@ public class WorkerStorageParameters
   )
   {
     long tmpStorageBytesPerTask = injector.getInstance(TaskConfig.class).getTmpStorageBytesPerTask();
-    log.info("Creating WorkerStorageParameters with value of tmpStorageBytesPerTask: [%s]", tmpStorageBytesPerTask);
     return createInstance(tmpStorageBytesPerTask, isIntermediateSuperSorterStorageEnabled);
   }
 
@@ -101,7 +100,7 @@ public class WorkerStorageParameters
     Preconditions.checkArgument(tmpStorageBytesPerTask > 0, "Temporary storage bytes passed: [%s] should be > 0", tmpStorageBytesPerTask);
     long intermediateSuperSorterStorageMaxLocalBytes = computeUsableStorage(tmpStorageBytesPerTask);
 
-    log.info("Useable storage: [%s]", intermediateSuperSorterStorageMaxLocalBytes);
+    log.info("Intermediate super sorter local storage size: %d bytes", intermediateSuperSorterStorageMaxLocalBytes);
 
     if (intermediateSuperSorterStorageMaxLocalBytes < MINIMUM_SUPER_SORTER_TMP_STORAGE_BYTES) {
       throw new MSQException(


### PR DESCRIPTION
Minor PR to improve debuggability by logging parameters received by WorkerStorageParameters

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
