### PR TITLE
Support complex variance object inputs for variance SQL agg function

### DIFF
--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorFactory.java
@@ -60,7 +60,7 @@ import java.util.Objects;
 @JsonTypeName("variance")
 public class VarianceAggregatorFactory extends AggregatorFactory
 {
-  private static final String VARIANCE_TYPE_NAME = "variance";
+  public static final String VARIANCE_TYPE_NAME = "variance";
   public static final ColumnType TYPE = ColumnType.ofComplex(VARIANCE_TYPE_NAME);
 
   protected final String fieldName;

--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/sql/BaseVarianceSqlAggregator.java
@@ -160,8 +160,8 @@ public abstract class BaseVarianceSqlAggregator implements SqlAggregator
   }
 
   /**
-   * Creates a SqlAggFunction that is the same as SqlAvgAggFunction but with an operand type that accepts
-   * variance aggregator objects in addition to numeric inputs.
+   * Creates a {@link SqlAggFunction} that is the same as {@link org.apache.calcite.sql.fun.SqlAvgAggFunction}
+   * but with an operand type that accepts variance aggregator objects in addition to numeric inputs.
    */
   private static SqlAggFunction buildSqlAvgAggFunction(String name)
   {

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/sql/VarianceSqlAggregatorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/sql/VarianceSqlAggregatorTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.query.aggregation.stats.DruidStatsModule;
 import org.apache.druid.query.aggregation.variance.StandardDeviationPostAggregator;
 import org.apache.druid.query.aggregation.variance.VarianceAggregatorCollector;
 import org.apache.druid.query.aggregation.variance.VarianceAggregatorFactory;
+import org.apache.druid.query.aggregation.variance.VarianceSerde;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
@@ -51,6 +52,7 @@ import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.join.JoinableFactoryWrapper;
+import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.sql.calcite.BaseCalciteQueryTest;
@@ -82,8 +84,10 @@ public class VarianceSqlAggregatorTest extends BaseCalciteQueryTest
       final Injector injector
   ) throws IOException
   {
+    ComplexMetrics.registerSerde(VarianceSerde.TYPE_NAME, new VarianceSerde());
+
     final QueryableIndex index =
-        IndexBuilder.create()
+        IndexBuilder.create(CalciteTests.getJsonMapper().registerModules(new DruidStatsModule().getJacksonModules()))
                     .tmpDir(temporaryFolder.newFolder())
                     .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
                     .schema(
@@ -100,7 +104,8 @@ public class VarianceSqlAggregatorTest extends BaseCalciteQueryTest
                             )
                             .withMetrics(
                                 new CountAggregatorFactory("cnt"),
-                                new DoubleSumAggregatorFactory("m1", "m1")
+                                new DoubleSumAggregatorFactory("m1", "m1"),
+                                new VarianceAggregatorFactory("var1", "m1", null, null)
                             )
                             .withRollup(false)
                             .build()
@@ -621,6 +626,55 @@ public class VarianceSqlAggregatorTest extends BaseCalciteQueryTest
             ? new Object[]{"a", 0.0, 0.0, 0.0, 0.0, 0L, 0L, 0L, 0L}
             : new Object[]{"a", null, null, null, null, null, null, null, null}
         )
+    );
+  }
+
+  @Test
+  public void testVarianceAggAsInput()
+  {
+    final List<Object[]> expectedResults = ImmutableList.of(
+        new Object[]{
+            "3.5",
+            "2.9166666666666665",
+            "3.5",
+            "1.8708286933869707",
+            "1.707825127659933",
+            "1.8708286933869707"
+        }
+    );
+    testQuery(
+        "SELECT\n"
+        + "VARIANCE(var1),\n"
+        + "VAR_POP(var1),\n"
+        + "VAR_SAMP(var1),\n"
+        + "STDDEV(var1),\n"
+        + "STDDEV_POP(var1),\n"
+        + "STDDEV_SAMP(var1)\n"
+        + "FROM numfoo",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE3)
+                  .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Filtration.eternity())))
+                  .granularity(Granularities.ALL)
+                  .aggregators(
+                      ImmutableList.of(
+                          new VarianceAggregatorFactory("a0:agg", "var1", "sample", "variance"),
+                          new VarianceAggregatorFactory("a1:agg", "var1", "population", "variance"),
+                          new VarianceAggregatorFactory("a2:agg", "var1", "sample", "variance"),
+                          new VarianceAggregatorFactory("a3:agg", "var1", "sample", "variance"),
+                          new VarianceAggregatorFactory("a4:agg", "var1", "population", "variance"),
+                          new VarianceAggregatorFactory("a5:agg", "var1", "sample", "variance")
+                      )
+                  )
+                  .postAggregators(
+                      new StandardDeviationPostAggregator("a3", "a3:agg", "sample"),
+                      new StandardDeviationPostAggregator("a4", "a4:agg", "population"),
+                      new StandardDeviationPostAggregator("a5", "a5:agg", "sample")
+                  )
+                  .context(BaseCalciteQueryTest.QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        expectedResults
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
@@ -23,11 +23,18 @@ import com.google.common.base.Preconditions;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeComparability;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.AbstractSqlType;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.ordering.StringComparator;
 import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.segment.column.ColumnHolder;
@@ -233,6 +240,66 @@ public class RowSignatures
     public String asTypeString()
     {
       return columnType.asTypeString();
+    }
+  }
+
+  public static ComplexSqlSingleOperandTypeChecker complexTypeChecker(ColumnType complexType)
+  {
+    return new ComplexSqlSingleOperandTypeChecker(
+        new ComplexSqlType(SqlTypeName.OTHER, complexType, true)
+    );
+  }
+
+  public static final class ComplexSqlSingleOperandTypeChecker implements SqlSingleOperandTypeChecker
+  {
+    private final ComplexSqlType type;
+
+    public ComplexSqlSingleOperandTypeChecker(
+        ComplexSqlType type
+    )
+    {
+      this.type = type;
+    }
+
+    @Override
+    public boolean checkSingleOperandType(
+        SqlCallBinding callBinding, SqlNode operand, int iFormalOperand, boolean throwOnFailure
+    )
+    {
+      return type.equals(callBinding.getValidator().deriveType(callBinding.getScope(), operand));
+    }
+
+    @Override
+    public boolean checkOperandTypes(SqlCallBinding callBinding, boolean throwOnFailure)
+    {
+      if (callBinding.getOperandCount() != 1) {
+        return false;
+      }
+      return checkSingleOperandType(callBinding, callBinding.operand(0), 0, throwOnFailure);
+    }
+
+    @Override
+    public SqlOperandCountRange getOperandCountRange()
+    {
+      return SqlOperandCountRanges.of(1);
+    }
+
+    @Override
+    public String getAllowedSignatures(SqlOperator op, String opName)
+    {
+      return StringUtils.format("'%s'(%s)", opName, type);
+    }
+
+    @Override
+    public Consistency getConsistency()
+    {
+      return Consistency.NONE;
+    }
+
+    @Override
+    public boolean isOptional(int i)
+    {
+      return false;
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
@@ -86,7 +86,9 @@ public class RowSignatures
   {
     Preconditions.checkNotNull(simpleExtraction, "simpleExtraction");
     if (simpleExtraction.getExtractionFn() != null
-        || rowSignature.getColumnType(simpleExtraction.getColumn()).map(type -> type.is(ValueType.STRING)).orElse(false)) {
+        || rowSignature.getColumnType(simpleExtraction.getColumn())
+                       .map(type -> type.is(ValueType.STRING))
+                       .orElse(false)) {
       return StringComparators.LEXICOGRAPHIC;
     } else {
       return StringComparators.NUMERIC;
@@ -171,7 +173,7 @@ public class RowSignatures
    * Creates a {@link ComplexSqlType} using the supplied {@link RelDataTypeFactory} to ensure that the
    * {@link ComplexSqlType} is interned. This is important because Calcite checks that the references are equal
    * instead of the objects being equivalent.
-   *
+   * <p>
    * This method uses {@link RelDataTypeFactory#createTypeWithNullability(RelDataType, boolean) ensures that if the
    * type factory is a {@link org.apache.calcite.rel.type.RelDataTypeFactoryImpl} that the type is passed through
    * {@link org.apache.calcite.rel.type.RelDataTypeFactoryImpl#canonize(RelDataType)} which interns the type.
@@ -186,15 +188,15 @@ public class RowSignatures
 
   /**
    * Calcite {@link RelDataType} for Druid complex columns, to preserve complex type information.
-   *
+   * <p>
    * If using with other operations of a {@link RelDataTypeFactory}, consider wrapping the creation of this type in
    * {@link RelDataTypeFactory#createTypeWithNullability(RelDataType, boolean) to ensure that if the type factory is a
    * {@link org.apache.calcite.rel.type.RelDataTypeFactoryImpl} that the type is passed through
    * {@link org.apache.calcite.rel.type.RelDataTypeFactoryImpl#canonize(RelDataType)} which interns the type.
-   *
+   * <p>
    * If {@link SqlTypeName} is going to be {@link SqlTypeName#OTHER} and a {@link RelDataTypeFactory} is available,
    * consider using {@link #makeComplexType(RelDataTypeFactory, ColumnType, boolean)}.
-   *
+   * <p>
    * This type does not work well with {@link org.apache.calcite.sql.type.ReturnTypes#explicit(RelDataType)}, which
    * will create new {@link RelDataType} using {@link SqlTypeName} during return type inference, so implementors of
    * {@link org.apache.druid.sql.calcite.expression.SqlOperatorConversion} should implement the
@@ -263,7 +265,10 @@ public class RowSignatures
 
     @Override
     public boolean checkSingleOperandType(
-        SqlCallBinding callBinding, SqlNode operand, int iFormalOperand, boolean throwOnFailure
+        SqlCallBinding callBinding,
+        SqlNode operand,
+        int iFormalOperand,
+        boolean throwOnFailure
     )
     {
       return type.equals(callBinding.getValidator().deriveType(callBinding.getScope(), operand));


### PR DESCRIPTION
This PR fixes an issue with the `VARIANCE` and related SQL aggregation functions, allowing them to accept variance aggregator objects as inputs (currently the SQL function only accepts numeric operands).

The new `SqlAggFunction` definitions are the same as `SqlAvgAggFunction` from `SqlStdOperatorTable` but with the operand type broadened to include variance aggregator objects in addition to numerics.

Note: This pulls in the `RowSignatures.complexTypeChecker` changes from https://github.com/apache/druid/pull/14195 for tighter operand type checking

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
