### PR TITLE
Update start-druid-main.py

### DIFF
--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -154,7 +154,7 @@ sample usage:
                              '\'common.jvm.config\' & \'common.runtime.properties\' files. \n'
                              'If this argument is not given, config from \n'
                              'conf/druid/auto directory is used.\n'
-                             'Note. zookeeper config cannot be overriden.\n')
+                             'Note. zookeeper config cannot be overridden.\n')
     parser.add_argument('--compute', action='store_true',
                         help='Does not start Druid, only displays the memory allocated \n'
                              'to each service if started with the given total memory.\n')


### PR DESCRIPTION
Quick typo correction in the startup script --hel

This PR has:

- [X] been self-reviewed.
- [ ] been tested in a test Druid cluster.
