### PR TITLE
Fix flaky test in `CostBalancerStrategyTest`

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
@@ -97,6 +96,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -169,7 +169,7 @@ public class DruidCoordinator
   private volatile SegmentReplicationStatus segmentReplicationStatus = null;
 
   private int cachedBalancerThreadNumber;
-  private ListeningExecutorService balancerExec;
+  private ExecutorService balancerExec;
 
   public static final String HISTORICAL_MANAGEMENT_DUTIES_DUTY_GROUP = "HistoricalManagementDuties";
   private static final String METADATA_STORE_MANAGEMENT_DUTIES_DUTY_GROUP = "MetadataStoreManagementDuties";
@@ -355,7 +355,7 @@ public class DruidCoordinator
   }
 
   @VisibleForTesting
-  public ListeningExecutorService getBalancerExec()
+  public ExecutorService getBalancerExec()
   {
     return balancerExec;
   }
@@ -565,12 +565,10 @@ public class DruidCoordinator
     }
   }
 
-  private ListeningExecutorService createNewBalancerExecutor(int numThreads)
+  private ExecutorService createNewBalancerExecutor(int numThreads)
   {
     cachedBalancerThreadNumber = numThreads;
-    return MoreExecutors.listeningDecorator(
-        Execs.multiThreaded(numThreads, "coordinator-cost-balancer-%s")
-    );
+    return Execs.multiThreaded(numThreads, "coordinator-cost-balancer-%s");
   }
 
   private List<CoordinatorDuty> makeHistoricalManagementDuties()

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
@@ -21,7 +21,8 @@ package org.apache.druid.server.coordinator.balancer;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.common.util.concurrent.ListeningExecutorService;
+
+import java.util.concurrent.ExecutorService;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "strategy", defaultImpl = CostBalancerStrategyFactory.class)
 @JsonSubTypes(value = {
@@ -32,5 +33,5 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 })
 public interface BalancerStrategyFactory
 {
-  BalancerStrategy createBalancerStrategy(ListeningExecutorService exec);
+  BalancerStrategy createBalancerStrategy(ExecutorService exec);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
@@ -21,20 +21,18 @@ package org.apache.druid.server.coordinator.balancer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.Collections;
 import java.util.Set;
-
+import java.util.concurrent.ExecutorService;
 
 public class CachingCostBalancerStrategy extends CostBalancerStrategy
 {
-
   private final ClusterCostCache clusterCostCache;
 
-  public CachingCostBalancerStrategy(ClusterCostCache clusterCostCache, ListeningExecutorService exec)
+  public CachingCostBalancerStrategy(ClusterCostCache clusterCostCache, ExecutorService exec)
   {
     super(exec);
     this.clusterCostCache = Preconditions.checkNotNull(clusterCostCache);

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyFactory.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.coordinator.balancer;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.druid.client.ServerInventoryView;
 import org.apache.druid.client.ServerView;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -123,7 +122,7 @@ public class CachingCostBalancerStrategyFactory implements BalancerStrategyFacto
   }
 
   @Override
-  public BalancerStrategy createBalancerStrategy(final ListeningExecutorService exec)
+  public BalancerStrategy createBalancerStrategy(ExecutorService exec)
   {
     if (!isInitialized() && config.isAwaitInitialization()) {
       try {

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyFactory.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.google.common.util.concurrent.ListeningExecutorService;
+import java.util.concurrent.ExecutorService;
 
 public class CostBalancerStrategyFactory implements BalancerStrategyFactory
 {
   @Override
-  public CostBalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
+  public CostBalancerStrategy createBalancerStrategy(ExecutorService exec)
   {
     return new CostBalancerStrategy(exec);
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategy.java
@@ -19,13 +19,14 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 
+import java.util.concurrent.ExecutorService;
+
 public class DiskNormalizedCostBalancerStrategy extends CostBalancerStrategy
 {
-  public DiskNormalizedCostBalancerStrategy(ListeningExecutorService exec)
+  public DiskNormalizedCostBalancerStrategy(ExecutorService exec)
   {
     super(exec);
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/DiskNormalizedCostBalancerStrategyFactory.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.google.common.util.concurrent.ListeningExecutorService;
+import java.util.concurrent.ExecutorService;
 
 public class DiskNormalizedCostBalancerStrategyFactory implements BalancerStrategyFactory
 {
   @Override
-  public BalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
+  public BalancerStrategy createBalancerStrategy(ExecutorService exec)
   {
     return new DiskNormalizedCostBalancerStrategy(exec);
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/RandomBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/RandomBalancerStrategyFactory.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.google.common.util.concurrent.ListeningExecutorService;
+import java.util.concurrent.ExecutorService;
 
 public class RandomBalancerStrategyFactory implements BalancerStrategyFactory
 {
   @Override
-  public BalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
+  public BalancerStrategy createBalancerStrategy(ExecutorService exec)
   {
     return new RandomBalancerStrategy();
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import org.apache.curator.framework.CuratorFramework;
@@ -81,6 +80,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -630,20 +630,20 @@ public class DruidCoordinatorTest extends CuratorTestBase
     // first initialization
     c.initBalancerExecutor();
     Assert.assertEquals(5, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService firstExec = c.getBalancerExec();
+    ExecutorService firstExec = c.getBalancerExec();
     Assert.assertNotNull(firstExec);
 
     // second initialization, expect no changes as cachedBalancerThreadNumber is not changed
     c.initBalancerExecutor();
     Assert.assertEquals(5, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService secondExec = c.getBalancerExec();
+    ExecutorService secondExec = c.getBalancerExec();
     Assert.assertNotNull(secondExec);
     Assert.assertSame(firstExec, secondExec);
 
     // third initialization, expect executor recreated as cachedBalancerThreadNumber is changed to 10
     c.initBalancerExecutor();
     Assert.assertEquals(10, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService thirdExec = c.getBalancerExec();
+    ExecutorService thirdExec = c.getBalancerExec();
     Assert.assertNotNull(thirdExec);
     Assert.assertNotSame(secondExec, thirdExec);
     Assert.assertNotSame(firstExec, thirdExec);

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/CostBalancerStrategyTest.java
@@ -19,13 +19,11 @@
 
 package org.apache.druid.server.coordinator.balancer;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.GranularityType;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.java.util.emitter.core.Event;
-import org.apache.druid.java.util.emitter.service.AlertEvent;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CreateDataSegments;
@@ -40,10 +38,12 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -62,7 +62,7 @@ public class CostBalancerStrategyTest
   public void setup()
   {
     balancerExecutor = new BlockingExecutorService("test-balance-exec-%d");
-    strategy = new CostBalancerStrategy(MoreExecutors.listeningDecorator(balancerExecutor));
+    strategy = new CostBalancerStrategy(balancerExecutor);
 
     serviceEmitter = new StubServiceEmitter("test-service", "host");
     EmittingLogger.registerEmitter(serviceEmitter);
@@ -265,7 +265,7 @@ public class CostBalancerStrategyTest
                           .withNumPartitions(30)
                           .eachOfSizeInMb(100);
 
-    // Distribute the segments randomly amongst 2 servers
+    // Distribute the segments randomly amongst 3 servers
     final List<DataSegment> segments = new ArrayList<>(daySegments);
     segments.addAll(monthSegments);
     segments.addAll(yearSegments);
@@ -284,35 +284,34 @@ public class CostBalancerStrategyTest
         server -> new ServerHolder(server.toImmutableDruidServer(), new LoadQueuePeonTester())
     ).collect(Collectors.toList());
 
+    final ServerHolder serverA = serverHolders.get(0);
+    final ServerHolder serverB = serverHolders.get(1);
+    final ServerHolder serverC = serverHolders.get(2);
+
     // Verify costs for DAY, MONTH and YEAR segments
-    verifyServerCosts(
-        daySegments.get(0),
-        serverHolders,
-        5191.500804, 8691.392080, 6418.467818
-    );
-    verifyServerCosts(
-        monthSegments.get(0),
-        serverHolders,
-        301935.940609, 301935.940606, 304333.677669
-    );
-    verifyServerCosts(
-        yearSegments.get(0),
-        serverHolders,
-        8468764.380437, 12098919.896931, 14501440.169452
-    );
+    final DataSegment daySegment = daySegments.get(0);
+    verifyComputeCostForServer(daySegment, serverA, 5191.500804);
+    verifyComputeCostForServer(daySegment, serverB, 8691.392080);
+    verifyComputeCostForServer(daySegment, serverC, 6418.467818);
+
+    final DataSegment monthSegment = monthSegments.get(0);
+    verifyComputeCostForServer(monthSegment, serverA, 301935.940609);
+    verifyComputeCostForServer(monthSegment, serverB, 301935.940606);
+    verifyComputeCostForServer(monthSegment, serverC, 304333.677669);
+
+    final DataSegment yearSegment = yearSegments.get(0);
+    verifyComputeCostForServer(yearSegment, serverA, 8468764.380437);
+    verifyComputeCostForServer(yearSegment, serverB, 12098919.896931);
+    verifyComputeCostForServer(yearSegment, serverC, 14501440.169452);
 
     // Verify costs for an ALL granularity segment
-    DataSegment allGranularitySegment =
+    final DataSegment allGranularitySegment =
         CreateDataSegments.ofDatasource(DS_WIKI)
                           .forIntervals(1, Granularities.ALL)
                           .eachOfSizeInMb(100).get(0);
-    verifyServerCosts(
-        allGranularitySegment,
-        serverHolders,
-        1.1534173737329768e7,
-        1.6340633534241956e7,
-        1.9026400521582970e7
-    );
+    verifyComputeCostForServer(allGranularitySegment, serverA, 1.1534173737329768e7);
+    verifyComputeCostForServer(allGranularitySegment, serverB, 1.6340633534241956e7);
+    verifyComputeCostForServer(allGranularitySegment, serverC, 1.9026400521582970e7);
   }
 
   @Test
@@ -334,8 +333,8 @@ public class CostBalancerStrategyTest
     );
   }
 
-  @Test(timeout = 90_000L)
-  public void testFindServerRaisesAlertOnTimeout()
+  @Test
+  public void testFindServerReturnsEmptyOnExecutorShutdown()
   {
     DataSegment segment = CreateDataSegments.ofDatasource(DS_WIKI)
                                             .forIntervals(1, Granularities.DAY)
@@ -346,30 +345,24 @@ public class CostBalancerStrategyTest
     ServerHolder serverA = new ServerHolder(createHistorical().toImmutableDruidServer(), peon);
     ServerHolder serverB = new ServerHolder(createHistorical().toImmutableDruidServer(), peon);
 
-    strategy.findServersToLoadSegment(segment, Arrays.asList(serverA, serverB));
+    // Shutdown the balancerExecutor from a separate thread after a 100 ms delay
+    final ScheduledExecutorService shutdownExecutor = ScheduledExecutors.fixed(1, "test-shutdown");
+    shutdownExecutor.schedule(() -> balancerExecutor.shutdownNow(), 100, TimeUnit.MILLISECONDS);
 
-    List<Event> events = serviceEmitter.getEvents();
-    Assert.assertEquals(1, events.size());
-    Assert.assertTrue(events.get(0) instanceof AlertEvent);
-
-    AlertEvent alertEvent = (AlertEvent) events.get(0);
-    Assert.assertEquals(
-        "Cost balancer strategy timed out in action [findServersToLoadSegment]."
-        + " Try setting a higher value of 'balancerComputeThreads'.",
-        alertEvent.getDescription()
-    );
+    try {
+      Iterator<ServerHolder> serversToLoad
+          = strategy.findServersToLoadSegment(segment, Arrays.asList(serverA, serverB));
+      Assert.assertFalse(serversToLoad.hasNext());
+    }
+    finally {
+      shutdownExecutor.shutdownNow();
+    }
   }
 
-  private void verifyServerCosts(
-      DataSegment segment,
-      List<ServerHolder> serverHolders,
-      double... expectedCosts
-  )
+  private void verifyComputeCostForServer(DataSegment segment, ServerHolder server, double expectedCost)
   {
-    for (int i = 0; i < serverHolders.size(); ++i) {
-      double observedCost = strategy.computeCost(segment, serverHolders.get(i), true);
-      Assert.assertEquals(expectedCosts[i], observedCost, DELTA);
-    }
+    double observedCost = strategy.computeCost(segment, server, true);
+    Assert.assertEquals(expectedCost, observedCost, DELTA);
   }
 
   private void verifyJointSegmentsCost(

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
@@ -167,9 +167,7 @@ public class BlockingExecutorService implements ExecutorService
   public void shutdown()
   {
     isShutdown = true;
-    taskQueue.forEach(
-        task -> task.future.cancel(true)
-    );
+    taskQueue.forEach(task -> task.future.cancel(true));
     taskQueue.clear();
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/BlockingExecutorService.java
@@ -167,6 +167,9 @@ public class BlockingExecutorService implements ExecutorService
   public void shutdown()
   {
     isShutdown = true;
+    taskQueue.forEach(
+        task -> task.future.cancel(true)
+    );
     taskQueue.clear();
   }
 


### PR DESCRIPTION
### Changes
- Remove flaky test from `CostBalancerStrategyTest`
- Use plain old `ExecutorService` with `CostBalancerStrategy` as `ListeningExecutorService` is not needed
- Add more tests
- Other minor cleanup

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
