### PR TITLE
Add query context parameter to control limiting select rows

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -467,7 +467,8 @@ public class ControllerImpl implements Controller
             queryDef,
             resultsYielder,
             task.getQuerySpec().getColumnMappings(),
-            task.getSqlTypeNames()
+            task.getSqlTypeNames(),
+            MultiStageQueryContext.limitSelectResults(task.getQuerySpec().getQuery().context())
         );
       } else {
         resultsReport = null;
@@ -2017,7 +2018,8 @@ public class ControllerImpl implements Controller
       final QueryDefinition queryDef,
       final Yielder<Object[]> resultsYielder,
       final ColumnMappings columnMappings,
-      @Nullable final List<SqlTypeName> sqlTypeNames
+      @Nullable final List<SqlTypeName> sqlTypeNames,
+      final boolean limitSelectResult
   )
   {
     final RowSignature querySignature = queryDef.getFinalStageDefinition().getSignature();
@@ -2032,7 +2034,7 @@ public class ControllerImpl implements Controller
       );
     }
 
-    return new MSQResultsReport(mappedSignature.build(), sqlTypeNames, resultsYielder, null);
+    return MSQResultsReport.createReportAndLimitRowsIfNeeded(mappedSignature.build(), sqlTypeNames, resultsYielder, limitSelectResult);
   }
 
   private static MSQStatusReport makeStatusReport(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -90,6 +90,7 @@ import org.apache.druid.msq.indexing.DataSourceMSQDestination;
 import org.apache.druid.msq.indexing.InputChannelFactory;
 import org.apache.druid.msq.indexing.InputChannelsImpl;
 import org.apache.druid.msq.indexing.MSQControllerTask;
+import org.apache.druid.msq.indexing.MSQSelectDestination;
 import org.apache.druid.msq.indexing.MSQSpec;
 import org.apache.druid.msq.indexing.MSQTuningConfig;
 import org.apache.druid.msq.indexing.MSQWorkerTaskLauncher;
@@ -468,7 +469,7 @@ public class ControllerImpl implements Controller
             resultsYielder,
             task.getQuerySpec().getColumnMappings(),
             task.getSqlTypeNames(),
-            MultiStageQueryContext.limitSelectResults(task.getQuerySpec().getQuery().context())
+            MultiStageQueryContext.getSelectDestination(task.getQuerySpec().getQuery().context())
         );
       } else {
         resultsReport = null;
@@ -2019,7 +2020,7 @@ public class ControllerImpl implements Controller
       final Yielder<Object[]> resultsYielder,
       final ColumnMappings columnMappings,
       @Nullable final List<SqlTypeName> sqlTypeNames,
-      final boolean limitSelectResult
+      final MSQSelectDestination selectDestination
   )
   {
     final RowSignature querySignature = queryDef.getFinalStageDefinition().getSignature();
@@ -2034,7 +2035,7 @@ public class ControllerImpl implements Controller
       );
     }
 
-    return MSQResultsReport.createReportAndLimitRowsIfNeeded(mappedSignature.build(), sqlTypeNames, resultsYielder, limitSelectResult);
+    return MSQResultsReport.createReportAndLimitRowsIfNeeded(mappedSignature.build(), sqlTypeNames, resultsYielder, selectDestination);
   }
 
   private static MSQStatusReport makeStatusReport(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQSelectDestination.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQSelectDestination.java
@@ -27,18 +27,21 @@ public enum MSQSelectDestination
   /**
    * Writes all the results directly to the report.
    */
-  REPORT(false),
-  S3(true);
+  TASK_REPORT(false),
+  /**
+   * Writes the results as frame files to durable storage. Task report can be truncated to a preview.
+   */
+  DURABLE_STORAGE(true);
 
-  private final boolean shouldTruncateResults;
+  private final boolean shouldTruncateResultsInTaskReport;
 
-  public boolean shouldTruncateResults()
+  public boolean shouldTruncateResultsInTaskReport()
   {
-    return shouldTruncateResults;
+    return shouldTruncateResultsInTaskReport;
   }
 
-  MSQSelectDestination(boolean shouldTruncateResults)
+  MSQSelectDestination(boolean shouldTruncateResultsInTaskReport)
   {
-    this.shouldTruncateResults = shouldTruncateResults;
+    this.shouldTruncateResultsInTaskReport = shouldTruncateResultsInTaskReport;
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQSelectDestination.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQSelectDestination.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.indexing;
+
+/**
+ * Determines the destination for results of select queries.
+ */
+public enum MSQSelectDestination
+{
+  /**
+   * Writes all the results directly to the report.
+   */
+  REPORT(false),
+  S3(true);
+
+  private final boolean shouldTruncateResults;
+
+  public boolean shouldTruncateResults()
+  {
+    return shouldTruncateResults;
+  }
+
+  MSQSelectDestination(boolean shouldTruncateResults)
+  {
+    this.shouldTruncateResults = shouldTruncateResults;
+  }
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.common.config.Configs;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.common.guava.Yielders;
@@ -44,30 +45,20 @@ public class MSQResultsReport
   private final List<ColumnAndType> signature;
   @Nullable
   private final List<SqlTypeName> sqlTypeNames;
-  private final List<Object[]> results;
+  private final Yielder<Object[]> resultYielder;
   private final boolean resultsTruncated;
 
   public MSQResultsReport(
       final List<ColumnAndType> signature,
       @Nullable final List<SqlTypeName> sqlTypeNames,
-      Yielder<Object[]> resultYielder,
+      final Yielder<Object[]> resultYielder,
       @Nullable Boolean resultsTruncated
   )
   {
     this.signature = Preconditions.checkNotNull(signature, "signature");
     this.sqlTypeNames = sqlTypeNames;
-    this.results = new ArrayList<>();
-    int rowCount = 0;
-    while (!resultYielder.isDone() && rowCount < Limits.MAX_SELECT_RESULT_ROWS) {
-      results.add(resultYielder.get());
-      resultYielder = resultYielder.next(null);
-      ++rowCount;
-    }
-    if (resultsTruncated != null) {
-      this.resultsTruncated = !resultYielder.isDone() || resultsTruncated;
-    } else {
-      this.resultsTruncated = !resultYielder.isDone();
-    }
+    this.resultYielder = Preconditions.checkNotNull(resultYielder, "resultYielder");
+    this.resultsTruncated = Configs.valueOrDefault(resultsTruncated, false);
   }
 
   /**
@@ -82,6 +73,27 @@ public class MSQResultsReport
   )
   {
     return new MSQResultsReport(signature, sqlTypeNames, Yielders.each(Sequences.simple(results)), resultsTruncated);
+  }
+
+  public static MSQResultsReport createReportAndLimitRowsIfNeeded(
+      final List<ColumnAndType> signature,
+      @Nullable final List<SqlTypeName> sqlTypeNames,
+      Yielder<Object[]> resultYielder,
+      boolean shouldTruncateResults
+  )
+  {
+    if (shouldTruncateResults) {
+      List<Object[]> results = new ArrayList<>();
+      int rowCount = 0;
+      while (!resultYielder.isDone() && rowCount < Limits.MAX_SELECT_RESULT_ROWS) {
+        results.add(resultYielder.get());
+        resultYielder = resultYielder.next(null);
+        ++rowCount;
+      }
+      return new MSQResultsReport(signature, sqlTypeNames, Yielders.each(Sequences.simple(results)), !resultYielder.isDone());
+    } else {
+      return new MSQResultsReport(signature, sqlTypeNames, resultYielder, false);
+    }
   }
 
   @JsonProperty("signature")
@@ -99,9 +111,9 @@ public class MSQResultsReport
   }
 
   @JsonProperty("results")
-  public List<Object[]> getResults()
+  public Yielder<Object[]> getResultYielder()
   {
-    return results;
+    return resultYielder;
   }
 
   @JsonProperty("resultsTruncted")

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
@@ -83,7 +83,7 @@ public class MSQResultsReport
       MSQSelectDestination selectDestination
   )
   {
-    if (selectDestination.shouldTruncateResults()) {
+    if (selectDestination.shouldTruncateResultsInTaskReport()) {
       List<Object[]> results = new ArrayList<>();
       int rowCount = 0;
       while (!resultYielder.isDone() && rowCount < Limits.MAX_SELECT_RESULT_ROWS) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.msq.exec.Limits;
+import org.apache.druid.msq.indexing.MSQSelectDestination;
 import org.apache.druid.segment.column.ColumnType;
 
 import javax.annotation.Nullable;
@@ -79,10 +80,10 @@ public class MSQResultsReport
       final List<ColumnAndType> signature,
       @Nullable final List<SqlTypeName> sqlTypeNames,
       Yielder<Object[]> resultYielder,
-      boolean shouldTruncateResults
+      MSQSelectDestination selectDestination
   )
   {
-    if (shouldTruncateResults) {
+    if (selectDestination.shouldTruncateResults()) {
       List<Object[]> results = new ArrayList<>();
       int rowCount = 0;
       while (!resultYielder.isDone() && rowCount < Limits.MAX_SELECT_RESULT_ROWS) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
  *
  * <li><b>selectDestination</b>: If the query is a Select, determines the location to write results to, once the query
  * is finished. Depending on the location, the results might also be truncated to {@link Limits#MAX_SELECT_RESULT_ROWS}.
- * Default value is {@link MSQSelectDestination#REPORT}, which writes all the results to the report.
+ * Default value is {@link MSQSelectDestination#TASK_REPORT}, which writes all the results to the report.
  *
  * <li><b>useAutoColumnSchemas</b>: Temporary flag to allow experimentation using
  * {@link org.apache.druid.segment.AutoTypeColumnSchema} for all 'standard' type columns during segment generation,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -64,6 +64,9 @@ import java.util.stream.Collectors;
  * Can be <b>PARALLEL</b>, <b>SEQUENTIAL</b> or <b>AUTO</b>. See {@link ClusterStatisticsMergeMode} for more information on each mode.
  * Default value is <b>PARALLEL</b></li>
  *
+ * <li><b>limitSelectResult</b>: Whether to limit the number of results returned in the query report. If true, limits the number of
+ * rows to {@link Limits#MAX_SELECT_RESULT_ROWS}. If false, all rows are passed on to the report.
+ *
  * <li><b>useAutoColumnSchemas</b>: Temporary flag to allow experimentation using
  * {@link org.apache.druid.segment.AutoTypeColumnSchema} for all 'standard' type columns during segment generation,
  * see {@link DimensionSchemaUtils#createDimensionSchema} for more details.
@@ -87,6 +90,8 @@ public class MultiStageQueryContext
 
   public static final String CTX_DURABLE_SHUFFLE_STORAGE = "durableShuffleStorage";
   private static final boolean DEFAULT_DURABLE_SHUFFLE_STORAGE = false;
+  public static final String CTX_LIMIT_SELECT_RESULT = "limitSelectResult";
+  private static final boolean DEFAULT_LIMIT_SELECT_RESULT = false;
 
   public static final String CTX_FAULT_TOLERANCE = "faultTolerance";
   public static final boolean DEFAULT_FAULT_TOLERANCE = false;
@@ -201,6 +206,14 @@ public class MultiStageQueryContext
     return queryContext.getInt(
         CTX_ROWS_PER_SEGMENT,
         DEFAULT_ROWS_PER_SEGMENT
+    );
+  }
+
+  public static boolean limitSelectResults(final QueryContext queryContext)
+  {
+    return queryContext.getBoolean(
+        CTX_LIMIT_SELECT_RESULT,
+        DEFAULT_LIMIT_SELECT_RESULT
     );
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -93,7 +93,7 @@ public class MultiStageQueryContext
   public static final String CTX_DURABLE_SHUFFLE_STORAGE = "durableShuffleStorage";
   private static final boolean DEFAULT_DURABLE_SHUFFLE_STORAGE = false;
   public static final String CTX_SELECT_DESTINATION = "selectDestination";
-  private static final String DEFAULT_SELECT_DESTINATION = MSQSelectDestination.REPORT.toString();
+  private static final String DEFAULT_SELECT_DESTINATION = MSQSelectDestination.TASK_REPORT.toString();
 
   public static final String CTX_FAULT_TOLERANCE = "faultTolerance";
   public static final boolean DEFAULT_FAULT_TOLERANCE = false;

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.test.CounterSnapshotMatcher;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestFileUtils;
+import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.LookupDataSource;
 import org.apache.druid.query.QueryDataSource;
@@ -89,6 +90,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -1790,6 +1792,9 @@ public class MSQSelectTest extends MSQTestBase
       result.add(new Object[]{1});
     }
 
+    Map<String, Object> queryContext = new HashMap<>(context);
+    queryContext.put(MultiStageQueryContext.CTX_LIMIT_SELECT_RESULT, true);
+
     testSelectQuery()
         .setSql(StringUtils.format(
             " SELECT 1 as \"timestamp\"\n"
@@ -1816,7 +1821,7 @@ public class MSQSelectTest extends MSQTestBase
                            .columns("v0")
                            .virtualColumns(new ExpressionVirtualColumn("v0", ExprEval.of(1L).toExpr(), ColumnType.LONG))
                            .context(defaultScanQueryContext(
-                               context,
+                               queryContext,
                                RowSignature.builder().add("v0", ColumnType.LONG).build()
                            ))
                            .build()
@@ -1828,7 +1833,7 @@ public class MSQSelectTest extends MSQTestBase
                 ))
                 .tuningConfig(MSQTuningConfig.defaultConfig())
                 .build())
-        .setQueryContext(context)
+        .setQueryContext(queryContext)
         .setExpectedResultRows(result)
         .verifyResults();
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQSelectTest.java
@@ -1795,7 +1795,7 @@ public class MSQSelectTest extends MSQTestBase
     }
 
     Map<String, Object> queryContext = new HashMap<>(context);
-    queryContext.put(MultiStageQueryContext.CTX_SELECT_DESTINATION, MSQSelectDestination.S3.toString());
+    queryContext.put(MultiStageQueryContext.CTX_SELECT_DESTINATION, MSQSelectDestination.DURABLE_STORAGE.toString());
 
     testSelectQuery()
         .setSql(StringUtils.format(

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -69,6 +69,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
+import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.metadata.input.InputSourceModule;
@@ -768,7 +769,20 @@ public class MSQTestBase extends BaseCalciteQueryTest
     if (resultsReport == null) {
       return null;
     } else {
-      return resultsReport.getResults();
+      Yielder<Object[]> yielder = resultsReport.getResultYielder();
+      List<Object[]> rows = new ArrayList<>();
+      while (!yielder.isDone()) {
+        rows.add(yielder.get());
+        yielder = yielder.next(null);
+      }
+      try {
+        yielder.close();
+      }
+      catch (IOException e) {
+        throw new ISE("Unable to get results from the report");
+      }
+
+      return rows;
     }
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -267,7 +267,7 @@ public class MultiStageQueryContextTest
   @Test
   public void limitSelectResultReturnsDefaultValue()
   {
-    Assert.assertEquals(MSQSelectDestination.REPORT, MultiStageQueryContext.getSelectDestination(QueryContext.empty()));
+    Assert.assertEquals(MSQSelectDestination.TASK_REPORT, MultiStageQueryContext.getSelectDestination(QueryContext.empty()));
   }
 
   @Test

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -264,6 +264,12 @@ public class MultiStageQueryContextTest
   }
 
   @Test
+  public void limitSelectResultReturnsDefaultValue()
+  {
+    Assert.assertFalse(MultiStageQueryContext.limitSelectResults(QueryContext.empty()));
+  }
+
+  @Test
   public void testUseAutoSchemas()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_USE_AUTO_SCHEMAS, true);

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.msq.indexing.MSQSelectDestination;
 import org.apache.druid.msq.kernel.WorkerAssignmentStrategy;
 import org.apache.druid.query.BadQueryContextException;
 import org.apache.druid.query.QueryContext;
@@ -266,7 +267,7 @@ public class MultiStageQueryContextTest
   @Test
   public void limitSelectResultReturnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.limitSelectResults(QueryContext.empty()));
+    Assert.assertEquals(MSQSelectDestination.REPORT, MultiStageQueryContext.getSelectDestination(QueryContext.empty()));
   }
 
   @Test

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.guava.Yielder;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
 import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReport;
@@ -200,15 +201,17 @@ public class MsqTestQueryHelper extends AbstractTestQueryHelper<MsqQueryWithResu
 
     List<Map<String, Object>> actualResults = new ArrayList<>();
 
-    List<Object[]> results = resultsReport.getResults();
+    Yielder<Object[]> yielder = resultsReport.getResultYielder();
     List<MSQResultsReport.ColumnAndType> rowSignature = resultsReport.getSignature();
 
-    for (Object[] row : results) {
+    while (!yielder.isDone()) {
+      Object[] row = yielder.get();
       Map<String, Object> rowWithFieldNames = new LinkedHashMap<>();
       for (int i = 0; i < row.length; ++i) {
         rowWithFieldNames.put(rowSignature.get(i).getName(), row[i]);
       }
       actualResults.add(rowWithFieldNames);
+      yielder = yielder.next(null);
     }
 
     QueryResultVerifier.ResultVerificationObject resultsComparison = QueryResultVerifier.compareResults(


### PR DESCRIPTION
This PR adds a new query context parameter for MSQ to decide if the result of an MSQ select query needs to be limited. This will help maintain backward compatibility and help people not be surprised by truncated results.

This parameter has been documented in `MultiStageQueryContext`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
