### PR TITLE
Filter on specific function names in `INFORMATION_SCHEMA.ROUTINES` tests

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -433,10 +433,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "SELECT\n"
         + "  COUNT(*)\n"
         + "FROM INFORMATION_SCHEMA.ROUTINES\n"
-        + "WHERE IS_AGGREGATOR = 'YES'",
+        + "WHERE IS_AGGREGATOR = 'YES' AND ROUTINE_NAME = 'COUNT'",
         ImmutableList.of(),
         ImmutableList.of(
-            new Object[]{30L}
+            new Object[]{1L}
         )
     );
   }
@@ -449,10 +449,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "SELECT\n"
         + "  COUNT(*)\n"
         + "FROM INFORMATION_SCHEMA.ROUTINES\n"
-        + "WHERE IS_AGGREGATOR = 'NO'",
+        + "WHERE IS_AGGREGATOR = 'NO' AND ROUTINE_NAME = 'CEIL'",
         ImmutableList.of(),
         ImmutableList.of(
-            new Object[]{152L}
+            new Object[]{1L}
         )
     );
   }


### PR DESCRIPTION
`testFilterAggregatorFunctionsOnInformationSchemaRoutines` and `testFilterScalarFunctionsOnInformationSchemaRoutines` now validate on specific function names injected into the operator table from the standard list. So developers don't need to update the count when adding a new function.

Ideally, we could inject a static set of operators into the operator table, but that seems a bit tricky to wire up, given the number of dependencies.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
