### PR TITLE
Druid server cache package migration to JUnit5 intial commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,20 @@
         <repoOrgName>Maven Central Repository</repoOrgName>
         <repoOrgUrl>https://repo1.maven.org/maven2/</repoOrgUrl>
 
+        <!-- Unit tests dependencies versions-->
+        <mockito.version>4.3.1</mockito.version>
+        <easymock.version>5.1.0</easymock.version>
+        <junit4.version>4.13.2</junit4.version>
+        <junit5.version>5.9.3</junit5.version>
+        <junit.benchmarks.version>0.7.2</junit.benchmarks.version>
+        <assertj.version>3.19.0</assertj.version>
+        <junit.params.version>1.1.1</junit.params.version>
+        <equalsverifier.version>3.10.1</equalsverifier.version>
+        <system.rules.version>1.19.0</system.rules.version>
+        <testng.version>7.3.0</testng.version>
+        <caliper.version>0.5-rc1</caliper.version>
+
+
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
 
@@ -989,6 +1003,13 @@
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit5.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
               <groupId>org.mockito</groupId>

--- a/processing/src/main/java/org/apache/druid/common/exception/SanitizableException.java
+++ b/processing/src/main/java/org/apache/druid/common/exception/SanitizableException.java
@@ -24,11 +24,14 @@ import java.util.function.Function;
 public interface SanitizableException
 {
   /**
-   * Apply the function for transforming the error message then return new Exception with sanitized fields and transformed message.
+   * Apply the function for transforming the error message then return new Exception with sanitized fields
+   * and transformed message.
    * The {@param errorMessageTransformFunction} is only intended to be use to transform the error message
    * String of the Exception as only the error message String is common to all Exception classes.
-   * For other fields (which may be unique to each particular Exception class), each implementation of this method can
-   * decide for itself how to sanitized those fields (i.e. leaving unchanged, changing to null, changing to a fixed String, etc.).
+   * For other fields (which may be unique to each particular Exception class), each implementation of this
+   * method can
+   * decide for itself how to sanitized those fields (i.e. leaving unchanged, changing to null, changing to
+   * a fixed String, etc.).
    * Note that this method returns a new Exception of the same type since Exception error message is immutable.
    */
   Exception sanitize(

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -312,12 +312,38 @@
             <artifactId>commons-lang3</artifactId>
     	</dependency>
 
+
         <!-- Tests -->
+        <!-- JUnit dependencies migration plan -->
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <!--<dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/server/src/test/java/org/apache/druid/client/BrokerInternalQueryConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerInternalQueryConfigTest.java
@@ -33,18 +33,20 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class BrokerInternalQueryConfigTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BrokerInternalQueryConfigTest
 {
   private static final ObjectMapper MAPPER = TestHelper.makeJsonMapper();
 
   @Test
-  public void testSerde() throws Exception
+  void testSerde() throws Exception
   {
     //defaults
     String json = "{}";
@@ -56,7 +58,7 @@ public class BrokerInternalQueryConfigTest
         BrokerInternalQueryConfig.class
     );
 
-    Assert.assertEquals(ImmutableMap.of(), config.getContext());
+    assertEquals(ImmutableMap.of(), config.getContext());
 
     //non-defaults
     json = "{ \"context\": {\"priority\": 5}}";
@@ -70,31 +72,30 @@ public class BrokerInternalQueryConfigTest
 
     Map<String, Object> expected = new HashMap<>();
     expected.put("priority", 5);
-    Assert.assertEquals(expected, config.getContext());
+    assertEquals(expected, config.getContext());
   }
 
   /**
    * Malformatted configuration will trigger an exception and fail to startup the service
    *
-   * @throws Exception
    */
-  @Test(expected = JsonEOFException.class)
-  public void testMalfomattedContext() throws Exception
+  @Test
+  void testMalfomattedContext()
   {
     String malformedJson = "{\"priority: 5}";
-    MAPPER.readValue(
+    assertThrows(JsonEOFException.class, () -> MAPPER.readValue(
         MAPPER.writeValueAsString(
             MAPPER.readValue(malformedJson, BrokerInternalQueryConfig.class)
         ),
         BrokerInternalQueryConfig.class
-    );
+    ));
   }
 
   /**
    * Test the behavior if the operator does not specify anything for druid.broker.internal.query.config.context in runtime.properties
    */
   @Test
-  public void testDefaultBehavior()
+  void testDefaultBehavior()
   {
     Injector injector = Guice.createInjector(
         new Module()
@@ -116,6 +117,6 @@ public class BrokerInternalQueryConfigTest
         }
     );
     BrokerInternalQueryConfig config = injector.getInstance(BrokerInternalQueryConfig.class);
-    Assert.assertEquals(ImmutableMap.of(), config.getContext());
+    assertEquals(ImmutableMap.of(), config.getContext());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/BrokerSegmentWatcherConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/BrokerSegmentWatcherConfigTest.java
@@ -22,17 +22,22 @@ package org.apache.druid.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
+ *
  */
-public class BrokerSegmentWatcherConfigTest
+class BrokerSegmentWatcherConfigTest
 {
   private static final ObjectMapper MAPPER = TestHelper.makeJsonMapper();
 
   @Test
-  public void testSerde() throws Exception
+  void testSerde() throws Exception
   {
     //defaults
     String json = "{}";
@@ -44,9 +49,9 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertNull(config.getWatchedTiers());
-    Assert.assertTrue(config.isWatchRealtimeTasks());
-    Assert.assertNull(config.getIgnoredTiers());
+    assertNull(config.getWatchedTiers());
+    assertTrue(config.isWatchRealtimeTasks());
+    assertNull(config.getIgnoredTiers());
 
     //non-defaults
     json = "{ \"watchedTiers\": [\"t1\", \"t2\"], \"watchedDataSources\": [\"ds1\", \"ds2\"], \"watchRealtimeTasks\": false }";
@@ -58,10 +63,10 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertEquals(ImmutableSet.of("t1", "t2"), config.getWatchedTiers());
-    Assert.assertNull(config.getIgnoredTiers());
-    Assert.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
-    Assert.assertFalse(config.isWatchRealtimeTasks());
+    assertEquals(ImmutableSet.of("t1", "t2"), config.getWatchedTiers());
+    assertNull(config.getIgnoredTiers());
+    assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
+    assertFalse(config.isWatchRealtimeTasks());
 
     // json with ignoredTiers
     json = "{ \"ignoredTiers\": [\"t3\", \"t4\"], \"watchedDataSources\": [\"ds1\", \"ds2\"] }";
@@ -73,9 +78,9 @@ public class BrokerSegmentWatcherConfigTest
         BrokerSegmentWatcherConfig.class
     );
 
-    Assert.assertNull(config.getWatchedTiers());
-    Assert.assertEquals(ImmutableSet.of("t3", "t4"), config.getIgnoredTiers());
-    Assert.assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
-    Assert.assertTrue(config.isWatchRealtimeTasks());
+    assertNull(config.getWatchedTiers());
+    assertEquals(ImmutableSet.of("t3", "t4"), config.getIgnoredTiers());
+    assertEquals(ImmutableSet.of("ds1", "ds2"), config.getWatchedDataSources());
+    assertTrue(config.isWatchRealtimeTasks());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
+++ b/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
@@ -32,12 +32,14 @@ import org.apache.druid.query.LookupDataSource;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-public class CacheUtilTest
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CacheUtilTest
 {
   private final TimeseriesQuery timeseriesQuery =
       Druids.newTimeseriesQueryBuilder()
@@ -47,9 +49,9 @@ public class CacheUtilTest
             .build();
 
   @Test
-  public void test_isQueryCacheable_cacheableOnBroker()
+  void test_isQueryCacheable_cacheableOnBroker()
   {
-    Assert.assertTrue(
+    assertTrue(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, true),
@@ -60,9 +62,9 @@ public class CacheUtilTest
   }
 
   @Test
-  public void test_isQueryCacheable_cacheableOnDataServer()
+  void test_isQueryCacheable_cacheableOnDataServer()
   {
-    Assert.assertTrue(
+    assertTrue(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, true),
@@ -75,7 +77,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableOnBroker()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(false, true),
@@ -88,7 +90,7 @@ public class CacheUtilTest
   @Test
   public void test_isQueryCacheable_unCacheableOnDataServer()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, false),
@@ -99,9 +101,9 @@ public class CacheUtilTest
   }
 
   @Test
-  public void test_isQueryCacheable_unCacheableType()
+  void test_isQueryCacheable_unCacheableType()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             new DummyCacheStrategy<>(true, false),
@@ -112,9 +114,9 @@ public class CacheUtilTest
   }
 
   @Test
-  public void test_isQueryCacheable_unCacheableDataSourceOnBroker()
+  void test_isQueryCacheable_unCacheableDataSourceOnBroker()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery.withDataSource(new GlobalTableDataSource("global")),
             new DummyCacheStrategy<>(true, true),
@@ -125,9 +127,9 @@ public class CacheUtilTest
   }
 
   @Test
-  public void test_isQueryCacheable_unCacheableDataSourceOnDataServer()
+  void test_isQueryCacheable_unCacheableDataSourceOnDataServer()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery.withDataSource(new LookupDataSource("lookyloo")),
             new DummyCacheStrategy<>(true, true),
@@ -138,9 +140,9 @@ public class CacheUtilTest
   }
 
   @Test
-  public void test_isQueryCacheable_nullCacheStrategy()
+  void test_isQueryCacheable_nullCacheStrategy()
   {
-    Assert.assertFalse(
+    assertFalse(
         CacheUtil.isQueryCacheable(
             timeseriesQuery,
             null,

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -58,10 +58,9 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.SingleElementPartitionChunk;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -73,10 +72,13 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
  *
  */
-public class CachingClusteredClientFunctionalityTest
+class CachingClusteredClientFunctionalityTest
 {
   private static final ObjectMapper OBJECT_MAPPER = CachingClusteredClientTestUtils.createObjectMapper();
   private static final Pair<QueryToolChestWarehouse, Closer> WAREHOUSE_AND_CLOSER =
@@ -89,14 +91,14 @@ public class CachingClusteredClientFunctionalityTest
   private TimelineServerView serverView;
   private Cache cache;
 
-  @AfterClass
-  public static void tearDownClass() throws IOException
+  @AfterAll
+  static void tearDownClass() throws IOException
   {
     RESOURCE_CLOSER.close();
   }
 
-  @Before
-  public void setUp()
+  @BeforeEach
+  void setUp()
   {
     timeline = new VersionedIntervalTimeline<>(Ordering.natural());
     serverView = EasyMock.createNiceMock(TimelineServerView.class);
@@ -107,7 +109,7 @@ public class CachingClusteredClientFunctionalityTest
   }
 
   @Test
-  public void testUncoveredInterval()
+  void testUncoveredInterval()
   {
     addToTimeline(Intervals.of("2015-01-02/2015-01-03"), "1");
     addToTimeline(Intervals.of("2015-01-04/2015-01-05"), "1");
@@ -127,7 +129,7 @@ public class CachingClusteredClientFunctionalityTest
 
     ResponseContext responseContext = ResponseContext.createEmpty();
     runQuery(client, builder.build(), responseContext);
-    Assert.assertNull(responseContext.getUncoveredIntervals());
+    assertNull(responseContext.getUncoveredIntervals());
 
     builder.intervals("2015-01-01/2015-01-03");
     responseContext = ResponseContext.createEmpty();
@@ -176,8 +178,8 @@ public class CachingClusteredClientFunctionalityTest
     for (String interval : intervals) {
       expectedList.add(Intervals.of(interval));
     }
-    Assert.assertEquals((Object) expectedList, context.getUncoveredIntervals());
-    Assert.assertEquals(uncoveredIntervalsOverflowed, context.get(ResponseContext.Keys.UNCOVERED_INTERVALS_OVERFLOWED));
+    assertEquals((Object) expectedList, context.getUncoveredIntervals());
+    assertEquals(uncoveredIntervalsOverflowed, context.get(ResponseContext.Keys.UNCOVERED_INTERVALS_OVERFLOWED));
   }
 
   private void addToTimeline(Interval interval, String version)

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -54,9 +54,8 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.timeout.ReadTimeoutException;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -68,7 +67,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class DirectDruidClientTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DirectDruidClientTest
 {
   private final String hostName = "localhost:8080";
 
@@ -89,8 +92,8 @@ public class DirectDruidClientTest
   private DirectDruidClient client;
   private QueryableDruidServer queryableDruidServer;
 
-  @Before
-  public void setup()
+  @BeforeEach
+  void setup()
   {
     httpClient = EasyMock.createMock(HttpClient.class);
     serverSelector = new ServerSelector(
@@ -123,7 +126,7 @@ public class DirectDruidClientTest
 
 
   @Test
-  public void testRun() throws Exception
+  void testRun() throws Exception
   {
     final URL url = new URL(StringUtils.format("http://%s/druid/v2/", hostName));
 
@@ -189,23 +192,23 @@ public class DirectDruidClientTest
     TimeBoundaryQuery query = Druids.newTimeBoundaryQueryBuilder().dataSource("test").build();
     query = query.withOverriddenContext(ImmutableMap.of(DirectDruidClient.QUERY_FAIL_TIME, Long.MAX_VALUE));
     Sequence s1 = client.run(QueryPlus.wrap(query));
-    Assert.assertTrue(capturedRequest.hasCaptured());
-    Assert.assertEquals(url, capturedRequest.getValue().getUrl());
-    Assert.assertEquals(HttpMethod.POST, capturedRequest.getValue().getMethod());
-    Assert.assertEquals(1, client.getNumOpenConnections());
+    assertTrue(capturedRequest.hasCaptured());
+    assertEquals(url, capturedRequest.getValue().getUrl());
+    assertEquals(HttpMethod.POST, capturedRequest.getValue().getMethod());
+    assertEquals(1, client.getNumOpenConnections());
 
     // simulate read timeout
     client.run(QueryPlus.wrap(query));
-    Assert.assertEquals(2, client.getNumOpenConnections());
+    assertEquals(2, client.getNumOpenConnections());
     futureException.setException(new ReadTimeoutException());
-    Assert.assertEquals(1, client.getNumOpenConnections());
+    assertEquals(1, client.getNumOpenConnections());
 
     // subsequent connections should work
     client.run(QueryPlus.wrap(query));
     client.run(QueryPlus.wrap(query));
     client.run(QueryPlus.wrap(query));
 
-    Assert.assertTrue(client.getNumOpenConnections() == 4);
+    assertTrue(client.getNumOpenConnections() == 4);
 
     // produce result for first connection
     futureResult.set(
@@ -214,16 +217,16 @@ public class DirectDruidClientTest
         )
     );
     List<Result> results = s1.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(DateTimes.of("2014-01-01T01:02:03Z"), results.get(0).getTimestamp());
-    Assert.assertEquals(3, client.getNumOpenConnections());
+    assertEquals(1, results.size());
+    assertEquals(DateTimes.of("2014-01-01T01:02:03Z"), results.get(0).getTimestamp());
+    assertEquals(3, client.getNumOpenConnections());
 
     client2.run(QueryPlus.wrap(query));
     client2.run(QueryPlus.wrap(query));
 
-    Assert.assertEquals(2, client2.getNumOpenConnections());
+    assertEquals(2, client2.getNumOpenConnections());
 
-    Assert.assertEquals(serverSelector.pick(null), queryableDruidServer2);
+    assertEquals(serverSelector.pick(null), queryableDruidServer2);
 
     EasyMock.verify(httpClient);
   }
@@ -262,8 +265,8 @@ public class DirectDruidClientTest
     query = query.withOverriddenContext(ImmutableMap.of(DirectDruidClient.QUERY_FAIL_TIME, Long.MAX_VALUE));
     cancellationFuture.set(new StatusResponseHolder(HttpResponseStatus.OK, new StringBuilder("cancelled")));
     Sequence results = client.run(QueryPlus.wrap(query));
-    Assert.assertEquals(HttpMethod.POST, capturedRequest.getValue().getMethod());
-    Assert.assertEquals(0, client.getNumOpenConnections());
+    assertEquals(HttpMethod.POST, capturedRequest.getValue().getMethod());
+    assertEquals(0, client.getNumOpenConnections());
 
 
     QueryInterruptedException exception = null;
@@ -273,7 +276,7 @@ public class DirectDruidClientTest
     catch (QueryInterruptedException e) {
       exception = e;
     }
-    Assert.assertNotNull(exception);
+    assertNotNull(exception);
 
     EasyMock.verify(httpClient);
   }
@@ -314,10 +317,10 @@ public class DirectDruidClientTest
     catch (QueryInterruptedException e) {
       actualException = e;
     }
-    Assert.assertNotNull(actualException);
-    Assert.assertEquals("testing1", actualException.getErrorCode());
-    Assert.assertEquals("testing2", actualException.getMessage());
-    Assert.assertEquals(hostName, actualException.getHost());
+    assertNotNull(actualException);
+    assertEquals("testing1", actualException.getErrorCode());
+    assertEquals("testing2", actualException.getMessage());
+    assertEquals(hostName, actualException.getHost());
     EasyMock.verify(httpClient);
   }
 
@@ -366,10 +369,10 @@ public class DirectDruidClientTest
     catch (QueryTimeoutException e) {
       actualException = e;
     }
-    Assert.assertNotNull(actualException);
-    Assert.assertEquals("Query timeout", actualException.getErrorCode());
-    Assert.assertEquals("url[http://localhost:8080/druid/v2/] timed out", actualException.getMessage());
-    Assert.assertEquals(hostName, actualException.getHost());
+    assertNotNull(actualException);
+    assertEquals("Query timeout", actualException.getErrorCode());
+    assertEquals("url[http://localhost:8080/druid/v2/] timed out", actualException.getMessage());
+    assertEquals(hostName, actualException.getHost());
     EasyMock.verify(httpClient);
   }
 
@@ -407,10 +410,10 @@ public class DirectDruidClientTest
     catch (QueryTimeoutException e) {
       actualException = e;
     }
-    Assert.assertNotNull(actualException);
-    Assert.assertEquals("Query timeout", actualException.getErrorCode());
-    Assert.assertEquals(StringUtils.format("Query [%s] timed out!", queryId), actualException.getMessage());
-    Assert.assertEquals(hostName, actualException.getHost());
+    assertNotNull(actualException);
+    assertEquals("Query timeout", actualException.getErrorCode());
+    assertEquals(StringUtils.format("Query [%s] timed out!", queryId), actualException.getMessage());
+    assertEquals(hostName, actualException.getHost());
     EasyMock.verify(httpClient);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/HttpServerInventoryViewConfigTest.java
@@ -20,29 +20,30 @@
 package org.apache.druid.client;
 
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  */
-public class HttpServerInventoryViewConfigTest
+class HttpServerInventoryViewConfigTest
 {
   @Test
-  public void testDeserializationWithDefaults() throws Exception
+  void testDeserializationWithDefaults() throws Exception
   {
     String json = "{}";
 
     HttpServerInventoryViewConfig config = TestHelper.makeJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
 
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(4), config.getServerTimeout());
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(1), config.getServerUnstabilityTimeout());
-    Assert.assertEquals(5, config.getNumThreads());
+    assertEquals(TimeUnit.MINUTES.toMillis(4), config.getServerTimeout());
+    assertEquals(TimeUnit.MINUTES.toMillis(1), config.getServerUnstabilityTimeout());
+    assertEquals(5, config.getNumThreads());
   }
 
   @Test
-  public void testDeserializationWithNonDefaults() throws Exception
+  void testDeserializationWithNonDefaults() throws Exception
   {
     String json = "{\n"
                   + "  \"serverTimeout\": \"PT2M\",\n"
@@ -52,8 +53,8 @@ public class HttpServerInventoryViewConfigTest
 
     HttpServerInventoryViewConfig config = TestHelper.makeJsonMapper().readValue(json, HttpServerInventoryViewConfig.class);
 
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(2), config.getServerTimeout());
-    Assert.assertEquals(TimeUnit.MINUTES.toMillis(3), config.getServerUnstabilityTimeout());
-    Assert.assertEquals(7, config.getNumThreads());
+    assertEquals(TimeUnit.MINUTES.toMillis(2), config.getServerTimeout());
+    assertEquals(TimeUnit.MINUTES.toMillis(3), config.getServerUnstabilityTimeout());
+    assertEquals(7, config.getNumThreads());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/ByteCountingLRUMapTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/ByteCountingLRUMapTest.java
@@ -19,29 +19,31 @@
 
 package org.apache.druid.client.cache;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 /**
  */
-public class ByteCountingLRUMapTest
+class ByteCountingLRUMapTest
 {
   private ByteCountingLRUMap map;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     map = new ByteCountingLRUMap(100);
   }
 
   @Test
-  public void testSanity()
+  void testSanity()
   {
     final ByteBuffer tenKey = ByteBuffer.allocate(10);
     final byte[] eightyEightVal = ByteBuffer.allocate(88).array();
@@ -52,22 +54,22 @@ public class ByteCountingLRUMapTest
     assertMapValues(0, 0, 0);
     map.put(tenKey, eightNineNineVal);
     assertMapValues(1, 99, 0);
-    Assert.assertEquals(ByteBuffer.wrap(eightNineNineVal), ByteBuffer.wrap(map.get(tenKey)));
+    assertEquals(ByteBuffer.wrap(eightNineNineVal), ByteBuffer.wrap(map.get(tenKey)));
 
     map.put(oneByte, oneByte.array());
     assertMapValues(1, 2, 1);
-    Assert.assertNull(map.get(tenKey));
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
+    assertNull(map.get(tenKey));
+    assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
 
     map.put(tenKey, eightyEightVal);
     assertMapValues(2, 100, 1);
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
-    Assert.assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
+    assertEquals(oneByte, ByteBuffer.wrap(map.get(oneByte)));
+    assertEquals(ByteBuffer.wrap(eightyEightVal), ByteBuffer.wrap(map.get(tenKey)));
 
     map.put(twoByte, oneByte.array());
     assertMapValues(1, 3, 3);
-    Assert.assertEquals(null, map.get(tenKey));
-    Assert.assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
+    assertNull(map.get(tenKey));
+    assertEquals(oneByte, ByteBuffer.wrap(map.get(twoByte)));
 
     Iterator<ByteBuffer> it = map.keySet().iterator();
     List<ByteBuffer> toRemove = new ArrayList<>();
@@ -77,9 +79,8 @@ public class ByteCountingLRUMapTest
         toRemove.add(buf);
       }
     }
-    for (ByteBuffer buf : toRemove) {
-      map.remove(buf);
-    }
+
+    toRemove.forEach(buf -> map.remove(buf));
     assertMapValues(1, 3, 3);
 
     map.remove(twoByte);
@@ -87,7 +88,7 @@ public class ByteCountingLRUMapTest
   }
 
   @Test
-  public void testSameKeyUpdate()
+  void testSameKeyUpdate()
   {
     final ByteBuffer k = ByteBuffer.allocate(1);
 
@@ -101,8 +102,8 @@ public class ByteCountingLRUMapTest
 
   private void assertMapValues(final int size, final int numBytes, final int evictionCount)
   {
-    Assert.assertEquals(size, map.size());
-    Assert.assertEquals(numBytes, map.getNumBytes());
-    Assert.assertEquals(evictionCount, map.getEvictionCount());
+    assertEquals(size, map.size());
+    assertEquals(numBytes, map.getNumBytes());
+    assertEquals(evictionCount, map.getEvictionCount());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/BytesBoundedLinkedQueueTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/BytesBoundedLinkedQueueTest.java
@@ -20,35 +20,41 @@
 package org.apache.druid.client.cache;
 
 
-import org.apache.druid.java.util.common.ISE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BytesBoundedLinkedQueueTest
+//from 278 lines to 245
+class BytesBoundedLinkedQueueTest
 {
-  private static int delayMS = 50;
-  private ExecutorService exec = Executors.newCachedThreadPool();
+  private static final int DELAY_MS = 50;
+  private final ExecutorService exec = Executors.newCachedThreadPool();
 
   private static BlockingQueue<TestObject> getQueue(final int capacity)
   {
     return new BytesBoundedLinkedQueue<TestObject>(capacity)
     {
       @Override
-      public long getBytesSize(TestObject o)
+      public long getBytesSize(final TestObject o)
       {
         return o.getSize();
       }
@@ -56,203 +62,166 @@ public class BytesBoundedLinkedQueueTest
   }
 
   @Test
-  public void testPoll() throws InterruptedException
+  void testPoll() throws InterruptedException
   {
-    final BlockingQueue q = getQueue(10);
+    final BlockingQueue<TestObject> q = getQueue(10);
     long startTime = System.nanoTime();
-    Assert.assertNull(q.poll(delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertTrue(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) >= delayMS);
+    assertNull(q.poll(DELAY_MS, TimeUnit.MILLISECONDS));
+    assertTrue(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) >= DELAY_MS);
+
     TestObject obj = new TestObject(2);
-    Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertSame(obj, q.poll(delayMS, TimeUnit.MILLISECONDS));
+    assertTrue(q.offer(obj, DELAY_MS, TimeUnit.MILLISECONDS));
+    assertSame(obj, q.poll(DELAY_MS, TimeUnit.MILLISECONDS));
 
     Thread.currentThread().interrupt();
-    try {
-      q.poll(delayMS, TimeUnit.MILLISECONDS);
-      throw new ISE("FAIL");
-    }
-    catch (InterruptedException success) {
-    }
-    Assert.assertFalse(Thread.interrupted());
+
+    assertThrows(
+        InterruptedException.class,
+        () -> q.poll(DELAY_MS, TimeUnit.MILLISECONDS)
+    );
+    assertFalse(Thread.interrupted());
   }
 
   @Test
-  public void testTake() throws Exception
+  void testTake() throws Exception
   {
     final BlockingQueue<TestObject> q = getQueue(10);
     Thread.currentThread().interrupt();
-    try {
-      q.take();
-      Assert.fail();
-    }
-    catch (InterruptedException success) {
-      //
-    }
+
+    assertThrows(InterruptedException.class, q::take);
+
     final CountDownLatch latch = new CountDownLatch(1);
     final TestObject object = new TestObject(4);
     Future<TestObject> future = exec.submit(
-        new Callable<TestObject>()
-        {
-          @Override
-          public TestObject call() throws Exception
-          {
-            latch.countDown();
-            return q.take();
+        () -> {
+          latch.countDown();
+          return q.take();
 
-          }
         }
     );
     latch.await();
     // test take blocks on empty queue
-    try {
-      future.get(delayMS, TimeUnit.MILLISECONDS);
-      Assert.fail();
-    }
-    catch (TimeoutException success) {
-
-    }
-
-    q.offer(object);
-    Assert.assertEquals(object, future.get());
+    assertThrows(TimeoutException.class, () -> future.get(DELAY_MS, TimeUnit.MILLISECONDS));
+    assertTrue(q.offer(object));
+    assertEquals(object, future.get());
   }
 
   @Test
-  public void testOfferAndPut() throws Exception
+  void testOfferAndPut() throws Exception
   {
     final BlockingQueue<TestObject> q = getQueue(10);
-    try {
-      q.offer(null);
-      Assert.fail();
-    }
-    catch (NullPointerException success) {
 
-    }
+    assertThrows(NullPointerException.class, () -> q.offer(null));
 
     final TestObject obj = new TestObject(2);
     while (q.remainingCapacity() > 0) {
-      Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
+      assertTrue(q.offer(obj, DELAY_MS, TimeUnit.MILLISECONDS));
     }
     // queue full
-    Assert.assertEquals(0, q.remainingCapacity());
-    Assert.assertFalse(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-    Assert.assertFalse(q.offer(obj));
+    assertEquals(0, q.remainingCapacity());
+    assertFalse(q.offer(obj, DELAY_MS, TimeUnit.MILLISECONDS));
+    assertFalse(q.offer(obj));
     final CyclicBarrier barrier = new CyclicBarrier(2);
 
     Future<Boolean> future = exec.submit(
-        new Callable<Boolean>()
-        {
-          @Override
-          public Boolean call() throws Exception
-          {
-            barrier.await();
-            Assert.assertTrue(q.offer(obj, delayMS, TimeUnit.MILLISECONDS));
-            Assert.assertEquals(q.remainingCapacity(), 0);
-            barrier.await();
-            q.put(obj);
-            return true;
-          }
+        () -> {
+          barrier.await();
+          assertTrue(q.offer(obj, DELAY_MS, TimeUnit.MILLISECONDS));
+          assertEquals(q.remainingCapacity(), 0);
+          barrier.await();
+          q.put(obj);
+          return true;
         }
     );
     barrier.await();
     q.take();
     barrier.await();
     q.take();
-    Assert.assertTrue(future.get());
+    assertTrue(future.get());
 
   }
 
   @Test
-  public void testAddBiggerElementThanCapacityFails()
+  void testAddBiggerElementThanCapacityFails()
   {
     BlockingQueue<TestObject> q = getQueue(5);
-    try {
-      q.offer(new TestObject(10));
-      Assert.fail();
-    }
-    catch (IllegalArgumentException success) {
-
-    }
+    assertThrows(IllegalArgumentException.class, () -> q.offer(new TestObject(10)));
   }
 
   @Test
-  public void testAddedObjectExceedsCapacity() throws Exception
+  void testAddedObjectExceedsCapacity() throws Exception
   {
     BlockingQueue<TestObject> q = getQueue(4);
-    Assert.assertTrue(q.offer(new TestObject(3)));
-    Assert.assertFalse(q.offer(new TestObject(2)));
-    Assert.assertFalse(q.offer(new TestObject(2), delayMS, TimeUnit.MILLISECONDS));
+    assertTrue(q.offer(new TestObject(3)));
+    assertFalse(q.offer(new TestObject(2)));
+    assertFalse(q.offer(new TestObject(2), DELAY_MS, TimeUnit.MILLISECONDS));
   }
 
   @Test
-  public void testConcurrentOperations() throws Exception
+  void testConcurrentOperations() throws Exception
   {
     final BlockingQueue<TestObject> q = getQueue(Integer.MAX_VALUE);
     long duration = TimeUnit.SECONDS.toMillis(10);
     ExecutorService executor = Executors.newCachedThreadPool();
     final AtomicBoolean stopTest = new AtomicBoolean(false);
-    List<Future> futures = new ArrayList<>();
-    for (int i = 0; i < 5; i++) {
-      futures.add(
-          executor.submit(
-              new Callable<Boolean>()
-              {
-                @Override
-                public Boolean call()
-                {
-                  while (!stopTest.get()) {
-                    q.add(new TestObject(1));
-                    q.add(new TestObject(2));
-                  }
-                  return true;
+    List<Future<Boolean>> futures = new ArrayList<>();
 
-                }
-              }
-          )
-      );
-    }
+    IntStream.range(0, 5)
+             .forEach(
+                 numberInRange ->
+                     futures.add(
+                         executor.submit(
+                             () -> {
+                               while (!stopTest.get()) {
+                                 q.add(new TestObject(1));
+                                 q.add(new TestObject(2));
+                               }
+                               return true;
+                             }
+                         )
+                     ));
 
-    for (int i = 0; i < 10; i++) {
-      futures.add(
-          executor.submit(
-              new Callable<Boolean>()
-              {
-                @Override
-                public Boolean call() throws InterruptedException
-                {
-                  while (!stopTest.get()) {
-                    q.poll(100, TimeUnit.MILLISECONDS);
-                    q.offer(new TestObject(2));
-                  }
-                  return true;
+    IntStream.range(0, 10)
+             .forEach(
+                 numberInRange ->
+                     futures.add(
+                         executor.submit(
+                             () -> {
+                               while (!stopTest.get()) {
+                                 q.poll(100, TimeUnit.MILLISECONDS);
+                                 q.offer(new TestObject(2));
+                               }
+                               return true;
+                             }
+                         )
+                     ));
 
-                }
-              }
-          )
-      );
-    }
+    IntStream.range(0, 5)
+             .forEach(
+                 numberInRange ->
+                     futures.add(
+                         executor.submit(
+                             () -> {
+                               while (!stopTest.get()) {
+                                 q.drainTo(new ArrayList<>(), Integer.MAX_VALUE);
+                               }
+                               return true;
+                             }
+                         )
+                     ));
 
-    for (int i = 0; i < 5; i++) {
-      futures.add(
-          executor.submit(
-              new Callable<Boolean>()
-              {
-                @Override
-                public Boolean call()
-                {
-                  while (!stopTest.get()) {
-                    q.drainTo(new ArrayList<>(), Integer.MAX_VALUE);
-                  }
-                  return true;
-                }
-              }
-          )
-      );
-    }
     Thread.sleep(duration);
     stopTest.set(true);
-    for (Future<Boolean> future : futures) {
-      Assert.assertTrue(future.get());
-    }
+
+    futures.forEach(future -> {
+      try {
+        Boolean aBoolean = (Boolean) future.get();
+        assertTrue(aBoolean);
+      }
+      catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   public static class TestObject

--- a/server/src/test/java/org/apache/druid/client/cache/CacheMonitorTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheMonitorTest.java
@@ -29,51 +29,54 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.server.DruidNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CacheMonitorTest
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CacheMonitorTest
 {
   @Test
-  public void testOptionalInject()
+  void testOptionalInject()
   {
-    Injector injector = Initialization.makeInjectorWithModules(GuiceInjectors.makeStartupInjector(), ImmutableList.of(
-        new Module() {
-          @Override
-          public void configure(Binder binder)
-          {
-            JsonConfigProvider.bindInstance(
+    Injector injector = Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.of(
+            binder -> JsonConfigProvider.bindInstance(
                 binder,
                 Key.get(DruidNode.class, Self.class),
                 new DruidNode("test-inject", null, false, null, null, true, false)
-            );
-          }
-        }
-    ));
+            )
+        )
+    );
 
     CacheMonitor monitor = injector.getInstance(CacheMonitor.class);
-    Assert.assertNull(monitor.cache);
+    assertNull(monitor.cache);
   }
 
   @Test
-  public void testInject()
+  void testInject()
   {
-    Injector injector = Initialization.makeInjectorWithModules(GuiceInjectors.makeStartupInjector(), ImmutableList.of(
-        new Module() {
-          @Override
-          public void configure(Binder binder)
-          {
-            JsonConfigProvider.bindInstance(
-                binder,
-                Key.get(DruidNode.class, Self.class),
-                new DruidNode("test-inject", null, false, null, null, true, false)
-            );
-            binder.bind(Cache.class).toInstance(MapCache.create(0));
-          }
-        }
-    ));
+    Injector injector = Initialization.makeInjectorWithModules(
+        GuiceInjectors.makeStartupInjector(),
+        ImmutableList.of(
+            new Module()
+            {
+              @Override
+              public void configure(Binder binder)
+              {
+                JsonConfigProvider.bindInstance(
+                    binder,
+                    Key.get(DruidNode.class, Self.class),
+                    new DruidNode("test-inject", null, false, null, null, true, false)
+                );
+                binder.bind(Cache.class).toInstance(MapCache.create(0));
+              }
+            }
+        )
+    );
 
     CacheMonitor monitor = injector.getInstance(CacheMonitor.class);
-    Assert.assertNotNull(monitor.cache);
+    assertNotNull(monitor.cache);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/MapCacheTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/MapCacheTest.java
@@ -21,55 +21,59 @@ package org.apache.druid.client.cache;
 
 import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  */
-public class MapCacheTest
+class MapCacheTest
 {
   private static final byte[] HI = StringUtils.toUtf8("hi");
   private static final byte[] HO = StringUtils.toUtf8("ho");
   private ByteCountingLRUMap baseMap;
   private MapCache cache;
 
-  @Before
-  public void setUp()
+  @BeforeEach
+  void setUp()
   {
     baseMap = new ByteCountingLRUMap(1024 * 1024);
     cache = new MapCache(baseMap);
   }
 
   @Test
-  public void testSanity()
+  void testSanity()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HI)));
-    Assert.assertEquals(0, baseMap.size());
+    assertNull(cache.get(new Cache.NamedKey("a", HI)));
+    assertEquals(0, baseMap.size());
     put(cache, "a", HI, 1);
-    Assert.assertEquals(1, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    assertEquals(1, baseMap.size());
+    assertEquals(1, get(cache, "a", HI));
+    assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 2);
-    Assert.assertEquals(2, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertEquals(2, get(cache, "the", HI));
+    assertEquals(2, baseMap.size());
+    assertEquals(1, get(cache, "a", HI));
+    assertEquals(2, get(cache, "the", HI));
 
     put(cache, "the", HO, 10);
-    Assert.assertEquals(3, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
-    Assert.assertEquals(2, get(cache, "the", HI));
-    Assert.assertEquals(10, get(cache, "the", HO));
+    assertEquals(3, baseMap.size());
+    assertEquals(1, get(cache, "a", HI));
+    assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    assertEquals(2, get(cache, "the", HI));
+    assertEquals(10, get(cache, "the", HO));
 
     cache.close("the");
-    Assert.assertEquals(1, baseMap.size());
-    Assert.assertEquals(1, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    assertEquals(1, baseMap.size());
+    assertEquals(1, get(cache, "a", HI));
+    assertNull(cache.get(new Cache.NamedKey("a", HO)));
 
     cache.close("a");
-    Assert.assertEquals(0, baseMap.size());
+    assertEquals(0, baseMap.size());
   }
 
   public void put(Cache cache, String namespace, byte[] key, Integer value)
@@ -79,6 +83,6 @@ public class MapCacheTest
 
   public int get(Cache cache, String namespace, byte[] key)
   {
-    return Ints.fromByteArray(cache.get(new Cache.NamedKey(namespace, key)));
+    return Ints.fromByteArray(Objects.requireNonNull(cache.get(new Cache.NamedKey(namespace, key))));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/cache/MemcacheClientPoolTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/MemcacheClientPoolTest.java
@@ -20,33 +20,33 @@
 package org.apache.druid.client.cache;
 
 import com.google.common.base.Suppliers;
-import net.spy.memcached.MemcachedClientIF;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MemcacheClientPoolTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MemcacheClientPoolTest
 {
 
   @Test
-  public void testSimpleUsage()
+  void testSimpleUsage()
   {
-    MemcacheClientPool pool = new MemcacheClientPool(3, Suppliers.ofInstance((MemcachedClientIF) null));
+    MemcacheClientPool pool = new MemcacheClientPool(3, Suppliers.ofInstance(null));
     // First round
     MemcacheClientPool.IdempotentCloseableHolder first = pool.get();
-    Assert.assertEquals(1, first.count());
+    assertEquals(1, first.count());
     MemcacheClientPool.IdempotentCloseableHolder second = pool.get();
-    Assert.assertEquals(1, second.count());
+    assertEquals(1, second.count());
     MemcacheClientPool.IdempotentCloseableHolder third = pool.get();
-    Assert.assertEquals(1, third.count());
+    assertEquals(1, third.count());
     // Second round
     MemcacheClientPool.IdempotentCloseableHolder firstClientSecondRound = pool.get();
-    Assert.assertEquals(2, firstClientSecondRound.count());
+    assertEquals(2, firstClientSecondRound.count());
     MemcacheClientPool.IdempotentCloseableHolder secondClientSecondRound = pool.get();
-    Assert.assertEquals(2, secondClientSecondRound.count());
+    assertEquals(2, secondClientSecondRound.count());
     first.close();
     firstClientSecondRound.close();
     MemcacheClientPool.IdempotentCloseableHolder firstAgain = pool.get();
-    Assert.assertEquals(1, firstAgain.count());
+    assertEquals(1, firstAgain.count());
     
     firstAgain.close();
     second.close();
@@ -55,7 +55,7 @@ public class MemcacheClientPoolTest
   }
 
   @Test
-  public void testClientLeakDetected() throws InterruptedException
+  void testClientLeakDetected() throws InterruptedException
   {
     long initialLeakedClients = MemcacheClientPool.leakedClients();
     createDanglingClient();
@@ -65,12 +65,12 @@ public class MemcacheClientPoolTest
       byte[] garbage = new byte[10_000_000];
       Thread.sleep(10);
     }
-    Assert.assertEquals(initialLeakedClients + 1, MemcacheClientPool.leakedClients());
+    assertEquals(initialLeakedClients + 1, MemcacheClientPool.leakedClients());
   }
 
   private void createDanglingClient()
   {
-    MemcacheClientPool pool = new MemcacheClientPool(1, Suppliers.ofInstance((MemcachedClientIF) null));
+    MemcacheClientPool pool = new MemcacheClientPool(1, Suppliers.ofInstance(null));
     pool.get();
   }
 }

--- a/server/src/test/java/org/apache/druid/client/client/ImmutableSegmentLoadInfoTest.java
+++ b/server/src/test/java/org/apache/druid/client/client/ImmutableSegmentLoadInfoTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.client.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
-import junit.framework.Assert;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.TestHelper;
@@ -29,16 +28,18 @@ import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-public class ImmutableSegmentLoadInfoTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ImmutableSegmentLoadInfoTest
 {
   private final ObjectMapper mapper = TestHelper.makeJsonMapper();
 
   @Test
-  public void testSerde() throws IOException
+  void testSerde() throws IOException
   {
     ImmutableSegmentLoadInfo segmentLoadInfo = new ImmutableSegmentLoadInfo(
         new DataSegment(
@@ -58,7 +59,7 @@ public class ImmutableSegmentLoadInfoTest
         ImmutableSegmentLoadInfo.class
     );
 
-    Assert.assertEquals(segmentLoadInfo, serde);
+    assertEquals(segmentLoadInfo, serde);
   }
 
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpecTest.java
@@ -26,13 +26,14 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-public class ClientCompactionIntervalSpecTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClientCompactionIntervalSpecTest
 {
   private final DataSegment dataSegment1 = new DataSegment(
       "test",
@@ -69,46 +70,65 @@ public class ClientCompactionIntervalSpecTest
   );
 
   @Test
-  public void testFromSegmentWithNoSegmentGranularity()
+  void testFromSegmentWithNoSegmentGranularity()
   {
     // The umbrella interval of segments is 2015-02-12/2015-04-14
-    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), null);
-    Assert.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getInterval());
+    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(
+        dataSegment1,
+        dataSegment2,
+        dataSegment3
+    ), null);
+    assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getInterval());
   }
 
   @Test
-  public void testFromSegmentWitSegmentGranularitySameAsSegment()
+  void testFromSegmentWitSegmentGranularitySameAsSegment()
   {
     // The umbrella interval of segments is 2015-04-11/2015-04-12
-    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(dataSegment1), Granularities.DAY);
-    Assert.assertEquals(Intervals.of("2015-04-11/2015-04-12"), actual.getInterval());
+    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(
+        ImmutableList.of(dataSegment1),
+        Granularities.DAY
+    );
+    assertEquals(Intervals.of("2015-04-11/2015-04-12"), actual.getInterval());
   }
 
   @Test
   public void testFromSegmentWithCoarserSegmentGranularity()
   {
     // The umbrella interval of segments is 2015-02-12/2015-04-14
-    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.YEAR);
+    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(
+        dataSegment1,
+        dataSegment2,
+        dataSegment3
+    ), Granularities.YEAR);
     // The compaction interval should be expanded to start of the year and end of the year to cover the segmentGranularity
-    Assert.assertEquals(Intervals.of("2015-01-01/2016-01-01"), actual.getInterval());
+    assertEquals(Intervals.of("2015-01-01/2016-01-01"), actual.getInterval());
   }
 
   @Test
-  public void testFromSegmentWithFinerSegmentGranularityAndUmbrellaIntervalAlign()
+  void testFromSegmentWithFinerSegmentGranularityAndUmbrellaIntervalAlign()
   {
     // The umbrella interval of segments is 2015-02-12/2015-04-14
-    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.DAY);
+    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(
+        dataSegment1,
+        dataSegment2,
+        dataSegment3
+    ), Granularities.DAY);
     // The segmentGranularity of DAY align with the umbrella interval (umbrella interval can be evenly divide into the segmentGranularity)
-    Assert.assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getInterval());
+    assertEquals(Intervals.of("2015-02-12/2015-04-14"), actual.getInterval());
   }
 
   @Test
-  public void testFromSegmentWithFinerSegmentGranularityAndUmbrellaIntervalNotAlign()
+  void testFromSegmentWithFinerSegmentGranularityAndUmbrellaIntervalNotAlign()
   {
     // The umbrella interval of segments is 2015-02-12/2015-04-14
-    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(dataSegment1, dataSegment2, dataSegment3), Granularities.WEEK);
+    ClientCompactionIntervalSpec actual = ClientCompactionIntervalSpec.fromSegments(ImmutableList.of(
+        dataSegment1,
+        dataSegment2,
+        dataSegment3
+    ), Granularities.WEEK);
     // The segmentGranularity of WEEK does not align with the umbrella interval (umbrella interval cannot be evenly divide into the segmentGranularity)
     // Hence the compaction interval is modified to aling with the segmentGranularity
-    Assert.assertEquals(Intervals.of("2015-02-09/2015-04-20"), actual.getInterval());
+    assertEquals(Intervals.of("2015-02-09/2015-04-20"), actual.getInterval());
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskDimensionsSpecTest.java
@@ -26,15 +26,17 @@ import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-public class ClientCompactionTaskDimensionsSpecTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClientCompactionTaskDimensionsSpecTest
 {
   @Test
-  public void testEquals()
+  void testEquals()
   {
     EqualsVerifier.forClass(ClientCompactionTaskDimensionsSpec.class)
                   .withPrefabValues(
@@ -47,25 +49,25 @@ public class ClientCompactionTaskDimensionsSpecTest
   }
 
   @Test
-  public void testSerde() throws IOException
+  void testSerde() throws IOException
   {
     final ClientCompactionTaskDimensionsSpec expected = new ClientCompactionTaskDimensionsSpec(
         DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim"))
     );
     final ObjectMapper mapper = new ObjectMapper();
     final byte[] json = mapper.writeValueAsBytes(expected);
-    final ClientCompactionTaskDimensionsSpec fromJson = (ClientCompactionTaskDimensionsSpec) mapper.readValue(
+    final ClientCompactionTaskDimensionsSpec fromJson = mapper.readValue(
         json,
         ClientCompactionTaskDimensionsSpec.class
     );
-    Assert.assertEquals(expected, fromJson);
+    assertEquals(expected, fromJson);
   }
 
-  @Test(expected = ParseException.class)
-  public void testInvalidDimensionsField()
+  @Test
+  void testInvalidDimensionsField()
   {
-    final ClientCompactionTaskDimensionsSpec expected = new ClientCompactionTaskDimensionsSpec(
+    assertThrows(ParseException.class, () -> new ClientCompactionTaskDimensionsSpec(
         DimensionsSpec.getDefaultSchemas(ImmutableList.of("ts", "dim", "dim"))
-    );
+    ));
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskTransformSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientCompactionTaskTransformSpecTest.java
@@ -24,16 +24,18 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.filter.SelectorDimFilter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class ClientCompactionTaskTransformSpecTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ClientCompactionTaskTransformSpecTest
 {
   @Test
-  public void testEquals()
+  void testEquals()
   {
     EqualsVerifier.forClass(ClientCompactionTaskTransformSpec.class)
                   .withNonnullFields("filter")
@@ -42,7 +44,7 @@ public class ClientCompactionTaskTransformSpecTest
   }
 
   @Test
-  public void testSerde() throws IOException
+  void testSerde() throws IOException
   {
     NullHandling.initializeForTests();
     final ClientCompactionTaskTransformSpec expected = new ClientCompactionTaskTransformSpec(
@@ -54,24 +56,28 @@ public class ClientCompactionTaskTransformSpecTest
         json,
         ClientCompactionTaskTransformSpec.class
     );
-    Assert.assertEquals(expected, fromJson);
+    assertEquals(expected, fromJson);
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testAsMap()
+  void testAsMap()
   {
     NullHandling.initializeForTests();
     final ObjectMapper objectMapper = new DefaultObjectMapper();
     String dimension = "dim1";
     String value = "foo";
-    final ClientCompactionTaskTransformSpec spec = new ClientCompactionTaskTransformSpec(new SelectorDimFilter(dimension, value, null));
+    final ClientCompactionTaskTransformSpec spec = new ClientCompactionTaskTransformSpec(new SelectorDimFilter(
+        dimension,
+        value,
+        null
+    ));
     final Map<String, Object> map = spec.asMap(objectMapper);
-    Assert.assertNotNull(map);
-    Assert.assertEquals(3, ((Map<String, Object>) map.get("filter")).size());
-    Assert.assertEquals(dimension, ((Map<String, Object>) map.get("filter")).get("dimension"));
-    Assert.assertEquals(value, ((Map<String, Object>) map.get("filter")).get("value"));
+    assertNotNull(map);
+    assertEquals(3, ((Map<String, Object>) map.get("filter")).size());
+    assertEquals(dimension, ((Map<String, Object>) map.get("filter")).get("dimension"));
+    assertEquals(value, ((Map<String, Object>) map.get("filter")).get("value"));
     ClientCompactionTaskTransformSpec actual = objectMapper.convertValue(map, ClientCompactionTaskTransformSpec.class);
-    Assert.assertEquals(spec, actual);
+    assertEquals(spec, actual);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQueryTest.java
@@ -23,58 +23,59 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ClientKillUnusedSegmentsTaskQueryTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ClientKillUnusedSegmentsTaskQueryTest
 {
   private static final String DATA_SOURCE = "data_source";
-  public static final DateTime START = DateTimes.nowUtc();
+  private static final DateTime START = DateTimes.nowUtc();
   private static final Interval INTERVAL = new Interval(START, START.plus(1));
   private static final Boolean MARK_UNUSED = true;
 
   ClientKillUnusedSegmentsTaskQuery clientKillUnusedSegmentsQuery;
 
-  @Before
-  public void setUp()
+  @BeforeEach
+  void setUp()
   {
     clientKillUnusedSegmentsQuery = new ClientKillUnusedSegmentsTaskQuery("killTaskId", DATA_SOURCE, INTERVAL, true);
   }
 
-  @After
-  public void tearDown()
+  @AfterEach
+  void tearDown()
   {
     clientKillUnusedSegmentsQuery = null;
   }
 
   @Test
-  public void testGetType()
+  void testGetType()
   {
-    Assert.assertEquals("kill", clientKillUnusedSegmentsQuery.getType());
+    assertEquals("kill", clientKillUnusedSegmentsQuery.getType());
   }
 
   @Test
-  public void testGetDataSource()
+  void testGetDataSource()
   {
-    Assert.assertEquals(DATA_SOURCE, clientKillUnusedSegmentsQuery.getDataSource());
+    assertEquals(DATA_SOURCE, clientKillUnusedSegmentsQuery.getDataSource());
   }
 
   @Test
-  public void testGetInterval()
+  void testGetInterval()
   {
-    Assert.assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
+    assertEquals(INTERVAL, clientKillUnusedSegmentsQuery.getInterval());
   }
 
   @Test
-  public void testGetMarkUnused()
+  void testGetMarkUnused()
   {
-    Assert.assertEquals(MARK_UNUSED, clientKillUnusedSegmentsQuery.getMarkAsUnused());
+    assertEquals(MARK_UNUSED, clientKillUnusedSegmentsQuery.getMarkAsUnused());
   }
 
   @Test
-  public void testEquals()
+  void testEquals()
   {
     EqualsVerifier.forClass(ClientKillUnusedSegmentsTaskQuery.class)
                   .usingGetClass()

--- a/server/src/test/java/org/apache/druid/client/indexing/SamplerSpecTest.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/SamplerSpecTest.java
@@ -20,29 +20,24 @@
 package org.apache.druid.client.indexing;
 
 import org.apache.druid.java.util.common.UOE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SamplerSpecTest
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SamplerSpecTest
 {
-  private static final SamplerSpec SAMPLER_SPEC = new SamplerSpec()
-  {
-    @Override
-    public SamplerResponse sample()
-    {
-      return null;
-    }
-  };
+  private static final SamplerSpec SAMPLER_SPEC = () -> null;
 
   @Test
-  public void testGetType()
+  void testGetType()
   {
-    Assert.assertNull(SAMPLER_SPEC.getType());
+    assertNull(SAMPLER_SPEC.getType());
   }
 
   @Test
-  public void testGetInputSourceResources()
+  void testGetInputSourceResources()
   {
-    Assert.assertThrows(UOE.class, SAMPLER_SPEC::getInputSourceResources);
+    assertThrows(UOE.class, SAMPLER_SPEC::getInputSourceResources);
   }
 }

--- a/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/ServerSelectorTest.java
@@ -29,21 +29,25 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ServerSelectorTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServerSelectorTest
 {
-  @Before
-  public void setUp()
+  @BeforeEach
+  void setUp()
   {
     TierSelectorStrategy tierSelectorStrategy = EasyMock.createMock(TierSelectorStrategy.class);
     EasyMock.expect(tierSelectorStrategy.getComparator()).andReturn(Integer::compare).anyTimes();
   }
 
   @Test
-  public void testSegmentUpdate()
+  void testSegmentUpdate()
   {
     final ServerSelector selector = new ServerSelector(
         DataSegment.builder()
@@ -99,20 +103,20 @@ public class ServerSelectorTest
                    .build()
     );
 
-    Assert.assertEquals(ImmutableList.of("a", "b", "c"), selector.getSegment().getDimensions());
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testSegmentCannotBeNull()
-  {
-    final ServerSelector selector = new ServerSelector(
-        null,
-        new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy())
-    );
+    assertEquals(ImmutableList.of("a", "b", "c"), selector.getSegment().getDimensions());
   }
 
   @Test
-  public void testSegmentWithNoData()
+  void testSegmentCannotBeNull()
+  {
+    assertThrows(NullPointerException.class, () -> new ServerSelector(
+        null,
+        new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy())
+    ));
+  }
+
+  @Test
+  void testSegmentWithNoData()
   {
     final ServerSelector selector = new ServerSelector(
         DataSegment.builder()
@@ -133,7 +137,7 @@ public class ServerSelectorTest
                    .build(),
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy())
     );
-    Assert.assertFalse(selector.hasData());
+    assertFalse(selector.hasData());
   }
 
   @Test
@@ -160,7 +164,7 @@ public class ServerSelectorTest
                    .build(),
         new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy())
     );
-    Assert.assertTrue(selector.hasData());
+    assertTrue(selector.hasData());
   }
 
 }

--- a/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/TierSelectorStrategyTest.java
@@ -29,8 +29,7 @@ import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -41,11 +40,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class TierSelectorStrategyTest
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TierSelectorStrategyTest
 {
-  
+
   @Test
-  public void testHighestPriorityTierSelectorStrategyRealtime()
+  void testHighestPriorityTierSelectorStrategyRealtime()
   {
     DirectDruidClient client = EasyMock.createMock(DirectDruidClient.class);
     QueryableDruidServer lowPriority = new QueryableDruidServer(
@@ -62,9 +63,9 @@ public class TierSelectorStrategyTest
         highPriority, lowPriority
     );
   }
-  
+
   @Test
-  public void testHighestPriorityTierSelectorStrategy()
+  void testHighestPriorityTierSelectorStrategy()
   {
     DirectDruidClient client = EasyMock.createMock(DirectDruidClient.class);
     QueryableDruidServer lowPriority = new QueryableDruidServer(
@@ -239,12 +240,12 @@ public class TierSelectorStrategyTest
       serverSelector.addServerAndUpdateSegment(server, serverSelector.getSegment());
     }
 
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(null));
-    Assert.assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class)));
-    Assert.assertEquals(expectedCandidates, serverSelector.getCandidates(-1));
-    Assert.assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2));
+    assertEquals(expectedSelection[0], serverSelector.pick(null));
+    assertEquals(expectedSelection[0], serverSelector.pick(EasyMock.createMock(Query.class)));
+    assertEquals(expectedCandidates, serverSelector.getCandidates(-1));
+    assertEquals(expectedCandidates.subList(0, 2), serverSelector.getCandidates(2));
   }
-  
+
   @Test
   public void testServerSelectorStrategyDefaults()
   {
@@ -256,18 +257,22 @@ public class TierSelectorStrategyTest
     Set<QueryableDruidServer> servers = new HashSet<>();
     servers.add(p0);
     RandomServerSelectorStrategy strategy = new RandomServerSelectorStrategy();
-    Assert.assertEquals(strategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
-    Assert.assertEquals(strategy.pick(EasyMock.createMock(Query.class), servers, EasyMock.createMock(DataSegment.class)), p0);
-    ServerSelectorStrategy defaultDeprecatedServerSelectorStrategy = new ServerSelectorStrategy() {
+    assertEquals(strategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
+    assertEquals(strategy.pick(EasyMock.createMock(Query.class), servers, EasyMock.createMock(DataSegment.class)), p0);
+    ServerSelectorStrategy defaultDeprecatedServerSelectorStrategy = new ServerSelectorStrategy()
+    {
       @Override
-      public <T> List<QueryableDruidServer> pick(@Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
-          int numServersToPick)
+      public <T> List<QueryableDruidServer> pick(
+          @Nullable Query<T> query, Set<QueryableDruidServer> servers, DataSegment segment,
+          int numServersToPick
+      )
       {
         return strategy.pick(servers, segment, numServersToPick);
       }
     };
-    Assert.assertEquals(defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
-    Assert.assertEquals(defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class), 1).get(0), p0);
+    assertEquals(defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class)), p0);
+    assertEquals(defaultDeprecatedServerSelectorStrategy.pick(servers, EasyMock.createMock(DataSegment.class), 1)
+                                                        .get(0), p0);
   }
 
 }


### PR DESCRIPTION
Issue #13948 druid server initial approach

Partially - Improves #13948.

### Description

This is a small PR for starting the migration of JUnit4 test to Junit5 test as mentioned in the above open issue. Is a small step Just to not create noise as the current codebase is big enough so not easy managed with massive PRs

#### Improvements
 - Choice of algorithms: Use the existing logic just align it with JUnit5 api
 - Behavioral aspects. Error are handled as previously except in some cases which were asserted through an ```assertThrow()``` and in some places Callables were replaced with lambda references

#### Release note
Improved: Adopt JUnit5 which is more modular than JUnit4 which is a whole framework. Support for java8+ key features. 

<hr>

##### Key changed/added classes in this PR
 * `druid-server client cache client test classes`
