### PR TITLE
Upgrade Hadoop version to 3.3.6

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2924,7 +2924,7 @@ name: Apache Hadoop
 license_category: binary
 module: hadoop-client
 license_name: Apache License version 2.0
-version: 3.3.5
+version: 3.3.6
 libraries:
   - org.apache.hadoop: hadoop-auth
   - org.apache.hadoop: hadoop-common
@@ -3826,7 +3826,7 @@ name: Hadoop Client API
 license_category: binary
 module: extensions/druid-hdfs-storage
 license_name: Apache License version 2.0
-version: 3.3.5
+version: 3.3.6
 libraries:
   - org.apache.hadoop: hadoop-client-api
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -810,7 +810,7 @@
   <suppress>
     <!-- from extensions using hadoop-client-runtime, these dependencies are shaded in the jar -->
     <notes><![CDATA[
-     file name: hadoop-client-runtime-3.3.5.jar
+     file name: hadoop-client-runtime-3.3.6.jar
      ]]></notes>
     <!-- this one is windows only - https://nvd.nist.gov/vuln/detail/CVE-2022-26612 -->
     <cve>CVE-2022-26612</cve>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <slf4j.version>1.7.36</slf4j.version>
         <jna.version>5.13.0</jna.version>
         <jna-platform.version>5.13.0</jna-platform.version>
-        <hadoop.compile.version>3.3.5</hadoop.compile.version>
+        <hadoop.compile.version>3.3.6</hadoop.compile.version>
         <mockito.version>4.3.1</mockito.version>
         <aws.sdk.version>1.12.317</aws.sdk.version>
         <caffeine.version>2.8.0</caffeine.version>


### PR DESCRIPTION
Latest Hadoop version fixes few security vulnerabilities. Updating the version to leverage the same.