### PR TITLE
Update .asf.yaml to simplify email subjects.

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,34 @@
+# note: documentation can be found here https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
 github:
   description: 'Apache Druid: a high performance real-time analytics database.'
   homepage: https://druid.apache.org/
+
+  # Attempt to make the auto-generated github emails more easily readable in email clients.
+  # Configuration adapted from https://github.com/apache/plc4x/blob/develop/.asf.yaml.
+  custom_subjects:
+    new_pr: "[PR] {title}"
+    close_pr: "Re: [PR] {title}"
+    comment_pr: "Re: [PR] {title}"
+    diffcomment: "Re: [PR] {title}"
+    merge_pr: "Re: [PR] {title}"
+    new_issue: "[I] {title}"
+    comment_issue: "Re: [I] {title}"
+    close_issue: "Re: [I] {title}"
+    catchall: "[GH] {title}"
+    new_discussion: "[D] {title}"
+    edit_discussion: "Re: [D] {title}"
+    close_discussion: "Re: [D] {title}"
+    close_discussion_with_comment: "Re: [D] {title}"
+    reopen_discussion: "Re: [D] {title}"
+    new_comment_discussion: "Re: [D] {title}"
+    edit_comment_discussion: "Re: [D] {title}"
+    delete_comment_discussion: "Re: [D] {title}"
+
+notifications:
+  commits: commits@druid.apache.org
+  issues: commits@druid.apache.org
+  discussions: commits@druid.apache.org
+  pullrequests_status: commits@druid.apache.org
+  pullrequests_comment: commits@druid.apache.org
+  pullrequests_bot_dependabot: commits@druid.apache.org


### PR DESCRIPTION
Currently, github notification emails to commits@druid.apache.org have a wide variety of subject lines. This foils email client threading and makes the firehose of emails hard to follow. This is an attempt, inspired by the config for plc4x, to make the emails easier to follow.

After this change, it may even make sense to send some to dev@ instead of commits@.