### PR TITLE
Add rocketship to extra.datasource.name.suffix.

### DIFF
--- a/integration-tests-ex/cases/pom.xml
+++ b/integration-tests-ex/cases/pom.xml
@@ -456,15 +456,14 @@
             <build>
                 <plugins>
                      <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.0.0-M7</version>
                         <dependencies>
                           <!-- Required to force Failsafe to use JUnit instead of TestNG.
                                junit47 is required to use test categories. -->
                           <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit47</artifactId>
-                            <version>3.0.0-M7</version>
                           </dependency>
                         </dependencies>
                         <executions>

--- a/integration-tests-ex/cases/pom.xml
+++ b/integration-tests-ex/cases/pom.xml
@@ -464,6 +464,7 @@
                           <dependency>
                             <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit47</artifactId>
+                            <version>${surefire.version}</version>
                           </dependency>
                         </dependencies>
                         <executions>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -570,9 +570,7 @@
                 <it.indexer>middleManager</it.indexer>
                 <override.config.path />
                 <resource.file.dir.path />
-
-                <!-- Would like to put emojis in here too, but they throw "Input buffer too short" errors due to https://issues.apache.org/jira/browse/SUREFIRE-1865 -->
-                <extra.datasource.name.suffix>\ %Россия\ 한국\ 中国!?</extra.datasource.name.suffix>
+                <extra.datasource.name.suffix>\ %Россия\ 🚀\ 한국\ 中国!?</extra.datasource.name.suffix>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <jna-platform.version>5.13.0</jna-platform.version>
         <hadoop.compile.version>3.3.6</hadoop.compile.version>
         <mockito.version>4.3.1</mockito.version>
+        <surefire.version>3.1.2</surefire.version>
         <aws.sdk.version>1.12.317</aws.sdk.version>
         <caffeine.version>2.8.0</caffeine.version>
         <jacoco.version>0.8.7</jacoco.version>
@@ -1583,10 +1584,15 @@
                     <artifactId>fmpp-maven-plugin</artifactId>
                     <version>1.0</version>
               </plugin>
-              <plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${surefire.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>${surefire.version}</version>
                     <configuration>
                         <!-- locale settings must be set on the command line before startup -->
                         <!-- set default options -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SUREFIRE-1865 has been fixed in our version of Surefire. Integration tests to the moon.