### PR TITLE
Add Continuous Profiling to Unit Tests

### DIFF
--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+set -e
+
+JAR_INPUT_FILE="jfr-profiler-1.0.0.jar"
+JAR_OUTPUT_FILE="jfr-profiler.jar"
+ENV_VAR="JFR_PROFILER_ARG_LINE"
+
+if [ "$#" -ne 5 ]; then
+    echo "usage: $0 <jdk_version> <run_id> <run_number> <run_attempt> <module>"
+fi
+
+if [[ "$1" == "17" ]];
+then
+  curl https://static.imply.io/cp/$JAR_INPUT_FILE -s -o $JAR_OUTPUT_FILE
+
+  echo $ENV_VAR=-javaagent:"$PWD"/$JAR_OUTPUT_FILE \
+  -Djfr.profiler.http.username=druid-ci \
+  -Djfr.profiler.http.password=w3Fb6PW8LIo849mViEkbgA== \
+  -Djfr.profiler.tags.project=druid \
+  -Djfr.profiler.tags.run_id=$2 \
+  -Djfr.profiler.tags.run_number=$3 \
+  -Djfr.profiler.tags.run_attempt=$4 \
+  -Djfr.profiler.tags.module=$5
+else
+  echo $ENV_VAR=\"\"
+fi
+
+

--- a/.github/scripts/unit_tests_script.sh
+++ b/.github/scripts/unit_tests_script.sh
@@ -21,7 +21,8 @@ unset _JAVA_OPTIONS
 
 # Set MAVEN_OPTS for Surefire launcher.
 MAVEN_OPTS='-Xmx2500m' ${MVN} test -pl ${MAVEN_PROJECTS} \
-${MAVEN_SKIP} -Ddruid.generic.useDefaultValueForNull=${DRUID_USE_DEFAULT_VALUE_FOR_NULL}
+${MAVEN_SKIP} -Ddruid.generic.useDefaultValueForNull=${DRUID_USE_DEFAULT_VALUE_FOR_NULL} \
+-DjfrProfilerArgLine="${JFR_PROFILER_ARG_LINE}"
 sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
 free -m
 ${MVN} -pl ${MAVEN_PROJECTS} jacoco:report || { echo "coverage_failure=false" >> "$GITHUB_ENV" && false; }

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -86,6 +86,11 @@ jobs:
             echo "DRUID_USE_DEFAULT_VALUE_FOR_NULL=true" >> $GITHUB_ENV
           fi
 
+      - name: test profiling
+        run: | 
+          ./.github/scripts/setup_test_profiling_env.sh ${{ inputs.jdk }} ${{ github.run_id }} \
+          ${{ github.run_number }} ${{ github.run_attempt }} ${{ inputs.module }} >> $GITHUB_ENV
+
       - name: fetch base branch for test coverage
         if: ${{ github.base_ref != '' }}
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,8 @@
              ref: https://github.com/mapstruct/mapstruct/pull/1241
              -->
          <jacocoArgLine />
+         <!--  used to enable continuous profiling of jdk17 unit tests in github actions  -->
+         <jfrProfilerArgLine></jfrProfilerArgLine>
     </properties>
 
     <modules>
@@ -1636,6 +1638,7 @@
                             -Ddruid.test.stupidPool.poison=true
                             <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
+                            ${jfrProfilerArgLine}
                         </argLine>
                         <!-- Skip the tests which Surefire runs. Surefire runs the unit tests,
                              while its sister plugin, Failsafe, runs the "new" ITs. -->

--- a/processing/src/main/java/org/apache/druid/common/guava/GuavaUtils.java
+++ b/processing/src/main/java/org/apache/druid/common/guava/GuavaUtils.java
@@ -75,12 +75,12 @@ public class GuavaUtils
    * except will not explode if both arguments are null.
    */
   @Nullable
-  public static <T> T firstNonNull(@Nullable T arg1, @Nullable T arg2)
+  public static <T> T firstNonNull(@Nullable T lhs, @Nullable T rhs)
   {
-    if (arg1 == null) {
-      return arg2;
+    if (lhs == null) {
+      return rhs;
     }
-    return arg1;
+    return lhs;
   }
 
   /**


### PR DESCRIPTION
### Description

Uses a custom continuous jfr profiler. Modifies the github actions for tests to do profiling only in the case of jdk17, as the profiler requires jdk17+ to use the JFR streaming API plus a few other language features in the code.

Continuous Profiling service is provided to the Apache Druid project free of charge by Imply and any committer can request free access to the UI.

#### Release note

No changes to the druid code base, only to how the unit tests are run (javaagent loaded in case of jdk17 unit test runs)

<hr>

##### Key changed/added classes in this PR
n/a

<hr>
This PR has:

- [ X] been self-reviewed.
- [X ] added documentation for new or modified features or behaviors.
- [ X] a release note entry in the PR description.
- [ X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ X] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ X] added integration tests.
- [ X] been tested in a test Druid cluster.
