### PR TITLE
Run IntelliJ-inspections in parallel to static-checks & web-checks in GHA

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -134,6 +134,12 @@ jobs:
         run: |
           echo "JAVA_HOME=$JAVA_HOME_8_X64" >> $GITHUB_ENV
 
+      - name: maven install
+        run: |
+          echo 'Running Maven install...' &&
+          ${MVN} clean install -q -ff -pl '!distribution,!:druid-it-image,!:druid-it-cases' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -T1C &&
+          ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
+
       - name: intellij inspections
         run: |
           docker run --rm \

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -122,8 +122,19 @@ jobs:
         if: ${{ matrix.java == 'jdk8' }}
         run: ${MVN} spotbugs:check --fail-at-end -pl '!benchmarks'
 
+  intellij-inspections:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout branch
+        uses: actions/checkout@v3
+
+      - name: setup JDK8
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_8_X64" >> $GITHUB_ENV
+
       - name: intellij inspections
-        if: ${{ matrix.java == 'jdk8' }}
         run: |
           docker run --rm \
           -v $(pwd):/project \


### PR DESCRIPTION
Currently, IntelliJ-inspections are run sequentially w.r.t static-checks, thereby increasing build time. Moving IntelliJ-inspections to a separate job to improve builds time and get a quick insight into such issues early on.