### PR TITLE
Allow multiple consoleAppender to be used in peon logging

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementConfigurationFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementConfigurationFactory.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -91,15 +91,18 @@ public class ConsoleLoggingEnforcementConfigurationFactory extends Configuration
     {
       super.doConfigure();
 
-      Appender consoleAppender = findConsoleAppender();
-      if (consoleAppender == null) {
+      List<Appender> consoleAppenders = findConsoleAppenders();
+      if (consoleAppenders.isEmpty()) {
         // create a ConsoleAppender with default pattern if no console appender is configured in the configuration file
-        consoleAppender = ConsoleAppender.newBuilder()
-                                         .setName("_Injected_Console_Appender_")
-                                         .setLayout(PatternLayout.newBuilder()
-                                                                 .withPattern("%d{ISO8601} %p [%t] %c - %m%n")
-                                                                 .build())
-                                         .build();
+        consoleAppenders.add(
+            ConsoleAppender.newBuilder()
+                           .setName("_Injected_Console_Appender_")
+                           .setLayout(PatternLayout.newBuilder()
+                                                   .withPattern("%d{ISO8601} %p [%t] %c - %m%n")
+                                                   .build()
+                           )
+                           .build()
+        );
       }
 
       List<LoggerConfig> loggerConfigList = new ArrayList<>();
@@ -112,36 +115,38 @@ public class ConsoleLoggingEnforcementConfigurationFactory extends Configuration
       // If not, replace it's appender to ConsoleAppender.
       //
       for (LoggerConfig logger : loggerConfigList) {
-        applyConsoleAppender(logger, consoleAppender);
+        applyConsoleAppender(logger, consoleAppenders);
       }
     }
 
-    @Nullable
-    private Appender findConsoleAppender()
+    @Nonnull
+    private List<Appender> findConsoleAppenders()
     {
+      List<Appender> consoleAppenders = new ArrayList<>();
       for (Map.Entry<String, Appender> entry : this.getAppenders().entrySet()) {
         Appender appender = entry.getValue();
         if (appender instanceof ConsoleAppender) {
-          return appender;
+          consoleAppenders.add(appender);
         }
       }
-      return null;
+      return consoleAppenders;
     }
 
     /**
      * Ensure there is a console logger defined. Without a console logger peon logs wont be able to be stored in deep storage
      */
-    private void applyConsoleAppender(LoggerConfig logger, Appender consoleAppender)
+    private void applyConsoleAppender(LoggerConfig logger, List<Appender> consoleAppenders)
     {
+      List<String> consoleAppenderNames = consoleAppenders.stream().map(Appender::getName).collect(Collectors.toList());
       for (AppenderRef appenderRef : logger.getAppenderRefs()) {
-        if (consoleAppender.getName().equals(appenderRef.getRef())) {
+        if (consoleAppenderNames.contains(appenderRef.getRef())) {
           // we need a console logger no matter what, but we want to be able to define a different appender if necessary
           return;
         }
       }
       Level level = Level.INFO;
       Filter filter = null;
-
+      Appender consoleAppender = consoleAppenders.get(0);
       if (!logger.getAppenderRefs().isEmpty()) {
         AppenderRef appenderRef = logger.getAppenderRefs().get(0);
 
@@ -159,7 +164,6 @@ public class ConsoleLoggingEnforcementConfigurationFactory extends Configuration
                  logger.toString(),
                  consoleAppender.getName());
       }
-
 
       // add ConsoleAppender to this logger
       logger.addAppender(consoleAppender, level, filter);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementConfigurationFactory.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementConfigurationFactory.java
@@ -94,15 +94,16 @@ public class ConsoleLoggingEnforcementConfigurationFactory extends Configuration
       List<Appender> consoleAppenders = findConsoleAppenders();
       if (consoleAppenders.isEmpty()) {
         // create a ConsoleAppender with default pattern if no console appender is configured in the configuration file
-        consoleAppenders.add(
-            ConsoleAppender.newBuilder()
-                           .setName("_Injected_Console_Appender_")
-                           .setLayout(PatternLayout.newBuilder()
-                                                   .withPattern("%d{ISO8601} %p [%t] %c - %m%n")
-                                                   .build()
-                           )
-                           .build()
-        );
+        Appender injectedConsoleAppender = ConsoleAppender.newBuilder()
+                                                          .setName("_Injected_Console_Appender_")
+                                                          .setLayout(
+                                                              PatternLayout.newBuilder()
+                                                                           .withPattern("%d{ISO8601} %p [%t] %c - %m%n")
+                                                                           .build()
+                                                          )
+                                                          .build();
+        injectedConsoleAppender.start();
+        consoleAppenders.add(injectedConsoleAppender);
       }
 
       List<LoggerConfig> loggerConfigList = new ArrayList<>();


### PR DESCRIPTION
Fixes ConsoleLoggingEnforcementConfigurationFactory would still enforce an additional ConsoleAppender if there are multiple ConsoleAppender defined

### Description

The PR https://github.com/apache/druid/pull/14094 allow for multiple/existing log4j appenders to be kept when there is a ConsoleAppender configured for a Logger. However, this doesn't work as expected when there are multiple ConsoleAppender defined. The function ConsoleLoggingEnforcementConfigurationFactory#findConsoleAppender currently only considered the first ConsoleAppender it finds and verify that this ConsoleAppender is set in the Loggers. However, this fails to consider that multiple ConsoleAppenders could be defined. When we ensure there is a console logger defined for each Logger (in the function ConsoleLoggingEnforcementConfigurationFactory#applyConsoleAppender), we should make it such that ANY of the defined ConsoleAppender is sufficient (not just the first ConsoleAppender in the list)

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
