### PR TITLE
[MSQ] Handle dimensionless group by queries with partitioning

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
@@ -97,8 +97,9 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
     final Granularity segmentGranularity =
         QueryKitUtils.getSegmentGranularityFromContext(jsonMapper, queryToRun.getContext());
     final RowSignature intermediateSignature = computeIntermediateSignature(queryToRun);
+    final ClusterBy resultClusterByWithoutGranularity = computeClusterByForResults(queryToRun);
     final ClusterBy resultClusterBy =
-        QueryKitUtils.clusterByWithSegmentGranularity(computeClusterByForResults(queryToRun), segmentGranularity);
+        QueryKitUtils.clusterByWithSegmentGranularity(resultClusterByWithoutGranularity, segmentGranularity);
     final RowSignature resultSignature =
         QueryKitUtils.sortableSignature(
             QueryKitUtils.signatureWithSegmentGranularity(computeResultSignature(queryToRun), segmentGranularity),
@@ -114,7 +115,12 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
     final ShuffleSpecFactory shuffleSpecFactoryPreAggregation;
     final ShuffleSpecFactory shuffleSpecFactoryPostAggregation;
 
-    if (intermediateClusterBy.getColumns().isEmpty()) {
+    // There can be a situation where intermediateClusterBy is empty, while the result is non-empty
+    // if we have PARTITIONED BY on anything except ALL, however we don't have a grouping dimension
+    // (i.e. no GROUP BY clause)
+    // __time in such queries is generated using either an aggregator (e.g. sum(metric) as __time) or using a
+    // post-aggregator (e.g. TIMESTAMP '2000-01-01' as __time)
+    if (intermediateClusterBy.getColumns().isEmpty() && resultClusterBy.isEmpty()) {
       // Ignore shuffleSpecFactory, since we know only a single partition will come out, and we can save some effort.
       shuffleSpecFactoryPreAggregation = ShuffleSpecFactories.singlePartition();
       shuffleSpecFactoryPostAggregation = ShuffleSpecFactories.singlePartition();


### PR DESCRIPTION
### Description

In MSQ, queries of the following sorts fail:

```
INSERT INTO foo1 
SELECT DATE_TRUNC('DAY', CURRENT_TIMESTAMP - INTERVAL '1'DAY) AS __time, SUM(m1) AS sum_m1
FROM foo
PARTITIONED BY DAY
```

This is a bug in the `GroupByQueryKit` because the absence of the dimensions causes the query kit to push everything into a single partition (using `GlobalSortMaxCountShuffleSpec`) however this shuffle spec doesn't support "buckets", which is needed in case the PARTITIONED BY is present.

The fix involves adding an additional check to ensure that the bucketing is not present in the clustering columns. 

Note 1: There can be multiple fixes for the above, and the current code should have worked as well if there was no sanity check in the `GlobalSortMaxCountShuffleSpec` class since we will ultimately get a single row in all the cases.

Note 2: The query would fail if the time was populated by an aggregator instead of a post-aggregator (expression)



<hr>

##### Key changed/added classes in this PR
 * `GroupByQueryKit`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
