### PR TITLE
Use async OverlordClient to submit auto-compaction tasks

### DIFF
--- a/processing/src/main/java/org/apache/druid/common/guava/FutureUtils.java
+++ b/processing/src/main/java/org/apache/druid/common/guava/FutureUtils.java
@@ -208,6 +208,9 @@ public class FutureUtils
     return retVal;
   }
 
+  /**
+   * Adds success and failure callbacks to the given future.
+   */
   public static <V> void addCallback(
       ListenableFuture<V> future,
       Executor executor,

--- a/processing/src/main/java/org/apache/druid/common/guava/FutureUtils.java
+++ b/processing/src/main/java/org/apache/druid/common/guava/FutureUtils.java
@@ -32,6 +32,8 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class FutureUtils
@@ -204,5 +206,32 @@ public class FutureUtils
     );
 
     return retVal;
+  }
+
+  public static <V> void addCallback(
+      ListenableFuture<V> future,
+      Executor executor,
+      Consumer<V> onSuccess,
+      Consumer<Throwable> onFailure
+  )
+  {
+    Futures.addCallback(
+        future,
+        new FutureCallback<V>()
+        {
+          @Override
+          public void onSuccess(@Nullable V result)
+          {
+            onSuccess.accept(result);
+          }
+
+          @Override
+          public void onFailure(Throwable t)
+          {
+            onFailure.accept(t);
+          }
+        },
+        executor
+    );
   }
 }

--- a/processing/src/main/java/org/apache/druid/java/util/common/Stopwatch.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Stopwatch.java
@@ -55,19 +55,22 @@ public class Stopwatch
     this.delegate = delegate;
   }
 
-  public synchronized void start()
+  public synchronized Stopwatch start()
   {
     delegate.start();
+    return this;
   }
 
-  public synchronized void stop()
+  public synchronized Stopwatch stop()
   {
     delegate.stop();
+    return this;
   }
 
-  public synchronized void reset()
+  public synchronized Stopwatch reset()
   {
     delegate.reset();
+    return this;
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/java/util/common/StopwatchTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/StopwatchTest.java
@@ -67,4 +67,22 @@ public class StopwatchTest
     Assert.assertTrue(stopwatch.hasNotElapsed(Duration.millis(101)));
     Assert.assertTrue(stopwatch.hasNotElapsed(Duration.millis(500)));
   }
+
+  @Test
+  public void testChainedMethods()
+  {
+    FakeTicker fakeTicker = new FakeTicker();
+    Stopwatch stopwatch = Stopwatch.createStarted(fakeTicker);
+
+    fakeTicker.advance(100, TimeUnit.MILLISECONDS);
+    Assert.assertEquals(100, stopwatch.millisElapsed());
+
+    stopwatch.stop().start();
+    Assert.assertTrue(stopwatch.isRunning());
+    Assert.assertEquals(100, stopwatch.millisElapsed());
+
+    stopwatch.stop().reset();
+    Assert.assertFalse(stopwatch.isRunning());
+    Assert.assertEquals(0, stopwatch.millisElapsed());
+  }
 }

--- a/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClient.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClient.java
@@ -23,8 +23,11 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.client.indexing.TaskPayloadResponse;
 import org.apache.druid.client.indexing.TaskStatusResponse;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.rpc.ServiceRetryPolicy;
+import org.joda.time.Interval;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,6 +57,14 @@ public interface OverlordClient
   ListenableFuture<Map<String, Object>> taskReportAsMap(String taskId);
 
   ListenableFuture<TaskPayloadResponse> taskPayload(String taskId);
+
+  ListenableFuture<List<TaskStatusPlus>> allActiveTasks();
+
+  ListenableFuture<Integer> totalWorkerCapacity();
+
+  ListenableFuture<Integer> totalWorkerCapacityWithAutoScale();
+
+  ListenableFuture<Map<String, List<Interval>>> lockedIntervals(Map<String, Integer> datasourceToMinTaskPriority);
 
   OverlordClient withRetryPolicy(ServiceRetryPolicy retryPolicy);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -575,7 +575,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
         throw new ISE("No segment is found?");
       }
     }
-    log.info("All segments look good! Nothing to compact");
+    log.info("All segments in datasource[%s] look good. Nothing to compact.", dataSourceName);
     return new SegmentsToCompact();
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -93,7 +93,7 @@ public class Stats
   public static class Compaction
   {
     public static final CoordinatorStat SUBMITTED_TASKS
-        = CoordinatorStat.toDebugAndEmit("compactTasks", "compact/task/count");
+        = CoordinatorStat.toLogAndEmit("compactTasks", "compact/task/count", CoordinatorStat.Level.INFO);
     public static final CoordinatorStat MAX_SLOTS
         = CoordinatorStat.toDebugAndEmit("compactMaxSlots", "compactTask/maxSlot/count");
     public static final CoordinatorStat AVAILABLE_SLOTS

--- a/server/src/test/java/org/apache/druid/client/indexing/NoopOverlordClient.java
+++ b/server/src/test/java/org/apache/druid/client/indexing/NoopOverlordClient.java
@@ -21,9 +21,12 @@ package org.apache.druid.client.indexing;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.rpc.ServiceRetryPolicy;
 import org.apache.druid.rpc.indexing.OverlordClient;
+import org.joda.time.Interval;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,6 +64,30 @@ public class NoopOverlordClient implements OverlordClient
 
   @Override
   public ListenableFuture<TaskPayloadResponse> taskPayload(String taskId)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListenableFuture<List<TaskStatusPlus>> allActiveTasks()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListenableFuture<Map<String, List<Interval>>> lockedIntervals(Map<String, Integer> datasourceToMinTaskPriority)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListenableFuture<Integer> totalWorkerCapacityWithAutoScale()
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ListenableFuture<Integer> totalWorkerCapacity()
   {
     throw new UnsupportedOperationException();
   }

--- a/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 public class OverlordClientImplTest
 {
 
-
   @Test
   public void testTaskPayload() throws ExecutionException, InterruptedException, JsonProcessingException
   {


### PR DESCRIPTION
All duties on the Coordinator run on the same single-threaded executor including historical management duties (segment loading and balancing) and auto-compaction.

If auto-compaction gets stuck for some reason (such as slowness while submitting tasks), it can block up the whole coordination flow causing delayed segment handoffs and ingestion failures.

This PR attempts to remedy this situation by not blocking coordinator while submitting compaction tasks by using the async `OverlordClient` instead of `IndexingServiceClient`.

### Changes
- Add new methods to `OverlordClient`
- Use `OverlordClient` in `CompactSegments`
- All methods except submission of task still happen synchronously by using `future.get()`.
- Fix up tests

### Pending validation
- Cluster testing
- Case: A compaction task is submitted to the overlord but the request hasn't finished yet and the next duty cycle has already started. In such a case, the coordinator might try to submit a duplicate compaction task for that interval. Ideally, the compaction task submitted later should just be cancelled if the first one is still running. Alternatively, we could simply maintain a state of recently submitted (but not started) compaction tasks in the `CompactSegments` duty to ensure that we do not submit duplicate tasks.


### Alternate approach/Further improvement
- The coordinator duties can be moved to a completely separate executor but that would require some validation to ensure that there are no race conditions between historical management duties and coordinator duties (most likely, there shouldn't be)

#### Release note

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
