### PR TITLE
Fix ColumnSignature error message and jdk17 test issue.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnSignature.java
@@ -50,7 +50,7 @@ class ColumnSignature
 
     // Name must be nonnull, but type can be null (if the type is unknown)
     if (name == null || name.isEmpty()) {
-      throw new IAE(name, "Column name must be non-empty");
+      throw new IAE("Column name must be provided and non-empty", name);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnSignature.java
@@ -50,7 +50,7 @@ class ColumnSignature
 
     // Name must be nonnull, but type can be null (if the type is unknown)
     if (name == null || name.isEmpty()) {
-      throw new IAE("Column name must be provided and non-empty", name);
+      throw new IAE("Column name must be provided and non-empty");
     }
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -1435,7 +1435,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
                                 "general"
                             )
                                 .expectMessageContains(
-                                    "Cannot construct instance of `org.apache.druid.segment.column.ColumnSignature`, problem: `java.lang.NullPointerException`\n"
+                                    "Cannot construct instance of `org.apache.druid.segment.column.ColumnSignature`, problem: Column name must be provided and non-empty"
                                 )
                         )
                         .verify();


### PR DESCRIPTION
On jdk17, the "problem" part of the error message could change from NullPointerException to:

```
  Cannot invoke "String.length()" because "s" is null
```

Due to the new more-helpful NPEs in Java 17. This broke the expectation and led to test failures on this case.

This patch fixes the problem by improving the error message so it isn't a generic NullPointerException.