### PR TITLE
ChangeRequestHttpSyncer: Don't wait 1ms when checking isInitialized().

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolder.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/WorkerHolder.java
@@ -346,13 +346,7 @@ public class WorkerHolder
 
   public boolean isInitialized()
   {
-    try {
-      return syncer.isInitialized();
-    }
-    catch (InterruptedException ignored) {
-      Thread.currentThread().interrupt();
-      return false;
-    }
+    return syncer.isInitialized();
   }
 
   public boolean isEnabled()

--- a/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/HttpServerInventoryView.java
@@ -571,12 +571,7 @@ public class HttpServerInventoryView implements ServerInventoryView, FilteredSer
 
     boolean isSyncedSuccessfullyAtleastOnce()
     {
-      try {
-        return syncer.isInitialized();
-      }
-      catch (InterruptedException ex) {
-        throw new ISE(ex, "Interrupted while waiting for first sync with server[%s].", druidServer.getName());
-      }
+      return syncer.isInitialized();
     }
 
     private ChangeRequestHttpSyncer.Listener<DataSegmentChangeRequest> createSyncListener()

--- a/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
@@ -172,11 +172,11 @@ public class ChangeRequestHttpSyncer<T>
   }
 
   /**
-   * Waits upto 1 millisecond for the first successful sync with this server.
+   * Whether this server has been synced successfully at least once.
    */
-  public boolean isInitialized() throws InterruptedException
+  public boolean isInitialized()
   {
-    return initializationLatch.await(1, TimeUnit.MILLISECONDS);
+    return initializationLatch.getCount() == 0;
   }
 
   /**


### PR DESCRIPTION
The wait doesn't seem to serve a purpose, other than causing delays when checking `isInitialized()` for a large number of things that have not yet been initialized.