### PR TITLE
Deprecate EntryExistsException in Druid 27 and remove in Druid 28

### DIFF
--- a/processing/src/main/java/org/apache/druid/metadata/EntryExistsException.java
+++ b/processing/src/main/java/org/apache/druid/metadata/EntryExistsException.java
@@ -25,7 +25,11 @@ import org.apache.druid.java.util.common.StringUtils;
 /**
  * A non-transient Druid metadata exception thrown when trying to insert a
  * duplicate entry in the metadata.
+ *
+ * @deprecated Usages of this exception will be replaced by the new
+ * {@link org.apache.druid.error.DruidException} in a future release.
  */
+@Deprecated
 public class EntryExistsException extends DruidException
 {
 

--- a/server/src/main/java/org/apache/druid/metadata/UnknownSegmentIdsException.java
+++ b/server/src/main/java/org/apache/druid/metadata/UnknownSegmentIdsException.java
@@ -23,7 +23,11 @@ import java.util.Collection;
 
 /**
  * Exception thrown by {@link SegmentsMetadataManager} when a segment id is unknown.
+ *
+ * @deprecated Usages of this exception will be replaced by the new
+ * {@link org.apache.druid.error.DruidException} in a future release.
  */
+@Deprecated
 public class UnknownSegmentIdsException extends Exception
 {
   private final Collection<String> unknownSegmentIds;


### PR DESCRIPTION
#14448 removes the outdated `DruidException` and `EntryExistsException`, but since there might be extensions using it, we are only deprecating this exception in Druid 27.

#14448 can be merged after Druid 27 code freeze is done.