### PR TITLE
Proper handling of null arrays in string frame writers

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -1959,7 +1959,7 @@ public class ControllerImpl implements Controller
    * If the output column is present in the outputColumnAggregatorFactories that means we already have the aggregator information for this column.
    * else treat this column as a dimension.
    *
-   * @param dimensions                      list is poulated if the output col is deemed to be a dimension
+   * @param dimensions                      list is populated if the output col is deemed to be a dimension
    * @param aggregators                     list is populated with the aggregator if the output col is deemed to be a aggregation column.
    * @param outputColumnAggregatorFactories output col -> AggregatorFactory map
    * @param outputColumn                    column name

--- a/processing/src/main/java/org/apache/druid/frame/field/FieldWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/FieldWriter.java
@@ -36,6 +36,9 @@ public interface FieldWriter extends Closeable
 {
   /**
    * Writes the current selection at the given memory position.
+   * If there is insufficient memory to write to the Memory, then the callers shouldn't rely on this method to clean up
+   * the data written from [position, position + maxSize). Essentialy, the region of memory between
+   * [position, position + maxSize) might change irrespective of whether the "write" was successful or not
    *
    * @param memory   memory region in little-endian order
    * @param position position to write

--- a/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
@@ -300,6 +300,7 @@ public class StringFieldReader implements FieldReader
       while (position < limit && !rowTerminatorSeen) {
 
         final byte kind = memory.getByte(position);
+        long curPosition = position;
         position++;
 
         switch (kind) {
@@ -314,13 +315,13 @@ public class StringFieldReader implements FieldReader
 
           case StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NULL:
           case StringFieldWriter.NULL_BYTE:
-            assert kind != StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NULL || position == fieldPosition;
+            assert kind != StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NULL || curPosition == fieldPosition;
             currentUtf8Strings.add(null);
             break;
 
           case StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NON_NULL:
           case StringFieldWriter.NOT_NULL_BYTE:
-            assert kind != StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NON_NULL || position == fieldPosition;
+            assert kind != StringFieldWriter.NON_NULL_ARRAY_BYTE_FIRST_ELEMENT_NON_NULL || curPosition == fieldPosition;
 
             for (long i = position; ; i++) {
               if (i >= limit) {
@@ -346,14 +347,17 @@ public class StringFieldReader implements FieldReader
               }
             }
 
-          case StringFieldWriter.NULL_ARRAY_BYTE:
-            assert position == fieldPosition;
-            currentUtf8StringsIsNullArray = true;
-            assert position + 1 < limit && memory.getByte(position + 1) == StringFieldWriter.ROW_TERMINATOR;
             break;
+            
+          case StringFieldWriter.NULL_ARRAY_BYTE:
+            assert curPosition == fieldPosition;
+            currentUtf8StringsIsNullArray = true;
+            assert curPosition + 1 < limit && memory.getByte(curPosition + 1) == StringFieldWriter.ROW_TERMINATOR;
+            break;
+
           case StringFieldWriter.EMPTY_ARRAY_BYTE:
-            assert position == fieldPosition;
-            assert position + 1 < limit && memory.getByte(position + 1) == StringFieldWriter.ROW_TERMINATOR;
+            assert curPosition == fieldPosition;
+            assert curPosition + 1 < limit && memory.getByte(curPosition + 1) == StringFieldWriter.ROW_TERMINATOR;
             break;
 
           default:

--- a/processing/src/main/java/org/apache/druid/frame/read/columnar/StringFrameColumnReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/columnar/StringFrameColumnReader.java
@@ -162,6 +162,8 @@ public class StringFrameColumnReader implements FrameColumnReader
     final int totalNumValues;
 
     if (multiValue) {
+      // TODO: This would fail in case the cumulative row length is negative.
+      //  Either add the max row length at the beginning, and then add versions in the StringFrameColumnWriter
       totalNumValues = getCumulativeRowLength(memory, numRows - 1);
     } else {
       totalNumValues = numRows;
@@ -511,7 +513,9 @@ public class StringFrameColumnReader implements FrameColumnReader
                               ? cumulativeRowLength
                               : cumulativeRowLength - getCumulativeRowLength(memory, physicalRow - 1);
 
-        if (rowLength == 0) {
+        if (rowLength == -1) {
+          return null;
+        } else if (rowLength == 0) {
           return Collections.emptyList();
         } else if (rowLength == 1) {
           final int index = cumulativeRowLength - 1;

--- a/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
@@ -129,15 +129,16 @@ public class FrameWriterUtils
    * Retrieves UTF-8 byte buffers from a {@link ColumnValueSelector}, which is expected to be the kind of
    * selector you get for an {@code ARRAY<STRING>} column.
    *
-   * Null strings are returned as {@link #NULL_STRING_MARKER_ARRAY}.
+   * Null strings are returned as {@code null}
    */
+  @Nullable
   public static List<ByteBuffer> getUtf8ByteBuffersFromStringArraySelector(
       @SuppressWarnings("rawtypes") final ColumnValueSelector selector
   )
   {
     Object row = selector.getObject();
     if (row == null) {
-      return Collections.singletonList(getUtf8ByteBufferFromString(null));
+      return null;
     } else if (row instanceof String) {
       return Collections.singletonList(getUtf8ByteBufferFromString((String) row));
     }

--- a/processing/src/main/java/org/apache/druid/frame/write/columnar/FrameColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/columnar/FrameColumnWriter.java
@@ -23,14 +23,43 @@ import org.apache.datasketches.memory.WritableMemory;
 
 import java.io.Closeable;
 
+/**
+ * Subclasses of this interface aid in writing the column values to a column-oriented Frame.
+ * The intended implementation of the interface is that the implementations acquire the necessary information and data
+ * to write a column (usually a {@link org.apache.druid.segment.ColumnValueSelector}) and write the selection
+ * to an internal memory location incrementally as {@link #addSelection()} is called.
+ *
+ * The {@link #writeTo} call then transfers the build up data from the internal buffer to the provided location, along
+ * with some metadata (for e.g. the column type)
+ */
 public interface FrameColumnWriter extends Closeable
 {
+  /**
+   * Process and add the value from a single row to the internal memory location. This call might fail
+   * due to internal errors, processing errors or if we are unable to reserve the internal memory required to
+   * make the call.
+   * @return true if we can succesfully add the row, false if not
+   */
   boolean addSelection();
 
+  /**
+   * Undo the last value that was added by {@link #addSelection}. This method helps clean up the last succesful write
+   * to the FrameColumnWriter, if the other FrameColumnWriters failed while trying to {@link #addSelection}
+   *
+   * Calling undo twice in a row, without adding any selection is undefined and may throw an
+   * error for some types of FrameColumnWriters like {@link StringFrameColumnWriterImpl}
+   */
   void undo();
 
+  /**
+   * Memory size required to write the data added so far to memory. This includes the overheads of writing the
+   * column types etc.
+   */
   long size();
 
+  /**
+   * Writes the data to the memory provided at the given location
+   */
   long writeTo(WritableMemory memory, long position);
 
   @Override

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
@@ -80,7 +80,7 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
   {
     writeToMemory(Collections.singletonList(null));
     Assert.assertTrue(new StringFieldReader(false).isNull(memory, MEMORY_POSITION));
-    Assert.assertTrue(new StringFieldReader(true).isNull(memory, MEMORY_POSITION));
+    Assert.assertFalse(new StringFieldReader(true).isNull(memory, MEMORY_POSITION));
   }
 
   @Test
@@ -174,7 +174,7 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
         new StringFieldReader(true).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
 
     Assert.assertNull(readSelector.getObject());
-    Assert.assertEquals(Collections.emptyList(), readSelectorAsArray.getObject());
+    Assert.assertEquals(null, readSelectorAsArray.getObject());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
@@ -174,7 +174,7 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
         new StringFieldReader(true).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
 
     Assert.assertNull(readSelector.getObject());
-    Assert.assertEquals(null, readSelectorAsArray.getObject());
+    Assert.assertEquals(Collections.emptyList(), readSelectorAsArray.getObject());
   }
 
   @Test


### PR DESCRIPTION
### Description

This is in context for the string writers present in the frames. Currently, Frames treat `[]` and `[null]` equivalently. This is fine for MVDs since there can be still some inconsistencies in how they are treated in the selectors, therefore we needn't make a special effort in Frames to support this difference.
However, for string arrays, this change is crucial as `[]`, `null`, and `[null]` are not the same, and should never be treated as such.
This PR adds support for distinguishing between these values in the frames written by string writers (both row-based and columnar)

#### For row-based writers (FieldWriters)
We prepend a byte denoting if the string is null or non-null.
We can prepend this to the string array to distinguish `null` values from all others. In my implementation, I have created a matric where we coalesce the array null-check byte with the first element's null-check byte to conserve some space (at the cost of increasing the code's complexity). 

#### For column-based writers (ColumnWriters)
We store the cumulative string length and the data length for the writers. For nulls, instead of storing 0, we can store it as -1. However, this warrants a change in the format (where we add another integer to the memory) that denotes the different region's start positions (as these can non-monotonically decrease).



Both the changes are forward compatible, i.e. the new readers would be able to read the columns written by old writers, however, the frame written by a new writer won't be read correctly by an older reader. 

Raising it as a draft PR to gather some feedback on the approach. 
#### Release note

<hr>

##### Key changed/added classes in this PR

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
