### PR TITLE
Batch segment deletes triggered by DropRules

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -719,7 +719,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     return connector.getDBI().withHandle(
         handle ->
             SqlSegmentsMetadataQuery.forHandle(handle, connector, dbTables.get(), jsonMapper)
-                                    .markSegments(segmentIds, true)
+                                    .markSegmentsAsUsed(segmentIds)
     );
   }
 
@@ -750,7 +750,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
       final int numSegments = connector.getDBI().withHandle(
           handle ->
               SqlSegmentsMetadataQuery.forHandle(handle, connector, dbTables.get(), jsonMapper)
-                                      .markSegments(Collections.singletonList(segmentId), false)
+                                      .markSegmentsAsUnused(Collections.singletonList(segmentId))
       );
 
       return numSegments > 0;
@@ -767,7 +767,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     return connector.getDBI().withHandle(
         handle ->
             SqlSegmentsMetadataQuery.forHandle(handle, connector, dbTables.get(), jsonMapper)
-                                    .markSegments(segmentIds, false)
+                                    .markSegmentsAsUnused(segmentIds)
     );
   }
 
@@ -933,7 +933,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     if (segments.isEmpty()) {
       log.info("No segments found in the database!");
     } else {
-      log.info("Polled and found %,d segments in the database", segments.size());
+      log.info("Polled and found [%,d] segments in the database", segments.size());
     }
     dataSourcesSnapshot = DataSourcesSnapshot.fromUsedSegments(
         Iterables.filter(segments, Objects::nonNull), // Filter corrupted entries (see above in this method).

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorRuntimeParams.java
@@ -28,7 +28,6 @@ import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
 import org.apache.druid.server.coordinator.loading.SegmentLoadQueueManager;
 import org.apache.druid.server.coordinator.loading.SegmentLoadingConfig;
-import org.apache.druid.server.coordinator.loading.SegmentReplicationStatus;
 import org.apache.druid.server.coordinator.loading.StrategicSegmentAssigner;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Dimension;
@@ -120,12 +119,6 @@ public class DruidCoordinatorRuntimeParams
   public MetadataRuleManager getDatabaseRuleManager()
   {
     return databaseRuleManager;
-  }
-
-  @Nullable
-  public SegmentReplicationStatus getSegmentReplicationStatus()
-  {
-    return segmentAssigner == null ? null : segmentAssigner.getReplicationStatus();
   }
 
   public StrategicSegmentAssigner getSegmentAssigner()

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -196,6 +196,11 @@ public class ServerHolder implements Comparable<ServerHolder>
     return isDecommissioning;
   }
 
+  public boolean isLoadQueueFull()
+  {
+    return totalAssignmentsInRun >= maxAssignmentsInRun;
+  }
+
   public long getAvailableSize()
   {
     return getMaxSize() - getSizeUsed();

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnused.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnused.java
@@ -24,7 +24,6 @@ import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.coordinator.DruidCluster;
-import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
@@ -42,15 +41,21 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Marks segments that are overshadowed by currently served segments as unused.
+ * This duty runs only if the Coordinator has been running long enough to have a
+ * refreshed metadata view. This duration is controlled by the dynamic config
+ * {@code millisToWaitBeforeDeleting}.
+ */
 public class MarkOvershadowedSegmentsAsUnused implements CoordinatorDuty
 {
   private static final Logger log = new Logger(MarkOvershadowedSegmentsAsUnused.class);
 
-  private final DruidCoordinator coordinator;
+  private final SegmentDeleteHandler deleteHandler;
 
-  public MarkOvershadowedSegmentsAsUnused(DruidCoordinator coordinator)
+  public MarkOvershadowedSegmentsAsUnused(SegmentDeleteHandler deleteHandler)
   {
-    this.coordinator = coordinator;
+    this.deleteHandler = deleteHandler;
   }
 
   @Override
@@ -104,7 +109,9 @@ public class MarkOvershadowedSegmentsAsUnused implements CoordinatorDuty
         (datasource, unusedSegments) -> {
           RowKey datasourceKey = RowKey.of(Dimension.DATASOURCE, datasource);
           stats.add(Stats.Segments.OVERSHADOWED, datasourceKey, unusedSegments.size());
-          coordinator.markSegmentsAsUnused(datasource, unusedSegments);
+
+          int updatedCount = deleteHandler.markSegmentsAsUnused(unusedSegments);
+          log.info("Successfully marked [%d] segments of datasource[%s] as unused.", updatedCount, datasource);
         }
     );
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/NewestSegmentFirstIterator.java
@@ -50,7 +50,6 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.NumberedPartitionChunk;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.PartitionChunk;
@@ -116,7 +115,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
       final DataSourceCompactionConfig config = compactionConfigs.get(dataSource);
       Granularity configuredSegmentGranularity = null;
       if (config != null && !timeline.isEmpty()) {
-        VersionedIntervalTimeline<String, DataSegment> originalTimeline = null;
+        SegmentTimeline originalTimeline = null;
         if (config.getGranularitySpec() != null && config.getGranularitySpec().getSegmentGranularity() != null) {
           String temporaryVersion = DateTimes.nowUtc().toString();
           Map<Interval, Set<DataSegment>> intervalToPartitionMap = new HashMap<>();
@@ -253,20 +252,20 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
   }
 
   /**
-   * Iterates the given {@link VersionedIntervalTimeline}. Only compactible {@link TimelineObjectHolder}s are returned,
+   * Iterates the given {@link SegmentTimeline}. Only compactible {@link TimelineObjectHolder}s are returned,
    * which means the holder always has at least one {@link DataSegment}.
    */
   private static class CompactibleTimelineObjectHolderCursor implements Iterator<List<DataSegment>>
   {
     private final List<TimelineObjectHolder<String, DataSegment>> holders;
     @Nullable
-    private final VersionedIntervalTimeline<String, DataSegment> originalTimeline;
+    private final SegmentTimeline originalTimeline;
 
     CompactibleTimelineObjectHolderCursor(
-        VersionedIntervalTimeline<String, DataSegment> timeline,
+        SegmentTimeline timeline,
         List<Interval> totalIntervalsToSearch,
         // originalTimeline can be nullable if timeline was not modified
-        @Nullable VersionedIntervalTimeline<String, DataSegment> originalTimeline
+        @Nullable SegmentTimeline originalTimeline
     )
     {
       this.holders = totalIntervalsToSearch
@@ -603,7 +602,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
    */
   private List<Interval> findInitialSearchInterval(
       String dataSourceName,
-      VersionedIntervalTimeline<String, DataSegment> timeline,
+      SegmentTimeline timeline,
       Period skipOffset,
       Granularity configuredSegmentGranularity,
       @Nullable List<Interval> skipIntervals

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/RunRules.java
@@ -19,7 +19,8 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import com.google.common.collect.Lists;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.EmittingLogger;
@@ -29,16 +30,25 @@ import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.loading.StrategicSegmentAssigner;
 import org.apache.druid.server.coordinator.rules.BroadcastDistributionRule;
 import org.apache.druid.server.coordinator.rules.Rule;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Dimension;
+import org.apache.druid.server.coordinator.stats.RowKey;
+import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Duty to run retention rules.
+ * Duty to run retention rules for all used non-overshadowed segments.
+ * Overshadowed segments are marked unused by {@link MarkOvershadowedSegmentsAsUnused}
+ * duty and are eventually unloaded from all servers by {@link UnloadUnusedSegments}.
  * <p>
  * The params returned from {@code run()} must have these fields initialized:
  * <ul>
@@ -49,7 +59,13 @@ import java.util.stream.Collectors;
 public class RunRules implements CoordinatorDuty
 {
   private static final EmittingLogger log = new EmittingLogger(RunRules.class);
-  private static final int MAX_MISSING_RULES = 10;
+
+  private final SegmentDeleteHandler deleteHandler;
+
+  public RunRules(SegmentDeleteHandler deleteHandler)
+  {
+    this.deleteHandler = deleteHandler;
+  }
 
   @Override
   public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
@@ -60,30 +76,28 @@ public class RunRules implements CoordinatorDuty
       return params;
     }
 
-    // Get used segments which are overshadowed by other used segments. Those would not need to be loaded and
-    // eventually will be unloaded from Historical servers. Segments overshadowed by *served* used segments are marked
-    // as unused in MarkAsUnusedOvershadowedSegments, and then eventually Coordinator sends commands to Historical nodes
-    // to unload such segments in UnloadUnusedSegments.
-    final Set<DataSegment> overshadowed = params.getDataSourcesSnapshot().getOvershadowedSegments();
+    final Set<DataSegment> overshadowedSegments = params.getDataSourcesSnapshot().getOvershadowedSegments();
     final Set<DataSegment> usedSegments = params.getUsedSegments();
     log.info(
         "Applying retention rules on [%,d] used segments, skipping [%,d] overshadowed segments.",
-        usedSegments.size(), overshadowed.size()
+        usedSegments.size(), overshadowedSegments.size()
     );
 
     final StrategicSegmentAssigner segmentAssigner = params.getSegmentAssigner();
     final MetadataRuleManager databaseRuleManager = params.getDatabaseRuleManager();
 
-    int missingRules = 0;
     final DateTime now = DateTimes.nowUtc();
-    final List<SegmentId> segmentsWithMissingRules = Lists.newArrayListWithCapacity(MAX_MISSING_RULES);
 
-    // Run through all matched rules for used segments
+    final Object2IntOpenHashMap<String> datasourceToSegmentsWithNoRule = new Object2IntOpenHashMap<>();
+
     for (DataSegment segment : usedSegments) {
-      if (overshadowed.contains(segment)) {
-        // Skip overshadowed segments
+      // Do not apply rules on overshadowed segments as they will be
+      // marked unused and eventually unloaded from all historicals
+      if (overshadowedSegments.contains(segment)) {
         continue;
       }
+
+      // Find and apply matching rule
       List<Rule> rules = databaseRuleManager.getRulesWithDefault(segment.getDataSource());
       boolean foundMatchingRule = false;
       for (Rule rule : rules) {
@@ -95,23 +109,51 @@ public class RunRules implements CoordinatorDuty
       }
 
       if (!foundMatchingRule) {
-        if (segmentsWithMissingRules.size() < MAX_MISSING_RULES) {
-          segmentsWithMissingRules.add(segment.getId());
-        }
-        missingRules++;
+        datasourceToSegmentsWithNoRule.addTo(segment.getDataSource(), 1);
       }
     }
 
-    if (!segmentsWithMissingRules.isEmpty()) {
-      log.makeAlert("Unable to find matching rules!")
-         .addData("segmentsWithMissingRulesCount", missingRules)
-         .addData("segmentsWithMissingRules", segmentsWithMissingRules)
-         .emit();
+    // Alert for segments with no matching rules
+    if (!datasourceToSegmentsWithNoRule.isEmpty()) {
+      log.noStackTrace().makeAlert(
+          "No matching retention rule for segments in datasources[%s]",
+          datasourceToSegmentsWithNoRule
+      ).emit();
     }
+
+    processSegmentDeletes(segmentAssigner, params.getCoordinatorStats());
+    alertForInvalidRules(segmentAssigner);
 
     return params.buildFromExisting()
                  .withBroadcastDatasources(getBroadcastDatasources(params))
                  .build();
+  }
+
+  private void processSegmentDeletes(
+      StrategicSegmentAssigner segmentAssigner,
+      CoordinatorRunStats runStats
+  )
+  {
+    segmentAssigner.getSegmentsToDelete().forEach((datasource, segmentIds) -> {
+      int numDeletedSegments = deleteHandler.markSegmentsAsUnused(segmentIds);
+      RowKey rowKey = RowKey.of(Dimension.DATASOURCE, datasource);
+      runStats.add(Stats.Segments.DELETED, rowKey, numDeletedSegments);
+
+      if (segmentIds.size() > numDeletedSegments) {
+        runStats.add(Stats.Segments.DELETE_SKIPPED, rowKey, segmentIds.size() - numDeletedSegments);
+      }
+    });
+  }
+
+  private void alertForInvalidRules(StrategicSegmentAssigner segmentAssigner)
+  {
+    segmentAssigner.getDatasourceToInvalidLoadTiers().forEach(
+        (datasource, invalidTiers) -> log.makeAlert(
+            "Load rules for datasource[%s] refer to invalid tiers[%s]."
+            + " Update the load rules or add servers for these tiers.",
+            datasource, invalidTiers
+        ).emit()
+    );
   }
 
   private Set<String> getBroadcastDatasources(DruidCoordinatorRuntimeParams params)

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/SegmentDeleteHandler.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/SegmentDeleteHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.duty;
+
+import org.apache.druid.timeline.SegmentId;
+
+import java.util.Set;
+
+public interface SegmentDeleteHandler
+{
+
+  int markSegmentsAsUnused(Set<SegmentId> segmentIds);
+
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegments.java
@@ -101,7 +101,7 @@ public class UnloadUnusedSegments implements CoordinatorDuty
         if (!usedSegments.contains(segment)
             && loadQueueManager.dropSegment(segment, serverHolder)) {
           totalUnneededCount++;
-          log.info(
+          log.debug(
               "Dropping uneeded segment [%s] from server [%s] in tier [%s]",
               segment.getId(), server.getName(), server.getTier()
           );

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/CuratorLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/CuratorLoadQueuePeon.java
@@ -172,6 +172,9 @@ public class CuratorLoadQueuePeon implements LoadQueuePeon
   @Override
   public CoordinatorRunStats getAndResetStats()
   {
+    stats.add(Stats.SegmentQueue.BYTES_TO_LOAD, getSizeOfSegmentsToLoad());
+    stats.add(Stats.SegmentQueue.NUM_TO_LOAD, getSegmentsToLoad().size());
+    stats.add(Stats.SegmentQueue.NUM_TO_DROP, getSegmentsToDrop().size());
     return stats.getSnapshotAndReset();
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -485,6 +485,9 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   @Override
   public CoordinatorRunStats getAndResetStats()
   {
+    stats.add(Stats.SegmentQueue.BYTES_TO_LOAD, getSizeOfSegmentsToLoad());
+    stats.add(Stats.SegmentQueue.NUM_TO_LOAD, getSegmentsToLoad().size());
+    stats.add(Stats.SegmentQueue.NUM_TO_DROP, getSegmentsToDrop().size());
     return stats.getSnapshotAndReset();
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -22,7 +22,6 @@ package org.apache.druid.server.coordinator.loading;
 import com.google.inject.Inject;
 import org.apache.druid.client.ServerInventoryView;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.druid.metadata.SegmentsMetadataManager;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 
@@ -36,17 +35,14 @@ public class SegmentLoadQueueManager
 
   private final LoadQueueTaskMaster taskMaster;
   private final ServerInventoryView serverInventoryView;
-  private final SegmentsMetadataManager segmentsMetadataManager;
 
   @Inject
   public SegmentLoadQueueManager(
       ServerInventoryView serverInventoryView,
-      SegmentsMetadataManager segmentsMetadataManager,
       LoadQueueTaskMaster taskMaster
   )
   {
     this.serverInventoryView = serverInventoryView;
-    this.segmentsMetadataManager = segmentsMetadataManager;
     this.taskMaster = taskMaster;
   }
 
@@ -146,14 +142,6 @@ public class SegmentLoadQueueManager
     }
 
     return true;
-  }
-
-  /**
-   * Marks the given segment as unused.
-   */
-  public boolean deleteSegment(DataSegment segment)
-  {
-    return segmentsMetadataManager.markSegmentAsUnused(segment.getId());
   }
 
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadingConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadingConfig.java
@@ -59,8 +59,8 @@ public class SegmentLoadingConfig
       final int maxSegmentsToMove = Math.min(1000, replicationThrottleLimit);
 
       log.info(
-          "Smart segment loading is enabled. Recomputed replicationThrottleLimit"
-          + " [%,d] (%d%% of used segments [%,d]) and maxSegmentsToMove [%,d].",
+          "Smart segment loading is enabled. Recomputed replicationThrottleLimit[%,d]"
+          + " (%d%% of used segments[%,d]) and maxSegmentsToMove[%,d].",
           replicationThrottleLimit, throttlePercentage, numUsedSegments, maxSegmentsToMove
       );
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -32,7 +32,9 @@ import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.coordinator.stats.RowKey;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -50,6 +52,7 @@ import java.util.stream.Collectors;
  * <p>
  * An instance of this class is freshly created for each coordinator run.
  */
+@NotThreadSafe
 public class StrategicSegmentAssigner implements SegmentActionHandler
 {
   private static final EmittingLogger log = new EmittingLogger(StrategicSegmentAssigner.class);
@@ -64,8 +67,9 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
 
   private final boolean useRoundRobinAssignment;
 
-  private final Set<String> tiersWithNoServer = new HashSet<>();
+  private final Map<String, Set<String>> datasourceToInvalidLoadTiers = new HashMap<>();
   private final Map<String, Integer> tierToHistoricalCount = new HashMap<>();
+  private final Map<String, Set<SegmentId>> segmentsToDelete = new HashMap<>();
 
   public StrategicSegmentAssigner(
       SegmentLoadQueueManager loadQueueManager,
@@ -99,11 +103,14 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
     return replicaCountMap.toReplicationStatus();
   }
 
-  public void makeAlerts()
+  public Map<String, Set<SegmentId>> getSegmentsToDelete()
   {
-    if (!tiersWithNoServer.isEmpty()) {
-      log.makeAlert("Tiers [%s] have no servers! Check your cluster configuration.", tiersWithNoServer).emit();
-    }
+    return segmentsToDelete;
+  }
+
+  public Map<String, Set<String>> getDatasourceToInvalidLoadTiers()
+  {
+    return datasourceToInvalidLoadTiers;
   }
 
   /**
@@ -203,7 +210,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       replicaCount.setRequired(requiredReplicas, tierToHistoricalCount.getOrDefault(tier, 0));
 
       if (!allTiersInCluster.contains(tier)) {
-        tiersWithNoServer.add(tier);
+        datasourceToInvalidLoadTiers.computeIfAbsent(segment.getDataSource(), ds -> new HashSet<>())
+                                    .add(tier);
       }
     });
 
@@ -342,13 +350,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   @Override
   public void deleteSegment(DataSegment segment)
   {
-    loadQueueManager.deleteSegment(segment);
-    RowKey rowKey = RowKey.of(Dimension.DATASOURCE, segment.getDataSource());
-    stats.add(Stats.Segments.DELETED, rowKey, 1);
+    segmentsToDelete
+        .computeIfAbsent(segment.getDataSource(), ds -> new HashSet<>())
+        .add(segment.getId());
   }
 
   /**
-   * Loads the broadcast segment if it is not loaded on the given server.
+   * Loads the broadcast segment if it is not already loaded on the given server.
    * Returns true only if the segment was successfully queued for load on the server.
    */
   private boolean loadBroadcastSegment(DataSegment segment, ServerHolder server)
@@ -357,19 +365,21 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       return false;
     } else if (server.isDroppingSegment(segment)) {
       return server.cancelOperation(SegmentAction.DROP, segment);
+    } else if (server.canLoadSegment(segment)) {
+      return loadSegment(segment, server);
     }
 
-    if (server.canLoadSegment(segment) && loadSegment(segment, server)) {
-      return true;
+    final String skipReason;
+    if (server.getAvailableSize() < segment.getSize()) {
+      skipReason = "Not enough disk space";
+    } else if (server.isLoadQueueFull()) {
+      skipReason = "Load queue is full";
     } else {
-      log.makeAlert("Could not assign broadcast segment for datasource [%s]", segment.getDataSource())
-         .addData("segmentId", segment.getId())
-         .addData("segmentSize", segment.getSize())
-         .addData("hostName", server.getServer().getHost())
-         .addData("availableSize", server.getAvailableSize())
-         .emit();
-      return false;
+      skipReason = "Unknown error";
     }
+
+    incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, skipReason, segment, server.getServer().getTier());
+    return false;
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -43,6 +43,8 @@ public class Stats
         = CoordinatorStat.toDebugAndEmit("dropSkip", "segment/dropSkipped/count");
     public static final CoordinatorStat MOVE_SKIPPED
         = CoordinatorStat.toDebugAndEmit("moveSkip", "segment/moveSkipped/count");
+    public static final CoordinatorStat DELETE_SKIPPED
+        = CoordinatorStat.toDebugAndEmit("deleteSkip", "segment/deleteSkipped/count");
 
     // Current state of segments of a datasource
     public static final CoordinatorStat USED

--- a/server/src/test/java/org/apache/druid/server/coordinator/BalanceSegmentsProfiler.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/BalanceSegmentsProfiler.java
@@ -65,7 +65,7 @@ public class BalanceSegmentsProfiler
   @Before
   public void setUp()
   {
-    loadQueueManager = new SegmentLoadQueueManager(null, null, null);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
     druidServer1 = EasyMock.createMock(ImmutableDruidServer.class);
     druidServer2 = EasyMock.createMock(ImmutableDruidServer.class);
     emitter = EasyMock.createMock(ServiceEmitter.class);
@@ -143,7 +143,7 @@ public class BalanceSegmentsProfiler
         .build();
 
     BalanceSegments tester = new BalanceSegments();
-    RunRules runner = new RunRules();
+    RunRules runner = new RunRules(ids -> 0);
     watch.start();
     DruidCoordinatorRuntimeParams balanceParams = tester.run(params);
     DruidCoordinatorRuntimeParams assignParams = runner.run(params);

--- a/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/CuratorDruidCoordinatorTest.java
@@ -333,8 +333,7 @@ public class CuratorDruidCoordinatorTest extends CuratorTestBase
     EasyMock.replay(taskMaster);
 
     // Move the segment from source to dest
-    SegmentLoadQueueManager loadQueueManager =
-        new SegmentLoadQueueManager(baseView, segmentsMetadataManager, taskMaster);
+    SegmentLoadQueueManager loadQueueManager = new SegmentLoadQueueManager(baseView, taskMaster);
     StrategicSegmentAssigner segmentAssigner = createSegmentAssigner(loadQueueManager, coordinatorRuntimeParams);
     segmentAssigner.moveSegment(
         segmentToMove,

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import org.apache.curator.framework.CuratorFramework;
@@ -179,7 +178,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
         scheduledExecutorFactory,
         null,
         loadQueueTaskMaster,
-        new SegmentLoadQueueManager(serverInventoryView, segmentsMetadataManager, loadQueueTaskMaster),
+        new SegmentLoadQueueManager(serverInventoryView, loadQueueTaskMaster),
         new LatchableServiceAnnouncer(leaderAnnouncerLatch, leaderUnannouncerLatch),
         druidNode,
         new HashSet<>(),
@@ -583,73 +582,6 @@ public class DruidCoordinatorTest extends CuratorTestBase
   }
 
   @Test
-  public void testBalancerThreadNumber()
-  {
-    CoordinatorDynamicConfig dynamicConfig = EasyMock.createNiceMock(CoordinatorDynamicConfig.class);
-    EasyMock.expect(dynamicConfig.getBalancerComputeThreads()).andReturn(5).times(2);
-    EasyMock.expect(dynamicConfig.getBalancerComputeThreads()).andReturn(10).once();
-
-    JacksonConfigManager configManager = EasyMock.createNiceMock(JacksonConfigManager.class);
-    EasyMock.expect(
-        configManager.watch(
-            EasyMock.eq(CoordinatorDynamicConfig.CONFIG_KEY),
-            EasyMock.anyObject(Class.class),
-            EasyMock.anyObject()
-        )
-    ).andReturn(new AtomicReference<>(dynamicConfig)).anyTimes();
-
-    ScheduledExecutorFactory scheduledExecutorFactory = EasyMock.createNiceMock(ScheduledExecutorFactory.class);
-    EasyMock.replay(configManager, dynamicConfig, scheduledExecutorFactory);
-
-    DruidCoordinator c = new DruidCoordinator(
-        druidCoordinatorConfig,
-        configManager,
-        null,
-        null,
-        null,
-        null,
-        scheduledExecutorFactory,
-        null,
-        loadQueueTaskMaster,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new CoordinatorCustomDutyGroups(ImmutableSet.of()),
-        null,
-        null,
-        null,
-        null
-    );
-
-    // before initialization
-    Assert.assertEquals(0, c.getCachedBalancerThreadNumber());
-    Assert.assertNull(c.getBalancerExec());
-
-    // first initialization
-    c.initBalancerExecutor();
-    Assert.assertEquals(5, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService firstExec = c.getBalancerExec();
-    Assert.assertNotNull(firstExec);
-
-    // second initialization, expect no changes as cachedBalancerThreadNumber is not changed
-    c.initBalancerExecutor();
-    Assert.assertEquals(5, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService secondExec = c.getBalancerExec();
-    Assert.assertNotNull(secondExec);
-    Assert.assertSame(firstExec, secondExec);
-
-    // third initialization, expect executor recreated as cachedBalancerThreadNumber is changed to 10
-    c.initBalancerExecutor();
-    Assert.assertEquals(10, c.getCachedBalancerThreadNumber());
-    ListeningExecutorService thirdExec = c.getBalancerExec();
-    Assert.assertNotNull(thirdExec);
-    Assert.assertNotSame(secondExec, thirdExec);
-    Assert.assertNotSame(firstExec, thirdExec);
-  }
-
-  @Test
   public void testCompactSegmentsDutyWhenCustomDutyGroupEmpty()
   {
     CoordinatorCustomDutyGroups emptyCustomDutyGroups = new CoordinatorCustomDutyGroups(ImmutableSet.of());
@@ -860,7 +792,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
         scheduledExecutorFactory,
         null,
         loadQueueTaskMaster,
-        new SegmentLoadQueueManager(serverInventoryView, segmentsMetadataManager, loadQueueTaskMaster),
+        new SegmentLoadQueueManager(serverInventoryView, loadQueueTaskMaster),
         new LatchableServiceAnnouncer(leaderAnnouncerLatch, leaderUnannouncerLatch),
         druidNode,
         new HashSet<>(),

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/BalanceSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/BalanceSegmentsTest.java
@@ -71,7 +71,7 @@ public class BalanceSegmentsTest
   @Before
   public void setUp()
   {
-    loadQueueManager = new SegmentLoadQueueManager(null, null, null);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
 
     // Create test segments for multiple datasources
     final DateTime start1 = DateTimes.of("2012-01-01");

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CollectSegmentAndServerStatsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CollectSegmentAndServerStatsTest.java
@@ -19,53 +19,49 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import it.unimi.dsi.fastutil.objects.Object2IntMaps;
-import it.unimi.dsi.fastutil.objects.Object2LongMaps;
+import org.apache.druid.client.DruidServer;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.DruidCluster;
-import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.balancer.RandomBalancerStrategy;
+import org.apache.druid.server.coordinator.loading.LoadQueuePeonTester;
 import org.apache.druid.server.coordinator.loading.SegmentLoadQueueManager;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.coordinator.stats.Stats;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Collections;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CollectSegmentAndServerStatsTest
 {
-  @Mock
-  private DruidCoordinator mockDruidCoordinator;
 
   @Test
   public void testCollectedSegmentStats()
   {
+    DruidServer server = new DruidServer("s1", "localhost", null, 100, ServerType.HISTORICAL, "tier1", 1);
+    DruidCluster cluster = DruidCluster.builder().add(
+        new ServerHolder(server.toImmutableDruidServer(), new LoadQueuePeonTester())
+    ).build();
+
     DruidCoordinatorRuntimeParams runtimeParams =
         DruidCoordinatorRuntimeParams.newBuilder(DateTimes.nowUtc())
-                                     .withDruidCluster(DruidCluster.EMPTY)
+                                     .withDruidCluster(cluster)
                                      .withUsedSegmentsInTest()
                                      .withBalancerStrategy(new RandomBalancerStrategy())
-                                     .withSegmentAssignerUsing(new SegmentLoadQueueManager(null, null, null))
+                                     .withSegmentAssignerUsing(new SegmentLoadQueueManager(null, null))
                                      .build();
 
-    Mockito.when(mockDruidCoordinator.getDatasourceToUnavailableSegmentCount())
-           .thenReturn(Object2IntMaps.singleton("ds", 10));
-    Mockito.when(mockDruidCoordinator.getTierToDatasourceToUnderReplicatedCount(false))
-           .thenReturn(Collections.singletonMap("ds", Object2LongMaps.singleton("tier1", 100)));
-
-    CoordinatorDuty duty = new CollectSegmentAndServerStats(mockDruidCoordinator);
+    CoordinatorDuty duty = new CollectSegmentAndServerStats();
     DruidCoordinatorRuntimeParams params = duty.run(runtimeParams);
 
     CoordinatorRunStats stats = params.getCoordinatorStats();
-    Assert.assertTrue(stats.hasStat(Stats.Segments.UNAVAILABLE));
-    Assert.assertTrue(stats.hasStat(Stats.Segments.UNDER_REPLICATED));
+    Assert.assertTrue(stats.hasStat(Stats.SegmentQueue.NUM_TO_LOAD));
+    Assert.assertTrue(stats.hasStat(Stats.SegmentQueue.NUM_TO_DROP));
+    Assert.assertTrue(stats.hasStat(Stats.SegmentQueue.BYTES_TO_LOAD));
   }
 
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -88,7 +88,6 @@ import org.apache.druid.timeline.CompactionState;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.PartitionChunk;
@@ -2287,7 +2286,7 @@ public class CompactSegmentsTest
     }
 
     private void compactSegments(
-        VersionedIntervalTimeline<String, DataSegment> timeline,
+        SegmentTimeline timeline,
         List<DataSegment> segments,
         ClientCompactionTaskQuery clientCompactionTaskQuery
     )

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnusedTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/MarkOvershadowedSegmentsAsUnusedTest.java
@@ -19,86 +19,107 @@
 
 package org.apache.druid.server.coordinator.duty;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.druid.client.DruidServer;
-import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.DruidCluster;
-import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.ServerHolder;
-import org.apache.druid.server.coordinator.loading.LoadQueuePeon;
+import org.apache.druid.server.coordinator.loading.LoadQueuePeonTester;
+import org.apache.druid.server.coordinator.simulate.TestSegmentsMetadataManager;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Dimension;
+import org.apache.druid.server.coordinator.stats.RowKey;
+import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.timeline.DataSegment;
-import org.easymock.EasyMock;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 @RunWith(JUnitParamsRunner.class)
 public class MarkOvershadowedSegmentsAsUnusedTest
 {
-  private final DruidCoordinator coordinator = EasyMock.createStrictMock(DruidCoordinator.class);
-
   private final DateTime start = DateTimes.of("2012-01-01");
 
-  private final LoadQueuePeon mockPeon = EasyMock.createMock(LoadQueuePeon.class);
-  private final ImmutableDruidDataSource druidDataSource = EasyMock.createMock(ImmutableDruidDataSource.class);
-  private final DataSegment segmentV0 = DataSegment.builder().dataSource("test")
-                                                   .interval(new Interval(start, start.plusHours(1)))
-                                                   .version("0")
-                                                   .size(0)
-                                                   .build();
+  private final DataSegment segmentV0
+      = DataSegment.builder()
+                   .dataSource("test")
+                   .interval(new Interval(start, start.plusHours(1)))
+                   .version("0")
+                   .size(0)
+                   .build();
   private final DataSegment segmentV1 = segmentV0.withVersion("1");
   private final DataSegment segmentV2 = segmentV0.withVersion("2");
 
+  private TestSegmentsMetadataManager segmentsMetadataManager;
+
+  @Before
+  public void setup()
+  {
+    segmentsMetadataManager = new TestSegmentsMetadataManager();
+  }
+
   @Test
   @Parameters({"historical", "broker"})
-  public void testRun(String serverTypeString)
+  public void testRun(String serverType)
   {
-    ServerType serverType = ServerType.fromString(serverTypeString);
+    segmentsMetadataManager.addSegment(segmentV0);
+    segmentsMetadataManager.addSegment(segmentV1);
+    segmentsMetadataManager.addSegment(segmentV2);
 
-    MarkOvershadowedSegmentsAsUnused markOvershadowedSegmentsAsUnused =
-        new MarkOvershadowedSegmentsAsUnused(coordinator);
-    final List<DataSegment> usedSegments = ImmutableList.of(segmentV1, segmentV0, segmentV2);
-
-    // Dummy values for comparisons in TreeSet
-    EasyMock.expect(mockPeon.getSegmentsInQueue())
-            .andReturn(Collections.emptySet()).anyTimes();
-    EasyMock.expect(mockPeon.getSegmentsMarkedToDrop())
-            .andReturn(Collections.emptySet()).anyTimes();
-    final ImmutableDruidServer druidServer = new DruidServer("", "", "", 0L, serverType, "", 0)
-        .addDataSegment(segmentV1)
-        .addDataSegment(segmentV2)
-        .toImmutableDruidServer();
-
-    coordinator.markSegmentsAsUnused("test", ImmutableSet.of(segmentV1.getId(), segmentV0.getId()));
-    EasyMock.expectLastCall();
-    EasyMock.replay(mockPeon, coordinator, druidDataSource);
+    final ImmutableDruidServer druidServer =
+        new DruidServer("", "", "", 0L, ServerType.fromString(serverType), "", 0)
+            .addDataSegment(segmentV1)
+            .addDataSegment(segmentV2)
+            .toImmutableDruidServer();
 
     DruidCluster druidCluster = DruidCluster
         .builder()
-        .addTier("normal", new ServerHolder(druidServer, mockPeon))
+        .addTier("normal", new ServerHolder(druidServer, new LoadQueuePeonTester()))
         .build();
 
     DruidCoordinatorRuntimeParams params = DruidCoordinatorRuntimeParams
         .newBuilder(DateTimes.nowUtc())
-        .withUsedSegmentsInTest(usedSegments)
+        .withSnapshotOfDataSourcesWithAllUsedSegments(
+            segmentsMetadataManager.getSnapshotOfDataSourcesWithAllUsedSegments()
+        )
         .withDruidCluster(druidCluster)
         .withDynamicConfigs(
             CoordinatorDynamicConfig.builder().withMarkSegmentAsUnusedDelayMillis(0).build()
         )
         .build();
-    markOvershadowedSegmentsAsUnused.run(params);
-    EasyMock.verify(coordinator, druidDataSource);
+
+    // Run the duty
+    params = new MarkOvershadowedSegmentsAsUnused(segmentsMetadataManager::markSegmentsAsUnused).run(params);
+
+    SegmentTimeline timeline = segmentsMetadataManager.getSnapshotOfDataSourcesWithAllUsedSegments()
+                                                      .getUsedSegmentsTimelinesPerDataSource()
+                                                      .get("test");
+
+    // Verify that the overshadowed segments have been marked as unused
+    Assert.assertTrue(timeline.isOvershadowed(segmentV0));
+    Assert.assertTrue(timeline.isOvershadowed(segmentV1));
+
+    Set<DataSegment> updatedUsedSegments = Sets.newHashSet(segmentsMetadataManager.iterateAllUsedSegments());
+    Assert.assertEquals(1, updatedUsedSegments.size());
+    Assert.assertTrue(updatedUsedSegments.contains(segmentV2));
+
+    // Verify metrics
+    CoordinatorRunStats runStats = params.getCoordinatorStats();
+    Assert.assertEquals(
+        2L,
+        runStats.get(Stats.Segments.OVERSHADOWED, RowKey.of(Dimension.DATASOURCE, "test"))
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/UnloadUnusedSegmentsTest.java
@@ -84,7 +84,7 @@ public class UnloadUnusedSegmentsTest
     brokerServer = EasyMock.createMock(ImmutableDruidServer.class);
     indexerServer = EasyMock.createMock(ImmutableDruidServer.class);
     databaseRuleManager = EasyMock.createMock(MetadataRuleManager.class);
-    loadQueueManager = new SegmentLoadQueueManager(null, null, null);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
 
     DateTime start1 = DateTimes.of("2012-01-01");
     DateTime start2 = DateTimes.of("2012-02-01");

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/RoundRobinServerSelectorTest.java
@@ -17,14 +17,14 @@
  * under the License.
  */
 
-package org.apache.druid.server.coordinator;
+package org.apache.druid.server.coordinator.loading;
 
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.server.coordination.ServerType;
-import org.apache.druid.server.coordinator.loading.LoadQueuePeonTester;
-import org.apache.druid.server.coordinator.loading.RoundRobinServerSelector;
+import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.junit.Assert;

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
@@ -64,7 +64,7 @@ public class BroadcastDistributionRuleTest
   @Before
   public void setUp()
   {
-    loadQueueManager = new SegmentLoadQueueManager(null, null, null);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
     smallSegment = new DataSegment(
         DS_SMALL,
         Intervals.of("0/1000"),

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/LoadRuleTest.java
@@ -97,7 +97,7 @@ public class LoadRuleTest
   {
     exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "LoadRuleTest-%d"));
     balancerStrategy = new CostBalancerStrategyFactory().createBalancerStrategy(exec);
-    loadQueueManager = new SegmentLoadQueueManager(null, null, null);
+    loadQueueManager = new SegmentLoadQueueManager(null, null);
   }
 
   @After

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorRunTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorRunTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.simulate;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.DruidCoordinator;
+import org.apache.druid.server.coordinator.DruidCoordinatorTest;
+import org.apache.druid.server.coordinator.stats.Dimension;
+import org.apache.druid.timeline.DataSegment;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Performs basic coordinator testing using simulations.
+ * <p>
+ * All the tests in {@link DruidCoordinatorTest} should eventually be moved here.
+ */
+public class CoordinatorRunTest extends CoordinatorSimulationBaseTest
+{
+  private DruidServer historicalT11;
+  private DruidServer historicalT12;
+
+  private final String datasource = DS.WIKI;
+  private final List<DataSegment> segments = Segments.WIKI_10X1D;
+
+  @Override
+  public void setUp()
+  {
+    historicalT11 = createHistorical(1, Tier.T1, 10_000);
+    historicalT12 = createHistorical(2, Tier.T1, 10_000);
+  }
+
+  @Test
+  public void testDutiesRunOnEmptyCluster()
+  {
+    CoordinatorSimulation sim = CoordinatorSimulation.builder().build();
+    startSimulation(sim);
+
+    runCoordinatorCycle();
+    verifyEmitted(Metric.DUTY_GROUP_RUN_TIME, filter(Dimension.DUTY_GROUP, "HistoricalManagementDuties"), 1);
+    verifyEmitted(Metric.DUTY_GROUP_RUN_TIME, filter(Dimension.DUTY_GROUP, "MetadataStoreManagementDuties"), 1);
+  }
+
+  @Test
+  public void testReplicationStatusAfterRun()
+  {
+    CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withSegments(segments)
+                             .withServers(historicalT11, historicalT12)
+                             .withRules(datasource, Load.on(Tier.T1, 2).forever())
+                             .build();
+    startSimulation(sim);
+
+    // Run coordinator and load segments
+    runCoordinatorCycle();
+    loadQueuedSegments();
+    verifyDatasourceIsFullyLoaded(datasource);
+
+    final DataSegment segment = segments.get(0);
+
+    // Verify that replication state is not updated yet
+    final DruidCoordinator coordinator = druidCoordinator();
+    Object2IntMap<String> unavailableSegmentCounts
+        = coordinator.getDatasourceToUnavailableSegmentCount();
+    Assert.assertEquals(1, unavailableSegmentCounts.size());
+    Assert.assertEquals(segments.size(), unavailableSegmentCounts.getInt(datasource));
+
+    Assert.assertEquals(Integer.valueOf(2), coordinator.getReplicationFactor(segment.getId()));
+
+    // Verify that replication state is updated after next coordinator run
+    runCoordinatorCycle();
+
+    unavailableSegmentCounts = coordinator.getDatasourceToUnavailableSegmentCount();
+    Assert.assertEquals(1, unavailableSegmentCounts.size());
+    Assert.assertEquals(0, unavailableSegmentCounts.getInt(datasource));
+
+    final Map<String, Object2LongMap<String>> tierToUnderReplicatedCounts
+        = coordinator.getTierToDatasourceToUnderReplicatedCount(false);
+    Assert.assertNotNull(tierToUnderReplicatedCounts);
+    Assert.assertEquals(1, tierToUnderReplicatedCounts.size());
+
+    Object2LongMap<String> datasourceToUnderReplicatedCounts = tierToUnderReplicatedCounts.get(Tier.T1);
+    Assert.assertNotNull(datasourceToUnderReplicatedCounts);
+    Assert.assertEquals(1, datasourceToUnderReplicatedCounts.size());
+    Assert.assertNotNull(datasourceToUnderReplicatedCounts.get(datasource));
+    Assert.assertEquals(0L, datasourceToUnderReplicatedCounts.getLong(datasource));
+
+    Map<String, Object2LongMap<String>> tierToUnderReplicatedUsingClusterView
+        = coordinator.getTierToDatasourceToUnderReplicatedCount(true);
+    Assert.assertNotNull(tierToUnderReplicatedCounts);
+    Assert.assertEquals(1, tierToUnderReplicatedCounts.size());
+
+    Object2LongMap<String> datasourceToUnderReplicatedUsingClusterView
+        = tierToUnderReplicatedUsingClusterView.get(Tier.T1);
+    Assert.assertNotNull(datasourceToUnderReplicatedUsingClusterView);
+    Assert.assertEquals(1, datasourceToUnderReplicatedUsingClusterView.size());
+    Assert.assertNotNull(datasourceToUnderReplicatedUsingClusterView.get(datasource));
+    Assert.assertEquals(0L, datasourceToUnderReplicatedUsingClusterView.getLong(datasource));
+  }
+
+  @Test
+  public void testBalancerThreadNumber()
+  {
+    CoordinatorDynamicConfig dynamicConfig
+        = CoordinatorDynamicConfig.builder()
+                                  .withBalancerComputeThreads(1)
+                                  .build();
+
+    CoordinatorSimulation sim
+        = CoordinatorSimulation.builder()
+                               .withDynamicConfig(dynamicConfig)
+                               .build();
+    startSimulation(sim);
+
+    // before initialization
+    // dynamicConfig.set(CoordinatorDynamicConfig.builder().withBalancerComputeThreads(5).build());
+    // Assert.assertNull(createdBalancerThreadPoolSize.get());
+
+    // Run 1: Thread pool is freshly created with 5 threads
+    runCoordinatorCycle();
+    // Assert.assertNotNull(createdBalancerThreadPoolSize.get());
+    // Assert.assertEquals(5, createdBalancerThreadPoolSize.get().intValue());
+
+    // Run 2: Thread pool is not created again as balancerComputeThreads is unchanged
+    runCoordinatorCycle();
+    // Assert.assertNull(createdBalancerThreadPoolSize.get());
+
+    // Run 3: Thread pool is created again as balancerComputeThreads has changed
+    setDynamicConfig(
+        CoordinatorDynamicConfig.builder().withBalancerComputeThreads(10).build()
+    );
+    runCoordinatorCycle();
+    // Assert.assertNotNull(createdBalancerThreadPoolSize.get());
+    // Assert.assertEquals(10, createdBalancerThreadPoolSize.get().intValue());
+  }
+
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.simulate;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.java.util.metrics.MetricsVerifier;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.timeline.DataSegment;
 
 import java.util.List;
@@ -58,6 +59,11 @@ public interface CoordinatorSimulation
 
   interface CoordinatorState
   {
+    /**
+     * @return The underlying coordinator for verification of state.
+     */
+    DruidCoordinator druidCoordinator();
+
     /**
      * Runs a single coordinator cycle.
      */

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.java.util.metrics.MetricsVerifier;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.DruidCoordinator;
 import org.apache.druid.server.coordinator.rules.ForeverBroadcastDistributionRule;
 import org.apache.druid.server.coordinator.rules.ForeverLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
@@ -80,6 +81,12 @@ public abstract class CoordinatorSimulationBaseTest implements
     this.sim = simulation;
     simulation.start();
     this.metricsVerifier = this.sim.coordinator().getMetricsVerifier();
+  }
+
+  @Override
+  public DruidCoordinator druidCoordinator()
+  {
+    return sim.coordinator().druidCoordinator();
   }
 
   @Override
@@ -214,6 +221,9 @@ public abstract class CoordinatorSimulationBaseTest implements
     static final String LOAD_QUEUE_COUNT = "segment/loadQueue/count";
     static final String DROP_QUEUE_COUNT = "segment/dropQueue/count";
     static final String CANCELLED_ACTIONS = "segment/loadQueue/cancelled";
+
+    static final String DUTY_GROUP_RUN_TIME = "coordinator/global/time";
+    static final String DUTY_RUN_TIME = "coordinator/time";
   }
 
   static class Segments

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -27,7 +27,7 @@ import org.apache.druid.metadata.SegmentsMetadataManager;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.Partitions;
 import org.apache.druid.timeline.SegmentId;
-import org.apache.druid.timeline.VersionedIntervalTimeline;
+import org.apache.druid.timeline.SegmentTimeline;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -45,6 +45,9 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
 
   private volatile DataSourcesSnapshot snapshot;
 
+  /**
+   * Adds the segment to the metadata manager and marks it as used.
+   */
   public void addSegment(DataSegment segment)
   {
     segments.put(segment.getId().toString(), segment);
@@ -52,6 +55,9 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
     snapshot = null;
   }
 
+  /**
+   * Removes the segment from the metadata manager.
+   */
   public void removeSegment(DataSegment segment)
   {
     segments.remove(segment.getId().toString());
@@ -174,13 +180,12 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
       boolean requiresLatest
   )
   {
-    VersionedIntervalTimeline<String, DataSegment> usedSegmentsTimeline
-        = getSnapshotOfDataSourcesWithAllUsedSegments().getUsedSegmentsTimelinesPerDataSource().get(datasource);
-    return Optional.fromNullable(usedSegmentsTimeline)
-                   .transform(timeline -> timeline.findNonOvershadowedObjectsInInterval(
-                       interval,
-                       Partitions.ONLY_COMPLETE
-                   ));
+    SegmentTimeline usedSegmentsTimeline = getSnapshotOfDataSourcesWithAllUsedSegments()
+        .getUsedSegmentsTimelinesPerDataSource().get(datasource);
+    return Optional.fromNullable(usedSegmentsTimeline).transform(
+        timeline ->
+            timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE)
+    );
   }
 
   @Override


### PR DESCRIPTION
If several segments become eligible for a DropRule in a single coordinator run, multiple metadata update statements are fired which could have potentially been batched.

### Changes:
- Collect segment delete operations in `StrategicSegmentAssigner`
- Perform batch delete for each datasource at the end of `RunRules` duty
- Move collection of some stats from `CollectSegmentAndServerStats` to the respective duties generating those stats for simplicity
- Clean up tests

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
