### PR TITLE
Add `aggregatorMergeStrategy` property in SegmentMetadata queries

### DIFF
--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -62,8 +62,8 @@ There are several main parts to a segment metadata query:
 |merge|Merge all individual segment metadata results into a single result|no|
 |context|See [Context](../querying/query-context.md)|no|
 |analysisTypes|A list of Strings specifying what column properties (e.g. cardinality, size) should be calculated and returned in the result. Defaults to ["cardinality", "interval", "minmax"], but can be overridden with using the [segment metadata query config](../configuration/index.md#segmentmetadata-query-config). See section [analysisTypes](#analysistypes) for more details.|no|
-|aggregatorMergeStrategy| The strategy used to merge aggregators across segments. If true, and if the "aggregators" analysisType is enabled, it defaults to "strict". Possible values include "strict", "lenient" and "latest". See [below](#aggregatormergestrategy) for details.|no|
-|lenientAggregatorMerge|Deprecated: Use aggregatorMergeStrategy property instead. If true, and if the "aggregators" analysisType is enabled, aggregators will be merged leniently. See below for details.|no|
+|aggregatorMergeStrategy| The strategy Druid uses to merge aggregators across segments. If true and if the `aggregators` analysis type is enabled, `aggregatorMergeStrategy` defaults to `strict`. Possible values include `strict`, `lenient`, and `latest`. See [`aggregatorMergeStrategy`](#aggregatormergestrategy) for details.|no|
+|lenientAggregatorMerge|Deprecated. Use `aggregatorMergeStrategy` property instead. If true, and if the `aggregators` analysis type is enabled, Druid merges aggregators leniently.|no|
 
 The format of the result is:
 
@@ -186,7 +186,7 @@ Currently, there is no API for retrieving this information.
 * `aggregators` in the result will contain the list of aggregators usable for querying metric columns. This may be
 null if the aggregators are unknown or unmergeable (if merging is enabled).
 
-* Merging can be `strict`, `lenient` or `latest`. See [`aggregatorMergeStrategy`](#aggregatormergestrategy) below for details.
+* Merging can be `strict`, `lenient`, or `latest`. See [`aggregatorMergeStrategy`](#aggregatormergestrategy) for details.
 
 * The form of the result is a map of column name to aggregator.
 
@@ -198,12 +198,12 @@ null if the aggregators are unknown or unmergeable (if merging is enabled).
 ### aggregatorMergeStrategy
 
 Conflicts between aggregator metadata across segments can occur if some segments have unknown aggregators, or if
-two segments use incompatible aggregators for the same column (e.g. `longSum` changed to `doubleSum`). The following
-aggregator merge strategies are supported:
+two segments use incompatible aggregators for the same column, such as `longSum` changed to `doubleSum`.
+Druid supports the following aggregator merge strategies:
 
-- `strict`:  If there are any segments with unknown aggregators, or any conflicts of any kind, the merged aggregators
-  list will be `null`.
-- `lenient`:  Segments with unknown aggregators will be ignored, and conflicts between aggregators will only null out
+- `strict`:  If there are any segments with unknown aggregators or any conflicts of any kind, the merged aggregators
+  list is `null`.
+- `lenient`:  Druid ignores segments with unknown aggregators. Conflicts between aggregators send the aggregator for that particular column to null.
 - the aggregator for that particular column.
 - `latest`: In the event of conflicts between segments, the aggregator from the most recent segment will be selected
    for that particular column.

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -203,7 +203,7 @@ Druid supports the following aggregator merge strategies:
 
 - `strict`:  If there are any segments with unknown aggregators or any conflicts of any kind, the merged aggregators
   list is `null`.
-- `lenient`:  Druid ignores segments with unknown aggregators. Conflicts between aggregators send the aggregator for that particular column to null.
+- `lenient`:  Druid ignores segments with unknown aggregators. Conflicts between aggregators set the aggregator for that particular column to null.
 - the aggregator for that particular column.
 - `latest`: In the event of conflicts between segments, the aggregator from the most recent segment will be selected
    for that particular column.

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -62,7 +62,8 @@ There are several main parts to a segment metadata query:
 |merge|Merge all individual segment metadata results into a single result|no|
 |context|See [Context](../querying/query-context.md)|no|
 |analysisTypes|A list of Strings specifying what column properties (e.g. cardinality, size) should be calculated and returned in the result. Defaults to ["cardinality", "interval", "minmax"], but can be overridden with using the [segment metadata query config](../configuration/index.md#segmentmetadata-query-config). See section [analysisTypes](#analysistypes) for more details.|no|
-|lenientAggregatorMerge|If true, and if the "aggregators" analysisType is enabled, aggregators will be merged leniently. See below for details.|no|
+|aggregatorMergeStrategy| The strategy used to merge aggregators across segments. If true, and if the "aggregators" analysisType is enabled, it defaults to "strict". Possible values include "strict", "lenient" and "latest". See [below](#aggregatormergestrategy) for details.|no|
+|lenientAggregatorMerge|Deprecated: Use aggregatorMergeStrategy property instead. If true, and if the "aggregators" analysisType is enabled, aggregators will be merged leniently. See below for details.|no|
 
 The format of the result is:
 
@@ -185,7 +186,7 @@ Currently, there is no API for retrieving this information.
 * `aggregators` in the result will contain the list of aggregators usable for querying metric columns. This may be
 null if the aggregators are unknown or unmergeable (if merging is enabled).
 
-* Merging can be strict or lenient. See *lenientAggregatorMerge* below for details.
+* Merging can be `strict`, `lenient` or `latest`. See [`aggregatorMergeStrategy`](#aggregatormergestrategy) below for details.
 
 * The form of the result is a map of column name to aggregator.
 
@@ -194,15 +195,20 @@ null if the aggregators are unknown or unmergeable (if merging is enabled).
 * `rollup` in the result is true/false/null.
 * When merging is enabled, if some are rollup, others are not, result is null.
 
-## lenientAggregatorMerge
+### aggregatorMergeStrategy
 
 Conflicts between aggregator metadata across segments can occur if some segments have unknown aggregators, or if
-two segments use incompatible aggregators for the same column (e.g. longSum changed to doubleSum).
+two segments use incompatible aggregators for the same column (e.g. `longSum` changed to `doubleSum`). The following
+aggregator merge strategies are supported:
 
-Aggregators can be merged strictly (the default) or leniently. With strict merging, if there are any segments
-with unknown aggregators, or any conflicts of any kind, the merged aggregators list will be `null`. With lenient
-merging, segments with unknown aggregators will be ignored, and conflicts between aggregators will only null out
-the aggregator for that particular column.
+- `strict`:  If there are any segments with unknown aggregators, or any conflicts of any kind, the merged aggregators
+  list will be `null`.
+- `lenient`:  Segments with unknown aggregators will be ignored, and conflicts between aggregators will only null out
+- the aggregator for that particular column.
+- `latest`: In the event of conflicts between segments, the aggregator from the most recent segment will be selected
+   for that particular column.
 
-In particular, with lenient merging, it is possible for an individual column's aggregator to be `null`. This will not
-occur with strict merging.
+
+### lenientAggregatorMerge (deprecated)
+
+This property is deprecated - consider using [`aggregatorMergeStrategy`](#aggregatormergestrategy) instead.

--- a/docs/querying/segmentmetadataquery.md
+++ b/docs/querying/segmentmetadataquery.md
@@ -205,10 +205,10 @@ Druid supports the following aggregator merge strategies:
   list is `null`.
 - `lenient`:  Druid ignores segments with unknown aggregators. Conflicts between aggregators set the aggregator for that particular column to null.
 - the aggregator for that particular column.
-- `latest`: In the event of conflicts between segments, the aggregator from the most recent segment will be selected
+- `latest`: In the event of conflicts between segments, Druid selects the aggregator from the most recent segment
    for that particular column.
 
 
 ### lenientAggregatorMerge (deprecated)
 
-This property is deprecated - consider using [`aggregatorMergeStrategy`](#aggregatormergestrategy) instead.
+Deprecated. Use [`aggregatorMergeStrategy`](#aggregatormergestrategy) instead.

--- a/processing/src/main/java/org/apache/druid/query/Druids.java
+++ b/processing/src/main/java/org/apache/druid/query/Druids.java
@@ -36,6 +36,7 @@ import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.ColumnIncluderator;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.query.scan.ScanQuery;
@@ -659,6 +660,7 @@ public class Druids
     private EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes;
     private Boolean merge;
     private Boolean lenientAggregatorMerge;
+    private AggregatorMergeStrategy aggregatorMergeStrategy;
     private Boolean usingDefaultInterval;
     private Map<String, Object> context;
 
@@ -670,6 +672,7 @@ public class Druids
       analysisTypes = null;
       merge = null;
       lenientAggregatorMerge = null;
+      aggregatorMergeStrategy = null;
       usingDefaultInterval = null;
       context = null;
     }
@@ -684,7 +687,8 @@ public class Druids
           context,
           analysisTypes,
           usingDefaultInterval,
-          lenientAggregatorMerge
+          lenientAggregatorMerge,
+          aggregatorMergeStrategy
       );
     }
 
@@ -696,7 +700,7 @@ public class Druids
           .toInclude(query.getToInclude())
           .analysisTypes(query.getAnalysisTypes())
           .merge(query.isMerge())
-          .lenientAggregatorMerge(query.isLenientAggregatorMerge())
+          .aggregatorMergeStrategy(query.getAggregatorMergeStrategy())
           .usingDefaultInterval(query.isUsingDefaultInterval())
           .context(query.getContext());
     }
@@ -761,9 +765,16 @@ public class Druids
       return this;
     }
 
+    @Deprecated
     public SegmentMetadataQueryBuilder lenientAggregatorMerge(boolean lenientAggregatorMerge)
     {
       this.lenientAggregatorMerge = lenientAggregatorMerge;
+      return this;
+    }
+
+    public SegmentMetadataQueryBuilder aggregatorMergeStrategy(AggregatorMergeStrategy aggregatorMergeStrategy)
+    {
+      this.aggregatorMergeStrategy = aggregatorMergeStrategy;
       return this;
     }
 

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -31,6 +31,8 @@ import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import org.apache.druid.common.guava.CombiningSequence;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Comparators;
@@ -50,15 +52,16 @@ import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException
 import org.apache.druid.query.aggregation.MetricManipulationFn;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.context.ResponseContext;
+import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.apache.druid.timeline.LogicalSegment;
 import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -139,10 +142,10 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
   public BinaryOperator<SegmentAnalysis> createMergeFn(Query<SegmentAnalysis> query)
   {
     return (arg1, arg2) -> mergeAnalyses(
-        Iterables.getFirst(query.getDataSource().getTableNames(), null),
+        query.getDataSource().getTableNames(),
         arg1,
         arg2,
-        ((SegmentMetadataQuery) query).isLenientAggregatorMerge()
+        ((SegmentMetadataQuery) query).getAggregatorMergeStrategy()
     );
   }
 
@@ -205,7 +208,6 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
         // need to include query "merge" and "lenientAggregatorMerge" for result level cache key
         return new CacheKeyBuilder(SEGMENT_METADATA_QUERY).appendByteArray(computeCacheKey(query))
                                                           .appendBoolean(query.isMerge())
-                                                          .appendBoolean(query.isLenientAggregatorMerge())
                                                           .build();
       }
 
@@ -254,10 +256,10 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
 
   @VisibleForTesting
   public static SegmentAnalysis mergeAnalyses(
-      @Nullable String dataSource,
+      Set<String> dataSources,
       SegmentAnalysis arg1,
       SegmentAnalysis arg2,
-      boolean lenientAggregatorMerge
+      AggregatorMergeStrategy aggregatorMergeStrategy
   )
   {
     if (arg1 == null) {
@@ -268,16 +270,30 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       return arg1;
     }
 
-    // Swap arg1, arg2 so the later-ending interval is first. This ensures we prefer the latest column order.
-    // We're preserving it so callers can see columns in their natural order.
-    if (dataSource != null) {
+    // This is a defensive check since SegementMetadata query instantiation guarantees this
+    if (CollectionUtils.isNullOrEmpty(dataSources)) {
+      throw InvalidInput.exception("SegementMetadata queries require at least one datasource.");
+    }
+
+    SegmentId mergedSegmentId = null;
+
+    for (String dataSource : dataSources) {
       final SegmentId id1 = SegmentId.tryParse(dataSource, arg1.getId());
       final SegmentId id2 = SegmentId.tryParse(dataSource, arg2.getId());
 
-      if (id1 != null && id2 != null && id2.getIntervalEnd().isAfter(id1.getIntervalEnd())) {
-        final SegmentAnalysis tmp = arg1;
-        arg1 = arg2;
-        arg2 = tmp;
+      // Swap arg1, arg2 so the later-ending interval is first. This ensures we prefer the latest column order.
+      // We're preserving it so callers can see columns in their natural order.
+      if (id1 != null && id2 != null) {
+        if (id2.getIntervalEnd().isAfter(id1.getIntervalEnd()) ||
+            (id2.getIntervalEnd().isEqual(id1.getIntervalEnd()) && id2.getPartitionNum() > id1.getPartitionNum())) {
+          mergedSegmentId = SegmentId.merged(dataSource, id2.getInterval(), id2.getPartitionNum());
+          final SegmentAnalysis tmp = arg1;
+          arg1 = arg2;
+          arg2 = tmp;
+        } else {
+          mergedSegmentId = SegmentId.merged(dataSource, id1.getInterval(), id1.getPartitionNum());
+        }
+        break;
       }
     }
 
@@ -309,7 +325,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
 
     final Map<String, AggregatorFactory> aggregators = new HashMap<>();
 
-    if (lenientAggregatorMerge) {
+    if (AggregatorMergeStrategy.LENIENT == aggregatorMergeStrategy) {
       // Merge each aggregator individually, ignoring nulls
       for (SegmentAnalysis analysis : ImmutableList.of(arg1, arg2)) {
         if (analysis.getAggregators() != null) {
@@ -331,7 +347,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
           }
         }
       }
-    } else {
+    } else if (AggregatorMergeStrategy.STRICT == aggregatorMergeStrategy) {
       final AggregatorFactory[] aggs1 = arg1.getAggregators() != null
                                         ? arg1.getAggregators()
                                               .values()
@@ -348,6 +364,20 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
           aggregators.put(aggregator.getName(), aggregator);
         }
       }
+    } else if (AggregatorMergeStrategy.LATEST == aggregatorMergeStrategy) {
+      // The segment analyses are already ordered above, where arg1 is the analysis pertaining to the latest interval
+      // followed by arg2.
+      for (SegmentAnalysis analysis : ImmutableList.of(arg1, arg2)) {
+        if (analysis.getAggregators() != null) {
+          for (Map.Entry<String, AggregatorFactory> entry : analysis.getAggregators().entrySet()) {
+            final String aggregatorName = entry.getKey();
+            final AggregatorFactory aggregator = entry.getValue();
+            aggregators.putIfAbsent(aggregatorName, aggregator);
+          }
+        }
+      }
+    } else {
+      throw DruidException.defensive("[%s] merge strategy is not implemented.", aggregatorMergeStrategy);
     }
 
     final TimestampSpec timestampSpec = TimestampSpec.mergeTimestampSpec(
@@ -369,7 +399,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     if (arg1.getId() != null && arg2.getId() != null && arg1.getId().equals(arg2.getId())) {
       mergedId = arg1.getId();
     } else {
-      mergedId = "merged";
+      mergedId = mergedSegmentId == null ? "merged" : mergedSegmentId.toString();
     }
 
     final Boolean rollup;

--- a/processing/src/main/java/org/apache/druid/query/metadata/metadata/AggregatorMergeStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/metadata/AggregatorMergeStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.metadata.metadata;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.common.StringUtils;
+
+public enum AggregatorMergeStrategy
+{
+  STRICT,
+  LENIENT,
+  LATEST;
+
+  @JsonValue
+  @Override
+  public String toString()
+  {
+    return StringUtils.toLowerCase(this.name());
+  }
+
+  @JsonCreator
+  public static AggregatorMergeStrategy fromString(String name)
+  {
+    return valueOf(StringUtils.toUpperCase(name));
+  }
+}

--- a/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
+++ b/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
@@ -231,6 +231,16 @@ public final class SegmentId implements Comparable<SegmentId>
     }
   }
 
+
+  /**
+   * Creates a merged SegmentId for the given data source, interval and partition number. Used when segments are
+   * merged.
+   */
+  public static SegmentId merged(String dataSource, Interval interval, int partitionNum)
+  {
+    return of(dataSource, interval, "merged", partitionNum);
+  }
+
   /**
    * Creates a dummy SegmentId with the given data source. This method is useful in benchmark and test code.
    */

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentAnalyzerTest.java
@@ -249,7 +249,15 @@ public class SegmentAnalyzerTest extends InitializedNullHandlingTest
     );
 
     final SegmentMetadataQuery query = new SegmentMetadataQuery(
-        new TableDataSource("test"), new LegacySegmentSpec("2011/2012"), null, null, null, analyses, false, false
+        new TableDataSource("test"),
+        new LegacySegmentSpec("2011/2012"),
+        null,
+        null,
+        null,
+        analyses,
+        false,
+        null,
+        null
     );
     return runner.run(QueryPlus.wrap(query)).toList();
   }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -23,9 +23,13 @@ package org.apache.druid.query.metadata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.CacheStrategy;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -33,6 +37,7 @@ import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentMetadataQuery;
@@ -40,11 +45,14 @@ import org.apache.druid.query.spec.LegacySegmentSpec;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.timeline.LogicalSegment;
+import org.apache.druid.timeline.SegmentId;
+import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,18 +61,23 @@ import java.util.stream.Collectors;
 
 public class SegmentMetadataQueryQueryToolChestTest
 {
+  private static final DataSource TEST_DATASOURCE = new TableDataSource("dummy");
+  private static final SegmentId TEST_SEGMENT_ID1 = SegmentId.of(TEST_DATASOURCE.toString(), Intervals.of("2020-01-01/2020-01-02"), "test", 0);
+  private static final SegmentId TEST_SEGMENT_ID2 = SegmentId.of(TEST_DATASOURCE.toString(), Intervals.of("2021-01-01/2021-01-02"), "test", 0);
+
   @Test
   public void testCacheStrategy() throws Exception
   {
     SegmentMetadataQuery query = new SegmentMetadataQuery(
-        new TableDataSource("dummy"),
+        TEST_DATASOURCE,
         new LegacySegmentSpec("2015-01-01/2015-01-02"),
         null,
         null,
         null,
         null,
         false,
-        false
+        false,
+        null
     );
 
     CacheStrategy<SegmentAnalysis, SegmentAnalysis, SegmentMetadataQuery> strategy =
@@ -76,7 +89,7 @@ public class SegmentMetadataQueryQueryToolChestTest
     Assert.assertArrayEquals(expectedKey, actualKey);
 
     SegmentAnalysis result = new SegmentAnalysis(
-        "testSegment",
+        TEST_SEGMENT_ID1.toString(),
         ImmutableList.of(Intervals.of("2011-01-12T00:00:00.000Z/2011-04-15T00:00:00.001Z")),
         new LinkedHashMap<>(
             ImmutableMap.of(
@@ -119,7 +132,7 @@ public class SegmentMetadataQueryQueryToolChestTest
   public void testMergeAggregators()
   {
     final SegmentAnalysis analysis1 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -133,7 +146,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -148,20 +161,154 @@ public class SegmentMetadataQueryQueryToolChestTest
     );
 
     Assert.assertEquals(
+        new SegmentAnalysis(
+        "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
         ImmutableMap.of(
             "foo", new LongSumAggregatorFactory("foo", "foo"),
             "bar", new DoubleSumAggregatorFactory("bar", "bar"),
             "baz", new DoubleSumAggregatorFactory("baz", "baz")
         ),
-        mergeStrict(analysis1, analysis2).getAggregators()
+        null,
+        null,
+        null
+        ),
+        mergeStrict(analysis1, analysis2)
     );
+
     Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new DoubleSumAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new DoubleSumAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
+    );
+  }
+
+  @Test
+  public void testMergeAggregatorsWithIntervals()
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis(
+        TEST_SEGMENT_ID1.toString(),
+        ImmutableList.of(TEST_SEGMENT_ID1.getInterval()),
+        new LinkedHashMap<>(),
+        0,
+        0,
         ImmutableMap.of(
             "foo", new LongSumAggregatorFactory("foo", "foo"),
-            "bar", new DoubleSumAggregatorFactory("bar", "bar"),
             "baz", new DoubleSumAggregatorFactory("baz", "baz")
         ),
-        mergeLenient(analysis1, analysis2).getAggregators()
+        null,
+        null,
+        null
+    );
+    final SegmentAnalysis analysis2 = new SegmentAnalysis(
+        TEST_SEGMENT_ID2.toString(),
+        ImmutableList.of(TEST_SEGMENT_ID2.getInterval()),
+        new LinkedHashMap<>(),
+        0,
+        0,
+        ImmutableMap.of(
+            "foo", new LongSumAggregatorFactory("foo", "foo"),
+            "bar", new DoubleSumAggregatorFactory("bar", "bar")
+        ),
+        null,
+        null,
+        null
+    );
+
+    final List<Interval> expectedIntervals = new ArrayList<>();
+    expectedIntervals.addAll(analysis1.getIntervals());
+    expectedIntervals.addAll(analysis2.getIntervals());
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            expectedIntervals,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new DoubleSumAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            expectedIntervals,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new DoubleSumAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            expectedIntervals,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new DoubleSumAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
     );
   }
 
@@ -169,7 +316,7 @@ public class SegmentMetadataQueryQueryToolChestTest
   public void testMergeAggregatorsOneNull()
   {
     final SegmentAnalysis analysis1 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -180,7 +327,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -194,13 +341,55 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
 
-    Assert.assertNull(mergeStrict(analysis1, analysis2).getAggregators());
     Assert.assertEquals(
-        ImmutableMap.of(
-            "foo", new LongSumAggregatorFactory("foo", "foo"),
-            "bar", new DoubleSumAggregatorFactory("bar", "bar")
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
         ),
-        mergeLenient(analysis1, analysis2).getAggregators()
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
     );
   }
 
@@ -208,7 +397,7 @@ public class SegmentMetadataQueryQueryToolChestTest
   public void testMergeAggregatorsAllNull()
   {
     final SegmentAnalysis analysis1 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -219,7 +408,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -230,15 +419,57 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
 
-    Assert.assertNull(mergeStrict(analysis1, analysis2).getAggregators());
-    Assert.assertNull(mergeLenient(analysis1, analysis2).getAggregators());
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
+    );
   }
 
   @Test
   public void testMergeAggregatorsConflict()
   {
     final SegmentAnalysis analysis1 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -252,7 +483,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -271,16 +502,363 @@ public class SegmentMetadataQueryQueryToolChestTest
     expectedLenient.put("foo", new LongSumAggregatorFactory("foo", "foo"));
     expectedLenient.put("bar", null);
     expectedLenient.put("baz", new LongMaxAggregatorFactory("baz", "baz"));
-    Assert.assertNull(mergeStrict(analysis1, analysis2).getAggregators());
-    Assert.assertEquals(expectedLenient, mergeLenient(analysis1, analysis2).getAggregators());
 
-    // Simulate multi-level merge
     Assert.assertEquals(
-        expectedLenient,
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
         mergeLenient(
             mergeLenient(analysis1, analysis2),
             mergeLenient(analysis1, analysis2)
-        ).getAggregators()
+        )
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(
+            mergeLatest(analysis1, analysis2),
+            mergeLatest(analysis1, analysis2)
+        )
+    );
+  }
+
+// For the latest strategy:
+// Test the tie-breaker case where intervals are the same, but partiion numbers are different.
+  @Test
+  public void testMergeAggregatorsConflictWithDifferentOrder()
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis(
+        TEST_SEGMENT_ID2.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        ImmutableMap.of(
+            "foo", new LongSumAggregatorFactory("foo", "foo"),
+            "bar", new DoubleSumAggregatorFactory("bar", "bar")
+        ),
+        null,
+        null,
+        null
+    );
+
+    final SegmentAnalysis analysis2 = new SegmentAnalysis(
+        TEST_SEGMENT_ID1.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        ImmutableMap.of(
+            "foo", new LongSumAggregatorFactory("foo", "foo"),
+            "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+            "baz", new LongMaxAggregatorFactory("baz", "baz")
+        ),
+        null,
+        null,
+        null
+    );
+
+    final Map<String, AggregatorFactory> expectedLenient = new HashMap<>();
+    expectedLenient.put("foo", new LongSumAggregatorFactory("foo", "foo"));
+    expectedLenient.put("bar", null);
+    expectedLenient.put("baz", new LongMaxAggregatorFactory("baz", "baz"));
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(
+            mergeLenient(analysis1, analysis2),
+            mergeLenient(analysis1, analysis2)
+        )
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2021-01-01T00:00:00.000Z_2021-01-02T00:00:00.000Z_merged",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleSumAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(
+            mergeLatest(analysis1, analysis2),
+            mergeLatest(analysis1, analysis2)
+        )
+    );
+  }
+
+  @Test
+  public void testMergeAggregatorsConflictWithEqualSegmentIntervalsAndDifferentPartitions()
+  {
+    final SegmentId segmentId1 = SegmentId.of(TEST_DATASOURCE.toString(), Intervals.of("2023-01-01/2023-01-02"), "test", 1);
+    final SegmentId segmentId2 = SegmentId.of(TEST_DATASOURCE.toString(), Intervals.of("2023-01-01/2023-01-02"), "test", 2);
+
+    final SegmentAnalysis analysis1 = new SegmentAnalysis(
+        segmentId1.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        ImmutableMap.of(
+            "foo", new LongSumAggregatorFactory("foo", "foo"),
+            "bar", new DoubleSumAggregatorFactory("bar", "bar")
+        ),
+        null,
+        null,
+        null
+    );
+
+    final SegmentAnalysis analysis2 = new SegmentAnalysis(
+        segmentId2.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        ImmutableMap.of(
+            "foo", new LongSumAggregatorFactory("foo", "foo"),
+            "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+            "baz", new LongMaxAggregatorFactory("baz", "baz")
+        ),
+        null,
+        null,
+        null
+    );
+
+    final Map<String, AggregatorFactory> expectedLenient = new HashMap<>();
+    expectedLenient.put("foo", new LongSumAggregatorFactory("foo", "foo"));
+    expectedLenient.put("bar", null);
+    expectedLenient.put("baz", new LongMaxAggregatorFactory("baz", "baz"));
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_merged_2",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            null,
+            null,
+            null,
+            null
+        ),
+        mergeStrict(analysis1, analysis2)
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_merged_2",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_merged_2",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            expectedLenient,
+            null,
+            null,
+            null
+        ),
+        mergeLenient(
+            mergeLenient(analysis1, analysis2),
+            mergeLenient(analysis1, analysis2)
+        )
+    );
+
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_merged_2",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(analysis1, analysis2)
+    );
+
+    // Simulate multi-level lenient merge
+    Assert.assertEquals(
+        new SegmentAnalysis(
+            "dummy_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_merged_2",
+            null,
+            new LinkedHashMap<>(),
+            0,
+            0,
+            ImmutableMap.of(
+                "foo", new LongSumAggregatorFactory("foo", "foo"),
+                "bar", new DoubleMaxAggregatorFactory("bar", "bar"),
+                "baz", new LongMaxAggregatorFactory("baz", "baz")
+            ),
+            null,
+            null,
+            null
+        ),
+        mergeLatest(
+            mergeLatest(analysis1, analysis2),
+            mergeLatest(analysis1, analysis2)
+        )
     );
   }
 
@@ -333,7 +911,7 @@ public class SegmentMetadataQueryQueryToolChestTest
   public void testMergeRollup()
   {
     final SegmentAnalysis analysis1 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -344,7 +922,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         null
     );
     final SegmentAnalysis analysis2 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -355,7 +933,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         false
     );
     final SegmentAnalysis analysis3 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -366,7 +944,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         false
     );
     final SegmentAnalysis analysis4 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID2.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -377,7 +955,7 @@ public class SegmentMetadataQueryQueryToolChestTest
         true
     );
     final SegmentAnalysis analysis5 = new SegmentAnalysis(
-        "id",
+        TEST_SEGMENT_ID1.toString(),
         null,
         new LinkedHashMap<>(),
         0,
@@ -393,16 +971,87 @@ public class SegmentMetadataQueryQueryToolChestTest
     Assert.assertNull(mergeStrict(analysis2, analysis4).isRollup());
     Assert.assertFalse(mergeStrict(analysis2, analysis3).isRollup());
     Assert.assertTrue(mergeStrict(analysis4, analysis5).isRollup());
+
+    Assert.assertNull(mergeLenient(analysis1, analysis2).isRollup());
+    Assert.assertNull(mergeLenient(analysis1, analysis4).isRollup());
+    Assert.assertNull(mergeLenient(analysis2, analysis4).isRollup());
+    Assert.assertFalse(mergeLenient(analysis2, analysis3).isRollup());
+    Assert.assertTrue(mergeLenient(analysis4, analysis5).isRollup());
+
+    Assert.assertNull(mergeLatest(analysis1, analysis2).isRollup());
+    Assert.assertNull(mergeLatest(analysis1, analysis4).isRollup());
+    Assert.assertNull(mergeLatest(analysis2, analysis4).isRollup());
+    Assert.assertFalse(mergeLatest(analysis2, analysis3).isRollup());
+    Assert.assertTrue(mergeLatest(analysis4, analysis5).isRollup());
+  }
+
+  @Test
+  public void testInvalidMergeAggregatorsWithNullOrEmptyDatasource()
+  {
+    final SegmentAnalysis analysis1 = new SegmentAnalysis(
+        TEST_SEGMENT_ID1.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        null
+    );
+    final SegmentAnalysis analysis2 = new SegmentAnalysis(
+        TEST_SEGMENT_ID2.toString(),
+        null,
+        new LinkedHashMap<>(),
+        0,
+        0,
+        null,
+        null,
+        null,
+        false
+    );
+
+    MatcherAssert.assertThat(
+        Assert.assertThrows(
+            DruidException.class,
+            () -> SegmentMetadataQueryQueryToolChest.mergeAnalyses(
+                null,
+                analysis1,
+                analysis2,
+                AggregatorMergeStrategy.STRICT
+            )
+        ),
+        DruidExceptionMatcher
+            .invalidInput()
+            .expectMessageIs(
+                "SegementMetadata queries require at least one datasource.")
+    );
+
+    MatcherAssert.assertThat(
+        Assert.assertThrows(
+            DruidException.class,
+            () -> SegmentMetadataQueryQueryToolChest.mergeAnalyses(
+                ImmutableSet.of(),
+                analysis1,
+                analysis2,
+                AggregatorMergeStrategy.STRICT
+            )
+        ),
+        DruidExceptionMatcher
+            .invalidInput()
+            .expectMessageIs(
+                "SegementMetadata queries require at least one datasource.")
+    );
   }
 
   private static SegmentAnalysis mergeStrict(SegmentAnalysis analysis1, SegmentAnalysis analysis2)
   {
     return SegmentMetadataQueryQueryToolChest.finalizeAnalysis(
         SegmentMetadataQueryQueryToolChest.mergeAnalyses(
-            null,
+            TEST_DATASOURCE.getTableNames(),
             analysis1,
             analysis2,
-            false
+            AggregatorMergeStrategy.STRICT
         )
     );
   }
@@ -411,10 +1060,22 @@ public class SegmentMetadataQueryQueryToolChestTest
   {
     return SegmentMetadataQueryQueryToolChest.finalizeAnalysis(
         SegmentMetadataQueryQueryToolChest.mergeAnalyses(
-            null,
+            TEST_DATASOURCE.getTableNames(),
             analysis1,
             analysis2,
-            true
+            AggregatorMergeStrategy.LENIENT
+        )
+    );
+  }
+
+  private static SegmentAnalysis mergeLatest(SegmentAnalysis analysis1, SegmentAnalysis analysis2)
+  {
+    return SegmentMetadataQueryQueryToolChest.finalizeAnalysis(
+        SegmentMetadataQueryQueryToolChest.mergeAnalyses(
+            TEST_DATASOURCE.getTableNames(),
+            analysis1,
+            analysis2,
+            AggregatorMergeStrategy.LATEST
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChestTest.java
@@ -76,8 +76,8 @@ public class SegmentMetadataQueryQueryToolChestTest
         null,
         null,
         false,
-        false,
-        null
+        null,
+        AggregatorMergeStrategy.STRICT
     );
 
     CacheStrategy<SegmentAnalysis, SegmentAnalysis, SegmentMetadataQuery> strategy =
@@ -595,8 +595,6 @@ public class SegmentMetadataQueryQueryToolChestTest
     );
   }
 
-// For the latest strategy:
-// Test the tie-breaker case where intervals are the same, but partiion numbers are different.
   @Test
   public void testMergeAggregatorsConflictWithDifferentOrder()
   {

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -873,7 +873,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
         .toInclude(new ListColumnIncluderator(Collections.singletonList("placement")))
         .analysisTypes(SegmentMetadataQuery.AnalysisType.AGGREGATORS)
         .merge(true)
-        .aggregatorMergeStrategy(AggregatorMergeStrategy.LENIENT) // explicitly specify the strategy.
+        .aggregatorMergeStrategy(AggregatorMergeStrategy.LENIENT)
         .build();
     TestHelper.assertExpectedObjects(
         ImmutableList.of(mergedSegmentAnalysis),
@@ -1556,7 +1556,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 null,
                 null,
                 false,
-                false,
+                null,
                 null
             )
         ),
@@ -1577,7 +1577,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 null,
                 null,
                 false,
-                false,
+                null,
                 null
             )
         ),
@@ -1607,7 +1607,7 @@ public class SegmentMetadataQueryTest extends InitializedNullHandlingTest
                 null,
                 null,
                 false,
-                false,
+                null,
                 null
             )
         ),

--- a/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/metadata/SegmentMetadataUnionQueryTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.query.metadata;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.QueryPlus;
@@ -50,9 +49,6 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class SegmentMetadataUnionQueryTest extends InitializedNullHandlingTest
 {
-  static {
-    NullHandling.initializeForTests();
-  }
 
   private static final QueryRunnerFactory FACTORY = new SegmentMetadataQueryRunnerFactory(
       new SegmentMetadataQueryQueryToolChest(new SegmentMetadataQueryConfig()),

--- a/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
+++ b/server/src/test/java/org/apache/druid/server/log/FilteredRequestLoggerTest.java
@@ -56,6 +56,7 @@ public class FilteredRequestLoggerTest
       null,
       null,
       null,
+      null,
       null
   );
 

--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -241,7 +241,8 @@ public class DumpSegment extends GuiceRunnable
         null,
         EnumSet.allOf(SegmentMetadataQuery.AnalysisType.class),
         false,
-        false
+        null,
+        null
     );
     withOutputStream(
         new Function<OutputStream, Object>()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
@@ -932,7 +932,8 @@ public class SegmentMetadataCache
         ),
         EnumSet.noneOf(SegmentMetadataQuery.AnalysisType.class),
         false,
-        false
+        null,
+        null // we don't care about merging strategy because merge is false
     );
 
     return queryLifecycleFactory

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
@@ -48,6 +48,7 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
+import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.AllColumnIncluderator;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
@@ -1309,7 +1310,8 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
         queryContext,
         EnumSet.noneOf(SegmentMetadataQuery.AnalysisType.class),
         false,
-        false
+        null,
+        AggregatorMergeStrategy.STRICT
     );
 
     QueryLifecycleFactory factoryMock = EasyMock.createMock(QueryLifecycleFactory.class);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
@@ -48,7 +48,6 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
-import org.apache.druid.query.metadata.metadata.AggregatorMergeStrategy;
 import org.apache.druid.query.metadata.metadata.AllColumnIncluderator;
 import org.apache.druid.query.metadata.metadata.ColumnAnalysis;
 import org.apache.druid.query.metadata.metadata.SegmentAnalysis;
@@ -1311,7 +1310,7 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
         EnumSet.noneOf(SegmentMetadataQuery.AnalysisType.class),
         false,
         null,
-        AggregatorMergeStrategy.STRICT
+        null
     );
 
     QueryLifecycleFactory factoryMock = EasyMock.createMock(QueryLifecycleFactory.class);

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -312,7 +312,7 @@ export async function sampleForConnect(
       dataSource,
       intervals,
       merge: true,
-      lenientAggregatorMerge: true,
+      aggregatorMergeStrategy: 'lenient',
       analysisTypes: ['aggregators', 'rollup'],
     });
 

--- a/website/.spelling
+++ b/website/.spelling
@@ -1799,6 +1799,7 @@ InsensitiveContainsSearchQuerySpec
 RegexSearchQuerySpec
 analysisType
 analysisTypes
+aggregatorMergeStrategy
 lenientAggregatorMerge
 minmax
 segmentMetadata


### PR DESCRIPTION
#### Motivation
[SegmentMetadata queries](https://druid.apache.org/docs/latest/querying/segmentmetadataquery.html) currently supports two types of aggregator merge strategies, namely strict and lenient, when "aggregators" analysis type is enabled. Users often want something less strict than a lenient policy, where the most recent aggregator is selected for a column in an evolving data model. A strict strategy is best suited once the data model is locked in.

This PR:
- Adds a new property, `aggregatorMergeStrategy`, to `segmentMetadata` queries. Please see `docs/querying/segmentmetadataquery.md` for more information.  This also allows us to define an earliest strategy (similar to the latest strategy) or more sophisticated merge strategies as needed.
- Deprecates the existing `lenientAggregatorMerge` boolean property in favor of `aggregatorMergeStrategy`.
- Validates that both the old and new property is not set. The new property is backwards compatible with the deprecated property, so the default is `strict` when aggregators analysis type is enabled. 
- Changes the segment id of merged segments as part of segmentMetadata analysis, from `merged` to  `<datasource>_<interval>_merged_<partition_number>`  format. 
- Adjusts unit tests to assert the complete `SegmentAnalysis` object instead of just the aggregators. Also, add tests for latest aggregator merge and backwards compatibility logic.


<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
 `lenientAggregatorMerge` property in segment metadata queries is deprecated in favor of a new property `aggregatorMergeStrategy`. `aggregatorMergeStrategy` also supports a latest strategy in addition to existing strict and lenient strategies from `lenientAggregatorMerge`.


<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

<hr>

##### Key changed/added classes in this PR
 * `AggregatorMergeStrategy.java`
 * `SegmentMetadataQuery.java`
 * `SegmentMetadataQueryQueryToolChest.java`
 * `SegmentMetadataQueryTest.java`
 * `SegmentMetadataQueryQueryToolChestTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
