### PR TITLE
Minor doc fixes.

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -351,6 +351,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 ### JVM
 
 These metrics are only available if the `JvmMonitor` module is included in `druid.monitoring.monitors`.
+For more information, see [Enabling Metrics](../configuration/index.md#enabling-metrics).
 
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -350,7 +350,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 
 ### JVM
 
-These metrics are only available if the `JvmMonitor` module is included.
+These metrics are only available if the `JvmMonitor` module is included in `druid.monitoring.monitors`.
 
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -350,7 +350,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 
 ### JVM
 
-These metrics are only available if the `JVMMonitor` module is included.
+These metrics are only available if the `JvmMonitor` module is included.
 
 |Metric|Description|Dimensions|Normal Value|
 |------|-----------|----------|------------|

--- a/docs/querying/lookups.md
+++ b/docs/querying/lookups.md
@@ -79,7 +79,7 @@ In native queries, lookups can be queried with [dimension specs or extraction fu
 
 Query Execution
 ---------------
-When executing an aggregation query involving lookup functions (like the SQL [`LOOKUP` function](sql-scalar.md#string-functions),
+When executing an aggregation query involving lookup functions, like the SQL [`LOOKUP` function](sql-scalar.md#string-functions),
 Druid can decide to apply them while scanning and aggregating rows, or to apply them after aggregation is complete. It
 is more efficient to apply lookups after aggregation is complete, so Druid will do this if it can. Druid decides this
 by checking if the lookup is marked as "injective" or not. In general, you should set this property for any lookup that


### PR DESCRIPTION
This change includes a few doc fixes:
- The jvm monitor's name is case-sensitive, so keep it as `JvmMonitor`. 
- Fixes missing paranthesis.

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
