### PR TITLE
AggregatorFactory: Use guessAggregatorHeapFootprint when factorizeWithSize is not implemented.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/AggregatorFactory.java
@@ -87,7 +87,7 @@ public abstract class AggregatorFactory implements Cacheable
    */
   public AggregatorAndSize factorizeWithSize(ColumnSelectorFactory metricFactory)
   {
-    return new AggregatorAndSize(factorize(metricFactory), getMaxIntermediateSize());
+    return new AggregatorAndSize(factorize(metricFactory), guessAggregatorHeapFootprint(0));
   }
 
   /**


### PR DESCRIPTION
There are two ways of estimating heap footprint of an Aggregator:

1) AggregatorFactory#guessAggregatorHeapFootprint
2) AggregatorFactory#factorizeWithSize + Aggregator#aggregateWithSize

When the second path is used, the default implementation of factorizeWithSize is now updated to delegate to guessAggregatorHeapFootprint, making these equivalent. The old logic used getMaxIntermediateSize, which is less accurate.

Also fixes a bug where, when using the second path, calling factorizeWithSize on PassthroughAggregatorFactory would fail because getMaxIntermediateSize was not implemented. (There is no buffer aggregator, so there would be no need.)