### PR TITLE
Fix a resource leak with Window processing

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
@@ -29,6 +29,7 @@ import org.apache.druid.frame.write.FrameWriterFactory;
 import org.apache.druid.frame.write.FrameWriters;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -41,6 +42,7 @@ import org.apache.druid.query.rowsandcols.concrete.FrameRowsAndColumns;
 import org.apache.druid.query.rowsandcols.semantic.ColumnSelectorFactoryMaker;
 import org.apache.druid.query.rowsandcols.semantic.DefaultRowsAndColumnsDecorator;
 import org.apache.druid.query.rowsandcols.semantic.RowsAndColumnsDecorator;
+import org.apache.druid.query.rowsandcols.semantic.WireTransferable;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.StorageAdapter;
@@ -56,11 +58,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
 {
+  private static final Map<Class<?>, Function<LazilyDecoratedRowsAndColumns, ?>> AS_MAP =
+      RowsAndColumns.makeAsMap(LazilyDecoratedRowsAndColumns.class);
+
   private RowsAndColumns base;
   private Interval interval;
   private Filter filter;
@@ -118,33 +125,48 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
   @Override
   public <T> T as(Class<T> clazz)
   {
-    if (RowsAndColumnsDecorator.class.equals(clazz)) {
-      // If we don't have a projection defined, then it's safe to continue collecting more decorations as we
-      // can meaningfully merge them together.
-      if (viewableColumns == null || viewableColumns.isEmpty()) {
-        return (T) new DefaultRowsAndColumnsDecorator(
-            base,
-            interval,
-            filter,
-            virtualColumns,
-            limit,
-            ordering
-        );
-      } else {
-        return (T) new DefaultRowsAndColumnsDecorator(this);
-      }
+    //noinspection ReturnOfNull
+    return (T) AS_MAP.getOrDefault(clazz, arg -> null).apply(this);
+  }
+
+  @SemanticCreator
+  public RowsAndColumnsDecorator toRowsAndColumnsDecorator()
+  {
+    // If we don't have a projection defined, then it's safe to continue collecting more decorations as we
+    // can meaningfully merge them together.
+    if (viewableColumns == null || viewableColumns.isEmpty()) {
+      return new DefaultRowsAndColumnsDecorator(base, interval, filter, virtualColumns, limit, ordering);
+    } else {
+      return new DefaultRowsAndColumnsDecorator(this);
     }
-    return null;
+  }
+
+  @SemanticCreator
+  public WireTransferable toWireTransferable()
+  {
+    return () -> {
+      final Pair<byte[], RowSignature> materialized = materialize();
+      if (materialized == null) {
+        return new byte[]{};
+      } else {
+        return materialized.lhs;
+      }
+    };
   }
 
   private void maybeMaterialize()
   {
     if (!(interval == null && filter == null && limit == -1 && ordering == null)) {
-      materialize();
+      final Pair<byte[], RowSignature> thePair = materialize();
+      if (thePair == null) {
+        reset(new EmptyRowsAndColumns());
+      } else {
+        reset(new FrameRowsAndColumns(Frame.wrap(thePair.lhs), thePair.rhs));
+      }
     }
   }
 
-  private void materialize()
+  private Pair<byte[], RowSignature> materialize()
   {
     if (ordering != null) {
       throw new ISE("Cannot reorder[%s] scan data right now", ordering);
@@ -152,13 +174,26 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
 
     final StorageAdapter as = base.as(StorageAdapter.class);
     if (as == null) {
-      reset(naiveMaterialize(base));
+      return naiveMaterialize(base);
     } else {
-      reset(materializeStorageAdapter(as));
+      return materializeStorageAdapter(as);
     }
+
   }
 
-  private RowsAndColumns materializeStorageAdapter(StorageAdapter as)
+  private void reset(RowsAndColumns rac)
+  {
+    base = rac;
+    interval = null;
+    filter = null;
+    virtualColumns = null;
+    limit = -1;
+    viewableColumns = null;
+    ordering = null;
+  }
+
+  @Nullable
+  private Pair<byte[], RowSignature> materializeStorageAdapter(StorageAdapter as)
   {
     final Sequence<Cursor> cursors = as.makeCursors(
         filter,
@@ -231,25 +266,15 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
       // This means that the accumulate was never called, which can only happen if we didn't have any cursors.
       // We would only have zero cursors if we essentially didn't match anything, meaning that our RowsAndColumns
       // should be completely empty.
-      return new EmptyRowsAndColumns();
+      return null;
     } else {
       final byte[] bytes = writer.toByteArray();
-      return new FrameRowsAndColumns(Frame.wrap(bytes), siggy.get());
+      return Pair.of(bytes, siggy.get());
     }
   }
 
-  private void reset(RowsAndColumns rac)
-  {
-    base = rac;
-    interval = null;
-    filter = null;
-    virtualColumns = null;
-    limit = -1;
-    viewableColumns = null;
-    ordering = null;
-  }
-
-  private RowsAndColumns naiveMaterialize(RowsAndColumns rac)
+  @Nullable
+  private Pair<byte[], RowSignature> naiveMaterialize(RowsAndColumns rac)
   {
     final int numRows = rac.numRows();
 
@@ -264,7 +289,7 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
         // long as is required by the time filter produces all 0s, so either 0 is included and matches all rows or
         // it's not and we skip all rows.
         if (!interval.contains(0)) {
-          return new EmptyRowsAndColumns();
+          return null;
         }
       } else {
         final ColumnAccessor accessor = racColumn.toAccessor();
@@ -355,7 +380,6 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
       frameWriter.addSelection();
     }
 
-    return new FrameRowsAndColumns(Frame.wrap(frameWriter.toByteArray()), sigBob.build());
+    return Pair.of(frameWriter.toByteArray(), sigBob.build());
   }
-
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
@@ -129,6 +129,7 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
     return (T) AS_MAP.getOrDefault(clazz, arg -> null).apply(this);
   }
 
+  @SuppressWarnings("unused")
   @SemanticCreator
   public RowsAndColumnsDecorator toRowsAndColumnsDecorator()
   {
@@ -141,6 +142,7 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
     }
   }
 
+  @SuppressWarnings("unused")
   @SemanticCreator
   public WireTransferable toWireTransferable()
   {

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/RowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/RowsAndColumns.java
@@ -19,13 +19,19 @@
 
 package org.apache.druid.query.rowsandcols;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.semantic.AppendableRowsAndColumns;
 import org.apache.druid.query.rowsandcols.semantic.FramedOnHeapAggregatable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * An interface representing a chunk of RowsAndColumns.  Essentially a RowsAndColumns is just a batch of rows
@@ -68,6 +74,31 @@ public interface RowsAndColumns
     }
     return retVal;
   }
+
+  static <T> Map<Class<?>, Function<T, ?>> makeAsMap(Class<T> clazz)
+  {
+    Map<Class<?>, Function<T, ?>> retVal = new HashMap<>();
+
+    for (Method method : clazz.getMethods()) {
+      if (method.isAnnotationPresent(SemanticCreator.class)) {
+        if (method.getParameterCount() != 0) {
+          throw DruidException.defensive("Method [%s] annotated with SemanticCreator was not 0-argument.", method);
+        }
+
+        retVal.put(method.getReturnType(), arg -> {
+          try {
+            return method.invoke(arg);
+          }
+          catch (InvocationTargetException | IllegalAccessException e) {
+            throw DruidException.defensive().build(e, "Problem invoking method [%s]", method);
+          }
+        });
+      }
+    }
+
+    return retVal;
+  }
+
 
   /**
    * The set of column names available from the RowsAndColumns

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/SemanticCreator.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/SemanticCreator.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.rowsandcols;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation used to indicate that the method is used as a creator for a semantic interface.
+ *
+ * Used in conjuction with {@link RowsAndColumns#makeAsMap(Class)} to build maps for simplified implementation of
+ * the {@link RowsAndColumns#as(Class)} method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SemanticCreator
+{
+}

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultNaiveSortMaker.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultNaiveSortMaker.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.rowsandcols.RowsAndColumns;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 
 public class DefaultNaiveSortMaker implements NaiveSortMaker
@@ -61,6 +62,7 @@ public class DefaultNaiveSortMaker implements NaiveSortMaker
     }
 
 
+    @Nullable
     @Override
     public RowsAndColumns moreData(RowsAndColumns rac)
     {
@@ -75,7 +77,12 @@ public class DefaultNaiveSortMaker implements NaiveSortMaker
         return new EmptyRowsAndColumns();
       }
 
-      ConcatRowsAndColumns rac = new ConcatRowsAndColumns(racBuffer);
+      final RowsAndColumns rac;
+      if (racBuffer.size() == 1) {
+        rac = racBuffer.get(0);
+      } else {
+        rac = new ConcatRowsAndColumns(racBuffer);
+      }
 
       // One int for the racBuffer, another for the rowIndex
       int[] sortedPointers = new int[rac.numRows()];

--- a/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexBuilder.java
@@ -62,6 +62,7 @@ import java.util.function.Function;
 /**
  * Helps tests make segments.
  */
+@SuppressWarnings({"NotNullFieldNotInitialized", "FieldMayBeFinal", "ConstantConditions", "NullableProblems"})
 public class IndexBuilder
 {
   private static final int ROWS_PER_INDEX_FOR_MERGING = 1;
@@ -261,7 +262,7 @@ public class IndexBuilder
           tmpDir,
           schema.getDimensionsSpec(),
           indexSpec,
-          Integer.MAX_VALUE
+          -1
       );
     }
     catch (IOException e) {


### PR DESCRIPTION
Additionally, in order to find the leak, there were adjustments to the StupidPool to track leaks a bit better. It would appear that the pool objects get GC'd during testing for some reason which was causing some incorrect identification of leaks from objects that had been returned but were GC'd along with the pool.
