### PR TITLE
Fixing an issue in sequential merge 

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerSketchFetcher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerSketchFetcher.java
@@ -245,24 +245,6 @@ public class WorkerSketchFetcher implements AutoCloseable
       throw new ISE("All worker partial key information not received for stage[%d]", stageId.getStageNumber());
     }
 
-    if (completeKeyStatisticsInformation.getTimeSegmentVsWorkerMap().isEmpty()) {
-      // No time chunks at all: skip fetching.
-      kernelActions.accept(
-          kernel -> {
-            for (final String taskId : tasks) {
-              final int workerNumber = MSQTasks.workerFromTaskId(taskId);
-              kernel.mergeClusterByStatisticsCollectorForAllTimeChunks(
-                  stageId,
-                  workerNumber,
-                  ClusterByStatisticsSnapshot.empty()
-              );
-            }
-          }
-      );
-
-      return;
-    }
-
     final Set<String> noBoundaries = new HashSet<>(tasks);
     completeKeyStatisticsInformation.getTimeSegmentVsWorkerMap().forEach((timeChunk, wks) -> {
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerSketchFetcherTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/WorkerSketchFetcherTest.java
@@ -113,8 +113,7 @@ public class WorkerSketchFetcherTest
       latch.countDown();
     }, stageDefinition.getId(), ImmutableSet.copyOf(TASK_IDS), ((queryKernel, integer, msqFault) -> {}));
 
-    latch.await(5, TimeUnit.SECONDS);
-    Assert.assertEquals(0, latch.getCount());
+    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
 
   }
 
@@ -122,7 +121,7 @@ public class WorkerSketchFetcherTest
   public void test_submitFetcherTask_sequentialFetch() throws InterruptedException
   {
     doReturn(true).when(completeKeyStatisticsInformation).isComplete();
-    final CountDownLatch latch = new CountDownLatch(TASK_IDS.size() - 1);
+    final CountDownLatch latch = new CountDownLatch(TASK_IDS.size());
 
     target = spy(new WorkerSketchFetcher(workerClient, workerTaskLauncher, true));
 
@@ -143,8 +142,8 @@ public class WorkerSketchFetcherTest
         ((queryKernel, integer, msqFault) -> {})
     );
 
-    latch.await(5, TimeUnit.SECONDS);
-    Assert.assertEquals(0, latch.getCount());
+    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+
   }
 
   @Test
@@ -186,17 +185,15 @@ public class WorkerSketchFetcherTest
         })
     );
 
-    latch.await(5, TimeUnit.SECONDS);
-    retryLatch.await(5, TimeUnit.SECONDS);
-    Assert.assertEquals(0, latch.getCount());
-    Assert.assertEquals(0, retryLatch.getCount());
+    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Assert.assertTrue(retryLatch.await(5, TimeUnit.SECONDS));
   }
 
   @Test
   public void test_SequentialRetryEnabled_retryInvoked() throws InterruptedException
   {
     doReturn(true).when(completeKeyStatisticsInformation).isComplete();
-    final CountDownLatch latch = new CountDownLatch(TASK_IDS.size() - 1);
+    final CountDownLatch latch = new CountDownLatch(TASK_IDS.size());
 
     target = spy(new WorkerSketchFetcher(workerClient, workerTaskLauncher, true));
 
@@ -217,10 +214,8 @@ public class WorkerSketchFetcherTest
         })
     );
 
-    latch.await(5, TimeUnit.SECONDS);
-    retryLatch.await(5, TimeUnit.SECONDS);
-    Assert.assertEquals(0, latch.getCount());
-    Assert.assertEquals(0, retryLatch.getCount());
+    Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
+    Assert.assertTrue(retryLatch.await(5, TimeUnit.SECONDS));
   }
 
   @Test

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITKeyStatisticsSketchMergeMode.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITKeyStatisticsSketchMergeMode.java
@@ -190,4 +190,79 @@ public class ITKeyStatisticsSketchMergeMode
 
     msqHelper.testQueriesFromFile(QUERY_FILE, datasource);
   }
+
+
+  @Test
+  public void testMsqIngestionSequentialMergingWithEmptyStatistics() throws Exception
+  {
+    String datasource = "dst";
+
+    // Clear up the datasource from the previous runs
+    coordinatorClient.unloadSegmentsForDataSource(datasource);
+
+    String queryLocal =
+        StringUtils.format(
+            "Replace INTO %s overwrite ALL \n"
+            + "SELECT\n"
+            + "  TIME_PARSE(\"timestamp\") AS __time,\n"
+            + "  isRobot,\n"
+            + "  diffUrl,\n"
+            + "  added,\n"
+            + "  countryIsoCode,\n"
+            + "  regionName,\n"
+            + "  channel,\n"
+            + "  flags,\n"
+            + "  delta,\n"
+            + "  isUnpatrolled,\n"
+            + "  isNew,\n"
+            + "  deltaBucket,\n"
+            + "  isMinor,\n"
+            + "  isAnonymous,\n"
+            + "  deleted,\n"
+            + "  cityName,\n"
+            + "  metroCode,\n"
+            + "  namespace,\n"
+            + "  comment,\n"
+            + "  page,\n"
+            + "  commentLength,\n"
+            + "  countryName,\n"
+            + "  user,\n"
+            + "  regionIsoCode\n"
+            + "FROM TABLE(\n"
+            + "  EXTERN(\n"
+            + "    '{\"type\":\"local\",\"files\":[\"/resources/data/batch_index/json/wikipedia_index_data1.json\",\"/resources/data/batch_index/json/wikipedia_index_data2.json\"]}',\n"
+            + "    '{\"type\":\"json\"}',\n"
+            + "    '[{\"type\":\"string\",\"name\":\"timestamp\"},{\"type\":\"string\",\"name\":\"isRobot\"},{\"type\":\"string\",\"name\":\"diffUrl\"},{\"type\":\"long\",\"name\":\"added\"},{\"type\":\"string\",\"name\":\"countryIsoCode\"},{\"type\":\"string\",\"name\":\"regionName\"},{\"type\":\"string\",\"name\":\"channel\"},{\"type\":\"string\",\"name\":\"flags\"},{\"type\":\"long\",\"name\":\"delta\"},{\"type\":\"string\",\"name\":\"isUnpatrolled\"},{\"type\":\"string\",\"name\":\"isNew\"},{\"type\":\"double\",\"name\":\"deltaBucket\"},{\"type\":\"string\",\"name\":\"isMinor\"},{\"type\":\"string\",\"name\":\"isAnonymous\"},{\"type\":\"long\",\"name\":\"deleted\"},{\"type\":\"string\",\"name\":\"cityName\"},{\"type\":\"long\",\"name\":\"metroCode\"},{\"type\":\"string\",\"name\":\"namespace\"},{\"type\":\"string\",\"name\":\"comment\"},{\"type\":\"string\",\"name\":\"page\"},{\"type\":\"long\",\"name\":\"commentLength\"},{\"type\":\"string\",\"name\":\"countryName\"},{\"type\":\"string\",\"name\":\"user\"},{\"type\":\"string\",\"name\":\"regionIsoCode\"}]'\n"
+            + "  )\n"
+            + ")\n"
+            + "where delta=111 "
+            // we add this filter since delta=111 is only present in wikipedia_index_data1.json. This means partitions from worker 2 will be empty.
+            + "PARTITIONED BY DAY\n"
+            + "CLUSTERED BY \"__time\"",
+            datasource
+        );
+
+    ImmutableMap<String, Object> context = ImmutableMap.of(
+        MultiStageQueryContext.CTX_CLUSTER_STATISTICS_MERGE_MODE,
+        ClusterStatisticsMergeMode.SEQUENTIAL,
+        MultiStageQueryContext.CTX_MAX_NUM_TASKS,
+        3
+    );
+
+    // Submit the task and wait for the datasource to get loaded
+    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, false, false, false, context, null);
+    SqlTaskStatus sqlTaskStatus = msqHelper.submitMsqTask(sqlQuery);
+
+    if (sqlTaskStatus.getState().isFailure()) {
+      Assert.fail(StringUtils.format(
+          "Unable to start the task successfully.\nPossible exception: %s",
+          sqlTaskStatus.getError()
+      ));
+    }
+
+    msqHelper.pollTaskIdForSuccess(sqlTaskStatus.getTaskId());
+    dataLoaderHelper.waitUntilDatasourceIsReady(datasource);
+
+    msqHelper.testQueriesFromFile("/multi-stage-query/wikipedia_msq_select_query_sequential_test.json", datasource);
+  }
 }

--- a/integration-tests-ex/cases/src/test/resources/multi-stage-query/wikipedia_msq_select_query_sequential_test.json
+++ b/integration-tests-ex/cases/src/test/resources/multi-stage-query/wikipedia_msq_select_query_sequential_test.json
@@ -1,0 +1,15 @@
+[
+  {
+    "query": "SELECT __time, isRobot, added, delta, deleted, namespace FROM %%DATASOURCE%%",
+    "expectedResults": [
+      {
+        "__time": 1377933081000,
+        "isRobot": "",
+        "added": 123,
+        "delta": 111,
+        "deleted": 12,
+        "namespace":"article"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Fixing an issue in sequential merge where workers without any partial key statistics would get stuck because controller did not change the worker state.

The symptom's are the controller task getting stuck after some of the worker boundaries are sent. 

```
2023-07-12T04:20:46,033 INFO [task-runner-0-priority-0] org.apache.druid.msq.exec.ControllerImpl - Query [xxx] sending out partition boundaries for stage 0 for workers {7, 8, 9, 10, 11, 12, 14, 15, 16, 17, 18, 34, 35, 36}
```

<hr>

##### Key changed/added classes in this PR
 * `WorkerSketchFetcher`
 
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
