### PR TITLE
Reserve threads for non-query requests without using laning

### DIFF
--- a/server/src/main/java/org/apache/druid/server/QueryScheduler.java
+++ b/server/src/main/java/org/apache/druid/server/QueryScheduler.java
@@ -106,9 +106,12 @@ public class QueryScheduler implements QueryWatcher
     this.laningStrategy = laningStrategy;
     this.queryFutures = Multimaps.synchronizedSetMultimap(HashMultimap.create());
     this.queryDatasources = Multimaps.synchronizedSetMultimap(HashMultimap.create());
-    // if totalNumThreads is above 0 and less than druid.server.http.numThreads, enforce total limit
+    // if totalNumThreads is above 0 and less than druid.server.http.numThreads and
+    // requests are not being queued by Jetty, enforce total limit
     final boolean limitTotal;
-    if (totalNumThreads > 0 && totalNumThreads < serverConfig.getNumThreads()) {
+    if (totalNumThreads > 0
+        && totalNumThreads < serverConfig.getNumThreads()
+        && !serverConfig.isEnableQueryRequestsQueuing()) {
       limitTotal = true;
       this.totalCapacity = totalNumThreads;
     } else {

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -179,6 +179,13 @@ public class ServerConfig
   @JsonProperty
   private boolean enableHSTS = false;
 
+  /**
+   * This is a feature flag to enable query requests queuing when admins want to reserve some threads for
+   * non-query requests. This feature flag is not documented and can be removed in the future.
+   */
+  @JsonProperty
+  private boolean enableQueryRequestsQueuing = false;
+
   @JsonProperty
   private boolean showDetailedJettyErrors = true;
 
@@ -288,6 +295,11 @@ public class ServerConfig
     return enableHSTS;
   }
 
+  public boolean isEnableQueryRequestsQueuing()
+  {
+    return enableQueryRequestsQueuing;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -318,7 +330,8 @@ public class ServerConfig
            allowedHttpMethods.equals(that.allowedHttpMethods) &&
            errorResponseTransformStrategy.equals(that.errorResponseTransformStrategy) &&
            Objects.equals(contentSecurityPolicy, that.getContentSecurityPolicy()) &&
-           enableHSTS == that.enableHSTS;
+           enableHSTS == that.enableHSTS &&
+           enableQueryRequestsQueuing == that.enableQueryRequestsQueuing;
   }
 
   @Override
@@ -345,7 +358,8 @@ public class ServerConfig
         errorResponseTransformStrategy,
         showDetailedJettyErrors,
         contentSecurityPolicy,
-        enableHSTS
+        enableHSTS,
+        enableQueryRequestsQueuing
     );
   }
 
@@ -374,6 +388,7 @@ public class ServerConfig
            ", showDetailedJettyErrors=" + showDetailedJettyErrors +
            ", contentSecurityPolicy=" + contentSecurityPolicy +
            ", enableHSTS=" + enableHSTS +
+           ", enableQueryRequestsQueuing=" + enableQueryRequestsQueuing +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/ServerConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.initialization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.common.exception.ErrorResponseTransformStrategy;
 import org.apache.druid.common.exception.NoErrorResponseTransformStrategy;
@@ -102,6 +103,12 @@ public class ServerConfig
   public ServerConfig()
   {
 
+  }
+
+  @VisibleForTesting
+  public ServerConfig(boolean enableQueryRequestsQueuing)
+  {
+    this.enableQueryRequestsQueuing = enableQueryRequestsQueuing;
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyBindings.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyBindings.java
@@ -65,10 +65,18 @@ public class JettyBindings
     private final String[] paths;
     private final int maxRequests;
 
-    public QosFilterHolder(String[] paths, int maxRequests)
+    private final long timeoutMs;
+
+    public QosFilterHolder(String[] paths, int maxRequests, long timeoutMs)
     {
       this.paths = paths;
       this.maxRequests = maxRequests;
+      this.timeoutMs = timeoutMs;
+    }
+
+    public QosFilterHolder(String[] paths, int maxRequests)
+    {
+      this(paths, maxRequests, -1);
     }
 
     @Override
@@ -86,6 +94,9 @@ public class JettyBindings
     @Override
     public Map<String, String> getInitParameters()
     {
+      if (timeoutMs >= 0) {
+        return ImmutableMap.of("maxRequests", String.valueOf(maxRequests), "suspendMs", String.valueOf(timeoutMs));
+      }
       return ImmutableMap.of("maxRequests", String.valueOf(maxRequests));
     }
 

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -349,6 +349,32 @@ public class QuerySchedulerTest
   }
 
   @Test
+  public void testTotalLimitWithQueryQueuing() throws Exception
+  {
+    ServerConfig serverConfig = new ServerConfig();
+    QueryScheduler queryScheduler = new QueryScheduler(
+        serverConfig.getNumThreads() - 1,
+        ManualQueryPrioritizationStrategy.INSTANCE,
+        new NoQueryLaningStrategy(),
+        serverConfig
+    );
+    Assert.assertEquals(serverConfig.getNumThreads() - 1, queryScheduler.getTotalAvailableCapacity());
+  }
+
+  @Test
+  public void testTotalLimitWithouQueryQueuing() throws Exception
+  {
+    ServerConfig serverConfig = new ServerConfig(true);
+    QueryScheduler queryScheduler = new QueryScheduler(
+        serverConfig.getNumThreads() - 1,
+        ManualQueryPrioritizationStrategy.INSTANCE,
+        new NoQueryLaningStrategy(),
+        serverConfig
+    );
+    Assert.assertEquals(-1, queryScheduler.getTotalAvailableCapacity());
+  }
+
+  @Test
   public void testExplodingWrapperDoesNotLeakLocks()
   {
     scheduler = new ObservableQueryScheduler(

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -349,7 +349,7 @@ public class QuerySchedulerTest
   }
 
   @Test
-  public void testTotalLimitWithQueryQueuing() throws Exception
+  public void testTotalLimitWithQueryQueuing()
   {
     ServerConfig serverConfig = new ServerConfig();
     QueryScheduler queryScheduler = new QueryScheduler(
@@ -362,7 +362,7 @@ public class QuerySchedulerTest
   }
 
   @Test
-  public void testTotalLimitWithouQueryQueuing() throws Exception
+  public void testTotalLimitWithouQueryQueuing()
   {
     ServerConfig serverConfig = new ServerConfig(true);
     QueryScheduler queryScheduler = new QueryScheduler(

--- a/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
@@ -110,7 +110,9 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     if (querySchedulerConfig.getNumThreads() > 0
         && querySchedulerConfig.getNumThreads() < serverConfig.getNumThreads()
         && serverConfig.isEnableQueryRequestsQueuing()) {
-      // Add QoS filter for query requests so they don't take up more than querySchedulerConfig#numThreads
+      // Add QoS filter for query requests, so they don't take up more than querySchedulerConfig#numThreads.
+      // While this will also pick up some extra endpoints other than Query, the primary objective is to protect
+      // health check endpoints from being starved by query requests.
       log.info("Enabling QoS Filter on query requests with limit [%d].", querySchedulerConfig.getNumThreads());
       JettyBindings.QosFilterHolder filterHolder = new JettyBindings.QosFilterHolder(
           new String[]{"/druid/v2/*"},

--- a/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -109,13 +108,14 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
     }
 
     if (querySchedulerConfig.getNumThreads() > 0
-        && querySchedulerConfig.getNumThreads() < serverConfig.getNumThreads()) {
-      // Add QoS filter for query requests
+        && querySchedulerConfig.getNumThreads() < serverConfig.getNumThreads()
+        && serverConfig.isEnableQueryRequestsQueuing()) {
+      // Add QoS filter for query requests so they don't take up more than querySchedulerConfig#numThreads
       log.info("Enabling QoS Filter on query requests with limit [%d].", querySchedulerConfig.getNumThreads());
       JettyBindings.QosFilterHolder filterHolder = new JettyBindings.QosFilterHolder(
           new String[]{"/druid/v2/*"},
           querySchedulerConfig.getNumThreads(),
-          TimeUnit.MINUTES.toMillis(5)
+          serverConfig.getMaxQueryTimeout()
       );
       JettyServerInitUtils.addFilters(root, Collections.singleton(filterHolder));
     }

--- a/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/QueryJettyServerInitializer.java
@@ -27,9 +27,12 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.servlet.GuiceFilter;
+import org.apache.druid.guice.annotations.Global;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.QuerySchedulerProvider;
 import org.apache.druid.server.initialization.ServerConfig;
+import org.apache.druid.server.initialization.jetty.JettyBindings;
 import org.apache.druid.server.initialization.jetty.JettyServerInitUtils;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.initialization.jetty.LimitRequestsFilter;
@@ -46,8 +49,10 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
@@ -67,12 +72,20 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
 
   private final AuthConfig authConfig;
 
+  private final QuerySchedulerProvider querySchedulerConfig;
+
   @Inject
-  public QueryJettyServerInitializer(Set<Handler> extensionHandlers, ServerConfig serverConfig, AuthConfig authConfig)
+  public QueryJettyServerInitializer(
+      Set<Handler> extensionHandlers,
+      ServerConfig serverConfig,
+      AuthConfig authConfig,
+      @Global QuerySchedulerProvider querySchedulerConfig
+  )
   {
     this.extensionHandlers = ImmutableList.copyOf(extensionHandlers);
     this.serverConfig = serverConfig;
     this.authConfig = authConfig;
+    this.querySchedulerConfig = querySchedulerConfig;
   }
 
   @Override
@@ -93,6 +106,18 @@ public class QueryJettyServerInitializer implements JettyServerInitializer
       root.addFilter(new FilterHolder(new LimitRequestsFilter(serverConfig.getNumThreads() - 1)),
                      "/*", null
       );
+    }
+
+    if (querySchedulerConfig.getNumThreads() > 0
+        && querySchedulerConfig.getNumThreads() < serverConfig.getNumThreads()) {
+      // Add QoS filter for query requests
+      log.info("Enabling QoS Filter on query requests with limit [%d].", querySchedulerConfig.getNumThreads());
+      JettyBindings.QosFilterHolder filterHolder = new JettyBindings.QosFilterHolder(
+          new String[]{"/druid/v2/*"},
+          querySchedulerConfig.getNumThreads(),
+          TimeUnit.MINUTES.toMillis(5)
+      );
+      JettyServerInitUtils.addFilters(root, Collections.singleton(filterHolder));
     }
 
     final ObjectMapper jsonMapper = injector.getInstance(Key.get(ObjectMapper.class, Json.class));


### PR DESCRIPTION
This PR uses the QoSFilter available in Jetty to park the query requests that exceed a configured limit. This is done so that other HTTP requests such as health check calls do not get blocked if the query server is busy serving long-running queries. The same mechanism can also be used in the future to isolate interactive queries from long-running select queries from interactive queries within the same broker. 

Right now, you can still get that isolation by setting druid.query.scheduler.numThreads to a value lowe than druid.server.http.numThreads. That enables total laning but the side effect is that excess requests are not queued and rejected outright that leads to a bad user experience. 

Parked requests are timed out after 30 seconds by default. I overrode that to the maxQueryTimeout in this PR. 

I tested it on a local cluster and verified that it works. 



This PR has:

- [x] been self-reviewed.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
