### PR TITLE
Add logging for downsampling sketches in MSQ

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollector.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollector.java
@@ -177,4 +177,13 @@ public class DelegateOrMinKeyCollector<TDelegate extends KeyCollector<TDelegate>
       return ClusterByPartitions.oneUniversalPartition();
     }
   }
+
+  @Override
+  public String toString()
+  {
+    return "DelegateOrMinKeyCollector{" +
+           "delegate=" + delegate +
+           ", minKey=" + minKey +
+           '}';
+  }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollector.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollector.java
@@ -312,4 +312,15 @@ public class DistinctKeyCollector implements KeyCollector<DistinctKeyCollector>
 
     return true;
   }
+
+  @Override
+  public String toString()
+  {
+    return "DistinctKeyCollector{" +
+           "maxBytes=" + maxBytes +
+           ", retainedBytes=" + retainedBytes +
+           ", spaceReductionFactor=" + spaceReductionFactor +
+           ", totalWeightUnadjusted=" + totalWeightUnadjusted +
+           '}';
+  }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollector.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollector.java
@@ -186,4 +186,15 @@ public class QuantilesSketchKeyCollector implements KeyCollector<QuantilesSketch
   {
     return averageKeyLength;
   }
+
+  @Override
+  public String toString()
+  {
+    return "QuantilesSketchKeyCollector{" +
+           "sketch=ItemsSketch{N=" + sketch.getN() +
+           ", K=" + sketch.getK() +
+           ", retainedKeys=" + sketch.getNumRetained() +
+           "}, averageKeyLength=" + averageKeyLength +
+           '}';
+  }
 }


### PR DESCRIPTION
Adds a few more log messages to improve visibility into the downsampling of sketches.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
