### PR TITLE
Upgrade Google Client libraries to latest version

### DIFF
--- a/extensions-contrib/gce-extensions/pom.xml
+++ b/extensions-contrib/gce-extensions/pom.xml
@@ -79,8 +79,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-compute</artifactId>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-compute</artifactId>
       <version>${com.google.apis.compute.version}</version>
       <scope>compile</scope>
     </dependency>

--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-storage</artifactId>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
             <version>${com.google.apis.storage.version}</version>
             <exclusions>
                 <exclusion>

--- a/integration-tests-ex/cases/pom.xml
+++ b/integration-tests-ex/cases/pom.xml
@@ -148,12 +148,12 @@
         <dependency>
             <groupId>com.google.api-client</groupId>
             <artifactId>google-api-client</artifactId>
-            <version>${com.google.apis.client.version}</version>
+            <version>${com.google.api.client.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-storage</artifactId>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
             <version>${com.google.apis.storage.version}</version>
             <exclusions>
                 <exclusion>
@@ -188,13 +188,13 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>${com.google.apis.client.version}</version>
+            <version>${com.google.http.client.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
-            <version>${com.google.apis.client.version}</version>
+            <version>${com.google.http.client.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- Tests can choose either the MySQL or MariaDB driver. -->

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4787,9 +4787,9 @@ name: Google Cloud Storage JSON API
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: v1-rev20190523-1.26.0
+version: 2.23.0
 libraries:
-  - com.google.apis: google-api-services-storage
+  - com.google.cloud: google-cloud-storage
 
 ---
 
@@ -4797,9 +4797,9 @@ name: Google Compute Engine API
 license_category: binary
 module: extensions/gce-extensions
 license_name: Apache License version 2.0
-version: v1-rev20190523-1.26.0
+version: 1.30.0
 libraries:
-  - com.google.apis: google-api-services-compute
+  - com.google.cloud: google-cloud-compute
 
 ---
 
@@ -4807,7 +4807,7 @@ name: Google APIs Client Library For Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.32.1
+version: 2.2.0
 libraries:
   - com.google.api-client: google-api-client
 
@@ -4817,20 +4817,10 @@ name: Google HTTP Client Library For Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.35.2
+version: 1.43.3
 libraries:
   - com.google.http-client: google-http-client
   - com.google.http-client: google-http-client-jackson2
-
----
-
-name: Google OAuth Client Library For Java
-license_category: binary
-module: java-core
-license_name: Apache License version 2.0
-version: 1.22.0
-libraries:
-  - com.google.oauth-client: google-oauth-client
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.5.10</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
-        <com.google.cloud.version>26.18.0</com.google.cloud.version>
         <com.google.http.client.version>1.43.3</com.google.http.client.version>
         <com.google.api.client.version>2.2.0</com.google.api.client.version>
         <com.google.apis.compute.version>1.30.0</com.google.apis.compute.version>
@@ -517,13 +516,6 @@
                 <groupId>com.ibm.icu</groupId>
                 <artifactId>icu4j</artifactId>
                 <version>55.1</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>libraries-bom</artifactId>
-                <version>${com.google.cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mozilla</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -121,9 +121,11 @@
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.5.10</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
-        <com.google.apis.client.version>1.26.0</com.google.apis.client.version>
-        <com.google.apis.compute.version>v1-rev20190607-${com.google.apis.client.version}</com.google.apis.compute.version>
-        <com.google.apis.storage.version>v1-rev20190523-${com.google.apis.client.version}</com.google.apis.storage.version>
+        <com.google.cloud.version>26.18.0</com.google.cloud.version>
+        <com.google.http.client.version>1.43.3</com.google.http.client.version>
+        <com.google.api.client.version>2.2.0</com.google.api.client.version>
+        <com.google.apis.compute.version>1.30.0</com.google.apis.compute.version>
+        <com.google.apis.storage.version>2.23.0</com.google.apis.storage.version>
         <jdk.strong.encapsulation.argLine><!-- empty placeholder --></jdk.strong.encapsulation.argLine>
         <repoOrgId>maven.org</repoOrgId>
         <repoOrgName>Maven Central Repository</repoOrgName>
@@ -515,6 +517,13 @@
                 <groupId>com.ibm.icu</groupId>
                 <artifactId>icu4j</artifactId>
                 <version>55.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${com.google.cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.mozilla</groupId>
@@ -1118,7 +1127,7 @@
             <dependency>
                 <groupId>com.google.api-client</groupId>
                 <artifactId>google-api-client</artifactId>
-                <version>${com.google.apis.client.version}</version>
+                <version>${com.google.api.client.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -1145,12 +1154,12 @@
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
-                <version>${com.google.apis.client.version}</version>
+                <version>${com.google.http.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client-jackson2</artifactId>
-                <version>${com.google.apis.client.version}</version>
+                <version>${com.google.http.client.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.fasterxml.jackson.core</groupId>
@@ -1169,8 +1178,8 @@
             </dependency>
             <!-- GCE -->
             <dependency>
-                <groupId>com.google.apis</groupId>
-                <artifactId>google-api-services-compute</artifactId>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-compute</artifactId>
                 <version>${com.google.apis.compute.version}</version>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
### Description
This PR upgrades Google's APIs clients used in Druid: API, HTTP client, Storage, and Compute.

The need for this bump is to utilize the `StorageBatch` class that's not available in the current version of the library that allows batching of requests made to the Google's storage engine. 

#### Release note
To be added

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
