### PR TITLE
fix filtering bug in filtering unnest cols and dim cols: Received a non-applicable rewrite

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -368,7 +368,8 @@ public class UnnestStorageAdapter implements StorageAdapter
 
     public FilterSplitter(
         String inputColumn,
-        ColumnCapabilities inputColumnCapabilites, VirtualColumns queryVirtualColumns
+        ColumnCapabilities inputColumnCapabilites,
+        VirtualColumns queryVirtualColumns
     )
     {
       this.inputColumn = inputColumn;

--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -512,7 +512,6 @@ public class UnnestStorageAdapter implements StorageAdapter
            */
           if (isTopLevelAndFilter && getUnnestInputIfDirectAccess(unnestColumn) != null) {
             filterSplitter.addPreFilter(newFilter != null ? newFilter : filter);
-            filterSplitter.addToPreFilterCount(1);
           }
           filterSplitter.addToOriginalFilterCount(1);
         }

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -424,7 +424,7 @@ public class Filters
     return retVal;
   }
 
-  public static int countNumberOfFilters(Filter filter)
+  public static int countNumberOfFilters(@Nullable Filter filter)
   {
     if (filter == null) {
       return 0;

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -26,6 +26,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.DefaultBitmapResultFactory;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.filter.BooleanFilter;
 import org.apache.druid.query.filter.ColumnIndexSelector;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.DruidPredicateFactory;
@@ -421,5 +422,20 @@ public class Filters
     }
 
     return retVal;
+  }
+
+  public static int countNumberOfFilters(Filter filter)
+  {
+    if (filter == null) {
+      return 0;
+    }
+    if (filter instanceof BooleanFilter) {
+      return ((BooleanFilter) filter).getFilters()
+                                     .stream()
+                                     .map(f -> countNumberOfFilters(f))
+                                     .mapToInt(Integer::intValue)
+                                     .sum();
+    }
+    return 1;
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
@@ -370,7 +370,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "unnested-multi-string1 = 3",
+        "multi-string1 = 3",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || unnested-multi-string1 = 1))"
     );
   }
@@ -393,7 +393,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "unnested-multi-string1 = 3",
+        "multi-string1 = 3",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || (newcol = 3 && multi-string1 = 7) || unnested-multi-string1 = 1))"
     );
   }
@@ -419,7 +419,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "",
+        "(multi-string1 = 3 || newcol = 2 || multi-string1 = 2 || (newcol = 3 && multi-string1 = 7 && newcol_1 = 10) || multi-string1 = 1)",
         "(unnested-multi-string1 = 3 || newcol = 2 || multi-string1 = 2 || (newcol = 3 && multi-string1 = 7 && newcol_1 = 10) || unnested-multi-string1 = 1)"
     );
   }
@@ -436,7 +436,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "",
+        "(multi-string1 = 3 || (newcol = 2 && multi-string1 = 2 && multi-string1 = 1))",
         "(unnested-multi-string1 = 3 || (newcol = 2 && multi-string1 = 2 && unnested-multi-string1 = 1))"
     );
   }
@@ -458,7 +458,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "unnested-multi-string1 = 3",
+        "multi-string1 = 3",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2) && (newcol = 4 || multi-string1 = 8 || unnested-multi-string1 = 6))"
     );
   }
@@ -472,7 +472,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "unnested-multi-string1 = 3",
+        "multi-string1 = 3",
         "(unnested-multi-string1 = 3 && multi-string1 = 2)"
     );
   }
@@ -580,7 +580,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
         null,
         VirtualColumns.EMPTY,
         inputColumn,
-        vc.capabilities(inputColumn)
+        vc.capabilities(UNNEST_STORAGE_ADAPTER, inputColumn)
     );
     Filter actualPushDownFilter = filterPair.lhs;
     Filter actualPostUnnestFilter = filterPair.rhs;

--- a/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
@@ -370,7 +370,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "multi-string1 = 3",
+        "(multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || multi-string1 = 1))",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || unnested-multi-string1 = 1))"
     );
   }
@@ -393,7 +393,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "multi-string1 = 3",
+        "(multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || (newcol = 3 && multi-string1 = 7) || multi-string1 = 1))",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2 || (newcol = 3 && multi-string1 = 7) || unnested-multi-string1 = 1))"
     );
   }
@@ -458,7 +458,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "multi-string1 = 3",
+        "(multi-string1 = 3 && (newcol = 2 || multi-string1 = 2) && (newcol = 4 || multi-string1 = 8 || multi-string1 = 6))",
         "(unnested-multi-string1 = 3 && (newcol = 2 || multi-string1 = 2) && (newcol = 4 || multi-string1 = 8 || unnested-multi-string1 = 6))"
     );
   }
@@ -472,7 +472,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     ));
     testComputeBaseAndPostUnnestFilters(
         testQueryFilter,
-        "multi-string1 = 3",
+        "(multi-string1 = 3 && multi-string1 = 2)",
         "(unnested-multi-string1 = 3 && multi-string1 = 2)"
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterTestUtils.java
@@ -19,7 +19,10 @@
 
 package org.apache.druid.segment.filter;
 
+import org.apache.druid.query.extraction.ExtractionFn;
+import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.SelectorDimFilter;
 
 import java.util.Arrays;
 
@@ -43,5 +46,20 @@ public class FilterTestUtils
   public static SelectorFilter selector(final String fieldName, final String value)
   {
     return new SelectorFilter(fieldName, value, null);
+  }
+
+  public static Filter sdf(String dimension, String value)
+  {
+    return new SelectorDimFilter(dimension, value, null).toFilter();
+  }
+
+  public static Filter sdf(String dimension, String value, ExtractionFn extractionFn)
+  {
+    return new SelectorDimFilter(dimension, value, extractionFn).toFilter();
+  }
+
+  public static DimFilter sdfd(String dimension, String value, ExtractionFn extractionFn)
+  {
+    return new SelectorDimFilter(dimension, value, extractionFn);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterTestUtils.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterTestUtils.java
@@ -19,10 +19,7 @@
 
 package org.apache.druid.segment.filter;
 
-import org.apache.druid.query.extraction.ExtractionFn;
-import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.Filter;
-import org.apache.druid.query.filter.SelectorDimFilter;
 
 import java.util.Arrays;
 
@@ -46,20 +43,5 @@ public class FilterTestUtils
   public static SelectorFilter selector(final String fieldName, final String value)
   {
     return new SelectorFilter(fieldName, value, null);
-  }
-
-  public static Filter sdf(String dimension, String value)
-  {
-    return new SelectorDimFilter(dimension, value, null).toFilter();
-  }
-
-  public static Filter sdf(String dimension, String value, ExtractionFn extractionFn)
-  {
-    return new SelectorDimFilter(dimension, value, extractionFn).toFilter();
-  }
-
-  public static DimFilter sdfd(String dimension, String value, ExtractionFn extractionFn)
-  {
-    return new SelectorDimFilter(dimension, value, extractionFn);
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -2881,6 +2881,222 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testUnnestThriceWithFiltersOnDimAndUnnestCol()
+  {
+    cannotVectorize();
+    String sql = "    SELECT dimZipf, dim3_unnest1, dim3_unnest2, dim3_unnest3 FROM \n"
+                 + "      ( SELECT * FROM \n"
+                 + "           ( SELECT * FROM lotsocolumns, UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest1) )"
+                 + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
+                 + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
+                 + " WHERE dimZipf=27 AND dim3_unnest1='Baz'";
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST,
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(
+                      UnnestDataSource.create(
+                          UnnestDataSource.create(
+                              UnnestDataSource.create(
+                                  new TableDataSource(CalciteTests.DATASOURCE5),
+                                  expressionVirtualColumn(
+                                      "j0.unnest",
+                                      "\"dimMultivalEnumerated\"",
+                                      ColumnType.STRING
+                                  ),
+                                  null
+                              ),
+                              expressionVirtualColumn(
+                                  "_j0.unnest",
+                                  "\"dimMultivalEnumerated\"",
+                                  ColumnType.STRING
+                              ), null
+                          ),
+                          expressionVirtualColumn(
+                              "__j0.unnest",
+                              "\"dimMultivalEnumerated\"",
+                              ColumnType.STRING
+                          ),
+                          null
+                      )
+                  )
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .filters(and(
+                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      new SelectorDimFilter("j0.unnest", "Baz", null)
+                  ))
+                  .legacy(false)
+                  .context(QUERY_CONTEXT_UNNEST)
+                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Hello"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Hello"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Hello", "Baz"},
+            new Object[]{"27", "Baz", "Hello", "Baz"},
+            new Object[]{"27", "Baz", "Hello", "Hello"},
+            new Object[]{"27", "Baz", "Hello", "World"},
+            new Object[]{"27", "Baz", "World", "Baz"},
+            new Object[]{"27", "Baz", "World", "Baz"},
+            new Object[]{"27", "Baz", "World", "Hello"},
+            new Object[]{"27", "Baz", "World", "World"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Hello"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Baz"},
+            new Object[]{"27", "Baz", "Baz", "Hello"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Hello", "Baz"},
+            new Object[]{"27", "Baz", "Hello", "Baz"},
+            new Object[]{"27", "Baz", "Hello", "Hello"},
+            new Object[]{"27", "Baz", "Hello", "World"},
+            new Object[]{"27", "Baz", "World", "Baz"},
+            new Object[]{"27", "Baz", "World", "Baz"},
+            new Object[]{"27", "Baz", "World", "Hello"},
+            new Object[]{"27", "Baz", "World", "World"}
+        )
+    );
+  }
+  @Test
+  public void testUnnestThriceWithFiltersOnDimAndAllUnnestColumns()
+  {
+    cannotVectorize();
+    String sql = "    SELECT dimZipf, dim3_unnest1, dim3_unnest2, dim3_unnest3 FROM \n"
+                 + "      ( SELECT * FROM \n"
+                 + "           ( SELECT * FROM lotsocolumns, UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest1) )"
+                 + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
+                 + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
+                 + " WHERE dimZipf=27 AND dim3_unnest1='Baz' AND dim3_unnest2='Hello' AND dim3_unnest3='World'";
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST,
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(
+                      UnnestDataSource.create(
+                          UnnestDataSource.create(
+                              UnnestDataSource.create(
+                                  new TableDataSource(CalciteTests.DATASOURCE5),
+                                  expressionVirtualColumn(
+                                      "j0.unnest",
+                                      "\"dimMultivalEnumerated\"",
+                                      ColumnType.STRING
+                                  ),
+                                  null
+                              ),
+                              expressionVirtualColumn(
+                                  "_j0.unnest",
+                                  "\"dimMultivalEnumerated\"",
+                                  ColumnType.STRING
+                              ), new SelectorDimFilter("_j0.unnest", "Hello", null)
+                          ),
+                          expressionVirtualColumn(
+                              "__j0.unnest",
+                              "\"dimMultivalEnumerated\"",
+                              ColumnType.STRING
+                          ),
+                          new SelectorDimFilter("__j0.unnest", "World", null)
+                      )
+                  )
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .filters(and(
+                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      new SelectorDimFilter("j0.unnest", "Baz", null)
+                  ))
+                  .legacy(false)
+                  .context(QUERY_CONTEXT_UNNEST)
+                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"27", "Baz", "Hello", "World"},
+            new Object[]{"27", "Baz", "Hello", "World"}
+        )
+    );
+  }
+
+  @Test
+  public void testUnnestThriceWithFiltersOnDimAndUnnestColumnsORCombinations()
+  {
+    cannotVectorize();
+    String sql = "    SELECT dimZipf, dim3_unnest1, dim3_unnest2, dim3_unnest3 FROM \n"
+                 + "      ( SELECT * FROM \n"
+                 + "           ( SELECT * FROM lotsocolumns, UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest1) )"
+                 + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
+                 + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
+                 + " WHERE dimZipf=27 AND (dim3_unnest1='Baz' OR dim3_unnest2='Hello') AND dim3_unnest3='World'";
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST,
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(
+                      UnnestDataSource.create(
+                          UnnestDataSource.create(
+                              UnnestDataSource.create(
+                                  new TableDataSource(CalciteTests.DATASOURCE5),
+                                  expressionVirtualColumn(
+                                      "j0.unnest",
+                                      "\"dimMultivalEnumerated\"",
+                                      ColumnType.STRING
+                                  ),
+                                  null
+                              ),
+                              expressionVirtualColumn(
+                                  "_j0.unnest",
+                                  "\"dimMultivalEnumerated\"",
+                                  ColumnType.STRING
+                              ), null
+                          ),
+                          expressionVirtualColumn(
+                              "__j0.unnest",
+                              "\"dimMultivalEnumerated\"",
+                              ColumnType.STRING
+                          ),
+                          new SelectorDimFilter("__j0.unnest", "World", null)
+                      )
+                  )
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .filters(and(
+                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      or(
+                          new SelectorDimFilter("j0.unnest", "Baz", null),
+                          new SelectorDimFilter("_j0.unnest", "Hello", null)
+                      )
+                  ))
+                  .legacy(false)
+                  .context(QUERY_CONTEXT_UNNEST)
+                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Hello", "World"},
+            new Object[]{"27", "Baz", "World", "World"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Baz", "World"},
+            new Object[]{"27", "Baz", "Hello", "World"},
+            new Object[]{"27", "Baz", "World", "World"},
+            new Object[]{"27", "Hello", "Hello", "World"},
+            new Object[]{"27", "World", "Hello", "World"}
+        )
+    );
+  }
+  @Test
   public void testUnnestWithGroupBy()
   {
     // This tells the test to skip generating (vectorize = force) path

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -2924,8 +2924,10 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .filters(and(
-                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
-                      new SelectorDimFilter("j0.unnest", "Baz", null)
+                      NullHandling.sqlCompatible()
+                      ? equality("dimZipf", "27", ColumnType.LONG)
+                      : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      equality("j0.unnest", "Baz", ColumnType.STRING)
                   ))
                   .legacy(false)
                   .context(QUERY_CONTEXT_UNNEST)
@@ -2999,21 +3001,23 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                   "_j0.unnest",
                                   "\"dimMultivalEnumerated\"",
                                   ColumnType.STRING
-                              ), new SelectorDimFilter("_j0.unnest", "Hello", null)
+                              ), equality("_j0.unnest", "Hello", ColumnType.STRING)
                           ),
                           expressionVirtualColumn(
                               "__j0.unnest",
                               "\"dimMultivalEnumerated\"",
                               ColumnType.STRING
                           ),
-                          new SelectorDimFilter("__j0.unnest", "World", null)
+                          equality("__j0.unnest", "World", ColumnType.STRING)
                       )
                   )
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .filters(and(
-                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
-                      new SelectorDimFilter("j0.unnest", "Baz", null)
+                      NullHandling.sqlCompatible()
+                      ? equality("dimZipf", "27", ColumnType.LONG)
+                      : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      equality("j0.unnest", "Baz", ColumnType.STRING)
                   ))
                   .legacy(false)
                   .context(QUERY_CONTEXT_UNNEST)
@@ -3065,16 +3069,24 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                               "\"dimMultivalEnumerated\"",
                               ColumnType.STRING
                           ),
-                          new SelectorDimFilter("__j0.unnest", "World", null)
+                          equality("__j0.unnest", "World", ColumnType.STRING)
                       )
                   )
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .filters(and(
-                      bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                      NullHandling.sqlCompatible() ? equality("dimZipf", "27", ColumnType.LONG) : bound(
+                          "dimZipf",
+                          "27",
+                          "27",
+                          false,
+                          false,
+                          null,
+                          StringComparators.NUMERIC
+                      ),
                       or(
-                          new SelectorDimFilter("j0.unnest", "Baz", null),
-                          new SelectorDimFilter("_j0.unnest", "Hello", null)
+                          equality("j0.unnest", "Baz", ColumnType.STRING),
+                          equality("_j0.unnest", "Hello", ColumnType.STRING)
                       )
                   ))
                   .legacy(false)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -2890,14 +2890,12 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                  + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
                  + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
                  + " WHERE dimZipf=27 AND dim3_unnest1='Baz'";
-    testQuery(
-        sql,
-        QUERY_CONTEXT_UNNEST,
-        ImmutableList.of(
-            Druids.newScanQueryBuilder()
-                  .dataSource(
+    List<Query<?>> expectedQuerySc = ImmutableList.of(
+        Druids.newScanQueryBuilder()
+              .dataSource(
+                  UnnestDataSource.create(
                       UnnestDataSource.create(
-                          UnnestDataSource.create(
+                          FilteredDataSource.create(
                               UnnestDataSource.create(
                                   new TableDataSource(CalciteTests.DATASOURCE5),
                                   expressionVirtualColumn(
@@ -2907,33 +2905,43 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                   ),
                                   null
                               ),
-                              expressionVirtualColumn(
-                                  "_j0.unnest",
-                                  "\"dimMultivalEnumerated\"",
-                                  ColumnType.STRING
-                              ), null
+                              and(
+                                  NullHandling.sqlCompatible()
+                                  ? equality("dimZipf", "27", ColumnType.LONG)
+                                  : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                                  equality("j0.unnest", "Baz", ColumnType.STRING)
+                              )
                           ),
                           expressionVirtualColumn(
-                              "__j0.unnest",
+                              "_j0.unnest",
                               "\"dimMultivalEnumerated\"",
                               ColumnType.STRING
-                          ),
-                          null
-                      )
+                          ), null
+                      ),
+                      expressionVirtualColumn(
+                          "__j0.unnest",
+                          "\"dimMultivalEnumerated\"",
+                          ColumnType.STRING
+                      ),
+                      null
                   )
-                  .intervals(querySegmentSpec(Filtration.eternity()))
-                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                  .filters(and(
-                      NullHandling.sqlCompatible()
-                      ? numericEquality("dimZipf", "27", ColumnType.LONG)
-                      : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
-                      equality("j0.unnest", "Baz", ColumnType.STRING)
-                  ))
-                  .legacy(false)
-                  .context(QUERY_CONTEXT_UNNEST)
-                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
-                  .build()
-        ),
+              )
+              .intervals(querySegmentSpec(Filtration.eternity()))
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+              .legacy(false)
+              .context(QUERY_CONTEXT_UNNEST)
+              .virtualColumns(expressionVirtualColumn(
+                  "v0",
+                  "'Baz'",
+                  ColumnType.STRING
+              ))
+              .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "v0"))
+              .build()
+    );
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST,
+        expectedQuerySc,
         ImmutableList.of(
             new Object[]{"27", "Baz", "Baz", "Baz"},
             new Object[]{"27", "Baz", "Baz", "Baz"},
@@ -2980,14 +2988,12 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                  + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
                  + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
                  + " WHERE dimZipf=27 AND dim3_unnest1='Baz' AND dim3_unnest2='Hello' AND dim3_unnest3='World'";
-    testQuery(
-        sql,
-        QUERY_CONTEXT_UNNEST,
-        ImmutableList.of(
-            Druids.newScanQueryBuilder()
-                  .dataSource(
+    List<Query<?>> expectedQuerySc = ImmutableList.of(
+        Druids.newScanQueryBuilder()
+              .dataSource(
+                  UnnestDataSource.create(
                       UnnestDataSource.create(
-                          UnnestDataSource.create(
+                          FilteredDataSource.create(
                               UnnestDataSource.create(
                                   new TableDataSource(CalciteTests.DATASOURCE5),
                                   expressionVirtualColumn(
@@ -2997,33 +3003,43 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                   ),
                                   null
                               ),
-                              expressionVirtualColumn(
-                                  "_j0.unnest",
-                                  "\"dimMultivalEnumerated\"",
-                                  ColumnType.STRING
-                              ), equality("_j0.unnest", "Hello", ColumnType.STRING)
+                              and(
+                                  NullHandling.sqlCompatible()
+                                  ? equality("dimZipf", "27", ColumnType.LONG)
+                                  : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
+                                  equality("j0.unnest", "Baz", ColumnType.STRING)
+                              )
                           ),
                           expressionVirtualColumn(
-                              "__j0.unnest",
+                              "_j0.unnest",
                               "\"dimMultivalEnumerated\"",
                               ColumnType.STRING
-                          ),
-                          equality("__j0.unnest", "World", ColumnType.STRING)
-                      )
+                          ), equality("_j0.unnest", "Hello", ColumnType.STRING)
+                      ),
+                      expressionVirtualColumn(
+                          "__j0.unnest",
+                          "\"dimMultivalEnumerated\"",
+                          ColumnType.STRING
+                      ),
+                      equality("__j0.unnest", "World", ColumnType.STRING)
                   )
-                  .intervals(querySegmentSpec(Filtration.eternity()))
-                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                  .filters(and(
-                      NullHandling.sqlCompatible()
-                      ? numericEquality("dimZipf", "27", ColumnType.LONG)
-                      : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
-                      equality("j0.unnest", "Baz", ColumnType.STRING)
-                  ))
-                  .legacy(false)
-                  .context(QUERY_CONTEXT_UNNEST)
-                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
-                  .build()
-        ),
+              )
+              .intervals(querySegmentSpec(Filtration.eternity()))
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+              .virtualColumns(expressionVirtualColumn(
+                  "v0",
+                  "'Baz'",
+                  ColumnType.STRING
+              ))
+              .legacy(false)
+              .context(QUERY_CONTEXT_UNNEST)
+              .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "v0"))
+              .build()
+    );
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST,
+        expectedQuerySc,
         ImmutableList.of(
             new Object[]{"27", "Baz", "Hello", "World"},
             new Object[]{"27", "Baz", "Hello", "World"}
@@ -3035,65 +3051,68 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   public void testUnnestThriceWithFiltersOnDimAndUnnestColumnsORCombinations()
   {
     cannotVectorize();
+    skipVectorize();
     String sql = "    SELECT dimZipf, dim3_unnest1, dim3_unnest2, dim3_unnest3 FROM \n"
                  + "      ( SELECT * FROM \n"
                  + "           ( SELECT * FROM lotsocolumns, UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest1) )"
                  + "           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) \n"
                  + "      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3) "
                  + " WHERE dimZipf=27 AND (dim3_unnest1='Baz' OR dim3_unnest2='Hello') AND dim3_unnest3='World'";
-    testQuery(
-        sql,
-        QUERY_CONTEXT_UNNEST,
-        ImmutableList.of(
-            Druids.newScanQueryBuilder()
-                  .dataSource(
-                      UnnestDataSource.create(
+    List<Query<?>> expectedQuerySqlCom = ImmutableList.of(
+        Druids.newScanQueryBuilder()
+              .dataSource(
+                  UnnestDataSource.create(
+                      FilteredDataSource.create(
                           UnnestDataSource.create(
-                              UnnestDataSource.create(
-                                  new TableDataSource(CalciteTests.DATASOURCE5),
-                                  expressionVirtualColumn(
-                                      "j0.unnest",
-                                      "\"dimMultivalEnumerated\"",
-                                      ColumnType.STRING
+                              FilteredDataSource.create(
+                                  UnnestDataSource.create(
+                                      new TableDataSource(CalciteTests.DATASOURCE5),
+                                      expressionVirtualColumn(
+                                          "j0.unnest",
+                                          "\"dimMultivalEnumerated\"",
+                                          ColumnType.STRING
+                                      ),
+                                      null
                                   ),
-                                  null
+                                  NullHandling.sqlCompatible() ? equality("dimZipf", "27", ColumnType.LONG) : range(
+                                      "dimZipf",
+                                      ColumnType.LONG,
+                                      "27",
+                                      "27",
+                                      false,
+                                      false
+                                  )
                               ),
                               expressionVirtualColumn(
                                   "_j0.unnest",
                                   "\"dimMultivalEnumerated\"",
                                   ColumnType.STRING
-                              ), null
+                              ),
+                              null
                           ),
-                          expressionVirtualColumn(
-                              "__j0.unnest",
-                              "\"dimMultivalEnumerated\"",
-                              ColumnType.STRING
-                          ),
-                          equality("__j0.unnest", "World", ColumnType.STRING)
-                      )
-                  )
-                  .intervals(querySegmentSpec(Filtration.eternity()))
-                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                  .filters(and(
-                      NullHandling.sqlCompatible() ? equality("dimZipf", "27", ColumnType.LONG) : bound(
-                          "dimZipf",
-                          "27",
-                          "27",
-                          false,
-                          false,
-                          null,
-                          StringComparators.NUMERIC
+                          or(
+                              equality("j0.unnest", "Baz", ColumnType.STRING),
+                              equality("_j0.unnest", "Hello", ColumnType.STRING)
+                          ) // (j0.unnest = Baz || _j0.unnest = Hello)
                       ),
-                      or(
-                          equality("j0.unnest", "Baz", ColumnType.STRING),
-                          equality("_j0.unnest", "Hello", ColumnType.STRING)
-                      )
-                  ))
-                  .legacy(false)
-                  .context(QUERY_CONTEXT_UNNEST)
-                  .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
-                  .build()
-        ),
+                      expressionVirtualColumn(
+                          "__j0.unnest",
+                          "\"dimMultivalEnumerated\"",
+                          ColumnType.STRING
+                      ),
+                      equality("__j0.unnest", "World", ColumnType.STRING)
+                  )
+              )
+              .intervals(querySegmentSpec(Filtration.eternity()))
+              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+              .legacy(false)
+              .context(QUERY_CONTEXT_UNNEST)
+              .columns(ImmutableList.of("__j0.unnest", "_j0.unnest", "dimZipf", "j0.unnest"))
+              .build()
+    );
+    testQuery(
+        sql,
+        QUERY_CONTEXT_UNNEST, expectedQuerySqlCom,
         ImmutableList.of(
             new Object[]{"27", "Baz", "Baz", "World"},
             new Object[]{"27", "Baz", "Baz", "World"},
@@ -3402,13 +3421,67 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                                .legacy(false)
                                .filters(or(
-                                   bound("m1", null, "10", false, false, null, StringComparators.NUMERIC),
+                                   NullHandling.sqlCompatible()
+                                   ? range("m1", ColumnType.LONG, null, "10", false, false)
+                                   : bound(
+                                       "m1",
+                                       null,
+                                       "10",
+                                       false,
+                                       false,
+                                       null,
+                                       StringComparators.NUMERIC
+                                   ),
                                    equality("j0.unnest", "b", ColumnType.STRING)
                                ))
                                .context(QUERY_CONTEXT_UNNEST)
                                .columns(ImmutableList.of("j0.unnest", "m1"))
                                .build()),
         ImmutableList.of(new Object[]{"a", 1.0f})
+    );
+  }
+
+  @Test
+  public void testUnnestVirtualWithColumns2()
+  {
+    // This tells the test to skip generating (vectorize = force) path
+    // Generates only 1 native query with vectorize = false
+    skipVectorize();
+    // This tells that both vectorize = force and vectorize = false takes the same path of non vectorization
+    // Generates 2 native queries with 2 different values of vectorize
+    cannotVectorize();
+    testQuery(
+        "SELECT strings, m1 FROM druid.numfoo, UNNEST(MV_TO_ARRAY(dim3)) as unnested (strings) where (strings='a' or (m1=2 and strings='b'))",
+        QUERY_CONTEXT_UNNEST,
+        ImmutableList.of(Druids.newScanQueryBuilder()
+                               .dataSource(UnnestDataSource.create(
+                                   new TableDataSource(CalciteTests.DATASOURCE3),
+                                   expressionVirtualColumn(
+                                       "j0.unnest",
+                                       "\"dim3\"",
+                                       ColumnType.STRING
+                                   ),
+                                   null
+                               ))
+                               .intervals(querySegmentSpec(Filtration.eternity()))
+                               .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                               .legacy(false) // (j0.unnest = a || (m1 = 2 && j0.unnest = b))
+                               .filters(or(
+                                   equality("j0.unnest", "a", ColumnType.STRING),
+                                   and(
+                                       NullHandling.sqlCompatible()
+                                       ? equality("m1", "2", ColumnType.FLOAT)
+                                       : equality("m1", "2", ColumnType.STRING),
+                                       equality("j0.unnest", "b", ColumnType.STRING)
+                                   )
+                               ))
+                               .context(QUERY_CONTEXT_UNNEST)
+                               .columns(ImmutableList.of("j0.unnest", "m1"))
+                               .build()),
+        ImmutableList.of(
+            new Object[]{"a", 1.0f},
+            new Object[]{"b", 2.0f}
+        )
     );
   }
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -2925,7 +2925,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .filters(and(
                       NullHandling.sqlCompatible()
-                      ? equality("dimZipf", "27", ColumnType.LONG)
+                      ? numericEquality("dimZipf", "27", ColumnType.LONG)
                       : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
                       equality("j0.unnest", "Baz", ColumnType.STRING)
                   ))
@@ -3015,7 +3015,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .filters(and(
                       NullHandling.sqlCompatible()
-                      ? equality("dimZipf", "27", ColumnType.LONG)
+                      ? numericEquality("dimZipf", "27", ColumnType.LONG)
                       : bound("dimZipf", "27", "27", false, false, null, StringComparators.NUMERIC),
                       equality("j0.unnest", "Baz", ColumnType.STRING)
                   ))


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

This PR fixes the bug in the following query, currently it throws the exception `org.apache.druid.query.QueryException: Received a non-applicable rewrite: {j0.unnest=c2}, filter's dimension: c1`
Whenever we have And / OR filters on unnest columns, we rewrite the filters on unnest cols. 
We were covering OR filters and disqualifying the rewrite for non unnest cols and we have to to do same thing with AND filters as well.  This PR checks for Boolean filter and disqualify the rewrite for non unnest cols. 

Adding the 3 tests that covers the given scenario. 
 
```
select * from ( 
          select * from (
                         select * from mytest, unnest(mv_to_array(c2)) as u(n1)
                     ), unnest(mv_to_array(c2)) as u(n2)
               ), unnest(mv_to_array(c2)) as u(n3)
where n1='A' and c1>=1
```

3rd test case cover the nested filer scenario for unnest filters, This PR address the unpack the nested OR/AND filters and attempt to rewrite only for qualified filters. 

```
SELECT dimZipf, dim3_unnest1, dim3_unnest2, dim3_unnest3 FROM 
      ( SELECT * FROM 
           ( SELECT * FROM lotsocolumns, UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest1) )           ,UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest2) 
      ), UNNEST(MV_TO_ARRAY(dimMultivalEnumerated)) as ut(dim3_unnest3)  WHERE dimZipf=27 AND (dim3_unnest1='Baz' OR dim3_unnest2='Hello') AND dim3_unnest3='World'
```

Thank you


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
