### PR TITLE
Web console: fix service view filtering on other bugs

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -397,7 +397,7 @@ export class ConsoleApplication extends React.PureComponent<
       'services',
       <ServicesView
         filters={stringToTableFilters(p.match.params.filters)}
-        onFiltersChange={viewFilterChange('tasks')}
+        onFiltersChange={viewFilterChange('services')}
         goToQuery={this.goToQuery}
         capabilities={capabilities}
       />,

--- a/web-console/src/druid-models/time/time.ts
+++ b/web-console/src/druid-models/time/time.ts
@@ -91,3 +91,15 @@ export function possibleDruidFormatForValues(values: any[]): string | undefined 
     return values.every(value => timeFormatMatches(format, value));
   });
 }
+
+export function chooseByBestTimestamp<T extends { column: string; format: string }>(
+  candidates: T[],
+): T | undefined {
+  return (
+    candidates.find(ts => ts.column === '__time') || // If there is a __time column, just pick it
+    candidates.find(ts => /time/i.test(ts.column) && !NUMERIC_TIME_FORMATS.includes(ts.format)) || // Prefer a suggestion that has "time" in the name and is not a numeric format
+    candidates.find(ts => /time/i.test(ts.column)) || // Otherwise anything that has "time" in the name
+    candidates.find(ts => !NUMERIC_TIME_FORMATS.includes(ts.format)) || // Use a suggestion that is not numeric
+    candidates[0]
+  );
+}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -74,6 +74,7 @@ import {
   adjustForceGuaranteedRollup,
   adjustId,
   BATCH_INPUT_FORMAT_FIELDS,
+  chooseByBestTimestamp,
   cleanSpec,
   computeFlattenPathsForData,
   CONSTANT_TIMESTAMP_SPEC,
@@ -114,7 +115,6 @@ import {
   MAX_INLINE_DATA_LENGTH,
   METRIC_SPEC_FIELDS,
   normalizeSpec,
-  NUMERIC_TIME_FORMATS,
   possibleDruidFormatForValues,
   PRIMARY_PARTITION_RELATED_FORM_FIELDS,
   removeTimestampTransform,
@@ -279,16 +279,7 @@ function getTimestampSpec(sampleResponse: SampleResponse | null): TimestampSpec 
     },
   );
 
-  return (
-    // Prefer a suggestion that has "time" in the name and is not a numeric format
-    timestampSpecs.find(
-      ts => /time/i.test(ts.column) && !NUMERIC_TIME_FORMATS.includes(ts.format),
-    ) ||
-    timestampSpecs.find(ts => /time/i.test(ts.column)) || // Otherwise anything that has "time" in the name
-    timestampSpecs.find(ts => !NUMERIC_TIME_FORMATS.includes(ts.format)) || // Use a suggestion that is not numeric
-    timestampSpecs[0] || // Fall back to the first one
-    CONSTANT_TIMESTAMP_SPEC // Ok, empty it is...
-  );
+  return chooseByBestTimestamp(timestampSpecs) || CONSTANT_TIMESTAMP_SPEC;
 }
 
 type Step =

--- a/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
+++ b/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
@@ -26,6 +26,7 @@ import { AutoForm, CenterMessage, LearnMore, Loader } from '../../../components'
 import type { InputFormat, InputSource } from '../../../druid-models';
 import {
   BATCH_INPUT_FORMAT_FIELDS,
+  chooseByBestTimestamp,
   DETECTION_TIMESTAMP_SPEC,
   guessColumnTypeFromSampleResponse,
   guessIsArrayFromSampleResponse,
@@ -40,7 +41,6 @@ import {
   deepSet,
   EMPTY_ARRAY,
   filterMap,
-  findMap,
   timeFormatToSql,
 } from '../../../utils';
 import type { SampleResponse, SampleSpec } from '../../../utils/sampler';
@@ -58,6 +58,7 @@ export interface InputFormatAndMore {
 
 interface PossibleTimeExpression {
   column: string;
+  format: string;
   timeExpression: SqlExpression;
 }
 
@@ -116,9 +117,8 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
 
   let possibleTimeExpression: PossibleTimeExpression | undefined;
   if (previewSampleResponse) {
-    possibleTimeExpression = findMap(
-      getHeaderNamesFromSampleResponse(previewSampleResponse),
-      column => {
+    possibleTimeExpression = chooseByBestTimestamp(
+      filterMap(getHeaderNamesFromSampleResponse(previewSampleResponse), column => {
         const values = filterMap(previewSampleResponse.data, d => d.input?.[column]);
         const possibleDruidFormat = possibleDruidFormatForValues(values);
         if (!possibleDruidFormat) return;
@@ -127,6 +127,7 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
         if (column === TIME_COLUMN) {
           return {
             column,
+            format: '',
             timeExpression: C(column),
           };
         }
@@ -136,9 +137,10 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
 
         return {
           column,
+          format: possibleDruidFormat,
           timeExpression: formatSql.fillPlaceholders([C(column)]),
         };
-      },
+      }),
     );
   }
 


### PR DESCRIPTION
This PR fixes 2 bugs (see 2 commits):

1. Typing in the search bar in the services page, takes you to the Tasks page.
2. The smart picking of "time" column in the classic batch data loader did not extend to the MSQ data loader so it would pick the first time column, not the "best" time column.