### PR TITLE
Web console: better schema discovery copy

### DIFF
--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2658,7 +2658,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             }}
           >
             <Radio value="type-aware-discovery">
-              Use the new type-aware schema discovery capability to discover columns according to data type. Columns with multiple values will be ingested as ARRAY types. For more
+              Use the new type-aware schema discovery capability to discover columns according to
+              data type. Columns with multiple values will be ingested as ARRAY types. For more
               information see the{' '}
               <ExternalLink
                 href={`${getLink(
@@ -2670,8 +2671,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               .
             </Radio>
             <Radio value="string-only-discovery">
-              Use classic string-only schema discovery to discover all new columns as
-              strings. Columns with multiple values will be ingested as multi-value-strings.
+              Use classic string-only schema discovery to discover all new columns as strings.
+              Columns with multiple values will be ingested as multi-value-strings.
             </Radio>
           </RadioGroup>
         )}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2670,8 +2670,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               .
             </Radio>
             <Radio value="string-only-discovery">
-              Use classic string-only schema discovery. This will discover all new columns as
-              strings, columns with multiple values will be ingested as multi-value-strings.
+              Use classic string-only schema discovery to discover all new columns as
+              strings. Columns with multiple values will be ingested as multi-value-strings.
             </Radio>
           </RadioGroup>
         )}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2376,7 +2376,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   checked={schemaMode === 'fixed'}
                   onChange={() =>
                     this.setState({
-                      newSchemaMode: schemaMode === 'fixed' ? 'string-only-discovery' : 'fixed',
+                      newSchemaMode: schemaMode === 'fixed' ? 'type-aware-discovery' : 'fixed',
                     })
                   }
                   label="Explicitly specify schema"
@@ -2645,8 +2645,9 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
         </p>
         <p>Making this change will reset all schema configuration done so far.</p>
         {autoDetect && (
-          <Switch
-            checked={newSchemaMode === 'type-aware-discovery'}
+          <RadioGroup
+            label="Schemaless mode"
+            selectedValue={newSchemaMode}
             onChange={() => {
               this.setState({
                 newSchemaMode:
@@ -2656,18 +2657,24 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               });
             }}
           >
-            Use the new type-aware schema discovery capability. Avoid this if you are appending to a
-            datasource created with string-only schema discovery of Druid and want to preserve
-            schema compatibility. For more information see the{' '}
-            <ExternalLink
-              href={`${getLink(
-                'DOCS',
-              )}/ingestion/schema-design.html#schema-auto-discovery-for-dimensions`}
-            >
-              documentation
-            </ExternalLink>
-            .
-          </Switch>
+            <Radio value="type-aware-discovery">
+              Use the new type-aware schema discovery capability. This will discover columns with
+              the best type, columns with multiple values will be ingested as ARRAY types. For more
+              information see the{' '}
+              <ExternalLink
+                href={`${getLink(
+                  'DOCS',
+                )}/ingestion/schema-design.html#schema-auto-discovery-for-dimensions`}
+              >
+                documentation
+              </ExternalLink>
+              .
+            </Radio>
+            <Radio value="string-only-discovery">
+              Use classic string-only schema discovery. This will discover all new columns as
+              strings, columns with multiple values will be ingested as multi-value-strings.
+            </Radio>
+          </RadioGroup>
         )}
       </AsyncActionDialog>
     );

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -2658,8 +2658,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             }}
           >
             <Radio value="type-aware-discovery">
-              Use the new type-aware schema discovery capability. This will discover columns with
-              the best type, columns with multiple values will be ingested as ARRAY types. For more
+              Use the new type-aware schema discovery capability to discover columns according to data type. Columns with multiple values will be ingested as ARRAY types. For more
               information see the{' '}
               <ExternalLink
                 href={`${getLink(


### PR DESCRIPTION
Changing the copy (and default choice) in the dialog that pops up when entering schemaless mode in the data loader.

New dialog:

<img width="426" alt="image" src="https://github.com/apache/druid/assets/177816/c7736d49-d481-4c31-bd56-433de19883ca">

Old dialog (for reference): 

![image](https://github.com/apache/druid/assets/177816/b1c57c2b-f5e3-41b5-baa1-6e43e3a30a68)
