### PR TITLE
Web console: make sure execution mode is set

### DIFF
--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -195,19 +195,14 @@ exports[`RuleEditor matches snapshot no tier in rule 1`] = `
                     test1
                   </option>
                   <option
-                    value="test"
+                    value="test2"
                   >
-                    test
+                    test2
                   </option>
                   <option
-                    value="test"
+                    value="test3"
                   >
-                    test
-                  </option>
-                  <option
-                    value="test"
-                  >
-                    test
+                    test3
                   </option>
                 </select>
                 <span

--- a/web-console/src/components/rule-editor/rule-editor.spec.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.spec.tsx
@@ -26,7 +26,7 @@ describe('RuleEditor', () => {
     const ruleEditor = (
       <RuleEditor
         rule={{ type: 'loadForever', tieredReplicants: { test1: 1 } }}
-        tiers={['test', 'test', 'test']}
+        tiers={['test1', 'test2', 'test3']}
         onChange={() => {}}
         onDelete={() => {}}
         moveUp={undefined}


### PR DESCRIPTION
This fixes an issue where currently the MSQ data loader is not setting executionMode which makes the queries fail.