### PR TITLE
Fix issue with long data source names

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -226,7 +226,7 @@ public class KubernetesPeonLifecycle
       return TaskLocation.unknown();
     }
 
-    Optional<Pod> maybePod = kubernetesClient.getPeonPod(taskId);
+    Optional<Pod> maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
     if (!maybePod.isPresent()) {
       return TaskLocation.unknown();
     }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskId.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskId.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public class K8sTaskId
 {
 
-  private final String k8sTaskId;
+  private final String k8sJobName;
   private final String originalTaskId;
 
   public K8sTaskId(Task task)
@@ -37,12 +37,12 @@ public class K8sTaskId
   public K8sTaskId(String taskId)
   {
     this.originalTaskId = taskId;
-    this.k8sTaskId = KubernetesOverlordUtils.convertTaskIdToK8sLabel(taskId);
+    this.k8sJobName = KubernetesOverlordUtils.convertTaskIdToJobName(taskId);
   }
 
-  public String getK8sTaskId()
+  public String getK8sJobName()
   {
-    return k8sTaskId;
+    return k8sJobName;
   }
 
   public String getOriginalTaskId()
@@ -60,18 +60,18 @@ public class K8sTaskId
       return false;
     }
     K8sTaskId k8sTaskId1 = (K8sTaskId) o;
-    return k8sTaskId.equals(k8sTaskId1.k8sTaskId) && originalTaskId.equals(k8sTaskId1.originalTaskId);
+    return k8sJobName.equals(k8sTaskId1.k8sJobName) && originalTaskId.equals(k8sTaskId1.originalTaskId);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(k8sTaskId, originalTaskId);
+    return Objects.hash(k8sJobName, originalTaskId);
   }
 
   @Override
   public String toString()
   {
-    return "[ " + originalTaskId + ", " + k8sTaskId + "]";
+    return "[ " + originalTaskId + ", " + k8sJobName + "]";
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtils.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtils.java
@@ -21,7 +21,9 @@ package org.apache.druid.k8s.overlord.common;
 
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.shaded.com.google.common.hash.Hashing;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -42,5 +44,11 @@ public class KubernetesOverlordUtils
   {
     return taskId == null ? "" : StringUtils.left(RegExUtils.replaceAll(taskId, K8S_TASK_ID_PATTERN, "")
         .toLowerCase(Locale.ENGLISH), 63);
+  }
+
+  public static String convertTaskIdToJobName(String taskId)
+  {
+    return taskId == null ? "" : StringUtils.left(RegExUtils.replaceAll(taskId, K8S_TASK_ID_PATTERN, "")
+        .toLowerCase(Locale.ENGLISH), 30) + "-" + Hashing.murmur3_128().hashString(taskId, StandardCharsets.UTF_8);
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
@@ -149,7 +149,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
   {
     return new JobBuilder()
         .withNewMetadata()
-        .withName(k8sTaskId.getK8sTaskId())
+        .withName(k8sTaskId.getK8sJobName())
         .addToLabels(labels)
         .addToAnnotations(annotations)
         .endMetadata()
@@ -309,7 +309,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     // clean up the podSpec
     podSpec.setNodeName(null);
     podSpec.setRestartPolicy("Never");
-    podSpec.setHostname(k8sTaskId.getK8sTaskId());
+    podSpec.setHostname(k8sTaskId.getK8sJobName());
     podSpec.setTerminationGracePeriodSeconds(taskRunnerConfig.getGraceTerminationPeriodSeconds());
 
     PodTemplateSpec podTemplate = new PodTemplateSpec();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -124,7 +124,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
 
     return new JobBuilder()
         .withNewMetadata()
-        .withName(new K8sTaskId(task).getK8sTaskId())
+        .withName(new K8sTaskId(task).getK8sJobName())
         .addToLabels(getJobLabels(taskRunnerConfig, task))
         .addToAnnotations(getJobAnnotations(taskRunnerConfig, task))
         .endMetadata()

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -576,7 +576,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(task, kubernetesClient, taskLogs, mapper);
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
-    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId)).andReturn(Optional.absent());
+    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.absent());
 
     replayAll();
 
@@ -598,7 +598,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         .endMetadata()
         .build();
 
-    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId)).andReturn(Optional.of(pod));
+    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.of(pod));
 
     replayAll();
 
@@ -623,7 +623,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         .endStatus()
         .build();
 
-    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId)).andReturn(Optional.of(pod));
+    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.of(pod));
 
     replayAll();
 
@@ -653,7 +653,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         .endStatus()
         .build();
 
-    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId)).andReturn(Optional.of(pod));
+    EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.of(pod));
 
     replayAll();
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskIdTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskIdTest.java
@@ -30,15 +30,15 @@ public class K8sTaskIdTest
   public void testModifyingTaskIDToBeK8sCompliant()
   {
     String original = "coordinator-issued_compact_k8smetrics_aeifmefd_2022-08-18T15:33:26.094Z";
-    String result = new K8sTaskId(original).getK8sTaskId();
-    assertEquals("coordinatorissuedcompactk8smetricsaeifmefd20220818t153326094z", result);
+    String result = new K8sTaskId(original).getK8sJobName();
+    assertEquals("coordinatorissuedcompactk8smet-2e2c1862cb7ad1d01f4794b27a4438b0", result);
   }
 
   @Test
   public void testEquals()
   {
     EqualsVerifier.forClass(K8sTaskId.class)
-                  .withNonnullFields("k8sTaskId", "originalTaskId")
+                  .withNonnullFields("k8sJobName", "originalTaskId")
                   .usingGetClass()
                   .verify();
   }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtilsTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtilsTest.java
@@ -59,4 +59,20 @@ public class KubernetesOverlordUtilsTest
   {
     Assert.assertEquals("", KubernetesOverlordUtils.convertTaskIdToK8sLabel(null));
   }
+
+  @Test
+  public void test_stripJobName()
+  {
+    Assert.assertEquals("apiissuedkillwikipedianewbalhn-8916017dfd5469fe9a8881b1035497a2", KubernetesOverlordUtils.convertTaskIdToJobName(
+        "api-issued_kill_wikipedia_new_balhnoib_1000-01-01T00:00:00.000Z_2023-05-14T00:00:00.000Z_2023-05-15T17:28:42.526Z"
+    ));
+  }
+
+  @Test
+  public void test_stripJobName_avoidDuplicatesWithLongDataSourceName()
+  {
+    String jobName1 = KubernetesOverlordUtils.convertTaskIdToJobName("coordinator-issued_compact_p1np_telemetry_native_npdrmgetpreorderfailure_agg_flex_116_pcgkebcl_2023-07-19T16:53:11.416Z");
+    String jobName2 = KubernetesOverlordUtils.convertTaskIdToJobName("coordinator-issued_compact_p1np_telemetry_native_npdrmgetpreorderfailure_agg_flex_117_pcgkebcl_2023-07-19T16:53:11.416Z");
+    Assert.assertNotEquals(jobName1, jobName2);
+  }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -46,6 +46,7 @@ public class KubernetesPeonClientTest
 {
   private static final String ID = "id";
   private static final String JOB_NAME = ID;
+  private static final String KUBERNETES_JOB_NAME = KubernetesOverlordUtils.convertTaskIdToJobName(JOB_NAME);
   private static final String POD_NAME = "name";
   private static final String NAMESPACE = "namespace";
 
@@ -66,14 +67,14 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
     Pod pod = new PodBuilder()
         .withNewMetadata()
         .withName(POD_NAME)
-        .addToLabels("job-name", JOB_NAME)
+        .addToLabels("job-name", KUBERNETES_JOB_NAME)
         .endMetadata()
         .withNewStatus()
         .withPodIP("ip")
@@ -92,12 +93,12 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
     server.expect().get()
-        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3Did")
+        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3D" + KUBERNETES_JOB_NAME)
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
             .addNewItem()
             .withNewMetadata()
@@ -119,7 +120,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .withNewStatus()
         .withActive(null)
@@ -144,7 +145,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .withNewStatus()
         .withActive(null)
@@ -182,7 +183,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
@@ -208,7 +209,7 @@ public class KubernetesPeonClientTest
 
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
@@ -217,7 +218,7 @@ public class KubernetesPeonClientTest
     Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(ID)));
 
     Assertions.assertNotNull(
-        client.batch().v1().jobs().inNamespace(NAMESPACE).withName(ID).get()
+        client.batch().v1().jobs().inNamespace(NAMESPACE).withName(KUBERNETES_JOB_NAME).get()
     );
   }
 
@@ -237,10 +238,10 @@ public class KubernetesPeonClientTest
   void test_getPeonLogs_withJob_returnsInputStreamInOptional()
   {
     server.expect().get()
-        .withPath("/apis/batch/v1/namespaces/namespace/jobs/id")
+        .withPath("/apis/batch/v1/namespaces/namespace/jobs/" + KUBERNETES_JOB_NAME)
         .andReturn(HttpURLConnection.HTTP_OK, new JobBuilder()
             .withNewMetadata()
-            .withName(JOB_NAME)
+            .withName(KUBERNETES_JOB_NAME)
             .withUid("uid")
             .endMetadata()
             .withNewSpec()
@@ -289,7 +290,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
@@ -311,7 +312,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .addToLabels("druid.k8s.peons", "true")
         .endMetadata()
         .build();
@@ -342,7 +343,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .endMetadata()
         .withNewStatus()
         .withActive(1)
@@ -361,7 +362,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .addToLabels("druid.k8s.peons", "true")
         .endMetadata()
         .withNewStatus()
@@ -381,7 +382,7 @@ public class KubernetesPeonClientTest
   {
     Job job = new JobBuilder()
         .withNewMetadata()
-        .withName(JOB_NAME)
+        .withName(KUBERNETES_JOB_NAME)
         .addToLabels("druid.k8s.peons", "true")
         .endMetadata()
         .withNewStatus()
@@ -401,7 +402,7 @@ public class KubernetesPeonClientTest
   {
     Job activeJob = new JobBuilder()
         .withNewMetadata()
-        .withName(StringUtils.format("%s-active", JOB_NAME))
+        .withName(StringUtils.format("%s-active", KUBERNETES_JOB_NAME))
         .endMetadata()
         .withNewStatus()
         .withActive(1)
@@ -410,7 +411,7 @@ public class KubernetesPeonClientTest
 
     Job deletableJob = new JobBuilder()
         .withNewMetadata()
-        .withName(StringUtils.format("%s-deleteable", JOB_NAME))
+        .withName(StringUtils.format("%s-deleteable", KUBERNETES_JOB_NAME))
         .addToLabels("druid.k8s.peons", "true")
         .endMetadata()
         .withNewStatus()
@@ -420,7 +421,7 @@ public class KubernetesPeonClientTest
 
     Job undeletableJob = new JobBuilder()
         .withNewMetadata()
-        .withName(StringUtils.format("%s-undeletable", JOB_NAME))
+        .withName(StringUtils.format("%s-undeletable", KUBERNETES_JOB_NAME))
         .addToLabels("druid.k8s.peons", "true")
         .endMetadata()
         .withNewStatus()
@@ -443,13 +444,13 @@ public class KubernetesPeonClientTest
     Pod pod = new PodBuilder()
         .withNewMetadata()
         .withName(POD_NAME)
-        .addToLabels("job-name", JOB_NAME)
+        .addToLabels("job-name", KUBERNETES_JOB_NAME)
         .endMetadata()
         .build();
 
     client.pods().inNamespace(NAMESPACE).resource(pod).create();
 
-    Optional<Pod> maybePod = instance.getPeonPod(new K8sTaskId(ID));
+    Optional<Pod> maybePod = instance.getPeonPod(KUBERNETES_JOB_NAME);
 
     Assertions.assertTrue(maybePod.isPresent());
   }
@@ -457,7 +458,7 @@ public class KubernetesPeonClientTest
   @Test
   void test_getPeonPod_withoutPod_returnsEmptyOptional()
   {
-    Optional<Pod> maybePod = instance.getPeonPod(new K8sTaskId(ID));
+    Optional<Pod> maybePod = instance.getPeonPod(KUBERNETES_JOB_NAME);
     Assertions.assertFalse(maybePod.isPresent());
   }
 
@@ -465,23 +466,23 @@ public class KubernetesPeonClientTest
   void test_getPeonPodWithRetries_withPod_returnsPod()
   {
     server.expect().get()
-        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3Did")
+        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3D" + KUBERNETES_JOB_NAME)
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder().build())
         .once();
 
     server.expect().get()
-        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3Did")
+        .withPath("/api/v1/namespaces/namespace/pods?labelSelector=job-name%3D" + KUBERNETES_JOB_NAME)
         .andReturn(HttpURLConnection.HTTP_OK, new PodListBuilder()
             .addNewItem()
             .withNewMetadata()
             .withName(POD_NAME)
-            .addToLabels("job-name", JOB_NAME)
+            .addToLabels("job-name", KUBERNETES_JOB_NAME)
             .endMetadata()
             .endItem()
             .build()
         ).once();
 
-    Pod pod = instance.getPeonPodWithRetries(new K8sTaskId(ID));
+    Pod pod = instance.getPeonPodWithRetries(new K8sTaskId(ID).getK8sJobName());
 
     Assertions.assertNotNull(pod);
   }
@@ -491,7 +492,7 @@ public class KubernetesPeonClientTest
   {
     Assertions.assertThrows(
         KubernetesResourceNotFoundException.class,
-        () -> instance.getPeonPodWithRetries(clientApi.getClient(), new K8sTaskId(ID), 1, 1),
+        () -> instance.getPeonPodWithRetries(clientApi.getClient(), new K8sTaskId(ID).getK8sJobName(), 1, 1),
         StringUtils.format("K8s pod with label: job-name=%s not found", ID)
     );
   }
@@ -500,10 +501,10 @@ public class KubernetesPeonClientTest
   void test_getPeonLogsWatcher_withJob_returnsWatchLogInOptional()
   {
     server.expect().get()
-        .withPath("/apis/batch/v1/namespaces/namespace/jobs/id")
+        .withPath("/apis/batch/v1/namespaces/namespace/jobs/" + KUBERNETES_JOB_NAME)
         .andReturn(HttpURLConnection.HTTP_OK, new JobBuilder()
             .withNewMetadata()
-            .withName(JOB_NAME)
+            .withName(KUBERNETES_JOB_NAME)
             .withUid("uid")
             .endMetadata()
             .withNewSpec()

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -159,7 +159,7 @@ public class DruidPeonClientIntegrationTest
 
     // now copy the task.json file from the pod and make sure its the same as our task.json we expected
     Path downloadPath = Paths.get(tempDir.toAbsolutePath().toString(), "task.json");
-    Pod mainJobPod = peonClient.getPeonPodWithRetries(taskId);
+    Pod mainJobPod = peonClient.getPeonPodWithRetries(taskId.getK8sJobName());
     k8sClient.executeRequest(client -> {
       client.pods()
             .inNamespace("default")

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/baseJobWithoutAnnotations.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/baseJobWithoutAnnotations.yaml
@@ -1,12 +1,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   template:
     metadata:
       labels:
-        job-name: id
+        job-name: id-3e70afe5cd823dfc7dd308eea616426b
       name: id-kmwkw
     spec:
       containers:

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedEphemeralOutput.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedEphemeralOutput.yaml
@@ -6,7 +6,7 @@ metadata:
     tls.enabled: "false"
   labels:
     druid.k8s.peons: "true"
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -60,6 +60,6 @@ spec:
               memory: "2400000000"
               cpu: "1000m"
               ephemeral-storage: 1Gi
-      hostname: "id"
+      hostname: "id-3e70afe5cd823dfc7dd308eea616426b"
       restartPolicy: "Never"
   ttlSecondsAfterFinished: 172800

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutput.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutput.yaml
@@ -6,7 +6,7 @@ metadata:
     tls.enabled: "false"
   labels:
     druid.k8s.peons: "true"
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -18,7 +18,7 @@ spec:
       labels:
         druid.k8s.peons: "true"
     spec:
-      hostname: "id"
+      hostname: "id-3e70afe5cd823dfc7dd308eea616426b"
       containers:
         - args:
             - "/kubexit/kubexit /bin/sh -c \"/peon.sh /druid/data/baseTaskDir/noop_2022-09-26T22:08:00.582Z_352988d2-5ff7-4b70-977c-3de96f9bfca6 1\""

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutputOrder.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedMultiContainerOutputOrder.yaml
@@ -6,7 +6,7 @@ metadata:
     tls.enabled: "false"
   labels:
     druid.k8s.peons: "true"
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -18,7 +18,7 @@ spec:
       labels:
         druid.k8s.peons: "true"
     spec:
-      hostname: "id"
+      hostname: "id-3e70afe5cd823dfc7dd308eea616426b"
       containers:
         - args:
             - "/kubexit/kubexit /bin/sh -c \"/peon.sh /druid/data/baseTaskDir/noop_2022-09-26T22:08:00.582Z_352988d2-5ff7-4b70-977c-3de96f9bfca6 1\""

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
   labels:
     druid.k8s.peons: "true"
     druid.task.id: "id"

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "apiissuedkillwikipedia3omjobnbc10000101t000000000z20230514t0000"
+  name: "apiissuedkillwikipedia3omjobnb-18ed64f09a02fab468b9bba38739871f"
   labels:
     druid.k8s.peons: "true"
     druid.task.id: "apiissuedkillwikipedia3omjobnbc10000101t000000000z20230514t0000"

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabled.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabled.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
   labels:
     druid.k8s.peons: "true"
     druid.task.id: "id"

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedPodSpec.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedPodSpec.yaml
@@ -6,7 +6,7 @@ metadata:
     tls.enabled: "false"
   labels:
     druid.k8s.peons: "true"
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -86,7 +86,7 @@ spec:
               name: "graveyard"
             - mountPath: "/kubexit"
               name: "kubexit"
-      hostname: "id"
+      hostname: "id-3e70afe5cd823dfc7dd308eea616426b"
       initContainers:
         - command:
             - "cp"

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedSingleContainerOutput.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedSingleContainerOutput.yaml
@@ -6,7 +6,7 @@ metadata:
     tls.enabled: "false"
   labels:
     druid.k8s.peons: "true"
-  name: "id"
+  name: "id-3e70afe5cd823dfc7dd308eea616426b"
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -18,7 +18,7 @@ spec:
       labels:
         druid.k8s.peons: "true"
     spec:
-      hostname: "id"
+      hostname: "id-3e70afe5cd823dfc7dd308eea616426b"
       containers:
         - args:
             - foo && bar


### PR DESCRIPTION
Fixes a issue where having data source names (or more generally task ids) that are too long cause the K8sTaskRunner to throw errors.

### Description

The K8sTaskRunner truncates task ids in order to get a valid K8s job name (less than 64 characters) and doing this can cause loss of uniquenes I fixed this by appending a 128 bit hash onto the end of the task id which i think should be sufficient to ensure uniqueness. (Change is in KubernetesOverlordUtils).

I also had to fix a related issue that was covered up by the fact that our truncation function can be applied repeatedly wihtout any affect.
The issue is the line in KubernetesPeonClient
K8sTaskId taskId = new K8sTaskId(job.getMetadata().getName());.
This takes the job name from the k8s api (which has already been truncated by our truncation function since it is a job name), and then passes it into the K8sTaskId constructor as the originalTaskId. The K8sTaskId calls the truncation function a second time to generate the k8sTaskId. This is okay when our truncation function just grabs the first 63 characters of the task id since repeatedly applying this won't do anything, but with my latest changes this is no longer the case.

I updated this logic to just use the job name directly from the kubernetes api (that's all it needs anyways) and I had to change a lot of function signatures to do this. I also explicitly changed the k8sTaskId field to k8sJobName since that's the only thing that field is used for.

This does make it slightly more confusing to find out which task a job corresponds to from a k8s client like k8s, but the PodTemplateTaskAdapter also applies the whole unmodified task id as a annotation.

#### Release note
- Fixes a issue where having data source names (or more generally task ids) that are too long cause the K8sTaskRunner to throw errors.
-->


<hr>

##### Key changed/added classes in this PR
 * `KubernetesOverlordUtils`
 * `KubernetesPeonClient`
 * `K8sTaskId`


This PR has:

- [ X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ X] been tested in a test Druid cluster.
