### PR TITLE
Web console: fix boolean segment filters

### DIFF
--- a/web-console/src/react-table/react-table-inputs.tsx
+++ b/web-console/src/react-table/react-table-inputs.tsx
@@ -94,19 +94,18 @@ export function GenericFilterInput({ column, filter, onChange, key }: FilterRend
 }
 
 export function BooleanFilterInput({ filter, onChange, key }: FilterRendererProps) {
-  const filterValue = filter ? filter.value : '';
   return (
     <HTMLSelect
       className="boolean-filter-input"
       key={key}
       style={{ width: '100%' }}
       onChange={(event: any) => onChange(event.target.value)}
-      value={filterValue || 'all'}
+      value={filter?.value || ''}
       fill
     >
-      <option value="all">Show all</option>
-      <option value="true">true</option>
-      <option value="false">false</option>
+      <option value="">Show all</option>
+      <option value="=true">true</option>
+      <option value="=false">false</option>
     </HTMLSelect>
   );
 }

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -199,7 +199,7 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
       visibleColumns.shown('Datasource') && `"datasource"`,
       `"start"`,
       `"end"`,
-      visibleColumns.shown('Version') && `"version"`,
+      `"version"`,
       visibleColumns.shown('Time span') &&
         `CASE
   WHEN "start" = '-146136543-09-08T08:23:32.096Z' AND "end" = '146140482-04-24T15:36:27.903Z' THEN 'All'
@@ -298,8 +298,16 @@ END AS "time_span"`,
                   return SqlComparison.like(shardSpecColumn, `%"type":"${modeAndNeedle.needle}%`);
               }
             } else if (f.id.startsWith('is_')) {
-              if (f.value === 'all') return;
-              return C(f.id).equal(f.value === 'true' ? 1 : 0);
+              switch (f.value) {
+                case '=false':
+                  return C(f.id).equal(0);
+
+                case '=true':
+                  return C(f.id).equal(1);
+
+                default:
+                  return;
+              }
             } else {
               return sqlQueryCustomTableFilter(f);
             }


### PR DESCRIPTION
Fixes two issues detected in the segments view:

1. Segment view issues an invalid query if `version` column is hidden: version column is now used as order by tie breaker and needs to always be queried for (in the CTE) even if it is not shown.
2. The boolean filters in the segments view (`is_available` and the other `is_*` columns) are broken with the new stateful filtering. 