### PR TITLE
Retention rules API documentation refactor

### DIFF
--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -33,7 +33,7 @@ In this topic, `http://ROUTER_IP:ROUTER_PORT` is a placeholder for your Router s
 
 Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the datasource does not exist.
+Note that this endpoint returns an `HTTP 200` even if the datasource does not exist.
 
 ### URL
 
@@ -76,19 +76,20 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/kttm1" \
 --header 'X-Druid-Comment: submitted via api' \
 --header 'Content-Type: application/json' \
 --data '[
-  {
-    "type": "broadcastForever"
-  },
-  {
-    "type": "loadForever",
-    "tieredReplicants": {
-      "_default_tier": 2
+    {
+        "type": "broadcastForever"
+    },
+    {
+        "type": "loadForever",
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "useDefaultTierForNull": true
+    },
+    {
+        "type": "dropByPeriod",
+        "period": "P1M"
     }
-  },
-  {
-    "type": "dropByPeriod",
-    "period": "P1M"
-  }
 ]'
 ```
 
@@ -103,19 +104,20 @@ Content-Type: application/json
 Content-Length: 192
 
 [
-  {
-    "type": "broadcastForever"
-  },
-  {
-    "type": "loadForever",
-    "tieredReplicants": {
-      "_default_tier": 2
+    {
+        "type": "broadcastForever"
+    },
+    {
+        "type": "loadForever",
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "useDefaultTierForNull": true
+    },
+    {
+        "type": "dropByPeriod",
+        "period": "P1M"
     }
-  },
-  {
-    "type": "dropByPeriod",
-    "period": "P1M"
-  }
 ]
 ```
 
@@ -280,9 +282,9 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 ## Get an array of retention rules for a datasource
 
-Retrieves an array of rule objects for a single datasource. If there are no retention rules, it returns an empty array. 
+Retrieves an array of rule objects for a single datasource. Returns an empty array if there are no retention rules.
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the datasource does not exist.
+Note that this endpoint returns an `HTTP 200` even if the datasource does not exist.
 
 ### URL
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -176,9 +176,7 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/_default" \
 --data '[
     {
         "type": "loadByInterval",
-        "tieredReplicants": {
-            "_default_tier": 2
-        },
+        "tieredReplicants": {},
         "useDefaultTierForNull": false,
         "interval": "2010-01-01/2020-01-01"
     }
@@ -196,9 +194,7 @@ Content-Length: 205
 [
     {
         "type": "loadByInterval",
-        "tieredReplicants": {
-            "_default_tier": 2
-        },
+        "tieredReplicants": {},
         "useDefaultTierForNull": false,
         "interval": "2010-01-01/2020-01-01"
     }

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -23,20 +23,21 @@ sidebar_label: Retention rules
   ~ under the License.
   -->
 
-This document describes the API endpoints for managing retention rules in Apache Druid.
+This topic describes the API endpoints for managing retention rules in Apache Druid. You can configure retention rules in the Druid web console or API.
 
 Druid uses retention rules to determine what data is retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
 
-In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the server address of deployment and the service port. For example, on the quickstart configuration, replace `http://ROUTER_IP:ROUTER_PORT` with `http://localhost:8888`.
+In this topic, `http://ROUTER_IP:ROUTER_PORT` is a place holder for your Router service address and port. Replace it with the information for your deployment. For example, use `http://localhost:8888` for quickstart deployments.
 
 ## Update retention rules for a datasource
 
 Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
+Note that this endpoint returns an `HTTP 200 Success` code message even if the datasource does not exist.
 
 ### URL
-<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/{datasource}`
+
+<code class="postAPI">POST</code> <code>/druid/coordinator/v1/rules/:datasource</code>
 
 ### Header parameters
 
@@ -54,7 +55,9 @@ The endpoint supports a set of optional header parameters to populate the `autho
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
+
 <br/>
+
 *Successfully updated retention rules for specified datasource* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -63,33 +66,36 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 ### Sample request
 
-The following example updates the retention rules for a datasource with specified ID `kttm1`.
+The following example updates the retention rules for a datasource with the name `kttm1`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--cURL-->
+
 ```shell
 curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/kttm1" \
---header "X-Druid-Author: doc intern" \
---header "X-Druid-Comment: submitted via api" \
---header "Content-Type: application/json" \
---data "[
+--header 'X-Druid-Author: doc intern' \
+--header 'X-Druid-Comment: submitted via api' \
+--header 'Content-Type: application/json' \
+--data '[
   {
-    \"type\": \"broadcastForever\"
+    "type": "broadcastForever"
   },
   {
-    \"type\": \"loadForever\",
-    \"tieredReplicants\": {
-      \"_default_tier\": 2
+    "type": "loadForever",
+    "tieredReplicants": {
+      "_default_tier": 2
     }
   },
   {
-    \"type\": \"dropByPeriod\",
-    \"period\": \"P1M\"
+    "type": "dropByPeriod",
+    "period": "P1M"
   }
-]"
+]'
 ```
+
 <!--HTTP-->
+
 ```HTTP
 POST /druid/coordinator/v1/rules/kttm1 HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
@@ -114,6 +120,7 @@ Content-Length: 192
   }
 ]
 ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Sample response
@@ -126,7 +133,7 @@ Update one or more default retention rules for all datasources. Retention rules 
 
 ### URL
 
-<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/_default`
+<code class="postAPI">POST</code> <code>/druid/coordinator/v1/rules/_default</code>
 
 ### Header parameters
 
@@ -144,10 +151,15 @@ The endpoint supports a set of optional header parameters to populate the `autho
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
+
 <br/>
+
 *Successfully updated default retention rules* 
+
 <!--500 SERVER ERROR-->
+
 <br/>
+
 *Error with request body* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -155,28 +167,32 @@ The endpoint supports a set of optional header parameters to populate the `autho
 ---
 
 ### Sample request
+
 The following example updates the default retention rule for all datasources with two new rules, `dropByPeriod` and `broadcastByPeriod`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--cURL-->
+
 ```shell
 curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/_default" \
---header "Content-Type: application/json" \
---data "[
+--header 'Content-Type: application/json' \
+--data '[
     {
-        \"type\": \"dropByPeriod\",
-        \"period\": \"P1M\",
-        \"includeFuture\": true
+        "type": "dropByPeriod",
+        "period": "P1M",
+        "includeFuture": true
     },
     {
-        \"type\": \"broadcastByPeriod\",
-        \"period\": \"P1M\",
-        \"includeFuture\": true
+        "type": "broadcastByPeriod",
+        "period": "P1M",
+        "includeFuture": true
     }
-]"
+]'
 ```
+
 <!--HTTP-->
+
 ```HTTP
 POST /druid/coordinator/v1/rules/_default HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
@@ -196,12 +212,12 @@ Content-Length: 207
     }
 ]
 ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Sample response
 
 A successful request returns an HTTP `200 OK` and an empty response body.
-
 
 ## Get an array of all retention rules
 
@@ -209,14 +225,16 @@ Retrieves all current retention rules in the cluster including the default reten
 
 ### URL
 
-<code class="getAPI">GET</code> `/druid/coordinator/v1/rules`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/rules</code>
 
 ### Responses
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
+
 <br/>
+
 *Successfully retrieved retention rules* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -228,14 +246,18 @@ Retrieves all current retention rules in the cluster including the default reten
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--cURL-->
+
 ```shell
 curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules"
 ```
+
 <!--HTTP-->
+
 ```HTTP
 GET /druid/coordinator/v1/rules HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
 ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Sample response
@@ -268,13 +290,14 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 Retrieves an array of rule objects for a single datasource. If there are no retention rules, it returns an empty array. 
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
+Note that this endpoint returns an `HTTP 200 Success` code message even if the datasource does not exist.
 
 ### URL
 
-<code class="getAPI">GET</code> `/druid/coordinator/v1/rules/{dataSource}`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/rules/:datasource</code>
 
 ### Query parameters
+
 * `full` (optional)
   * Include the default retention rule for the datasource in the response.
 
@@ -283,7 +306,9 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the `
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
+
 <br/>
+
 *Successfully retrieved retention rules* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -292,19 +317,23 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the `
 
 ### Sample request
 
-The following example retrieves the custom retention rules and default retention rules for datasource with specified ID `social_media`.
+The following example retrieves the custom retention rules and default retention rules for datasource with the name `social_media`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--cURL-->
+
 ```shell
 curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/social_media?full=null"
 ```
+
 <!--HTTP-->
+
 ```HTTP
 GET /druid/coordinator/v1/rules/social_media?full=null HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
 ```
+
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Sample response
@@ -333,15 +362,16 @@ Host: http://ROUTER_IP:ROUTER_PORT
     }
 ]
   ```
+
 </details>
 
 ## Get audit history for all datasources
 
-Retrieves the audit history of rules for all datasources over an interval of time. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+Retrieves the audit history of rules for all datasources over an interval of time. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in the `runtime.properties` file for the Coordinator.
 
 ### URL
 
-<code class="getAPI">GET</code> `/druid/coordinator/v1/rules/history`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/rules/history</code>
 
 ### Query parameters
 
@@ -359,13 +389,21 @@ Note that the following query parameters cannot be chained.
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
+
 <br/>
+
 *Successfully retrieved audit history* 
+
 <!--400 BAD REQUEST-->
+
 <br/>
+
 *Request in the incorrect format* 
+
 <!--404 NOT FOUND-->
+
 <br/>
+
 *`count` query parameter too large* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -373,19 +411,24 @@ Note that the following query parameters cannot be chained.
 ---
 
 ### Sample request
+
 The following example retrieves the audit history for all datasources from `2023-07-13` to `2023-07-19`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--cURL-->
+
 ```shell
 curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/history?interval=2023-07-13%2F2023-07-19"
 ```
+
 <!--HTTP-->
+
 ```HTTP
 GET /druid/coordinator/v1/rules/history?interval=2023-07-13/2023-07-19 HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
 ```
+ 
 <!--END_DOCUSAURUS_CODE_TABS-->
 
 ### Sample response

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -25,19 +25,26 @@ sidebar_label: Retention rules
 
 This topic describes the API endpoints for managing retention rules in Apache Druid. You can configure retention rules in the Druid web console or API.
 
-Druid uses retention rules to determine what data is retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
+Druid uses retention rules to determine what data is retained in the cluster. Druid supports load, drop, and broadcast rules. For more information, see [Using rules to drop and retain data](../operations/rule-configuration.md).
 
 In this topic, `http://ROUTER_IP:ROUTER_PORT` is a placeholder for your Router service address and port. Replace it with the information for your deployment. For example, use `http://localhost:8888` for quickstart deployments.
 
 ## Update retention rules for a datasource
 
-Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
+Updates one or more retention rules for a datasource. The request body takes an array of retention rule objects. For details on defining retention rules, see the following sources:
 
-Note that this endpoint returns an `HTTP 200` even if the datasource does not exist.
+* [Load rules](../operations/rule-configuration.md#load-rules)
+* [Drop rules](../operations/rule-configuration.md#drop-rules)
+* [Broadcast rules](../operations/rule-configuration.md#broadcast-rules)
+
+This request overwrites any existing rules for the datasource.
+Druid reads rules in the order in which they appear; for more information, see [rule structure](../operations/rule-configuration.md).
+
+Note that this endpoint returns an HTTP `200 OK` even if the datasource does not exist.
 
 ### URL
 
-<code class="postAPI">POST</code> <code>/druid/coordinator/v1/rules/:datasource</code>
+<code class="postAPI">POST</code> <code>/druid/coordinator/v1/rules/:dataSource</code>
 
 ### Header parameters
 
@@ -125,11 +132,17 @@ Content-Length: 273
 
 ### Sample response
 
-A successful request returns an HTTP `200 OK` and an empty response body.
+A successful request returns an HTTP `200 OK` message code and an empty response body.
 
 ## Update default retention rules for all datasources
 
-Update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
+Updates one or more default retention rules for all datasources. Submit retention rules as an array of objects in the request body. For details on defining retention rules, see the following sources:
+
+* [Load rules](../operations/rule-configuration.md#load-rules)
+* [Drop rules](../operations/rule-configuration.md#drop-rules)
+* [Broadcast rules](../operations/rule-configuration.md#broadcast-rules)
+
+This request overwrites any existing rules for all datasources. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear; for more information, see [rule structure](../operations/rule-configuration.md).
 
 ### URL
 
@@ -205,11 +218,11 @@ Content-Length: 205
 
 ### Sample response
 
-A successful request returns an HTTP `200 OK` and an empty response body.
+A successful request returns an HTTP `200 OK` message code and an empty response body.
 
 ## Get an array of all retention rules
 
-Retrieves all current retention rules in the cluster including the default retention rule. Returns an array of objects for each datasource and their associated retention rule.
+Retrieves all current retention rules in the cluster including the default retention rule. Returns an array of objects for each datasource and their associated retention rules.
 
 ### URL
 
@@ -276,16 +289,16 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 Retrieves an array of rule objects for a single datasource. Returns an empty array if there are no retention rules.
 
-Note that this endpoint returns an `HTTP 200` even if the datasource does not exist.
+Note that this endpoint returns an HTTP `200 OK` message code even if the datasource does not exist.
 
 ### URL
 
-<code class="getAPI">GET</code> <code>/druid/coordinator/v1/rules/:datasource</code>
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/rules/:dataSource</code>
 
 ### Query parameters
 
 * `full` (optional)
-  * Include the default retention rule for the datasource in the response.
+  * Includes the default retention rule for the datasource in the response.
 
 ### Responses
 
@@ -351,7 +364,7 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 ## Get audit history for all datasources
 
-Retrieves the audit history of rules for all datasources over an interval of time. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in the `runtime.properties` file for the Coordinator.
+Retrieves the audit history of rules for all datasources over an interval of time. The default interval is 1 week. You can change this period by setting `druid.audit.manager.auditHistoryMillis` in the `runtime.properties` file for the Coordinator.
 
 ### URL
 
@@ -363,10 +376,10 @@ Note that the following query parameters cannot be chained.
 
 * `interval` (optional)
   * Type: ISO 8601.
-  * Limit the number of results to the specified time interval. Delimit with `/`. For example, `2023-07-13/2023-07-19`.
+  * Limits the number of results to the specified time interval. Delimit with `/`. For example, `2023-07-13/2023-07-19`.
 * `count` (optional)
   * Type: Int
-  * Limit the number of results to the last `n` entries.
+  * Limits the number of results to the last `n` entries.
 
 ### Responses
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -31,7 +31,7 @@ In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the serv
 
 ## Create or update retention rules for a datasource
 
-Update a datasource with a list of rules. Retention rules can be submitted as an array of rule objects in the request body. The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
+Update a datasource with a list of rules. Retention rules can be submitted as an array of rule objects in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information. The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
 
 Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
 
@@ -60,6 +60,8 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the `
 ---
 
 ### Sample request
+
+The following example updates the retention rules for a datasource with specified ID `kttm1`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -118,7 +120,7 @@ A successful request returns an HTTP `200 OK` and empty response body.
 
 ## Create or update default retention rules for all datasources
 
-Create or update one or more default retention rules for all datasources. To remove default retention rules for all datasources, submit an empty rule array in the request body. 
+Create or update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
 The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
 
@@ -201,7 +203,7 @@ A successful request returns an HTTP `200 OK` and empty response body.
 
 ## Get an array of all retention rules
 
-Retrieves all current retention rules in the cluster including the default retention rule. The response object is an array of objects for each datasource with a retention rule.
+Retrieves all current retention rules in the cluster including the default retention rule. The response object is an array of objects for each datasource and their associated retention rule.
 
 ### URL
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -25,45 +25,375 @@ sidebar_label: Retention rules
 
 This document describes the API endpoints for managing retention rules in Apache Druid.
 
-## Retention rules
+In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the server address of deployment and the service port. For example, on the quickstart configuration, replace `http://ROUTER_IP:ROUTER_PORT` with `http://localhost:8888`.
 
-Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` instead of a `/` as in `2016-06-27_2016-06-28`.
+## Create retention rules for a datasource or update a datasource's retention rules
 
-`GET /druid/coordinator/v1/rules`
+Update a datasource with a list of rules. The retention rules can be submitted as an array of rule objects in the request body. 
 
-Returns all rules as JSON objects for all datasources in the cluster including the default datasource.
+Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
 
-`GET /druid/coordinator/v1/rules/{dataSourceName}`
+### URL
+<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/{dataSource}`
 
-Returns all rules for a specified datasource.
+### Header parameters
 
-`GET /druid/coordinator/v1/rules/{dataSourceName}?full`
+* `X-Druid-Author`
+  * Type: String
+  * A string representing the author making the configuration change.
+* `X-Druid-Comment`
+  * Type: String
+  * A string describing the change being done.
 
-Returns all rules for a specified datasource and includes default datasource.
+### Responses
 
-`GET /druid/coordinator/v1/rules/history?interval=<interval>`
+<!--DOCUSAURUS_CODE_TABS-->
 
-Returns audit history of rules for all datasources. Default value of interval can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+<!--200 SUCCESS-->
+<br/>
+*Successfully updated retention rules for specified datasource* 
 
-`GET /druid/coordinator/v1/rules/history?count=<n>`
+<!--END_DOCUSAURUS_CODE_TABS-->
 
-Returns last `n` entries of audit history of rules for all datasources.
+---
 
-`GET /druid/coordinator/v1/rules/{dataSourceName}/history?interval=<interval>`
+### Sample request
 
-Returns audit history of rules for a specified datasource. Default value of interval can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+<!--DOCUSAURUS_CODE_TABS-->
 
-`GET /druid/coordinator/v1/rules/{dataSourceName}/history?count=<n>`
+<!--cURL-->
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/kttm1" \
+--header "X-Druid-Author: doc intern" \
+--header "X-Druid-Comment: submitted via api" \
+--header "Content-Type: application/json" \
+--data "[
+  {
+    \"type\": \"broadcastForever\"
+  },
+  {
+    \"type\": \"loadForever\",
+    \"tieredReplicants\": {
+      \"_default_tier\": 2
+    }
+  },
+  {
+    \"type\": \"dropByPeriod\",
+    \"period\": \"P1M\"
+  }
+]"
+```
+<!--HTTP-->
+```HTTP
+POST /druid/coordinator/v1/rules/kttm1 HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+X-Druid-Author: doc intern
+X-Druid-Comment: submitted via api
+Content-Type: application/json
+Content-Length: 192
 
-Returns last `n` entries of audit history of rules for a specified datasource.
+[
+  {
+    "type": "broadcastForever"
+  },
+  {
+    "type": "loadForever",
+    "tieredReplicants": {
+      "_default_tier": 2
+    }
+  },
+  {
+    "type": "dropByPeriod",
+    "period": "P1M"
+  }
+]
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
-`POST /druid/coordinator/v1/rules/{dataSourceName}`
+### Sample response
 
-POST with a list of rules in JSON form to update rules.
+A successful request returns an HTTP `200 OK` and empty response body.
 
-Optional Header Parameters for auditing the config change can also be specified.
+## Get all retention rules
 
-|Header Param Name| Description | Default |
-|----------|-------------|---------|
-|`X-Druid-Author`| Author making the config change|`""`|
-|`X-Druid-Comment`| Comment describing the change being done|`""`|
+Retrieves all current retention rules in the cluster including the default retention rule. The response object is an array of objects for each datasource with a retention rule.
+
+### URL
+
+<code class="getAPI">GET</code> `/druid/coordinator/v1/rules`
+
+### Responses
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--200 SUCCESS-->
+<br/>
+*Successfully retrieved retention rules* 
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+---
+
+### Sample request
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--cURL-->
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules"
+```
+<!--HTTP-->
+```HTTP
+GET /druid/coordinator/v1/rules HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Sample response
+
+<details>
+  <summary>Click to show sample response</summary>
+
+  ```json
+{
+    "_default": [
+        {
+            "tieredReplicants": {
+                "_default_tier": 2
+            },
+            "type": "loadForever"
+        }
+    ],
+    "social_media": [
+        {
+            "interval": "2023-01-01T00:00:00.000Z/2023-02-01T00:00:00.000Z",
+            "type": "dropByInterval"
+        }
+    ],
+    "wikipedia_api": [],
+}
+  ```
+</details>
+
+## Get an array of retention rules for a datasource
+
+Retrieves an array of rule objects for a single datasource. If there are no retention rules, it returns an empty array. 
+
+Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
+
+### URL
+
+<code class="getAPI">GET</code> `/druid/coordinator/v1/rules/{dataSource}`
+
+### Query parameters
+* `full` (optional)
+  * Include the default retention rule for the datasource in the response.
+
+### Responses
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--200 SUCCESS-->
+<br/>
+*Successfully retrieved retention rules* 
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+---
+
+### Sample request
+
+The following example retrieves retention rules for datasource with specified ID `social_media`.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--cURL-->
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/social_media?full=null"
+```
+<!--HTTP-->
+```HTTP
+GET /druid/coordinator/v1/rules/social_media?full=null HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Sample response
+
+<details>
+  <summary>Click to show sample response</summary>
+
+  ```json
+[
+    {
+        "interval": "2020-01-01T00:00:00.000Z/2022-02-01T00:00:00.000Z",
+        "type": "dropByInterval"
+    },
+    {
+        "interval": "2010-01-01T00:00:00.000Z/2020-01-01T00:00:00.000Z",
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "type": "loadByInterval"
+    },
+    {
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "type": "loadForever"
+    }
+]
+  ```
+</details>
+
+## Get audit history for all datasources
+
+Retrieves the audit history of rules for all datasources. 
+
+### URL
+
+`GET /druid/coordinator/v1/rules/history`
+
+### Query parameters
+
+Note that the following query parameters cannot be chained.
+
+* `inverval` (optional)
+  * Type: ISO 8601 delimited with `/`. For example, `2023-07-13/2023-07-19`.
+  * Limit the number of results to the specified time interval. Default value of interval can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+* `count` (optional)
+  * Type: Int
+  * Limit the number of results to the last `n` entries.
+
+### Responses
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--200 SUCCESS-->
+<br/>
+*Successfully retrieved audit history* 
+<!--400 BAD REQUEST-->
+<br/>
+*Request in incorrect format* 
+<!--404 NOT FOUND-->
+<br/>
+*`count` query parameter too large* 
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+---
+
+### Sample request
+The following example retrieves the audit history for all datasources from `2023-07-13` to `2023-07-19`.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--cURL-->
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/history?interval=2023-07-13%2F2023-07-19"
+```
+<!--HTTP-->
+```HTTP
+GET /druid/coordinator/v1/rules/history?interval=2023-07-13/2023-07-19 HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Sample response
+
+<details>
+  <summary>Click to show sample response</summary>
+
+  ```json
+[
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"interval\":\"2023-01-01T00:00:00.000Z/2023-02-01T00:00:00.000Z\",\"type\":\"dropByInterval\"}]",
+        "auditTime": "2023-07-13T18:05:33.066Z"
+    },
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[]",
+        "auditTime": "2023-07-18T18:10:21.203Z"
+    },
+    {
+        "key": "wikipedia_api",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"tieredReplicants\":{\"_default_tier\":2},\"type\":\"loadForever\"}]",
+        "auditTime": "2023-07-18T18:10:44.519Z"
+    },
+    {
+        "key": "wikipedia_api",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[]",
+        "auditTime": "2023-07-18T18:11:02.110Z"
+    },
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"interval\":\"2023-07-03T18:49:54.848Z/2023-07-03T18:49:55.861Z\",\"type\":\"dropByInterval\"}]",
+        "auditTime": "2023-07-18T18:32:50.060Z"
+    },
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"interval\":\"2020-01-01T00:00:00.000Z/2022-02-01T00:00:00.000Z\",\"type\":\"dropByInterval\"}]",
+        "auditTime": "2023-07-18T18:34:09.657Z"
+    },
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"interval\":\"2020-01-01T00:00:00.000Z/2022-02-01T00:00:00.000Z\",\"type\":\"dropByInterval\"},{\"tieredReplicants\":{\"_default_tier\":2},\"type\":\"loadForever\"}]",
+        "auditTime": "2023-07-18T18:38:37.223Z"
+    },
+    {
+        "key": "social_media",
+        "type": "rules",
+        "auditInfo": {
+            "author": "console",
+            "comment": "test",
+            "ip": "127.0.0.1"
+        },
+        "payload": "[{\"interval\":\"2020-01-01T00:00:00.000Z/2022-02-01T00:00:00.000Z\",\"type\":\"dropByInterval\"},{\"interval\":\"2010-01-01T00:00:00.000Z/2020-01-01T00:00:00.000Z\",\"tieredReplicants\":{\"_default_tier\":2},\"type\":\"loadByInterval\"}]",
+        "auditTime": "2023-07-18T18:49:43.964Z"
+    }
+]
+  ```
+</details>

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -25,13 +25,13 @@ sidebar_label: Retention rules
 
 This document describes the API endpoints for managing retention rules in Apache Druid.
 
-Druid uses retention rules to determine what data should be retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
+Druid uses retention rules to determine what data is retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
 
 In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the server address of deployment and the service port. For example, on the quickstart configuration, replace `http://ROUTER_IP:ROUTER_PORT` with `http://localhost:8888`.
 
 ## Update retention rules for a datasource
 
-Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrites any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
+Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
 Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
 
@@ -118,11 +118,11 @@ Content-Length: 192
 
 ### Sample response
 
-A successful request returns an HTTP `200 OK` and empty response body.
+A successful request returns an HTTP `200 OK` and an empty response body.
 
 ## Update default retention rules for all datasources
 
-Update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body and overwrites any existing rules for the datasource. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
+Update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body and overwrite any existing rules for the datasource. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
 ### URL
 
@@ -200,7 +200,7 @@ Content-Length: 207
 
 ### Sample response
 
-A successful request returns an HTTP `200 OK` and empty response body.
+A successful request returns an HTTP `200 OK` and an empty response body.
 
 
 ## Get an array of all retention rules
@@ -349,7 +349,7 @@ Note that the following query parameters cannot be chained.
 
 * `inverval` (optional)
   * Type: ISO 8601 delimited with `/`. For example, `2023-07-13/2023-07-19`.
-  * Limit the number of results to the specified time interval. Default value of interval can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+  * Limit the number of results to the specified time interval. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
 * `count` (optional)
   * Type: Int
   * Limit the number of results to the last `n` entries.
@@ -363,7 +363,7 @@ Note that the following query parameters cannot be chained.
 *Successfully retrieved audit history* 
 <!--400 BAD REQUEST-->
 <br/>
-*Request in incorrect format* 
+*Request in the incorrect format* 
 <!--404 NOT FOUND-->
 <br/>
 *`count` query parameter too large* 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -56,8 +56,6 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 <!--200 SUCCESS-->
 
-<br/>
-
 *Successfully updated retention rules for specified datasource* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -152,13 +150,9 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 <!--200 SUCCESS-->
 
-<br/>
-
 *Successfully updated default retention rules* 
 
 <!--500 SERVER ERROR-->
-
-<br/>
 
 *Error with request body* 
 
@@ -233,8 +227,6 @@ Retrieves all current retention rules in the cluster including the default reten
 
 <!--200 SUCCESS-->
 
-<br/>
-
 *Successfully retrieved retention rules* 
 
 <!--END_DOCUSAURUS_CODE_TABS-->
@@ -306,8 +298,6 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the d
 <!--DOCUSAURUS_CODE_TABS-->
 
 <!--200 SUCCESS-->
-
-<br/>
 
 *Successfully retrieved retention rules* 
 
@@ -390,19 +380,13 @@ Note that the following query parameters cannot be chained.
 
 <!--200 SUCCESS-->
 
-<br/>
-
 *Successfully retrieved audit history* 
 
 <!--400 BAD REQUEST-->
 
-<br/>
-
 *Request in the incorrect format* 
 
 <!--404 NOT FOUND-->
-
-<br/>
 
 *`count` query parameter too large* 
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -25,27 +25,29 @@ sidebar_label: Retention rules
 
 This document describes the API endpoints for managing retention rules in Apache Druid.
 
-Druid uses retention rules to determine what data should be retained in the cluster. Druid supports load, drop, and broadcast rules. For reference, see [using rules to drop and retain data](../operations/rule-configuration.md). 
+Druid uses retention rules to determine what data should be retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
 
 In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the server address of deployment and the service port. For example, on the quickstart configuration, replace `http://ROUTER_IP:ROUTER_PORT` with `http://localhost:8888`.
 
-## Create or update retention rules for a datasource
+## Update retention rules for a datasource
 
-Update a datasource with a list of rules. Retention rules can be submitted as an array of rule objects in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information. The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
+Update one or more retention rules for a datasource. Retention rules can be submitted as an array of rule objects in the request body and overwrites any existing rules for the datasource. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
+Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
 
 ### URL
 <code class="postAPI">POST</code> `/druid/coordinator/v1/rules/{dataSource}`
 
 ### Header parameters
 
-* `X-Druid-Author`
+The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property for audit history. 
+
+* `X-Druid-Author`(optional)
   * Type: String
   * A string representing the author making the configuration change.
-* `X-Druid-Comment`
+* `X-Druid-Comment` (optional)
   * Type: String
-  * A string describing the change being done.
+  * A string describing the update.
 
 ### Responses
 
@@ -118,11 +120,9 @@ Content-Length: 192
 
 A successful request returns an HTTP `200 OK` and empty response body.
 
-## Create or update default retention rules for all datasources
+## Update default retention rules for all datasources
 
-Create or update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
-
-The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
+Update one or more default retention rules for all datasources. Retention rules can be submitted as an array of rule objects in the request body and overwrites any existing rules for the datasource. To remove default retention rules for all datasources, submit an empty rule array in the request body. Rules are read in the order in which they appear, see [rule structure](../operations/rule-configuration.md) for more information.
 
 ### URL
 
@@ -130,12 +130,14 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 ### Header parameters
 
-* `X-Druid-Author`
+The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property for audit history.  
+
+* `X-Druid-Author` (optional)
   * Type: String
   * A string representing the author making the configuration change.
-* `X-Druid-Comment`
+* `X-Druid-Comment` (optional)
   * Type: String
-  * A string describing the change being done.
+  * A string describing the update.
 
 ### Responses
 
@@ -266,7 +268,7 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 Retrieves an array of rule objects for a single datasource. If there are no retention rules, it returns an empty array. 
 
-Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
+Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
 
 ### URL
 
@@ -339,7 +341,7 @@ Retrieves the audit history of rules for all datasources.
 
 ### URL
 
-`GET /druid/coordinator/v1/rules/history`
+<code class="getAPI">GET</code> `/druid/coordinator/v1/rules/history`
 
 ### Query parameters
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -42,7 +42,7 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the `
 
 The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property for audit history. 
 
-* `X-Druid-Author`(optional)
+* `X-Druid-Author` (optional)
   * Type: String
   * A string representing the author making the configuration change.
 * `X-Druid-Comment` (optional)
@@ -337,7 +337,7 @@ Host: http://ROUTER_IP:ROUTER_PORT
 
 ## Get audit history for all datasources
 
-Retrieves the audit history of rules for all datasources. 
+Retrieves the audit history of rules for all datasources over an interval of time. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
 
 ### URL
 
@@ -348,8 +348,8 @@ Retrieves the audit history of rules for all datasources.
 Note that the following query parameters cannot be chained.
 
 * `inverval` (optional)
-  * Type: ISO 8601 delimited with `/`. For example, `2023-07-13/2023-07-19`.
-  * Limit the number of results to the specified time interval. The default value of `interval` can be specified by setting `druid.audit.manager.auditHistoryMillis` (1 week if not configured) in Coordinator `runtime.properties`.
+  * Type: ISO 8601.
+  * Limit the number of results to the specified time interval. Delimit with `/`. For example, `2023-07-13/2023-07-19`.
 * `count` (optional)
   * Type: Int
   * Limit the number of results to the last `n` entries.

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -101,7 +101,7 @@ Host: http://ROUTER_IP:ROUTER_PORT
 X-Druid-Author: doc intern
 X-Druid-Comment: submitted via api
 Content-Type: application/json
-Content-Length: 192
+Content-Length: 273
 
 [
     {
@@ -110,7 +110,7 @@ Content-Length: 192
     {
         "type": "loadForever",
         "tieredReplicants": {
-            "_default_tier": 2
+            "_default_tier": 1
         },
         "useDefaultTierForNull": true
     },
@@ -164,7 +164,7 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 ### Sample request
 
-The following example updates the default retention rule for all datasources with two new rules, `dropByPeriod` and `broadcastByPeriod`.
+The following example updates the default retention rule for all datasources with a `loadByInterval` rule.
 
 <!--DOCUSAURUS_CODE_TABS-->
 
@@ -175,14 +175,12 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/_default" \
 --header 'Content-Type: application/json' \
 --data '[
     {
-        "type": "dropByPeriod",
-        "period": "P1M",
-        "includeFuture": true
-    },
-    {
-        "type": "broadcastByPeriod",
-        "period": "P1M",
-        "includeFuture": true
+        "type": "loadByInterval",
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "useDefaultTierForNull": false,
+        "interval": "2010-01-01/2020-01-01"
     }
 ]'
 ```
@@ -193,18 +191,16 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/_default" \
 POST /druid/coordinator/v1/rules/_default HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
 Content-Type: application/json
-Content-Length: 207
+Content-Length: 205
 
 [
     {
-        "type": "dropByPeriod",
-        "period": "P1M",
-        "includeFuture": true
-    },
-    {
-        "type": "broadcastByPeriod",
-        "period": "P1M",
-        "includeFuture": true
+        "type": "loadByInterval",
+        "tieredReplicants": {
+            "_default_tier": 2
+        },
+        "useDefaultTierForNull": false,
+        "interval": "2010-01-01/2020-01-01"
     }
 ]
 ```

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -36,7 +36,7 @@ Update one or more retention rules for a datasource. Retention rules can be subm
 Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` does not exist.
 
 ### URL
-<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/{dataSource}`
+<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/{datasource}`
 
 ### Header parameters
 
@@ -205,7 +205,7 @@ A successful request returns an HTTP `200 OK` and an empty response body.
 
 ## Get an array of all retention rules
 
-Retrieves all current retention rules in the cluster including the default retention rule. The response object is an array of objects for each datasource and their associated retention rule.
+Retrieves all current retention rules in the cluster including the default retention rule. Returns an array of objects for each datasource and their associated retention rule.
 
 ### URL
 
@@ -347,7 +347,7 @@ Retrieves the audit history of rules for all datasources over an interval of tim
 
 Note that the following query parameters cannot be chained.
 
-* `inverval` (optional)
+* `interval` (optional)
   * Type: ISO 8601.
   * Limit the number of results to the specified time interval. Delimit with `/`. For example, `2023-07-13/2023-07-19`.
 * `count` (optional)

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -25,11 +25,13 @@ sidebar_label: Retention rules
 
 This document describes the API endpoints for managing retention rules in Apache Druid.
 
+Druid uses retention rules to determine what data should be retained in the cluster. Druid supports load, drop, and broadcast rules. For reference, see [using rules to drop and retain data](../operations/rule-configuration.md). 
+
 In this document, `http://SERVICE_IP:SERVICE_PORT` is a placeholder for the server address of deployment and the service port. For example, on the quickstart configuration, replace `http://ROUTER_IP:ROUTER_PORT` with `http://localhost:8888`.
 
-## Create retention rules for a datasource or update a datasource's retention rules
+## Create or update retention rules for a datasource
 
-Update a datasource with a list of rules. The retention rules can be submitted as an array of rule objects in the request body. 
+Update a datasource with a list of rules. Retention rules can be submitted as an array of rule objects in the request body. The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
 
 Note that this endpoint returns an `HTTP 200 Success` code message even if the `datasource` is invalid.
 
@@ -114,7 +116,90 @@ Content-Length: 192
 
 A successful request returns an HTTP `200 OK` and empty response body.
 
-## Get all retention rules
+## Create or update default retention rules for all datasources
+
+Create or update one or more default retention rules for all datasources. To remove default retention rules for all datasources, submit an empty rule array in the request body. 
+
+The endpoint supports a set of optional header parameters to populate the `author` and `comment` fields in the `auditInfo` property retrieved in audit history. 
+
+### URL
+
+<code class="postAPI">POST</code> `/druid/coordinator/v1/rules/_default`
+
+### Header parameters
+
+* `X-Druid-Author`
+  * Type: String
+  * A string representing the author making the configuration change.
+* `X-Druid-Comment`
+  * Type: String
+  * A string describing the change being done.
+
+### Responses
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--200 SUCCESS-->
+<br/>
+*Successfully updated default retention rules* 
+<!--500 SERVER ERROR-->
+<br/>
+*Error with request body* 
+
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+---
+
+### Sample request
+The following example updates the default retention rule for all datasources with two new rules, `dropByPeriod` and `broadcastByPeriod`.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--cURL-->
+```shell
+curl "http://ROUTER_IP:ROUTER_PORT/druid/coordinator/v1/rules/_default" \
+--header "Content-Type: application/json" \
+--data "[
+    {
+        \"type\": \"dropByPeriod\",
+        \"period\": \"P1M\",
+        \"includeFuture\": true
+    },
+    {
+        \"type\": \"broadcastByPeriod\",
+        \"period\": \"P1M\",
+        \"includeFuture\": true
+    }
+]"
+```
+<!--HTTP-->
+```HTTP
+POST /druid/coordinator/v1/rules/_default HTTP/1.1
+Host: http://ROUTER_IP:ROUTER_PORT
+Content-Type: application/json
+Content-Length: 207
+
+[
+    {
+        "type": "dropByPeriod",
+        "period": "P1M",
+        "includeFuture": true
+    },
+    {
+        "type": "broadcastByPeriod",
+        "period": "P1M",
+        "includeFuture": true
+    }
+]
+```
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+### Sample response
+
+A successful request returns an HTTP `200 OK` and empty response body.
+
+
+## Get an array of all retention rules
 
 Retrieves all current retention rules in the cluster including the default retention rule. The response object is an array of objects for each datasource with a retention rule.
 
@@ -203,7 +288,7 @@ Note that this endpoint returns an `HTTP 200 Success` code message even if the `
 
 ### Sample request
 
-The following example retrieves retention rules for datasource with specified ID `social_media`.
+The following example retrieves the custom retention rules and default retention rules for datasource with specified ID `social_media`.
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/docs/api-reference/retention-rules-api.md
+++ b/docs/api-reference/retention-rules-api.md
@@ -27,7 +27,7 @@ This topic describes the API endpoints for managing retention rules in Apache Dr
 
 Druid uses retention rules to determine what data is retained in the cluster. Druid supports load, drop, and broadcast rules. See [using rules to drop and retain data](../operations/rule-configuration.md) for more information. 
 
-In this topic, `http://ROUTER_IP:ROUTER_PORT` is a place holder for your Router service address and port. Replace it with the information for your deployment. For example, use `http://localhost:8888` for quickstart deployments.
+In this topic, `http://ROUTER_IP:ROUTER_PORT` is a placeholder for your Router service address and port. Replace it with the information for your deployment. For example, use `http://localhost:8888` for quickstart deployments.
 
 ## Update retention rules for a datasource
 
@@ -64,7 +64,7 @@ The endpoint supports a set of optional header parameters to populate the `autho
 
 ### Sample request
 
-The following example updates the retention rules for a datasource with the name `kttm1`.
+The following example sets a set of broadcast, load, and drop retention rules for the `kttm1` datasource.
 
 <!--DOCUSAURUS_CODE_TABS-->
 


### PR DESCRIPTION
Update the retention rules API documentation page

Preview: https://druid-git-retention-rules-api-refactor-demo-kratia.vercel.app/docs/api-reference/retention-rules-api.html

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
