### PR TITLE
Web console: make typing fun again

### DIFF
--- a/web-console/src/react-table/react-table-inputs.tsx
+++ b/web-console/src/react-table/react-table-inputs.tsx
@@ -41,7 +41,7 @@ interface FilterRendererProps {
 
 export function GenericFilterInput({ column, filter, onChange, key }: FilterRendererProps) {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [focused, setFocused] = useState(false);
+  const [focusedText, setFocusedText] = useState<string | undefined>();
 
   const enableComparisons = String(column.headerClassName).includes('enable-comparisons');
 
@@ -53,7 +53,7 @@ export function GenericFilterInput({ column, filter, onChange, key }: FilterRend
   return (
     <InputGroup
       className={classNames('generic-filter-input', {
-        'hide-icon': !filter && !(menuOpen || focused),
+        'hide-icon': !filter && !(menuOpen || typeof focusedText === 'string'),
       })}
       key={key}
       leftElement={
@@ -79,14 +79,18 @@ export function GenericFilterInput({ column, filter, onChange, key }: FilterRend
           <Button className="filter-mode-button" icon={filterModeToIcon(mode)} minimal />
         </Popover2>
       }
-      value={needle}
-      onChange={e => onChange(combineModeAndNeedle(mode, e.target.value))}
+      value={focusedText ?? needle}
+      onChange={e => {
+        const enteredText = e.target.value;
+        setFocusedText(enteredText);
+        onChange(combineModeAndNeedle(mode, enteredText));
+      }}
       rightElement={
         filter ? <Button icon={IconNames.CROSS} minimal onClick={() => onChange('')} /> : undefined
       }
-      onFocus={() => setFocused(true)}
+      onFocus={() => setFocusedText(needle)}
       onBlur={e => {
-        setFocused(false);
+        setFocusedText(undefined);
         if (filter && !e.target.value) onChange('');
       }}
     />

--- a/web-console/src/utils/date.ts
+++ b/web-console/src/utils/date.ts
@@ -24,6 +24,10 @@ export function dateToIsoDateString(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
+export function prettyFormatIsoDate(isoDate: string): string {
+  return isoDate.replace('T', ' ').replace(/\.\d\d\dZ$/, '');
+}
+
 export function utcToLocalDate(utcDate: Date): Date {
   // Function removes the local timezone of the date and displays it in UTC
   return new Date(utcDate.getTime() + utcDate.getTimezoneOffset() * 60000);

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -49,6 +49,7 @@ import {
   formatInteger,
   formatPercent,
   oneOf,
+  prettyFormatIsoDate,
   twoLines,
 } from '../../../utils';
 
@@ -685,7 +686,7 @@ ${title} uncompressed size: ${formatBytesCompact(
             if (!value) return null;
             return (
               <div title={value + (duration ? `/${formatDurationWithMs(duration)}` : '')}>
-                <div>{value.replace('T', ' ').replace(/\.\d\d\dZ$/, '')}</div>
+                <div>{prettyFormatIsoDate(value)}</div>
                 <div>{duration ? formatDurationDynamic(duration) : ''}</div>
               </div>
             );

--- a/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
+++ b/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
@@ -32,7 +32,12 @@ import { Execution, WorkbenchQuery } from '../../../druid-models';
 import { cancelTaskExecution, getTaskExecution } from '../../../helpers';
 import { useClock, useInterval, useQueryManager } from '../../../hooks';
 import { AppToaster } from '../../../singletons';
-import { downloadQueryDetailArchive, formatDuration, queryDruidSql } from '../../../utils';
+import {
+  downloadQueryDetailArchive,
+  formatDuration,
+  prettyFormatIsoDate,
+  queryDruidSql,
+} from '../../../utils';
 import { CancelQueryDialog } from '../cancel-query-dialog/cancel-query-dialog';
 import { workStateStore } from '../work-state-store';
 
@@ -231,7 +236,7 @@ LIMIT 100`,
                       style={{ color }}
                     />
                     <div className="timing">
-                      {w.createdTime.replace('T', ' ').replace(/\.\d\d\dZ$/, '') +
+                      {prettyFormatIsoDate(w.createdTime) +
                         (duration > 0 ? ` (${formatDuration(duration)})` : '')}
                     </div>
                   </div>


### PR DESCRIPTION
Fixes a UX bug with typing filters where the filter inputs get a bit too many updates causing the cursor to jump to the end (or sometimes missing letters if you type fast enough.

<img width="1191" alt="image" src="https://github.com/apache/druid/assets/177816/566ed08c-ee1f-481c-b6fb-9c2b391fd614">

The simplest way to see a manifestation of the bug is try to type in the middle of the text, the bug will put the cursor at the end.

### The detailed issue (for those who care)

Say `"ka"` is already typed and the user adds an `f`. The on change will be called with `"kaf"` but the table will re-render also rendering the input once with the old value of `"ka"` reseting the cursor at the end before the URL is updated and parsed as `"kaf"`.

### The solution

The source of truth for the input box will now be the local state `focusedText` for the entire time the input is in focus. This means that no update thrashing will bubble up to the user while they are focused on the input. When focus is lost (onBlur) the text in the input will 'revert' to the state from the URL which should be the same as what was entered.