### PR TITLE
Improve streaming ingestion completion timeout error message

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3271,7 +3271,9 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             log.warn("All tasks in group [%d] failed to publish, killing all tasks for these partitions", groupId);
           } else {
             log.makeAlert(
-                "No task in [%s] for taskGroup [%d] succeeded before the completion timeout elapsed [%s]!",
+                "No task in [%s] for taskGroup [%d] succeeded before the completion timeout elapsed [%s]! "
+                + "Please check the total time taken for each segment's creation and publish to deep storage, "
+                + "as well as the total time taken for segment handoff to the historicals.",
                 group.taskIds(),
                 groupId,
                 ioConfig.getCompletionTimeout()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3272,8 +3272,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           } else {
             log.makeAlert(
                 "No task in [%s] for taskGroup [%d] succeeded before the completion timeout elapsed [%s]! "
-                + "Check metrics and logs to see if the creation, publish or handoff of any segment is taking longer "
-                + "than usual.",
+                + "Check metrics and logs to see if the creation, publish or handoff"
+                + "  of any segment is taking longer than usual.",
                 group.taskIds(),
                 groupId,
                 ioConfig.getCompletionTimeout()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3272,8 +3272,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           } else {
             log.makeAlert(
                 "No task in [%s] for taskGroup [%d] succeeded before the completion timeout elapsed [%s]! "
-                + "Please check the total time taken for each segment's creation and publish to deep storage, "
-                + "as well as the total time taken for segment handoff to the historicals.",
+                + "Check metrics and logs to see if the creation, publish or handoff of any segment is taking longer "
+                + "than usual.",
                 group.taskIds(),
                 groupId,
                 ioConfig.getCompletionTimeout()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3273,7 +3273,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             log.makeAlert(
                 "No task in [%s] for taskGroup [%d] succeeded before the completion timeout elapsed [%s]! "
                 + "Check metrics and logs to see if the creation, publish or handoff"
-                + "  of any segment is taking longer than usual.",
+                + " of any segment is taking longer than usual.",
                 group.taskIds(),
                 groupId,
                 ioConfig.getCompletionTimeout()


### PR DESCRIPTION
A streaming ingestion supervisor spec has the property: `completionTimeout` (defaults to 30 minutes), which is the total time to wait after the taskDuration has elapsed for the tasks to stop reading, create segments from intermediate persists, publish segments to deep storage, and finally hand them off from the peons to the historicals.

A task fails if the above operations are not completed before the completionTimeout has elapsed.

This PR adds steps for better debugging when such failures occur.
