### PR TITLE
docs: k8s-jobs peonMonitors info extended

### DIFF
--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -81,7 +81,7 @@ Additional Configuration
 |`druid.indexer.runner.javaOptsArray`|`JsonArray`|java opts for the task.|`-Xmx1g`|No|
 |`druid.indexer.runner.labels`|`JsonObject`|Additional labels you want to add to peon pod|`{}`|No|
 |`druid.indexer.runner.annotations`|`JsonObject`|Additional annotations you want to add to peon pod|`{}`|No|
-|`druid.indexer.runner.peonMonitors`|`JsonArray`|Overrides `druid.monitoring.monitors`. Use this property if you don't want to inherit monitors from the Overlord.|`[]`|No|
+|`druid.indexer.runner.peonMonitors`|`JsonArray`|Overrides peon pod's `druid_monitoring_monitors` environment variable. Use this property if you don't want to inherit monitors from the Overlord.|`[]`|No|
 |`druid.indexer.runner.graceTerminationPeriodSeconds`|`Long`|Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete.  Keep at a smaller value if you want tasks to hold locks for shorter periods.|`PT30S` (K8s default)|No|
 
 ### Gotchas
@@ -144,4 +144,9 @@ roleRef:
   kind: Role
   name: druid-cluster
   apiGroup: rbac.authorization.k8s.io
+```
+
+To use `druid.indexer.runner.peonMonitors` option properly define Overlord's monitors like below:
+```
+druid.monitoring.monitors=${env:druid_monitoring_monitors:-["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.TaskCountStatsMonitor"]}
 ```

--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -81,7 +81,7 @@ Additional Configuration
 |`druid.indexer.runner.javaOptsArray`|`JsonArray`|java opts for the task.|`-Xmx1g`|No|
 |`druid.indexer.runner.labels`|`JsonObject`|Additional labels you want to add to peon pod|`{}`|No|
 |`druid.indexer.runner.annotations`|`JsonObject`|Additional annotations you want to add to peon pod|`{}`|No|
-|`druid.indexer.runner.peonMonitors`|`JsonArray`|Overrides peon pod's `druid_monitoring_monitors` environment variable. Use this property if you don't want to inherit monitors from the Overlord.|`[]`|No|
+|`druid.indexer.runner.peonMonitors`|`JsonArray`|Overrides the `druid.monitoring.monitors` environment variable of a peon pod. Use this property if you don't want to inherit monitors from the Overlord.|`[]`|No|
 |`druid.indexer.runner.graceTerminationPeriodSeconds`|`Long`|Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete.  Keep at a smaller value if you want tasks to hold locks for shorter periods.|`PT30S` (K8s default)|No|
 
 ### Gotchas
@@ -146,7 +146,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-To use `druid.indexer.runner.peonMonitors` option properly define Overlord's monitors like below:
+To use the `druid.indexer.runner.peonMonitors` option, configure monitors on the Overlord as follows:
 ```
 druid.monitoring.monitors=${env:druid_monitoring_monitors:-["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.TaskCountStatsMonitor"]}
 ```


### PR DESCRIPTION
Stems from [#14599](https://github.com/apache/druid/issues/14599).

### Description
Extends [instructions of MM-less `druid-overlord-extension`](https://druid.apache.org/docs/latest/development/extensions-contrib/k8s-jobs.html). I've changed wording in docs of `druid.indexer.runner.peonMonitors` option, since it doesn't override Overlord's `druid.monitoring.monitors` but rather it overrides peon pod's `druid_monitoring_monitors` environment variable.
For this to work properly I use a workaround described in _Gotchas_ section, where I use `druid_monitoring_monitors` variable in definition of Overlord monitors. 

Possible improvement would be to avoid using `druid_monitoring_monitors` env variable and directly override `runtime.properties` that peon pod's would use. But I'm not proficient enough in java, so I'm not sure if that's possible to be implemented.

I'm not sure if this is best wording and if this workaround is good enough, but this at least clears ambiguous description that resulted in breaking errors.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] been tested in a test Druid cluster.
