### PR TITLE
Fix time unit for handoff in CoordinatorBasedSegmentHandoffNotifier

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
+++ b/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
@@ -26,8 +26,8 @@ import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.server.coordination.DruidServerMetadata;
-
 import org.joda.time.Duration;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
+++ b/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
@@ -118,7 +118,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
               "Exception while checking handoff for dataSource[%s] Segment[%s]; will try again after [%s]",
               dataSource,
               descriptor,
-              pollDuration.toString()
+              pollDuration
           );
         }
       }
@@ -131,7 +131,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
           t,
           "Exception while checking handoff for dataSource[%s]; will try again after [%s]",
           dataSource,
-          pollDuration.toString()
+          pollDuration
       );
     }
   }

--- a/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
+++ b/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
@@ -27,7 +27,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 
-import java.time.Duration;
+import org.joda.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
   private final ConcurrentMap<SegmentDescriptor, Pair<Executor, Runnable>> handOffCallbacks = new ConcurrentHashMap<>();
   private final CoordinatorClient coordinatorClient;
   private volatile ScheduledExecutorService scheduledExecutor;
-  private final long pollDurationMillis;
+  private final Duration pollDuration;
   private final String dataSource;
 
   public CoordinatorBasedSegmentHandoffNotifier(
@@ -55,7 +55,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
   {
     this.dataSource = dataSource;
     this.coordinatorClient = coordinatorClient;
-    this.pollDurationMillis = config.getPollDuration().getMillis();
+    this.pollDuration = config.getPollDuration();
   }
 
   @Override
@@ -81,7 +81,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
           {
             checkForSegmentHandoffs();
           }
-        }, 0L, pollDurationMillis, TimeUnit.MILLISECONDS
+        }, 0L, pollDuration.getMillis(), TimeUnit.MILLISECONDS
     );
   }
 
@@ -118,7 +118,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
               "Exception while checking handoff for dataSource[%s] Segment[%s]; will try again after [%s]",
               dataSource,
               descriptor,
-              Duration.ofMillis(pollDurationMillis).toString()
+              pollDuration.toString()
           );
         }
       }
@@ -131,7 +131,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
           t,
           "Exception while checking handoff for dataSource[%s]; will try again after [%s]",
           dataSource,
-          Duration.ofMillis(pollDurationMillis).toString()
+          pollDuration.toString()
       );
     }
   }

--- a/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
+++ b/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
@@ -114,7 +114,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
         catch (Exception e) {
           log.error(
               e,
-              "Exception while checking handoff for dataSource[%s] Segment[%s], Will try again after [%d]secs",
+              "Exception while checking handoff for dataSource[%s] Segment[%s], Will try again after [%d]ms",
               dataSource,
               descriptor,
               pollDurationMillis
@@ -128,7 +128,7 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
     catch (Throwable t) {
       log.error(
           t,
-          "Exception while checking handoff for dataSource[%s], Will try again after [%d]secs",
+          "Exception while checking handoff for dataSource[%s], Will try again after [%d]ms",
           dataSource,
           pollDurationMillis
       );

--- a/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
+++ b/server/src/main/java/org/apache/druid/segment/handoff/CoordinatorBasedSegmentHandoffNotifier.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -114,10 +115,10 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
         catch (Exception e) {
           log.error(
               e,
-              "Exception while checking handoff for dataSource[%s] Segment[%s], Will try again after [%d]ms",
+              "Exception while checking handoff for dataSource[%s] Segment[%s]; will try again after [%s]",
               dataSource,
               descriptor,
-              pollDurationMillis
+              Duration.ofMillis(pollDurationMillis).toString()
           );
         }
       }
@@ -128,9 +129,9 @@ public class CoordinatorBasedSegmentHandoffNotifier implements SegmentHandoffNot
     catch (Throwable t) {
       log.error(
           t,
-          "Exception while checking handoff for dataSource[%s], Will try again after [%d]ms",
+          "Exception while checking handoff for dataSource[%s]; will try again after [%s]",
           dataSource,
-          pollDurationMillis
+          Duration.ofMillis(pollDurationMillis).toString()
       );
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description
Fixes time unit for Segment Handoff log from seconds to milliseconds
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
Changed secs to ms for time unit in CoordinatorBasedSegmentHandoffNotifier
<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 
Improved logging in CoordinatorBasedSegmentHandoffNotifier during segment handoff
If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
CoordinatorBasedSegmentHandoffNotifier

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
- [X] a release note entry in the PR description.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] been tested in a test Druid cluster.
