### PR TITLE
Suppress ambari metrics CVEs

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -392,6 +392,16 @@
     <cve>CVE-2022-33915</cve>
   </suppress>
   <suppress>
+       <!--
+         - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
+         -->
+     <notes><![CDATA[
+     file name: ambari-metrics-common-2.7.0.0.0.jar
+    ]]></notes>
+    <cve>CVE-2022-45855</cve>
+    <cve>CVE-2022-42009</cve>
+  </suppress>
+  <suppress>
     <!--
       - TODO: The lastest version of ambari-metrics-common is 2.7.0.0.0, released in July 2018.
       -->


### PR DESCRIPTION
Suppress CVEs for ambari-metrics-emitter

1. `CVE-2022-45855`  (SpringEL injection in the metrics source in Apache Ambari version 2.7.0 to 2.7.6 allows a malicious authenticated user to execute arbitrary code remotely.) - `Suppressing as Druid doesn't use SpringEL injection.`
2.`CVE-2022-42009` (SpringEL injection in the server agent in Apache Ambari version 2.7.0 to 2.7.6 allows a malicious authenticated user to execute arbitrary code remotely.) - `Suppressing as Druid doesn't use SpringEL injection.`