### PR TITLE
Fix the NPE in stringLast vector aggregation

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregator.java
@@ -42,7 +42,7 @@ public class StringLastVectorAggregator implements VectorAggregator
   protected long lastTime;
 
   public StringLastVectorAggregator(
-      final BaseLongVectorValueSelector timeSelector,
+      @Nullable final BaseLongVectorValueSelector timeSelector,
       final VectorObjectSelector valueSelector,
       final int maxStringBytes
   )
@@ -124,6 +124,9 @@ public class StringLastVectorAggregator implements VectorAggregator
       int positionOffset
   )
   {
+    if (timeSelector == null) {
+      return;
+    }
     long[] timeVector = timeSelector.getLongVector();
     Object[] objectsWhichMightBeStrings = valueSelector.getObjectVector();
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregatorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregatorTest.java
@@ -130,6 +130,25 @@ public class StringLastVectorAggregatorTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void aggregateNoOp()
+  {
+    // Test that aggregates run just fine when the input field does not exist
+    StringLastVectorAggregator aggregator = new StringLastVectorAggregator(null, selector, 10);
+    aggregator.aggregate(buf, 0, 0, VALUES.length);
+  }
+
+  @Test
+  public void aggregateBatchNoOp()
+  {
+    // Test that aggregates run just fine when the input field does not exist
+    StringLastVectorAggregator aggregator = new StringLastVectorAggregator(null, selector, 10);
+    int[] positions = new int[]{0, 43, 70};
+    int positionOffset = 2;
+    clearBufferForPositions(positionOffset, positions);
+    aggregator.aggregate(buf, 3, positions, null, positionOffset);
+  }
+
+  @Test
   public void aggregateBatchWithoutRows()
   {
     int[] positions = new int[]{0, 43, 70};


### PR DESCRIPTION
If a field does not exist, StringLastVectorAggregator will throw NPE. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
