### PR TITLE
arrays and approximate count aggregators

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -62,6 +62,8 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
   private final boolean shouldFinalize;
   private final boolean round;
 
+  private final boolean processAsArray;
+
   HllSketchAggregatorFactory(
       final String name,
       final String fieldName,
@@ -69,7 +71,8 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
       @Nullable final String tgtHllType,
       @Nullable final StringEncoding stringEncoding,
       final Boolean shouldFinalize,
-      final boolean round
+      final boolean round,
+      final boolean processAsArray
   )
   {
     this.name = Objects.requireNonNull(name);
@@ -79,6 +82,7 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
     this.stringEncoding = stringEncoding == null ? DEFAULT_STRING_ENCODING : stringEncoding;
     this.shouldFinalize = shouldFinalize == null ? DEFAULT_SHOULD_FINALIZE : shouldFinalize;
     this.round = round;
+    this.processAsArray = processAsArray;
   }
 
   @Override
@@ -127,6 +131,13 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
     return round;
   }
 
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public boolean isProcessAsArray()
+  {
+    return processAsArray;
+  }
+
   @Override
   public List<String> requiredFields()
   {
@@ -149,7 +160,8 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
             tgtHllType.toString(),
             stringEncoding,
             shouldFinalize,
-            round
+            round,
+            false
         )
     );
   }
@@ -284,13 +296,14 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
            && Objects.equals(name, that.name)
            && Objects.equals(fieldName, that.fieldName)
            && tgtHllType == that.tgtHllType
-           && stringEncoding == that.stringEncoding;
+           && stringEncoding == that.stringEncoding
+           && processAsArray == that.processAsArray;
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round);
+    return Objects.hash(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round, processAsArray);
   }
 
   @Override
@@ -304,6 +317,7 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
            (stringEncoding != DEFAULT_STRING_ENCODING ? ", stringEncoding=" + stringEncoding : "") +
            (shouldFinalize != DEFAULT_SHOULD_FINALIZE ? ", shouldFinalize=" + shouldFinalize : "") +
            (round != DEFAULT_ROUND ? ", round=" + round : "") +
+           (processAsArray ? ", processAsArray=true" : "") +
            '}';
   }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactory.java
@@ -23,9 +23,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.hll.TgtHllType;
-import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringEncoding;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
@@ -54,6 +55,7 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
 {
   public static final ColumnType TYPE = ColumnType.ofComplex(HllSketchModule.BUILD_TYPE_NAME);
 
+
   @JsonCreator
   public HllSketchBuildAggregatorFactory(
       @JsonProperty("name") final String name,
@@ -62,10 +64,11 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
       @JsonProperty("tgtHllType") @Nullable final String tgtHllType,
       @JsonProperty("stringEncoding") @Nullable final StringEncoding stringEncoding,
       @JsonProperty("shouldFinalize") final Boolean shouldFinalize,
-      @JsonProperty("round") final boolean round
+      @JsonProperty("round") final boolean round,
+      @JsonProperty("processAsArray") final boolean processAsArray
   )
   {
-    super(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round);
+    super(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round, processAsArray);
   }
 
 
@@ -144,7 +147,8 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
         getTgtHllType(),
         getStringEncoding(),
         isShouldFinalize(),
-        isRound()
+        isRound(),
+        isProcessAsArray()
     );
   }
 
@@ -223,12 +227,20 @@ public class HllSketchBuildAggregatorFactory extends HllSketchAggregatorFactory
           };
           break;
         case ARRAY:
-          throw InvalidInput.exception("ARRAY types are not supported for hll sketch");
+          final ExpressionType expressionType = ExpressionType.fromColumnTypeStrict(capabilities);
+          updater = sketch -> {
+            final Object o = selector.getObject();
+            if (o != null) {
+              byte[] bytes = ExprEval.toBytes(expressionType, o);
+              sketch.get().update(bytes);
+            }
+          };
+          break;
         default:
           updater = sketch -> {
             Object obj = selector.getObject();
             if (obj != null) {
-              HllSketchBuildUtil.updateSketch(sketch.get(), getStringEncoding(), obj);
+              HllSketchBuildUtil.updateSketch(sketch.get(), getStringEncoding(), obj, isProcessAsArray());
             }
           };
       }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtil.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtil.java
@@ -25,6 +25,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.segment.DimensionDictionarySelector;
 
 import javax.annotation.Nullable;
@@ -33,7 +34,12 @@ import java.util.List;
 
 public class HllSketchBuildUtil
 {
-  public static void updateSketch(final HllSketch sketch, final StringEncoding stringEncoding, final Object value)
+  public static void updateSketch(
+      final HllSketch sketch,
+      final StringEncoding stringEncoding,
+      final Object value,
+      final boolean processAsArray
+  )
   {
     if (value instanceof Integer || value instanceof Long) {
       sketch.update(((Number) value).longValue());
@@ -41,11 +47,21 @@ public class HllSketchBuildUtil
       sketch.update(((Number) value).doubleValue());
     } else if (value instanceof String) {
       updateSketchWithString(sketch, stringEncoding, (String) value);
+    } else if (value instanceof Object[] && processAsArray) {
+      byte[] arrayBytes = ExprEval.toBytesBestEffort(value);
+      sketch.update(arrayBytes);
     } else if (value instanceof List) {
-      // noinspection rawtypes
-      for (Object entry : (List) value) {
-        if (entry != null) {
-          updateSketchWithString(sketch, stringEncoding, entry.toString());
+      if (processAsArray) {
+        final ExprEval eval = ExprEval.bestEffortArray((List) value);
+        final byte[] arrayBytes = ExprEval.toBytes(eval);
+        sketch.update(arrayBytes);
+      } else {
+        // Lists are treated as multi-value strings, which count each element as a separate distinct value
+        // noinspection rawtypes
+        for (Object entry : (List) value) {
+          if (entry != null) {
+            updateSketchWithString(sketch, stringEncoding, entry.toString());
+          }
         }
       }
     } else if (value instanceof char[]) {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -64,7 +64,7 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
       @JsonProperty("round") final boolean round
   )
   {
-    super(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round);
+    super(name, fieldName, lgK, tgtHllType, stringEncoding, shouldFinalize, round, false);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -193,7 +193,8 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
             tgtHllType,
             stringEncoding,
             finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
-            ROUND
+            ROUND,
+            inputType.isArray()
         );
       }
     }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/vector/ObjectHllSketchBuildVectorProcessor.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/vector/ObjectHllSketchBuildVectorProcessor.java
@@ -59,7 +59,8 @@ public class ObjectHllSketchBuildVectorProcessor implements HllSketchBuildVector
         HllSketchBuildUtil.updateSketch(
             sketch,
             stringEncoding,
-            vector[i]
+            vector[i],
+            false
         );
       }
     }
@@ -79,7 +80,8 @@ public class ObjectHllSketchBuildVectorProcessor implements HllSketchBuildVector
         HllSketchBuildUtil.updateSketch(
             sketch,
             stringEncoding,
-            vector[idx]
+            vector[idx],
+            false
         );
       }
     }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -65,7 +65,9 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   protected final int size;
   private final byte cacheId;
 
-  public SketchAggregatorFactory(String name, String fieldName, Integer size, byte cacheId)
+  protected final boolean processAsArray;
+
+  public SketchAggregatorFactory(String name, String fieldName, Integer size, byte cacheId, boolean processAsArray)
   {
     this.name = Preconditions.checkNotNull(name, "Must have a valid, non-null aggregator name");
     this.fieldName = Preconditions.checkNotNull(fieldName, "Must have a valid, non-null fieldName");
@@ -74,6 +76,7 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
     Util.checkIfIntPowerOf2(this.size, "size");
 
     this.cacheId = cacheId;
+    this.processAsArray = processAsArray;
   }
 
   @SuppressWarnings("unchecked")
@@ -85,7 +88,7 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
       throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
     }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
-    return new SketchAggregator(selector, size);
+    return new SketchAggregator(selector, size, processAsArray);
   }
 
   @Override
@@ -96,7 +99,7 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
       throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
     }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
-    final SketchAggregator aggregator = new SketchAggregator(selector, size);
+    final SketchAggregator aggregator = new SketchAggregator(selector, size, processAsArray);
     return new AggregatorAndSize(aggregator, aggregator.getInitialSizeBytes());
   }
 
@@ -109,13 +112,13 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
       throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
     }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
-    return new SketchBufferAggregator(selector, size, getMaxIntermediateSizeWithNulls());
+    return new SketchBufferAggregator(selector, size, getMaxIntermediateSizeWithNulls(), processAsArray);
   }
 
   @Override
   public VectorAggregator factorizeVector(VectorColumnSelectorFactory selectorFactory)
   {
-    return new SketchVectorAggregator(selectorFactory, fieldName, size, getMaxIntermediateSizeWithNulls());
+    return new SketchVectorAggregator(selectorFactory, fieldName, size, getMaxIntermediateSizeWithNulls(), processAsArray);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchBufferAggregator.java
@@ -31,11 +31,13 @@ public class SketchBufferAggregator implements BufferAggregator
 {
   private final BaseObjectColumnValueSelector selector;
   private final SketchBufferAggregatorHelper helper;
+  private final boolean processAsArray;
 
-  public SketchBufferAggregator(BaseObjectColumnValueSelector selector, int size, int maxIntermediateSize)
+  public SketchBufferAggregator(BaseObjectColumnValueSelector selector, int size, int maxIntermediateSize, boolean processAsArray)
   {
     this.selector = selector;
     this.helper = new SketchBufferAggregatorHelper(size, maxIntermediateSize);
+    this.processAsArray = processAsArray;
   }
 
   @Override
@@ -53,7 +55,7 @@ public class SketchBufferAggregator implements BufferAggregator
     }
 
     Union union = helper.getOrCreateUnion(buf, position);
-    SketchAggregator.updateUnion(union, update);
+    SketchAggregator.updateUnion(union, update, processAsArray);
   }
 
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchMergeAggregatorFactory.java
@@ -46,10 +46,11 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
       @JsonProperty("size") @Nullable Integer size,
       @JsonProperty("shouldFinalize") @Nullable Boolean shouldFinalize,
       @JsonProperty("isInputThetaSketch") @Nullable Boolean isInputThetaSketch,
-      @JsonProperty("errorBoundsStdDev") @Nullable Integer errorBoundsStdDev
+      @JsonProperty("errorBoundsStdDev") @Nullable Integer errorBoundsStdDev,
+      @JsonProperty("processAsArray") boolean processAsArray
   )
   {
-    super(name, fieldName, size, AggregatorUtil.SKETCH_MERGE_CACHE_TYPE_ID);
+    super(name, fieldName, size, AggregatorUtil.SKETCH_MERGE_CACHE_TYPE_ID, processAsArray);
     this.shouldFinalize = (shouldFinalize == null) ? true : shouldFinalize;
     this.isInputThetaSketch = (isInputThetaSketch == null) ? false : isInputThetaSketch;
     this.errorBoundsStdDev = errorBoundsStdDev;
@@ -65,7 +66,8 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
             size,
             shouldFinalize,
             isInputThetaSketch,
-            errorBoundsStdDev
+            errorBoundsStdDev,
+            processAsArray
         )
     );
   }
@@ -73,7 +75,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, false, errorBoundsStdDev);
+    return new SketchMergeAggregatorFactory(name, name, size, shouldFinalize, false, errorBoundsStdDev, processAsArray);
   }
 
   @Override
@@ -88,7 +90,8 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
           Math.max(size, castedOther.size),
           shouldFinalize,
           false,
-          errorBoundsStdDev
+          errorBoundsStdDev,
+          processAsArray
       );
     } else {
       throw new AggregatorFactoryNotMergeableException(this, other);
@@ -115,6 +118,13 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
   public Integer getErrorBoundsStdDev()
   {
     return errorBoundsStdDev;
+  }
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public boolean isProcessAsArray()
+  {
+    return processAsArray;
   }
 
   /**
@@ -178,7 +188,8 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
         getSize(),
         getShouldFinalize(),
         getIsInputThetaSketch(),
-        getErrorBoundsStdDev()
+        getErrorBoundsStdDev(),
+        isProcessAsArray()
     );
   }
 
@@ -212,7 +223,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
       return false;
     }
 
-    return isInputThetaSketch == that.isInputThetaSketch;
+    return isInputThetaSketch == that.isInputThetaSketch && processAsArray == that.processAsArray;
   }
 
   @Override
@@ -222,6 +233,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
     result = 31 * result + (shouldFinalize ? 1 : 0);
     result = 31 * result + (isInputThetaSketch ? 1 : 0);
     result = 31 * result + (errorBoundsStdDev != null ? errorBoundsStdDev.hashCode() : 0);
+    result = 31 * result + (processAsArray ? 1 : 0);
     return result;
   }
 
@@ -235,6 +247,7 @@ public class SketchMergeAggregatorFactory extends SketchAggregatorFactory
            + ", shouldFinalize=" + shouldFinalize
            + ", isInputThetaSketch=" + isInputThetaSketch
            + ", errorBoundsStdDev=" + errorBoundsStdDev
+           + ", processAsArray=" + processAsArray
            + "}";
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchVectorAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchVectorAggregator.java
@@ -33,15 +33,18 @@ public class SketchVectorAggregator implements VectorAggregator
 {
   private final SketchBufferAggregatorHelper helper;
   private final Supplier<Object[]> objectSupplier;
+  private final boolean processAsArray;
 
   SketchVectorAggregator(
       final VectorColumnSelectorFactory columnSelectorFactory,
       final String column,
       final int size,
-      final int maxIntermediateSize
+      final int maxIntermediateSize,
+      final boolean processAsArray
   )
   {
     this.helper = new SketchBufferAggregatorHelper(size, maxIntermediateSize);
+    this.processAsArray = processAsArray;
     this.objectSupplier =
         ColumnProcessors.makeVectorProcessor(
             column,
@@ -65,7 +68,7 @@ public class SketchVectorAggregator implements VectorAggregator
     for (int i = startRow; i < endRow; i++) {
       final Object o = vector[i];
       if (o != null) {
-        SketchAggregator.updateUnion(union, o);
+        SketchAggregator.updateUnion(union, o, processAsArray);
       }
     }
   }
@@ -87,7 +90,7 @@ public class SketchVectorAggregator implements VectorAggregator
       if (o != null) {
         final int position = positions[i] + positionOffset;
         final Union union = helper.getOrCreateUnion(buf, position);
-        SketchAggregator.updateUnion(union, o);
+        SketchAggregator.updateUnion(union, o, processAsArray);
       }
     }
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchBuildAggregatorFactory.java
@@ -35,7 +35,7 @@ public class OldSketchBuildAggregatorFactory extends SketchMergeAggregatorFactor
       @JsonProperty("size") Integer size
   )
   {
-    super(name, fieldName, size, true, false, null);
+    super(name, fieldName, size, true, false, null, false);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldSketchMergeAggregatorFactory.java
@@ -36,7 +36,7 @@ public class OldSketchMergeAggregatorFactory extends SketchMergeAggregatorFactor
       @JsonProperty("shouldFinalize") Boolean shouldFinalize
   )
   {
-    super(name, fieldName, size, shouldFinalize, true, null);
+    super(name, fieldName, size, shouldFinalize, true, null, false);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -116,7 +116,8 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
           sketchSize,
           finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
           null,
-          null
+          null,
+          columnArg.getDruidType() != null && columnArg.getDruidType().isArray()
       );
     } else {
       final RelDataType dataType = columnRexNode.getType();
@@ -147,7 +148,8 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
           sketchSize,
           finalizeSketch || SketchQueryContext.isFinalizeOuterSketches(plannerContext),
           null,
-          null
+          null,
+          inputType.isArray()
       );
     }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -263,7 +263,7 @@ public class HllSketchAggregatorFactoryTest
                                        .collect(Collectors.toList());
 
     for (Field field : toStringFields) {
-      if ("shouldFinalize".equals(field.getName()) || "stringEncoding".equals(field.getName())) {
+      if ("shouldFinalize".equals(field.getName()) || "stringEncoding".equals(field.getName()) || "processAsArray".equals(field.getName())) {
         // Skip; not included in the toString if it has the default value.
         continue;
       }
@@ -290,6 +290,7 @@ public class HllSketchAggregatorFactoryTest
                       null,
                       null,
                       null,
+                      false,
                       false
                   ),
                   new HllSketchBuildAggregatorFactory(
@@ -299,7 +300,8 @@ public class HllSketchAggregatorFactoryTest
                       null,
                       null,
                       null,
-                      true
+                      true,
+                      false
                   ),
                   new HllSketchMergeAggregatorFactory(
                       "hllMerge",
@@ -382,7 +384,7 @@ public class HllSketchAggregatorFactoryTest
         boolean round
     )
     {
-      super(name, fieldName, lgK, tgtHllType, stringEncoding, null, round);
+      super(name, fieldName, lgK, tgtHllType, stringEncoding, null, round, false);
     }
 
     @Override

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -23,21 +23,34 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.data.input.ResourceInputSource;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
+import org.apache.druid.segment.IncrementalIndexSegment;
+import org.apache.druid.segment.IndexBuilder;
+import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.timeline.SegmentId;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +59,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,6 +83,8 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
   @Rule
   public final TemporaryFolder timeseriesFolder = new TemporaryFolder();
 
+  private final Closer closer;
+
   public HllSketchAggregatorTest(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding)
   {
     HllSketchModule.registerSerde();
@@ -80,6 +96,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
     );
     this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
     this.stringEncoding = stringEncoding;
+    this.closer = Closer.create();
   }
 
   @Parameterized.Parameters(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
@@ -96,6 +113,12 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
       }
     }
     return constructors;
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    closer.close();
   }
 
   @Test
@@ -415,6 +438,153 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
     Assert.assertEquals(expectedSummary, row.get(3));
     // union with self = self
     Assert.assertEquals(expectedSummary, ((HllSketchHolder) row.get(4)).getSketch().toString());
+  }
+
+  @Test
+  public void testArrays() throws Exception
+  {
+    AggregatorFactory[] aggs = new AggregatorFactory[]{
+        new HllSketchBuildAggregatorFactory("hll0", "arrayString", null, null, null, false, false, true),
+        new HllSketchBuildAggregatorFactory("hll1", "arrayLong", null, null, null, false, false, true),
+        new HllSketchBuildAggregatorFactory("hll2", "arrayDouble", null, null, null, false, false, true),
+        new HllSketchBuildAggregatorFactory("hll3", "arrayString", null, null, null, false, false, false),
+        new HllSketchBuildAggregatorFactory("hll4", "arrayLong", null, null, null, false, false, false),
+        new HllSketchBuildAggregatorFactory("hll5", "arrayDouble", null, null, null, false, false, false)
+    };
+
+    IndexBuilder bob = IndexBuilder.create(timeseriesHelper.getObjectMapper())
+                                   .tmpDir(groupByFolder.newFolder())
+                                   .schema(
+                                       IncrementalIndexSchema.builder()
+                                                             .withTimestampSpec(NestedDataTestUtils.TIMESTAMP_SPEC)
+                                                             .withDimensionsSpec(NestedDataTestUtils.AUTO_DISCOVERY)
+                                                             .withMetrics(aggs)
+                                                             .withQueryGranularity(Granularities.NONE)
+                                                             .withRollup(true)
+                                                             .withMinTimestamp(0)
+                                                             .build()
+                                   )
+                                   .inputSource(
+                                       ResourceInputSource.of(
+                                           NestedDataTestUtils.class.getClassLoader(),
+                                           NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+                                       )
+                                   )
+                                   .inputFormat(NestedDataTestUtils.DEFAULT_JSON_INPUT_FORMAT)
+                                   .transform(TransformSpec.NONE)
+                                   .inputTmpDir(groupByFolder.newFolder());
+
+    List<Segment> realtimeSegs = ImmutableList.of(
+        new IncrementalIndexSegment(bob.buildIncrementalIndex(), SegmentId.dummy("test_datasource"))
+    );
+    List<Segment> segs = ImmutableList.of(
+        new QueryableIndexSegment(bob.buildMMappedMergedIndex(), SegmentId.dummy("test_datasource"))
+    );
+
+    GroupByQuery query = GroupByQuery.builder()
+                                     .setDataSource("test_datasource")
+                                     .setGranularity(Granularities.ALL)
+                                     .setInterval(Intervals.ETERNITY)
+                                     .setAggregatorSpecs(
+                                         new HllSketchBuildAggregatorFactory("a0", "arrayString", null, null, null, false, false, false),
+                                         new HllSketchBuildAggregatorFactory("a1", "arrayLong", null, null, null, false, false, false),
+                                         new HllSketchBuildAggregatorFactory("a2", "arrayDouble", null, null, null, false, false, false),
+                                         new HllSketchMergeAggregatorFactory("a3", "hll0", null, null, null, false, false),
+                                         new HllSketchMergeAggregatorFactory("a4", "hll1", null, null, null, false, false),
+                                         new HllSketchMergeAggregatorFactory("a5", "hll2", null, null, null, false, false),
+                                         new HllSketchMergeAggregatorFactory("a6", "hll3", null, null, null, false, false),
+                                         new HllSketchMergeAggregatorFactory("a7", "hll4", null, null, null, false, false),
+                                         new HllSketchMergeAggregatorFactory("a8", "hll5", null, null, null, false, false),
+                                         new CountAggregatorFactory("a9")
+                                     )
+                                     .setPostAggregatorSpecs(
+                                         ImmutableList.of(
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p0",
+                                                 new FieldAccessPostAggregator("f0", "a0"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p1",
+                                                 new FieldAccessPostAggregator("f1", "a1"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p2",
+                                                 new FieldAccessPostAggregator("f2", "a2"),
+                                                 false
+                                             ),
+                                             // pre-aggregated array counts
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p3",
+                                                 new FieldAccessPostAggregator("f3", "a3"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p4",
+                                                 new FieldAccessPostAggregator("f4", "a4"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p5",
+                                                 new FieldAccessPostAggregator("f5", "a5"),
+                                                 false
+                                             ),
+                                             // array element counts
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p6",
+                                                 new FieldAccessPostAggregator("f6", "a6"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p7",
+                                                 new FieldAccessPostAggregator("f7", "a7"),
+                                                 false
+                                             ),
+                                             new HllSketchToEstimatePostAggregator(
+                                                 "p8",
+                                                 new FieldAccessPostAggregator("f8", "a8"),
+                                                 false
+                                             )
+                                         )
+                                     )
+                                     .build();
+
+    Sequence<ResultRow> realtimeSeq = groupByHelper.runQueryOnSegmentsObjs(realtimeSegs, query);
+    Sequence<ResultRow> seq = groupByHelper.runQueryOnSegmentsObjs(segs, query);
+    List<ResultRow> realtimeList = realtimeSeq.toList();
+    List<ResultRow> list = seq.toList();
+
+    // expect 4 distinct arrays for each of these columns from 14 rows
+    Assert.assertEquals(1, realtimeList.size());
+    Assert.assertEquals(14L, realtimeList.get(0).get(9));
+    // array column estimate counts
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(10), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(11), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(12), 0.01);
+    // pre-aggregated arrays counts
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(13), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(14), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(15), 0.01);
+    // if processAsArray is false, count is done as string mvds so it counts the total number of elements
+    Assert.assertEquals(5.0, (Double) realtimeList.get(0).get(16), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(17), 0.01);
+    Assert.assertEquals(6.0, (Double) realtimeList.get(0).get(18), 0.01);
+
+    Assert.assertEquals(1, list.size());
+    Assert.assertEquals(14L, list.get(0).get(9));
+    // array column estimate counts
+    Assert.assertEquals(4.0, (Double) list.get(0).get(10), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(11), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(12), 0.01);
+    // pre-aggregated arrays counts
+    Assert.assertEquals(4.0, (Double) list.get(0).get(13), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(14), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(15), 0.01);
+    // if processAsArray is false, count is done as string mvds so it counts the total number of elements
+    Assert.assertEquals(5.0, (Double) list.get(0).get(16), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(17), 0.01);
+    Assert.assertEquals(6.0, (Double) list.get(0).get(18), 0.01);
   }
 
   private static String buildParserJson(List<String> dimensions, List<String> columns)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactoryTest.java
@@ -50,6 +50,7 @@ public class HllSketchBuildAggregatorFactoryTest
         TgtHllType.HLL_8.name(),
         StringEncoding.UTF8,
         false,
+        true,
         true
     );
 
@@ -57,7 +58,7 @@ public class HllSketchBuildAggregatorFactoryTest
 
     Assert.assertEquals(
         "{\"type\":\"HLLSketchBuild\",\"name\":\"foo\",\"fieldName\":\"bar\",\"lgK\":18,\"tgtHllType\":\"HLL_8\","
-        + "\"stringEncoding\":\"utf8\",\"shouldFinalize\":false,\"round\":true}",
+        + "\"stringEncoding\":\"utf8\",\"shouldFinalize\":false,\"round\":true,\"processAsArray\":true}",
         serializedString
     );
 
@@ -79,6 +80,7 @@ public class HllSketchBuildAggregatorFactoryTest
         null,
         null,
         null,
+        false,
         false
     );
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtilTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtilTest.java
@@ -204,12 +204,12 @@ public class HllSketchBuildUtilTest extends InitializedNullHandlingTest
   {
     // first != null check mimics how updateSketch is called: it's always guarded by a null check on the outer value.
     if (first != null) {
-      HllSketchBuildUtil.updateSketch(sketch, stringEncoding, first);
+      HllSketchBuildUtil.updateSketch(sketch, stringEncoding, first, false);
     }
 
     for (final Object o : others) {
       if (o != null) {
-        HllSketchBuildUtil.updateSketch(sketch, stringEncoding, o);
+        HllSketchBuildUtil.updateSketch(sketch, stringEncoding, o, false);
       }
     }
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -93,7 +93,8 @@ public class HllSketchMergeAggregatorFactoryTest
         TGT_HLL_TYPE,
         STRING_ENCODING,
         SHOULD_FINALIZE,
-        ROUND
+        ROUND,
+        false
     );
     targetRound.getMergingFactory(other);
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/BufferHashGrouperUsingSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/BufferHashGrouperUsingSketchMergeAggregatorFactoryTest.java
@@ -52,7 +52,7 @@ public class BufferHashGrouperUsingSketchMergeAggregatorFactoryTest
         AggregatorAdapters.factorizeBuffered(
             columnSelectorFactory,
             ImmutableList.of(
-                new SketchMergeAggregatorFactory("sketch", "sketch", 16, false, true, 2),
+                new SketchMergeAggregatorFactory("sketch", "sketch", 16, false, true, 2, false),
                 new CountAggregatorFactory("count")
             )
         ),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -31,14 +31,19 @@ import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.druid.data.input.MapBasedRow;
+import org.apache.druid.data.input.ResourceInputSource;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
@@ -48,6 +53,13 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.groupby.epinephelinae.GroupByTestColumnSelectorFactory;
 import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
+import org.apache.druid.segment.IncrementalIndexSegment;
+import org.apache.druid.segment.IndexBuilder;
+import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.incremental.IncrementalIndexSchema;
+import org.apache.druid.segment.transform.TransformSpec;
+import org.apache.druid.timeline.SegmentId;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -78,6 +90,8 @@ public class SketchAggregationTest
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
 
+  private final Closer closer;
+
   public SketchAggregationTest(final GroupByQueryConfig config, final String vectorize)
   {
     SketchModule.registerSerde();
@@ -87,6 +101,7 @@ public class SketchAggregationTest
         tempFolder
     );
     this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
+    this.closer = Closer.create();
   }
 
   @Parameterized.Parameters(name = "config = {0}, vectorize = {1}")
@@ -104,6 +119,7 @@ public class SketchAggregationTest
   @After
   public void teardown() throws IOException
   {
+    closer.close();
     helper.close();
   }
 
@@ -299,10 +315,10 @@ public class SketchAggregationTest
   @Test
   public void testSketchMergeAggregatorFactorySerde() throws Exception
   {
-    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null));
-    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, false, true, null));
-    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, null));
-    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, 2));
+    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null, false));
+    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, false, true, null, false));
+    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, null, false));
+    assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, 2, false));
   }
 
   @Test
@@ -310,22 +326,286 @@ public class SketchAggregationTest
   {
     SketchHolder sketch = SketchHolder.of(Sketches.updateSketchBuilder().setNominalEntries(128).build());
 
-    SketchMergeAggregatorFactory agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null);
+    SketchMergeAggregatorFactory agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null, false);
     Assert.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
 
-    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, null);
+    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, null, false);
     Assert.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
 
-    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, false, null, null);
+    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, false, null, null, false);
     Assert.assertEquals(sketch, agg.finalizeComputation(sketch));
 
-    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, 2);
+    agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, 2, false);
     SketchEstimateWithErrorBounds est = (SketchEstimateWithErrorBounds) agg.finalizeComputation(sketch);
     Assert.assertEquals(0.0, est.getEstimate(), 0.0001);
     Assert.assertEquals(0.0, est.getHighBound(), 0.0001);
     Assert.assertEquals(0.0, est.getLowBound(), 0.0001);
     Assert.assertEquals(2, est.getNumStdDev());
 
+  }
+
+  @Test
+  public void testArrays() throws Exception
+  {
+    AggregatorFactory[] aggs = new AggregatorFactory[]{
+        new SketchMergeAggregatorFactory(
+            "sketch0",
+            "arrayString",
+            null,
+            null,
+            null,
+            null,
+            true
+        ),
+        new SketchMergeAggregatorFactory(
+            "sketch1",
+            "arrayLong",
+            null,
+            null,
+            null,
+            null,
+            true
+        ),
+        new SketchMergeAggregatorFactory(
+            "sketch2",
+            "arrayDouble",
+            null,
+            null,
+            null,
+            null,
+            true
+        ),
+        new SketchMergeAggregatorFactory(
+            "sketch3",
+            "arrayString",
+            null,
+            null,
+            null,
+            null,
+            false
+        ),
+        new SketchMergeAggregatorFactory(
+            "sketch4",
+            "arrayLong",
+            null,
+            null,
+            null,
+            null,
+            false
+        ),
+        new SketchMergeAggregatorFactory(
+            "sketch5",
+            "arrayDouble",
+            null,
+            null,
+            null,
+            null,
+            false
+        )
+    };
+    IndexBuilder bob = IndexBuilder.create(helper.getObjectMapper())
+                                   .tmpDir(tempFolder.newFolder())
+                                   .schema(
+                                       IncrementalIndexSchema.builder()
+                                                             .withTimestampSpec(NestedDataTestUtils.TIMESTAMP_SPEC)
+                                                             .withDimensionsSpec(NestedDataTestUtils.AUTO_DISCOVERY)
+                                                             .withMetrics(aggs)
+                                                             .withQueryGranularity(Granularities.NONE)
+                                                             .withRollup(true)
+                                                             .withMinTimestamp(0)
+                                                             .build()
+                                   )
+                                   .inputSource(
+                                       ResourceInputSource.of(
+                                           NestedDataTestUtils.class.getClassLoader(),
+                                           NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+                                       )
+                                   )
+                                   .inputFormat(NestedDataTestUtils.DEFAULT_JSON_INPUT_FORMAT)
+                                   .transform(TransformSpec.NONE)
+                                   .inputTmpDir(tempFolder.newFolder());
+
+    List<Segment> realtimeSegs = ImmutableList.of(
+        new IncrementalIndexSegment(bob.buildIncrementalIndex(), SegmentId.dummy("test_datasource"))
+    );
+    List<Segment> segs = ImmutableList.of(
+        new QueryableIndexSegment(bob.buildMMappedMergedIndex(), SegmentId.dummy("test_datasource"))
+    );
+
+    GroupByQuery query = GroupByQuery.builder()
+                                     .setDataSource("test_datasource")
+                                     .setGranularity(Granularities.ALL)
+                                     .setInterval(Intervals.ETERNITY)
+                                     .setAggregatorSpecs(
+                                         new SketchMergeAggregatorFactory(
+                                             "a0",
+                                             "arrayString",
+                                             null,
+                                             null,
+                                             null,
+                                             null,
+                                             true
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a1",
+                                             "arrayLong",
+                                             null,
+                                             null,
+                                             null,
+                                             null,
+                                             true
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a2",
+                                             "arrayDouble",
+                                             null,
+                                             null,
+                                             null,
+                                             null,
+                                             true
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a3",
+                                             "sketch0",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a4",
+                                             "sketch1",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a5",
+                                             "sketch2",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a6",
+                                             "sketch3",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a7",
+                                             "sketch4",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new SketchMergeAggregatorFactory(
+                                             "a8",
+                                             "sketch5",
+                                             null,
+                                             null,
+                                             true,
+                                             null,
+                                             false
+                                         ),
+                                         new CountAggregatorFactory("a9")
+                                     )
+                                     .setPostAggregatorSpecs(
+                                         ImmutableList.of(
+                                             new SketchEstimatePostAggregator(
+                                                 "p0",
+                                                 new FieldAccessPostAggregator("f0", "a0"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p1",
+                                                 new FieldAccessPostAggregator("f1", "a1"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p2",
+                                                 new FieldAccessPostAggregator("f2", "a2"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p3",
+                                                 new FieldAccessPostAggregator("f3", "a3"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p4",
+                                                 new FieldAccessPostAggregator("f4", "a4"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p5",
+                                                 new FieldAccessPostAggregator("f5", "a5"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p6",
+                                                 new FieldAccessPostAggregator("f6", "a6"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p7",
+                                                 new FieldAccessPostAggregator("f7", "a7"),
+                                                 null
+                                             ),
+                                             new SketchEstimatePostAggregator(
+                                                 "p8",
+                                                 new FieldAccessPostAggregator("f8", "a8"),
+                                                 null
+                                             )
+                                         )
+                                     )
+                                     .build();
+
+    Sequence<ResultRow> realtimeSeq = helper.runQueryOnSegmentsObjs(realtimeSegs, query);
+    Sequence<ResultRow> seq = helper.runQueryOnSegmentsObjs(segs, query);
+    List<ResultRow> realtimeList = realtimeSeq.toList();
+    List<ResultRow> list = seq.toList();
+
+    // expect 4 distinct arrays for each of these columns from 14 rows
+    Assert.assertEquals(1, realtimeList.size());
+    Assert.assertEquals(14L, realtimeList.get(0).get(9));
+    // array column estimate counts
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(10), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(11), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(12), 0.01);
+    // pre-aggregated arrays counts
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(13), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(14), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(15), 0.01);
+    // if processAsArray is false, count is done as string mvds so it counts the total number of elements
+    Assert.assertEquals(5.0, (Double) realtimeList.get(0).get(16), 0.01);
+    Assert.assertEquals(4.0, (Double) realtimeList.get(0).get(17), 0.01);
+    Assert.assertEquals(6.0, (Double) realtimeList.get(0).get(18), 0.01);
+
+    Assert.assertEquals(1, list.size());
+    Assert.assertEquals(14L, list.get(0).get(9));
+    // array column estimate counts
+    Assert.assertEquals(4.0, (Double) list.get(0).get(10), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(11), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(12), 0.01);
+    // pre-aggregated arrays counts
+    Assert.assertEquals(4.0, (Double) list.get(0).get(13), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(14), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(15), 0.01);
+    // if processAsArray is false, count is done as string mvds so it counts the total number of elements
+    Assert.assertEquals(5.0, (Double) list.get(0).get(16), 0.01);
+    Assert.assertEquals(4.0, (Double) list.get(0).get(17), 0.01);
+    Assert.assertEquals(6.0, (Double) list.get(0).get(18), 0.01);
   }
 
   private void assertAggregatorFactorySerde(AggregatorFactory agg) throws Exception
@@ -404,7 +684,8 @@ public class SketchAggregationTest
         16,
         null,
         null,
-        null
+        null,
+        false
     );
     final SketchMergeAggregatorFactory factory2 = new SketchMergeAggregatorFactory(
         "name",
@@ -412,7 +693,8 @@ public class SketchAggregationTest
         16,
         null,
         null,
-        null
+        null,
+        false
     );
     final SketchMergeAggregatorFactory factory3 = new SketchMergeAggregatorFactory(
         "name",
@@ -420,7 +702,8 @@ public class SketchAggregationTest
         32,
         null,
         null,
-        null
+        null,
+        false
     );
 
     Assert.assertTrue(Arrays.equals(factory1.getCacheKey(), factory2.getCacheKey()));
@@ -505,7 +788,7 @@ public class SketchAggregationTest
 
     columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("sketch", sketchHolder)));
     SketchHolder[] holders = helper.runRelocateVerificationTest(
-        new SketchMergeAggregatorFactory("sketch", "sketch", 16, false, true, 2),
+        new SketchMergeAggregatorFactory("sketch", "sketch", 16, false, true, 2, false),
         columnSelectorFactory,
         SketchHolder.class
     );
@@ -522,7 +805,7 @@ public class SketchAggregationTest
     value.add("bar");
     List[] columnValues = new List[]{value};
     final TestObjectColumnSelector selector = new TestObjectColumnSelector(columnValues);
-    final Aggregator agg = new SketchAggregator(selector, 4096);
+    final Aggregator agg = new SketchAggregator(selector, 4096, false);
     agg.aggregate();
     Assert.assertFalse(agg.isNull());
     Assert.assertNotNull(agg.get());
@@ -537,7 +820,7 @@ public class SketchAggregationTest
   {
     Double[] columnValues = new Double[]{2.0};
     final TestObjectColumnSelector selector = new TestObjectColumnSelector(columnValues);
-    final Aggregator agg = new SketchAggregator(selector, 4096);
+    final Aggregator agg = new SketchAggregator(selector, 4096, false);
     agg.aggregate();
     Assert.assertFalse(agg.isNull());
     Assert.assertNotNull(agg.get());
@@ -556,7 +839,7 @@ public class SketchAggregationTest
     }
 
     final TestObjectColumnSelector<String> selector = new TestObjectColumnSelector<>(columnValues);
-    final SketchAggregator agg = new SketchAggregator(selector, 128);
+    final SketchAggregator agg = new SketchAggregator(selector, 128, false);
 
     // Verify initial size of sketch
     Assert.assertEquals(48L, agg.getInitialSizeBytes());

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
@@ -41,10 +41,10 @@ import org.junit.Test;
 public class SketchAggregatorFactoryTest
 {
   private static final SketchMergeAggregatorFactory AGGREGATOR_16384 =
-      new SketchMergeAggregatorFactory("x", "x", 16384, null, false, null);
+      new SketchMergeAggregatorFactory("x", "x", 16384, null, false, null, false);
 
   private static final SketchMergeAggregatorFactory AGGREGATOR_32768 =
-      new SketchMergeAggregatorFactory("x", "x", 32768, null, false, null);
+      new SketchMergeAggregatorFactory("x", "x", 32768, null, false, null, false);
 
   @Test
   public void testGuessAggregatorHeapFootprint()
@@ -94,8 +94,8 @@ public class SketchAggregatorFactoryTest
                   new OldSketchBuildAggregatorFactory("oldBuild", "col", 16),
                   new OldSketchMergeAggregatorFactory("oldMerge", "col", 16, false),
                   new OldSketchMergeAggregatorFactory("oldMergeFinalize", "col", 16, true),
-                  new SketchMergeAggregatorFactory("merge", "col", 16, false, false, null),
-                  new SketchMergeAggregatorFactory("mergeFinalize", "col", 16, true, false, null)
+                  new SketchMergeAggregatorFactory("merge", "col", 16, false, false, null, false),
+                  new SketchMergeAggregatorFactory("mergeFinalize", "col", 16, true, false, null, false)
               )
               .postAggregators(
                   new FieldAccessPostAggregator("oldBuild-access", "oldBuild"),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchToStringPostAggregatorTest.java
@@ -111,7 +111,7 @@ public class SketchToStringPostAggregatorTest
   {
     // not going to iterate over the selector since getting a summary of an empty sketch is sufficient
     final TestObjectColumnSelector selector = new TestObjectColumnSelector(new Object[0]);
-    final Aggregator agg = new SketchAggregator(selector, 4096);
+    final Aggregator agg = new SketchAggregator(selector, 4096, false);
 
     final Map<String, Object> fields = new HashMap<>();
     fields.put("sketch", agg.get());

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactory.java
@@ -287,13 +287,29 @@ public class BloomFilterAggregatorFactory extends AggregatorFactory
               maxNumEntries,
               onHeap
           );
-        case COMPLEX:
-          // in an ideal world, we would check complex type, but until then assume it's a bloom filter
-          return new BloomFilterMergeAggregator(
+        case ARRAY:
+          return new ByteBloomFilterAggregator(
               columnFactory.makeColumnValueSelector(field.getDimension()),
+              capabilities,
               maxNumEntries,
               onHeap
           );
+        case COMPLEX:
+          if (BloomFilterSerializersModule.BLOOM_FILTER_TYPE_NAME.equals(capabilities.getComplexTypeName())) {
+            return new BloomFilterMergeAggregator(
+                columnFactory.makeColumnValueSelector(field.getDimension()),
+                maxNumEntries,
+                onHeap
+            );
+          } else {
+            // fall back to bytes aggregator
+            return new ByteBloomFilterAggregator(
+                columnFactory.makeColumnValueSelector(field.getDimension()),
+                capabilities,
+                maxNumEntries,
+                onHeap
+            );
+          }
         default:
           throw new IAE(
               "Cannot create bloom filter %s for invalid column type [%s]",

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/ByteBloomFilterAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/ByteBloomFilterAggregator.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.aggregation.bloom;
+
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.query.filter.BloomKFilter;
+import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.column.TypeSignature;
+import org.apache.druid.segment.column.ValueType;
+
+import java.nio.ByteBuffer;
+
+public class ByteBloomFilterAggregator extends BaseBloomFilterAggregator<BaseObjectColumnValueSelector<Object>>
+{
+  private final ExpressionType columnType;
+
+  ByteBloomFilterAggregator(
+      BaseObjectColumnValueSelector<Object> baseObjectColumnValueSelector,
+      TypeSignature<ValueType> columnType,
+      int maxNumEntries,
+      boolean onHeap
+  )
+  {
+    super(baseObjectColumnValueSelector, maxNumEntries, onHeap);
+    this.columnType = ExpressionType.fromColumnTypeStrict(columnType);
+  }
+
+  @Override
+  void bufferAdd(ByteBuffer buf)
+  {
+    final Object val = selector.getObject();
+    if (val == null) {
+      BloomKFilter.addBytes(buf, null, 0, 0);
+    } else {
+      BloomKFilter.addBytes(buf, ExprEval.toBytes(columnType, val));
+    }
+  }
+}

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/ObjectBloomFilterAggregator.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/aggregation/bloom/ObjectBloomFilterAggregator.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.bloom;
 
+import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.segment.BaseObjectColumnValueSelector;
 
@@ -54,6 +55,8 @@ class ObjectBloomFilterAggregator extends BaseBloomFilterAggregator<BaseObjectCo
         BloomKFilter.addFloat(buf, (float) object);
       } else if (object instanceof String) {
         BloomKFilter.addString(buf, (String) object);
+      } else if (object instanceof Object[]) {
+        BloomKFilter.addBytes(buf, ExprEval.toBytesBestEffort(object));
       } else {
         BloomKFilter.addBytes(buf, null, 0, 0);
       }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/sql/BloomDimFilterSqlTest.java
@@ -93,6 +93,7 @@ public class BloomDimFilterSqlTest extends BaseCalciteQueryTest
     }
     byte[] bytes = BloomFilterSerializersModule.bloomKFilterToBytes(filter);
     String base64 = StringUtils.encodeBase64String(bytes);
+    skipVectorize();
 
     // fool the planner to make an expression virtual column to test bloom filter Druid expression
     testQuery(

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -171,8 +171,8 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
               new CountAggregatorFactory("count"),
               // FloatSumAggregator combine method takes in two Float but return Double
               new FloatSumAggregatorFactory("sum_added", "added"),
-              new SketchMergeAggregatorFactory("thetaSketch", "user", 16384, true, false, null),
-              new HllSketchBuildAggregatorFactory("HLLSketchBuild", "user", 12, TgtHllType.HLL_4.name(), null, false, false),
+              new SketchMergeAggregatorFactory("thetaSketch", "user", 16384, true, false, null, false),
+              new HllSketchBuildAggregatorFactory("HLLSketchBuild", "user", 12, TgtHllType.HLL_4.name(), null, false, false, false),
               new DoublesSketchAggregatorFactory("quantilesDoublesSketch", "delta", 128, 1000000000L, null)
           },
           false
@@ -265,13 +265,14 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
           new AggregatorFactory[]{
               new CountAggregatorFactory("count"),
               new LongSumAggregatorFactory("sum_added", "added"),
-              new SketchMergeAggregatorFactory("thetaSketch", "user", 16384, true, false, null),
+              new SketchMergeAggregatorFactory("thetaSketch", "user", 16384, true, false, null, false),
               new HllSketchBuildAggregatorFactory(
                   "HLLSketchBuild",
                   "user",
                   12,
                   TgtHllType.HLL_4.name(),
                   null,
+                  false,
                   false,
                   false
               ),

--- a/processing/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -142,6 +142,27 @@ public abstract class ExprEval<T>
     }
   }
 
+  public static byte[] toBytes(ExpressionType expressionType, Object o)
+  {
+    final ExprEval<?> eval = ExprEval.ofType(expressionType, o);
+    return toBytes(eval);
+  }
+
+  public static byte[] toBytesBestEffort(Object o)
+  {
+    final ExprEval<?> eval = ExprEval.bestEffortOf(o);
+    return toBytes(eval);
+  }
+
+  public static byte[] toBytes(ExprEval<?> eval)
+  {
+    final NullableTypeStrategy<Object> strategy = eval.type().getNullableStrategy();
+    final int size = strategy.estimateSizeBytes(eval.valueOrDefault());
+    final ByteBuffer buffer = ByteBuffer.allocate(size);
+    strategy.write(buffer, eval.valueOrDefault(), size);
+    return buffer.array();
+  }
+
   /**
    * Converts a List to an appropriate array type, optionally doing some conversion to make multi-valued strings
    * consistent across selector types, which are not consistent in treatment of null, [], and [null].


### PR DESCRIPTION
### Description
Split out support for ARRAY typed inputs to HLL and Theta sketches, as well as bloom filter and aggregator from #14542 to give it a proper standalone review.

changes:
* add support to hll and theta sketch aggs for array inputs, converting arrays to byte[] form. native agg specs have a flag to indicate if ingest time lists should be handled as arrays or mvds
* add support to bloom filter and aggregator for array inputs, converting arrays to byte[] form

![Screenshot 2023-07-07 at 1 28 50 AM](https://github.com/apache/druid/assets/1577461/d0084faf-0b57-4541-85a7-28cab88b1ee0)


#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
