### PR TITLE
prometheus-emitter: add clusterName parameter

### DIFF
--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -45,7 +45,8 @@ All the configuration parameters for the Prometheus emitter are under `druid.emi
 | `druid.emitter.prometheus.addHostAsLabel`     | Flag to include the hostname as a prometheus label.                                                                                                                                                                                    | no        | false                                |
 | `druid.emitter.prometheus.addServiceAsLabel`  | Flag to include the druid service name (e.g. `druid/broker`, `druid/coordinator`, etc.) as a prometheus label.                                                                                                                         | no        | false                                |
 | `druid.emitter.prometheus.pushGatewayAddress` | Pushgateway address. Required if using `pushgateway` strategy.                                                                                                                                                                         | no        | none                                 |
-|`druid.emitter.prometheus.flushPeriod`|Emit metrics to Pushgateway every `flushPeriod` seconds. Required if `pushgateway` strategy is used.|no|15|
+| `druid.emitter.prometheus.flushPeriod`        | Emit metrics to Pushgateway every `flushPeriod` seconds. Required if `pushgateway` strategy is used.                                                                                                                                   | no        | 15                                   |
+| `druid.emitter.prometheus.clusterName`        | Optional cluster name. Adds the cluster name as a Prometheus label to distinguish between multiple clusters.	                                                                                                                          | no	       | none                                 |
 
 ### Ports for colocated Druid processes
 

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/Metrics.java
@@ -52,6 +52,7 @@ public class Metrics
 
   private static final String TAG_HOSTNAME = "host_name";
   private static final String TAG_SERVICE = "druid_service";
+  private static final String TAG_CLUSTER = "cluster_name";
 
   public DimensionsAndCollector getByName(String name, String service)
   {
@@ -62,7 +63,7 @@ public class Metrics
     }
   }
 
-  public Metrics(String namespace, String path, boolean isAddHostAsLabel, boolean isAddServiceAsLabel)
+  public Metrics(String namespace, String path, boolean isAddHostAsLabel, boolean isAddServiceAsLabel, String clusterName)
   {
     Map<String, DimensionsAndCollector> registeredMetrics = new HashMap<>();
     Map<String, Metric> metrics = readConfig(path);
@@ -77,6 +78,10 @@ public class Metrics
 
       if (isAddServiceAsLabel) {
         metric.dimensions.add(TAG_SERVICE);
+      }
+
+      if (clusterName != null && !clusterName.isEmpty()) {
+        metric.dimensions.add(TAG_CLUSTER);
       }
 
       String[] dimensions = metric.dimensions.toArray(new String[0]);

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitter.java
@@ -54,6 +54,7 @@ public class PrometheusEmitter implements Emitter
 
   private static final String TAG_HOSTNAME = "host_name";
   private static final String TAG_SERVICE = "druid_service";
+  private static final String TAG_CLUSTER = "cluster_name";
 
   private HTTPServer server;
   private PushGateway pushGateway;
@@ -69,7 +70,7 @@ public class PrometheusEmitter implements Emitter
   {
     this.config = config;
     this.strategy = config.getStrategy();
-    metrics = new Metrics(config.getNamespace(), config.getDimensionMapPath(), config.isAddHostAsLabel(), config.isAddServiceAsLabel());
+    metrics = new Metrics(config.getNamespace(), config.getDimensionMapPath(), config.isAddHostAsLabel(), config.isAddServiceAsLabel(), config.getClusterName());
   }
 
 
@@ -148,6 +149,8 @@ public class PrometheusEmitter implements Emitter
             labelValues[i] = host;
           } else if (config.isAddServiceAsLabel() && TAG_SERVICE.equals(labelName)) {
             labelValues[i] = service;
+          } else if (TAG_CLUSTER.equals(labelName)) {
+            labelValues[i] = config.getClusterName();
           } else {
             labelValues[i] = "unknown";
           }

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -143,6 +143,7 @@ public class PrometheusEmitterConfig
     return addServiceAsLabel;
   }
 
+  @Nullable
   public String getClusterName()
   {
     return clusterName;

--- a/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
+++ b/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfig.java
@@ -63,6 +63,10 @@ public class PrometheusEmitterConfig
   @JsonProperty
   private final boolean addServiceAsLabel;
 
+  @JsonProperty
+  @Nullable
+  private final String clusterName;
+
   @JsonCreator
   public PrometheusEmitterConfig(
       @JsonProperty("strategy") @Nullable Strategy strategy,
@@ -72,7 +76,8 @@ public class PrometheusEmitterConfig
       @JsonProperty("pushGatewayAddress") @Nullable String pushGatewayAddress,
       @JsonProperty("addHostAsLabel") boolean addHostAsLabel,
       @JsonProperty("addServiceAsLabel") boolean addServiceAsLabel,
-      @JsonProperty("flushPeriod") Integer flushPeriod
+      @JsonProperty("flushPeriod") Integer flushPeriod,
+      @JsonProperty("clusterName") @Nullable String clusterName
   )
   {
     this.strategy = strategy != null ? strategy : Strategy.exporter;
@@ -94,6 +99,7 @@ public class PrometheusEmitterConfig
     this.flushPeriod = flushPeriod;
     this.addHostAsLabel = addHostAsLabel;
     this.addServiceAsLabel = addServiceAsLabel;
+    this.clusterName = clusterName;
   }
 
   public String getNamespace()
@@ -135,6 +141,11 @@ public class PrometheusEmitterConfig
   public boolean isAddServiceAsLabel()
   {
     return addServiceAsLabel;
+  }
+
+  public String getClusterName()
+  {
+    return clusterName;
   }
 
   public enum Strategy

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -28,7 +28,29 @@ public class MetricsTest
   @Test
   public void testMetricsConfiguration()
   {
-    Metrics metrics = new Metrics("test", null, true, true, "test_cluster");
+    Metrics metrics = new Metrics("test", null, true, true, null);
+    DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
+    Assert.assertNotNull(dimensionsAndCollector);
+    String[] dimensions = dimensionsAndCollector.getDimensions();
+    Assert.assertEquals("dataSource", dimensions[0]);
+    Assert.assertEquals("druid_service", dimensions[1]);
+    Assert.assertEquals("host_name", dimensions[2]);
+    Assert.assertEquals("type", dimensions[3]);
+    Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
+    Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
+
+    DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
+    Assert.assertNotNull(d);
+    String[] dims = d.getDimensions();
+    Assert.assertEquals("druid_service", dims[0]);
+    Assert.assertEquals("host_name", dims[1]);
+    Assert.assertEquals("server", dims[2]);
+  }
+
+  @Test
+  public void testMetricsConfigurationWithClusterName()
+  {
+    Metrics metrics = new Metrics("test_2", null, true, true, "test_cluster");
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
     Assert.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -28,22 +28,24 @@ public class MetricsTest
   @Test
   public void testMetricsConfiguration()
   {
-    Metrics metrics = new Metrics("test", null, true, true);
+    Metrics metrics = new Metrics("test", null, true, true, "test_cluster");
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
     Assert.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
-    Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("druid_service", dimensions[1]);
-    Assert.assertEquals("host_name", dimensions[2]);
-    Assert.assertEquals("type", dimensions[3]);
+    Assert.assertEquals("cluster_name", dimensions[0]);
+    Assert.assertEquals("dataSource", dimensions[1]);
+    Assert.assertEquals("druid_service", dimensions[2]);
+    Assert.assertEquals("host_name", dimensions[3]);
+    Assert.assertEquals("type", dimensions[4]);
     Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
 
     DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
     Assert.assertNotNull(d);
     String[] dims = d.getDimensions();
-    Assert.assertEquals("druid_service", dims[0]);
-    Assert.assertEquals("host_name", dims[1]);
-    Assert.assertEquals("server", dims[2]);
+    Assert.assertEquals("cluster_name", dims[0]);
+    Assert.assertEquals("druid_service", dims[1]);
+    Assert.assertEquals("host_name", dims[2]);
+    Assert.assertEquals("server", dims[3]);
   }
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -80,7 +80,8 @@ public class PrometheusEmitterTest
   }
   
   @Test
-  public void testEmitterWithClusterLabel() {
+  public void testEmitterWithClusterLabel() 
+  {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(
         PrometheusEmitterConfig.Strategy.exporter,
         null,


### PR DESCRIPTION
### Description

This PR introduces the ability to add a cluster name as a Prometheus label. This is particularly useful when managing multiple Druid clusters and needing to distinguish between the metrics they emit.

This was achieved by adding a new optional configuration parameter (`druid.emitter.prometheus.clusterName`) to the Prometheus emitter.

### Changes Made

- Added a new configuration parameter (`druid.emitter.prometheus.clusterName`) to the Prometheus emitter.
- Modified the PrometheusEmitter to include the cluster name as a Prometheus label if the configuration parameter is set.
- Modified the unit tests to include and test this new functionality.

### Release note

The Prometheus emitter now supports an additional optional configuration parameter, `druid.emitter.prometheus.clusterName`. This allows users to add a cluster name as a Prometheus label to distinguish between multiple Druid clusters.
<hr>
Key changed/added classes in this PR:
- PrometheusEmitter
- PrometheusEmitterConfig
- PrometheusEmitterTest

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.