### PR TITLE
doc: fix duplicate sidebar item

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -23,7 +23,6 @@
       "tutorials/docker",
       "tutorials/tutorial-kerberos-hadoop",
       "tutorials/tutorial-msq-convert-spec",
-      "tutorials/tutorial-jdbc",
       "tutorials/tutorial-sql-query-view",
       "tutorials/tutorial-unnest-arrays",
       "tutorials/tutorial-jupyter-index",


### PR DESCRIPTION
Removes a duplicate entry in the sidebar. Probably came about while resolving a merge conflict when we switched ot the format for Docusaurus2. Same issue does not exist for 27.0 or master's upgrades

- [x] been self-reviewed.
