### PR TITLE
Fix maxCompletedTasks parameter in OverlordClientImpl.

### DIFF
--- a/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClientImpl.java
@@ -147,7 +147,7 @@ public class OverlordClientImpl implements OverlordClient
     }
 
     if (maxCompletedTasks != null) {
-      pathBuilder.append(params == 0 ? '?' : '&').append("maxCompletedTasks=").append(maxCompletedTasks);
+      pathBuilder.append(params == 0 ? '?' : '&').append("max=").append(maxCompletedTasks);
     }
 
     return FutureUtils.transform(

--- a/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
@@ -184,7 +184,7 @@ public class OverlordClientImplTest
     serviceClient.expectAndRespond(
         new RequestBuilder(
             HttpMethod.GET,
-            "/druid/indexer/v1/tasks?state=RUNNING&datasource=foo%3F&maxCompletedTasks=0"
+            "/druid/indexer/v1/tasks?state=RUNNING&datasource=foo%3F&max=0"
         ),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),
@@ -203,7 +203,7 @@ public class OverlordClientImplTest
     serviceClient.expectAndRespond(
         new RequestBuilder(
             HttpMethod.GET,
-            "/druid/indexer/v1/tasks?maxCompletedTasks=0"
+            "/druid/indexer/v1/tasks?max=0"
         ),
         HttpResponseStatus.OK,
         ImmutableMap.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON),


### PR DESCRIPTION
It was sent to the server as "maxCompletedTasks", but the server expects "max". This caused it to be ignored. This bug was introduced in #14581.