### PR TITLE
Configure dependency-check for apache-release

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -690,6 +690,7 @@
    ]]></notes>
     <cve>CVE-2021-0341</cve>
     <cve>CVE-2016-2402</cve>	<!-- Suppressed since okhttp requests in Druid are internal, and not user-facing -->
+    <cve>CVE-2023-3782</cve>	<!-- Suppressed since okhttp in Druid doesn't use the BrotliInterceptor -->
   </suppress>
 
   <suppress>
@@ -748,6 +749,38 @@
     <packageUrl regex="true">^pkg:npm/d3\-color@.*$</packageUrl>
     <vulnerabilityName>1084597</vulnerabilityName>
     <vulnerabilityName>1088594</vulnerabilityName>
+  </suppress>
+
+  <suppress>
+    <!-- package-lock.json?ansi-regex -->
+    <notes><![CDATA[
+   file name: ansi-regex:5.0.0
+   ]]></notes>
+    <vulnerabilityName>1091190</vulnerabilityName>
+  </suppress>
+
+  <suppress>
+    <!-- package-lock.json?glob-parent -->
+    <notes><![CDATA[
+   file name: glob-parent:5.1.1
+   ]]></notes>
+    <vulnerabilityName>1091181</vulnerabilityName>
+  </suppress>
+
+  <suppress>
+    <!-- package-lock.json?minimatch -->
+    <notes><![CDATA[
+   file name: minimatch:3.0.4
+   ]]></notes>
+    <vulnerabilityName>1092637</vulnerabilityName>
+  </suppress>
+
+  <suppress>
+    <!-- package-lock.json?y18n -->
+    <notes><![CDATA[
+   file name: y18n:4.0.0
+   ]]></notes>
+    <vulnerabilityName>1091234</vulnerabilityName>
   </suppress>
 
   <suppress>
@@ -820,6 +853,7 @@
     <!-- this one seems to apply to backend server - https://nvd.nist.gov/vuln/detail/CVE-2023-25613 -->
     <cve>CVE-2023-25613</cve>
     <cve>CVE-2023-2976</cve> <!-- hadoop-client-runtime isn't using com.google.common.io.FileBackedOutputStream -->
+    <cve>CVE-2023-37475</cve> <!-- Druid does not use Hamba avro -->
   </suppress>
   <suppress>
     <!-- from extensions using hadoop-client-api, these dependencies are shaded in the jar -->

--- a/pom.xml
+++ b/pom.xml
@@ -2036,16 +2036,16 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
-			<version>7.4.4</version>
-			<configuration>
-			    <failBuildOnCVSS>7</failBuildOnCVSS>
-			    <skipProvidedScope>true</skipProvidedScope>
-			    <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
-			    <!-- For node analysis info, see https://github.com/jeremylong/DependencyCheck/issues/2482#issuecomment-603755623 -->
-			    <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>  <!-- plugin author (jeremylong) recommends to disable, since this analyzer is retired -->
-			    <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
-			    <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
-			</configuration>
+                      <version>7.4.4</version>
+                      <configuration>
+                          <failBuildOnCVSS>7</failBuildOnCVSS>
+                          <skipProvidedScope>true</skipProvidedScope>
+                          <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
+                          <!-- For node analysis info, see https://github.com/jeremylong/DependencyCheck/issues/2482#issuecomment-603755623 -->
+                          <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>  <!-- plugin author (jeremylong) recommends to disable, since this analyzer is retired -->
+                          <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
+                          <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
+                      </configuration>
                       <executions>
                           <execution>
                               <phase>compile</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -2036,6 +2036,16 @@
                     <plugin>
                       <groupId>org.owasp</groupId>
                       <artifactId>dependency-check-maven</artifactId>
+			<version>7.4.4</version>
+			<configuration>
+			    <failBuildOnCVSS>7</failBuildOnCVSS>
+			    <skipProvidedScope>true</skipProvidedScope>
+			    <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
+			    <!-- For node analysis info, see https://github.com/jeremylong/DependencyCheck/issues/2482#issuecomment-603755623 -->
+			    <nodeAnalyzerEnabled>false</nodeAnalyzerEnabled>  <!-- plugin author (jeremylong) recommends to disable, since this analyzer is retired -->
+			    <nodeAuditSkipDevDependencies>true</nodeAuditSkipDevDependencies>
+			    <suppressionFile>owasp-dependency-check-suppressions.xml</suppressionFile>
+			</configuration>
                       <executions>
                           <execution>
                               <phase>compile</phase>


### PR DESCRIPTION
Add configuration to fail only on vulnerabilities having a severity of at least 7 (and other configs) in the apache-release profile

Also suppress the following CVEs
CVE-2023-3782
CVE-2023-37475

Web-console / Static website vulnerabilities:
package-lock.json?ansi-regex (pkg:npm/ansi-regex@5.0.0) : 1091190
package-lock.json?glob-parent (pkg:npm/glob-parent@5.1.1) : 1091181
package-lock.json?minimatch (pkg:npm/minimatch@3.0.4) : 1092637
package-lock.json?y18n (pkg:npm/y18n@4.0.0) : 1091234