### PR TITLE
Change the default format from OBJECT to OBJECTLINES

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -768,7 +768,7 @@ public class SqlStatementResource
   ) throws IOException
   {
     try {
-      try (final ResultFormat.Writer writer = ResultFormat.OBJECT.createFormatter(os, jsonMapper)) {
+      try (final ResultFormat.Writer writer = ResultFormat.OBJECTLINES.createFormatter(os, jsonMapper)) {
         Yielder<Object[]> yielder = results.get();
         List<ColumnNameAndTypes> rowSignature = signature.get();
         writer.writeResponseStart();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/SqlMSQStatementResourcePostTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.msq.sql;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -49,8 +50,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -315,26 +318,52 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         SqlStatementResourceTest.makeOkRequest()
     ).getEntity();
 
+    assertExpectedResults(
+        "{\"cnt\":1,\"dim1\":\"\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"10.1\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"2\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"1\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"def\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"abc\"}\n"
+        + "\n",
+        resource.doGetResults(
+            sqlStatementResult.getQueryId(),
+            null,
+            SqlStatementResourceTest.makeOkRequest()
+        ),
+        objectMapper);
 
-    List<Map<String, Object>> rows = new ArrayList<>();
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", ""));
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", "10.1"));
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", "2"));
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", "1"));
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", "def"));
-    rows.add(ImmutableMap.of("cnt", 1, "dim1", "abc"));
+    assertExpectedResults(
+        "{\"cnt\":1,\"dim1\":\"\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"10.1\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"2\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"1\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"def\"}\n"
+        + "{\"cnt\":1,\"dim1\":\"abc\"}\n"
+        + "\n",
+        resource.doGetResults(
+            sqlStatementResult.getQueryId(),
+            0L,
+            SqlStatementResourceTest.makeOkRequest()
+        ),
+        objectMapper);
+  }
 
-    Assert.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
-        sqlStatementResult.getQueryId(),
-        null,
-        SqlStatementResourceTest.makeOkRequest()
-    )));
+  private void assertExpectedResults(String expectedResult, Response resultsResponse, ObjectMapper objectMapper) throws IOException
+  {
+    byte[] bytes = responseToByteArray(resultsResponse, objectMapper);
+    Assert.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
+  }
 
-    Assert.assertEquals(rows, SqlStatementResourceTest.getResultRowsFromResponse(resource.doGetResults(
-        sqlStatementResult.getQueryId(),
-        0L,
-        SqlStatementResourceTest.makeOkRequest()
-    )));
+  public static byte[] responseToByteArray(Response resp, ObjectMapper objectMapper) throws IOException
+  {
+    if (resp.getEntity() instanceof StreamingOutput) {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ((StreamingOutput) resp.getEntity()).write(baos);
+      return baos.toByteArray();
+    } else {
+      return objectMapper.writeValueAsBytes(resp.getEntity());
+    }
   }
 
   @Test

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/SqlStatementResourceTest.java
@@ -87,8 +87,8 @@ import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -740,39 +740,44 @@ public class SqlStatementResourceTest extends MSQTestBase
     Response resultsResponse = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
 
-    List<Map<String, Object>> rows = new ArrayList<>();
-    rows.add(ROW1);
-    rows.add(ROW2);
+    String expectedResult = "{\"_time\":123,\"alias\":\"foo\",\"market\":\"bar\"}\n"
+                            + "{\"_time\":234,\"alias\":\"foo1\",\"market\":\"bar1\"}\n\n";
 
-    Assert.assertEquals(rows, getResultRowsFromResponse(resultsResponse));
+    assertExpectedResults(expectedResult, resultsResponse);
 
     Assert.assertEquals(
         Response.Status.OK.getStatusCode(),
         resource.deleteQuery(FINISHED_SELECT_MSQ_QUERY, makeOkRequest()).getStatus()
     );
 
-    Assert.assertEquals(
-        rows,
-        getResultRowsFromResponse(resource.doGetResults(
+    assertExpectedResults(
+        expectedResult,
+        resource.doGetResults(
             FINISHED_SELECT_MSQ_QUERY,
             0L,
             makeOkRequest()
-        ))
+        )
     );
 
-    Assert.assertEquals(
-        rows,
-        getResultRowsFromResponse(resource.doGetResults(
+    assertExpectedResults(
+        expectedResult,
+        resource.doGetResults(
             FINISHED_SELECT_MSQ_QUERY,
             null,
             makeOkRequest()
-        ))
+        )
     );
 
     Assert.assertEquals(
         Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, -1L, makeOkRequest()).getStatus()
     );
+  }
+
+  private void assertExpectedResults(String expectedResult, Response resultsResponse) throws IOException
+  {
+    byte[] bytes = SqlResourceTest.responseToByteArray(resultsResponse);
+    Assert.assertEquals(expectedResult, new String(bytes, StandardCharsets.UTF_8));
   }
 
   @Test


### PR DESCRIPTION
Change the default results format for the SqlStatementResource from OBJECT to OBJECTLINES for better formatting.

New format:
<img width="690" alt="Screenshot 2023-07-31 at 12 10 53 PM" src="https://github.com/apache/druid/assets/9818861/65964d22-2197-47c7-8358-2600707f3be7">

<hr>


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
