### PR TITLE
MSQ WorkerImpl: Ignore ServiceClosedException on postCounters.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -132,6 +132,7 @@ import org.apache.druid.query.PrioritizedCallable;
 import org.apache.druid.query.PrioritizedRunnable;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryProcessingPool;
+import org.apache.druid.rpc.ServiceClosedException;
 import org.apache.druid.server.DruidNode;
 
 import javax.annotation.Nullable;
@@ -850,7 +851,16 @@ public class WorkerImpl implements Worker
     final CounterSnapshotsTree snapshotsTree = getCounters();
 
     if (controllerAlive && !snapshotsTree.isEmpty()) {
-      controllerClient.postCounters(id(), snapshotsTree);
+      try {
+        controllerClient.postCounters(id(), snapshotsTree);
+      } catch (IOException e) {
+        if (e.getCause() instanceof ServiceClosedException) {
+          // Suppress. This can happen if the controller goes away while a postCounters call is in flight.
+          log.debug(e, "Ignoring failure on postCounters, because controller has gone away.");
+        }
+
+        throw e;
+      }
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -853,13 +853,14 @@ public class WorkerImpl implements Worker
     if (controllerAlive && !snapshotsTree.isEmpty()) {
       try {
         controllerClient.postCounters(id(), snapshotsTree);
-      } catch (IOException e) {
+      }
+      catch (IOException e) {
         if (e.getCause() instanceof ServiceClosedException) {
           // Suppress. This can happen if the controller goes away while a postCounters call is in flight.
           log.debug(e, "Ignoring failure on postCounters, because controller has gone away.");
+        } else {
+          throw e;
         }
-
-        throw e;
       }
     }
   }


### PR DESCRIPTION
A race can happen where postCounters is in flight while the controller goes offline. When this happens, we should ignore the ServiceClosedException and continue without posting counters.