### PR TITLE
Retry S3 task log fetch

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -107,8 +107,10 @@ public class S3TaskLogs implements TaskLogs
       long contentLength = objectMetadata.getContentLength();
       if (offset >= contentLength || offset <= -contentLength) {
         start = 0;
+      } else if (offset >= 0) {
+        start = offset;
       } else {
-        start = offset >= 0 ? offset : contentLength + offset;
+        start = contentLength + offset;
       }
 
       final GetObjectRequest request = new GetObjectRequest(config.getS3Bucket(), taskKey)

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
@@ -66,6 +67,11 @@ public class S3TaskLogs implements TaskLogs
   public Optional<InputStream> streamTaskLog(final String taskid, final long offset) throws IOException
   {
     final String taskKey = getTaskLogKey(taskid, "log");
+    // this is to satisfy CodeQL scan
+    Preconditions.checkArgument(
+        offset <= Long.MAX_VALUE && offset >= Long.MIN_VALUE,
+        "offset is out of range"
+    );
     return streamTaskFileWithRetry(offset, taskKey);
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -92,7 +92,7 @@ public class S3TaskLogs implements TaskLogs
       return S3Utils.retryS3Operation(() -> streamTaskFile(offset, taskKey));
     }
     catch (Exception e) {
-      throw new IOE(e, "Failed to stream logs from: %s", taskKey);
+      throw new IOE(e, "Failed to stream logs for task[%s] starting at offset[%d]", taskKey, offset);
     }
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -23,7 +23,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
@@ -67,67 +66,66 @@ public class S3TaskLogs implements TaskLogs
   public Optional<InputStream> streamTaskLog(final String taskid, final long offset) throws IOException
   {
     final String taskKey = getTaskLogKey(taskid, "log");
-    // this is to satisfy CodeQL scan
-    Preconditions.checkArgument(
-        offset < Long.MAX_VALUE && offset > Long.MIN_VALUE,
-        "offset is out of range"
-    );
-    return streamTaskFile(offset, taskKey);
+    return streamTaskFileWithRetry(offset, taskKey);
   }
 
   @Override
   public Optional<InputStream> streamTaskReports(String taskid) throws IOException
   {
     final String taskKey = getTaskLogKey(taskid, "report.json");
-    return streamTaskFile(0, taskKey);
+    return streamTaskFileWithRetry(0, taskKey);
   }
 
   @Override
   public Optional<InputStream> streamTaskStatus(String taskid) throws IOException
   {
     final String taskKey = getTaskLogKey(taskid, "status.json");
-    return streamTaskFile(0, taskKey);
+    return streamTaskFileWithRetry(0, taskKey);
   }
 
-  private Optional<InputStream> streamTaskFile(final long offset, String taskKey) throws IOException
+  /**
+   * Using the retry conditions defined in {@link S3Utils#S3RETRY}.
+   */
+  private Optional<InputStream> streamTaskFileWithRetry(final long offset, String taskKey) throws IOException
   {
     try {
-      return S3Utils.retryS3Operation(
-          () -> {
-            try {
-              final ObjectMetadata objectMetadata = service.getObjectMetadata(config.getS3Bucket(), taskKey);
-
-              final long start;
-              final long end = objectMetadata.getContentLength() - 1;
-
-              if (offset > 0 && offset < objectMetadata.getContentLength()) {
-                start = offset;
-              } else if (offset < 0 && (-1 * offset) < objectMetadata.getContentLength()) {
-                start = objectMetadata.getContentLength() + offset;
-              } else {
-                start = 0;
-              }
-
-              final GetObjectRequest request = new GetObjectRequest(config.getS3Bucket(), taskKey)
-                  .withMatchingETagConstraint(ensureQuotated(objectMetadata.getETag()))
-                  .withRange(start, end);
-
-              return Optional.of(service.getObject(request).getObjectContent());
-            }
-            catch (AmazonS3Exception e) {
-              if (404 == e.getStatusCode()
-                  || "NoSuchKey".equals(e.getErrorCode())
-                  || "NoSuchBucket".equals(e.getErrorCode())) {
-                return Optional.absent();
-              } else {
-                throw e;
-              }
-            }
-          }
-      );
+      return S3Utils.retryS3Operation(() -> streamTaskFile(offset, taskKey));
     }
     catch (Exception e) {
       throw new IOE(e, "Failed to stream logs from: %s", taskKey);
+    }
+  }
+
+  private Optional<InputStream> streamTaskFile(final long offset, String taskKey)
+  {
+    try {
+      final ObjectMetadata objectMetadata = service.getObjectMetadata(config.getS3Bucket(), taskKey);
+
+      final long start;
+      final long end = objectMetadata.getContentLength() - 1;
+
+      if (offset > 0 && offset < objectMetadata.getContentLength()) {
+        start = offset;
+      } else if (offset < 0 && (-1 * offset) < objectMetadata.getContentLength()) {
+        start = objectMetadata.getContentLength() + offset;
+      } else {
+        start = 0;
+      }
+
+      final GetObjectRequest request = new GetObjectRequest(config.getS3Bucket(), taskKey)
+          .withMatchingETagConstraint(ensureQuotated(objectMetadata.getETag()))
+          .withRange(start, end);
+
+      return Optional.of(service.getObject(request).getObjectContent());
+    }
+    catch (AmazonS3Exception e) {
+      if (404 == e.getStatusCode()
+          || "NoSuchKey".equals(e.getErrorCode())
+          || "NoSuchBucket".equals(e.getErrorCode())) {
+        return Optional.absent();
+      } else {
+        throw e;
+      }
     }
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3TaskLogs.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
@@ -66,6 +67,11 @@ public class S3TaskLogs implements TaskLogs
   public Optional<InputStream> streamTaskLog(final String taskid, final long offset) throws IOException
   {
     final String taskKey = getTaskLogKey(taskid, "log");
+    // this is to satisfy CodeQL scan
+    Preconditions.checkArgument(
+        offset < Long.MAX_VALUE && offset > Long.MIN_VALUE,
+        "offset is out of range"
+    );
     return streamTaskFile(offset, taskKey);
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -492,11 +492,13 @@ public class S3TaskLogsTest extends EasyMockSupport
   public void test_retryStatusFetch_whenExceptionThrown() throws IOException
   {
     EasyMock.reset(s3Client);
+    // throw exception on first call
     AmazonS3Exception awsError = new AmazonS3Exception("AWS Error");
     awsError.setErrorCode("503");
     awsError.setStatusCode(503);
     EasyMock.expect(s3Client.getObjectMetadata(EasyMock.anyString(), EasyMock.anyString())).andThrow(awsError);
     EasyMock.expectLastCall().once();
+
     String logPath = TEST_PREFIX + "/" + KEY_1 + "/status.json";
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentLength(STATUS_CONTENTS.length());
@@ -508,6 +510,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.expectLastCall().once();
+
     replayAll();
 
     S3TaskLogs s3TaskLogs = getS3TaskLogs();

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -513,10 +513,13 @@ public class S3TaskLogsTest extends EasyMockSupport
     S3TaskLogs s3TaskLogs = getS3TaskLogs();
 
     Optional<InputStream> inputStreamOptional = s3TaskLogs.streamTaskStatus(KEY_1);
-    String report = new BufferedReader(
-        new InputStreamReader(inputStreamOptional.get(), StandardCharsets.UTF_8))
-        .lines()
-        .collect(Collectors.joining("\n"));
+    String report;
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+        inputStreamOptional.get(),
+        StandardCharsets.UTF_8
+    ))) {
+      report = reader.lines().collect(Collectors.joining("\n"));
+    }
 
     Assert.assertEquals(STATUS_CONTENTS, report);
   }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.storage.s3;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.Grant;
@@ -475,6 +476,39 @@ public class S3TaskLogsTest extends EasyMockSupport
     getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
     EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
     EasyMock.replay(s3Client);
+
+    S3TaskLogs s3TaskLogs = getS3TaskLogs();
+
+    Optional<InputStream> inputStreamOptional = s3TaskLogs.streamTaskStatus(KEY_1);
+    String report = new BufferedReader(
+        new InputStreamReader(inputStreamOptional.get(), StandardCharsets.UTF_8))
+        .lines()
+        .collect(Collectors.joining("\n"));
+
+    Assert.assertEquals(STATUS_CONTENTS, report);
+  }
+
+  @Test
+  public void test_retryStatusFetch_whenExceptionThrown() throws IOException
+  {
+    EasyMock.reset(s3Client);
+    AmazonS3Exception awsError = new AmazonS3Exception("AWS Error");
+    awsError.setErrorCode("503");
+    awsError.setStatusCode(503);
+    EasyMock.expect(s3Client.getObjectMetadata(EasyMock.anyString(), EasyMock.anyString())).andThrow(awsError);
+    EasyMock.expectLastCall().once();
+    String logPath = TEST_PREFIX + "/" + KEY_1 + "/status.json";
+    ObjectMetadata objectMetadata = new ObjectMetadata();
+    objectMetadata.setContentLength(STATUS_CONTENTS.length());
+    EasyMock.expect(s3Client.getObjectMetadata(TEST_BUCKET, logPath)).andReturn(objectMetadata);
+    S3Object s3Object = new S3Object();
+    s3Object.setObjectContent(new ByteArrayInputStream(STATUS_CONTENTS.getBytes(StandardCharsets.UTF_8)));
+    GetObjectRequest getObjectRequest = new GetObjectRequest(TEST_BUCKET, logPath);
+    getObjectRequest.setRange(0, STATUS_CONTENTS.length() - 1);
+    getObjectRequest.withMatchingETagConstraint(objectMetadata.getETag());
+    EasyMock.expect(s3Client.getObject(getObjectRequest)).andReturn(s3Object);
+    EasyMock.expectLastCall().once();
+    replayAll();
 
     S3TaskLogs s3TaskLogs = getS3TaskLogs();
 


### PR DESCRIPTION
### Description
Saw the following error when fetching task status from S3. This is due to S3 rate limiting on query, we should retry the operation in this case.
```
com.amazonaws.services.s3.model.AmazonS3Exception: Slow Down (Service: Amazon S3; Status Code: 503; Error Code: 503 Slow Down; Request ID:; S3 Extended Request ID: ; Proxy: null)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541) ~[aws-java-sdk-core-1.12.317.jar:?]
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5456) ~[aws-java-sdk-s3-1.12.317.jar:?]
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5403) ~[aws-java-sdk-s3-1.12.317.jar:?]
	at com.amazonaws.services.s3.AmazonS3Client.getObjectMetadata(AmazonS3Client.java:1372) ~[aws-java-sdk-s3-1.12.317.jar:?]
	at org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3.getObjectMetadata(ServerSideEncryptingAmazonS3.java:97) ~[?:?]
	at org.apache.druid.storage.s3.S3TaskLogs.streamTaskFile(S3TaskLogs.java:90) ~[?:?]

```
Now change to use `S3Utils.retryS3Operation` for task log fetch, same as task file push method.

#### Release note
Retry S3 task log fetch

<hr>

##### Key changed/added classes in this PR
 * make `streamTaskFile` method retry on transient S3 error in `S3TaskLogs` class

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
