### PR TITLE
upgrade core Apache Kafka dependencies to 3.5.1

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3913,7 +3913,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 3.4.0
+version: 3.5.1
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -4850,7 +4850,7 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 3.4.0
+version: 3.5.1
 libraries:
   - org.apache.kafka: kafka-clients
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>5.4.0</apache.curator.version>
-        <apache.kafka.version>3.4.0</apache.kafka.version>
+        <apache.kafka.version>3.5.1</apache.kafka.version>
         <apache.ranger.version>2.0.0</apache.ranger.version>
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <scala.library.version>2.13.9</scala.library.version>


### PR DESCRIPTION
Release notes: https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html
Announcement: https://lists.apache.org/thread/p7jyv3ys7b6jowcb6lys7821qcbcpb07

Release notes: https://downloads.apache.org/kafka/3.5.0/RELEASE_NOTES.html
Announcement: https://lists.apache.org/thread/s6x3zvkrv32v5y8yb6hh31h57spdbylk
