### PR TITLE
Catch integer overflow in BytesFullResponseHolder

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHolder.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/response/BytesFullResponseHolder.java
@@ -21,6 +21,7 @@ package org.apache.druid.java.util.http.client.response;
 
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
+import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,13 +43,16 @@ public class BytesFullResponseHolder extends FullResponseHolder<byte[]>
   }
 
   @Override
-  public byte[] getContent()
+  public byte[] getContent() throws BufferOverflowException
   {
-    int size = 0;
+    long size = 0L;
     for (byte[] chunk : chunks) {
       size += chunk.length;
+      if (size > Integer.MAX_VALUE) {
+        throw new BufferOverflowException();
+      }
     }
-    ByteBuffer buf = ByteBuffer.wrap(new byte[size]);
+    ByteBuffer buf = ByteBuffer.wrap(new byte[(int) size]);
 
     for (byte[] chunk : chunks) {
       buf.put(chunk);


### PR DESCRIPTION
### Description
For certain tasks, `RemoteTaskActionClient` can return a response whose total size exceeds the max value of `int`. Inside `BytesFullResponseHolder`, the `getContent` method finds the total size of an array of `byte[]` using an `int`, which causes it to overflow. We see this in production for `kill` tasks containing many segments, where `size` has overflowed to a negative value:

```
2023-08-03T00:05:33,888 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner - Exception while running task[AbstractTask{id='kill_mydatasource_ghadgifn_2022-09-28T00:00:00.000Z_2022-10-28T00:00:00.000Z_2023-08-03T00:02:07.108Z', groupId='kill_mydatasource_ghadgifn_2022-09-28T00:00:00.000Z_2022-10-28T00:00:00.000Z_2023-08-03T00:02:07.108Z', taskResource=TaskResource{availabilityGroup='kill_mydatasource_ghadgifn_2022-09-28T00:00:00.000Z_2022-10-28T00:00:00.000Z_2023-08-03T00:02:07.108Z', requiredCapacity=1}, dataSource='mydatasource', context={forceTimeChunkLock=true, useLineageBasedSegmentAllocation=true}}]
java.lang.NegativeArraySizeException: -1752691501
	at org.apache.druid.java.util.http.client.response.BytesFullResponseHolder.getContent(BytesFullResponseHolder.java:51) ~[druid-processing-26.0.0.jar:26.0.0]
	at org.apache.druid.indexing.common.actions.RemoteTaskActionClient.submit(RemoteTaskActionClient.java:71) ~[druid-indexing-service-26.0.0.jar:26.0.0]
	at org.apache.druid.indexing.common.task.KillUnusedSegmentsTask.runTask(KillUnusedSegmentsTask.java:119) ~[druid-indexing-service-26.0.0.jar:26.0.0]
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:173) ~[druid-indexing-service-26.0.0.jar:26.0.0]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:477) ~[druid-indexing-service-26.0.0.jar:26.0.0]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:449) ~[druid-indexing-service-26.0.0.jar:26.0.0]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```



<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Use long to compute the response size, and throw BufferOverflowException before allocating ByteBuffer
Catching the overflow with a `long` & throwing an exception gives context about what's going wrong. It also detects a wraparound so large that it becomes positive again. In that case, the ByteBuffer would be allocated, but it would be too small to fit all the data. I checked the existing codebase and found the ByteBufferWriteOutBytes class uses BufferOverflowException for a similar task.


#### Release note
Catch an integer overflow for task response sizes exceeding the maximum ByteBuffer size


##### Key changed/added classes in this PR
 * `BytesFullResponseHandler`

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
