### PR TITLE
Additional dimensions for service/heartbeat

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -336,8 +336,8 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 
 ### Service Health
 
-|Metric|Description| Dimensions                                                                                                                                                                              |Normal value|
-|------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+|Metric|Description|Dimensions|Normal value|
+|------|-----------|----------|------------|
 | `service/heartbeat` | Metric indicating the service is up. `ServiceStatusMonitor` must be enabled. | `leader` on the Overlord and Coordinator.<br />`workerVersion`, `workerCapacity`, `workerEnabled` on the Middle Manager.<br />`taskId`, `groupId`, `taskType`, `dataSource` on the Peon |1|
 
 ### Historical

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -336,9 +336,9 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 
 ### Service Health
 
-|Metric|Description|Dimensions|Normal value|
-|------|-----------|----------|------------|
-| `service/heartbeat` | Metric indicating the service is up. `ServiceStatusMonitor` must be enabled. |`leader` on the Overlord and Coordinator.|1|
+|Metric|Description| Dimensions                                                                                                                                                                              |Normal value|
+|------|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+| `service/heartbeat` | Metric indicating the service is up. `ServiceStatusMonitor` must be enabled. | `leader` on the Overlord and Coordinator.<br />`workerVersion`, `workerCapacity`, `workerEnabled` on the Middle Manager.<br />`taskId`, `groupId`, `taskType`, `dataSource` on the Peon |1|
 
 ### Historical
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -338,7 +338,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 
 |Metric|Description|Dimensions|Normal value|
 |------|-----------|----------|------------|
-| `service/heartbeat` | Metric indicating the service is up. `ServiceStatusMonitor` must be enabled. | `leader` on the Overlord and Coordinator.<br />`workerVersion`, `workerCapacity`, `workerEnabled` on the Middle Manager.<br />`taskId`, `groupId`, `taskType`, `dataSource` on the Peon |1|
+| `service/heartbeat` | Metric indicating the service is up. `ServiceStatusMonitor` must be enabled. | `leader` on the Overlord and Coordinator.<br />`workerVersion`, `category`, `status` on the Middle Manager.<br />`taskId`, `groupId`, `taskType`, `dataSource` on the Peon |1|
 
 ### Historical
 

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -175,5 +175,5 @@
   "namespace/cache/numEntries" : { "dimensions" : [], "type" : "gauge" },
   "namespace/cache/heapSizeInBytes" : { "dimensions" : [], "type" : "gauge" },
 
-  "service/heartbeat" : { "dimensions" : ["leader"], "type" : "gauge" }
+  "service/heartbeat" : { "dimensions" : ["leader"], "type" : "count" }
 }

--- a/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DruidMetrics.java
@@ -49,6 +49,9 @@ public class DruidMetrics
 
   public static final String TAGS = "tags";
 
+  public static final String CATEGORY = "category";
+  public static final String WORKER_VERSION = "workerVersion";
+
   public static int findNumComplexAggs(List<AggregatorFactory> aggs)
   {
     int retVal = 0;

--- a/server/src/main/java/org/apache/druid/server/metrics/ServiceStatusMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/ServiceStatusMonitor.java
@@ -36,9 +36,9 @@ public class ServiceStatusMonitor extends AbstractMonitor
   /**
    * The named binding for tags that should be reported with the `service/heartbeat` metric.
    */
-  public static final String TAGS_BINDING = "heartbeat";
+  public static final String HEARTBEAT_TAGS_BINDING = "heartbeat";
 
-  @Named(TAGS_BINDING)
+  @Named(HEARTBEAT_TAGS_BINDING)
   @Inject(optional = true)
   Supplier<Map<String, Object>> heartbeatTagsSupplier = null;
 

--- a/server/src/main/java/org/apache/druid/server/metrics/ServiceStatusMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/ServiceStatusMonitor.java
@@ -33,8 +33,12 @@ import java.util.Map;
  */
 public class ServiceStatusMonitor extends AbstractMonitor
 {
+  /**
+   * The named binding for tags that should be reported with the `service/heartbeat` metric.
+   */
+  public static final String TAGS_BINDING = "heartbeat";
 
-  @Named("heartbeat")
+  @Named(TAGS_BINDING)
   @Inject(optional = true)
   Supplier<Map<String, Object>> heartbeatTagsSupplier = null;
 
@@ -43,9 +47,7 @@ public class ServiceStatusMonitor extends AbstractMonitor
   {
     final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
     if (heartbeatTagsSupplier != null && heartbeatTagsSupplier.get() != null) {
-      heartbeatTagsSupplier.get().forEach((k, v) -> {
-        builder.setDimension(k, v);
-      });
+      heartbeatTagsSupplier.get().forEach(builder::setDimension);
     }
 
     emitter.emit(builder.build("service/heartbeat", 1));

--- a/server/src/main/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitor.java
@@ -26,6 +26,7 @@ import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.apache.druid.query.DruidMetrics;
 
 import java.util.Set;
 
@@ -71,8 +72,8 @@ public class WorkerTaskCountStatsMonitor extends AbstractMonitor
   {
     if (value != null) {
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder();
-      builder.setDimension("category", workerCategory);
-      builder.setDimension("workerVersion", workerVersion);
+      builder.setDimension(DruidMetrics.CATEGORY, workerCategory);
+      builder.setDimension(DruidMetrics.WORKER_VERSION, workerVersion);
       emitter.emit(builder.build(metricName, value));
     }
   }

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -333,7 +333,7 @@ public class CliCoordinator extends ServerRunnable
               binder.bind(RowIngestionMetersFactory.class).toProvider(Providers.of(null));
               // Bind HeartbeatSupplier only when the service operates independently of Overlord.
               binder.bind(new TypeLiteral<Supplier<Map<String, Object>>>() {})
-                  .annotatedWith(Names.named(ServiceStatusMonitor.TAGS_BINDING))
+                  .annotatedWith(Names.named(ServiceStatusMonitor.HEARTBEAT_TAGS_BINDING))
                   .toProvider(HeartbeatSupplier.class);
             }
 

--- a/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
+++ b/services/src/main/java/org/apache/druid/cli/CliCoordinator.java
@@ -114,6 +114,7 @@ import org.apache.druid.server.initialization.ZkPathsConfig;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
 import org.apache.druid.server.lookup.cache.LookupCoordinatorManager;
 import org.apache.druid.server.lookup.cache.LookupCoordinatorManagerConfig;
+import org.apache.druid.server.metrics.ServiceStatusMonitor;
 import org.apache.druid.server.router.TieredBrokerConfig;
 import org.eclipse.jetty.server.Server;
 import org.joda.time.Duration;
@@ -332,7 +333,7 @@ public class CliCoordinator extends ServerRunnable
               binder.bind(RowIngestionMetersFactory.class).toProvider(Providers.of(null));
               // Bind HeartbeatSupplier only when the service operates independently of Overlord.
               binder.bind(new TypeLiteral<Supplier<Map<String, Object>>>() {})
-                  .annotatedWith(Names.named("heartbeat"))
+                  .annotatedWith(Names.named(ServiceStatusMonitor.TAGS_BINDING))
                   .toProvider(HeartbeatSupplier.class);
             }
 

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -21,7 +21,6 @@ package org.apache.druid.cli;
 
 import com.github.rvesse.airline.annotations.Command;
 import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -54,7 +53,6 @@ import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.TaskStorageDirTracker;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
-import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClientProvider;
 import org.apache.druid.indexing.common.task.batch.parallel.ShuffleClient;
 import org.apache.druid.indexing.overlord.ForkingTaskRunner;
@@ -204,12 +202,12 @@ public class CliMiddleManager extends ServerRunnable
 
           @Provides
           @LazySingleton
-          @Named(ServiceStatusMonitor.TAGS_BINDING)
+          @Named(ServiceStatusMonitor.HEARTBEAT_TAGS_BINDING)
           public Supplier<Map<String, Object>> heartbeatDimensions(WorkerConfig workerConfig, WorkerTaskManager workerTaskManager)
           {
             return () -> ImmutableMap.of(
                 "workerVersion", workerConfig.getVersion(),
-                "workerCapacity", workerConfig.getCapacity(),
+                "workerCategory", workerConfig.getCategory(),
                 "workerEnabled", workerTaskManager.isWorkerEnabled() ? 1 : 0
             );
           }

--- a/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
+++ b/services/src/main/java/org/apache/druid/cli/CliMiddleManager.java
@@ -70,6 +70,7 @@ import org.apache.druid.indexing.worker.shuffle.LocalIntermediaryDataManager;
 import org.apache.druid.indexing.worker.shuffle.ShuffleModule;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.input.InputSourceModule;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.lookup.LookupSerdeModule;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.realtime.appenderator.AppenderatorsManager;
@@ -206,9 +207,9 @@ public class CliMiddleManager extends ServerRunnable
           public Supplier<Map<String, Object>> heartbeatDimensions(WorkerConfig workerConfig, WorkerTaskManager workerTaskManager)
           {
             return () -> ImmutableMap.of(
-                "workerVersion", workerConfig.getVersion(),
-                "workerCategory", workerConfig.getCategory(),
-                "workerEnabled", workerTaskManager.isWorkerEnabled() ? 1 : 0
+                DruidMetrics.WORKER_VERSION, workerConfig.getVersion(),
+                DruidMetrics.CATEGORY, workerConfig.getCategory(),
+                DruidMetrics.STATUS, workerTaskManager.isWorkerEnabled() ? "Enabled" : "Disabled"
             );
           }
 

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -362,7 +362,7 @@ public class CliOverlord extends ServerRunnable
 
               @Provides
               @LazySingleton
-              @Named(ServiceStatusMonitor.TAGS_BINDING)
+              @Named(ServiceStatusMonitor.HEARTBEAT_TAGS_BINDING)
               public Supplier<Map<String, Object>> getHeartbeatSupplier(TaskMaster taskMaster)
               {
                 return () -> {

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -118,6 +118,7 @@ import org.apache.druid.server.http.SelfDiscoveryResource;
 import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.initialization.jetty.JettyServerInitUtils;
 import org.apache.druid.server.initialization.jetty.JettyServerInitializer;
+import org.apache.druid.server.metrics.ServiceStatusMonitor;
 import org.apache.druid.server.metrics.TaskCountStatsProvider;
 import org.apache.druid.server.metrics.TaskSlotCountStatsProvider;
 import org.apache.druid.server.security.AuthConfig;
@@ -361,7 +362,7 @@ public class CliOverlord extends ServerRunnable
 
               @Provides
               @LazySingleton
-              @Named("heartbeat")
+              @Named(ServiceStatusMonitor.TAGS_BINDING)
               public Supplier<Map<String, Object>> getHeartbeatSupplier(TaskMaster taskMaster)
               {
                 return () -> {

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -100,6 +100,7 @@ import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator;
 import org.apache.druid.metadata.input.InputSourceModule;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.lookup.LookupModule;
 import org.apache.druid.segment.handoff.CoordinatorBasedSegmentHandoffNotifierConfig;
@@ -272,10 +273,10 @@ public class CliPeon extends GuiceRunnable
           {
             return Suppliers.ofInstance(
                 ImmutableMap.of(
-                    "taskId", task.getId(),
-                    "dataSource", task.getDataSource(),
-                    "taskType", task.getType(),
-                    "groupId", task.getGroupId()
+                    DruidMetrics.TASK_ID, task.getId(),
+                    DruidMetrics.DATASOURCE, task.getDataSource(),
+                    DruidMetrics.TASK_TYPE, task.getType(),
+                    DruidMetrics.GROUP_ID, task.getGroupId()
                 )
             );
           }

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -36,7 +36,6 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
@@ -268,7 +267,7 @@ public class CliPeon extends GuiceRunnable
 
           @Provides
           @LazySingleton
-          @Named(ServiceStatusMonitor.TAGS_BINDING)
+          @Named(ServiceStatusMonitor.HEARTBEAT_TAGS_BINDING)
           public Supplier<Map<String, Object>> heartbeatDimensions(Task task)
           {
             return Suppliers.ofInstance(


### PR DESCRIPTION
### Description

This patch builds on top of #14443  to report some additional dimensions along with the heartbeat metric for the peons and middle managers.

The peons now report the task id, group id, datasource and task type. This will be useful as operators can use these dimensions to see how much of their cluster capacity is being used by different types, datasources, group, etc.

The middle managers will now report the worker version, category and whether it is enabled or not.
#### Release note
Improved: The service/heartbeat metric now has additional dimensions to provide more insight into ingestion on the cluster.

The metric on the middle manager looks like
```
{"feed":"metrics","metric":"service/heartbeat","workerCapacity":2,"workerEnabled":1,"service":"druid/middleManager","workerVersion":"0","host":"localhost:8091","version":"28.0.0-SNAPSHOT","value":1,"timestamp":"2023-08-03T01:57:34.335Z"}
```

The metric on the peon looks like
```
{"feed":"metrics","taskType":"index_parallel","metric":"service/heartbeat","service":"druid/middleManager","groupId":"index_parallel_wikipedia_hibldimn_2023-08-03T02:00:01.754Z","host":"localhost:8100","version":"28.0.0-SNAPSHOT","value":1,"dataSource":"wikipedia","taskId":"index_parallel_wikipedia_hibldimn_2023-08-03T02:00:01.754Z","timestamp":"2023-08-03T02:00:07.146Z"}
```

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
