### PR TITLE
Enable ServiceStatusMonitor in the examples

### DIFF
--- a/examples/conf/druid/auto/_common/common.runtime.properties
+++ b/examples/conf/druid/auto/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/cluster/_common/common.runtime.properties
+++ b/examples/conf/druid/cluster/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/large/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/large/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/medium/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/medium/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/micro-quickstart/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/micro-quickstart/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/nano-quickstart/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/nano-quickstart/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/small/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/small/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 

--- a/examples/conf/druid/single-server/xlarge/_common/common.runtime.properties
+++ b/examples/conf/druid/single-server/xlarge/_common/common.runtime.properties
@@ -119,7 +119,7 @@ druid.selectors.coordinator.serviceName=druid/coordinator
 # Monitoring
 #
 
-druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor"]
+druid.monitoring.monitors=["org.apache.druid.java.util.metrics.JvmMonitor", "org.apache.druid.server.metrics.ServiceStatusMonitor"]
 druid.emitter=noop
 druid.emitter.logging.logLevel=info
 


### PR DESCRIPTION
### Description

Enable the ServiceStatusMonitor introduced in #14443 to the list of monitors enabled in the example configurations.

This monitor seems like a good candidate to be enabled by default on clusters. However, I did not see an obvious pattern in the code to enable the monitor in all services by default. So I decided to follow the pattern of enabling the monitor in the common runtime properties instead.

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader..
- [x] been tested in a test Druid cluster.
