### PR TITLE
Update example configs to log events to its own log file

### DIFF
--- a/examples/conf/druid/auto/_common/log4j2.xml
+++ b/examples/conf/druid/auto/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/cluster/_common/log4j2.xml
+++ b/examples/conf/druid/cluster/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/large/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/large/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/medium/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/medium/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/micro-quickstart/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/micro-quickstart/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/nano-quickstart/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/nano-quickstart/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/small/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/small/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">

--- a/examples/conf/druid/single-server/xlarge/_common/log4j2.xml
+++ b/examples/conf/druid/single-server/xlarge/_common/log4j2.xml
@@ -45,12 +45,32 @@
       </DefaultRolloverStrategy>
     </RollingRandomAccessFile>
 
+    <RollingRandomAccessFile name="EmitterAppender"
+                             fileName="${sys:druid.log.path}/events.log"
+                             filePattern="${sys:druid.log.path}/events.%d{yyyyMMdd}.log">
+      <PatternLayout pattern="%m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+      </Policies>
+      <DefaultRolloverStrategy>
+        <Delete basePath="${sys:druid.log.path}/" maxDepth="1">
+          <IfFileName glob="*.log" />
+          <IfLastModified age="7d" />
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingRandomAccessFile>
+
   </Appenders>
 
   <Loggers>
     <Root level="info">
       <AppenderRef ref="FileAppender"/>
     </Root>
+
+    <!-- Events via the LoggingEmitter are logged to it's own location for easy processing. -->
+    <Logger name="org.apache.druid.java.util.emitter.core.LoggingEmitter" level="info" additivity="false">
+      <Appender-ref ref="EmitterAppender"/>
+    </Logger>
 
     <!-- Set level="debug" to see stack traces for query errors -->
     <Logger name="org.apache.druid.server.QueryResource" level="info" additivity="false">


### PR DESCRIPTION
### Description

Updates the example config to log all events emitted via the LoggingEmitter to a new events log file.

This will make it easier for devs who are testing locally to look at the events being emitted from the local deployment of Druid. Since all the events are in a separate file it makes it easy to upload these events into Druid if devs want to do some quick slice and dice of the events.

The only thing worth noting is that event if emitting is configured to be noop, an empty events.log file is found in the logs folder.


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
