### PR TITLE
Bump jclouds.version from 1.9.1 to 2.0.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       # Even then this will involve significant effort.
       # See https://github.com/apache/druid/pull/12258
       - dependency-name: "org.apache.calcite"
+      # jclouds 2.1 needs Guava 18+
+      - dependency-name: "org.apache.jclouds"
+        versions: "[2.1,)"

--- a/extensions-contrib/cloudfiles-extensions/pom.xml
+++ b/extensions-contrib/cloudfiles-extensions/pom.xml
@@ -35,10 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jclouds.version>1.9.1</jclouds.version>
-        <!-- The version of guice is forced to 3.0 since JClouds 1.9.1 does not
-          work with guice 4.0-beta -->
-        <guice.version>3.0</guice.version>
+        <jclouds.version>2.0.0</jclouds.version>
     </properties>
 
     <dependencies>
@@ -151,8 +148,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesByteSourceTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesByteSourceTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.storage.cloudfiles;
 
-import org.easymock.EasyMock;
-import org.easymock.EasyMockSupport;
 import org.jclouds.io.Payload;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,30 +26,35 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class CloudFilesByteSourceTest extends EasyMockSupport
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CloudFilesByteSourceTest
 {
   @Test
   public void openStreamTest() throws IOException
   {
     final String path = "path";
 
-    CloudFilesObjectApiProxy objectApi = createMock(CloudFilesObjectApiProxy.class);
-    CloudFilesObject cloudFilesObject = createMock(CloudFilesObject.class);
-    Payload payload = createMock(Payload.class);
-    InputStream stream = createMock(InputStream.class);
+    CloudFilesObjectApiProxy objectApi = mock(CloudFilesObjectApiProxy.class);
+    CloudFilesObject cloudFilesObject = mock(CloudFilesObject.class);
+    Payload payload = mock(Payload.class);
+    InputStream stream = mock(InputStream.class);
 
-    EasyMock.expect(objectApi.get(path, 0)).andReturn(cloudFilesObject);
-    EasyMock.expect(cloudFilesObject.getPayload()).andReturn(payload);
-    EasyMock.expect(payload.openStream()).andReturn(stream);
+    when(objectApi.get(path, 0)).thenReturn(cloudFilesObject);
+    when(cloudFilesObject.getPayload()).thenReturn(payload);
+    when(payload.openStream()).thenReturn(stream);
     payload.close();
-
-    replayAll();
 
     CloudFilesByteSource byteSource = new CloudFilesByteSource(objectApi, path);
     Assert.assertEquals(stream, byteSource.openStream());
     byteSource.closeStream();
 
-    verifyAll();
+    verify(objectApi).get(path, 0);
+    verify(cloudFilesObject).getPayload();
+    verify(payload).openStream();
   }
 
   @Test()
@@ -59,17 +62,16 @@ public class CloudFilesByteSourceTest extends EasyMockSupport
   {
     final String path = "path";
 
-    CloudFilesObjectApiProxy objectApi = createMock(CloudFilesObjectApiProxy.class);
-    CloudFilesObject cloudFilesObject = createMock(CloudFilesObject.class);
-    Payload payload = createMock(Payload.class);
-    InputStream stream = createMock(InputStream.class);
+    CloudFilesObjectApiProxy objectApi = mock(CloudFilesObjectApiProxy.class);
+    CloudFilesObject cloudFilesObject = mock(CloudFilesObject.class);
+    Payload payload = mock(Payload.class);
+    InputStream stream = mock(InputStream.class);
 
-    EasyMock.expect(objectApi.get(path, 0)).andReturn(cloudFilesObject);
-    EasyMock.expect(cloudFilesObject.getPayload()).andReturn(payload);
-    EasyMock.expect(payload.openStream()).andThrow(new IOException()).andReturn(stream);
+    when(objectApi.get(path, 0)).thenReturn(cloudFilesObject);
+    when(cloudFilesObject.getPayload()).thenReturn(payload);
+    when(payload.openStream()).thenThrow(new IOException())
+                              .thenReturn(stream);
     payload.close();
-
-    replayAll();
 
     CloudFilesByteSource byteSource = new CloudFilesByteSource(objectApi, path);
     try {
@@ -82,6 +84,8 @@ public class CloudFilesByteSourceTest extends EasyMockSupport
     Assert.assertEquals(stream, byteSource.openStream());
     byteSource.closeStream();
 
-    verifyAll();
+    verify(objectApi).get(path, 0);
+    verify(cloudFilesObject).getPayload();
+    verify(payload, times(2)).openStream();
   }
 }

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.easymock.EasyMock;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
 import org.junit.Assert;
@@ -36,6 +35,12 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  */
 public class CloudFilesDataSegmentPusherTest
@@ -46,16 +51,12 @@ public class CloudFilesDataSegmentPusherTest
   @Test
   public void testPush() throws Exception
   {
-    ObjectApi objectApi = EasyMock.createStrictMock(ObjectApi.class);
-    EasyMock.expect(objectApi.put(EasyMock.anyString(), EasyMock.anyObject())).andReturn(null).atLeastOnce();
-    EasyMock.replay(objectApi);
+    ObjectApi objectApi = mock(ObjectApi.class);
+    when(objectApi.put(any(), any())).thenReturn(null);
 
-    CloudFilesApi api = EasyMock.createStrictMock(CloudFilesApi.class);
-    EasyMock.expect(api.getObjectApi(EasyMock.anyString(), EasyMock.anyString()))
-            .andReturn(objectApi)
-            .atLeastOnce();
-    EasyMock.replay(api);
-
+    CloudFilesApi api = mock(CloudFilesApi.class);
+    when(api.getObjectApi(any(), any()))
+            .thenReturn(objectApi);
 
     CloudFilesDataSegmentPusherConfig config = new CloudFilesDataSegmentPusherConfig();
     config.setRegion("region");
@@ -87,6 +88,7 @@ public class CloudFilesDataSegmentPusherTest
 
     Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
 
-    EasyMock.verify(api);
+    verify(objectApi, atLeastOnce()).put(any(), any());
+    verify(api, atLeastOnce()).getObjectApi(any(), any());
   }
 }

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesObjectApiProxyTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesObjectApiProxyTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.storage.cloudfiles;
 
-import org.easymock.EasyMock;
-import org.easymock.EasyMockSupport;
 import org.jclouds.io.Payload;
 import org.jclouds.openstack.swift.v1.domain.SwiftObject;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
@@ -28,7 +26,11 @@ import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class CloudFilesObjectApiProxyTest extends EasyMockSupport
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class CloudFilesObjectApiProxyTest
 {
   @Test
   public void getTest()
@@ -37,16 +39,14 @@ public class CloudFilesObjectApiProxyTest extends EasyMockSupport
     final String region = "region";
     final String container = "container";
 
-    CloudFilesApi cloudFilesApi = createMock(CloudFilesApi.class);
-    ObjectApi objectApi = createMock(ObjectApi.class);
-    SwiftObject swiftObject = createMock(SwiftObject.class);
-    Payload payload = createMock(Payload.class);
+    CloudFilesApi cloudFilesApi = mock(CloudFilesApi.class);
+    ObjectApi objectApi = mock(ObjectApi.class);
+    SwiftObject swiftObject = mock(SwiftObject.class);
+    Payload payload = mock(Payload.class);
 
-    EasyMock.expect(cloudFilesApi.getObjectApi(region, container)).andReturn(objectApi);
-    EasyMock.expect(objectApi.get(path)).andReturn(swiftObject);
-    EasyMock.expect(swiftObject.getPayload()).andReturn(payload);
-
-    replayAll();
+    when(cloudFilesApi.getObjectApi(region, container)).thenReturn(objectApi);
+    when(objectApi.get(path)).thenReturn(swiftObject);
+    when(swiftObject.getPayload()).thenReturn(payload);
 
     CloudFilesObjectApiProxy cfoApiProxy = new CloudFilesObjectApiProxy(cloudFilesApi, region, container);
     CloudFilesObject cloudFilesObject = cfoApiProxy.get(path, 0);
@@ -56,6 +56,8 @@ public class CloudFilesObjectApiProxyTest extends EasyMockSupport
     Assert.assertEquals(cloudFilesObject.getContainer(), container);
     Assert.assertEquals(cloudFilesObject.getPath(), path);
 
-    verifyAll();
+    verify(cloudFilesApi).getObjectApi(region, container);
+    verify(objectApi).get(path);
+    verify(swiftObject).getPayload();
   }
 }


### PR DESCRIPTION
* Updates `org.apache.jclouds:*` from 1.9.1 to 2.0.3
* Pin jclouds to 2.0.x since 2.1.x requires Guava 18+
* replace easymock with mockito
