### PR TITLE
Fix the bug in getIndexInfo for mysql

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java
@@ -864,13 +864,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
         {
           DatabaseMetaData databaseMetaData = handle.getConnection().getMetaData();
           // Fetch the index for given table
-          ResultSet resultSet = databaseMetaData.getIndexInfo(
-              null,
-              null,
-              StringUtils.toUpperCase(tableName),
-              false,
-              false
-          );
+          ResultSet resultSet = getIndexInfo(databaseMetaData, tableName);
           while (resultSet.next()) {
             String indexName = resultSet.getString("INDEX_NAME");
             if (org.apache.commons.lang.StringUtils.isNotBlank(indexName)) {
@@ -885,6 +879,24 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
       log.error(e, "Exception while listing the index on table %s ", tableName);
     }
     return ImmutableSet.copyOf(res);
+  }
+
+  /**
+   * Get the ResultSet for indexInfo for given table
+   *
+   * @param databaseMetaData DatabaseMetaData
+   * @param tableName        Name of table
+   * @return ResultSet with index info
+   */
+  public ResultSet getIndexInfo(DatabaseMetaData databaseMetaData, String tableName) throws SQLException
+  {
+    return databaseMetaData.getIndexInfo(
+        null,
+        null,
+        tableName,  // tableName is case-sensitive in mysql default setting
+        false,
+        false
+    );
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/metadata/storage/derby/DerbyConnector.java
+++ b/server/src/main/java/org/apache/druid/metadata/storage/derby/DerbyConnector.java
@@ -168,6 +168,24 @@ public class DerbyConnector extends SQLMetadataConnector
     );
   }
 
+  /**
+   * Get the ResultSet for indexInfo for given table
+   *
+   * @param databaseMetaData DatabaseMetaData
+   * @param tableName        Name of table
+   * @return ResultSet with index info
+   */
+  @Override
+  public ResultSet getIndexInfo(DatabaseMetaData databaseMetaData, String tableName) throws SQLException
+  {
+    return databaseMetaData.getIndexInfo(
+        null,
+        null,
+        StringUtils.toUpperCase(tableName),  // tableName needs to be uppercase in derby default setting
+        false,
+        false
+    );
+  }
   @LifecycleStart
   public void start()
   {


### PR DESCRIPTION

### Description

This PR fixes the bug in getIndex List on given table, mysql implementation of DatabaseMetadata has different behavior then Derby, default settings in mysql are strict and accept only case sensitive name of the tableName in databaseMetaData.getIndexInfo, while in derby it strictly accept the upper case. 
I am moving this databaseMetaData.getIndexInfo to connector specific overrides. 
I have tested this PR on docker based MySQL metadata connector, local docker based mariadb as well as Postgres and it works well. 


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
