### PR TITLE
Latest aggregator factories should accept time as VectorValueSelecto…

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstLastUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstLastUtils.java
@@ -27,8 +27,8 @@ import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -79,7 +79,7 @@ public class StringFirstLastUtils
    * index of bounds issues is the responsibility of the caller
    */
   public static SerializablePairLongString readPairFromVectorSelectorsAtIndex(
-      BaseLongVectorValueSelector timeSelector,
+      VectorValueSelector timeSelector,
       VectorObjectSelector valueSelector,
       int index
   )

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/DoubleLastAggregatorFactory.java
@@ -43,7 +43,6 @@ import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -129,8 +128,8 @@ public class DoubleLastAggregatorFactory extends AggregatorFactory
   {
     ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(fieldName);
     VectorValueSelector valueSelector = columnSelectorFactory.makeValueSelector(fieldName);
-    //time is always long
-    BaseLongVectorValueSelector timeSelector = (BaseLongVectorValueSelector) columnSelectorFactory.makeValueSelector(
+
+    VectorValueSelector timeSelector = columnSelectorFactory.makeValueSelector(
         timeColumn);
     if (capabilities == null || capabilities.isNumeric()) {
       return new DoubleLastVectorAggregator(timeSelector, valueSelector);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/FloatLastAggregatorFactory.java
@@ -43,7 +43,6 @@ import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -141,8 +140,8 @@ public class FloatLastAggregatorFactory extends AggregatorFactory
   {
     ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(fieldName);
     VectorValueSelector valueSelector = columnSelectorFactory.makeValueSelector(fieldName);
-    //time is always long
-    BaseLongVectorValueSelector timeSelector = (BaseLongVectorValueSelector) columnSelectorFactory.makeValueSelector(
+
+    VectorValueSelector timeSelector = columnSelectorFactory.makeValueSelector(
         timeColumn);
     if (capabilities == null || capabilities.isNumeric()) {
       return new FloatLastVectorAggregator(timeSelector, valueSelector);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/LongLastAggregatorFactory.java
@@ -42,7 +42,6 @@ import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -140,7 +139,7 @@ public class LongLastAggregatorFactory extends AggregatorFactory
   {
     ColumnCapabilities capabilities = columnSelectorFactory.getColumnCapabilities(fieldName);
     VectorValueSelector valueSelector = columnSelectorFactory.makeValueSelector(fieldName);
-    BaseLongVectorValueSelector timeSelector = (BaseLongVectorValueSelector) columnSelectorFactory.makeValueSelector(
+    VectorValueSelector timeSelector = columnSelectorFactory.makeValueSelector(
         timeColumn);
     if (capabilities == null || capabilities.isNumeric()) {
       return new LongLastVectorAggregator(timeSelector, valueSelector);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastAggregatorFactory.java
@@ -42,9 +42,9 @@ import org.apache.druid.segment.NilColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -159,7 +159,7 @@ public class StringLastAggregatorFactory extends AggregatorFactory
 
     ColumnCapabilities capabilities = selectorFactory.getColumnCapabilities(fieldName);
     VectorObjectSelector vSelector = selectorFactory.makeObjectSelector(fieldName);
-    BaseLongVectorValueSelector timeSelector = (BaseLongVectorValueSelector) selectorFactory.makeValueSelector(
+    VectorValueSelector timeSelector = selectorFactory.makeValueSelector(
         timeColumn);
     if (capabilities != null) {
       return new StringLastVectorAggregator(timeSelector, vSelector, maxStringBytes);

--- a/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/last/StringLastVectorAggregator.java
@@ -24,8 +24,8 @@ import org.apache.druid.query.aggregation.SerializablePairLongString;
 import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.query.aggregation.first.StringFirstLastUtils;
 import org.apache.druid.segment.DimensionHandlerUtils;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -36,13 +36,13 @@ public class StringLastVectorAggregator implements VectorAggregator
       DateTimes.MIN.getMillis(),
       null
   );
-  private final BaseLongVectorValueSelector timeSelector;
+  private final VectorValueSelector timeSelector;
   private final VectorObjectSelector valueSelector;
   private final int maxStringBytes;
   protected long lastTime;
 
   public StringLastVectorAggregator(
-      @Nullable final BaseLongVectorValueSelector timeSelector,
+      @Nullable final VectorValueSelector timeSelector,
       final VectorObjectSelector valueSelector,
       final int maxStringBytes
   )

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -853,6 +853,38 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  // This test is to check if expressions are accepted properly by the vectorized last aggregator
+  @Test
+  public void testLatestVectorAggregatorsOnExpression()
+  {
+    notMsqCompatible();
+    testQuery(
+        "SELECT \n"
+        + "  LATEST_BY(m1, MILLIS_TO_TIMESTAMP(BITWISE_SHIFT_RIGHT(TIMESTAMP_TO_MILLIS(__time), 3)))\n"
+        + " FROM druid.foo GROUP BY TIME_FLOOR(__time, 'P1Y', null, 'America/Los_Angeles')",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .granularity(new PeriodGranularity(Period.years(1), null, DateTimes.inferTzFromString(LOS_ANGELES)))
+                  .virtualColumns(
+                      expressionVirtualColumn("v1", "bitwiseShiftRight(\"__time\",3)", ColumnType.LONG)
+                  )
+                  .aggregators(
+                      aggregators(
+                          new FloatLastAggregatorFactory("a0", "m1", "v1")
+                      )
+                  )
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1.0f},
+            new Object[]{4.0f},
+            new Object[]{6.0f}
+        )
+    );
+  }
   // This test the off-heap (buffer) version of the AnyAggregator (Double/Float/Long) against numeric columns
   // that have null values (when run in SQL compatible null mode)
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -855,7 +855,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
 
   // This test is to check if time expressions are accepted properly by the vectorized last aggregator
   @Test
-  public void testLatestVectorAggregatorsOnExpression()
+  public void testLatestVectorAggregatorsOnTimeExpression()
   {
     notMsqCompatible();
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -853,7 +853,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  // This test is to check if expressions are accepted properly by the vectorized last aggregator
+  // This test is to check if time expressions are accepted properly by the vectorized last aggregator
   @Test
   public void testLatestVectorAggregatorsOnExpression()
   {


### PR DESCRIPTION
…r instead of BaseLongVectorValueSelector

Currently the existing factories were assuming that time would always be BaseLongVectorValueSelector. This would cause issues for queries during vectorization where the time can be an expression. For example
```
SELECT 
  LATEST_BY(num2, MILLIS_TO_TIMESTAMP(BITWISE_SHIFT_RIGHT(TIMESTAMP_TO_MILLIS(__time), 3)))
FROM "signals" GROUP BY TIME_FLOOR(__time, 'P1Y', null, 'America/New_York')

Error: Unknown exception

org.apache.druid.segment.virtual.ExpressionVectorValueSelector cannot be cast to org.apache.druid.segment.vector.BaseLongVectorValueSelector

java.lang.ClassCastException
```
This PR addresses the issue by removing BaseLongVectorValueSelector with the VectorValueSelector. The test case has also been added to our unit tests

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
