### PR TITLE
Upgrades `org.mozilla:rhino` 

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4633,7 +4633,7 @@ name: Rhino
 license_category: binary
 module: java-core
 license_name: Mozilla Public License Version 2.0
-version: 1.7.11
+version: 1.7.14
 copyright: Mozilla and individual contributors.
 license_file_path: licenses/bin/rhino.MPL2
 libraries:

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
             <dependency>
                 <groupId>org.mozilla</groupId>
                 <artifactId>rhino</artifactId>
-                <version>1.7.11</version>
+                <version>1.7.14</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade dependency `org.mozilla:rhino` to remediate security vulnerability [CWE-611](https://cwe.mitre.org/data/definitions/611.html). 