### PR TITLE
Upgrade jackson-databind to 2.12.7

### DIFF
--- a/extensions-contrib/compressed-bigdecimal/pom.xml
+++ b/extensions-contrib/compressed-bigdecimal/pom.xml
@@ -126,7 +126,6 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -138,12 +137,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.10.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.10.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -82,6 +82,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.emitter.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.DateTimes;
@@ -102,9 +103,11 @@ public class KafkaEmitterTest
         requestTopic == null ? totalEventsExcludingRequestLogEvents : totalEvents);
 
     final KafkaProducer<String, String> producer = mock(KafkaProducer.class);
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JodaModule());
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
         new KafkaEmitterConfig("", eventsType, "metrics", "alerts", requestTopic, "metadata", "test-cluster", null),
-        new ObjectMapper()
+        mapper
     )
     {
       @Override

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -248,7 +248,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5
+version: 2.12.7
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -289,7 +289,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.10.5.1
+version: 2.12.7
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -3592,7 +3592,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.10.5
+version: 2.12.7
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -117,13 +117,6 @@
      -->
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
-    <!-- CVE-2021-46877 only applies to jdk serialization which we do not use
-    https://nvd.nist.gov/vuln/detail/CVE-2021-46877
-    https://github.com/FasterXML/jackson-databind/issues/3328
-    -->
-    <cve>CVE-2021-46877</cve>
-    <!-- According to jackson community, this is not a security issue, see https://github.com/FasterXML/jackson-databind/issues/3972#issuecomment-1596193098, https://github.com/jeremylong/DependencyCheck/issues/5779 -->
-    <cve>CVE-2023-35116</cve>
   </suppress>
 
 
@@ -638,7 +631,6 @@
     <notes><![CDATA[
    file name: *jackson-*.jar
    ]]></notes>
-    <cve>CVE-2020-36518</cve>
     <cve>CVE-2022-45688</cve>
   </suppress>
 
@@ -673,14 +665,6 @@
    file name: cassandra-all-1.0.8.jar
    ]]></notes>
     <cve>CVE-2020-17516</cve>
-  </suppress>
-
-  <suppress>
-    <!-- jackson-dataformat-cbor-2.10.5.jar -->
-    <notes><![CDATA[
-   file name: jackson-dataformat-cbor-2.10.5.jar
-   ]]></notes>
-    <cve>CVE-2020-28491</cve>
   </suppress>
 
   <suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.51.v20230217</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.10.5.20201202</jackson.version>
+        <jackson.version>2.12.7</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>

--- a/processing/src/test/java/org/apache/druid/segment/TestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/TestHelper.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,7 +86,7 @@ public class TestHelper
     return new GuiceAnnotationIntrospector()
     {
       @Override
-      public Object findInjectableValueId(AnnotatedMember m)
+      public JacksonInject.Value findInjectableValue(AnnotatedMember m)
       {
         return null;
       }

--- a/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
@@ -130,22 +130,22 @@ public class CacheConfigTest
     throw new IllegalStateException("Should have already failed");
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testTRUE()
   {
     properties.put(PROPERTY_PREFIX + ".populateCache", "TRUE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get();
-    throw new IllegalStateException("Should have already failed");
+    Assert.assertTrue(config.isPopulateCache());
   }
 
-  @Test(expected = ProvisionException.class)
+  @Test
   public void testFALSE()
   {
     properties.put(PROPERTY_PREFIX + ".populateCache", "FALSE");
     configProvider.inject(properties, configurator);
     CacheConfig config = configProvider.get();
-    throw new IllegalStateException("Should have already failed");
+    Assert.assertFalse(config.isPopulateCache());
   }
 
 


### PR DESCRIPTION
The current version of `jackson-databind` is flagged for vulnerabilities CVE-2020-28491 (Although cbor format is not used in druid), CVE-2020-36518 (Seems genuine as deeply nested json in can cause resource exhaustion). Updating the dependency to the latest version 2.12.7 to fix these vulnerabilities.

Now that Hadoop2 is being removed, this upgrade is deemed to be safely made.