### PR TITLE
retry when killing s3 based segments 

### DIFF
--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
@@ -22,11 +22,46 @@ package org.apache.druid.common.aws;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.retry.RetryUtils;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
+import java.util.Set;
 
 public class AWSClientUtil
 {
+  /**
+   * This list of error code come from {@link RetryUtils}. At the moment, aws sdk does not expose a good
+   * way of retrying {@link com.amazonaws.services.s3.AmazonS3#deleteObjects(DeleteObjectsRequest)} requests. This
+   * request is used in org.apache.druid.storage.s3.S3DataSegmentKiller to delete a batch of segments from deep
+   * storage.
+   */
+  private static final Set<String> RECOVERABLE_ERROR_CODES = ImmutableSet.of(
+      "Throttling",
+      "ThrottlingException",
+      "ThrottledException",
+      "ProvisionedThroughputExceededException",
+      "SlowDown",
+      "TooManyRequestsException",
+      "RequestLimitExceeded",
+      "BandwidthLimitExceeded",
+      "RequestThrottled",
+      "RequestThrottledException",
+      "EC2ThrottledException",
+      "PriorRequestNotComplete",
+      "RequestTimeTooSkewed",
+      "RequestExpired",
+      "InvalidSignatureException",
+      "SignatureDoesNotMatch",
+      "AuthFailure",
+      "RequestInTheFuture",
+      "TransactionInProgressException",
+      "RequestTimeout",
+      "RequestTimeoutException",
+      "IDPCommunicationError"
+  );
+
   /**
    * Checks whether an exception can be retried or not. Implementation is copied
    * from {@link com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition} except deprecated methods
@@ -54,6 +89,19 @@ public class AWSClientUtil
       return true;
     }
 
-    return RetryUtils.isClockSkewError(exception);
+    if (RetryUtils.isClockSkewError(exception)) {
+      return true;
+    }
+
+    if (exception instanceof MultiObjectDeleteException) {
+      MultiObjectDeleteException multiObjectDeleteException = (MultiObjectDeleteException) exception;
+      for (MultiObjectDeleteException.DeleteError error : multiObjectDeleteException.getErrors()) {
+        if (RECOVERABLE_ERROR_CODES.contains(error.getCode())) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientUtil.java
@@ -32,34 +32,38 @@ import java.util.Set;
 public class AWSClientUtil
 {
   /**
-   * This list of error code come from {@link RetryUtils}. At the moment, aws sdk does not expose a good
-   * way of retrying {@link com.amazonaws.services.s3.AmazonS3#deleteObjects(DeleteObjectsRequest)} requests. This
-   * request is used in org.apache.druid.storage.s3.S3DataSegmentKiller to delete a batch of segments from deep
-   * storage.
+   * This list of error code come from {@link RetryUtils}, and
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html">...</a>. At the moment, aws sdk
+   * does not expose a good way of retrying
+   * {@link com.amazonaws.services.s3.AmazonS3#deleteObjects(DeleteObjectsRequest)} requests. This request is used in
+   * org.apache.druid.storage.s3.S3DataSegmentKiller to delete a batch of segments from deep storage.
    */
   private static final Set<String> RECOVERABLE_ERROR_CODES = ImmutableSet.of(
-      "Throttling",
-      "ThrottlingException",
-      "ThrottledException",
-      "ProvisionedThroughputExceededException",
-      "SlowDown",
-      "TooManyRequestsException",
-      "RequestLimitExceeded",
+      "503 SlowDown",
+      "AuthFailure",
       "BandwidthLimitExceeded",
+      "EC2ThrottledException",
+      "IDPCommunicationError",
+      "InternalError",
+      "InvalidSignatureException",
+      "PriorRequestNotComplete",
+      "ProvisionedThroughputExceededException",
+      "RequestExpired",
+      "RequestInTheFuture",
+      "RequestLimitExceeded",
       "RequestThrottled",
       "RequestThrottledException",
-      "EC2ThrottledException",
-      "PriorRequestNotComplete",
       "RequestTimeTooSkewed",
-      "RequestExpired",
-      "InvalidSignatureException",
-      "SignatureDoesNotMatch",
-      "AuthFailure",
-      "RequestInTheFuture",
-      "TransactionInProgressException",
       "RequestTimeout",
       "RequestTimeoutException",
-      "IDPCommunicationError"
+      "ServiceUnavailable",
+      "SignatureDoesNotMatch",
+      "SlowDown",
+      "ThrottledException",
+      "ThrottlingException",
+      "TooManyRequestsException",
+      "TransactionInProgressException",
+      "Throttling"
   );
 
   /**

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientUtilTest.java
@@ -21,6 +21,8 @@ package org.apache.druid.common.aws;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -79,6 +81,20 @@ public class AWSClientUtilTest
   {
     AmazonServiceException ex = new AmazonServiceException(null);
     ex.setErrorCode("RequestExpired");
+    Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
+  }
+
+  @Test
+  public void testRecoverableException_MultiObjectDeleteException()
+  {
+    MultiObjectDeleteException.DeleteError retryableError = new MultiObjectDeleteException.DeleteError();
+    retryableError.setCode("RequestLimitExceeded");
+    MultiObjectDeleteException.DeleteError nonRetryableError = new MultiObjectDeleteException.DeleteError();
+    nonRetryableError.setCode("nonRetryableError");
+    MultiObjectDeleteException ex = new MultiObjectDeleteException(
+        ImmutableList.of(retryableError, nonRetryableError),
+        ImmutableList.of()
+    );
     Assert.assertTrue(AWSClientUtil.isClientExceptionRecoverable(ex));
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.MapUtils;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
@@ -49,6 +50,8 @@ public class S3DataSegmentKiller implements DataSegmentKiller
 
   // AWS has max limit of 1000 objects that can be requested to be deleted at a time.
   private static final int MAX_MULTI_OBJECT_DELETE_SIZE = 1000;
+
+  private static final String MULTI_OBJECT_DELETE_EXEPTION_ERROR_FORMAT = "message: [%s], code: [%s]";
 
   /**
    * Any implementation of DataSegmentKiller is initialized when an ingestion job starts if the extension is loaded,
@@ -162,7 +165,11 @@ public class S3DataSegmentKiller implements DataSegmentKiller
         hadException = true;
         Map<String, List<String>> errorToKeys = new HashMap<>();
         for (MultiObjectDeleteException.DeleteError error : e.getErrors()) {
-          errorToKeys.computeIfAbsent(error.getMessage(), k -> new ArrayList<>()).add(error.getKey());
+          errorToKeys.computeIfAbsent(StringUtils.format(
+              MULTI_OBJECT_DELETE_EXEPTION_ERROR_FORMAT,
+              error.getMessage(),
+              error.getCode()
+          ), k -> new ArrayList<>()).add(error.getKey());
         }
         errorToKeys.forEach((key, value) -> log.error(
             "Unable to delete from bucket [%s], the following keys [%s], because [%s]",

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.MapUtils;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
@@ -150,11 +151,12 @@ public class S3DataSegmentKiller implements DataSegmentKiller
             s3Bucket,
             keysToDeleteStrings
         );
-        S3Utils.retryS3Operation(
+        RetryUtils.retry(
             () -> {
               s3Client.deleteObjects(deleteObjectsRequest);
               return null;
             },
+            exception -> (exception instanceof MultiObjectDeleteException) || S3Utils.S3RETRY.apply(exception),
             3
         );
       }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
@@ -153,13 +153,8 @@ public class S3DataSegmentKiller implements DataSegmentKiller
         );
         RetryUtils.retry(
             () -> {
-              try {
-                s3Client.deleteObjects(deleteObjectsRequest);
-                return null;
-              }
-              catch (Exception e) {
-                throw e;
-              }
+              s3Client.deleteObjects(deleteObjectsRequest);
+              return null;
             },
             S3Utils.S3RETRY,
             3

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
@@ -28,7 +28,6 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.MapUtils;
-import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
@@ -151,12 +150,11 @@ public class S3DataSegmentKiller implements DataSegmentKiller
             s3Bucket,
             keysToDeleteStrings
         );
-        RetryUtils.retry(
+        S3Utils.retryS3Operation(
             () -> {
               s3Client.deleteObjects(deleteObjectsRequest);
               return null;
             },
-            exception -> (exception instanceof MultiObjectDeleteException) || S3Utils.S3RETRY.apply(exception),
             3
         );
       }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
@@ -412,7 +412,7 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(TEST_BUCKET);
     deleteObjectsRequest.withKeys(KEY_1_PATH, KEY_1_PATH);
     s3Client.deleteObjects(EasyMock.anyObject(DeleteObjectsRequest.class));
-    EasyMock.expectLastCall().andThrow(new SdkClientException("Unable to execute HTTP request")).once();
+    EasyMock.expectLastCall().andThrow(new MultiObjectDeleteException(ImmutableList.of(), ImmutableList.of())).once();
     EasyMock.expectLastCall().andVoid().times(2);
 
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
@@ -405,4 +405,19 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     );
     Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
+
+  @Test
+  public void test_kill_listOfSegments_retryableExceptionThrown() throws SegmentLoadingException
+  {
+    DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(TEST_BUCKET);
+    deleteObjectsRequest.withKeys(KEY_1_PATH, KEY_1_PATH);
+    s3Client.deleteObjects(EasyMock.anyObject(DeleteObjectsRequest.class));
+    EasyMock.expectLastCall().andThrow(new SdkClientException("Unable to execute HTTP request")).once();
+    EasyMock.expectLastCall().andVoid().times(2);
+
+
+    EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
+    segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);
+    segmentKiller.kill(ImmutableList.of(DATA_SEGMENT_1, DATA_SEGMENT_1));
+  }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.s3;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
@@ -437,7 +438,7 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     deleteObjectsRequest.withKeys(KEY_1_PATH, KEY_2_PATH);
     // struggled with the idea of making it match on equaling this
     s3Client.deleteObjects(EasyMock.anyObject(DeleteObjectsRequest.class));
-    EasyMock.expectLastCall().andThrow(new RuntimeException("")).once();
+    EasyMock.expectLastCall().andThrow(new AbortedException("")).once();
 
     EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
     segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
@@ -412,7 +412,16 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(TEST_BUCKET);
     deleteObjectsRequest.withKeys(KEY_1_PATH, KEY_1_PATH);
     s3Client.deleteObjects(EasyMock.anyObject(DeleteObjectsRequest.class));
-    EasyMock.expectLastCall().andThrow(new MultiObjectDeleteException(ImmutableList.of(), ImmutableList.of())).once();
+    MultiObjectDeleteException.DeleteError retryableError = new MultiObjectDeleteException.DeleteError();
+    retryableError.setCode("RequestLimitExceeded");
+    MultiObjectDeleteException.DeleteError nonRetryableError = new MultiObjectDeleteException.DeleteError();
+    nonRetryableError.setCode("nonRetryableError");
+    EasyMock.expectLastCall()
+        .andThrow(new MultiObjectDeleteException(
+            ImmutableList.of(retryableError, nonRetryableError),
+            ImmutableList.of()
+        ))
+        .once();
     EasyMock.expectLastCall().andVoid().times(2);
 
 


### PR DESCRIPTION
### Description

s3 deleteObjects request sent when killing s3 based segments now being retried, if failure is retry-able. 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
