### PR TITLE
Display the output column name in InvalidNullByteException

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2658,9 +2658,15 @@ public class ControllerImpl implements Controller
    * by the user in the SQL query) for certain errors reported by workers (where they have limited knowledge of the
    * ColumnMappings). For remaining errors not relying on the query column names, it returns it as is.
    */
-  private MSQErrorReport mapQueryColumnNameToOutputColumnName(final MSQErrorReport workerErrorReport)
+  @Nullable
+  private MSQErrorReport mapQueryColumnNameToOutputColumnName(
+      @Nullable final MSQErrorReport workerErrorReport
+  )
   {
-    if (workerErrorReport.getFault() instanceof InvalidNullByteFault) {
+
+    if (workerErrorReport == null) {
+      return null;
+    } else if (workerErrorReport.getFault() instanceof InvalidNullByteFault) {
       InvalidNullByteFault inbf = (InvalidNullByteFault) workerErrorReport.getFault();
       return MSQErrorReport.fromException(
           workerErrorReport.getTaskId(),
@@ -2675,8 +2681,9 @@ public class ControllerImpl implements Controller
                                   .build(),
           task.getQuerySpec().getColumnMappings()
       );
+    } else {
+      return workerErrorReport;
     }
-    return workerErrorReport;
   }
 
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -422,7 +422,7 @@ public class ControllerImpl implements Controller
               task.getQuerySpec().getColumnMappings()
           )
           : null;
-      MSQErrorReport workerError = mapQueryColumnNameToOutputColumnName(workerErrorRef.get());
+      MSQErrorReport workerError = workerErrorRef.get();
 
       taskStateForReport = TaskState.FAILED;
       errorForReport = MSQTasks.makeErrorReport(id(), selfHost, controllerError, workerError);
@@ -750,7 +750,10 @@ public class ControllerImpl implements Controller
         !workerTaskLauncher.isTaskLatest(errorReport.getTaskId())) {
       log.info("Ignoring task %s", errorReport.getTaskId());
     } else {
-      workerErrorRef.compareAndSet(null, errorReport);
+      workerErrorRef.compareAndSet(
+          null,
+          mapQueryColumnNameToOutputColumnName(errorReport)
+      );
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/InvalidNullByteFault.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/InvalidNullByteFault.java
@@ -63,7 +63,8 @@ public class InvalidNullByteFault extends BaseMSQFault
   {
     super(
         CODE,
-        "Invalid null byte at source [%s], rowNumber [%d], column[%s], value[%s], position[%d]. Consider sanitizing the string using REPLACE(\"%s\", U&'\\0000', '') AS %s",
+        "Invalid null byte at source [%s], rowNumber [%d], column[%s], value[%s], position[%d]. "
+        + "Consider sanitizing the input string column using REPLACE(\"%s\", U&'\\0000', '') AS %s",
         source,
         rowNumber,
         column,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.druid.frame.processor.FrameRowTooLargeException;
 import org.apache.druid.frame.write.InvalidNullByteException;
 import org.apache.druid.frame.write.UnsupportedColumnTypeException;
@@ -31,6 +32,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.msq.statistics.TooManyBucketsException;
 import org.apache.druid.query.groupby.epinephelinae.UnexpectedMultiValueDimensionException;
+import org.apache.druid.sql.calcite.planner.ColumnMappings;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -79,11 +81,22 @@ public class MSQErrorReport
       final Throwable e
   )
   {
+    return fromException(taskId, host, stageNumber, e, null);
+  }
+
+  public static MSQErrorReport fromException(
+      final String taskId,
+      @Nullable final String host,
+      @Nullable final Integer stageNumber,
+      final Throwable e,
+      @Nullable final ColumnMappings columnMappings
+  )
+  {
     return new MSQErrorReport(
         taskId,
         host,
         stageNumber,
-        getFaultFromException(e),
+        getFaultFromException(e, columnMappings),
         Throwables.getStackTraceAsString(e)
     );
   }
@@ -159,12 +172,17 @@ public class MSQErrorReport
            '}';
   }
 
+  public static MSQFault getFaultFromException(@Nullable final Throwable e)
+  {
+    return getFaultFromException(e, null);
+  }
+
   /**
    * Magical code that extracts a useful fault from an exception, even if that exception is not necessarily a
    * {@link MSQException}. This method walks through the causal chain, and also "knows" about various exception
    * types thrown by other Druid code.
    */
-  public static MSQFault getFaultFromException(@Nullable final Throwable e)
+  public static MSQFault getFaultFromException(@Nullable final Throwable e, @Nullable final ColumnMappings columnMappings)
   {
     // Unwrap exception wrappers to find an underlying fault. The assumption here is that the topmost recognizable
     // exception should be used to generate the fault code for the entire report.
@@ -195,10 +213,19 @@ public class MSQErrorReport
         return new RowTooLargeFault(((FrameRowTooLargeException) cause).getMaxFrameSize());
       } else if (cause instanceof InvalidNullByteException) {
         InvalidNullByteException invalidNullByteException = (InvalidNullByteException) cause;
+        String columnName = invalidNullByteException.getColumn();
+        if (columnMappings != null) {
+          IntList outputColumnsForQueryColumn = columnMappings.getOutputColumnsForQueryColumn(columnName);
+          if (outputColumnsForQueryColumn.size() >= 1) {
+            int outputColumn = outputColumnsForQueryColumn.getInt(0);
+            columnName = columnMappings.getOutputColumnName(outputColumn);
+          }
+        }
+
         return new InvalidNullByteFault(
             invalidNullByteException.getSource(),
             invalidNullByteException.getRowNumber(),
-            invalidNullByteException.getColumn(),
+            columnName,
             invalidNullByteException.getValue(),
             invalidNullByteException.getPosition()
         );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/error/MSQErrorReport.java
@@ -216,6 +216,8 @@ public class MSQErrorReport
         String columnName = invalidNullByteException.getColumn();
         if (columnMappings != null) {
           IntList outputColumnsForQueryColumn = columnMappings.getOutputColumnsForQueryColumn(columnName);
+
+          // outputColumnsForQueryColumn.size should always be 1 due to hasUniqueOutputColumnNames check that is done
           if (outputColumnsForQueryColumn.size() >= 1) {
             int outputColumn = outputColumnsForQueryColumn.getInt(0);
             columnName = columnMappings.getOutputColumnName(outputColumn);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
@@ -43,7 +43,10 @@ public class ParseExceptionUtils
   public static String generateReadableInputSourceNameFromMappedSegment(Segment segment)
   {
     if (segment instanceof ExternalSegment) {
-      return StringUtils.format("external input source: %s", ((ExternalSegment) segment).externalInputSource().toString());
+      return StringUtils.format(
+          "external input source: %s",
+          ((ExternalSegment) segment).externalInputSource().toString()
+      );
     } else if (segment instanceof LookupSegment) {
       return StringUtils.format("lookup input source: %s", segment.getId().getDataSource());
     } else if (segment instanceof QueryableIndexSegment) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQParseExceptionsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQParseExceptionsTest.java
@@ -104,7 +104,7 @@ public class MSQParseExceptionsTest extends MSQTestBase
   }
 
   @Test
-  public void testIngestWithNullByteInSqlExpression() throws IOException
+  public void testIngestWithNullByteInSqlExpression()
   {
 
     RowSignature rowSignature = RowSignature.builder()
@@ -130,14 +130,11 @@ public class MSQParseExceptionsTest extends MSQTestBase
         .setExpectedDataSource("foo1")
         .setExpectedMSQFault(
             new InvalidNullByteFault(
-                StringUtils.format(
-                    "external input source: LocalInputSource{baseDir=\"null\", filter=null, files=[%s]}",
-                    "f"
-                ),
+                "external input source: InlineInputSource{data='{\"desc\":\"Row with NULL\",\"text\":\"There is a null in\\u0000 here somewhere\"}\n'}",
                 1,
-                "agent_category",
-                "Personal computer\u0000",
-                17
+                "text",
+                "There is A null in\u0000 here somewhere",
+                18
             )
         )
         .setQueryContext(DEFAULT_MSQ_CONTEXT)


### PR DESCRIPTION
### Description
InvalidNullByteFault for MSQ displayed the query column name (the one that is used internally while planning and executing the query) instead of the output column name (the one that is given by the user). Sometimes the two are similar, however, for columns involving expressions, it is not the case.
It can be misleading for someone who is not familiar with this quirk, and even then it would require reading the native plan to figure out the culprit column.

This PR maps the query column to the output column name while surfacing the fault since that is readily visible to the user while executing the query.

<hr>

For a query like:

```sql
WITH "ext" AS (SELECT *
FROM TABLE(
  EXTERN(
    '{"type":"inline","data":"{\"desc\":\"Normal row\",\"text\":\"Hi I am a normal row\"}\n{\"desc\":\"Row with NULL\",\"text\":\"There is a null in\\u0000 here somewhere\"}\n{\"desc\":\"Anther normal row\",\"text\":\"Nice\"}\n"}',
    '{"type":"json"}'
  )
) EXTEND ("desc" VARCHAR, "text" VARCHAR))
SELECT
  "desc",
  REPLACE("text", 'a', 'A') AS "text"
FROM "ext"
```
Original Behaviour:

```InvalidNullByte: Invalid null byte at source [external input source: InlineInputSource{data='{"desc":"Normal row","text":"Hi I am a normal row"} {"desc":"Row with NULL","text":"There is a null in\u0000 here somewhere"} {"desc":"Anther normal row","text":"Nice"} '}], rowNumber [2], column[v0], value[There is A null in here somewhere], position[18]. Consider sanitizing the string using REPLACE("v0", U&'\0000', '') AS v0. ```

Notice it refers to the column as 'v0'

Modified Behaviour
```InvalidNullByte: Invalid null byte at source [external input source: InlineInputSource{data='{"desc":"Normal row","text":"Hi I am a normal row"} {"desc":"Row with NULL","text":"There is a null in\u0000 here somewhere"} {"desc":"Anther normal row","text":"Nice"} '}], rowNumber [2], column[text], value[There is A null in here somewhere], position[18]. Consider sanitizing the string using REPLACE("text", U&'\0000', '') AS text. ```

<hr>

Note, for columns without alias, it will display it as `EXPR$<number>` which is still more informative than something like v0. 

```sql
WITH "ext" AS (SELECT *
FROM TABLE(
  EXTERN(
    '{"type":"inline","data":"{\"desc\":\"Normal row\",\"text\":\"Hi I am a normal row\"}\n{\"desc\":\"Row with NULL\",\"text\":\"There is a null in\\u0000 here somewhere\"}\n{\"desc\":\"Anther normal row\",\"text\":\"Nice\"}\n"}',
    '{"type":"json"}'
  )
) EXTEND ("desc" VARCHAR, "text" VARCHAR))
SELECT
  "desc",
  REPLACE("text", 'a', 'A')
FROM "ext"
```
Modified Behaviour
```InvalidNullByte: Invalid null byte at source [external input source: InlineInputSource{data='{"desc":"Normal row","text":"Hi I am a normal row"} {"desc":"Row with NULL","text":"There is a null in\u0000 here somewhere"} {"desc":"Anther normal row","text":"Nice"} '}], rowNumber [2], column[EXPR$1], value[There is A null in here somewhere], position[18]. Consider sanitizing the string using REPLACE("EXPR$1", U&'\0000', '') AS EXPR$1. ```

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
