### PR TITLE
Web console: fix result count

### DIFF
--- a/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
+++ b/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
@@ -23,7 +23,12 @@ import type { JSX } from 'react';
 import React, { useState } from 'react';
 
 import type { Execution } from '../../../druid-models';
-import { downloadQueryResults, formatDurationHybrid, pluralIfNeeded } from '../../../utils';
+import {
+  downloadQueryResults,
+  formatDurationHybrid,
+  formatInteger,
+  pluralIfNeeded,
+} from '../../../utils';
 import { DestinationPagesDialog } from '../destination-pages-dialog/destination-pages-dialog';
 
 import './execution-summary-panel.scss';
@@ -44,12 +49,18 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
   const buttons: JSX.Element[] = [];
 
   if (queryResult) {
-    const wrapQueryLimit = queryResult.getSqlOuterLimit();
-    const hasMoreResults = queryResult.getNumResults() === wrapQueryLimit;
+    let resultCount: string;
+    const numTotalRows = execution?.destination?.numTotalRows;
+    if (typeof numTotalRows === 'number') {
+      resultCount = pluralIfNeeded(numTotalRows, 'result');
+    } else {
+      const wrapQueryLimit = queryResult.getSqlOuterLimit();
+      const hasMoreResults = queryResult.getNumResults() === wrapQueryLimit;
 
-    const resultCount = hasMoreResults
-      ? `${queryResult.getNumResults() - 1}+ results`
-      : pluralIfNeeded(queryResult.getNumResults(), 'result');
+      resultCount = hasMoreResults
+        ? `${formatInteger(queryResult.getNumResults() - 1)}+ results`
+        : pluralIfNeeded(queryResult.getNumResults(), 'result');
+    }
 
     const warningCount = execution?.stages?.getWarningCount();
 

--- a/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
+++ b/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
@@ -49,12 +49,12 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
   const buttons: JSX.Element[] = [];
 
   if (queryResult) {
+    const wrapQueryLimit = queryResult.getSqlOuterLimit();
     let resultCount: string;
     const numTotalRows = execution?.destination?.numTotalRows;
-    if (typeof numTotalRows === 'number') {
+    if (typeof wrapQueryLimit === 'undefined' && typeof numTotalRows === 'number') {
       resultCount = pluralIfNeeded(numTotalRows, 'result');
     } else {
-      const wrapQueryLimit = queryResult.getSqlOuterLimit();
       const hasMoreResults = queryResult.getNumResults() === wrapQueryLimit;
 
       resultCount = hasMoreResults

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -347,7 +347,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                       ))}
                       <MenuDivider />
                       <MenuCheckbox
-                        checked={selectDestination === 'taskReport' ? !query.unlimited : undefined}
+                        checked={selectDestination === 'taskReport' ? !query.unlimited : false}
                         intent={intent}
                         disabled={selectDestination !== 'taskReport'}
                         text="Limit SELECT results in taskReport"


### PR DESCRIPTION
Display the actual number of results (vs the truncated number) when using durable storage

<img width="259" alt="image" src="https://github.com/apache/druid/assets/177816/0d2b81d0-3f3c-4ecd-b152-6b1434f9d335">
