### PR TITLE
Support broadcast segments

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -34,6 +34,7 @@ public class DruidK8sConstants
   public static final String TASK_JSON_ENV = "TASK_JSON";
   public static final String TASK_DIR_ENV = "TASK_DIR";
   public static final String TASK_ID_ENV = "TASK_ID";
+  public static final String LOAD_BROADCAST_SEGMENTS_ENV = "LOAD_BROADCAST_SEGMENTS";
   public static final String JAVA_OPTS = "JAVA_OPTS";
   public static final String DRUID_HOST_ENV = "druid_host";
   public static final String DRUID_HOSTNAME_ENV = "HOSTNAME";

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -224,7 +224,11 @@ public class PodTemplateTaskAdapter implements TaskAdapter
             .withValueFrom(new EnvVarSourceBuilder().withFieldRef(new ObjectFieldSelector(
                 null,
                 StringUtils.format("metadata.annotations['%s']", DruidK8sConstants.TASK)
-            )).build()).build()
+            )).build()).build(),
+        new EnvVarBuilder()
+            .withName(DruidK8sConstants.LOAD_BROADCAST_SEGMENTS_ENV)
+            .withValue(Boolean.toString(task.supportsQueries()))
+            .build()
     );
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.k8s.overlord.common.Base64Compression;
 import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
 import org.apache.druid.k8s.overlord.common.K8sTestUtils;
 import org.apache.druid.server.DruidNode;
+import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class PodTemplateTaskAdapterTest
 {
@@ -352,6 +354,42 @@ public class PodTemplateTaskAdapterTest
     Job expected = K8sTestUtils.fileToResource("expectedNoopJobLongIds.yaml", Job.class);
 
     assertJobSpecsEqual(actual, expected);
+  }
+
+  @Test
+  public void test_fromTask_taskSupportsQueries() throws IOException
+  {
+    Path templatePath = Files.createFile(tempDir.resolve("noop.yaml"));
+    mapper.writeValue(templatePath.toFile(), podTemplateSpec);
+
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.k8s.podTemplate.base", templatePath.toString());
+    props.setProperty("druid.indexer.runner.k8s.podTemplate.queryable", templatePath.toString());
+
+    PodTemplateTaskAdapter adapter = new PodTemplateTaskAdapter(
+        taskRunnerConfig,
+        taskConfig,
+        node,
+        mapper,
+        props
+    );
+
+    Task task = EasyMock.mock(Task.class);
+    EasyMock.expect(task.supportsQueries()).andReturn(true);
+    EasyMock.expect(task.getType()).andReturn("queryable").anyTimes();
+    EasyMock.expect(task.getId()).andReturn("id").anyTimes();
+    EasyMock.expect(task.getGroupId()).andReturn("groupid").anyTimes();
+    EasyMock.expect(task.getDataSource()).andReturn("datasource").anyTimes();
+
+    EasyMock.replay(task);
+    Job actual = adapter.fromTask(task);
+    EasyMock.verify(task);
+
+    Assertions.assertEquals("true", actual.getSpec().getTemplate()
+        .getSpec().getContainers()
+        .get(0).getEnv().stream()
+        .filter(env -> env.getName().equals(DruidK8sConstants.LOAD_BROADCAST_SEGMENTS_ENV))
+        .collect(Collectors.toList()).get(0).getValue());
   }
 
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
@@ -46,5 +46,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: "metadata.annotations['task']"
+            - name: "LOAD_BROADCAST_SEGMENTS"
+              value: "false"
           image: one
           name: primary

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
@@ -46,5 +46,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: "metadata.annotations['task']"
+            - name: "LOAD_BROADCAST_SEGMENTS"
+              value: "false"
           image: one
           name: primary

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabled.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabled.yaml
@@ -46,5 +46,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: "metadata.annotations['task']"
+            - name: "LOAD_BROADCAST_SEGMENTS"
+              value: "false"
           image: one
           name: primary


### PR DESCRIPTION
Since the pod template adapter does not generate the internal peon ... run command itself (the command is passed in the pod templates), we need a way to account for the optional --load-broadcast-segments flag in CliPeon for tasks that are queryable.

### Description
Based on the task being launched, pass whether the task can handle queries as a environment variable to the job launched by the pod template adapter. The operator can then configure their k8s command in the pod template to include this env variable in the internal peon run command.

#### Release note
Allow the PodTemplateTaskAdapter to account for queryable tasks.

##### Key changed/added classes in this PR
 * PodTemplateTaskAdapter



This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
