### PR TITLE
Add lifecycle hooks to KubernetesTaskRunner

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -42,6 +42,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
+import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -325,6 +327,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   }
 
   @Override
+  @LifecycleStart
   public void start()
   {
     cleanupExecutor.scheduleAtFixedRate(
@@ -342,6 +345,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
 
 
   @Override
+  @LifecycleStop
   public void stop()
   {
     log.debug("Stopping KubernetesTaskRunner");


### PR DESCRIPTION
The KubernetesTaskRunner doesn't actually register itself to be managed by @Lifecycle, and nothing ever manually calls start() on it, so the cleanup job thats supposed to get started in start() never runs.

### Description
Add annotations to manage the KubernetesTaskRunner with LIfecycle.

Tested this in my local cluster by making sure a job was actually cleaned up

#### Release note
Bugfix to druid-kubernetes-overlord-extensions

##### Key changed/added classes in this PR
 * KubernetesTaskRunner

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
