### PR TITLE
Completely disable cachingCost balancer strategy

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
@@ -26,7 +26,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "strategy", defaultImpl = CostBalancerStrategyFactory.class)
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "cost", value = CostBalancerStrategyFactory.class),
-    @JsonSubTypes.Type(name = "cachingCost", value = CachingCostBalancerStrategyFactory.class),
+    @JsonSubTypes.Type(name = "cachingCost", value = DisabledCachingCostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "diskNormalized", value = DiskNormalizedCostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class)
 })

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
@@ -28,6 +28,11 @@ import org.apache.druid.timeline.DataSegment;
 import java.util.Collections;
 import java.util.Set;
 
+/**
+ * @deprecated This is currently being used only in tests for benchmarking purposes
+ * and will be removed in future releases.
+ */
+@Deprecated
 public class CachingCostBalancerStrategy extends CostBalancerStrategy
 {
   private final ClusterCostCache clusterCostCache;

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategyFactory.java
@@ -39,6 +39,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
+/**
+ * @deprecated This is currently being used only in tests for benchmarking purposes
+ * and will be removed in future releases.
+ */
+@Deprecated
 public class CachingCostBalancerStrategyFactory implements BalancerStrategyFactory
 {
   private static final EmittingLogger LOG = new EmittingLogger(CachingCostBalancerStrategyFactory.class);

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/DisabledCachingCostBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/DisabledCachingCostBalancerStrategyFactory.java
@@ -20,12 +20,16 @@
 package org.apache.druid.server.coordinator.balancer;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
+import org.apache.druid.java.util.common.logger.Logger;
 
-public class CostBalancerStrategyFactory implements BalancerStrategyFactory
+public class DisabledCachingCostBalancerStrategyFactory implements BalancerStrategyFactory
 {
+  private static final Logger log = new Logger(BalancerStrategyFactory.class);
+
   @Override
   public BalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
   {
+    log.warn("Balancer strategy 'cachingCost' is disabled. Using 'cost' strategy instead.");
     return new CostBalancerStrategy(exec);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BalancerStrategyFactoryTest
+{
+  private final ObjectMapper MAPPER = TestHelper.makeJsonMapper();
+
+  private ListeningExecutorService executorService;
+
+  @Before
+  public void setup()
+  {
+    executorService = MoreExecutors.listeningDecorator(
+        new BlockingExecutorService("StrategyFactoryTest-%s")
+    );
+  }
+
+  @After
+  public void tearDown()
+  {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  public void testCachingCostStrategyFallsBackToCost() throws JsonProcessingException
+  {
+    final String json = "{\"strategy\":\"cachingCost\"}";
+    BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
+    BalancerStrategy strategy = factory.createBalancerStrategy(executorService);
+
+    Assert.assertTrue(strategy instanceof CostBalancerStrategy);
+    Assert.assertFalse(strategy instanceof CachingCostBalancerStrategy);
+  }
+}


### PR DESCRIPTION
### Description
`cachingCost` has been deprecated in #14484 and is not advised to be used in production clusters as it may cause usage skew across historicals which the coordinator is unable to rectify. This PR completely disables `cachingCost` strategy as it has now been rendered redundant due to recent performance improvements made to `cost` strategy.

### Changes
- Disable `cachingCost` strategy
- Add `DisabledCachingCostBalancerStrategyFactory` for the time being so that we can give a proper error message before falling back to `CostBalancerStrategy`. This will be removed in subsequent releases.
- Retain `CachingCostBalancerStrategy` and related classes for testing and benchmarking purposes.
- Add javadocs to `DiskCostBalancerStrategy`.

### Release note
`cachingCost` balancer strategy is now disabled and cannot be used in a Druid cluster. Using `cachingCost` falls back to `cost` balancer strategy.