### PR TITLE
When restoring tasks from kubernetes, compare to tasks in task storage to get the Task object.

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -49,6 +49,7 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.apache.druid.tasklogs.TaskLogStreamer;
@@ -322,7 +323,8 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
         String taskId = adapter.getTaskId(job);
         Task task = tasksFromStorage.get(taskId);
         if (task == null) {
-          log.warn("Found K8s job running task id %s that was not in taskStorage during restore, ignoring it.", taskId);
+          log.warn("Found K8s job running task id %s that was not in taskStorage during restore, deleting it.", taskId);
+          client.deletePeonJob(new K8sTaskId(taskId));
           continue;
         }
         restoredTasks.add(Pair.of(tasksFromStorage.get(taskId), joinAsync(task)));

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -62,7 +62,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -317,10 +316,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   public List<Pair<Task, ListenableFuture<TaskStatus>>> restore()
   {
     List<Pair<Task, ListenableFuture<TaskStatus>>> restoredTasks = new ArrayList<>();
-    Map<String, Task> tasksFromStorage = new HashMap<>();
-    for (Task task: taskStorage.getActiveTasks()) {
-      tasksFromStorage.put(task.getId(), task);
-    }
+    Map<String, Task> tasksFromStorage = taskStorage.getActiveTasks().stream().collect(Collectors.toMap(Task::getId, task -> task));
     for (Job job : client.getPeonJobs()) {
       try {
         String taskId = adapter.getTaskId(job);

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
@@ -27,6 +27,7 @@ import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.overlord.TaskRunnerFactory;
+import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
@@ -57,6 +58,7 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
   private final DruidKubernetesClient druidKubernetesClient;
   private final ServiceEmitter emitter;
   private KubernetesTaskRunner runner;
+  private TaskStorage taskStorage;
 
 
   @Inject
@@ -70,7 +72,8 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
       TaskConfig taskConfig,
       Properties properties,
       DruidKubernetesClient druidKubernetesClient,
-      ServiceEmitter emitter
+      ServiceEmitter emitter,
+      TaskStorage taskStorage
   )
   {
     this.smileMapper = smileMapper;
@@ -83,6 +86,7 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
     this.properties = properties;
     this.druidKubernetesClient = druidKubernetesClient;
     this.emitter = emitter;
+    this.taskStorage = taskStorage;
   }
 
   @Override
@@ -101,7 +105,8 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
         peonClient,
         httpClient,
         new KubernetesPeonLifecycleFactory(peonClient, taskLogs, smileMapper),
-        emitter
+        emitter,
+        taskStorage
     );
     return runner;
   }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -172,6 +172,19 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     return mapper.readValue(Base64Compression.decompressBase64(task), Task.class);
   }
 
+  @Override
+  public String getTaskId(Job from) throws IOException {
+    Map<String, String> annotations = from.getSpec().getTemplate().getMetadata().getAnnotations();
+    if (annotations == null) {
+      throw new IOE("No annotations found on pod spec for job [%s]", from.getMetadata().getName());
+    }
+    String taskId = annotations.get(DruidK8sConstants.TASK_ID);
+    if (taskId == null) {
+      throw new IOE("No task.id annotation found on pod spec for job [%s]", from.getMetadata().getName());
+    }
+    return taskId;
+  }
+
   private HashMap<String, PodTemplate> initializePodTemplates(Properties properties)
   {
     HashMap<String, PodTemplate> podTemplateMap = new HashMap<>();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -30,7 +30,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.ObjectFieldSelector;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
@@ -148,32 +147,9 @@ public class PodTemplateTaskAdapter implements TaskAdapter
         .build();
   }
 
-  /**
-   * Transform a {@link Pod} to a {@link Task}
-   *
-   * 1. Find task annotation on the pod
-   * 2. Base 64 decode and decompress task, read into {@link Task}
-   *
-   * @param from
-   * @return {@link Task}
-   * @throws IOException
-   */
   @Override
-  public Task toTask(Job from) throws IOException
+  public String getTaskId(Job from) throws IOException
   {
-    Map<String, String> annotations = from.getSpec().getTemplate().getMetadata().getAnnotations();
-    if (annotations == null) {
-      throw new IOE("No annotations found on pod spec for job [%s]", from.getMetadata().getName());
-    }
-    String task = annotations.get(DruidK8sConstants.TASK);
-    if (task == null) {
-      throw new IOE("No task annotation found on pod spec for job [%s]", from.getMetadata().getName());
-    }
-    return mapper.readValue(Base64Compression.decompressBase64(task), Task.class);
-  }
-
-  @Override
-  public String getTaskId(Job from) throws IOException {
     Map<String, String> annotations = from.getSpec().getTemplate().getMetadata().getAnnotations();
     if (annotations == null) {
       throw new IOE("No annotations found on pod spec for job [%s]", from.getMetadata().getName());

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/TaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/TaskAdapter.java
@@ -31,4 +31,6 @@ public interface TaskAdapter
 
   Task toTask(Job from) throws IOException;
 
+  String getTaskId(Job from) throws IOException;
+
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/TaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/TaskAdapter.java
@@ -29,8 +29,6 @@ public interface TaskAdapter
 
   Job fromTask(Task task) throws IOException;
 
-  Task toTask(Job from) throws IOException;
-
   String getTaskId(Job from) throws IOException;
 
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.config.TaskConfigBuilder;
+import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
@@ -53,6 +54,8 @@ public class KubernetesTaskRunnerFactoryTest
 
   private DruidKubernetesClient druidKubernetesClient;
   @Mock private ServiceEmitter emitter;
+
+  @Mock private TaskStorage taskStorage;
 
   @Before
   public void setup()
@@ -90,7 +93,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         properties,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner expectedRunner = factory.build();
@@ -112,7 +116,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         properties,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();
@@ -139,7 +144,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         properties,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();
@@ -164,7 +170,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         props,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();
@@ -194,7 +201,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         props,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     Assert.assertThrows(
@@ -225,7 +233,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         props,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();
@@ -250,7 +259,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         props,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();
@@ -278,7 +288,8 @@ public class KubernetesTaskRunnerFactoryTest
         taskConfig,
         props,
         druidKubernetesClient,
-        emitter
+        emitter,
+        taskStorage
     );
 
     KubernetesTaskRunner runner = factory.build();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -314,7 +314,8 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         .build();
 
     EasyMock.expect(peonClient.getPeonJobs()).andReturn(ImmutableList.of(job));
-    EasyMock.expect(taskAdapter.toTask(job)).andReturn(task);
+    EasyMock.expect(taskAdapter.getTaskId(job)).andReturn(ID);
+    EasyMock.expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of(task));
 
     replayAll();
 
@@ -352,7 +353,8 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         .build();
 
     EasyMock.expect(peonClient.getPeonJobs()).andReturn(ImmutableList.of(job));
-    EasyMock.expect(taskAdapter.toTask(job)).andThrow(new IOException());
+    EasyMock.expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of());
+    EasyMock.expect(taskAdapter.getTaskId(job)).andThrow(new IOException());
 
     replayAll();
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
+import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
@@ -76,6 +77,7 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
   @Mock private KubernetesPeonClient peonClient;
   @Mock private KubernetesPeonLifecycle kubernetesPeonLifecycle;
   @Mock private ServiceEmitter emitter;
+  @Mock private TaskStorage taskStorage;
 
   private KubernetesTaskRunnerConfig config;
   private KubernetesTaskRunner runner;
@@ -96,7 +98,8 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         peonClient,
         httpClient,
         new TestPeonLifecycleFactory(kubernetesPeonLifecycle),
-        emitter
+        emitter,
+        taskStorage
     );
   }
 
@@ -294,7 +297,8 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         peonClient,
         httpClient,
         new TestPeonLifecycleFactory(kubernetesPeonLifecycle),
-        emitter
+        emitter,
+        taskStorage
     ) {
       @Override
       protected ListenableFuture<TaskStatus> joinAsync(Task task)
@@ -331,7 +335,8 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
         peonClient,
         httpClient,
         new TestPeonLifecycleFactory(kubernetesPeonLifecycle),
-        emitter
+        emitter,
+        taskStorage
     ) {
       @Override
       protected ListenableFuture<TaskStatus> joinAsync(Task task)

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -154,8 +154,8 @@ public class DruidPeonClientIntegrationTest
     thread.start();
 
     // assert that the env variable is corret
-    Task taskFromEnvVar = adapter.toTask(job);
-    assertEquals(task, taskFromEnvVar);
+    String taskIdFromEnvVar = adapter.getTaskId(job);
+    assertEquals(task.getId(), taskIdFromEnvVar);
 
     // now copy the task.json file from the pod and make sure its the same as our task.json we expected
     Path downloadPath = Paths.get(tempDir.toAbsolutePath().toString(), "task.json");

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
@@ -185,8 +185,8 @@ class K8sTaskAdapterTest
     assertEquals(2400000000L, Long.valueOf(amount));
     assertTrue(StringUtils.isBlank(containerMemory.getFormat())); // no units specified we talk in bytes
 
-    Task taskFromJob = adapter.toTask(Iterables.getOnlyElement(jobList.getItems()));
-    assertEquals(task, taskFromJob);
+    String taskId = adapter.getTaskId(Iterables.getOnlyElement(jobList.getItems()));
+    assertEquals(task.getId(), taskId);
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
@@ -242,7 +242,7 @@ public class PodTemplateTaskAdapterTest
   }
 
   @Test
-  public void test_fromTask_withoutAnnotations_throwsIOE() throws IOException
+  public void test_getTaskId_withoutAnnotations_throwsIOE() throws IOException
   {
     Path templatePath = Files.createFile(tempDir.resolve("base.yaml"));
     mapper.writeValue(templatePath.toFile(), podTemplateSpec);
@@ -261,11 +261,11 @@ public class PodTemplateTaskAdapterTest
     Job job = K8sTestUtils.fileToResource("baseJobWithoutAnnotations.yaml", Job.class);
 
 
-    Assert.assertThrows(IOE.class, () -> adapter.toTask(job));
+    Assert.assertThrows(IOE.class, () -> adapter.getTaskId(job));
   }
 
   @Test
-  public void test_fromTask_withoutTaskAnnotation_throwsIOE() throws IOException
+  public void test_getTaskId_withoutTaskAnnotation_throwsIOE() throws IOException
   {
     Path templatePath = Files.createFile(tempDir.resolve("base.yaml"));
     mapper.writeValue(templatePath.toFile(), podTemplateSpec);
@@ -292,31 +292,7 @@ public class PodTemplateTaskAdapterTest
         .endTemplate()
         .endSpec()
         .build();
-    Assert.assertThrows(IOE.class, () -> adapter.toTask(job));
-  }
-
-  @Test
-  public void test_fromTask() throws IOException
-  {
-    Path templatePath = Files.createFile(tempDir.resolve("base.yaml"));
-    mapper.writeValue(templatePath.toFile(), podTemplateSpec);
-
-    Properties props = new Properties();
-    props.put("druid.indexer.runner.k8s.podTemplate.base", templatePath.toString());
-
-    PodTemplateTaskAdapter adapter = new PodTemplateTaskAdapter(
-        taskRunnerConfig,
-        taskConfig,
-        node,
-        mapper,
-        props
-    );
-
-    Job job = K8sTestUtils.fileToResource("baseJob.yaml", Job.class);
-    Task actual = adapter.toTask(job);
-    Task expected = NoopTask.create("id", 1);
-
-    Assertions.assertEquals(expected, actual);
+    Assert.assertThrows(IOE.class, () -> adapter.getTaskId(job));
   }
 
   @Test


### PR DESCRIPTION
The main motivation behind this PR is to fix a bug I noticed with large task payloads (>~1MB). Since we compress the task.json and then store it in an environment variable (TASK_JSON), we are limited by the max environment variable size of the (usually linux) OS we are running the peon on, which is normally 128 KB (https://askubuntu.com/questions/1385551/how-long-can-display-environment-variable-value-be#:~:text=As%20a%20result%2C%20the%20maximum,131%2C072%20single%2Dbyte%20ASCII%20characters.)

This issue can be replicated by trying to create a task with a payload that gzip compresses to >128KB. You'll get a "Argument list too long" when starting the container.

### Description
I think the best way to get around this problem is to introduce a flag into the internal peon command that lets you choose to have the peon pull the task payload from the overlord during startup, rather than expecting it to be provided via environment variable.

The problem with this solution is that the KubernetesTaskRunner currently relies on a toTask(Job) interface on each of the taskAdapters to restore tasks from k8s. When the runner is restarted, it lists the running jobs in the cluster and then uses the TASK_JSON environment variable to reconstruct the task.

However, I don't think we actually need to do this, because for a task to be restored properly it needs to also be available in TaskStorage. If a job is restored from K8s in the KubernetesTaskRunner, but it's not available in taskStorage, then you get errors like below.
```
java.lang.RuntimeException: org.apache.druid.java.util.common.ISE: Unable to grant lock to inactive Task [index_parallel_wikipedia_lngdjhog_2023-08-10T14:00:12.586Z]
```

And eventually TaskQueue sends a request to the KubernetesTaskRunner to shut the task down.
```
2023-08-10T14:01:12,443 INFO [TaskQueue-Manager] org.apache.druid.k8s.overlord.KubernetesTaskRunner - Shutdown [index_parallel_wikipedia_lngdjhog_2023-08-10T14:00:12.586Z] because [Task is not in knownTaskIds]
```
This is reproducible by deploying the overlord with HeapMemoryTaskStorage (instead of storing tasks in a metadataDB) creating a long running task (like a kafka ingest or bigger batch ingest), then restarting the overlord. The KubernetesTaskRunner will restore the task but it will get killed by TaskQueue since the task will not be in TaskStorage.

Because of this, I updated the restore() method to check each Job (by taskId) in TaskStorage before restoring it. This has the side effect of letting us deprecate toTask(Job) on the TaskAdapter, so we can add the feature to have the peons pull the task.json from the overlord instead of providing it via environment variable.

Will have a second PR that actually adds the flag to get the peon to pull the task.json instead of passing it via TASK_JSON soon.
#### Release note
- Update KubernetesTaskRunner.restore() to check with TaskStorage before restoring a task.

##### Key changed/added classes in this PR
 * KubernetesTaskRunner
 * K8sTaskAdapter/PodTemplateTaskAdapter

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
