### PR TITLE
increase dependabot PR limit for Java dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
     ignore:
       - dependency-name: "com.google.guava:guava"
       # pin ZooKeeper dependencies to 3.5.x


### PR DESCRIPTION
Many dependabot PRs are currently stuck due to API changes or incompatibilities.
Temporarily Increasing the limit so we can get updates for other dependencies.