### PR TITLE
Fix a bug in index_hadoop that leads to orphaned indexing files in hdfs after jobs run

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -526,6 +526,9 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       }
     }
     finally {
+      // The indexGenerator job does not always use the version in the spec. Instead, the version can be dynamically
+      // set. If this is the case, we need to clean up the job with the dynamic version, otherwise intermediate indexing
+      // files will be orphaned and require manual cleanup
       indexerGeneratorCleanupJob(
           indexGeneratorJobAttempted,
           indexGeneratorJobSuccess,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -342,6 +342,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
     boolean indexGeneratorJobAttempted = false;
     boolean indexGeneratorJobSuccess = false;
     HadoopIngestionSpec indexerSchema = null;
+    String version = null;
     try {
       registerResourceCloserOnAbnormalExit(config -> killHadoopJob());
       String hadoopJobIdFile = getHadoopJobIdFileName();
@@ -407,7 +408,6 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       }
 
       // We should have a lock from before we started running only if interval was specified
-      String version;
       if (determineIntervals) {
         Interval interval = JodaUtils.umbrellaInterval(
             JodaUtils.condenseIntervals(
@@ -529,7 +529,10 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
       indexerGeneratorCleanupJob(
           indexGeneratorJobAttempted,
           indexGeneratorJobSuccess,
-          indexerSchema == null ? null : toolbox.getJsonMapper().writeValueAsString(indexerSchema)
+          indexerSchema == null ? null : toolbox.getJsonMapper().writeValueAsString(
+                  indexerSchema.withTuningConfig(
+                          indexerSchema.getTuningConfig().withVersion(
+                                  version == null ? indexerSchema.getTuningConfig().getVersion() : version)))
       );
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

My org found an accumulation of files under our `druid.indexer.task.hadoopWorkingPath` path in HDFS. We discovered many directories for tasks that ran long in past. After investigation, we determined that our index_hadoop jobs were not deleting the temp dir after the generate index MR job. After adding this patch into our fork, we confirmed that the temp dirs were properly cleaned up

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

### Background

For each MR job, a "temporary working directory for hadoop tasks" is created. This is controlled via `druid.indexer.task.hadoopWorkingPath`. The contents of this directory during the task aren't relevant to this PR. Just the fact that it exists matters. At the end of the MR job, the directory is to be deleted since the files were only needed for the running of that one job.

### Bug

The bug is that this temporary directory is not always cleaned up after the indexGenerator part of the index task runs. The root cause is that the indexGenerator MR job can set a dynamic version that strays from the version in the task spec. This version is used in the path for the aforementioned temporary working directory for a hadoop task. If the code that cleans up the temporary directory is not aware of the dynamic change of the version, the directory will not be cleaned up. Over time this leads to accumulation of useless files in HDFS.

### Fix

The fix is super simple. We just need to honor the dynamic version when calling to cleanup after the indexGenerator task is complete. There is a little bit of ugliness to protect against an NPE that should be impossible, but the IDE complains so I put in some protection just in case.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

Fix a bug in Hadoop Batch Ingestion that could lead to a large amount of useless files under `druid.indexer.task.hadoopWorkingPath` in HDFS. Note that this does not retroactively cleanup orphaned temp files from ingestion jobs that have run in the past. It is suggested that you do some analysis of the contents in `druid.indexer.task.hadoopWorkingPath` and perform cleanup as you need to.

-->


<hr>

##### Key changed/added classes in this PR
 * `HadoopIndexTask.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
