### PR TITLE
update checkstyle to 9.3 and maven-checkstyle-plugin to 3.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
       # jclouds 2.1 needs Guava 18+
       - dependency-name: "org.apache.jclouds"
         versions: "[2.1,)"
+      # checkstyle >= 10.x requires Java 11
+      - dependency-name: "com.puppycrawl.tools"
+        versions: "[10,)"

--- a/pom.xml
+++ b/pom.xml
@@ -1341,7 +1341,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <sourceDirectories>
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
@@ -1362,7 +1362,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.21</version>
+                        <version>9.3</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
- checkstyle 9.3 is the highest version which still supports Java 8
- checkstyle 10 and above require Java 11, ignoring those versions in dependabot until we drop Java 8 support
- update maven-checkstyle-plugin to the latest 3.3.0 version
