### PR TITLE
(Donot Merge) Use transfer manager to speed up S3StorageConnector

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2654,6 +2654,7 @@ public class ControllerImpl implements Controller
     ListenableFuture<Void> contactTask(WorkerClient client, String taskId, int workerNumber);
   }
 
+
   /**
    * Interface used when {@link TaskContactFn#contactTask(WorkerClient, String, int)} returns a successful future.
    */

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3Entity.java
@@ -98,17 +98,16 @@ public class S3Entity extends RetryingInputEntity
   }
 
   @Override
-  public CleanableFile fetch(File temporaryDirectory, byte[] fetchBuffer) throws IOException
+  public CleanableFile fetchInternal(File tempFile, byte[] fetchBuffer) throws IOException
   {
 
     log.info("doing fetch on s3 file");
     if (!isUseTransferManager()) {
-      return super.fetch(temporaryDirectory, fetchBuffer);
+      return super.fetchInternal(tempFile, fetchBuffer);
     }
 
     final GetObjectRequest request = new GetObjectRequest(object.getBucket(), object.getPath());
 
-    File tempFile = new File(tempDir.getAbsolutePath(), UUID.randomUUID().toString());
     boolean parallelizable = TransferManagerUtils.isDownloadParallelizable(
         s3Client.getUnderlyingS3Client(),
         request,

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -328,7 +328,7 @@ public class S3Utils
       putObjectRequest.setAccessControlList(S3Utils.grantFullControlToBucketOwner(service, bucket));
     }
     log.info("Pushing [%s] to bucket[%s] and key[%s].", file, bucket, key);
-    service.putObject(putObjectRequest);
+    service.putObject2(putObjectRequest);
   }
 
   @Nullable

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
@@ -43,6 +43,9 @@ import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.amazonaws.services.s3.transfer.Upload;
 import org.apache.druid.java.util.common.ISE;
 
 import java.io.File;
@@ -65,11 +68,15 @@ public class ServerSideEncryptingAmazonS3
 
   private final AmazonS3 amazonS3;
   private final ServerSideEncryption serverSideEncryption;
+  private final TransferManager transferManager;
 
   public ServerSideEncryptingAmazonS3(AmazonS3 amazonS3, ServerSideEncryption serverSideEncryption)
   {
     this.amazonS3 = amazonS3;
     this.serverSideEncryption = serverSideEncryption;
+    this.transferManager = TransferManagerBuilder.standard()
+                                                 .withS3Client(amazonS3)
+                                                 .build();
   }
 
   public boolean doesObjectExist(String bucket, String objectName)
@@ -126,6 +133,11 @@ public class ServerSideEncryptingAmazonS3
   public PutObjectResult putObject(PutObjectRequest request)
   {
     return amazonS3.putObject(serverSideEncryption.decorate(request));
+  }
+
+  public void putObject2(PutObjectRequest request) {
+
+    transferManager.upload(serverSideEncryption.decorate(request));
   }
 
   public CopyObjectResult copyObject(CopyObjectRequest request)

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
@@ -168,6 +168,16 @@ public class ServerSideEncryptingAmazonS3
     return amazonS3.completeMultipartUpload(request);
   }
 
+  public AmazonS3 getUnderlyingS3Client()
+  {
+    return amazonS3;
+  }
+
+  public ServerSideEncryption getUnderlyingServerSideEncryption()
+  {
+    return serverSideEncryption;
+  }
+
   public static class Builder
   {
     private AmazonS3ClientBuilder amazonS3ClientBuilder = AmazonS3Client.builder();

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -109,16 +109,14 @@ public class RetryableS3OutputStream extends OutputStream
       String s3Key
   ) throws IOException
   {
-
-    this(config, s3, s3Key, true);
+    this(config, s3, s3Key, config.getChunkSize());
   }
 
-  @VisibleForTesting
-  protected RetryableS3OutputStream(
+  public RetryableS3OutputStream(
       S3OutputConfig config,
       ServerSideEncryptingAmazonS3 s3,
       String s3Key,
-      boolean chunkValidation
+      long uploadChunkSize
   ) throws IOException
   {
     this.config = config;
@@ -137,13 +135,12 @@ public class RetryableS3OutputStream extends OutputStream
     this.uploadId = result.getUploadId();
     this.chunkStorePath = new File(config.getTempDir(), uploadId + UUID.randomUUID());
     FileUtils.mkdirp(this.chunkStorePath);
-    this.chunkSize = config.getChunkSize();
+    this.chunkSize = uploadChunkSize;
     this.pushStopwatch = Stopwatch.createUnstarted();
     this.pushStopwatch.reset();
 
     this.currentChunk = new Chunk(nextChunkId, new File(chunkStorePath, String.valueOf(nextChunkId++)));
   }
-
 
   @Override
   public void write(int b) throws IOException

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -28,7 +28,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.CountingOutputStream;
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -138,7 +138,7 @@ public class RetryableS3OutputStream extends OutputStream
     this.pushStopwatch = Stopwatch.createUnstarted();
     this.pushStopwatch.reset();
 
-    this.currentChunk = new Chunk(nextChunkId, new File(chunkStorePath, String.valueOf(nextChunkId++)));
+    this.currentChunk = new Chunk(nextChunkId, new File(chunkStorePath, String.valueOf(nextChunkId++)), chunkSize);
   }
 
   @Override
@@ -171,7 +171,7 @@ public class RetryableS3OutputStream extends OutputStream
 
         if (currentChunk.length() >= chunkSize) {
           pushCurrentChunk();
-          currentChunk = new Chunk(nextChunkId, new File(chunkStorePath, String.valueOf(nextChunkId++)));
+          currentChunk = new Chunk(nextChunkId, new File(chunkStorePath, String.valueOf(nextChunkId++)), chunkSize);
         }
 
         offsetToWrite += writtenBytes;
@@ -316,12 +316,12 @@ public class RetryableS3OutputStream extends OutputStream
     private final ByteArrayOutputStream baos;
     private boolean closed;
 
-    private Chunk(int id, File file) throws FileNotFoundException
+    private Chunk(int id, File file, long chunkSize) throws FileNotFoundException
     {
       this.id = id;
       // this.file = file;
       // this.outputStream = new CountingOutputStream(new FastBufferedOutputStream(new FileOutputStream(file)));
-      this.baos = new ByteArrayOutputStream();
+      this.baos = new ByteArrayOutputStream((int) chunkSize);
       this.outputStream = new CountingOutputStream(baos);
     }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3OutputConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3OutputConfig.java
@@ -48,7 +48,7 @@ public class S3OutputConfig
   private HumanReadableBytes chunkSize = new HumanReadableBytes("128MiB");
 
   @JsonProperty
-  private boolean testingTransferManager = true;
+  private boolean testingTransferManager = false;
 
 
   /**

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3OutputConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3OutputConfig.java
@@ -65,7 +65,7 @@ public class S3OutputConfig
       Integer maxRetry
   )
   {
-    this(bucket, prefix, tempDir, chunkSize, maxRetry, false, true);
+    this(bucket, prefix, tempDir, chunkSize, maxRetry, false, false);
   }
 
   @JsonCreator
@@ -78,7 +78,7 @@ public class S3OutputConfig
       @JsonProperty("testingTransferManager") Boolean testingTransferManager
   )
   {
-    this(bucket, prefix, tempDir, chunkSize, maxRetry, testingTransferManager, true);
+    this(bucket, prefix, tempDir, chunkSize, maxRetry, testingTransferManager, false);
   }
 
   @VisibleForTesting

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.data.input.impl.prefetch.ObjectOpenFunction;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -41,6 +42,8 @@ import org.apache.druid.storage.remote.ChunkingStorageConnectorParameters;
 import org.apache.druid.storage.s3.NoopServerSideEncryption;
 import org.apache.druid.storage.s3.S3Utils;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -189,7 +192,14 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
           if (downloadFile == null) {
             downloadFile = new File(config.getTempDir(), UUID.randomUUID().toString());
             Download download = transferManager.download(object, downloadFile);
+            DateTime start = DateTimes.nowUtc();
             download.waitForCompletion();
+            log.info(
+                "Download path [%s], size [%d] took [%d] ms",
+                path,
+                size,
+                new Interval(start, DateTimes.nowUtc()).toDurationMillis()
+            );
           }
 
           return new FileInputStream(downloadFile)

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -197,6 +197,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
 
           DateTime start = DateTimes.nowUtc();
           InputStream is = implementParallelDownload(object, 4, DOWNLOAD_SIZE_BYTES);
+
           log.info(
               "Download path [%s], size [%d] took [%d] ms",
               path,
@@ -363,6 +364,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
                                             config.getTempDir().getAbsolutePath(),
                                             UUID.randomUUID().toString()
                                         );
+                                        DateTime startTime = DateTimes.nowUtc();
                                         IOUtils.copy(
                                             s3Client.getObject(
                                                 new GetObjectRequest(
@@ -371,6 +373,15 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
                                                 ).withRange(division.lhs, division.rhs)
                                             ).getObjectContent(),
                                             new FileOutputStream(outFile)
+                                        );
+                                        DateTime endTime = DateTimes.nowUtc();
+                                        log.info(
+                                            "Download path [%s], chunk [%d], started from [%s], ended at [%s], total time [%d]",
+                                            getObjectRequest.getKey(),
+                                            division.lhs,
+                                            startTime.toString(),
+                                            endTime,
+                                            new Interval(startTime, endTime).toDurationMillis()
                                         );
 
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -108,7 +108,10 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
       boolean cacheLocally
   )
   {
-    super(DOWNLOAD_PARALLELISM * DOWNLOAD_SIZE_BYTES, cacheLocally);
+    super(
+        cacheLocally ? config.getChunkSize() : DOWNLOAD_PARALLELISM * DOWNLOAD_SIZE_BYTES,
+        cacheLocally
+    );
     this.uploadChunkSize = uploadChunkSize;
     this.cacheLocally = cacheLocally;
     this.config = config;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -22,7 +22,6 @@ package org.apache.druid.storage.s3.output;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.amazonaws.services.s3.transfer.Download;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
 import com.google.common.base.Joiner;
@@ -30,10 +29,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
+import org.apache.commons.io.IOUtils;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
 import org.apache.druid.data.input.impl.prefetch.ObjectOpenFunction;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -49,14 +50,21 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.SequenceInputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 /**
  * In this implementation, all remote calls to aws s3 are retried {@link S3OutputConfig#getMaxRetry()} times.
@@ -75,6 +83,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
   private static final String DELIM = "/";
   private static final Joiner JOINER = Joiner.on(DELIM).skipNulls();
   private static final int MAX_NUMBER_OF_LISTINGS = 1000;
+  private static final long DOWNLOAD_SIZE_BYTES = 32 * 1024 * 1024;
 
   private final long uploadChunkSize;
 
@@ -101,7 +110,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
       boolean cacheLocally
   )
   {
-    super(downloadChunkSize, cacheLocally);
+    super(DOWNLOAD_PARALLELISM * DOWNLOAD_SIZE_BYTES, cacheLocally);
     this.uploadChunkSize = uploadChunkSize;
     this.cacheLocally = cacheLocally;
     this.config = config;
@@ -175,9 +184,6 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
     ));
     builder.objectOpenFunction(new ObjectOpenFunction<GetObjectRequest>()
     {
-
-      File downloadFile = null;
-
       @Override
       public InputStream open(GetObjectRequest object)
       {
@@ -189,34 +195,16 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
             );
           }
 
-          if (downloadFile == null) {
-            downloadFile = new File(config.getTempDir(), UUID.randomUUID().toString());
-            Download download = transferManager.download(object, downloadFile);
-            DateTime start = DateTimes.nowUtc();
-            download.waitForCompletion();
-            log.info(
-                "Download path [%s], size [%d] took [%d] ms",
-                path,
-                size,
-                new Interval(start, DateTimes.nowUtc()).toDurationMillis()
-            );
-          }
+          DateTime start = DateTimes.nowUtc();
+          InputStream is = implementParallelDownload(object, 4, DOWNLOAD_SIZE_BYTES);
+          log.info(
+              "Download path [%s], size [%d] took [%d] ms",
+              path,
+              size,
+              new Interval(start, DateTimes.nowUtc()).toDurationMillis()
+          );
 
-          return new FileInputStream(downloadFile)
-          {
-            AtomicBoolean closed = new AtomicBoolean(false);
-
-            @Override
-            public void close() throws IOException
-            {
-              if (closed.get()) {
-                return;
-              }
-              super.close();
-              downloadFile.delete();
-              closed.set(true);
-            }
-          };
+          return is;
         }
         catch (Exception e) {
           throw new RuntimeException(e);
@@ -351,5 +339,92 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
   private String objectPath(String path)
   {
     return JOINER.join(config.getPrefix(), path);
+  }
+
+  // Add some buffering as well
+  InputStream implementParallelDownload(GetObjectRequest getObjectRequest, int parallelism, long rangeSize)
+  {
+    ForkJoinPool fjp = new ForkJoinPool(parallelism);
+    long start = getObjectRequest.getRange()[0];
+    long end = getObjectRequest.getRange()[1];
+    List<Pair<Long, Long>> divisions = new ArrayList<>();
+
+    for (long st = start; st <= end; st += rangeSize) {
+      divisions.add(Pair.of(st, Math.min(st + rangeSize - 1, end)));
+    }
+
+    try {
+      List<Pair<Long, File>> startToIs =
+          fjp.submit(() -> divisions.stream()
+                                    .parallel()
+                                    .map(division -> {
+                                      try {
+                                        File outFile = new File(
+                                            config.getTempDir().getAbsolutePath(),
+                                            UUID.randomUUID().toString()
+                                        );
+                                        IOUtils.copy(
+                                            s3Client.getObject(
+                                                new GetObjectRequest(
+                                                    getObjectRequest.getBucketName(),
+                                                    getObjectRequest.getKey()
+                                                ).withRange(division.lhs, division.rhs)
+                                            ).getObjectContent(),
+                                            new FileOutputStream(outFile)
+                                        );
+
+
+                                        return Pair.of(
+                                            division.lhs,
+                                            outFile
+                                        );
+                                      }
+                                      catch (IOException e) {
+                                        throw new RE(e);
+                                      }
+                                    })
+                                    .collect(Collectors.toList())
+          ).get();
+      startToIs.sort((o1, o2) -> {
+        if (o1.lhs < o2.lhs) {
+          return -1;
+        } else if (o1.lhs > o2.lhs) {
+          return 1;
+        } else {
+          return 0;
+        }
+      });
+      return new SequenceInputStream(
+          Collections.enumeration(startToIs.stream().map(pair -> {
+            try {
+              AtomicBoolean fileInputStreamClosed = new AtomicBoolean(false);
+              return new FileInputStream(pair.rhs)
+              {
+                @Override
+                public void close() throws IOException
+                {
+                  if (fileInputStreamClosed.get()) {
+                    return;
+                  }
+                  fileInputStreamClosed.set(true);
+                  super.close();
+                  if (!pair.rhs.delete()) {
+                    throw new RE("Cannot delete temp file [%s]", outFile);
+                  }
+                }
+              };
+            }
+            catch (FileNotFoundException e) {
+              e.printStackTrace();
+            }
+          }).collect(Collectors.toList()))
+      );
+    }
+    catch (InterruptedException e) {
+      throw new RE(e);
+    }
+    catch (ExecutionException e) {
+      throw new RE(e);
+    }
   }
 }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -96,8 +96,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
         config,
         serverSideEncryptingAmazonS3,
         config.getChunkSize(),
-        !(config.isTestingTransferManager()
-          && serverSideEncryptingAmazonS3.getUnderlyingServerSideEncryption() instanceof NoopServerSideEncryption)
+        !(config.isTestingTransferManager())
     );
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -62,7 +62,7 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
   private static final String DELIM = "/";
   private static final Joiner JOINER = Joiner.on(DELIM).skipNulls();
   private static final int MAX_NUMBER_OF_LISTINGS = 1000;
-  private static final long DOWNLOAD_SIZE_BYTES = 32 * 1024 * 1024;
+  private static final long DOWNLOAD_SIZE_BYTES = 100 * 1024 * 1024;
 
   private static final long UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024L;
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -40,7 +40,6 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.storage.remote.ChunkingStorageConnector;
 import org.apache.druid.storage.remote.ChunkingStorageConnectorParameters;
-import org.apache.druid.storage.s3.NoopServerSideEncryption;
 import org.apache.druid.storage.s3.S3Utils;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.joda.time.DateTime;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnector.java
@@ -409,13 +409,13 @@ public class S3StorageConnector extends ChunkingStorageConnector<GetObjectReques
                   fileInputStreamClosed.set(true);
                   super.close();
                   if (!pair.rhs.delete()) {
-                    throw new RE("Cannot delete temp file [%s]", outFile);
+                    throw new RE("Cannot delete temp file [%s]", pair.rhs);
                   }
                 }
               };
             }
             catch (FileNotFoundException e) {
-              e.printStackTrace();
+              throw new RE(e);
             }
           }).collect(Collectors.toList()))
       );

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnectorProvider.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/S3StorageConnectorProvider.java
@@ -44,10 +44,11 @@ public class S3StorageConnectorProvider extends S3OutputConfig implements Storag
       @JsonProperty(value = "prefix", required = true) String prefix,
       @JsonProperty(value = "tempDir", required = true) File tempDir,
       @JsonProperty("chunkSize") HumanReadableBytes chunkSize,
-      @JsonProperty("maxRetry") Integer maxRetry
+      @JsonProperty("maxRetry") Integer maxRetry,
+      @JsonProperty("testingTransferManager") Boolean testingTransferManager
   )
   {
-    super(bucket, prefix, tempDir, chunkSize, maxRetry);
+    super(bucket, prefix, tempDir, chunkSize, maxRetry, testingTransferManager);
   }
 
   @Override

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -106,12 +106,7 @@ public class RetryableS3OutputStreamTest
   {
     chunkSize = 10;
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES);
-    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
-        config,
-        s3,
-        path,
-        false
-    )) {
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(config, s3, path)) {
       for (int i = 0; i < 25; i++) {
         bb.clear();
         bb.putInt(i);
@@ -128,12 +123,7 @@ public class RetryableS3OutputStreamTest
   {
     chunkSize = 10;
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES * 3);
-    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
-        config,
-        s3,
-        path,
-        false
-    )) {
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(config, s3, path)) {
       bb.clear();
       bb.putInt(1);
       bb.putInt(2);
@@ -149,12 +139,7 @@ public class RetryableS3OutputStreamTest
   public void testWriteSmallBufferShouldSucceed() throws IOException
   {
     chunkSize = 128;
-    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
-        config,
-        s3,
-        path,
-        false
-    )) {
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(config, s3, path)) {
       for (int i = 0; i < 600; i++) {
         out.write(i);
       }
@@ -171,12 +156,7 @@ public class RetryableS3OutputStreamTest
 
     chunkSize = 10;
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES);
-    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
-        config,
-        s3,
-        path,
-        false
-    )) {
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(config, s3, path)) {
       for (int i = 0; i < 25; i++) {
         bb.clear();
         bb.putInt(i);
@@ -194,12 +174,7 @@ public class RetryableS3OutputStreamTest
     final TestAmazonS3 s3 = new TestAmazonS3(3);
 
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES);
-    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
-        config,
-        s3,
-        path,
-        false
-    )) {
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(config, s3, path)) {
       for (int i = 0; i < 2; i++) {
         bb.clear();
         bb.putInt(i);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
@@ -52,7 +52,7 @@ public class S3OutputConfigTest
         temporaryFolder.newFolder(),
         HumanReadableBytes.valueOf(chunkSize),
         MAX_RETRY_COUNT,
-        true
+        false
     );
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3StorageConnectorTest.java
@@ -83,7 +83,7 @@ public class S3StorageConnectorTest
           temporaryFolder.newFolder(),
           null,
           null,
-          true
+          false
       ), service);
     }
     catch (IOException e) {

--- a/processing/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
+++ b/processing/src/main/java/org/apache/druid/data/input/RetryingInputEntity.java
@@ -24,6 +24,7 @@ import org.apache.druid.data.input.impl.prefetch.ObjectOpenFunction;
 import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.utils.CompressionUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -88,6 +89,12 @@ public abstract class RetryingInputEntity implements InputEntity
     public InputStream open(RetryingInputEntity object, long start) throws IOException
     {
       return object.readFrom(start);
+    }
+
+    @Override
+    public CleanableFile fetchInternal(RetryingInputEntity object, File tempFile, byte[] fetchBuffer) throws IOException
+    {
+      return object.fetchInternal(tempFile, fetchBuffer);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/storage/remote/ChunkingStorageConnector.java
+++ b/processing/src/main/java/org/apache/druid/storage/remote/ChunkingStorageConnector.java
@@ -62,6 +62,7 @@ public abstract class ChunkingStorageConnector<T> implements StorageConnector
   private static final int FETCH_BUFFER_SIZE_BYTES = 8 * 1024;
 
   private final long chunkSizeBytes;
+  private final boolean cacheLocally;
 
   public ChunkingStorageConnector()
   {
@@ -72,8 +73,18 @@ public abstract class ChunkingStorageConnector<T> implements StorageConnector
       final long chunkSizeBytes
   )
   {
-    this.chunkSizeBytes = chunkSizeBytes;
+    this(chunkSizeBytes, false);
   }
+
+  public ChunkingStorageConnector(
+      final long chunkSizeBytes,
+      final boolean cacheLocally
+  )
+  {
+    this.chunkSizeBytes = chunkSizeBytes;
+    this.cacheLocally = cacheLocally;
+  }
+
 
   @Override
   public InputStream read(String path) throws IOException


### PR DESCRIPTION
### Description

Currently, a draft PR, adds some settings and changes which won't make it into the final PR if it works as expected. Used for testing.

This PR tests the impact of using a TransferManager which parallelizes the download of multipart uploads.

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
