### PR TITLE
Fix flaky test `LookupCoordinatorManagerTest`

### DIFF
--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -42,7 +42,6 @@ import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.lookup.LookupsState;
 import org.apache.druid.server.http.HostAndPortWithScheme;
 import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -104,19 +103,15 @@ public class LookupCoordinatorManagerTest
       Collections.emptySet()
   );
 
-  private static final StubServiceEmitter serviceEmitter = new StubServiceEmitter("test", "localhost");
-
   @BeforeClass
   public static void setUpStatic()
   {
-    EmittingLogger.registerEmitter(serviceEmitter);
+    EmittingLogger.registerEmitter(new StubServiceEmitter("test", "localhost"));
   }
 
   @Before
   public void setUp() throws IOException
   {
-    serviceEmitter.flush();
-
     EasyMock.reset(lookupNodeDiscovery);
 
     EasyMock.reset(configManager);
@@ -139,12 +134,6 @@ public class LookupCoordinatorManagerTest
         new AtomicReference<>(null)
     ).anyTimes();
     EasyMock.replay(configManager);
-  }
-
-  @After
-  public void tearDown() throws IOException
-  {
-    serviceEmitter.flush();
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -110,7 +110,7 @@ public class LookupCoordinatorManagerTest
   }
 
   @Before
-  public void setUp() throws IOException
+  public void setUp()
   {
     EasyMock.reset(lookupNodeDiscovery);
 

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupCoordinatorManagerTest.java
@@ -35,12 +35,10 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.java.util.emitter.core.Event;
-import org.apache.druid.java.util.emitter.core.LoggingEmitter;
-import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.apache.druid.java.util.http.client.response.SequenceInputStreamResponseHandler;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.lookup.LookupsState;
 import org.apache.druid.server.http.HostAndPortWithScheme;
 import org.easymock.EasyMock;
@@ -48,9 +46,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.ws.rs.core.Response;
 import java.io.ByteArrayInputStream;
@@ -61,13 +57,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class LookupCoordinatorManagerTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
   private final ObjectMapper mapper = new DefaultObjectMapper();
   private final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createStrictMock(DruidNodeDiscoveryProvider.class);
   private final LookupNodeDiscovery lookupNodeDiscovery = EasyMock.createStrictMock(
@@ -111,31 +104,18 @@ public class LookupCoordinatorManagerTest
       Collections.emptySet()
   );
 
-  private static final AtomicLong EVENT_EMITS = new AtomicLong(0L);
-  private static ServiceEmitter SERVICE_EMITTER;
+  private static final StubServiceEmitter serviceEmitter = new StubServiceEmitter("test", "localhost");
 
   @BeforeClass
   public static void setUpStatic()
   {
-    LoggingEmitter loggingEmitter = EasyMock.createNiceMock(LoggingEmitter.class);
-    EasyMock.replay(loggingEmitter);
-    SERVICE_EMITTER = new ServiceEmitter("", "", loggingEmitter)
-    {
-      @Override
-      public void emit(Event event)
-      {
-        EVENT_EMITS.incrementAndGet();
-        super.emit(event);
-      }
-    };
-    EmittingLogger.registerEmitter(SERVICE_EMITTER);
+    EmittingLogger.registerEmitter(serviceEmitter);
   }
 
   @Before
   public void setUp() throws IOException
   {
-    SERVICE_EMITTER.flush();
-    EVENT_EMITS.set(0L);
+    serviceEmitter.flush();
 
     EasyMock.reset(lookupNodeDiscovery);
 
@@ -164,8 +144,7 @@ public class LookupCoordinatorManagerTest
   @After
   public void tearDown() throws IOException
   {
-    SERVICE_EMITTER.flush();
-    Assert.assertEquals(0, EVENT_EMITS.get());
+    serviceEmitter.flush();
   }
 
   @Test
@@ -546,8 +525,7 @@ public class LookupCoordinatorManagerTest
     };
     manager.start();
     final AuditInfo auditInfo = new AuditInfo("author", "comment", "localhost");
-    expectedException.expect(ISE.class);
-    manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo);
+    Assert.assertThrows(ISE.class, () -> manager.updateLookups(TIERED_LOOKUP_MAP_V0, auditInfo));
   }
 
   @Test


### PR DESCRIPTION
This test has been failing repeatedly on this PR
https://github.com/apache/druid/actions/runs/5879335614/job/15943751560?pr=14845

The number of events emitted seems to oscillate between 1 and 0 resulting in the flakiness.

The error is not reproducible locally though.

---

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
