### PR TITLE
Speed up SQLMetadataStorageActionHandlerTest

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -62,6 +62,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
 public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, LockType>
     implements MetadataStorageActionHandler<EntryType, StatusType, LogType, LockType>
@@ -1032,16 +1033,14 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
                             .orElse(null);
   }
 
-  private List<TaskIdentifier> fetchTaskMetadatas(String tableName, String id, int limit)
+  private List<TaskIdentifier> fetchTasksWithTypeColumnNullAndIdGreaterThan(String id, int limit)
   {
     List<TaskIdentifier> taskIdentifiers = new ArrayList<>();
     connector.retryWithHandle(
         handle -> {
           String sql = StringUtils.format(
               "SELECT * FROM %1$s WHERE id > '%2$s' AND type IS null ORDER BY id %3$s",
-              tableName,
-              id,
-              connector.limitClause(limit)
+              entryTable, id, connector.limitClause(limit)
           );
           Query<Map<String, Object>> query = handle.createQuery(sql);
           taskIdentifiers.addAll(query.map(taskIdentifierMapper).list());
@@ -1051,19 +1050,21 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
     return taskIdentifiers;
   }
 
-  private void updateTaskMetadatas(String tasksTable, List<TaskIdentifier> taskIdentifiers)
+  private int updateColumnsTypeAndGroupIdForTasks(List<TaskIdentifier> taskIdentifiers)
   {
-    connector.retryWithHandle(
+    return connector.retryWithHandle(
         handle -> {
-          Batch batch = handle.createBatch();
-          String sql = "UPDATE %1$s SET type = '%2$s', group_id = '%3$s' WHERE id = '%4$s'";
-          for (TaskIdentifier metadata : taskIdentifiers) {
+          final Batch batch = handle.createBatch();
+          for (TaskIdentifier task : taskIdentifiers) {
             batch.add(
-                StringUtils.format(sql, tasksTable, metadata.getType(), metadata.getGroupId(), metadata.getId())
+                StringUtils.format(
+                    "UPDATE %1$s SET type = '%2$s', group_id = '%3$s' WHERE id = '%4$s'",
+                    entryTable, task.getType(), task.getGroupId(), task.getId()
+                )
             );
           }
-          batch.execute();
-          return null;
+          int[] result = batch.execute();
+          return IntStream.of(result).sum();
         }
     );
   }
@@ -1083,14 +1084,14 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   @VisibleForTesting
   boolean populateTaskTypeAndGroupId()
   {
-    log.info("Populating columns [task] and [group_id] in task table[%s] from payload.", entryTable);
-    String id = "";
-    int limit = 100;
-    int count = 0;
+    log.debug("Populating columns [task] and [group_id] in task table[%s] from payload.", entryTable);
+    String lastUpdatedTaskId = "";
+    final int limit = 100;
+    int numUpdatedTasks = 0;
     while (true) {
       List<TaskIdentifier> taskIdentifiers;
       try {
-        taskIdentifiers = fetchTaskMetadatas(entryTable, id, limit);
+        taskIdentifiers = fetchTasksWithTypeColumnNullAndIdGreaterThan(lastUpdatedTaskId, limit);
       }
       catch (Exception e) {
         log.warn(e, "Task migration failed while reading entries from task table");
@@ -1100,15 +1101,17 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
         break;
       }
       try {
-        updateTaskMetadatas(entryTable, taskIdentifiers);
-        count += taskIdentifiers.size();
-        log.info("Successfully updated columns [type] and [group_id] for [%d] tasks.", count);
+        final int updatedCount = updateColumnsTypeAndGroupIdForTasks(taskIdentifiers);
+        if (updatedCount > 0) {
+          log.info("Successfully updated columns [type] and [group_id] for [%d] tasks.", updatedCount);
+          numUpdatedTasks += updatedCount;
+        }
       }
       catch (Exception e) {
         log.warn(e, "Task migration failed while updating entries in task table");
         return false;
       }
-      id = taskIdentifiers.get(taskIdentifiers.size() - 1).getId();
+      lastUpdatedTaskId = taskIdentifiers.get(taskIdentifiers.size() - 1).getId();
 
       try {
         Thread.sleep(1000);
@@ -1118,7 +1121,9 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
         Thread.currentThread().interrupt();
       }
     }
-    log.info("Task migration for table[%s] successful.", entryTable);
+    if (numUpdatedTasks > 0) {
+      log.info("Task migration for table[%s] successful.", entryTable);
+    }
     return true;
   }
 }

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -1083,7 +1083,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
   @VisibleForTesting
   boolean populateTaskTypeAndGroupId()
   {
-    log.info("Populate fields task and group_id of task entry table [%s] from payload", entryTable);
+    log.info("Populating columns [task] and [group_id] in task table[%s] from payload.", entryTable);
     String id = "";
     int limit = 100;
     int count = 0;
@@ -1102,7 +1102,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
       try {
         updateTaskMetadatas(entryTable, taskIdentifiers);
         count += taskIdentifiers.size();
-        log.info("Successfully updated type and groupId for [%d] tasks", count);
+        log.info("Successfully updated columns [type] and [group_id] for [%d] tasks.", count);
       }
       catch (Exception e) {
         log.warn(e, "Task migration failed while updating entries in task table");
@@ -1118,7 +1118,7 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
         Thread.currentThread().interrupt();
       }
     }
-    log.info("Task migration for table [%s] successful", entryTable);
+    log.info("Task migration for table[%s] successful.", entryTable);
     return true;
   }
 }

--- a/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -1103,8 +1103,8 @@ public abstract class SQLMetadataStorageActionHandler<EntryType, StatusType, Log
       try {
         final int updatedCount = updateColumnsTypeAndGroupIdForTasks(taskIdentifiers);
         if (updatedCount > 0) {
-          log.info("Successfully updated columns [type] and [group_id] for [%d] tasks.", updatedCount);
           numUpdatedTasks += updatedCount;
+          log.info("Successfully updated columns [type] and [group_id] for [%d] tasks.", numUpdatedTasks);
         }
       }
       catch (Exception e) {


### PR DESCRIPTION
### Motivation
`testMigration` creates about 3k tasks and verifies their migration. This takes around 45s since tasks are updated in batches of 100 after every 1s.
The same assertions can be made with a much smaller number of tasks, reducing the test time to 4s.

### Changes
- Reduce test time of `SQLMetadataStorageActionHandlerTest.testMigration`
- Slightly modify log messages to adhere to Druid style