### PR TITLE
Add topic name as a column in the Kafka Input format

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputFormat.java
@@ -40,6 +40,7 @@ public class KafkaInputFormat implements InputFormat
 {
   private static final String DEFAULT_HEADER_COLUMN_PREFIX = "kafka.header.";
   private static final String DEFAULT_TIMESTAMP_COLUMN_NAME = "kafka.timestamp";
+  private static final String DEFAULT_TOPIC_COLUMN_NAME = "kafka.topic";
   private static final String DEFAULT_KEY_COLUMN_NAME = "kafka.key";
   public static final String DEFAULT_AUTO_TIMESTAMP_STRING = "__kif_auto_timestamp";
 
@@ -54,6 +55,7 @@ public class KafkaInputFormat implements InputFormat
   private final String headerColumnPrefix;
   private final String keyColumnName;
   private final String timestampColumnName;
+  private final String topicColumnName;
 
   public KafkaInputFormat(
       @JsonProperty("headerFormat") @Nullable KafkaHeaderFormat headerFormat,
@@ -61,7 +63,8 @@ public class KafkaInputFormat implements InputFormat
       @JsonProperty("valueFormat") InputFormat valueFormat,
       @JsonProperty("headerColumnPrefix") @Nullable String headerColumnPrefix,
       @JsonProperty("keyColumnName") @Nullable String keyColumnName,
-      @JsonProperty("timestampColumnName") @Nullable String timestampColumnName
+      @JsonProperty("timestampColumnName") @Nullable String timestampColumnName,
+      @JsonProperty("topicColumnName") @Nullable String topicColumnName
   )
   {
     this.headerFormat = headerFormat;
@@ -70,6 +73,7 @@ public class KafkaInputFormat implements InputFormat
     this.headerColumnPrefix = headerColumnPrefix != null ? headerColumnPrefix : DEFAULT_HEADER_COLUMN_PREFIX;
     this.keyColumnName = keyColumnName != null ? keyColumnName : DEFAULT_KEY_COLUMN_NAME;
     this.timestampColumnName = timestampColumnName != null ? timestampColumnName : DEFAULT_TIMESTAMP_COLUMN_NAME;
+    this.topicColumnName = topicColumnName != null ? topicColumnName : DEFAULT_TOPIC_COLUMN_NAME;
   }
 
   @Override
@@ -116,7 +120,8 @@ public class KafkaInputFormat implements InputFormat
             temporaryDirectory
         ),
         keyColumnName,
-        timestampColumnName
+        timestampColumnName,
+        topicColumnName
     );
   }
 
@@ -161,6 +166,13 @@ public class KafkaInputFormat implements InputFormat
     return timestampColumnName;
   }
 
+  @Nullable
+  @JsonProperty
+  public String getTopicColumnName()
+  {
+    return topicColumnName;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -176,14 +188,15 @@ public class KafkaInputFormat implements InputFormat
            && Objects.equals(keyFormat, that.keyFormat)
            && Objects.equals(headerColumnPrefix, that.headerColumnPrefix)
            && Objects.equals(keyColumnName, that.keyColumnName)
-           && Objects.equals(timestampColumnName, that.timestampColumnName);
+           && Objects.equals(timestampColumnName, that.timestampColumnName)
+           && Objects.equals(topicColumnName, that.topicColumnName);
   }
 
   @Override
   public int hashCode()
   {
     return Objects.hash(headerFormat, valueFormat, keyFormat,
-                        headerColumnPrefix, keyColumnName, timestampColumnName
+                        headerColumnPrefix, keyColumnName, timestampColumnName, topicColumnName
     );
   }
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -131,8 +131,7 @@ public class KafkaInputReader implements InputEntityReader
     // the header list
     mergedHeaderMap.putIfAbsent(timestampColumnName, record.getRecord().timestamp());
 
-    // Add kafka record topic to the mergelist, we will skip record topic if the same key exists already in
-    // the header list
+    // Add kafka record topic to the mergelist, only if the key doesn't already exist
     mergedHeaderMap.putIfAbsent(topicColumnName, record.getRecord().topic());
 
     return mergedHeaderMap;

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/data/input/kafkainput/KafkaInputReader.java
@@ -56,6 +56,7 @@ public class KafkaInputReader implements InputEntityReader
   private final InputEntityReader valueParser;
   private final String keyColumnName;
   private final String timestampColumnName;
+  private final String topicColumnName;
 
   /**
    *
@@ -74,7 +75,8 @@ public class KafkaInputReader implements InputEntityReader
       @Nullable Function<KafkaRecordEntity, InputEntityReader> keyParserSupplier,
       InputEntityReader valueParser,
       String keyColumnName,
-      String timestampColumnName
+      String timestampColumnName,
+      String topicColumnName
   )
   {
     this.inputRowSchema = inputRowSchema;
@@ -84,6 +86,7 @@ public class KafkaInputReader implements InputEntityReader
     this.valueParser = valueParser;
     this.keyColumnName = keyColumnName;
     this.timestampColumnName = timestampColumnName;
+    this.topicColumnName = topicColumnName;
   }
 
   @Override
@@ -127,6 +130,10 @@ public class KafkaInputReader implements InputEntityReader
     // Add kafka record timestamp to the mergelist, we will skip record timestamp if the same key exists already in
     // the header list
     mergedHeaderMap.putIfAbsent(timestampColumnName, record.getRecord().timestamp());
+
+    // Add kafka record topic to the mergelist, we will skip record topic if the same key exists already in
+    // the header list
+    mergedHeaderMap.putIfAbsent(topicColumnName, record.getRecord().topic());
 
     return mergedHeaderMap;
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -59,6 +59,7 @@ public class KafkaInputFormatTest
 {
   private KafkaRecordEntity inputEntity;
   private final long timestamp = DateTimes.of("2021-06-24").getMillis();
+  private final String TOPIC = "sample";
   private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(
       new Header()
       {
@@ -126,7 +127,8 @@ public class KafkaInputFormatTest
         ),
         "kafka.newheader.",
         "kafka.newkey.key",
-        "kafka.newts.timestamp"
+        "kafka.newts.timestamp",
+        "kafka.newtopic.topic"
     );
   }
 
@@ -166,7 +168,8 @@ public class KafkaInputFormatTest
         ),
         "kafka.newheader.",
         "kafka.newkey.key",
-        "kafka.newts.timestamp"
+        "kafka.newts.timestamp",
+        "kafka.newtopic.topic"
     );
     Assert.assertEquals(format, kif);
 
@@ -209,7 +212,8 @@ public class KafkaInputFormatTest
                         "foo",
                         "kafka.newheader.encoding",
                         "kafka.newheader.kafkapkc",
-                        "kafka.newts.timestamp"
+                        "kafka.newts.timestamp",
+                        "kafka.newtopic.topic"
                     )
                 )
             ),
@@ -231,7 +235,8 @@ public class KafkaInputFormatTest
                 "foo",
                 "kafka.newheader.encoding",
                 "kafka.newheader.kafkapkc",
-                "kafka.newts.timestamp"
+                "kafka.newts.timestamp",
+                "kafka.newtopic.topic"
             ),
             row.getDimensions()
         );
@@ -253,6 +258,10 @@ public class KafkaInputFormatTest
         Assert.assertEquals(
             String.valueOf(DateTimes.of("2021-06-24").getMillis()),
             Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            TOPIC,
+            Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
         );
         Assert.assertEquals(
             "2021-06-25",
@@ -302,7 +311,8 @@ public class KafkaInputFormatTest
                         "foo",
                         "kafka.newheader.encoding",
                         "kafka.newheader.kafkapkc",
-                        "kafka.newts.timestamp"
+                        "kafka.newts.timestamp",
+                        "kafka.newtopic.topic"
                     )
                 )
             ),
@@ -478,7 +488,7 @@ public class KafkaInputFormatTest
             null, null, false, //make sure JsonReader is used
             false, false
         ),
-        "kafka.newheader.", "kafka.newkey.", "kafka.newts."
+        "kafka.newheader.", "kafka.newkey.", "kafka.newts.", "kafka.newtopic."
     );
 
     final InputEntityReader reader = localFormat.createReader(
@@ -489,7 +499,8 @@ public class KafkaInputFormatTest
                     ImmutableList.of(
                         "bar",
                         "foo",
-                        "kafka.newts.timestamp"
+                        "kafka.newts.timestamp",
+                        "kafka.newtopic.topic"
                     )
                 )
             ),
@@ -567,7 +578,8 @@ public class KafkaInputFormatTest
                         "foo",
                         "kafka.newheader.encoding",
                         "kafka.newheader.kafkapkc",
-                        "kafka.newts.timestamp"
+                        "kafka.newts.timestamp",
+                        "kafka.newtopic.topic"
                     )
                 )
             ),
@@ -612,6 +624,10 @@ public class KafkaInputFormatTest
           Assert.assertEquals(
               String.valueOf(DateTimes.of("2021-06-24").getMillis()),
               Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+          );
+          Assert.assertEquals(
+              TOPIC,
+              Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
           );
           Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("kafka.newheader.indexH")));
 
@@ -669,7 +685,8 @@ public class KafkaInputFormatTest
                         "foo",
                         "kafka.newheader.encoding",
                         "kafka.newheader.kafkapkc",
-                        "kafka.newts.timestamp"
+                        "kafka.newts.timestamp",
+                        "kafka.newtopic.topic"
                     )
                 )
             ),
@@ -683,7 +700,8 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
         Throwable t = Assert.assertThrows(ParseException.class, () -> iterator.next());
         Assert.assertEquals(
-            "Timestamp[null] is unparseable! Event: {foo=x, kafka.newts.timestamp=1624492800000, kafka.newkey.key=sampleKey, root_baz=4, bar=null, kafka...",
+            "Timestamp[null] is unparseable! Event: {kafka.newtopic.topic=sample, foo=x, kafka.newts"
+            + ".timestamp=1624492800000, kafka.newkey.key=sampleKey...",
             t.getMessage()
         );
       }
@@ -733,6 +751,7 @@ public class KafkaInputFormatTest
         final InputRow row = iterator.next();
         Assert.assertEquals(
             Arrays.asList(
+                "kafka.newtopic.topic",
                 "foo",
                 "kafka.newts.timestamp",
                 "kafka.newkey.key",
@@ -766,6 +785,10 @@ public class KafkaInputFormatTest
         Assert.assertEquals(
             String.valueOf(DateTimes.of("2021-06-24").getMillis()),
             Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
+        );
+        Assert.assertEquals(
+            TOPIC,
+            Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
         );
         Assert.assertEquals(
             "2021-06-25",
@@ -834,6 +857,7 @@ public class KafkaInputFormatTest
             Arrays.asList(
                 "bar",
                 "kafka.newheader.kafkapkc",
+                "kafka.newtopic.topic",
                 "foo",
                 "kafka.newts.timestamp",
                 "kafka.newkey.key",
@@ -867,6 +891,10 @@ public class KafkaInputFormatTest
             Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
         );
         Assert.assertEquals(
+            TOPIC,
+            Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
+        );
+        Assert.assertEquals(
             "2021-06-25",
             Iterables.getOnlyElement(row.getDimension("timestamp"))
         );
@@ -889,7 +917,7 @@ public class KafkaInputFormatTest
   {
     return new KafkaRecordEntity(
         new ConsumerRecord<>(
-            "sample",
+            TOPIC,
             0,
             0,
             timestamp,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -59,7 +59,7 @@ public class KafkaInputFormatTest
 {
   private KafkaRecordEntity inputEntity;
   private final long timestamp = DateTimes.of("2021-06-24").getMillis();
-  private final String TOPIC = "sample";
+  private static final String TOPIC = "sample";
   private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(
       new Header()
       {

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -171,7 +171,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       new KafkaStringHeaderFormat(null),
       INPUT_FORMAT,
       INPUT_FORMAT,
-      "kafka.testheader.", "kafka.key", "kafka.timestamp"
+      "kafka.testheader.", "kafka.key", "kafka.timestamp", "kafka.topic"
   );
 
   private static TestingCluster zkServer;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -277,6 +277,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
                 new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
                 null,
                 null,
+                null,
                 null
             ),
 


### PR DESCRIPTION
This PR adds a way to store the topic name in a column. Such a column can be used to distinguish messages coming from different topics in multi-topic ingestion. 

Release notes 
You can now optionally ingest the name of the Kafka topic to the datasource. It is particularly helpful when datasource is getting data from multiple Kafka topics.  

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
