### PR TITLE
Use alternate nodejs mirror

### DIFF
--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -58,6 +58,7 @@
               <npmVersion>${npm.version}</npmVersion>
               <workingDirectory>${project.build.directory}</workingDirectory>
               <installDirectory>${project.build.directory}</installDirectory>
+              <nodeDownloadRoot>http://npm.taobao.org/mirrors/node/</nodeDownloadRoot>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Recently I've started to see errors like:

```
2023-08-17T13:11:19.9098699Z [INFO] Installing node version v16.17.0
2023-08-17T13:11:19.9103714Z [INFO] Downloading https://nodejs.org/dist/v16.17.0/node-v16.17.0-linux-x64.tar.gz to /home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz
2023-08-17T13:11:19.9112098Z [INFO] No proxies configured
2023-08-17T13:11:19.9112661Z [INFO] No proxy was configured, downloading directly
[...]
2023-08-17T13:15:45.6895389Z [INFO] Unpacking /home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz into /home/runner/work/druid/druid/web-console/target/node/tmp
2023-08-17T13:15:45.7381810Z [ERROR] The archive file /home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz is corrupted and will be deleted. Please try the build again.
[...]
2023-08-17T13:15:45.7604121Z [ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.11.3:install-node-and-npm (install-node-and-npm) on project web-console: Could not extract the Node archive: Could not extract archive: '/home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz': EOFException -> [Help 1]
```

I can access the artifact from my system and it looks good.
This change tries to use a different mirror.