### PR TITLE
docs: fix autolabeler for jupyter notebooks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,4 +23,4 @@
 "Area - Documentation":
   - "docs/**/*"
   - "website/**"
-  - "examples/quickstart/jupyter-notebooks/*"
+  - "examples/quickstart/jupyter-notebooks/**"


### PR DESCRIPTION
Accidentally discarded the commit for https://github.com/apache/druid/pull/14851 so reopening.

Will properly label changes in the subdirectories now. 
<hr>



This PR has:

- [x] been self-reviewed.
