### PR TITLE
Web console: add Kafka topic column controls

### DIFF
--- a/web-console/src/druid-models/input-format/input-format.tsx
+++ b/web-console/src/druid-models/input-format/input-format.tsx
@@ -42,6 +42,7 @@ export interface InputFormat {
 
   // type: kafka
   readonly timestampColumnName?: string;
+  readonly topicColumnName?: string;
   readonly headerFormat?: { type: 'string'; encoding?: string };
   readonly headerColumnPrefix?: string;
   readonly keyFormat?: InputFormat;
@@ -253,7 +254,15 @@ export const KAFKA_METADATA_INPUT_FORMAT_FIELDS: Field<InputFormat>[] = [
     type: 'string',
     defaultValue: 'kafka.timestamp',
     defined: typeIsKnown(KNOWN_TYPES, 'kafka'),
-    info: `Name of the column for the kafka record's timestamp.`,
+    info: `Name of the column for the Kafka record's timestamp.`,
+  },
+  {
+    name: 'topicColumnName',
+    label: 'Kafka topic column name',
+    type: 'string',
+    defaultValue: 'kafka.topic',
+    defined: typeIsKnown(KNOWN_TYPES, 'kafka'),
+    info: `Name of the column for the topic from which the Kafka record came.`,
   },
 
   // -----------------------------------------------------

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -226,6 +226,7 @@ function showKafkaLine(line: SampleEntry): string {
   if (!input) return 'Invalid kafka row';
   return compact([
     `[ Kafka timestamp: ${input['kafka.timestamp']}`,
+    `  Topic: ${input['kafka.topic']}`,
     ...filterMap(Object.entries(input), ([k, v]) => {
       if (!k.startsWith('kafka.header.')) return;
       return `  Header: ${k.slice(13)}=${v}`;


### PR DESCRIPTION
This is the console follow up to https://github.com/apache/druid/pull/14857

<img width="407" alt="image" src="https://github.com/apache/druid/assets/177816/fd9bf544-38eb-4595-9d7b-1cfb06cb2125">

<img width="1553" alt="image" src="https://github.com/apache/druid/assets/177816/3f2eaf3e-9153-4adc-9bac-58a89fad15c0">
