### PR TITLE
Wrapper for init-metadata

### DIFF
--- a/docs/operations/metadata-migration.md
+++ b/docs/operations/metadata-migration.md
@@ -73,15 +73,13 @@ In the example commands below:
 #### MySQL
 
 ```bash
-cd ${DRUID_ROOT}
-java -classpath "lib/*" -Dlog4j.configurationFile=conf/druid/cluster/_common/log4j2.xml -Ddruid.extensions.directory="extensions" -Ddruid.extensions.loadList="[\"mysql-metadata-storage\"]" -Ddruid.metadata.storage.type=mysql -Ddruid.node.type=metadata-init org.apache.druid.cli.Main tools metadata-init --connectURI="<mysql-uri>" --user <user> --password <pass> --base druid
+${DRUID_ROOT}/examples/bin/init-metadata.sh -d mysql -u <username> -p <password> -c <mysql-uri>
 ```
 
 #### PostgreSQL
 
 ```bash
-cd ${DRUID_ROOT}
-java -classpath "lib/*" -Dlog4j.configurationFile=conf/druid/cluster/_common/log4j2.xml -Ddruid.extensions.directory="extensions" -Ddruid.extensions.loadList="[\"postgresql-metadata-storage\"]" -Ddruid.metadata.storage.type=postgresql -Ddruid.node.type=metadata-init org.apache.druid.cli.Main tools metadata-init --connectURI="<postgresql-uri>" --user <user> --password <pass> --base druid
+${DRUID_ROOT}/examples/bin/init-metadata.sh -d postgresql -u <username> -p <password> -c <postgresql-uri>
 ```
 
 ### Update Druid tables to latest compatible schema

--- a/examples/bin/init-metadata.sh
+++ b/examples/bin/init-metadata.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -eu
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Tool for creating Druid's metadata tables
+# Usage: init-metadata [-d|c|u|p|v]
+
+
+#params : type loadList 
+setup()
+{
+  cd ${DRUID_ROOT}
+  java -classpath "lib/*" -Dlog4j.configurationFile=conf/druid/cluster/_common/log4j2.xml -Ddruid.extensions.directory="extensions" -Ddruid.extensions.loadList="[\"$2\"]" -Ddruid.metadata.storage.type=$1 -Ddruid.node.type=metadata-init org.apache.druid.cli.Main tools metadata-init --connectURI=$connectURI --user $username --password $password --base druid
+}
+
+
+help()
+{
+  echo "Tool for creating Druid's metadata tables"
+  echo
+  echo "Syntax: init-metadata [-d|c|u|p|v]"
+  echo "options:"
+  echo "d     Metadata storage type eg. mysql, postgresql."
+  echo "c     Metadata storage connector connection URI"
+  echo "u     Metadata storage connector username"
+  echo "p     Metadata storage connector password"
+  echo "h     Help"
+  echo "example usage init-metadata -d mysql -c localhost -u username -p password"
+}
+
+while getopts d:c:u:p:h: args
+do
+            case "${args}" in
+                d) database=${OPTARG};;
+                c) connectURI=${OPTARG};;
+                u) username=${OPTARG};;
+                p) password=${OPTARG};;
+                h) help=${OPTARG};;
+            esac
+done
+
+while getopts d:c:u:p:h: args
+do
+           case "${args}" in
+                 d) database=${OPTARG};;
+                 c) connectURI=${OPTARG};;
+                 u) username=${OPTARG};;
+                 p) password=${OPTARG};;
+           esac
+done
+
+if [ "$database" = "mysql" ]
+then
+        setup mysql mysql-metadata-storage
+elif [ "$database" = "postgresql" ]
+then
+        setup postgresql postgresql-metadata-storage
+else
+        help
+        exit 0
+fi


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/13738

Description
As described part of the issue, created a wrapper shell script with druid database init scripts

Release note
Wrapper for druid database init scripts

Replace [13756](https://github.com/apache/druid/pull/13756)
This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [X] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
