### PR TITLE
Fix Peon not fail gracefully

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -236,7 +236,7 @@ public abstract class AbstractTask implements Task
     try {
       if (cleanupCompletionLatch != null) {
         // block until the cleanup process completes
-        return cleanupCompletionLatch.await(100, TimeUnit.SECONDS);
+        return cleanupCompletionLatch.await(300, TimeUnit.SECONDS);
       }
 
       return true;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -233,16 +233,19 @@ public abstract class AbstractTask implements Task
   }
 
   @Override
-  public void waitForCleanupToFinish()
+  public boolean waitForCleanupToFinish()
   {
     try {
       if (cleanupCompletionLatch != null) {
         // block until the cleanup process completes
-        cleanupCompletionLatch.await(30, TimeUnit.SECONDS);
+        return cleanupCompletionLatch.await(30, TimeUnit.SECONDS);
       }
+
+      return true;
     }
     catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+      return false;
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -194,7 +194,8 @@ public abstract class AbstractTask implements Task
 
   public abstract TaskStatus runTask(TaskToolbox taskToolbox) throws Exception;
 
-  protected void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
+  @Override
+  public void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
   {
     if (Thread.currentThread().isInterrupted()) {
       // clears the interrupted status so the subsequent cleanup work can continue without interruption
@@ -231,6 +232,7 @@ public abstract class AbstractTask implements Task
     }
   }
 
+  @Override
   public void waitForCleanupToFinish()
   {
     try {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -197,10 +197,8 @@ public abstract class AbstractTask implements Task
   @Override
   public void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
   {
-    if (Thread.currentThread().isInterrupted()) {
-      // clears the interrupted status so the subsequent cleanup work can continue without interruption
-      Thread.interrupted();
-    }
+    // clear any interrupted status to ensure subsequent cleanup proceeds without interruption.
+    Thread.interrupted();
 
     if (!toolbox.getConfig().isEncapsulatedTask()) {
       log.debug("Not pushing task logs and reports from task.");
@@ -238,12 +236,13 @@ public abstract class AbstractTask implements Task
     try {
       if (cleanupCompletionLatch != null) {
         // block until the cleanup process completes
-        return cleanupCompletionLatch.await(30, TimeUnit.SECONDS);
+        return cleanupCompletionLatch.await(60, TimeUnit.SECONDS);
       }
 
       return true;
     }
     catch (InterruptedException e) {
+      log.warn("Interrupted while waiting for task cleanUp to finish!");
       Thread.currentThread().interrupt();
       return false;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -236,7 +236,7 @@ public abstract class AbstractTask implements Task
     try {
       if (cleanupCompletionLatch != null) {
         // block until the cleanup process completes
-        return cleanupCompletionLatch.await(60, TimeUnit.SECONDS);
+        return cleanupCompletionLatch.await(100, TimeUnit.SECONDS);
       }
 
       return true;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -55,6 +55,8 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractTask implements Task
 {
@@ -100,6 +102,8 @@ public abstract class AbstractTask implements Task
   private File statusFile;
 
   private final ServiceMetricEvent.Builder metricBuilder = new ServiceMetricEvent.Builder();
+
+  private volatile CountDownLatch cleanupCompletionLatch;
 
   protected AbstractTask(String id, String dataSource, Map<String, Object> context, IngestionMode ingestionMode)
   {
@@ -166,6 +170,7 @@ public abstract class AbstractTask implements Task
   {
     TaskStatus taskStatus = TaskStatus.running(getId());
     try {
+      cleanupCompletionLatch = new CountDownLatch(1);
       String errorMessage = setup(taskToolbox);
       if (org.apache.commons.lang3.StringUtils.isNotBlank(errorMessage)) {
         return TaskStatus.failure(getId(), errorMessage);
@@ -178,14 +183,24 @@ public abstract class AbstractTask implements Task
       throw e;
     }
     finally {
-      cleanUp(taskToolbox, taskStatus);
+      try {
+        cleanUp(taskToolbox, taskStatus);
+      }
+      finally {
+        cleanupCompletionLatch.countDown();
+      }
     }
   }
 
   public abstract TaskStatus runTask(TaskToolbox taskToolbox) throws Exception;
 
-  public void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
+  protected void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
   {
+    if (Thread.currentThread().isInterrupted()) {
+      // clears the interrupted status so the subsequent cleanup work can continue without interruption
+      Thread.interrupted();
+    }
+
     if (!toolbox.getConfig().isEncapsulatedTask()) {
       log.debug("Not pushing task logs and reports from task.");
       return;
@@ -213,6 +228,19 @@ public abstract class AbstractTask implements Task
       log.debug("Pushed task status");
     } else {
       log.debug("No task status file exists to push");
+    }
+  }
+
+  public void waitForCleanupToFinish()
+  {
+    try {
+      if (cleanupCompletionLatch != null) {
+        // block until the cleanup process completes
+        cleanupCompletionLatch.await(30, TimeUnit.SECONDS);
+      }
+    }
+    catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -257,12 +257,30 @@ public interface Task
    */
   TaskStatus run(TaskToolbox toolbox) throws Exception;
 
+  /**
+   * Performs cleanup operations after the task execution.
+   * This method is intended to be overridden by tasks that need to perform
+   * specific cleanup actions upon task completion or termination.
+   *
+   * @param toolbox Toolbox for this task
+   * @param taskStatus Provides the final status of the task, indicating if the task
+   *                   was successful, failed, or was killed.
+   * @throws Exception If any error occurs during the cleanup process.
+   */
   default void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
   {
   }
 
-  default void waitForCleanupToFinish()
+  /**
+   * Waits for the cleanup operations to finish.
+   * This method can be overridden by tasks that need to ensure that certain cleanup
+   * operations have completed before proceeding further.
+   *
+   * @return true if the cleanup completed successfully, false otherwise.
+   */
+  default boolean waitForCleanupToFinish()
   {
+    return true;
   }
 
   default Map<String, Object> addToContext(String key, Object val)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -257,6 +257,12 @@ public interface Task
    */
   TaskStatus run(TaskToolbox toolbox) throws Exception;
 
+  default void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
+  {}
+
+  default void waitForCleanupToFinish()
+  {}
+
   default Map<String, Object> addToContext(String key, Object val)
   {
     getContext().put(key, val);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -258,10 +258,12 @@ public interface Task
   TaskStatus run(TaskToolbox toolbox) throws Exception;
 
   default void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
-  {}
+  {
+  }
 
   default void waitForCleanupToFinish()
-  {}
+  {
+  }
 
   default Map<String, Object> addToContext(String key, Object val)
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
@@ -33,6 +33,7 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
+import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.java.util.common.DateTimes;
@@ -185,6 +186,10 @@ public class SingleTaskBackgroundRunner implements TaskRunner, QuerySegmentWalke
       // stopGracefully for resource cleaning
       log.info("Starting graceful shutdown of task[%s].", task.getId());
       task.stopGracefully(taskConfig);
+      // Only certain tasks, primarily from unit tests, are not subclasses of AbstractTask.
+      if (task instanceof AbstractTask) {
+        ((AbstractTask) task).waitForCleanupToFinish();
+      }
 
       if (taskConfig.isRestoreTasksOnRestart() && task.canRestore()) {
         try {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunner.java
@@ -33,7 +33,6 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TaskToolboxFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
-import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.java.util.common.DateTimes;
@@ -186,10 +185,7 @@ public class SingleTaskBackgroundRunner implements TaskRunner, QuerySegmentWalke
       // stopGracefully for resource cleaning
       log.info("Starting graceful shutdown of task[%s].", task.getId());
       task.stopGracefully(taskConfig);
-      // Only certain tasks, primarily from unit tests, are not subclasses of AbstractTask.
-      if (task instanceof AbstractTask) {
-        ((AbstractTask) task).waitForCleanupToFinish();
-      }
+      task.waitForCleanupToFinish();
 
       if (taskConfig.isRestoreTasksOnRestart() && task.canRestore()) {
         try {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1422,7 +1422,10 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
   {
     log.info("Stopping forcefully (status: [%s])", status);
     stopRequested.set(true);
-    runThread.interrupt();
+    // Interrupt if the task has started to run
+    if (runThread != null) {
+      runThread.interrupt();
+    }
   }
 
   public void stopGracefully()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestTasks.java
@@ -84,6 +84,8 @@ public class TestTasks
   @JsonTypeName("unending")
   public static class UnendingTask extends AbstractTask
   {
+    private Thread runningThread;
+
     @JsonCreator
     public UnendingTask(@JsonProperty("id") String id)
     {
@@ -105,12 +107,16 @@ public class TestTasks
     @Override
     public void stopGracefully(TaskConfig taskConfig)
     {
+      if (runningThread != null) {
+        runningThread.interrupt();
+      }
     }
 
     @Override
     public TaskStatus runTask(TaskToolbox toolbox) throws Exception
     {
-      while (!Thread.currentThread().isInterrupted()) {
+      runningThread = Thread.currentThread();
+      while (!runningThread.isInterrupted()) {
         Thread.sleep(1000);
       }
       return TaskStatus.failure(getId(), "Dummy task status failure for testing");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/SingleTaskBackgroundRunnerTest.java
@@ -179,14 +179,24 @@ public class SingleTaskBackgroundRunnerTest
   @Test
   public void testStop() throws ExecutionException, InterruptedException, TimeoutException
   {
+    AtomicReference<Boolean> methodCallHolder = new AtomicReference<>();
     final ListenableFuture<TaskStatus> future = runner.run(
         new NoopTask(null, null, null, Long.MAX_VALUE, 0, null) // infinite task
+        {
+          @Override
+          public boolean waitForCleanupToFinish()
+          {
+            methodCallHolder.set(true);
+            return true;
+          }
+        }
     );
     runner.stop();
     Assert.assertEquals(
         TaskState.FAILED,
         future.get(1000, TimeUnit.MILLISECONDS).getStatusCode()
     );
+    Assert.assertTrue(methodCallHolder.get());
   }
 
   @Test

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -56,6 +56,7 @@ import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.guice.ManageLifecycleServer;
 import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.QueryRunnerFactoryModule;
 import org.apache.druid.guice.QueryableModule;
@@ -246,7 +247,10 @@ public class CliPeon extends GuiceRunnable
 
             binder.bind(TaskRunner.class).to(SingleTaskBackgroundRunner.class);
             binder.bind(QuerySegmentWalker.class).to(SingleTaskBackgroundRunner.class);
-            binder.bind(SingleTaskBackgroundRunner.class).in(ManageLifecycle.class);
+            // Bind to ManageLifecycleServer to ensure SingleTaskBackgroundRunner is closed before
+            // its dependent services, such as DiscoveryServiceLocator and OverlordClient.
+            // This order ensures that tasks can finalize their cleanup operations before service location closure.
+            binder.bind(SingleTaskBackgroundRunner.class).in(ManageLifecycleServer.class);
 
             bindRealtimeCache(binder);
             bindCoordinatorHandoffNotifer(binder);


### PR DESCRIPTION
### Description

During testing of the K8s task runner, peon pods faced challenges in achieving a graceful termination upon receiving a SIGTERM signal. Typically, they would encounter an `InterruptedException` and subsequently fail to push their `status.json`. As a result, the Druid console would display a vague "task status not found" message. Such graceful terminations may arise when a pod is manually deleted by K8s or is terminated due to out-of-memory conditions.

The primary issues behind this behavior are:

1. When attempting to halt a task, the thread is interrupted. This interruption inadvertently prevents the completion of the task `cleanUp` operation.
2. The task relies on services like `DiscoveryServiceLocator` and `OverlordClient` to execute its cleanUp work. However, since they all exist within the same lifecycle scope (NORMAL scope), there's a risk that the dependent services might be stopped before the task's `cleanUp` process concludes. To rectify this, we've transitioned the `SingleTaskBackgroundRunner` to the SERVER scope, ensuring the task stops prior to its dependent services, allowing for a successful cleanUp.

Note: although the issue is from running K8sTaskRunner, but it's a general fix to peon jvms when receiving a sigint (instruction to gracefully stop) that we didn't notice before since it rarely happened within MiddleManager's
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix Peon not fail gracefully.
<hr>

##### Key changed/added classes in this PR
 * In `AbstractTask` add `cleanupCompletionLatch`
 * In `SingleTaskBackgroundRunner` wait for the latch to finish when stopping.
 * In `CliPeon` move `SingleTaskBackgroundRunner` to the SERVER scope.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
