### PR TITLE
Fix capacity response in mm-less ingestion

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -397,12 +397,6 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   }
 
   @Override
-  public boolean isK8sTaskRunner()
-  {
-    return true;
-  }
-
-  @Override
   public void unregisterListener(String listenerId)
   {
     for (Pair<TaskRunnerListener, Executor> pair : listeners) {
@@ -456,5 +450,17 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
     }
 
     return workItem.getRunnerTaskState();
+  }
+
+  @Override
+  public int getTotalCapacity()
+  {
+    return config.getCapacity();
+  }
+
+  @Override
+  public int getUsedCapacity()
+  {
+    return tasks.size();
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -627,4 +627,22 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
 
     verifyAll();
   }
+
+  @Test
+  public void test_getTotalCapacity()
+  {
+    Assert.assertEquals(1, runner.getTotalCapacity());
+  }
+
+  @Test
+  public void test_getUsedCapacity()
+  {
+    Assert.assertEquals(0, runner.getUsedCapacity());
+    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null);
+    runner.tasks.put(task.getId(), workItem);
+    Assert.assertEquals(1, runner.getUsedCapacity());
+    runner.tasks.remove(task.getId());
+    Assert.assertEquals(0, runner.getUsedCapacity());
+
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1639,4 +1639,16 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
 
     return totalBlacklistedPeons;
   }
+
+  @Override
+  public int getTotalCapacity()
+  {
+    return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
+  }
+
+  @Override
+  public int getUsedCapacity()
+  {
+    return getWorkers().stream().mapToInt(ImmutableWorkerInfo::getCurrCapacityUsed).sum();
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
@@ -136,14 +136,6 @@ public interface TaskRunner
 
   Map<String, Long> getBlacklistedTaskSlotCount();
 
-  /**
-   * Beacause the k8s task runner is an extension, we need to know the task runner type in the overlord resource
-   */
-  default boolean isK8sTaskRunner()
-  {
-    return false;
-  }
-
   default void updateStatus(Task task, TaskStatus status)
   {
     // do nothing
@@ -154,5 +146,14 @@ public interface TaskRunner
     // do nothing
   }
 
+  default int getTotalCapacity()
+  {
+    return -1;
+  }
+
+  default int getUsedCapacity()
+  {
+    return -1;
+  }
 
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
@@ -146,11 +146,19 @@ public interface TaskRunner
     // do nothing
   }
 
+  /**
+   * The maximum number of tasks this TaskRunner can run concurrently.
+   * Can return -1 if this method is not implemented or capacity can't be found.
+   */
   default int getTotalCapacity()
   {
     return -1;
   }
 
+  /**
+   * The current number of tasks this TaskRunner is running.
+   * Can return -1 if this method is not implemented or the # of tasks can't be found.
+   */
   default int getUsedCapacity()
   {
     return -1;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1778,6 +1778,18 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     return totalBlacklistedPeons;
   }
 
+  @Override
+  public int getTotalCapacity()
+  {
+    return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
+  }
+
+  @Override
+  public int getUsedCapacity()
+  {
+    return getWorkers().stream().mapToInt(ImmutableWorkerInfo::getCurrCapacityUsed).sum();
+  }
+
   private static class HttpRemoteTaskRunnerWorkItem extends RemoteTaskRunnerWorkItem
   {
     enum State

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -32,8 +32,6 @@ import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.audit.AuditInfo;
 import org.apache.druid.audit.AuditManager;
 import org.apache.druid.client.indexing.ClientTaskQuery;
-import org.apache.druid.client.indexing.IndexingWorker;
-import org.apache.druid.client.indexing.IndexingWorkerInfo;
 import org.apache.druid.common.config.ConfigManager.SetResult;
 import org.apache.druid.common.config.JacksonConfigManager;
 import org.apache.druid.common.exception.DruidException;
@@ -469,27 +467,17 @@ public class OverlordResource
   public Response getTotalWorkerCapacity()
   {
     // Calculate current cluster capacity
-    int currentCapacity;
     Optional<TaskRunner> taskRunnerOptional = taskMaster.getTaskRunner();
     if (!taskRunnerOptional.isPresent()) {
       // Cannot serve call as not leader
       return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
     }
     TaskRunner taskRunner = taskRunnerOptional.get();
-    Collection<ImmutableWorkerInfo> workers;
-    if (taskRunner instanceof WorkerTaskRunner) {
-      workers = ((WorkerTaskRunner) taskRunner).getWorkers();
-      currentCapacity = workers.stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
-    } else {
-      log.debug(
-          "Cannot calculate capacity as task runner [%s] of type [%s] does not support listing workers",
-          taskRunner,
-          taskRunner.getClass().getName()
-      );
-      workers = ImmutableList.of();
-      currentCapacity = -1;
-    }
+    Collection<ImmutableWorkerInfo> workers = taskRunner instanceof WorkerTaskRunner ?
+        ((WorkerTaskRunner) taskRunner).getWorkers() : ImmutableList.of();
 
+    int currentCapacity = taskRunner.getTotalCapacity();
+    int usedCapacity = taskRunner.getUsedCapacity();
     // Calculate maximum capacity with auto scale
     int maximumCapacity;
     if (workerConfigRef == null) {
@@ -520,7 +508,7 @@ public class OverlordResource
       );
       maximumCapacity = -1;
     }
-    return Response.ok(new TotalWorkerCapacityResponse(currentCapacity, maximumCapacity)).build();
+    return Response.ok(new TotalWorkerCapacityResponse(currentCapacity, maximumCapacity, usedCapacity)).build();
   }
 
   // default value is used for backwards compatibility
@@ -939,24 +927,6 @@ public class OverlordResource
           {
             if (taskRunner instanceof WorkerTaskRunner) {
               return Response.ok(((WorkerTaskRunner) taskRunner).getWorkers()).build();
-            } else if (taskRunner.isK8sTaskRunner()) {
-              // required because kubernetes task runner has no concept of a worker, so returning a dummy worker.
-              return Response.ok(ImmutableList.of(
-                  new IndexingWorkerInfo(
-                      new IndexingWorker(
-                          "http",
-                          "host",
-                          "8100",
-                          taskRunner.getTotalTaskSlotCount().getOrDefault("_k8s_worker_category", 0L).intValue(),
-                          "version"
-                      ),
-                      0,
-                      Collections.emptySet(),
-                      Collections.emptyList(),
-                      DateTimes.EPOCH,
-                      null
-                  )
-              )).build();
             } else {
               log.debug(
                   "Task runner [%s] of type [%s] does not support listing workers",

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -947,7 +947,7 @@ public class OverlordResource
                           "http",
                           "host",
                           "8100",
-                          taskRunner.getTotalTaskSlotCount().getOrDefault("taskQueue", 0L).intValue(),
+                          taskRunner.getTotalTaskSlotCount().getOrDefault("_k8s_worker_category", 0L).intValue(),
                           "version"
                       ),
                       0,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/TotalWorkerCapacityResponse.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/TotalWorkerCapacityResponse.java
@@ -37,15 +37,22 @@ public class TotalWorkerCapacityResponse
    * This can be -1 if it cannot be determined or if auto scaling is not configured.
    */
   private final int maximumCapacityWithAutoScale;
+  /**
+   * Used cluster capacity of the current state of the cluster. This can be -1 if
+   * it cannot be determined.
+   */
+  private final int usedClusterCapacity;
 
   @JsonCreator
   public TotalWorkerCapacityResponse(
       @JsonProperty("currentClusterCapacity") int currentClusterCapacity,
-      @JsonProperty("maximumCapacityWithAutoScale") int maximumCapacityWithAutoScale
+      @JsonProperty("maximumCapacityWithAutoScale") int maximumCapacityWithAutoScale,
+      @JsonProperty("usedClusterCapacity") int usedClusterCapacity
   )
   {
     this.currentClusterCapacity = currentClusterCapacity;
     this.maximumCapacityWithAutoScale = maximumCapacityWithAutoScale;
+    this.usedClusterCapacity = usedClusterCapacity;
   }
 
   @JsonProperty
@@ -58,5 +65,11 @@ public class TotalWorkerCapacityResponse
   public int getMaximumCapacityWithAutoScale()
   {
     return maximumCapacityWithAutoScale;
+  }
+
+  @JsonProperty
+  public int getUsedClusterCapacity()
+  {
+    return usedClusterCapacity;
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -147,6 +147,9 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(3, remoteTaskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(3, remoteTaskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(0, remoteTaskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(3, remoteTaskRunner.getTotalCapacity());
+    Assert.assertEquals(0, remoteTaskRunner.getUsedCapacity());
+
 
     ListenableFuture<TaskStatus> result = remoteTaskRunner.run(task);
 
@@ -164,6 +167,8 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(3, remoteTaskRunner.getTotalTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(3, remoteTaskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(0, remoteTaskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
+    Assert.assertEquals(3, remoteTaskRunner.getTotalCapacity());
+    Assert.assertEquals(0, remoteTaskRunner.getUsedCapacity());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -146,6 +146,8 @@ public class HttpRemoteTaskRunnerTest
 
     Assert.assertEquals(numTasks, taskRunner.getKnownTasks().size());
     Assert.assertEquals(numTasks, taskRunner.getCompletedTasks().size());
+    Assert.assertEquals(4, taskRunner.getTotalCapacity());
+    Assert.assertEquals(0, taskRunner.getUsedCapacity());
   }
 
   /*

--- a/web-console/src/helpers/capacity.ts
+++ b/web-console/src/helpers/capacity.ts
@@ -16,24 +16,17 @@
  * limitations under the License.
  */
 
-import { sum } from 'd3-array';
-
 import type { CapacityInfo } from '../druid-models';
 import { Api } from '../singletons';
 
 export async function getClusterCapacity(): Promise<CapacityInfo> {
-  const workersResponse = await Api.instance.get('/druid/indexer/v1/workers', {
+  const workersResponse = await Api.instance.get('/druid/indexer/v1/totalWorkerCapacity', {
     timeout: 5000,
   });
 
-  const usedTaskSlots = sum(
-    workersResponse.data,
-    (workerInfo: any) => Number(workerInfo.currCapacityUsed) || 0,
-  );
+  const usedTaskSlots = Number(workersResponse.data.usedClusterCapacity)
 
-  const totalTaskSlots = sum(workersResponse.data, (workerInfo: any) =>
-    Number(workerInfo.worker.capacity),
-  );
+  const totalTaskSlots = Number(workersResponse.data.currentClusterCapacity)
 
   return {
     availableTaskSlots: totalTaskSlots - usedTaskSlots,

--- a/web-console/src/helpers/capacity.ts
+++ b/web-console/src/helpers/capacity.ts
@@ -24,9 +24,9 @@ export async function getClusterCapacity(): Promise<CapacityInfo> {
     timeout: 5000,
   });
 
-  const usedTaskSlots = Number(workersResponse.data.usedClusterCapacity)
+  const usedTaskSlots = Number(workersResponse.data.usedClusterCapacity);
 
-  const totalTaskSlots = Number(workersResponse.data.currentClusterCapacity)
+  const totalTaskSlots = Number(workersResponse.data.currentClusterCapacity);
 
   return {
     availableTaskSlots: totalTaskSlots - usedTaskSlots,


### PR DESCRIPTION
Fixing bug where capacity for mm-less ingestion was not being properly reported
### Description
This change: https://github.com/georgew5656/druid/commit/3954685aae1f9a78c81bf788e8f69d10324c28d1 to report additional metrics for mm-less ingestion changed the key of the capacity hint returned in getTotalTaskSlotCount and didn't change it in OverlordResource, causing capacity to be returned as 0.

**Initial plan was:**
I decided to just update the hardcoded value in OverlordResource because we can't ref classes from the optional extension in core and I couldn't really find a good constants file to put the constant in for OverlordResource. Open to changing this if someone has a strong opinion here.

After some discussion I decided to move the logic for calculating capacity to the existing totalWorkerCapacity API instead of the /workers api. This cleans up the logic in the workers api (no need to pretend the k8s task runner has a worker), and lets us delete the isK8sTaskRunner method on the taskRunner.

#### Release note
* Fix capacity response in mm-less ingestion.
* Adds a new usedClusterCapacity to the GET /totalWorkerCapacity response. This API should be used to get the total ingestion capacity on the overlord.

##### Key changed/added classes in this PR
 * `OverlordResource`
 * `TaskRunner,RemoteTaskRunner,HttpRemoteTaskRunner,KubernetesTaskRunner`

K8s Task Runner with capacity of 100
<img width="1701" alt="Screenshot 2023-08-24 at 9 52 15 AM" src="https://github.com/apache/druid/assets/17736581/200f54ac-655b-41a1-876e-1dc3038e1940">

Http Remote Task runner with a worker with capacity of 5
<img width="1724" alt="Screenshot 2023-08-24 at 9 53 29 AM" src="https://github.com/apache/druid/assets/17736581/41f4e2d2-0b38-4f8c-97dc-f6e6c83d6d8a">

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [] added integration tests.
- [X] been tested in a test Druid cluster.
