### PR TITLE
Doc changes for avatica transparent reconnection

### DIFF
--- a/docs/api-reference/sql-jdbc.md
+++ b/docs/api-reference/sql-jdbc.md
@@ -36,19 +36,19 @@ Once you've downloaded the Avatica client jar, add it to your classpath.
 Example connection string:
 
 ```
-jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnect=true
+jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true
 ```
 
 Or, to use the protobuf protocol instead of JSON:
 
 ```
-jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica-protobuf/;transparent_reconnect=true;serialization=protobuf
+jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica-protobuf/;transparent_reconnection=true;serialization=protobuf
 ```
 
 The `url` is the `/druid/v2/sql/avatica/` endpoint on the Router, which routes JDBC connections to a consistent Broker.
 For more information, see [Connection stickiness](#connection-stickiness).
 
-Set `transparent_reconnect` to `true` so your connection is not interrupted if the pool of Brokers changes membership,
+Set `transparent_reconnection` to `true` so your connection is not interrupted if the pool of Brokers changes membership,
 or if a Broker is restarted.
 
 Set `serialization` to `protobuf` if using the protobuf endpoint.
@@ -61,7 +61,7 @@ Example Java code:
 
 ```java
 // Connect to /druid/v2/sql/avatica/ on your Broker.
-String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnect=true";
+String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true";
 
 // Set any connection context parameters you need here.
 // Any property from https://druid.apache.org/docs/latest/querying/sql-query-context.html can go here.
@@ -85,7 +85,7 @@ For a runnable example that includes a query that you might run, see [Examples](
 It is also possible to use a protocol buffers JDBC connection with Druid, this offer reduced bloat and potential performance
 improvements for larger result sets. To use it apply the following connection URL instead, everything else remains the same
 ```
-String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica-protobuf/;transparent_reconnect=true;serialization=protobuf";
+String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica-protobuf/;transparent_reconnection=true;serialization=protobuf";
 ```
 
 :::info
@@ -155,7 +155,7 @@ public class JdbcListColumns {
     {
         // Connect to /druid/v2/sql/avatica/ on your Router. 
         // You can connect to a Broker but must configure connection stickiness if you do. 
-        String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnect=true";
+        String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true";
 
         String query = "SELECT COLUMN_NAME,* FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'wikipedia' and TABLE_SCHEMA='druid'";
 
@@ -195,7 +195,7 @@ public class JdbcCountryAndTime {
     {
         // Connect to /druid/v2/sql/avatica/ on your Router. 
         // You can connect to a Broker but must configure connection stickiness if you do. 
-        String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnect=true";
+        String url = "jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true";
 
         //The query you want to run.
         String query = "SELECT __time, isRobot, countryName, comment FROM wikipedia WHERE countryName='Japan'";


### PR DESCRIPTION
Updating to the correct name for this parameter. The customer can continue to use older versions of Calcite client jar file.  If they are using a version that is 1.20.0 or lower, then they do not need to do anything.
If the customer uses a version that is 1.21.0 or higher, they will have to add the connection option `transparent_reconnection=true`.  

See https://calcite.apache.org/avatica/docs/client_reference.html#transparent_reconnection for more details.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
