### PR TITLE
override retry attempts for InputEntityIteratingReaderTest for much faster test run

### DIFF
--- a/processing/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/InputEntityIteratingReaderTest.java
@@ -125,6 +125,15 @@ public class InputEntityIteratingReaderTest extends InitializedNullHandlingTest
         ),
         ImmutableList.of(
             new HttpEntity(new URI("testscheme://some/path"), null, null)
+            {
+              @Override
+              protected int getMaxRetries()
+              {
+                // override so this test does not take like 4 minutes to run
+                return 2;
+              }
+            }
+
         ).iterator(),
         temporaryFolder.newFolder()
     );


### PR DESCRIPTION
This test is supposed to fail, but retry backoff makes it run for like 4 minutes.

before:
![Screenshot 2023-08-22 at 7 04 56 PM](https://github.com/apache/druid/assets/1577461/bf76a992-9669-4fcf-babd-9b7b6ed00659)

after:
![Screenshot 2023-08-22 at 7 05 10 PM](https://github.com/apache/druid/assets/1577461/a576a579-7f8b-4871-bf1b-70d93321edeb)

To be fair, this should actually probably not be eligible for retry at all given the underlying exception that would never be able to be successful
```
java.net.MalformedURLException: unknown protocol: testscheme
```
but I'll save fixing that for another day.