### PR TITLE
remove unecessarily strict check on partitioning type

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -1296,10 +1296,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
           if (!partitionsSpec.isForceGuaranteedRollupCompatibleType()) {
             throw new IAE(partitionsSpec.getClass().getSimpleName() + " cannot be used for perfect rollup");
           }
-        } else {
-          if (!(partitionsSpec instanceof DynamicPartitionsSpec)) {
-            throw new IAE("DynamicPartitionsSpec must be used for best-effort rollup");
-          }
         }
         return partitionsSpec;
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
@@ -242,8 +242,6 @@ public class IndexTaskSerdeTest
   @Test
   public void testBestEffortRollupWithHashedPartitionsSpec()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
     final IndexTuningConfig tuningConfig = new IndexTuningConfig(
         null,
         null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
@@ -251,10 +251,8 @@ public class ParallelIndexTuningConfigTest
   }
 
   @Test
-  public void testConstructorWithHashedPartitionsSpecAndNonForceGuaranteedRollupFailToCreate()
+  public void testConstructorWithHashedPartitionsSpecAndNonForceGuaranteedRollup()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
     final boolean forceGuaranteedRollup = false;
     new ParallelIndexTuningConfig(
         null,
@@ -297,10 +295,8 @@ public class ParallelIndexTuningConfigTest
   }
 
   @Test
-  public void testConstructorWithSingleDimensionPartitionsSpecAndNonForceGuaranteedRollupFailToCreate()
+  public void testConstructorWithSingleDimensionPartitionsSpecAndNonForceGuaranteedRollup()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
     final boolean forceGuaranteedRollup = false;
     new ParallelIndexTuningConfig(
         null,


### PR DESCRIPTION
Index task enforcement of PartitionSpec is overly strict with respect to choice of rollup guarantee.  If forceGuaranteeRollup is  disabled, any PartitionSpec should be allowed.  In the case that 'forceGuaranteeRollup' is enabled we still need to enforce that the PartitionSpec can support this guarantee. 

This PR removes the requirement that the user pick dynamic PartitionSpec when forceGuaranteedRollup is false

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
