### PR TITLE
Web console: show execution dialog in task view

### DIFF
--- a/web-console/src/views/workbench-view/execution-details-pane/execution-details-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-details-pane/execution-details-pane.tsx
@@ -95,6 +95,7 @@ export const ExecutionDetailsPane = React.memo(function ExecutionDetailsPane(
                 ? String(execution.sqlQuery)
                 : JSONBig.stringify(execution.nativeQuery, undefined, 2)
             }
+            leaveBackground
           />
         );
 

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -221,7 +221,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
             accessor: d => d.index,
             width: 100,
             Cell({ value }) {
-              const taskId = `${execution.id}-worker${value}`;
+              const taskId = `${execution.id}-worker${value}_0`;
               return (
                 <TableClickableCell
                   hoverIcon={IconNames.SHARE}


### PR DESCRIPTION
Show the execution dialog for a query_controller tasks in task view instead of the generic raw task details dialog (the raw task details dialog is still accessible from the `...` menu).

<img width="1733" alt="image" src="https://github.com/apache/druid/assets/177816/7c10df02-d8a5-469b-a99f-2c00a1497a7c">

Also make attaching queries more robust to permission issues with the statements API.