### PR TITLE
Overlord incremental select worker strategy

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWithAffinityWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWithAffinityWorkerSelectStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.setup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Only exists for backwards compatibility with existing "FillIncrementallyWithAffinity" worker configs.
+ */
+public class FillIncrementallyWithAffinityWorkerSelectStrategy extends FillIncrementallyWorkerSelectStrategy
+{
+  @JsonCreator
+  public FillIncrementallyWithAffinityWorkerSelectStrategy(
+      @JsonProperty("affinityConfig") AffinityConfig affinityConfig
+  )
+  {
+    super(affinityConfig);
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWithCategorySpecWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWithCategorySpecWorkerSelectStrategy.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.setup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class FillIncrementallyWithCategorySpecWorkerSelectStrategy implements WorkerSelectStrategy
+{
+  private final WorkerCategorySpec workerCategorySpec;
+
+  @JsonCreator
+  public FillIncrementallyWithCategorySpecWorkerSelectStrategy(
+      @JsonProperty("workerCategorySpec") WorkerCategorySpec workerCategorySpec
+  )
+  {
+    this.workerCategorySpec = workerCategorySpec;
+  }
+
+  @JsonProperty
+  public WorkerCategorySpec getWorkerCategorySpec()
+  {
+    return workerCategorySpec;
+  }
+
+  @Nullable
+  @Override
+  public ImmutableWorkerInfo findWorkerForTask(
+      final WorkerTaskRunnerConfig config,
+      final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
+      final Task task
+  )
+  {
+    return WorkerSelectUtils.selectWorker(
+        task,
+        zkWorkers,
+        config,
+        workerCategorySpec,
+        FillIncrementallyWorkerSelectStrategy::selectFromEligibleWorkers
+    );
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FillIncrementallyWithCategorySpecWorkerSelectStrategy that = (FillIncrementallyWithCategorySpecWorkerSelectStrategy) o;
+    return Objects.equals(workerCategorySpec, that.workerCategorySpec);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(workerCategorySpec);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "FillIncrementallyWithCategorySpecWorkerSelectStrategy{" +
+           "workerCategorySpec=" + workerCategorySpec +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillIncrementallyWorkerSelectStrategy.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.setup;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
+import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class FillIncrementallyWorkerSelectStrategy implements WorkerSelectStrategy
+{
+  private final AffinityConfig affinityConfig;
+
+  @JsonCreator
+  public FillIncrementallyWorkerSelectStrategy(
+      @JsonProperty("affinityConfig") AffinityConfig affinityConfig
+  )
+  {
+    this.affinityConfig = affinityConfig;
+  }
+
+  @JsonProperty
+  public AffinityConfig getAffinityConfig()
+  {
+    return affinityConfig;
+  }
+
+  @Override
+  public ImmutableWorkerInfo findWorkerForTask(
+      final WorkerTaskRunnerConfig config,
+      final ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
+      final Task task
+  )
+  {
+    return WorkerSelectUtils.selectWorker(
+        task,
+        zkWorkers,
+        config,
+        affinityConfig,
+        FillIncrementallyWorkerSelectStrategy::selectFromEligibleWorkers
+    );
+  }
+
+  static ImmutableWorkerInfo selectFromEligibleWorkers(final Map<String, ImmutableWorkerInfo> eligibleWorkers)
+  {
+    List<ImmutableWorkerInfo> sortedWorkers = eligibleWorkers.values()
+        .stream()
+        .sorted(
+          Comparator.comparing(
+            worker -> {
+              String host = worker.getWorker().getHost();
+              int hostNumber = extractHostNumber(host);
+              return hostNumber;
+            }
+          )
+        ).collect(Collectors.toList());
+
+    ImmutableWorkerInfo selectedWorker = null;
+
+    for (ImmutableWorkerInfo worker : sortedWorkers) {
+      if (worker.getAvailableCapacity() > 0) {
+        selectedWorker = worker;
+        break;
+      }
+    }
+
+    return selectedWorker;
+  }
+
+  private static int extractHostNumber(String host)
+  {
+    // Assumes the host format is based on k8s statefulset FQDN - "druid-middlemanager-<numeral>.druid-middlemanager..."
+    String[] parts = host.split("\\.");
+    String numeralPart = parts[0].substring(parts[0].lastIndexOf("-") + 1);
+    return Integer.parseInt(numeralPart);
+  }
+
+  @Override
+  public boolean equals(final Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FillIncrementallyWorkerSelectStrategy that = (FillIncrementallyWorkerSelectStrategy) o;
+    return Objects.equals(affinityConfig, that.affinityConfig);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(affinityConfig);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "FillIncrementallyWorkerSelectStrategy{" +
+           "affinityConfig=" + affinityConfig +
+           '}';
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectStrategy.java
@@ -36,10 +36,13 @@ import javax.annotation.Nullable;
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "fillCapacity", value = FillCapacityWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "fillCapacityWithAffinity", value = FillCapacityWithAffinityWorkerSelectStrategy.class),
+    @JsonSubTypes.Type(name = "fillIncrementally", value = FillIncrementallyWorkerSelectStrategy.class),
+    @JsonSubTypes.Type(name = "fillIncrementallyWithAffinity", value = FillIncrementallyWithAffinityWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "equalDistribution", value = EqualDistributionWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "equalDistributionWithAffinity", value = EqualDistributionWithAffinityWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "javascript", value = JavaScriptWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "fillCapacityWithCategorySpec", value = FillCapacityWithCategorySpecWorkerSelectStrategy.class),
+    @JsonSubTypes.Type(name = "fillIncrementallyWithCategorySpec", value = FillIncrementallyWithCategorySpecWorkerSelectStrategy.class),
     @JsonSubTypes.Type(name = "equalDistributionWithCategorySpec", value = EqualDistributionWithCategorySpecWorkerSelectStrategy.class)
 })
 @PublicApi

--- a/web-console/src/druid-models/overlord-dynamic-config/overlord-dynamic-config.tsx
+++ b/web-console/src/druid-models/overlord-dynamic-config/overlord-dynamic-config.tsx
@@ -69,6 +69,8 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
       'equalDistributionWithCategorySpec',
       'fillCapacity',
       'fillCapacityWithCategorySpec',
+      'fillIncrementally',
+      'fillIncrementallyWithCategorySpec',
     ],
   },
 
@@ -82,6 +84,7 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
         deepGet(c, 'selectStrategy.type') ?? 'equalDistribution',
         'equalDistribution',
         'fillCapacity',
+        'fillIncrementally',
       ),
     info: (
       <>
@@ -104,6 +107,7 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
         deepGet(c, 'selectStrategy.type') ?? 'equalDistribution',
         'equalDistribution',
         'fillCapacity',
+        'fillIncrementally',
       ),
   },
 
@@ -117,6 +121,7 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
         deepGet(c, 'selectStrategy.type'),
         'equalDistributionWithCategorySpec',
         'fillCapacityWithCategorySpec',
+        'fillIncrementallyWithCategorySpec',
       ),
     info: (
       <>
@@ -143,6 +148,7 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
         deepGet(c, 'selectStrategy.type'),
         'equalDistributionWithCategorySpec',
         'fillCapacityWithCategorySpec',
+        'fillIncrementallyWithCategorySpec',
       ),
   },
 
@@ -160,7 +166,7 @@ export const OVERLORD_DYNAMIC_CONFIG_FIELDS: Field<OverlordDynamicConfig>[] = [
     label: 'Auto scaler type',
     type: 'string',
     suggestions: [undefined, 'ec2', 'gce'],
-    defined: c => oneOf(deepGet(c, 'selectStrategy.type'), 'fillCapacity', 'javascript'),
+    defined: c => oneOf(deepGet(c, 'selectStrategy.type'), 'fillCapacity', 'fillIncrementally', 'javascript'),
   },
   {
     name: 'autoScaler.minNumWorkers',

--- a/website/.spelling
+++ b/website/.spelling
@@ -2000,6 +2000,7 @@ extractionFn
 filename
 file.encoding
 fillCapacity
+fillIncrementally
 first_location
 floatMax
 floatAny


### PR DESCRIPTION
### Description

I was trying to use existing `fillCapacity` select worker strategy in an effort to implement MiddleManager autoscaling, but since MM instances that I use are created by k8s statefulsets it wasn't consistent enough. Proposed strategy fills capacity based on worker's hostname, with assumption that host is k8s FQDN - eg. `druid-middlemanager-0.druid-middlemanager.druid-test.svc.cluster.local:8091`.

Similar problem was discussed in https://github.com/apache/druid/issues/8801.
I'm not sure if this feature is desirable and this is my first java admission, so I'll take every bit of critique here. I can add tests if it will appear that this feature might be useful and we want to add it to codebase.

##### Key changed/added classes in this PR
 * `FillIncrementallyWorkerSelectStrategy`
 * `FillIncrementallyWithAffinityWorkerSelectStrategy`
 * `FillIncrementallyWithCategorySpecWorkerSelectStrategy`

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
