### PR TITLE
Allow users with STATE permissions to read and write the state APIs for querying with deep storage

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -630,14 +630,13 @@ public class SqlStatementResource
 
 
   /**
-   * This method contacts the overlord for the controller task and returns it if the requested user has the necessary
-   * permissions to do so. A user has the necessary permissions if they satisfy one of the following criterias:
-   * 1. They are the one who has submitted the query
-   * 2. They belong to a role containing the READ or WRITE permissions over the STATE resource. For endpoints like GET,
-   *   the user should have READ permission for the STATE resource, while for endpoints like POST and DELETE, the user
-   *   should have WRITE permission for the STATE resource (note: POST is only required when the user submits the query
-   *   so the currentUser should be equal to the queryUser, and we won't need to check the permissions for STATE resource
-   *   for them anyway)
+   * This method contacts the overlord for the controller task and checks if the requested user has the
+   * necessary permissions. A user has the necessary permissions if one of the following criteria is satisfied:
+   * 1. The user is the one who submitted the query
+   * 2. The user belongs to a role containing the READ or WRITE permissions over the STATE resource. For endpoints like GET,
+   *   the user should have READ permission for the STATE resource, while for endpoints like DELETE, the user should
+   *   have WRITE permission for the STATE resource. (Note: POST API does not need to check the state permissions since
+   *   the currentUser always equal to the queryUser)
    */
   private MSQControllerTask getMSQControllerTaskAndCheckPermission(
       String queryId,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -656,7 +656,6 @@ public class SqlStatementResource
 
     String currentUser = authenticationResult.getIdentity();
 
-
     if (currentUser != null && currentUser.equals(queryUser)) {
       return msqControllerTask;
     }
@@ -672,10 +671,9 @@ public class SqlStatementResource
     }
 
     throw new ForbiddenException(StringUtils.format(
-        "The current user[%s] cannot view query id[%s] since the query is owned by user[%s]",
+        "The current user[%s] cannot view query id[%s] since the query is owned by another user",
         currentUser,
-        queryId,
-        queryUser
+        queryId
     ));
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -74,9 +74,14 @@ import org.apache.druid.query.QueryException;
 import org.apache.druid.rpc.HttpResponseException;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.server.QueryResponse;
+import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.AuthorizationUtils;
+import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
+import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.sql.DirectStatement;
 import org.apache.druid.sql.HttpStatement;
 import org.apache.druid.sql.SqlRowTransformer;
@@ -103,6 +108,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -120,6 +126,7 @@ public class SqlStatementResource
   private final ObjectMapper jsonMapper;
   private final OverlordClient overlordClient;
   private final StorageConnector storageConnector;
+  private final AuthorizerMapper authorizerMapper;
 
 
   @Inject
@@ -127,13 +134,15 @@ public class SqlStatementResource
       final @MSQ SqlStatementFactory msqSqlStatementFactory,
       final ObjectMapper jsonMapper,
       final OverlordClient overlordClient,
-      final @MultiStageQuery StorageConnector storageConnector
+      final @MultiStageQuery StorageConnector storageConnector,
+      final AuthorizerMapper authorizerMapper
   )
   {
     this.msqSqlStatementFactory = msqSqlStatementFactory;
     this.jsonMapper = jsonMapper;
     this.overlordClient = overlordClient;
     this.storageConnector = storageConnector;
+    this.authorizerMapper = authorizerMapper;
   }
 
   /**
@@ -178,7 +187,7 @@ public class SqlStatementResource
       final boolean isTaskStruct = MSQTaskSqlEngine.TASK_STRUCT_FIELD_NAMES.equals(rowTransformer.getFieldList());
 
       if (isTaskStruct) {
-        return buildTaskResponse(sequence, stmt.query().authResult().getIdentity());
+        return buildTaskResponse(sequence, stmt.query().authResult());
       } else {
         // Used for EXPLAIN
         return buildStandardResponse(sequence, modifiedQuery, sqlQueryId, rowTransformer);
@@ -231,8 +240,9 @@ public class SqlStatementResource
 
       Optional<SqlStatementResult> sqlStatementResult = getStatementStatus(
           queryId,
-          authenticationResult.getIdentity(),
-          true
+          authenticationResult,
+          true,
+          Action.READ
       );
 
       if (sqlStatementResult.isPresent()) {
@@ -288,7 +298,11 @@ public class SqlStatementResource
         throw queryNotFoundException(queryId);
       }
 
-      MSQControllerTask msqControllerTask = getMSQControllerTaskOrThrow(queryId, authenticationResult.getIdentity());
+      MSQControllerTask msqControllerTask = getMSQControllerTaskAndCheckPermission(
+          queryId,
+          authenticationResult,
+          Action.READ
+      );
       throwIfQueryIsNotSuccessful(queryId, statusPlus);
 
       Optional<List<ColumnNameAndTypes>> signature = SqlStatementResourceHelper.getSignature(msqControllerTask);
@@ -353,8 +367,9 @@ public class SqlStatementResource
 
       Optional<SqlStatementResult> sqlStatementResult = getStatementStatus(
           queryId,
-          authenticationResult.getIdentity(),
-          false
+          authenticationResult,
+          false,
+          Action.WRITE
       );
       if (sqlStatementResult.isPresent()) {
         switch (sqlStatementResult.get().getState()) {
@@ -448,7 +463,7 @@ public class SqlStatementResource
     }
   }
 
-  private Response buildTaskResponse(Sequence<Object[]> sequence, String user)
+  private Response buildTaskResponse(Sequence<Object[]> sequence, AuthenticationResult authenticationResult)
   {
     List<Object[]> rows = sequence.toList();
     int numRows = rows.size();
@@ -464,7 +479,7 @@ public class SqlStatementResource
     }
     String taskId = String.valueOf(firstRow[0]);
 
-    Optional<SqlStatementResult> statementResult = getStatementStatus(taskId, user, true);
+    Optional<SqlStatementResult> statementResult = getStatementStatus(taskId, authenticationResult, true, Action.READ);
 
     if (statementResult.isPresent()) {
       return Response.status(Response.Status.OK).entity(statementResult.get()).build();
@@ -565,8 +580,12 @@ public class SqlStatementResource
   }
 
 
-  private Optional<SqlStatementResult> getStatementStatus(String queryId, String currentUser, boolean withResults)
-      throws DruidException
+  private Optional<SqlStatementResult> getStatementStatus(
+      String queryId,
+      AuthenticationResult authenticationResult,
+      boolean withResults,
+      Action forAction
+  ) throws DruidException
   {
     TaskStatusResponse taskResponse = contactOverlord(overlordClient.taskStatus(queryId), queryId);
     if (taskResponse == null) {
@@ -579,7 +598,7 @@ public class SqlStatementResource
     }
 
     // since we need the controller payload for auth checks.
-    MSQControllerTask msqControllerTask = getMSQControllerTaskOrThrow(queryId, currentUser);
+    MSQControllerTask msqControllerTask = getMSQControllerTaskAndCheckPermission(queryId, authenticationResult, forAction);
     SqlStatementState sqlStatementState = SqlStatementResourceHelper.getSqlStatementState(statusPlus);
 
     if (SqlStatementState.FAILED == sqlStatementState) {
@@ -610,7 +629,21 @@ public class SqlStatementResource
   }
 
 
-  private MSQControllerTask getMSQControllerTaskOrThrow(String queryId, String currentUser)
+  /**
+   * This method contacts the overlord for the controller task and returns it if the requested user has the necessary
+   * permissions to do so. A user has the necessary permissions if they satisfy one of the following criterias:
+   * 1. They are the one who has submitted the query
+   * 2. They belong to a role containing the READ or WRITE permissions over the STATE resource. For endpoints like GET,
+   *   the user should have READ permission for the STATE resource, while for endpoints like POST and DELETE, the user
+   *   should have WRITE permission for the STATE resource (note: POST is only required when the user submits the query
+   *   so the currentUser should be equal to the queryUser, and we won't need to check the permissions for STATE resource
+   *   for them anyway)
+   */
+  private MSQControllerTask getMSQControllerTaskAndCheckPermission(
+      String queryId,
+      AuthenticationResult authenticationResult,
+      Action forAction
+  ) throws ForbiddenException
   {
     TaskPayloadResponse taskPayloadResponse = contactOverlord(overlordClient.taskPayload(queryId), queryId);
     SqlStatementResourceHelper.isMSQPayload(taskPayloadResponse, queryId);
@@ -620,15 +653,30 @@ public class SqlStatementResource
                                                        .getQuery()
                                                        .getContext()
                                                        .get(MSQTaskQueryMaker.USER_KEY));
-    if (currentUser == null || !currentUser.equals(queryUser)) {
-      throw new ForbiddenException(StringUtils.format(
-          "The current user[%s] cannot view query id[%s] since the query is owned by user[%s]",
-          currentUser,
-          queryId,
-          queryUser
-      ));
+
+    String currentUser = authenticationResult.getIdentity();
+
+
+    if (currentUser != null && currentUser.equals(queryUser)) {
+      return msqControllerTask;
     }
-    return msqControllerTask;
+
+    Access access = AuthorizationUtils.authorizeAllResourceActions(
+        authenticationResult,
+        Collections.singletonList(new ResourceAction(Resource.STATE_RESOURCE, forAction)),
+        authorizerMapper
+    );
+
+    if (access.isAllowed()) {
+      return msqControllerTask;
+    }
+
+    throw new ForbiddenException(StringUtils.format(
+        "The current user[%s] cannot view query id[%s] since the query is owned by user[%s]",
+        currentUser,
+        queryId,
+        queryUser
+    ));
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -74,7 +74,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementFactory,
         objectMapper,
         indexingServiceClient,
-        localFileStorageConnector
+        localFileStorageConnector,
+        authorizerMapper
     );
   }
 
@@ -274,7 +275,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementFactory,
         objectMapper,
         indexingServiceClient,
-        NilStorageConnector.getInstance()
+        NilStorageConnector.getInstance(),
+        authorizerMapper
     );
 
     String errorMessage = "The sql statement api cannot read from the select destination [durableStorage] provided in "

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -651,7 +651,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         objectMapper,
         overlordClient,
         new LocalFileStorageConnector(tmpFolder.newFolder("local")),
-        authorizerMappeextensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.javar
+        authorizerMapper
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -650,7 +650,8 @@ public class SqlStatementResourceTest extends MSQTestBase
         sqlStatementFactory,
         objectMapper,
         overlordClient,
-        new LocalFileStorageConnector(tmpFolder.newFolder("local"))
+        new LocalFileStorageConnector(tmpFolder.newFolder("local")),
+        authorizerMappeextensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.javar
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -319,8 +319,6 @@ public class SqlStatementResourceTest extends MSQTestBase
       )
   );
   private static final DateTime QUEUE_INSERTION_TIME = DateTimes.of("2023-05-31T12:01Z");
-  private static final Map<String, Object> ROW1 = ImmutableMap.of("_time", 123, "alias", "foo", "market", "bar");
-  private static final Map<String, Object> ROW2 = ImmutableMap.of("_time", 234, "alias", "foo1", "market", "bar1");
   public static final ImmutableList<ColumnNameAndTypes> COL_NAME_AND_TYPES = ImmutableList.of(
       new ColumnNameAndTypes(
           "_time",
@@ -940,6 +938,37 @@ public class SqlStatementResourceTest extends MSQTestBase
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
             makeExpectedReq(CalciteTests.SUPER_USER_AUTH_RESULT)
+        ).getStatus()
+    );
+  }
+
+  @Test
+  public void testAPIBehaviourWithForbiddenUser()
+  {
+    AuthenticationResult differentUserAuthResult = new AuthenticationResult(
+        "differentUser", AuthConfig.ALLOW_ALL_NAME, null, null
+    );
+    Assert.assertEquals(
+        Response.Status.FORBIDDEN.getStatusCode(),
+        resource.doGetStatus(
+            RUNNING_SELECT_MSQ_QUERY,
+            makeExpectedReq(differentUserAuthResult)
+        ).getStatus()
+    );
+    Assert.assertEquals(
+        Response.Status.FORBIDDEN.getStatusCode(),
+        resource.doGetResults(
+            RUNNING_SELECT_MSQ_QUERY,
+            1L,
+            null,
+            makeExpectedReq(differentUserAuthResult)
+        ).getStatus()
+    );
+    Assert.assertEquals(
+        Response.Status.FORBIDDEN.getStatusCode(),
+        resource.deleteQuery(
+            RUNNING_SELECT_MSQ_QUERY,
+            makeExpectedReq(differentUserAuthResult)
         ).getStatus()
     );
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -917,17 +917,17 @@ public class SqlStatementResourceTest extends MSQTestBase
   }
 
   @Test
-  public void testForbiddenRequest()
+  public void testAPIBehaviourWithSuperUsers()
   {
     Assert.assertEquals(
-        Response.Status.FORBIDDEN.getStatusCode(),
+        Response.Status.OK.getStatusCode(),
         resource.doGetStatus(
             RUNNING_SELECT_MSQ_QUERY,
             makeExpectedReq(CalciteTests.SUPER_USER_AUTH_RESULT)
         ).getStatus()
     );
     Assert.assertEquals(
-        Response.Status.FORBIDDEN.getStatusCode(),
+        Response.Status.BAD_REQUEST.getStatusCode(),
         resource.doGetResults(
             RUNNING_SELECT_MSQ_QUERY,
             1L,
@@ -936,7 +936,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         ).getStatus()
     );
     Assert.assertEquals(
-        Response.Status.FORBIDDEN.getStatusCode(),
+        Response.Status.ACCEPTED.getStatusCode(),
         resource.deleteQuery(
             RUNNING_SELECT_MSQ_QUERY,
             makeExpectedReq(CalciteTests.SUPER_USER_AUTH_RESULT)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -144,6 +144,7 @@ import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.coordination.DataSegmentAnnouncer;
 import org.apache.druid.server.coordination.NoopDataSegmentAnnouncer;
 import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.sql.DirectStatement;
 import org.apache.druid.sql.SqlQueryPlus;
 import org.apache.druid.sql.SqlStatementFactory;
@@ -282,6 +283,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
   protected MSQTestOverlordServiceClient indexingServiceClient;
   protected MSQTestTaskActionClient testTaskActionClient;
   protected SqlStatementFactory sqlStatementFactory;
+  protected AuthorizerMapper authorizerMapper;
   private IndexIO indexIO;
 
   private MSQTestSegmentManager segmentManager;
@@ -516,6 +518,8 @@ public class MSQTestBase extends BaseCalciteQueryTest
     );
 
     sqlStatementFactory = CalciteTests.createSqlStatementFactory(engine, plannerFactory);
+
+    authorizerMapper = CalciteTests.TEST_EXTERNAL_AUTHORIZER_MAPPER;
   }
 
   protected CatalogResolver createMockCatalogResolver()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -209,13 +209,15 @@ public class CalciteTests
   public static final AuthenticationResult REGULAR_USER_AUTH_RESULT = new AuthenticationResult(
       AuthConfig.ALLOW_ALL_NAME,
       AuthConfig.ALLOW_ALL_NAME,
-      null, null
+      null,
+      null
   );
 
   public static final AuthenticationResult SUPER_USER_AUTH_RESULT = new AuthenticationResult(
       TEST_SUPERUSER_NAME,
       AuthConfig.ALLOW_ALL_NAME,
-      null, null
+      null,
+      null
   );
 
   public static final Injector INJECTOR = new CalciteTestInjectorBuilder()


### PR DESCRIPTION
### Description

Currently, only the user who has submitted the async query has permission to interact with the status APIs for that async query. However, often we want an administrator to interact with these resources as well. 
Druid handles these with the `STATE` resource traditionally, and if the requesting user has necessary permissions on it as well, alternatively, they should be allowed to interact with the status APIs, irrespective of whether they are the submitter of the query. This PR adds the same behavior to these async API resources as well, as documented below:

(Path is relative to `/druid/v2/sql/statements/`)

| Method and Path  | Original Behavior | New Behaviour (In conjunction with the original behavior) |
|--------|--------|--------|
| `GET /enabled` | Unguarded | Unguarded |
| `POST /` | Doesn't matter since caller will be the submitter of the query | Doesn't matter since caller will be the submitter of the query |
| `GET /{id}` | Original submitter can access the status | Original Behavior + Users with `READ` permissions on `STATE`  |
| `GET /{id}/results` | Original submitter can access the results | Original Behavior + Users with `READ` permissions on `STATE` |
| `DELETE /{id}` | Original submitter can cancel the query | Original Behavior + Users with `WRITE` permissions on `STATE` | 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
