### PR TITLE
fix(sec): upgrade org.testng:testng to 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1203,7 +1203,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.7.0</version>
+                <version>7.8.0</version>
                 <!-- testng ships guice 4.2, which requires a newer version of guava -->
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1203,7 +1203,7 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <version>7.3.0</version>
+                <version>7.7.0</version>
                 <!-- testng ships guice 4.2, which requires a newer version of guava -->
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.testng:testng 7.3.0
- [CVE-2022-4065](https://www.oscs1024.com/hd/CVE-2022-4065)


### What did I do？
Upgrade org.testng:testng from 7.3.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS