### PR TITLE
Fix bug in computed value of balancerComputeThreads

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/PrepareBalancerAndLoadQueues.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/PrepareBalancerAndLoadQueues.java
@@ -94,7 +94,7 @@ public class PrepareBalancerAndLoadQueues implements CoordinatorDuty
     collectHistoricalStats(cluster, stats);
     collectUsedSegmentStats(params, stats);
 
-    int numBalancerThreads = params.getCoordinatorDynamicConfig().getBalancerComputeThreads();
+    final int numBalancerThreads = segmentLoadingConfig.getBalancerComputeThreads();
     final BalancerStrategy balancerStrategy = balancerStrategyFactory.createBalancerStrategy(numBalancerThreads);
     log.info(
         "Using balancer strategy [%s] with [%d] threads.",

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadingConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadingConfig.java
@@ -49,9 +49,11 @@ public class SegmentLoadingConfig
       // Compute replicationThrottleLimit with a lower bound of 100
       final int throttlePercentage = 5;
       final int replicationThrottleLimit = Math.max(100, numUsedSegments * throttlePercentage / 100);
+      final int numBalancerThreads = CoordinatorDynamicConfig.getDefaultBalancerComputeThreads();
       log.info(
-          "Smart segment loading is enabled. Calculated replicationThrottleLimit[%,d] (%d%% of used segments[%,d]).",
-          replicationThrottleLimit, throttlePercentage, numUsedSegments
+          "Smart segment loading is enabled. Calculated replicationThrottleLimit[%,d]"
+          + " (%d%% of used segments[%,d]) and numBalancerThreads[%d].",
+          replicationThrottleLimit, throttlePercentage, numUsedSegments, numBalancerThreads
       );
 
       return new SegmentLoadingConfig(
@@ -59,7 +61,7 @@ public class SegmentLoadingConfig
           replicationThrottleLimit,
           60,
           true,
-          CoordinatorDynamicConfig.getDefaultBalancerComputeThreads()
+          numBalancerThreads
       );
     } else {
       // Use the configured values


### PR DESCRIPTION
### Changes
- In `smartSegmentLoading` mode, use computed value of `balancerComputeThreads` rather than configured value