### PR TITLE
fix issue with segment metadata cache and complex types when doing out of order upgrades from 0.22

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCache.java
@@ -961,6 +961,9 @@ public class SegmentMetadataCache
         // likelyhood of upgrading from some version lower than 0.23 is low
         try {
           valueType = ColumnType.fromString(entry.getValue().getType());
+          if (valueType == null) {
+            valueType = ColumnType.ofComplex(entry.getValue().getType());
+          }
         }
         catch (IllegalArgumentException ignored) {
           valueType = ColumnType.UNKNOWN_COMPLEX;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SegmentMetadataCacheTest.java
@@ -1417,9 +1417,21 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
                         false,
                         true,
                         1234,
-                        26,
-                        "a",
-                        "z",
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    "distinct",
+                    new ColumnAnalysis(
+                        null,
+                        "hyperUnique",
+                        false,
+                        true,
+                        1234,
+                        null,
+                        null,
+                        null,
                         null
                     )
                 )
@@ -1433,7 +1445,7 @@ public class SegmentMetadataCacheTest extends SegmentMetadataCacheCommon
         )
     );
     Assert.assertEquals(
-        RowSignature.builder().add("a", ColumnType.STRING).add("count", ColumnType.LONG).build(),
+        RowSignature.builder().add("a", ColumnType.STRING).add("count", ColumnType.LONG).add("distinct", ColumnType.ofComplex("hyperUnique")).build(),
         signature
     );
   }


### PR DESCRIPTION
### Description
Fixes an issue with complex type handling that was intended to be fixed as part of #12016 to handle cases where the broker is updated before historical and realtime nodes.

Since complex types were sending back the response with just the complex type name, the valueType was still null resulting in errors of the form:

```
org.apache.druid.java.util.common.ISE: Encountered null type for column [theta_user]
	at org.apache.druid.sql.calcite.schema.SegmentMetadataCache.lambda$buildDruidTable$13(SegmentMetadataCache.java:825) ~[classes/:?]
	at java.util.Optional.orElseThrow(Optional.java:403) ~[?:?]
...
```

I will update the release notes of 0.23 to indicate that the brokers must be updated last for now...

This PR has:

- [x] been self-reviewed.
- [ ] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
