### PR TITLE
Add DOAP file for Druid

### DIFF
--- a/doap_Druid.rdf
+++ b/doap_Druid.rdf
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         https://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://druid.apache.org/">
+    <created>2023-09-08</created>
+    <license rdf:resource="https://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Druid</name>
+    <homepage rdf:resource="https://druid.apache.org/" />
+    <asfext:pmc rdf:resource="https://druid.apache.org" />
+    <shortdesc>High performance, real-time analytics database for sub-second queries at scale and under load.</shortdesc>
+    <description>Apache Druid is a high performance real-time analytics database. Druid's main value add is to reduce time to insight and action.
+
+Apache Druid is designed for workflows where fast queries and ingest really matter. Druid excels at powering UIs, running operational (ad-hoc) queries, or handling high concurrency. Consider Druid as an open source alternative to data warehouses for a variety of use cases.</description>
+    <bug-database rdf:resource="https://github.com/apache/druid/issues" />
+    <mailing-list rdf:resource="https://lists.apache.org/list.html?dev@druid.apache.org" />
+    <download-page rdf:resource="https://druid.apache.org/downloads/" />
+    <programming-language>Java</programming-language>
+    <category rdf:resource="https://projects.apache.org/category/big-data" />
+    <category rdf:resource="https://projects.apache.org/category/database" />
+  </Project>
+</rdf:RDF>
+


### PR DESCRIPTION
### Description

The DOAP file is a standard RDF file that describes a project's metadata. The Apache Software Foundation uses DOAP files for projects to keep project listing information at https://projects.apache.org/projects.html

This change just introduces basic information about the project. Future changes can add more information like each release that goes out.

The descriptions were pulled from the website and the README in this repo.

Once this file is available in the repo, a separate change is needed to link to this file (more details in the instructions link below.

<hr>

The file was validated by using [this rdf validator](https://www.w3.org/RDF/Validator/rdfval)

Instructions for the DOAP files (including a form to create it): https://projects.apache.org/create.html
Guidelines: https://projects.apache.org/guidelines.html
FAQ: https://projects.apache.org/doapfaq.html

This PR has:

- [x] been self-reviewed.
