### PR TITLE
use VectorValueSelector instead of BaseLongVectorValueSelector for StringFirstAggregatorFactory.factorizeVector

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/SingleStringFirstDimensionVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/SingleStringFirstDimensionVectorAggregator.java
@@ -23,22 +23,22 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.SerializablePairLongString;
 import org.apache.druid.query.aggregation.VectorAggregator;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 public class SingleStringFirstDimensionVectorAggregator implements VectorAggregator
 {
-  private final BaseLongVectorValueSelector timeSelector;
+  private final VectorValueSelector timeSelector;
   private final SingleValueDimensionVectorSelector valueDimensionVectorSelector;
   private long firstTime;
   private final int maxStringBytes;
   private final boolean useDefault = NullHandling.replaceWithDefault();
 
   public SingleStringFirstDimensionVectorAggregator(
-      BaseLongVectorValueSelector timeSelector,
+      VectorValueSelector timeSelector,
       SingleValueDimensionVectorSelector valueDimensionVectorSelector,
       int maxStringBytes
   )

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstAggregatorFactory.java
@@ -43,10 +43,10 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
+import org.apache.druid.segment.vector.VectorValueSelector;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -186,8 +186,7 @@ public class StringFirstAggregatorFactory extends AggregatorFactory
   @Override
   public VectorAggregator factorizeVector(VectorColumnSelectorFactory selectorFactory)
   {
-    BaseLongVectorValueSelector timeSelector = (BaseLongVectorValueSelector) selectorFactory.makeValueSelector(
-        timeColumn);
+    final VectorValueSelector timeSelector = selectorFactory.makeValueSelector(timeColumn);
     ColumnCapabilities capabilities = selectorFactory.getColumnCapabilities(fieldName);
     if (capabilities != null) {
       if (capabilities.is(ValueType.STRING) && capabilities.isDictionaryEncoded().isTrue()) {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstVectorAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/first/StringFirstVectorAggregator.java
@@ -23,7 +23,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.query.aggregation.SerializablePairLongString;
 import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.segment.DimensionHandlerUtils;
-import org.apache.druid.segment.vector.BaseLongVectorValueSelector;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
 
@@ -42,7 +41,7 @@ public class StringFirstVectorAggregator implements VectorAggregator
 
 
   public StringFirstVectorAggregator(
-      BaseLongVectorValueSelector timeSelector,
+      VectorValueSelector timeSelector,
       VectorObjectSelector valueSelector,
       int maxStringBytes
   )


### PR DESCRIPTION
Cannot assume that the time selector will be `BaseLongVectorValueSelector`, so just use `VectorValueSelector`. This should fix `CalciteSimpleQueryTest.testEarliestByLatestByWithExpression` which is failing CI


