### PR TITLE
Set task location as k8sPodName for mm-less ingestion

### DIFF
--- a/processing/src/main/java/org/apache/druid/indexer/TaskLocation.java
+++ b/processing/src/main/java/org/apache/druid/indexer/TaskLocation.java
@@ -20,8 +20,10 @@
 package org.apache.druid.indexer;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.net.HostAndPort;
 import org.apache.druid.java.util.common.IAE;
 
 import javax.annotation.Nullable;
@@ -100,6 +102,25 @@ public class TaskLocation
   public String getK8sPodName()
   {
     return k8sPodName;
+  }
+
+  @JsonIgnore
+  @Nullable
+  public String getTaskLocation()
+  {
+    if (k8sPodName != null) {
+      return k8sPodName;
+    } else if (host == null) {
+      return null;
+    } else {
+      final int thePort;
+      if (tlsPort >= 0) {
+        thePort = tlsPort;
+      } else {
+        thePort = port;
+      }
+      return HostAndPort.fromParts(host, thePort).toString();
+    }
   }
 
   public URL makeURL(final String encodedPathAndQueryString) throws MalformedURLException

--- a/processing/src/main/java/org/apache/druid/indexer/TaskLocation.java
+++ b/processing/src/main/java/org/apache/druid/indexer/TaskLocation.java
@@ -106,7 +106,7 @@ public class TaskLocation
 
   @JsonIgnore
   @Nullable
-  public String getTaskLocation()
+  public String getLocation()
   {
     if (k8sPodName != null) {
       return k8sPodName;

--- a/processing/src/test/java/org/apache/druid/indexer/TaskLocationTest.java
+++ b/processing/src/test/java/org/apache/druid/indexer/TaskLocationTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexer;
 
 
+import com.google.common.net.HostAndPort;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
 import org.junit.Test;
@@ -74,5 +75,47 @@ public class TaskLocationTest
   public void testEqualsAndHashCode()
   {
     EqualsVerifier.forClass(TaskLocation.class).usingGetClass().verify();
+  }
+
+  @Test
+  public void testGetLocationWithK8sPodNameShouldReturnK8sPodName()
+  {
+    TaskLocation taskLocation = TaskLocation.create("foo", 1, 2, false, "job-name");
+    Assert.assertEquals("job-name", taskLocation.getLocation());
+  }
+
+  @Test
+  public void testGetLocationWithK8sPodNameAndTlsShouldReturnK8sPodName()
+  {
+    TaskLocation taskLocation = TaskLocation.create("foo", 1, 2, true, "job-name");
+    Assert.assertEquals("job-name", taskLocation.getLocation());
+  }
+
+  @Test
+  public void testGetLocationWithK8sPodNameAndNoHostShouldReturnK8sPodName()
+  {
+    TaskLocation taskLocation = TaskLocation.create(null, 1, 2, true, "job-name");
+    Assert.assertEquals("job-name", taskLocation.getLocation());
+  }
+
+  @Test
+  public void testGetLocationWithoutK8sPodNameAndHostShouldReturnNull()
+  {
+    TaskLocation taskLocation = TaskLocation.create(null, 1, 2, false);
+    Assert.assertNull(taskLocation.getLocation());
+  }
+
+  @Test
+  public void testGetLocationWithoutK8sPodNameAndNoTlsPortShouldReturnLocation()
+  {
+    TaskLocation taskLocation = TaskLocation.create("foo", 1, -1, false);
+    Assert.assertEquals(HostAndPort.fromParts("foo", 1).toString(), taskLocation.getLocation());
+  }
+
+  @Test
+  public void testGetLocationWithoutK8sPodNameAndNonZeroTlsPortShouldReturnLocation()
+  {
+    TaskLocation taskLocation = TaskLocation.create("foo", 1, 2, true);
+    Assert.assertEquals(HostAndPort.fromParts("foo", 2).toString(), taskLocation.getLocation());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -822,21 +822,7 @@ public class SystemSchema extends AbstractSchema
             public Object[] current()
             {
               final TaskStatusPlus task = it.next();
-              @Nullable final String host = task.getLocation().getHost();
-              @Nullable final String hostAndPort;
 
-              if (host == null) {
-                hostAndPort = null;
-              } else {
-                final int port;
-                if (task.getLocation().getTlsPort() >= 0) {
-                  port = task.getLocation().getTlsPort();
-                } else {
-                  port = task.getLocation().getPort();
-                }
-
-                hostAndPort = HostAndPort.fromParts(host, port).toString();
-              }
               return new Object[]{
                   task.getId(),
                   task.getGroupId(),
@@ -847,8 +833,8 @@ public class SystemSchema extends AbstractSchema
                   toStringOrNull(task.getStatusCode()),
                   toStringOrNull(task.getRunnerStatusCode()),
                   task.getDuration() == null ? 0L : task.getDuration(),
-                  hostAndPort,
-                  host,
+                  task.getLocation().getTaskLocation(),
+                  task.getLocation().getHost(),
                   (long) task.getLocation().getPort(),
                   (long) task.getLocation().getTlsPort(),
                   task.getErrorMsg()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
 import org.apache.calcite.DataContext;
@@ -833,7 +832,7 @@ public class SystemSchema extends AbstractSchema
                   toStringOrNull(task.getStatusCode()),
                   toStringOrNull(task.getRunnerStatusCode()),
                   task.getDuration() == null ? 0L : task.getDuration(),
-                  task.getLocation().getTaskLocation(),
+                  task.getLocation().getLocation(),
                   task.getLocation().getHost(),
                   (long) task.getLocation().getPort(),
                   (long) task.getLocation().getTlsPort(),


### PR DESCRIPTION
### Description

When using middle manager less ingestion, the k8s pod name is more useful in identifying the location
where the peon ran. This change makes it so that the k8sPodName shows up in the web-console and as the
location for queries against the sys.tasks table.

<img width="1592" alt="Screenshot 2023-09-10 at 7 48 18 PM" src="https://github.com/apache/druid/assets/44787917/3bd052a3-1f0b-48b2-aba8-ef211fe449ac">

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
