### PR TITLE
Fix bug in KillStalePendingSegments

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillStalePendingSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillStalePendingSegments.java
@@ -118,9 +118,7 @@ public class KillStalePendingSegments implements CoordinatorDuty
     DateTime earliestActiveTaskStart = DateTimes.nowUtc();
     DateTime latestCompletedTaskStart = null;
     for (TaskStatusPlus status : statuses) {
-      if (status.getStatusCode() == null) {
-        // Unknown status
-      } else if (status.getStatusCode().isComplete()) {
+      if (status.getStatusCode() != null && status.getStatusCode().isComplete()) {
         latestCompletedTaskStart = DateTimes.laterOf(
             latestCompletedTaskStart,
             status.getCreatedTime()


### PR DESCRIPTION
This bug was introduced in #14951 

A task should be considered as running if the task status returned from Overlord contains a null status code.