### PR TITLE
Tweak GHA runner label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,7 +34,6 @@
   - 'examples/quickstart/jupyter-notebooks/**'
 
 'Area - Ingestion':
-  - 'processing/**'
   - 'indexing-service/**'
 
 'Area - Lookups':
@@ -49,6 +48,7 @@
 
 'Area - Querying':
   - 'sql/**'
+  - 'extensions-core/multi-stage-query/**'
 
 'Area - Segment Format and Ser/De':
   - 'processing/src/main/java/org/apache/druid/segment/**'


### PR DESCRIPTION
This change:
- Removes ingestion label for `processing/**` changes. Changes in `processing/` directory  can be ingestion, querying or other miscellaneous things
- Add querying label for MSQ extension


This PR has:

- [x] been self-reviewed.
