### PR TITLE
Upload docker and druid service logs as artifacts on GitHub Actions IT run failure

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -136,9 +136,11 @@ jobs:
 
       - name: Collect docker logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
-        uses: jwalton/gh-docker-logs@v2
-        with:
-          dest: './docker-logs'
+        run: |
+          for c in $(docker ps -a --format="{{.Names}}")
+          do
+            docker logs $c > ./docker-logs/$c.log
+          done
 
       - name: Tar docker logs
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -133,3 +133,33 @@ jobs:
 
       - name: Run IT
         run: ${{ inputs.script }}
+
+      - name: Collect docker logs on failure
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './docker-logs'
+
+      - name: Tar docker logs
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        run: tar cvzf ./docker-logs.tgz ./docker-logs
+
+      - name: Upload docker logs to GitHub
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: IT-${{ inputs.it }} docker logs (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }}, Indexer=${{ inputs.use_indexer }}, Mysql=${{ inputs.mysql_driver }})
+          path: docker-logs.tgz
+
+      - name: Collect service logs on failure
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        run: |
+          docker cp middlemanager:/shared/logs/ ./service-logs
+          tar cvzf ./service-logs.tgz ./service-logs
+
+      - name: Upload Druid service logs to GitHub
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: IT-${{ inputs.it }} service logs (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }}, Indexer=${{ inputs.use_indexer }}, Mysql=${{ inputs.mysql_driver }})
+          path: service-logs.tgz

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -90,9 +90,11 @@ jobs:
 
       - name: Collect docker logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
-        uses: jwalton/gh-docker-logs@v2
-        with:
-          dest: './docker-logs'
+        run: |
+          for c in $(docker ps -a --format="{{.Names}}")
+          do
+            docker logs $c > ./docker-logs/$c.log
+          done
 
       - name: Tar docker logs
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -88,13 +88,32 @@ jobs:
           echo "${MVN} verify -pl integration-tests -P integration-tests ${{ inputs.testing_groups }} -Djvm.runtime=${{ inputs.runtime_jdk }} -Dit.indexer=${{ inputs.use_indexer }} ${MAVEN_SKIP} -Doverride.config.path=${{ inputs.override_config_path }}"
           ${MVN} verify -pl integration-tests -P integration-tests ${{ inputs.testing_groups }} -Djvm.runtime=${{ inputs.runtime_jdk }} -Dit.indexer=${{ inputs.use_indexer }} ${MAVEN_SKIP} -Doverride.config.path=${{ inputs.override_config_path }}
 
-      - name: Debug IT
+      - name: Collect docker logs on failure
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './docker-logs'
+
+      - name: Tar docker logs
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        run: tar cvzf ./docker-logs.tgz ./docker-logs
+
+      - name: Upload docker logs to GitHub
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: IT-${{ inputs.group }} docker logs (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }}, Indexer=${{ inputs.use_indexer }}, Mysql=${{ inputs.mysql_driver }})
+          path: docker-logs.tgz
+
+      - name: Collect service logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
-          for v in broker router ${{ inputs.use_indexer }} historical coordinator overlord; do
-            echo "=======================druid-"$v"========================";
-            echo "-----------------------docker logs-----------------------";
-            sudo docker logs druid-"$v" 2>&1 | tail -1000 ||:;
-            echo "-----------------------service logs----------------------";
-            sudo docker exec druid-"$v" tail -1000 /shared/logs/"$v".log 2>&1 ||:;
-          done
+          docker cp druid-middlemanager:/shared/logs/ ./service-logs
+          tar cvzf ./service-logs.tgz ./service-logs
+
+      - name: Upload Druid service logs to GitHub
+        if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: IT-${{ inputs.group }} service logs (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }}, Indexer=${{ inputs.use_indexer }}, Mysql=${{ inputs.mysql_driver }})
+          path: service-logs.tgz


### PR DESCRIPTION
With this PR, docker and druid service logs are uploaded as artifacts onto GitHub when an IT job fails so that we can later download them for investigation.

<img width="1710" alt="Screenshot 2023-09-12 at 4 30 44 PM" src="https://github.com/apache/druid/assets/96047043/8a3f1140-e23e-4a0b-bfd4-50d01ae17d53">
