### PR TITLE
Fix the uncaught exceptions when materializing results as frames

### DIFF
--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -767,6 +767,30 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
           new ArenaMemoryAllocatorFactory(FRAME_SIZE),
           useNestedForUnknownTypeInSubquery
       );
+
+      if (!framesOptional.isPresent()) {
+        log.debug("Unable to materialize the results as frames. Defaulting to materializing the results as rows");
+        return Optional.empty();
+      }
+
+      Sequence<FrameSignaturePair> frames = framesOptional.get();
+      List<FrameSignaturePair> frameSignaturePairs = new ArrayList<>();
+      frames.forEach(
+          frame -> {
+            limitAccumulator.addAndGet(frame.getFrame().numRows());
+            if (memoryLimitAccumulator.addAndGet(frame.getFrame().numBytes()) >= memoryLimit) {
+              subqueryStatsProvider.incrementQueriesExceedingByteLimit();
+              throw ResourceLimitExceededException.withMessage(
+                  "Subquery generated results beyond maximum[%d] bytes",
+                  memoryLimit
+              );
+
+            }
+            frameSignaturePairs.add(frame);
+          }
+      );
+      return Optional.of(new FrameBasedInlineDataSource(frameSignaturePairs, toolChest.resultArraySignature(query)));
+
     }
     catch (UnsupportedColumnTypeException e) {
       subqueryStatsProvider.incrementSubqueriesFallingBackDueToUnsufficientTypeInfo();
@@ -779,29 +803,6 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
                    + "while conversion. Defaulting to materializing the results as rows");
       return Optional.empty();
     }
-
-    if (!framesOptional.isPresent()) {
-      log.debug("Unable to materialize the results as frames. Defaulting to materializing the results as rows");
-      return Optional.empty();
-    }
-
-    Sequence<FrameSignaturePair> frames = framesOptional.get();
-    List<FrameSignaturePair> frameSignaturePairs = new ArrayList<>();
-    frames.forEach(
-        frame -> {
-          limitAccumulator.addAndGet(frame.getFrame().numRows());
-          if (memoryLimitAccumulator.addAndGet(frame.getFrame().numBytes()) >= memoryLimit) {
-            subqueryStatsProvider.incrementQueriesExceedingByteLimit();
-            throw ResourceLimitExceededException.withMessage(
-                "Subquery generated results beyond maximum[%d] bytes",
-                memoryLimit
-            );
-
-          }
-          frameSignaturePairs.add(frame);
-        }
-    );
-    return Optional.of(new FrameBasedInlineDataSource(frameSignaturePairs, toolChest.resultArraySignature(query)));
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -769,8 +769,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
       );
 
       if (!framesOptional.isPresent()) {
-        log.debug("Unable to materialize the results as frames. Defaulting to materializing the results as rows");
-        return Optional.empty();
+        throw DruidException.defensive("Unable to materialize the results as frames. Defaulting to materializing the results as rows");
       }
 
       Sequence<FrameSignaturePair> frames = framesOptional.get();
@@ -791,6 +790,9 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
       );
       return Optional.of(new FrameBasedInlineDataSource(frameSignaturePairs, toolChest.resultArraySignature(query)));
 
+    }
+    catch (ResourceLimitExceededException e) {
+      throw e;
     }
     catch (UnsupportedColumnTypeException e) {
       subqueryStatsProvider.incrementSubqueriesFallingBackDueToUnsufficientTypeInfo();


### PR DESCRIPTION
### Description

When materializing the results as frames, we defer the creation of the frames in `ScanQueryQueryToolChest`, which passes through the catch-all block reserved for catching cases when we don't have the complete row signature in the query (and falls back to the old code). 
This PR aims to resolve it by adding the frame generation code to the try-catch block we have at the outer level.


<hr>

##### Key changed/added classes in this PR
 * `ClienQuerySegmentWalker`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
