### PR TITLE
Add metrics for number of segments generated per task in MSQ

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -52,6 +52,7 @@
   "ingest/handoff/failed" : { "dimensions" : ["dataSource"], "type" : "count" },
   "ingest/merge/time" : { "dimensions" : ["dataSource"], "type" : "timer" },
   "ingest/merge/cpu" : { "dimensions" : ["dataSource"], "type" : "timer" },
+  "ingest/segments/count" : { "dimensions" : ["dataSource"], "type" : "count" },
 
   "ingest/kafka/lag" : { "dimensions" : ["dataSource", "stream"], "type" : "gauge" },
   "ingest/kafka/maxLag" : { "dimensions" : ["dataSource", "stream"], "type" : "gauge" },

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
@@ -25,6 +25,7 @@ import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.server.DruidNode;
 
 import java.util.Map;
@@ -36,6 +37,8 @@ import java.util.Map;
  */
 public interface ControllerContext
 {
+  ServiceEmitter emitter();
+
   ObjectMapper jsonMapper();
 
   /**

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -1330,7 +1330,7 @@ public class ControllerImpl implements Controller
     final DataSourceMSQDestination destination =
         (DataSourceMSQDestination) task.getQuerySpec().getDestination();
     final Set<DataSegment> segmentsWithTombstones = new HashSet<>(segments);
-    int tombstoneSize = 0;
+    int numTombstones = 0;
 
     if (destination.isReplaceTimeChunks()) {
       final List<Interval> intervalsToDrop = findIntervalsToDrop(Preconditions.checkNotNull(segments, "segments"));
@@ -1345,7 +1345,7 @@ public class ControllerImpl implements Controller
               destination.getSegmentGranularity()
           );
           segmentsWithTombstones.addAll(tombstones);
-          tombstoneSize = tombstones.size();
+          numTombstones = tombstones.size();
         }
         catch (IllegalStateException e) {
           throw new MSQException(e, InsertLockPreemptedFault.instance());
@@ -1392,7 +1392,7 @@ public class ControllerImpl implements Controller
       );
     }
 
-    task.emitMetric(context.emitter(), "ingest/tombstones/count", tombstoneSize);
+    task.emitMetric(context.emitter(), "ingest/tombstones/count", numTombstones);
     // Include tombstones in the reported segments count
     task.emitMetric(context.emitter(), "ingest/segments/count", segmentsWithTombstones.size());
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -1393,7 +1393,7 @@ public class ControllerImpl implements Controller
     }
 
     task.emitMetric(context.emitter(), "ingest/tombstones/count", tombstoneSize);
-    // segments count metric is documented to include tombstones
+    // Include tombstones in the reported segments count
     task.emitMetric(context.emitter(), "ingest/segments/count", segmentsWithTombstones.size());
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -28,6 +28,7 @@ import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.msq.exec.Controller;
 import org.apache.druid.msq.exec.ControllerContext;
 import org.apache.druid.msq.exec.WorkerClient;
@@ -65,6 +66,12 @@ public class IndexerControllerContext implements ControllerContext
     this.clientFactory = clientFactory;
     this.overlordClient = overlordClient;
     this.workerManager = new IndexerWorkerManagerClient(overlordClient);
+  }
+
+  @Override
+  public ServiceEmitter emitter()
+  {
+    return toolbox.getEmitter();
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.msq.exec.Controller;
 import org.apache.druid.msq.exec.ControllerContext;
 import org.apache.druid.msq.exec.Worker;
@@ -214,6 +215,12 @@ public class MSQTestControllerContext implements ControllerContext
       //do nothing
     }
   };
+
+  @Override
+  public ServiceEmitter emitter()
+  {
+    return null;
+  }
 
   @Override
   public ObjectMapper jsonMapper()

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -49,6 +49,7 @@ import org.apache.druid.msq.indexing.MSQWorkerTask;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.sql.calcite.util.SpecificSegmentsQuerySegmentWalker;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -83,6 +84,7 @@ public class MSQTestControllerContext implements ControllerContext
   );
   private final Injector injector;
   private final ObjectMapper mapper;
+  private final ServiceEmitter emitter = new NoopServiceEmitter();
 
   private Controller controller;
   private Map<String, TaskReport> report = null;
@@ -219,7 +221,7 @@ public class MSQTestControllerContext implements ControllerContext
   @Override
   public ServiceEmitter emitter()
   {
-    return null;
+    return emitter;
   }
 
   @Override


### PR DESCRIPTION
### Description

Report `ingest/tombstones/count` and `ingest/segments/count` metrics in MSQ when finish publishing segments.

Following are two examples:
```
{"taskIngestionMode":"NONE","feed":"metrics","taskType":"query_controller","metric":"ingest/tombstones/count","service":"druid/indexer","groupId":"query-481a0c2d-1f04-4a5b-bc30-f343240850d3","host":"localhost:8091","version":"","value":0,"dataSource":"wikipedia","taskId":"query-481a0c2d-1f04-4a5b-bc30-f343240850d3","timestamp":"2023-09-14T17:01:47.951Z"}

{"taskIngestionMode":"NONE","feed":"metrics","taskType":"query_controller","metric":"ingest/segments/count","service":"druid/indexer","groupId":"query-481a0c2d-1f04-4a5b-bc30-f343240850d3","host":"localhost:8091","version":"","value":1,"dataSource":"wikipedia","taskId":"query-481a0c2d-1f04-4a5b-bc30-f343240850d3","timestamp":"2023-09-14T17:01:47.954Z"}
```

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Add `ingest/tombstones/count` and `ingest/segments/count` metrics in MSQ.

<hr>

##### Key changed/added classes in this PR
 * In `ControllerImpl` report the new metrics

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
