### PR TITLE
Tweak GHA runner label for MSQ

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -46,6 +46,9 @@
   - 'processing/src/main/java/org/apache/druid/java/util/emitter/**'
   - 'extensions-contrib/*-emitter/**'
 
+'Area - MSQ':
+  - 'extensions-core/multi-stage-query/**'
+
 'Area - Querying':
   - 'sql/**'
   - 'extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/**'
@@ -62,6 +65,3 @@
 
 'Kubernetes':
   - 'extensions-contrib/kubernetes-overlord-extensions/**'
-
-'Area - MSQ':
-  - 'extensions-core/multi-stage-query/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,7 +48,7 @@
 
 'Area - Querying':
   - 'sql/**'
-  - 'extensions-core/multi-stage-query/**'
+  - 'extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/**'
 
 'Area - Segment Format and Ser/De':
   - 'processing/src/main/java/org/apache/druid/segment/**'
@@ -63,5 +63,5 @@
 'Kubernetes':
   - 'extensions-contrib/kubernetes-overlord-extensions/**'
 
-'MSQ':
+'Area - MSQ':
   - 'extensions-core/multi-stage-query/**'


### PR DESCRIPTION
Modifies the following things:
1. Uses label `Area - MSQ` instead of `MSQ` to keep it consistent with other label types and the past labels used for MSQ
2. Change the scope the `Area - Querying` label to changes contained in the sql package in MSQ

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
