### PR TITLE
Fixing nullif with unnest by not creating an and filter in case of em…

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -478,13 +478,16 @@ public class UnnestStorageAdapter implements StorageAdapter
     for (Filter filter : queryFilter.getFilters()) {
       if (filter.getRequiredColumns().contains(outputColumnName)) {
         if (filter instanceof AndFilter) {
-          preFilterList.add(new AndFilter(recursiveRewriteOnUnnestFilters(
+          List<Filter> andChildFilters = recursiveRewriteOnUnnestFilters(
               (BooleanFilter) filter,
               inputColumn,
               inputColumnCapabilites,
               filterSplitter,
               isTopLevelAndFilter
-          )));
+          );
+          if (!andChildFilters.isEmpty()) {
+            preFilterList.add(new AndFilter(andChildFilters));
+          }
         } else if (filter instanceof OrFilter) {
           // in case of Or Fiters, we set isTopLevelAndFilter to false that prevents pushing down any child filters to base
           List<Filter> orChildFilters = recursiveRewriteOnUnnestFilters(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -4825,13 +4825,15 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                   ))
                   .intervals(querySegmentSpec(Filtration.eternity()))
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                  .filters(or(
-                      expressionFilter("(\"j0.unnest\" == \"m2\")"),
-                      and(
-                          isNull("j0.unnest"),
-                          not(expressionFilter("(\"j0.unnest\" == \"m2\")"))
-                      )
-                  ))
+                  .filters(
+                      useDefault ? expressionFilter("(\"j0.unnest\" == \"m2\")") :
+                      or(
+                          expressionFilter("(\"j0.unnest\" == \"m2\")"),
+                          and(
+                              isNull("j0.unnest"),
+                              not(expressionFilter("(\"j0.unnest\" == \"m2\")"))
+                          )
+                      ))
                   .legacy(false)
                   .context(QUERY_CONTEXT_UNNEST)
                   .columns(ImmutableList.of("j0.unnest", "m2"))


### PR DESCRIPTION
…pty children

Currently null if on unnest fails with an error 
![image](https://github.com/apache/druid/assets/93540295/850a29d8-a4ac-4772-8c50-907c49e7a0e2)

This is due to the recursive filter creation in unnest storage adapter not performing correctly in case of an empty children. This PR addresses the issue

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
