### PR TITLE
Fix log syntax for KubernetesTaskRunner

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
@@ -121,13 +121,13 @@ public class KubernetesPeonClient
                                                                  .withName(taskId.getK8sJobName())
                                                                  .delete().isEmpty());
       if (result) {
-        log.info("Cleaned up k8s task: %s", taskId);
+        log.info("Cleaned up k8s job: %s", taskId);
       } else {
-        log.info("K8s task does not exist: %s", taskId);
+        log.info("K8s job does not exist: %s", taskId);
       }
       return result;
     } else {
-      log.info("Not cleaning up task %s due to flag: debugJobs=true", taskId);
+      log.info("Not cleaning up job %s due to flag: debugJobs=true", taskId);
       return true;
     }
   }


### PR DESCRIPTION
Since this function (deletePeonJobs) is deleting jobs and not tasks (doesn't make sense to delete tasks from k8s), we should log accordingly.

### Description
Make debugging the KubernetesTaskRunner easier.

#### Release note
Cleanup some logs in the KubernetesTaskRunner for easier debugging.

##### Key changed/added classes in this PR
 * KubernetesPeonClient

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
