### PR TITLE
update RoaringBitmap to 0.9.49

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2464,7 +2464,7 @@ name: RoaringBitmap
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.9.0
+version: 0.9.49
 libraries:
   - org.roaringbitmap: RoaringBitmap
   - org.roaringbitmap: shims

--- a/pom.xml
+++ b/pom.xml
@@ -912,7 +912,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.9.0</version>
+                <version>0.9.49</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/BatchIteratorAdapter.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/BatchIteratorAdapter.java
@@ -21,13 +21,13 @@ package org.apache.druid.collections.bitmap;
 
 import com.google.common.base.Preconditions;
 import org.roaringbitmap.BatchIterator;
-import org.roaringbitmap.IntIterator;
+import org.roaringbitmap.PeekableIntIterator;
 
 public final class BatchIteratorAdapter implements BatchIterator
 {
-  private final IntIterator iterator;
+  private final PeekableIntIterator iterator;
 
-  public BatchIteratorAdapter(IntIterator iterator)
+  public BatchIteratorAdapter(PeekableIntIterator iterator)
   {
     this.iterator = Preconditions.checkNotNull(iterator, "iterator");
   }
@@ -47,6 +47,12 @@ public final class BatchIteratorAdapter implements BatchIterator
   public boolean hasNext()
   {
     return iterator.hasNext();
+  }
+
+  @Override
+  public void advanceIfNeeded(int target)
+  {
+    iterator.advanceIfNeeded(target);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/collections/bitmap/ImmutableBitmap.java
+++ b/processing/src/main/java/org/apache/druid/collections/bitmap/ImmutableBitmap.java
@@ -47,7 +47,7 @@ public interface ImmutableBitmap
    */
   default BatchIterator batchIterator()
   {
-    return new BatchIteratorAdapter(iterator());
+    return new BatchIteratorAdapter(peekableIterator());
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/collections/bitmap/BatchIteratorAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/bitmap/BatchIteratorAdapterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections.bitmap;
+
+import org.apache.druid.collections.IntSetTestUtility;
+import org.junit.Assert;
+import org.junit.Test;
+import org.roaringbitmap.BatchIterator;
+
+import java.util.BitSet;
+
+public class BatchIteratorAdapterTest
+{
+  @Test
+  public void advanceIfNeeded()
+  {
+    BitSet simpleBitSet = IntSetTestUtility.createSimpleBitSet(IntSetTestUtility.getSetBits());
+    WrappedBitSetBitmap bitSetBitmap = new WrappedBitSetBitmap(simpleBitSet);
+    BatchIterator batchIterator = bitSetBitmap.batchIterator();
+    batchIterator.advanceIfNeeded(4);
+    int[] batch = new int[3];
+    batchIterator.nextBatch(batch);
+    Assert.assertArrayEquals(new int[]{5, 8, 13}, batch);
+  }
+}


### PR DESCRIPTION
* update RoaringBitmap from 0.9.0 to 0.9.49

  Many optimizations and improvements have gone into recent releases of RoaringBitmap.
  It seems worthwhile to incorporate those.
  https://github.com/RoaringBitmap/RoaringBitmap/releases

* update `BatchIteratorAdapter` to use `PeekableIntIterator` in order to implement
  newly added `BatchIterator.advanceIfNeeded` method