### PR TITLE
Update maven-shade-plugin to 3.4.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1730,7 +1730,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.4</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We have been seeing issues recently with "Error creating shaded jar: duplicate entry" errors. It may be that this is due to building twice without an intervening clean. If so, [MSHADE-425](https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-425) fixes this case in maven-shade-plugin 3.4.0.