### PR TITLE
Validate datasource retention rules: Reject rules that fully contain subsequent rules' interval

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverBroadcastDistributionRule.java
@@ -57,6 +57,12 @@ public class ForeverBroadcastDistributionRule extends BroadcastDistributionRule
   }
 
   @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return Rules.FOREVER_INTERVAL;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -74,5 +80,11 @@ public class ForeverBroadcastDistributionRule extends BroadcastDistributionRule
   public int hashCode()
   {
     return Objects.hash(getType());
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ForeverBroadcastDistributionRule{}";
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverBroadcastDistributionRule.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -57,9 +58,9 @@ public class ForeverBroadcastDistributionRule extends BroadcastDistributionRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return Rules.FOREVER_INTERVAL;
+    return Intervals.ETERNITY;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverDropRule.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -48,9 +49,9 @@ public class ForeverDropRule extends DropRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return Rules.FOREVER_INTERVAL;
+    return Intervals.ETERNITY;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverDropRule.java
@@ -46,4 +46,16 @@ public class ForeverDropRule extends DropRule
   {
     return true;
   }
+
+  @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return Rules.FOREVER_INTERVAL;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ForeverDropRule{}";
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverLoadRule.java
@@ -60,4 +60,18 @@ public class ForeverLoadRule extends LoadRule
     return true;
   }
 
+  @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return Rules.FOREVER_INTERVAL;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "ForeverLoadRule{" +
+           "tieredReplicants=" + getTieredReplicants() +
+           ", useDefaultTierForNull=" + useDefaultTierForNull() +
+           '}';
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/ForeverLoadRule.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -61,9 +62,9 @@ public class ForeverLoadRule extends LoadRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return Rules.FOREVER_INTERVAL;
+    return Intervals.ETERNITY;
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalBroadcastDistributionRule.java
@@ -66,7 +66,7 @@ public class IntervalBroadcastDistributionRule extends BroadcastDistributionRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return interval;
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalBroadcastDistributionRule.java
@@ -66,6 +66,12 @@ public class IntervalBroadcastDistributionRule extends BroadcastDistributionRule
   }
 
   @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return interval;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -82,5 +88,13 @@ public class IntervalBroadcastDistributionRule extends BroadcastDistributionRule
   public int hashCode()
   {
     return Objects.hash(getInterval());
+  }
+
+  @Override
+  public String toString()
+  {
+    return "IntervalBroadcastDistributionRule{" +
+           "interval=" + interval +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalDropRule.java
@@ -67,7 +67,7 @@ public class IntervalDropRule extends DropRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return interval;
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalDropRule.java
@@ -67,6 +67,12 @@ public class IntervalDropRule extends DropRule
   }
 
   @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return interval;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -83,5 +89,13 @@ public class IntervalDropRule extends DropRule
   public int hashCode()
   {
     return Objects.hash(interval);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "IntervalDropRule{" +
+           "interval=" + interval +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalLoadRule.java
@@ -72,7 +72,7 @@ public class IntervalLoadRule extends LoadRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return interval;
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/IntervalLoadRule.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -34,8 +33,6 @@ import java.util.Objects;
  */
 public class IntervalLoadRule extends LoadRule
 {
-  private static final Logger log = new Logger(IntervalLoadRule.class);
-
   private final Interval interval;
 
   @JsonCreator
@@ -75,6 +72,12 @@ public class IntervalLoadRule extends LoadRule
   }
 
   @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return interval;
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -94,5 +97,15 @@ public class IntervalLoadRule extends LoadRule
   public int hashCode()
   {
     return Objects.hash(super.hashCode(), interval);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "IntervalLoadRule{" +
+           "interval=" + interval +
+           ", tieredReplicants=" + getTieredReplicants() +
+           ", useDefaultTierForNull=" + useDefaultTierForNull() +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
@@ -65,6 +65,12 @@ public class PeriodBroadcastDistributionRule extends BroadcastDistributionRule
     return Rules.eligibleForLoad(period, interval, referenceTimestamp, includeFuture);
   }
 
+  @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+  }
+
   @JsonProperty
   public Period getPeriod()
   {
@@ -95,5 +101,14 @@ public class PeriodBroadcastDistributionRule extends BroadcastDistributionRule
   public int hashCode()
   {
     return Objects.hash(getPeriod(), isIncludeFuture());
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PeriodBroadcastDistributionRule{" +
+           "period=" + period +
+           ", includeFuture=" + includeFuture +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -68,7 +70,7 @@ public class PeriodBroadcastDistributionRule extends BroadcastDistributionRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT))
                          : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
@@ -66,9 +66,9 @@ public class PeriodBroadcastDistributionRule extends BroadcastDistributionRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+    return new Interval(period, referenceTimestamp);
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodBroadcastDistributionRule.java
@@ -68,7 +68,8 @@ public class PeriodBroadcastDistributionRule extends BroadcastDistributionRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return new Interval(period, referenceTimestamp);
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+                         : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 
   @JsonProperty

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
@@ -66,7 +66,7 @@ public class PeriodDropBeforeRule extends DropRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return new Interval(DateTimes.utc(Long.MIN_VALUE), referenceTimestamp.minus(period));
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -62,5 +63,19 @@ public class PeriodDropBeforeRule extends DropRule
   {
     final DateTime periodAgo = referenceTimestamp.minus(period);
     return theInterval.getEndMillis() <= periodAgo.getMillis();
+  }
+
+  @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return new Interval(DateTimes.utc(Long.MIN_VALUE), referenceTimestamp.minus(period));
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PeriodDropBeforeRule{" +
+           "period=" + period +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropBeforeRule.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordinator.rules;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -68,6 +69,7 @@ public class PeriodDropBeforeRule extends DropRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
+//    return new Interval(DateTimes.utc(JodaUtils.MIN_INSTANT), referenceTimestamp.minus(period));
     return new Interval(DateTimes.utc(Long.MIN_VALUE), referenceTimestamp.minus(period));
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -82,7 +82,7 @@ public class PeriodDropRule extends DropRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -85,7 +87,7 @@ public class PeriodDropRule extends DropRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT))
                          : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -22,7 +22,6 @@ package org.apache.druid.server.coordinator.rules;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -87,7 +86,7 @@ public class PeriodDropRule extends DropRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT))
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.MAX)
                          : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -80,4 +80,19 @@ public class PeriodDropRule extends DropRule
       return currInterval.contains(theInterval);
     }
   }
+
+  @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PeriodDropRule{" +
+           "period=" + period +
+           ", includeFuture=" + includeFuture +
+           '}';
+  }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodDropRule.java
@@ -27,6 +27,7 @@ import org.joda.time.Interval;
 import org.joda.time.Period;
 
 /**
+ *
  */
 public class PeriodDropRule extends DropRule
 {
@@ -84,7 +85,8 @@ public class PeriodDropRule extends DropRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+                         : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -22,7 +22,6 @@ package org.apache.druid.server.coordinator.rules;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -88,7 +87,7 @@ public class PeriodLoadRule extends LoadRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT))
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.MAX)
                          : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -21,7 +21,6 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -35,7 +34,6 @@ import java.util.Objects;
  */
 public class PeriodLoadRule extends LoadRule
 {
-  private static final Logger log = new Logger(PeriodLoadRule.class);
   static final boolean DEFAULT_INCLUDE_FUTURE = true;
 
   private final Period period;
@@ -86,6 +84,12 @@ public class PeriodLoadRule extends LoadRule
   }
 
   @Override
+  public Interval getInterval(DateTime referenceTimestamp)
+  {
+    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {
@@ -105,5 +109,16 @@ public class PeriodLoadRule extends LoadRule
   public int hashCode()
   {
     return Objects.hash(super.hashCode(), period, includeFuture);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PeriodLoadRule{" +
+           "period=" + period +
+           ", includeFuture=" + includeFuture +
+           ", tieredReplicants=" + getTieredReplicants() +
+           ", useDefaultTierForNull=" + useDefaultTierForNull() +
+           '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.coordinator.rules;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -86,7 +88,7 @@ public class PeriodLoadRule extends LoadRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT))
                          : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -84,7 +84,7 @@ public class PeriodLoadRule extends LoadRule
   }
 
   @Override
-  public Interval getInterval(DateTime referenceTimestamp)
+  public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
     return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/PeriodLoadRule.java
@@ -86,7 +86,8 @@ public class PeriodLoadRule extends LoadRule
   @Override
   public Interval getEligibleInterval(DateTime referenceTimestamp)
   {
-    return new Interval(referenceTimestamp.minus(period), referenceTimestamp);
+    return includeFuture ? new Interval(referenceTimestamp.minus(period), referenceTimestamp.plus(period))
+                         : new Interval(referenceTimestamp.minus(period), referenceTimestamp);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -53,8 +53,8 @@ public interface Rule
 
   /**
    * Returns the interval eligible for this rule. The interval must be computed based on the rule type
-   * optionally using {@code referenceTimestamp}. {@code referenceTimestamp} must be a timestamp
-   * between [{@link org.apache.druid.java.util.common.DateTimes.MIN}, {@link org.apache.druid.java.util.common.DateTimes.MAX}).
+   * optionally using {@code referenceTimestamp}. {@code referenceTimestamp} must be a {@link DateTime}
+   * between [{@link org.apache.druid.java.util.common.DateTimes#MIN}, {@link org.apache.druid.java.util.common.DateTimes#MAX}].
    */
   Interval getEligibleInterval(DateTime referenceTimestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -50,4 +50,6 @@ public interface Rule
   boolean appliesTo(Interval interval, DateTime referenceTimestamp);
 
   void run(DataSegment segment, SegmentActionHandler segmentHandler);
+
+  Interval getInterval(DateTime referenceTimestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -52,10 +52,9 @@ public interface Rule
   void run(DataSegment segment, SegmentActionHandler segmentHandler);
 
   /**
-   * Return an eligible interval from the reference timestamp. Implemntations
+   * Return an eligible interval from the reference timestamp. Implementations
    * must return a valid interval based on the rule type.
    * @param referenceTimestamp base timestamp
-   * @return
    */
   Interval getEligibleInterval(DateTime referenceTimestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -51,5 +51,11 @@ public interface Rule
 
   void run(DataSegment segment, SegmentActionHandler segmentHandler);
 
-  Interval getInterval(DateTime referenceTimestamp);
+  /**
+   * Return an eligible interval from the reference timestamp. Implemntations
+   * must return a valid interval based on the rule type.
+   * @param referenceTimestamp base timestamp
+   * @return
+   */
+  Interval getEligibleInterval(DateTime referenceTimestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rule.java
@@ -52,9 +52,9 @@ public interface Rule
   void run(DataSegment segment, SegmentActionHandler segmentHandler);
 
   /**
-   * Return an eligible interval from the reference timestamp. Implementations
-   * must return a valid interval based on the rule type.
-   * @param referenceTimestamp base timestamp
+   * Returns the interval eligible for this rule. The interval must be computed based on the rule type
+   * optionally using {@code referenceTimestamp}. {@code referenceTimestamp} must be a timestamp
+   * between [{@link org.apache.druid.java.util.common.DateTimes.MIN}, {@link org.apache.druid.java.util.common.DateTimes.MAX}).
    */
   Interval getEligibleInterval(DateTime referenceTimestamp);
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
@@ -25,7 +25,11 @@ import org.apache.druid.java.util.common.Intervals;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
+import org.joda.time.base.BaseInterval;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 
 public class Rules
@@ -60,6 +64,7 @@ public class Rules
     if (rules == null) {
       return;
     }
+
     final DateTime now = DateTimes.nowUtc();
     for (int i = 0; i < rules.size() - 1; i++) {
       final Rule currRule = rules.get(i);

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
@@ -19,12 +19,15 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import org.apache.druid.java.util.common.DateTimes;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
 public class Rules
 {
+  public static final Interval FOREVER_INTERVAL = new Interval(DateTimes.utc(Long.MIN_VALUE), DateTimes.utc(Long.MAX_VALUE));
+
   public static boolean eligibleForLoad(Interval src, Interval target)
   {
     return src.overlaps(target);

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
@@ -55,14 +55,15 @@ public class Rules
    * is not fully covered by the eligible interval of any preceding rule in the list.
    * <p>
    * Consider two rules r1 and r2. Assume r1 and r2's eligible intervals at the time when the rules are evaluated are
-   * i1 and i2 respectively. r1 and r2 are invalid if:
+   * i1 and i2, respectively. r1 and r2 are invalid if:
    *  <ul>
    *    <li> i1 is eternity. i.e., eternity fully covers i2 and any other interval that follows it. Or </li>
    *    <li> i1 fully contains i2 and </li>
-   *    <li> r1's eligible interval at i1's start and end fully contain r2's eligible interval at i1's start and end
-   *    respectively. This boundary check is used to identify rules that will fire at some point. i.e., period based rules
-   *    will return distinct eligible intervals at the boundaries, whereas broadcast and interval based rules will return
-   *    fixed intervals regardless of the boundary.  </li>
+   *    <li> r1's eligible intervals at i1's start and end fully contain r2's eligible intervals at i1's start and end,
+   *    respectively. This boundary check is used to identify rules that will fire at some point. i.e., period type rules
+   *    will yield distinct eligible intervals at the boundaries, whereas broadcast and interval type rules will return
+   *    fixed intervals regardless of the boundary. Therefore, period rules cannot always fully contain interval
+   *    rules and vice-versa. </li>
    *  </ul>
    *  </p>
    * @throws org.apache.druid.error.DruidException with error code "invalidInput" if any of the given rules is not valid.

--- a/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/rules/Rules.java
@@ -19,15 +19,17 @@
 
 package org.apache.druid.server.coordinator.rules;
 
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 
+import java.util.List;
+
 public class Rules
 {
-  public static final Interval FOREVER_INTERVAL = new Interval(DateTimes.utc(Long.MIN_VALUE), DateTimes.utc(Long.MAX_VALUE));
-
   public static boolean eligibleForLoad(Interval src, Interval target)
   {
     return src.overlaps(target);
@@ -45,5 +47,41 @@ public class Rules
 
   private Rules()
   {
+  }
+
+  /**
+   * Validate rules. This method throws an exception if a rule contain an interval that
+   * will fully cover the next rules' interval in the list. Rules that will be evaluated at some point
+   * are considered to be legitimate.
+   * @param rules Datasource rules.
+   */
+  public static void validateRules(final List<Rule> rules)
+  {
+    if (rules == null) {
+      return;
+    }
+    final DateTime now = DateTimes.nowUtc();
+    for (int i = 0; i < rules.size() - 1; i++) {
+      final Rule currRule = rules.get(i);
+      final Rule nextRule = rules.get(i + 1);
+      final Interval currInterval = currRule.getEligibleInterval(now);
+      final Interval nextInterval = nextRule.getEligibleInterval(now);
+      if (currInterval.contains(nextInterval)) {
+        // If the current rule has an eternity interval, it covers everything following it.
+        // Or if the current rule still covers the next rule at the current interval boundaries, then the
+        // next rule will never fire at any time, so throw an exception.
+        if (Intervals.ETERNITY.equals(currInterval) ||
+            (currRule.getEligibleInterval(currInterval.getStart()).contains(nextRule.getEligibleInterval(currInterval.getStart()))
+             && currRule.getEligibleInterval(currInterval.getEnd()).contains(nextRule.getEligibleInterval(currInterval.getEnd())))) {
+          throw InvalidInput.exception(
+              "Rule[%s] has an interval that contains interval for rule[%s]. The interval[%s] also covers interval[%s].",
+              currRule,
+              nextRule,
+              currInterval,
+              nextInterval
+          );
+        }
+      }
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/RulesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/RulesResource.java
@@ -25,15 +25,12 @@ import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.audit.AuditInfo;
 import org.apache.druid.audit.AuditManager;
-import org.apache.druid.error.InvalidInput;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.server.coordinator.rules.Rules;
 import org.apache.druid.server.http.security.RulesResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
-import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
 import javax.servlet.http.HttpServletRequest;
@@ -112,7 +109,7 @@ public class RulesResource
   )
   {
     try {
-      validateRules(rules);
+      Rules.validateRules(rules);
       final AuditInfo auditInfo = new AuditInfo(author, comment, req.getRemoteAddr());
       if (databaseRuleManager.overrideRule(dataSourceName, rules, auditInfo)) {
         return Response.ok().build();
@@ -184,39 +181,5 @@ public class RulesResource
       return auditManager.fetchAuditHistory(dataSourceName, AUDIT_HISTORY_TYPE, theInterval);
     }
     return auditManager.fetchAuditHistory(AUDIT_HISTORY_TYPE, theInterval);
-  }
-
-  /**
-   * Validate rules. Throws an exception if a rule contain an interval that will overshadow another rules' interval.
-   * Rules that will be evaluated at some point are considered to be non-overshadowing.
-   * @param rules Datasource rules.
-   */
-  private void validateRules(final List<Rule> rules)
-  {
-    if (rules == null) {
-      return;
-    }
-    final DateTime now = DateTimes.nowUtc();
-    for (int i = 0; i < rules.size() - 1; i++) {
-      final Rule currRule = rules.get(i);
-      final Rule nextRule = rules.get(i + 1);
-      final Interval currInterval = currRule.getInterval(now);
-      final Interval nextInterval = nextRule.getInterval(now);
-      if (currInterval.contains(nextInterval)) {
-        // If the current rule overshaows the next rule even at the intervals' boundaries, then we know that the next
-        // rule will always be a no-op. Also, a forever rule spans eternity and overshadows everything that follows it.
-        if (Rules.FOREVER_INTERVAL.equals(currInterval) ||
-                    (currRule.getInterval(currInterval.getStart()).contains(nextRule.getInterval(currInterval.getStart()))
-                     && currRule.getInterval(currInterval.getEnd()).contains(nextRule.getInterval(currInterval.getEnd())))) {
-          throw InvalidInput.exception(
-              "Rule[%s] has an interval that contains interval for rule[%s]. The interval[%s] also covers interval[%s].",
-              currRule,
-              nextRule,
-              currInterval,
-              nextInterval
-          );
-        }
-      }
-    }
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/RulesEligibleIntervalTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/RulesEligibleIntervalTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.rules;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.JodaUtils;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class RulesEligibleIntervalTest
+{
+  private final DateTime referenceTime;
+
+  @Parameterized.Parameters
+  public static Object[] getReferenceTimestamps()
+  {
+    final DateTime now = DateTimes.nowUtc();
+    return new Object[]{
+        now,
+        now.minusYears(5),
+        now.plusYears(10),
+        DateTimes.utc(0),
+        DateTimes.utc(JodaUtils.MIN_INSTANT + 1),
+        DateTimes.utc(JodaUtils.MIN_INSTANT),
+        DateTimes.utc(JodaUtils.MAX_INSTANT - 1),
+        DateTimes.utc(JodaUtils.MAX_INSTANT)
+    };
+  }
+
+  public RulesEligibleIntervalTest(final DateTime referenceTimestamp)
+  {
+    this.referenceTime = referenceTimestamp;
+  }
+
+  @Test
+  public void testPeriodLoadEligibleInterval()
+  {
+    final Period period = new Period("P50Y");
+    final PeriodLoadRule loadPT1H = new PeriodLoadRule(
+        period,
+        true,
+        null,
+        null
+    );
+    Assert.assertEquals(
+        new Interval(this.referenceTime.minus(period), DateTimes.MAX),
+        loadPT1H.getEligibleInterval(this.referenceTime)
+    );
+  }
+
+  @Test
+  public void testPeriodLoadExcludingFutureEligibleInterval()
+  {
+    final Period period = new Period("PT1H");
+    final PeriodLoadRule rule = new PeriodLoadRule(
+        period,
+        false,
+        null,
+        null
+    );
+    Assert.assertEquals(new Interval(period, this.referenceTime), rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testIntervalLoadEligibleInterval()
+  {
+    final Interval interval = Intervals.of("2000/3000");
+    final IntervalLoadRule rule = new IntervalLoadRule(
+        interval,
+        null,
+        null
+    );
+    Assert.assertEquals(interval, rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testForeverLoadEligibleInterval()
+  {
+    final ForeverLoadRule rule = new ForeverLoadRule(ImmutableMap.of(), false);
+    Assert.assertEquals(Intervals.ETERNITY, rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testPeriodDropEligibleInterval()
+  {
+    final Period period = new Period("P5000Y");
+    final PeriodDropRule rule = new PeriodDropRule(
+        period,
+        true
+    );
+    Assert.assertEquals(
+        new Interval(this.referenceTime.minus(period), DateTimes.utc(JodaUtils.MAX_INSTANT)),
+        rule.getEligibleInterval(this.referenceTime)
+    );
+  }
+
+  @Test
+  public void testPeriodDropExcludingFutureEligibleInterval()
+  {
+    final Period period = new Period("P50Y");
+    final PeriodDropRule rule = new PeriodDropRule(
+        period,
+        false
+    );
+    Assert.assertEquals(
+        new Interval(this.referenceTime.minus(period), this.referenceTime),
+        rule.getEligibleInterval(this.referenceTime)
+    );
+  }
+
+  @Test
+  public void testPeriodDropBeforeEligibleInterval()
+  {
+    final Period period = new Period("P50Y");
+    final PeriodDropBeforeRule rule = new PeriodDropBeforeRule(period);
+
+    if (this.referenceTime.minus(period).isBefore(DateTimes.MIN)) {
+      Assert.assertEquals(
+          new Interval(DateTimes.utc(Long.MIN_VALUE), this.referenceTime.minus(period)),
+          rule.getEligibleInterval(this.referenceTime)
+      );
+    } else {
+      Assert.assertEquals(
+          new Interval(DateTimes.MIN, this.referenceTime.minus(period)),
+          rule.getEligibleInterval(this.referenceTime)
+      );
+    }
+  }
+
+  @Test
+  public void testForeverDropEligibleInterval()
+  {
+    final ForeverDropRule rule = new ForeverDropRule();
+    Assert.assertEquals(Intervals.ETERNITY, rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testPeriodBroadcastEligibleInterval()
+  {
+    final Period period = new Period("P15Y");
+    final PeriodBroadcastDistributionRule rule = new PeriodBroadcastDistributionRule(period, true);
+    Assert.assertEquals(
+        new Interval(referenceTime.minus(period), DateTimes.MAX),
+        rule.getEligibleInterval(referenceTime)
+    );
+  }
+
+  @Test
+  public void testPeriodBroadcastExcludingFutureEligibleInterval()
+  {
+    final Period period = new Period("P15Y");
+    final PeriodBroadcastDistributionRule rule = new PeriodBroadcastDistributionRule(period, false);
+    Assert.assertEquals(new Interval(period, this.referenceTime), rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testForeverBroadcastEligibleInterval()
+  {
+    final ForeverBroadcastDistributionRule rule = new ForeverBroadcastDistributionRule();
+    Assert.assertEquals(Intervals.ETERNITY, rule.getEligibleInterval(this.referenceTime));
+  }
+
+  @Test
+  public void testIntervalBroadcastEligibleInterval()
+  {
+    final Interval interval = Intervals.of("1993/2070");
+    final IntervalBroadcastDistributionRule rule = new IntervalBroadcastDistributionRule(interval);
+    Assert.assertEquals(interval, rule.getEligibleInterval(this.referenceTime));
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/RulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/RulesTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.rules;
+
+import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
+import org.joda.time.Period;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(Parameterized.class)
+public class RulesTest
+{
+  // Load rules
+  private static final PeriodLoadRule LOAD_PT1H = new PeriodLoadRule(
+      new Period("PT1H"), true, null, null
+  );
+  private static final PeriodLoadRule LOAD_PT1H_EXLUDE_FUTURE = new PeriodLoadRule(
+      new Period("PT1H"), false, null, null
+  );
+  private static final PeriodLoadRule LOAD_P3M = new PeriodLoadRule(
+      new Period("P3M"), true, null, null
+  );
+  private static final IntervalLoadRule LOAD_2020_2023 = new IntervalLoadRule(
+      Intervals.of("2020/2023"), null, null
+  );
+  private static final IntervalLoadRule LOAD_2021_2022 = new IntervalLoadRule(
+      Intervals.of("2021/2022"), null, null
+  );
+  private static final IntervalLoadRule LOAD_1980_2050 = new IntervalLoadRule(
+      Intervals.of("1980/2050"), null, null
+  );
+  private static final ForeverLoadRule LOAD_FOREVER = new ForeverLoadRule(null, null);
+
+  // Drop rules
+  private static final PeriodDropBeforeRule DROP_BEFORE_P3M = new PeriodDropBeforeRule(new Period("P3M"));
+  private static final PeriodDropBeforeRule DROP_BEFORE_P6M = new PeriodDropBeforeRule(new Period("P6M"));
+  private static final PeriodDropRule DROP_P1M = new PeriodDropRule(new Period("P1M"), true);
+  private static final PeriodDropRule DROP_P2M = new PeriodDropRule(new Period("P2M"), true);
+  private static final IntervalDropRule DROP_2000_2020 = new IntervalDropRule(Intervals.of("2000/2020"));
+  private static final IntervalDropRule DROP_2010_2020 = new IntervalDropRule(Intervals.of("2010/2020"));
+  private static final ForeverDropRule DROP_FOREVER = new ForeverDropRule();
+
+  // Broadcast rules
+  private static final PeriodBroadcastDistributionRule BROADCAST_PT1H = new PeriodBroadcastDistributionRule(
+      new Period("PT1H"), true
+  );
+  private static final PeriodBroadcastDistributionRule BROADCAST_PT1H_EXCLUDE_FUTURE = new PeriodBroadcastDistributionRule(
+      new Period("PT1H"), false
+  );
+  private static final PeriodBroadcastDistributionRule BROADCAST_PT2H = new PeriodBroadcastDistributionRule(
+      new Period("PT2H"), true
+  );
+  private static final IntervalBroadcastDistributionRule BROADCAST_2000_2050 = new IntervalBroadcastDistributionRule(
+      Intervals.of("2000/2050")
+  );
+  private static final IntervalBroadcastDistributionRule BROADCAST_2010_2020 = new IntervalBroadcastDistributionRule(
+      Intervals.of("2010/2020")
+  );
+  private static final ForeverBroadcastDistributionRule BROADCAST_FOREVER = new ForeverBroadcastDistributionRule();
+
+  private final List<Rule> rules;
+  private final boolean isInvalid;
+  private final Rule invalidRule1;
+  private final Rule invalidRule2;
+
+  public RulesTest(final List<Rule> rules, final boolean isInvalid, final Rule invalidRule1, final Rule invalidRule2)
+  {
+    this.rules = rules;
+    this.isInvalid = isInvalid;
+    this.invalidRule1 = invalidRule1;
+    this.invalidRule2 = invalidRule2;
+  }
+
+  @Parameterized.Parameters
+  public static Object[] inputsAndExpectations()
+  {
+    return new Object[][] {
+        // Invalid rules
+        {getRules(LOAD_PT1H, LOAD_2021_2022, LOAD_FOREVER, LOAD_P3M), true, LOAD_FOREVER, LOAD_P3M},
+        {getRules(LOAD_PT1H, LOAD_P3M, LOAD_PT1H_EXLUDE_FUTURE, LOAD_1980_2050), true, LOAD_PT1H, LOAD_PT1H_EXLUDE_FUTURE},
+        {getRules(LOAD_PT1H, LOAD_P3M, LOAD_2020_2023, LOAD_P3M), true, LOAD_P3M, LOAD_P3M},
+        {getRules(LOAD_2020_2023, LOAD_2021_2022, LOAD_P3M, LOAD_FOREVER), true, LOAD_2020_2023, LOAD_2021_2022},
+        {getRules(LOAD_P3M, LOAD_2021_2022, LOAD_PT1H, LOAD_2020_2023), true, LOAD_P3M, LOAD_PT1H},
+        {getRules(LOAD_P3M, LOAD_2021_2022, LOAD_FOREVER, LOAD_2020_2023), true, LOAD_FOREVER, LOAD_2020_2023},
+        {getRules(DROP_BEFORE_P3M, DROP_P1M, DROP_BEFORE_P6M, DROP_FOREVER), true, DROP_BEFORE_P3M, DROP_BEFORE_P6M},
+        {getRules(DROP_P2M, DROP_P1M, DROP_FOREVER), true, DROP_P2M, DROP_P1M},
+        {getRules(DROP_2000_2020, DROP_P1M, DROP_P2M, DROP_2010_2020), true, DROP_2000_2020, DROP_2010_2020},
+        {getRules(DROP_P1M, DROP_FOREVER, DROP_P2M), true, DROP_FOREVER, DROP_P2M},
+        {getRules(BROADCAST_2000_2050, BROADCAST_PT1H, BROADCAST_2010_2020, BROADCAST_FOREVER), true, BROADCAST_2000_2050, BROADCAST_2010_2020},
+        {getRules(BROADCAST_PT2H, BROADCAST_2000_2050, BROADCAST_PT1H, BROADCAST_FOREVER), true, BROADCAST_PT2H, BROADCAST_PT1H},
+        {getRules(BROADCAST_PT1H, BROADCAST_PT1H_EXCLUDE_FUTURE, BROADCAST_FOREVER), true, BROADCAST_PT1H, BROADCAST_PT1H_EXCLUDE_FUTURE},
+        {getRules(BROADCAST_PT1H, BROADCAST_PT2H, BROADCAST_2010_2020, BROADCAST_FOREVER, BROADCAST_2000_2050), true, BROADCAST_FOREVER, BROADCAST_2000_2050},
+        {getRules(LOAD_PT1H, LOAD_1980_2050, LOAD_P3M, LOAD_FOREVER, DROP_FOREVER), true, LOAD_FOREVER, DROP_FOREVER},
+
+        // Valid rules
+        {null, false, null, null},
+        {getRules(), false, null, null},
+        {getRules(LOAD_FOREVER), false, null, null},
+        {getRules(LOAD_PT1H_EXLUDE_FUTURE, LOAD_PT1H, LOAD_P3M, LOAD_FOREVER), false, null, null},
+        {getRules(DROP_2010_2020, DROP_2000_2020, DROP_P1M, DROP_P2M, DROP_BEFORE_P3M, DROP_FOREVER), false, null, null},
+        {getRules(BROADCAST_PT1H, BROADCAST_PT2H, BROADCAST_2010_2020, BROADCAST_2000_2050, BROADCAST_FOREVER), false, null, null},
+        {getRules(DROP_BEFORE_P6M, DROP_P1M, DROP_BEFORE_P3M, LOAD_2020_2023, DROP_FOREVER), false, null, null},
+        {getRules(DROP_2000_2020, LOAD_PT1H, BROADCAST_2000_2050, LOAD_1980_2050, LOAD_P3M, LOAD_FOREVER), false, null, null},
+    };
+  }
+
+  private static ArrayList<Rule> getRules(Rule... rules)
+  {
+    return new ArrayList<>(Arrays.asList(rules));
+  }
+
+  @Test
+  public void testValidateRules()
+  {
+    if (this.isInvalid) {
+      DruidExceptionMatcher.invalidInput().expectMessageContains(
+          StringUtils.format("Rule[%s] has an interval that fully contains the interval for rule[%s].",
+                             invalidRule1, invalidRule2
+          )
+      ).assertThrowsAndMatches(() -> Rules.validateRules(rules));
+    } else {
+      Rules.validateRules(rules);
+    }
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
@@ -38,6 +38,7 @@ import org.apache.druid.server.coordinator.rules.PeriodDropBeforeRule;
 import org.apache.druid.server.coordinator.rules.PeriodDropRule;
 import org.apache.druid.server.coordinator.rules.PeriodLoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
+import org.apache.druid.server.coordinator.rules.Rules;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.joda.time.Period;
@@ -281,21 +282,21 @@ public class RulesResourceTest
     final RulesResource rulesResource = new RulesResource(databaseRuleManager, auditManager);
     final HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
 
-    final PeriodDropBeforeRule dropBeforeP3M = new PeriodDropBeforeRule(new Period("P3M"));
-    final PeriodDropBeforeRule dropBeforeP6M = new PeriodDropBeforeRule(new Period("P6M"));
+    final PeriodDropBeforeRule dropBeforeByP3M = new PeriodDropBeforeRule(new Period("P3M"));
+    final PeriodDropBeforeRule dropBeforeByP6M = new PeriodDropBeforeRule(new Period("P6M"));
     final PeriodDropRule dropByP1M = new PeriodDropRule(new Period("P1M"), true);
     final PeriodDropRule dropByP1MNoFuture = new PeriodDropRule(new Period("P1M"), false);
     final PeriodDropRule dropByP2M = new PeriodDropRule(new Period("P2M"), true);
     final ForeverDropRule dropForever = new ForeverDropRule();
 
     final List<Rule> rules = new ArrayList<>();
-    rules.add(dropBeforeP3M);
-    rules.add(dropBeforeP6M);
+    rules.add(dropBeforeByP3M);
+    rules.add(dropBeforeByP6M);
     rules.add(dropByP1M);
     rules.add(dropForever);
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
-        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", dropBeforeP3M, dropBeforeP6M)
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", dropBeforeByP3M, dropBeforeByP6M)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
@@ -336,9 +337,9 @@ public class RulesResourceTest
     final HttpServletRequest req = EasyMock.createMock(HttpServletRequest.class);
 
     final ForeverBroadcastDistributionRule broadcastForever = new ForeverBroadcastDistributionRule();
-    final PeriodBroadcastDistributionRule broadcastPeriodPT1H = new PeriodBroadcastDistributionRule(new Period("PT1H"), true);
-    final PeriodBroadcastDistributionRule broadcastPeriodPT1HNoFuture = new PeriodBroadcastDistributionRule(new Period("PT1H"), false);
-    final PeriodBroadcastDistributionRule broadcastPeriodPT2H = new PeriodBroadcastDistributionRule(new Period("PT2H"), true);
+    final PeriodBroadcastDistributionRule broadcastPT1H = new PeriodBroadcastDistributionRule(new Period("PT1H"), true);
+    final PeriodBroadcastDistributionRule broadcastPT1HNoFuture = new PeriodBroadcastDistributionRule(new Period("PT1H"), false);
+    final PeriodBroadcastDistributionRule broadcastPT2H = new PeriodBroadcastDistributionRule(new Period("PT2H"), true);
     final IntervalBroadcastDistributionRule broadcastInterval1 = new IntervalBroadcastDistributionRule(
         Intervals.of("2000-09-29T01:00:00Z/2050-10-30T01:00:00Z")
     );
@@ -356,36 +357,36 @@ public class RulesResourceTest
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
-    rules.add(broadcastPeriodPT2H);
-    rules.add(broadcastPeriodPT1H);
+    rules.add(broadcastPT2H);
+    rules.add(broadcastPT1H);
     rules.add(broadcastForever);
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
-        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT2H, broadcastPeriodPT1H)
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPT2H, broadcastPT1H)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
-    rules.add(broadcastPeriodPT1H);
-    rules.add(broadcastPeriodPT1H);
+    rules.add(broadcastPT1H);
+    rules.add(broadcastPT1H);
     rules.add(broadcastForever);
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
-        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT1H, broadcastPeriodPT1H)
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPT1H, broadcastPT1H)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     // Same interval with and without future.
     rules.clear();
-    rules.add(broadcastPeriodPT1H);
-    rules.add(broadcastPeriodPT1HNoFuture);
+    rules.add(broadcastPT1H);
+    rules.add(broadcastPT1HNoFuture);
     rules.add(broadcastForever);
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
-        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT1H, broadcastPeriodPT1HNoFuture)
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPT1H, broadcastPT1HNoFuture)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
-    rules.add(broadcastPeriodPT1H);
-    rules.add(broadcastPeriodPT2H);
+    rules.add(broadcastPT1H);
+    rules.add(broadcastPT2H);
     rules.add(broadcastInterval2);
     rules.add(broadcastForever);
     rules.add(broadcastInterval1);
@@ -413,25 +414,25 @@ public class RulesResourceTest
         null,
         null
     );
-    final PeriodLoadRule periodPT1H = new PeriodLoadRule(new Period("PT1H"), null, null, null);
-    final PeriodLoadRule periodP3M = new PeriodLoadRule(new Period("P3M"), null, null, null);
-    final PeriodLoadRule periodP6M = new PeriodLoadRule(new Period("P6M"), null, null, null);
-    final ForeverLoadRule foreverLoadRule = new ForeverLoadRule(null, null);
-    final ForeverDropRule foreverDropRule = new ForeverDropRule();
-    final PeriodBroadcastDistributionRule broadcastPeriodPT15m = new PeriodBroadcastDistributionRule(new Period("PT15m"), true);
+    final PeriodLoadRule loadPT1H = new PeriodLoadRule(new Period("PT1H"), null, null, null);
+    final PeriodLoadRule loadP3M = new PeriodLoadRule(new Period("P3M"), null, null, null);
+    final PeriodLoadRule loadP6M = new PeriodLoadRule(new Period("P6M"), null, null, null);
+    final ForeverLoadRule loadForever = new ForeverLoadRule(null, null);
+    final ForeverDropRule dropForever = new ForeverDropRule();
+    final PeriodBroadcastDistributionRule broadcastPT15m = new PeriodBroadcastDistributionRule(new Period("PT15m"), true);
 
     final List<Rule> rules = new ArrayList<>();
     rules.add(loadSmallInterval);
     rules.add(loadLargeInteval);
-    rules.add(broadcastPeriodPT15m);
-    rules.add(periodPT1H);
-    rules.add(periodP3M);
-    rules.add(periodP6M);
-    rules.add(foreverLoadRule);
-    rules.add(foreverDropRule);
+    rules.add(broadcastPT15m);
+    rules.add(loadPT1H);
+    rules.add(loadP3M);
+    rules.add(loadP6M);
+    rules.add(loadForever);
+    rules.add(dropForever);
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
-        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", foreverLoadRule, foreverDropRule)
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", loadForever, dropForever)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
   }
 
@@ -453,45 +454,45 @@ public class RulesResourceTest
         null,
         null
     );
-    final PeriodLoadRule periodPT1H = new PeriodLoadRule(new Period("PT1H"), true, null, null);
-    final PeriodLoadRule periodPT1HNoFuture = new PeriodLoadRule(new Period("PT1H"), false, null, null);
-    final PeriodLoadRule periodP3M = new PeriodLoadRule(new Period("P3M"), true, null, null);
-    final PeriodLoadRule periodP6M = new PeriodLoadRule(new Period("P6M"), true, null, null);
+    final PeriodLoadRule loadPT1H = new PeriodLoadRule(new Period("PT1H"), true, null, null);
+    final PeriodLoadRule loadPT1HNoFuture = new PeriodLoadRule(new Period("PT1H"), false, null, null);
+    final PeriodLoadRule loadP3M = new PeriodLoadRule(new Period("P3M"), true, null, null);
+    final PeriodLoadRule loadP6M = new PeriodLoadRule(new Period("P6M"), true, null, null);
     final PeriodDropRule dropByP1M = new PeriodDropRule(new Period("P1M"), true);
     final PeriodDropRule dropByP1MNoFuture = new PeriodDropRule(new Period("P1M"), false);
-    final ForeverLoadRule foreverLoadRule = new ForeverLoadRule(null, null);
-    final ForeverDropRule foreverDropRule = new ForeverDropRule();
-    final PeriodBroadcastDistributionRule broadcastPeriodPT15m = new PeriodBroadcastDistributionRule(new Period("PT15m"), true);
-    final PeriodBroadcastDistributionRule broadcastPeriodPT15mNoFuture = new PeriodBroadcastDistributionRule(new Period("PT15m"), false);
+    final ForeverLoadRule loadForever = new ForeverLoadRule(null, null);
+    final ForeverDropRule dropForever = new ForeverDropRule();
+    final PeriodBroadcastDistributionRule broadcastPT15m = new PeriodBroadcastDistributionRule(new Period("PT15m"), true);
+    final PeriodBroadcastDistributionRule broadcastPT15mNoFuture = new PeriodBroadcastDistributionRule(new Period("PT15m"), false);
 
     final List<Rule> rules = new ArrayList<>();
     rules.add(loadSmallInterval);
     rules.add(loadLargeInteval);
-    rules.add(broadcastPeriodPT15m);
-    rules.add(periodPT1HNoFuture);
-    rules.add(periodPT1H);
+    rules.add(broadcastPT15m);
+    rules.add(loadPT1HNoFuture);
+    rules.add(loadPT1H);
     rules.add(dropByP1MNoFuture);
     rules.add(dropByP1M);
-    rules.add(periodP3M);
-    rules.add(periodP6M);
-    rules.add(foreverLoadRule);
+    rules.add(loadP3M);
+    rules.add(loadP6M);
+    rules.add(loadForever);
 
     final Response resp = rulesResource.setDatasourceRules("dataSource1", rules, null, null, EasyMock.createMock(HttpServletRequest.class));
     Assert.assertEquals(200, resp.getStatus());
     EasyMock.verify(databaseRuleManager);
 
     rules.clear();
-    rules.add(broadcastPeriodPT15mNoFuture);
-    rules.add(broadcastPeriodPT15m);
-    rules.add(periodPT1HNoFuture);
-    rules.add(periodPT1H);
+    rules.add(broadcastPT15mNoFuture);
+    rules.add(broadcastPT15m);
+    rules.add(loadPT1HNoFuture);
+    rules.add(loadPT1H);
     rules.add(dropByP1MNoFuture);
     rules.add(dropByP1M);
-    rules.add(periodP3M);
-    rules.add(periodP6M);
+    rules.add(loadP3M);
+    rules.add(loadP6M);
     rules.add(loadSmallInterval);
     rules.add(loadLargeInteval);
-    rules.add(foreverDropRule);
+    rules.add(dropForever);
 
     final Response resp2 = rulesResource.setDatasourceRules("dataSource1", rules, null, null, EasyMock.createMock(HttpServletRequest.class));
     Assert.assertEquals(200, resp2.getStatus());

--- a/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
@@ -234,6 +234,15 @@ public class RulesResourceTest
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
+    rules.add(loadPT1H);
+    rules.add(loadPT1H);
+    rules.add(loadP6M);
+
+    DruidExceptionMatcher.invalidInput().expectMessageContains(
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", loadPT1H, loadPT1H)
+    ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
+
+    rules.clear();
     rules.add(loadInterval1);
     rules.add(loadInterval2);
     rules.add(loadP6M);
@@ -332,7 +341,6 @@ public class RulesResourceTest
     DruidExceptionMatcher.invalidInput().expectMessageContains(
         StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT2H, broadcastPeriodPT1H)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
-
 
     rules.clear();
     rules.add(broadcastPeriodPT1H);

--- a/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RulesResourceTest.java
@@ -200,9 +200,10 @@ public class RulesResourceTest
         null,
         null
     );
-    final PeriodLoadRule loadPT1H = new PeriodLoadRule(new Period("PT1H"), null, null, null);
-    final PeriodLoadRule loadP3M = new PeriodLoadRule(new Period("P3M"), null, null, null);
-    final PeriodLoadRule loadP6M = new PeriodLoadRule(new Period("P6M"), null, null, null);
+    final PeriodLoadRule loadPT1H = new PeriodLoadRule(new Period("PT1H"), true, null, null);
+    final PeriodLoadRule loadPT1HNoFuture = new PeriodLoadRule(new Period("PT1H"), false, null, null);
+    final PeriodLoadRule loadP3M = new PeriodLoadRule(new Period("P3M"), true, null, null);
+    final PeriodLoadRule loadP6M = new PeriodLoadRule(new Period("P6M"), true, null, null);
     final ForeverLoadRule loadForever = new ForeverLoadRule(null, null);
 
     final List<Rule> rules = new ArrayList<>();
@@ -231,6 +232,15 @@ public class RulesResourceTest
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
         StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", loadForever, loadPT1H)
+    ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
+
+    rules.clear();
+    rules.add(loadPT1H);
+    rules.add(loadPT1HNoFuture);
+    rules.add(loadP6M);
+
+    DruidExceptionMatcher.invalidInput().expectMessageContains(
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", loadPT1H, loadPT1HNoFuture)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
@@ -274,6 +284,7 @@ public class RulesResourceTest
     final PeriodDropBeforeRule dropBeforeP3M = new PeriodDropBeforeRule(new Period("P3M"));
     final PeriodDropBeforeRule dropBeforeP6M = new PeriodDropBeforeRule(new Period("P6M"));
     final PeriodDropRule dropByP1M = new PeriodDropRule(new Period("P1M"), true);
+    final PeriodDropRule dropByP1MNoFuture = new PeriodDropRule(new Period("P1M"), false);
     final PeriodDropRule dropByP2M = new PeriodDropRule(new Period("P2M"), true);
     final ForeverDropRule dropForever = new ForeverDropRule();
 
@@ -297,6 +308,16 @@ public class RulesResourceTest
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
+    rules.add(dropByP1M);
+    rules.add(dropByP1MNoFuture);
+    rules.add(dropForever);
+
+    DruidExceptionMatcher.invalidInput().expectMessageContains(
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", dropByP1M, dropByP1MNoFuture)
+    ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
+
+
+    rules.clear();
     rules.add(dropForever);
     rules.add(dropByP1M);
     rules.add(dropByP2M);
@@ -316,6 +337,7 @@ public class RulesResourceTest
 
     final ForeverBroadcastDistributionRule broadcastForever = new ForeverBroadcastDistributionRule();
     final PeriodBroadcastDistributionRule broadcastPeriodPT1H = new PeriodBroadcastDistributionRule(new Period("PT1H"), true);
+    final PeriodBroadcastDistributionRule broadcastPeriodPT1HNoFuture = new PeriodBroadcastDistributionRule(new Period("PT1H"), false);
     final PeriodBroadcastDistributionRule broadcastPeriodPT2H = new PeriodBroadcastDistributionRule(new Period("PT2H"), true);
     final IntervalBroadcastDistributionRule broadcastInterval1 = new IntervalBroadcastDistributionRule(
         Intervals.of("2000-09-29T01:00:00Z/2050-10-30T01:00:00Z")
@@ -340,6 +362,25 @@ public class RulesResourceTest
 
     DruidExceptionMatcher.invalidInput().expectMessageContains(
         StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT2H, broadcastPeriodPT1H)
+    ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
+
+    rules.clear();
+    rules.add(broadcastPeriodPT1H);
+    rules.add(broadcastPeriodPT1H);
+    rules.add(broadcastForever);
+
+    DruidExceptionMatcher.invalidInput().expectMessageContains(
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT1H, broadcastPeriodPT1H)
+    ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
+
+    // Same interval with and without future.
+    rules.clear();
+    rules.add(broadcastPeriodPT1H);
+    rules.add(broadcastPeriodPT1HNoFuture);
+    rules.add(broadcastForever);
+
+    DruidExceptionMatcher.invalidInput().expectMessageContains(
+        StringUtils.format("Rule[%s] has an interval that contains interval for rule[%s].", broadcastPeriodPT1H, broadcastPeriodPT1HNoFuture)
     ).assertThrowsAndMatches(() -> rulesResource.setDatasourceRules("dataSource1", rules, null, null, req));
 
     rules.clear();
@@ -412,18 +453,25 @@ public class RulesResourceTest
         null,
         null
     );
-    final PeriodLoadRule periodPT1H = new PeriodLoadRule(new Period("PT1H"), null, null, null);
-    final PeriodLoadRule periodP3M = new PeriodLoadRule(new Period("P3M"), null, null, null);
-    final PeriodLoadRule periodP6M = new PeriodLoadRule(new Period("P6M"), null, null, null);
+    final PeriodLoadRule periodPT1H = new PeriodLoadRule(new Period("PT1H"), true, null, null);
+    final PeriodLoadRule periodPT1HNoFuture = new PeriodLoadRule(new Period("PT1H"), false, null, null);
+    final PeriodLoadRule periodP3M = new PeriodLoadRule(new Period("P3M"), true, null, null);
+    final PeriodLoadRule periodP6M = new PeriodLoadRule(new Period("P6M"), true, null, null);
+    final PeriodDropRule dropByP1M = new PeriodDropRule(new Period("P1M"), true);
+    final PeriodDropRule dropByP1MNoFuture = new PeriodDropRule(new Period("P1M"), false);
     final ForeverLoadRule foreverLoadRule = new ForeverLoadRule(null, null);
     final ForeverDropRule foreverDropRule = new ForeverDropRule();
     final PeriodBroadcastDistributionRule broadcastPeriodPT15m = new PeriodBroadcastDistributionRule(new Period("PT15m"), true);
+    final PeriodBroadcastDistributionRule broadcastPeriodPT15mNoFuture = new PeriodBroadcastDistributionRule(new Period("PT15m"), false);
 
     final List<Rule> rules = new ArrayList<>();
     rules.add(loadSmallInterval);
     rules.add(loadLargeInteval);
     rules.add(broadcastPeriodPT15m);
+    rules.add(periodPT1HNoFuture);
     rules.add(periodPT1H);
+    rules.add(dropByP1MNoFuture);
+    rules.add(dropByP1M);
     rules.add(periodP3M);
     rules.add(periodP6M);
     rules.add(foreverLoadRule);
@@ -433,8 +481,12 @@ public class RulesResourceTest
     EasyMock.verify(databaseRuleManager);
 
     rules.clear();
+    rules.add(broadcastPeriodPT15mNoFuture);
     rules.add(broadcastPeriodPT15m);
+    rules.add(periodPT1HNoFuture);
     rules.add(periodPT1H);
+    rules.add(dropByP1MNoFuture);
+    rules.add(dropByP1M);
     rules.add(periodP3M);
     rules.add(periodP6M);
     rules.add(loadSmallInterval);


### PR DESCRIPTION
Druid's retention rules are evaluated in the order in which they are set. Unfortunately, a mistake in the order of rules by an operator can lead to unintentional data loss, and if it goes unnoticed and auto-kill is enabled, data could be permanently deleted.

To address this issue, a guard rail is added in the rules API. This guard rail aims to identify rules that fully contains the interval for any subsequent rules A rule is considered good as long as it will run at _some_ point (and doesn't fully hide other rules in the chain) - it's ensured by checking at the interval boundaries as well.

Some examples of bad rules that will be disallowed (see unit tests for more examples):
- [`loadByPeriod(P6M)`, `loadByPeriod(P3M)`]
- [`loadByInterval(2020-01-01/2050-01-01)`, `loadByInterval(2021-01-01/2023-01-01)`]
- [`dropBeforeByPeriod(P3M)`, `dropBeforeByPeriod(P6M)`]
- [`loadForever`, `loadByPeriod(P1M)`]
- [`loadForever`, `dropForever`]

Examples of rules that will be allowed because they will be evaluated at _some_ point:
- [`loadByPeriod(P5Y)`, `loadByInterval(2021-01-01/2023-01-01)`]; the loadByInterval rule will be evaluated at some point.
-  [`loadByPeriod(P1Y)`, `loadByPeriod(P2Y)`]



For testing purposes, if a user wants to intentionally set a rule that fully contains other rules, they can do it temporarily and then fetch the correct set of rules from the rules audit history after their testing is done.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Datasource rules API will reject the rules payload if a rule fully contains subsequent rules' interval. 

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `Rule.java`
 * `Rules.java`
 * `RulesTest.java`
 * `RulesEligibleIntervalTest.java`
 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
