### PR TITLE
Fixup the maximum concurrent queries in Druid used for calculation in ClientQuerySegmentWalker

### DIFF
--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -389,7 +389,6 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
         null,
         new CacheConfig(),
         null,
-        httpClientConfig,
         new SubqueryCountStatsProvider()
     );
 

--- a/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/server/ClientQuerySegmentWalker.java
@@ -31,8 +31,6 @@ import org.apache.druid.client.cache.CacheConfig;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.allocation.ArenaMemoryAllocatorFactory;
 import org.apache.druid.frame.write.UnsupportedColumnTypeException;
-import org.apache.druid.guice.annotations.Client;
-import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -123,7 +121,6 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
       Cache cache,
       CacheConfig cacheConfig,
       LookupExtractorFactoryContainerProvider lookupManager,
-      DruidHttpClientConfig httpClientConfig,
       SubqueryCountStatsProvider subqueryStatsProvider
   )
   {
@@ -140,7 +137,7 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
     this.subqueryGuardrailHelper = new SubqueryGuardrailHelper(
         lookupManager,
         Runtime.getRuntime().maxMemory(),
-        httpClientConfig.getNumConnections()
+        serverConfig.getNumThreads()
     );
     this.subqueryStatsProvider = subqueryStatsProvider;
   }
@@ -158,7 +155,6 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
       Cache cache,
       CacheConfig cacheConfig,
       LookupExtractorFactoryContainerProvider lookupManager,
-      @Client DruidHttpClientConfig httpClientConfig,
       SubqueryCountStatsProvider subqueryStatsProvider
   )
   {
@@ -174,7 +170,6 @@ public class ClientQuerySegmentWalker implements QuerySegmentWalker
         cache,
         cacheConfig,
         lookupManager,
-        httpClientConfig,
         subqueryStatsProvider
     );
   }

--- a/server/src/test/java/org/apache/druid/server/QueryStackTests.java
+++ b/server/src/test/java/org/apache/druid/server/QueryStackTests.java
@@ -22,7 +22,6 @@ package org.apache.druid.server;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.cache.CacheConfig;
-import org.apache.druid.guice.http.DruidHttpClientConfig;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.BrokerParallelMergeConfig;
@@ -166,14 +165,6 @@ public class QueryStackTests
           }
         },
         lookupManager,
-        new DruidHttpClientConfig()
-        {
-          @Override
-          public int getNumConnections()
-          {
-            return 1;
-          }
-        },
         new SubqueryCountStatsProvider()
     );
   }


### PR DESCRIPTION
### Description

https://github.com/apache/druid/pull/14808 introduced `auto` mode for calculating the size to be reserved for inlining the subquery results per query, however, I incorrectly used `druid.broker.http.numConnections` as the maximum number of queries that the broker can serve concurrently instead of `druid.server.http.numThreads`. The former refers to the connections per query that the broker can use to contact data nodes, whereas the latter refers to the number of threads in the broker reserved for serving the queries (which represents the correct figure). 

This PR corrects that patch.


<hr>


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
