### PR TITLE
Remove `EOFException` catch block from the Avro decoders

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
@@ -35,7 +35,6 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
@@ -35,7 +35,6 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
@@ -87,8 +86,8 @@ public class InlineSchemaAvroBytesDecoder implements AvroBytesDecoder
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (IOException e) {
-      throw new ParseException(null, e, "Failed to decode Avro message");
+    catch (Exception e) {
+      throw new ParseException(null, e, "Failed to read Avro message");
     }
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.io.EOFException;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
@@ -87,16 +88,8 @@ public class InlineSchemaAvroBytesDecoder implements AvroBytesDecoder
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (EOFException eof) {
-      throw new ParseException(
-          null,
-          eof,
-          "Avro's unnecessary EOFException, detail: [%s]",
-          "https://issues.apache.org/jira/browse/AVRO-813"
-      );
-    }
-    catch (Exception e) {
-      throw new ParseException(null, e, "Fail to decode avro message!");
+    catch (IOException e) {
+      throw new ParseException(null, e, "Failed to decode Avro message");
     }
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoder.java
@@ -88,7 +88,6 @@ public class InlineSchemaAvroBytesDecoder implements AvroBytesDecoder
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
     catch (EOFException eof) {
-      // waiting for avro v1.9.0 (#AVRO-813)
       throw new ParseException(
           null,
           eof,

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
@@ -37,6 +37,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import java.io.EOFException;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
@@ -119,16 +120,8 @@ public class InlineSchemasAvroBytesDecoder implements AvroBytesDecoder
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (EOFException eof) {
-      throw new ParseException(
-          null,
-          eof,
-          "Avro's unnecessary EOFException, detail: [%s]",
-          "https://issues.apache.org/jira/browse/AVRO-813"
-      );
-    }
-    catch (Exception e) {
-      throw new ParseException(null, e, "Fail to decode avro message with schemaId [%s].", schemaId);
+    catch (IOException ioe) {
+      throw new ParseException(null, ioe, "Failed to decode Avro message with schema id[%s]", schemaId);
     }
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
@@ -120,7 +120,6 @@ public class InlineSchemasAvroBytesDecoder implements AvroBytesDecoder
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
     catch (EOFException eof) {
-      // waiting for avro v1.9.0 (#AVRO-813)
       throw new ParseException(
           null,
           eof,

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
@@ -36,7 +36,6 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoder.java
@@ -36,7 +36,6 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
@@ -101,26 +100,26 @@ public class InlineSchemasAvroBytesDecoder implements AvroBytesDecoder
   public GenericRecord parse(ByteBuffer bytes)
   {
     if (bytes.remaining() < 5) {
-      throw new ParseException(null, "record must have at least 5 bytes carrying version and schemaId");
+      throw new ParseException(null, "Record must have at least 5 bytes carrying version and schemaId");
     }
 
     byte version = bytes.get();
     if (version != V1) {
-      throw new ParseException(null, "found record of arbitrary version [%s]", version);
+      throw new ParseException(null, "Found record of arbitrary version[%s]", version);
     }
 
     int schemaId = bytes.getInt();
     Schema schemaObj = schemaObjs.get(schemaId);
     if (schemaObj == null) {
-      throw new ParseException(null, "Failed to find schema for id [%s]", schemaId);
+      throw new ParseException(null, "Failed to find schema for id[%s]", schemaId);
     }
 
     DatumReader<GenericRecord> reader = new GenericDatumReader<>(schemaObj);
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (IOException ioe) {
-      throw new ParseException(null, ioe, "Failed to decode Avro message with schema id[%s]", schemaId);
+    catch (Exception e) {
+      throw new ParseException(null, e, "Failed to read Avro message with schema id[%s]", schemaId);
     }
   }
 }

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
@@ -84,7 +84,6 @@ public class SchemaRepoBasedAvroBytesDecoder<SUBJECT, ID> implements AvroBytesDe
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
     catch (EOFException eof) {
-      // waiting for avro v1.9.0 (#AVRO-813)
       throw new ParseException(
           null,
           eof,

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
@@ -34,7 +34,6 @@ import org.schemarepo.Repository;
 import org.schemarepo.api.TypedSchemaRepository;
 import org.schemarepo.api.converter.AvroSchemaConverter;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Objects;
@@ -82,8 +81,8 @@ public class SchemaRepoBasedAvroBytesDecoder<SUBJECT, ID> implements AvroBytesDe
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (IOException e) {
-      throw new ParseException(null, e, "Failed to decode Avro message");
+    catch (Exception e) {
+      throw new ParseException(null, e, "Failed to read Avro message");
     }
   }
 

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
@@ -34,7 +34,6 @@ import org.schemarepo.Repository;
 import org.schemarepo.api.TypedSchemaRepository;
 import org.schemarepo.api.converter.AvroSchemaConverter;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRepoBasedAvroBytesDecoder.java
@@ -83,16 +83,8 @@ public class SchemaRepoBasedAvroBytesDecoder<SUBJECT, ID> implements AvroBytesDe
     try (ByteBufferInputStream inputStream = new ByteBufferInputStream(Collections.singletonList(bytes))) {
       return reader.read(null, DecoderFactory.get().binaryDecoder(inputStream, null));
     }
-    catch (EOFException eof) {
-      throw new ParseException(
-          null,
-          eof,
-          "Avro's unnecessary EOFException, detail: [%s]",
-          "https://issues.apache.org/jira/browse/AVRO-813"
-      );
-    }
     catch (IOException e) {
-      throw new ParseException(null, e, "Fail to decode avro message!");
+      throw new ParseException(null, e, "Failed to decode Avro message");
     }
   }
 

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
@@ -43,6 +44,7 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -297,6 +299,45 @@ public class AvroStreamInputRowParserTest
 
       assertInputRowCorrect(inputRow, DIMENSIONS_SCHEMALESS, false);
     }
+  }
+
+  @Test
+  public void testParseInvalidData() throws IOException, SchemaValidationException
+  {
+    Repository repository = new InMemoryRepository(null);
+    SchemaRepoBasedAvroBytesDecoder<String, Integer> decoder = new SchemaRepoBasedAvroBytesDecoder<>(
+        new Avro1124SubjectAndIdConverter(TOPIC),
+        repository
+    );
+
+    // prepare data
+    GenericRecord someAvroDatum = buildSomeAvroDatum();
+
+    // encode schema id
+    Avro1124SubjectAndIdConverter converter = new Avro1124SubjectAndIdConverter(TOPIC);
+    TypedSchemaRepository<Integer, Schema, String> repositoryClient = new TypedSchemaRepository<>(
+        repository,
+        new IntegerConverter(),
+        new AvroSchemaConverter(),
+        new IdentityConverter()
+    );
+    Integer id = repositoryClient.registerSchema(TOPIC, SomeAvroDatum.getClassSchema());
+    ByteBuffer byteBuffer = ByteBuffer.allocate(20);
+    converter.putSubjectAndId(id, byteBuffer);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(new byte[0]);
+    out.write(byteBuffer.array());
+
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(someAvroDatum.getSchema());
+    // write avro datum to bytes
+    writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
+
+    ParseException parseException = Assert.assertThrows(
+        ParseException.class,
+        () -> decoder.parse(ByteBuffer.wrap(out.toByteArray()))
+    );
+    Assert.assertTrue(parseException.getCause() instanceof AvroRuntimeException);
+    Assert.assertTrue(parseException.getMessage().contains("Failed to read Avro message"));
   }
 
   static void assertInputRowCorrect(InputRow inputRow, List<String> expectedDimensions, boolean isFromPigAvro)

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
@@ -109,7 +109,7 @@ public class InlineSchemasAvroBytesDecoderTest
   }
 
   @Test
-  public void testParseWithInvalidVersion() throws Exception
+  public void testParseInvalidVersion() throws Exception
   {
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
@@ -128,11 +128,11 @@ public class InlineSchemasAvroBytesDecoderTest
             )
         ).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("found record of arbitrary version"));
+    Assert.assertTrue(parseException.getMessage().contains("Found record of arbitrary version"));
   }
 
   @Test
-  public void testParseWithInvalidSchemaId() throws Exception
+  public void testParseInvalidSchemaId() throws Exception
   {
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
@@ -156,7 +156,7 @@ public class InlineSchemasAvroBytesDecoderTest
   }
 
   @Test
-  public void testParseWithBadData() throws Exception
+  public void testParseInvalidData() throws Exception
   {
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
     Schema schema = SomeAvroDatum.getClassSchema();
@@ -178,6 +178,6 @@ public class InlineSchemasAvroBytesDecoderTest
             )
         ).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("Failed to decode Avro message with schema id[10]"));
+    Assert.assertTrue(parseException.getMessage().contains("Failed to read Avro message with schema id[10]"));
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
@@ -30,6 +30,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -105,5 +106,78 @@ public class InlineSchemasAvroBytesDecoderTest
         )
     ).parse(ByteBuffer.wrap(out.toByteArray()));
     Assert.assertEquals(someAvroDatum.get("id"), actual.get("id"));
+  }
+
+  @Test
+  public void testParseWithInvalidVersion() throws Exception
+  {
+    GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    Schema schema = SomeAvroDatum.getClassSchema();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
+    writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
+
+    ParseException parseException = Assert.assertThrows(
+        ParseException.class,
+        () -> new InlineSchemasAvroBytesDecoder(
+            ImmutableMap.of(
+                10,
+                schema
+            )
+        ).parse(ByteBuffer.wrap(out.toByteArray()))
+    );
+    Assert.assertTrue(parseException.getMessage().contains("found record of arbitrary version"));
+  }
+
+  @Test
+  public void testParseWithInvalidSchemaId() throws Exception
+  {
+    GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    Schema schema = SomeAvroDatum.getClassSchema();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(new byte[]{1});
+
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
+    writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
+
+    ParseException parseException = Assert.assertThrows(
+        ParseException.class,
+        () -> new InlineSchemasAvroBytesDecoder(
+            ImmutableMap.of(
+                10,
+                schema
+            )
+        ).parse(ByteBuffer.wrap(out.toByteArray()))
+    );
+    Assert.assertTrue(parseException.getMessage().contains("Failed to find schema for id"));
+  }
+
+  @Test
+  public void testParseWithBadData() throws Exception
+  {
+    GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    Schema schema = SomeAvroDatum.getClassSchema();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.write(new byte[]{1});
+    out.write(ByteBuffer.allocate(4).putInt(10).array());
+    out.write(ByteBuffer.allocate(24).putInt(777).array()); // add some junk
+
+    DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
+    writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
+
+    ParseException parseException = Assert.assertThrows(
+        ParseException.class,
+        () -> new InlineSchemasAvroBytesDecoder(
+            ImmutableMap.of(
+                10,
+                schema
+            )
+        ).parse(ByteBuffer.wrap(out.toByteArray()))
+    );
+    Assert.assertTrue(parseException.getMessage().contains("Failed to decode Avro message with schema id[10]"));
   }
 }


### PR DESCRIPTION
With Avro [1.11.1](https://github.com/apache/druid/blob/master/pom.xml#L84), the `read()` method only [throws](https://avro.apache.org/docs/1.11.1/api/java/org/apache/avro/util/ByteBufferInputStream.html#read--) `IOException`.
This PR removes the old `EOFException` catch block and now only has an `Exception` block to catch `IOException` or other classes of exceptions, which is then thrown as a generic `ParseException`.

Also, did a minor cleanup of surrounding exception messages around interpolations and capitalization. Added unit tests to tests different parsing errors.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
