### PR TITLE
Rename IMSC.announceHistoricalSegments to commitSegments

### DIFF
--- a/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
+++ b/extensions-contrib/materialized-view-maintenance/src/test/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorTest.java
@@ -192,8 +192,8 @@ public class MaterializedViewSupervisorTest
             1024
         )
     );
-    indexerMetadataStorageCoordinator.announceHistoricalSegments(baseSegments);
-    indexerMetadataStorageCoordinator.announceHistoricalSegments(derivativeSegments);
+    indexerMetadataStorageCoordinator.commitSegments(baseSegments);
+    indexerMetadataStorageCoordinator.commitSegments(derivativeSegments);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of()).anyTimes();
@@ -252,7 +252,7 @@ public class MaterializedViewSupervisorTest
             1024
         )
     );
-    indexerMetadataStorageCoordinator.announceHistoricalSegments(baseSegments);
+    indexerMetadataStorageCoordinator.commitSegments(baseSegments);
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.absent()).anyTimes();
     EasyMock.expect(taskStorage.getActiveTasks()).andReturn(ImmutableList.of()).anyTimes();

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
@@ -160,7 +160,7 @@ public class DatasourceOptimizerTest extends CuratorTestBase
               1024 * 1024
           );
           try {
-            metadataStorageCoordinator.announceHistoricalSegments(Sets.newHashSet(segment));
+            metadataStorageCoordinator.commitSegments(Sets.newHashSet(segment));
             announceSegmentForServer(druidServer, segment, zkPathsConfig, jsonMapper);
           }
           catch (IOException e) {
@@ -185,7 +185,7 @@ public class DatasourceOptimizerTest extends CuratorTestBase
               1024
           );
           try {
-            metadataStorageCoordinator.announceHistoricalSegments(Sets.newHashSet(segment));
+            metadataStorageCoordinator.commitSegments(Sets.newHashSet(segment));
             announceSegmentForServer(druidServer, segment, zkPathsConfig, jsonMapper);
           }
           catch (IOException e) {

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -37,19 +37,7 @@ public class SQLServerConnectorTest
     SQLServerConnector connector = new SQLServerConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(
-            new MetadataStorageTablesConfig(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            MetadataStorageTablesConfig.fromBase(null)
         )
     );
 
@@ -70,7 +58,7 @@ public class SQLServerConnectorTest
     SQLServerConnector connector = new SQLServerConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(
-            new MetadataStorageTablesConfig(null, null, null, null, null, null, null, null, null, null, null)
+            MetadataStorageTablesConfig.fromBase(null)
         )
     );
     Assert.assertEquals("FETCH NEXT 100 ROWS ONLY", connector.limitClause(100));

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
@@ -45,7 +45,7 @@ public class MySQLConnectorTest
   private static final Supplier<MetadataStorageConnectorConfig> CONNECTOR_CONFIG_SUPPLIER =
       MetadataStorageConnectorConfig::new;
   private static final Supplier<MetadataStorageTablesConfig> TABLES_CONFIG_SUPPLIER =
-      () -> new MetadataStorageTablesConfig(null, null, null, null, null, null, null, null, null, null, null);
+      () -> MetadataStorageTablesConfig.fromBase(null);
 
 
   @Test

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -35,21 +35,7 @@ public class PostgreSQLConnectorTest
   {
     PostgreSQLConnector connector = new PostgreSQLConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
-        Suppliers.ofInstance(
-            new MetadataStorageTablesConfig(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
-        ),
+        Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase(null)),
         new PostgreSQLConnectorConfig(),
         new PostgreSQLTablesConfig()
     );
@@ -68,9 +54,7 @@ public class PostgreSQLConnectorTest
   {
     PostgreSQLConnector connector = new PostgreSQLConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
-        Suppliers.ofInstance(
-            new MetadataStorageTablesConfig(null, null, null, null, null, null, null, null, null, null, null)
-        ),
+        Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase(null)),
         new PostgreSQLConnectorConfig(),
         new PostgreSQLTablesConfig()
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentInsertAction.java
@@ -65,7 +65,7 @@ public class SegmentInsertAction implements TaskAction<Set<DataSegment>>
 
   /**
    * Behaves similarly to
-   * {@link org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator#announceHistoricalSegments},
+   * {@link org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator#commitSegments},
    * with startMetadata and endMetadata both null.
    */
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentMetadataUpdateAction.java
@@ -69,7 +69,7 @@ public class SegmentMetadataUpdateAction implements TaskAction<Void>
     try {
       toolbox.getTaskLockbox().doInCriticalSection(
           task,
-          segments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
+          segments.stream().map(DataSegment::getInterval).collect(Collectors.toSet()),
           CriticalAction.builder()
                         .onValidLocks(
                             () -> {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentNukeAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentNukeAction.java
@@ -71,7 +71,7 @@ public class SegmentNukeAction implements TaskAction<Void>
     try {
       toolbox.getTaskLockbox().doInCriticalSection(
           task,
-          segments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
+          segments.stream().map(DataSegment::getInterval).collect(Collectors.toSet()),
           CriticalAction.builder()
                         .onValidLocks(
                             () -> {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertAction.java
@@ -200,10 +200,10 @@ public class SegmentTransactionalInsertAction implements TaskAction<SegmentPubli
     try {
       retVal = toolbox.getTaskLockbox().doInCriticalSection(
           task,
-          allSegments.stream().map(DataSegment::getInterval).collect(Collectors.toList()),
+          allSegments.stream().map(DataSegment::getInterval).collect(Collectors.toSet()),
           CriticalAction.<SegmentPublishResult>builder()
               .onValidLocks(
-                  () -> toolbox.getIndexerMetadataStorageCoordinator().announceHistoricalSegments(
+                  () -> toolbox.getIndexerMetadataStorageCoordinator().commitSegmentsAndMetadata(
                       segments,
                       startMetadata,
                       endMetadata

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/LockRequestForNewSegment.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/LockRequestForNewSegment.java
@@ -41,7 +41,7 @@ public class LockRequestForNewSegment implements LockRequest
   private final int priority;
   private final String sequenceName;
   @Nullable
-  private final String previsousSegmentId;
+  private final String previousSegmentId;
   private final boolean skipSegmentLineageCheck;
 
   private String version;
@@ -55,7 +55,7 @@ public class LockRequestForNewSegment implements LockRequest
       PartialShardSpec partialShardSpec,
       int priority,
       String sequenceName,
-      @Nullable String previsousSegmentId,
+      @Nullable String previousSegmentId,
       boolean skipSegmentLineageCheck
   )
   {
@@ -67,7 +67,7 @@ public class LockRequestForNewSegment implements LockRequest
     this.partialShardSpec = partialShardSpec;
     this.priority = priority;
     this.sequenceName = sequenceName;
-    this.previsousSegmentId = previsousSegmentId;
+    this.previousSegmentId = previousSegmentId;
     this.skipSegmentLineageCheck = skipSegmentLineageCheck;
   }
 
@@ -79,7 +79,7 @@ public class LockRequestForNewSegment implements LockRequest
       Interval interval,
       PartialShardSpec partialShardSpec,
       String sequenceName,
-      @Nullable String previsousSegmentId,
+      @Nullable String previousSegmentId,
       boolean skipSegmentLineageCheck
   )
   {
@@ -92,7 +92,7 @@ public class LockRequestForNewSegment implements LockRequest
         partialShardSpec,
         task.getPriority(),
         sequenceName,
-        previsousSegmentId,
+        previousSegmentId,
         skipSegmentLineageCheck
     );
   }
@@ -168,9 +168,9 @@ public class LockRequestForNewSegment implements LockRequest
   }
 
   @Nullable
-  public String getPrevisousSegmentId()
+  public String getPreviousSegmentId()
   {
-    return previsousSegmentId;
+    return previousSegmentId;
   }
 
   public boolean isSkipSegmentLineageCheck()
@@ -190,7 +190,7 @@ public class LockRequestForNewSegment implements LockRequest
            ", partialShardSpec=" + partialShardSpec +
            ", priority=" + priority +
            ", sequenceName='" + sequenceName + '\'' +
-           ", previsousSegmentId='" + previsousSegmentId + '\'' +
+           ", previousSegmentId='" + previousSegmentId + '\'' +
            ", skipSegmentLineageCheck=" + skipSegmentLineageCheck +
            '}';
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -754,7 +754,7 @@ public class TaskLockbox
     return metadataStorageCoordinator.allocatePendingSegment(
         request.getDataSource(),
         request.getSequenceName(),
-        request.getPrevisousSegmentId(),
+        request.getPreviousSegmentId(),
         request.getInterval(),
         request.getPartialShardSpec(),
         version,
@@ -773,7 +773,7 @@ public class TaskLockbox
    * @param intervals intervals
    * @param action    action to be performed inside of the critical section
    */
-  public <T> T doInCriticalSection(Task task, List<Interval> intervals, CriticalAction<T> action) throws Exception
+  public <T> T doInCriticalSection(Task task, Set<Interval> intervals, CriticalAction<T> action) throws Exception
   {
     giant.lock();
 
@@ -790,7 +790,7 @@ public class TaskLockbox
    * It doesn't check other semantics like acquired locks are enough to overwrite existing segments.
    * This kind of semantic should be checked in each caller of {@link #doInCriticalSection}.
    */
-  private boolean isTaskLocksValid(Task task, List<Interval> intervals)
+  private boolean isTaskLocksValid(Task task, Set<Interval> intervals)
   {
     giant.lock();
     try {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveSegmentsActionsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveSegmentsActionsTest.java
@@ -60,7 +60,7 @@ public class RetrieveSegmentsActionsTest
     expectedUnusedSegments.add(createSegment(Intervals.of("2017-10-07/2017-10-08"), "1"));
 
     actionTestKit.getMetadataStorageCoordinator()
-                 .announceHistoricalSegments(expectedUnusedSegments);
+                 .commitSegments(expectedUnusedSegments);
 
     expectedUnusedSegments.forEach(s -> actionTestKit.getTaskLockbox().unlock(task, s.getInterval()));
 
@@ -70,7 +70,7 @@ public class RetrieveSegmentsActionsTest
     expectedUsedSegments.add(createSegment(Intervals.of("2017-10-07/2017-10-08"), "2"));
 
     actionTestKit.getMetadataStorageCoordinator()
-                 .announceHistoricalSegments(expectedUsedSegments);
+                 .commitSegments(expectedUsedSegments);
 
     expectedUsedSegments.forEach(s -> actionTestKit.getTaskLockbox().unlock(task, s.getInterval()));
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
@@ -574,7 +574,7 @@ public class SegmentAllocateActionTest
   {
     final Task task = NoopTask.create();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)
@@ -639,7 +639,7 @@ public class SegmentAllocateActionTest
   {
     final Task task = NoopTask.create();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)
@@ -702,7 +702,7 @@ public class SegmentAllocateActionTest
   {
     final Task task = NoopTask.create();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)
@@ -741,7 +741,7 @@ public class SegmentAllocateActionTest
   {
     final Task task = NoopTask.create();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)
@@ -780,7 +780,7 @@ public class SegmentAllocateActionTest
   {
     final Task task = NoopTask.create();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)
@@ -825,7 +825,7 @@ public class SegmentAllocateActionTest
 
     final ObjectMapper objectMapper = new DefaultObjectMapper();
 
-    taskActionTestKit.getMetadataStorageCoordinator().announceHistoricalSegments(
+    taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         ImmutableSet.of(
             DataSegment.builder()
                        .dataSource(DATA_SOURCE)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentInsertActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentInsertActionTest.java
@@ -107,7 +107,7 @@ public class SegmentInsertActionTest
     acquireTimeChunkLock(TaskLockType.EXCLUSIVE, task, INTERVAL, 5000);
     actionTestKit.getTaskLockbox().doInCriticalSection(
         task,
-        Collections.singletonList(INTERVAL),
+        Collections.singleton(INTERVAL),
         CriticalAction.builder()
                       .onValidLocks(() -> action.perform(task, actionTestKit.getTaskActionToolbox()))
                       .onInvalidLocks(
@@ -137,7 +137,7 @@ public class SegmentInsertActionTest
     thrown.expectMessage(CoreMatchers.containsString("are not covered by locks"));
     final Set<DataSegment> segments = actionTestKit.getTaskLockbox().doInCriticalSection(
         task,
-        Collections.singletonList(INTERVAL),
+        Collections.singleton(INTERVAL),
         CriticalAction.<Set<DataSegment>>builder()
             .onValidLocks(() -> action.perform(task, actionTestKit.getTaskActionToolbox()))
             .onInvalidLocks(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTaskTest.java
@@ -1507,9 +1507,9 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
     )
     {
       @Override
-      public Set<DataSegment> announceHistoricalSegments(Set<DataSegment> segments) throws IOException
+      public Set<DataSegment> commitSegments(Set<DataSegment> segments) throws IOException
       {
-        Set<DataSegment> result = super.announceHistoricalSegments(segments);
+        Set<DataSegment> result = super.commitSegments(segments);
 
         Assert.assertFalse(
             "Segment latch not initialized, did you forget to call expectPublishSegments?",
@@ -1523,13 +1523,13 @@ public class AppenderatorDriverRealtimeIndexTaskTest extends InitializedNullHand
       }
 
       @Override
-      public SegmentPublishResult announceHistoricalSegments(
+      public SegmentPublishResult commitSegmentsAndMetadata(
           Set<DataSegment> segments,
           DataSourceMetadata startMetadata,
           DataSourceMetadata endMetadata
       ) throws IOException
       {
-        SegmentPublishResult result = super.announceHistoricalSegments(segments, startMetadata, endMetadata);
+        SegmentPublishResult result = super.commitSegmentsAndMetadata(segments, startMetadata, endMetadata);
 
         Assert.assertNotNull(
             "Segment latch not initialized, did you forget to call expectPublishSegments?",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -59,7 +59,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         newSegment(Intervals.of("2019-03-01/2019-04-01"), version),
         newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
-    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
+    final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments);
 
     Assert.assertEquals(segments, announced);
 
@@ -114,7 +114,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         newSegment(Intervals.of("2019-03-01/2019-04-01"), version),
         newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
-    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
+    final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments);
 
     Assert.assertEquals(segments, announced);
 
@@ -178,7 +178,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             newSegment(Intervals.of("2019-03-01/2019-04-01"), version),
             newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
-    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
+    final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments);
 
     Assert.assertEquals(segments, announced);
 
@@ -223,7 +223,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             newSegment(Intervals.of("2019-03-01/2019-04-01"), version),
             newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
-    final Set<DataSegment> announced = getMetadataStorageCoordinator().announceHistoricalSegments(segments);
+    final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments);
 
     Assert.assertEquals(segments, announced);
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -562,9 +562,9 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
     return new TestIndexerMetadataStorageCoordinator()
     {
       @Override
-      public Set<DataSegment> announceHistoricalSegments(Set<DataSegment> segments)
+      public Set<DataSegment> commitSegments(Set<DataSegment> segments)
       {
-        Set<DataSegment> retVal = super.announceHistoricalSegments(segments);
+        Set<DataSegment> retVal = super.commitSegments(segments);
         if (publishCountDown != null) {
           publishCountDown.countDown();
         }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockBoxConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockBoxConcurrencyTest.java
@@ -42,6 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -120,7 +121,7 @@ public class TaskLockBoxConcurrencyTest
 
       return lockbox.doInCriticalSection(
           lowPriorityTask,
-          Collections.singletonList(interval),
+          Collections.singleton(interval),
           CriticalAction.<Integer>builder()
               .onValidLocks(
                   () -> {
@@ -150,7 +151,7 @@ public class TaskLockBoxConcurrencyTest
 
       return lockbox.doInCriticalSection(
           highPriorityTask,
-          Collections.singletonList(interval),
+          Collections.singleton(interval),
           CriticalAction.<Integer>builder()
               .onValidLocks(
                   () -> {
@@ -200,7 +201,7 @@ public class TaskLockBoxConcurrencyTest
 
     final Future<Integer> future1 = service.submit(() -> lockbox.doInCriticalSection(
         task,
-        intervals.subList(0, 2),
+        new HashSet<>(intervals.subList(0, 2)),
         CriticalAction.<Integer>builder()
             .onValidLocks(
                 () -> {
@@ -223,7 +224,7 @@ public class TaskLockBoxConcurrencyTest
       latch.await();
       return lockbox.doInCriticalSection(
           task,
-          intervals.subList(1, 3),
+          new HashSet<>(intervals.subList(1, 3)),
           CriticalAction.<Integer>builder()
               .onValidLocks(
                   () -> {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -528,7 +528,7 @@ public class TaskLockboxTest
     Assert.assertTrue(
         lockbox.doInCriticalSection(
             task,
-            Collections.singletonList(interval),
+            Collections.singleton(interval),
             CriticalAction.<Boolean>builder().onValidLocks(() -> true).onInvalidLocks(() -> false).build()
         )
     );
@@ -546,7 +546,7 @@ public class TaskLockboxTest
     Assert.assertTrue(
         lockbox.doInCriticalSection(
             task,
-            Collections.singletonList(interval),
+            Collections.singleton(interval),
             CriticalAction.<Boolean>builder().onValidLocks(() -> true).onInvalidLocks(() -> false).build()
         )
     );
@@ -565,7 +565,7 @@ public class TaskLockboxTest
     Assert.assertTrue(
         lockbox.doInCriticalSection(
             task,
-            Collections.singletonList(interval),
+            Collections.singleton(interval),
             CriticalAction.<Boolean>builder().onValidLocks(() -> true).onInvalidLocks(() -> false).build()
         )
     );
@@ -591,7 +591,7 @@ public class TaskLockboxTest
     Assert.assertTrue(
         lockbox.doInCriticalSection(
             highPriorityTask,
-            Collections.singletonList(interval),
+            Collections.singleton(interval),
             CriticalAction.<Boolean>builder().onValidLocks(() -> true).onInvalidLocks(() -> false).build()
         )
     );
@@ -616,7 +616,7 @@ public class TaskLockboxTest
     Assert.assertFalse(
         lockbox.doInCriticalSection(
             lowPriorityTask,
-            Collections.singletonList(interval),
+            Collections.singleton(interval),
             CriticalAction.<Boolean>builder().onValidLocks(() -> true).onInvalidLocks(() -> false).build()
         )
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -134,7 +134,7 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
-  public Set<DataSegment> announceHistoricalSegments(Set<DataSegment> segments)
+  public Set<DataSegment> commitSegments(Set<DataSegment> segments)
   {
     Set<DataSegment> added = new HashSet<>();
     for (final DataSegment segment : segments) {
@@ -157,14 +157,14 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   }
 
   @Override
-  public SegmentPublishResult announceHistoricalSegments(
+  public SegmentPublishResult commitSegmentsAndMetadata(
       Set<DataSegment> segments,
-      DataSourceMetadata oldCommitMetadata,
-      DataSourceMetadata newCommitMetadata
+      @Nullable DataSourceMetadata startMetadata,
+      @Nullable DataSourceMetadata endMetadata
   )
   {
     // Don't actually compare metadata, just do it!
-    return SegmentPublishResult.ok(announceHistoricalSegments(segments));
+    return SegmentPublishResult.ok(commitSegments(segments));
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/indexing/overlord/DataSourceMetadata.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/DataSourceMetadata.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 /**
  * Commit metadata for a dataSource. Used by
- * {@link IndexerMetadataStorageCoordinator#announceHistoricalSegments(Set, DataSourceMetadata, DataSourceMetadata)}
+ * {@link IndexerMetadataStorageCoordinator#commitSegmentsAndMetadata(Set, DataSourceMetadata, DataSourceMetadata)}
  * to provide metadata transactions for segment inserts.
  *
  * Two metadata instances can be added together, and any conflicts are resolved in favor of the right-hand side.
@@ -45,7 +45,7 @@ public interface DataSourceMetadata
   boolean isValidStart();
 
   /**
-   * As in {@link IndexerMetadataStorageCoordinator#announceHistoricalSegments}, this class can represent start and
+   * As in {@link IndexerMetadataStorageCoordinator#commitSegments}, this class can represent start and
    * end of a sequence.
    *
    * This method converts itself into the one for start of a sequence. Most implementations can simply return

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -166,7 +166,7 @@ public interface IndexerMetadataStorageCoordinator
    *
    * @return set of segments actually added
    */
-  Set<DataSegment> announceHistoricalSegments(Set<DataSegment> segments) throws IOException;
+  Set<DataSegment> commitSegments(Set<DataSegment> segments) throws IOException;
 
   /**
    * Allocates pending segments for the given requests in the pending segments table.
@@ -271,7 +271,7 @@ public interface IndexerMetadataStorageCoordinator
    * @throws IllegalArgumentException if startMetadata and endMetadata are not either both null or both non-null
    * @throws RuntimeException         if the state of metadata storage after this call is unknown
    */
-  SegmentPublishResult announceHistoricalSegments(
+  SegmentPublishResult commitSegmentsAndMetadata(
       Set<DataSegment> segments,
       @Nullable DataSourceMetadata startMetadata,
       @Nullable DataSourceMetadata endMetadata
@@ -321,11 +321,11 @@ public interface IndexerMetadataStorageCoordinator
   int removeDataSourceMetadataOlderThan(long timestamp, @NotNull Set<String> excludeDatasources);
 
   /**
-   * Similar to {@link #announceHistoricalSegments(Set)}, but meant for streaming ingestion tasks for handling
+   * Similar to {@link #commitSegments}, but meant for streaming ingestion tasks for handling
    * the case where the task ingested no records and created no segments, but still needs to update the metadata
    * with the progress that the task made.
    *
-   * The metadata should undergo the same validation checks as performed by {@link #announceHistoricalSegments}.
+   * The metadata should undergo the same validation checks as performed by {@link #commitSegments}.
    *
    *
    * @param dataSource the datasource

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -301,9 +301,9 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public Set<DataSegment> announceHistoricalSegments(final Set<DataSegment> segments) throws IOException
+  public Set<DataSegment> commitSegments(final Set<DataSegment> segments) throws IOException
   {
-    final SegmentPublishResult result = announceHistoricalSegments(segments, null, null);
+    final SegmentPublishResult result = commitSegmentsAndMetadata(segments, null, null);
 
     // Metadata transaction cannot fail because we are not trying to do one.
     if (!result.isSuccess()) {
@@ -314,7 +314,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
   }
 
   @Override
-  public SegmentPublishResult announceHistoricalSegments(
+  public SegmentPublishResult commitSegmentsAndMetadata(
       final Set<DataSegment> segments,
       @Nullable final DataSourceMetadata startMetadata,
       @Nullable final DataSourceMetadata endMetadata
@@ -1512,7 +1512,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
    *
    * @return SUCCESS if dataSource metadata was updated from matching startMetadata to matching endMetadata, FAILURE or
    * TRY_AGAIN if it definitely was not updated. This guarantee is meant to help
-   * {@link #announceHistoricalSegments(Set, DataSourceMetadata, DataSourceMetadata)}
+   * {@link #commitSegmentsAndMetadata(Set, DataSourceMetadata, DataSourceMetadata)}
    * achieve its own guarantee.
    *
    * @throws RuntimeException if state is unknown after this call

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -454,7 +454,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSimpleAnnounce() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     for (DataSegment segment : SEGMENTS) {
       Assert.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
@@ -496,7 +496,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
       );
     }
 
-    coordinator.announceHistoricalSegments(segments);
+    coordinator.commitSegments(segments);
     for (DataSegment segment : segments) {
       Assert.assertArrayEquals(
           mapper.writeValueAsString(segment).getBytes(StandardCharsets.UTF_8),
@@ -525,7 +525,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   {
     final ImmutableSet<DataSegment> segments = ImmutableSet.of(defaultSegment, defaultSegment2, defaultSegment4);
 
-    coordinator.announceHistoricalSegments(segments);
+    coordinator.commitSegments(segments);
 
     for (DataSegment segment : segments) {
       Assert.assertArrayEquals(
@@ -546,7 +546,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   public void testTransactionalAnnounceSuccess() throws IOException
   {
     // Insert first segment.
-    final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -564,7 +564,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     );
 
     // Insert second segment.
-    final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
@@ -620,7 +620,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     };
 
     // Insert first segment.
-    final SegmentPublishResult result1 = failOnceCoordinator.announceHistoricalSegments(
+    final SegmentPublishResult result1 = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -641,7 +641,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     attemptCounter.set(0);
 
     // Insert second segment.
-    final SegmentPublishResult result2 = failOnceCoordinator.announceHistoricalSegments(
+    final SegmentPublishResult result2 = failOnceCoordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
@@ -671,7 +671,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testTransactionalAnnounceFailDbNullWantNotNull() throws IOException
   {
-    final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
@@ -688,14 +688,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testTransactionalAnnounceFailDbNotNullWantNull() throws IOException
   {
-    final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
     );
     Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
 
-    final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
@@ -727,14 +727,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testTransactionalAnnounceFailDbNotNullWantDifferent() throws IOException
   {
-    final SegmentPublishResult result1 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result1 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
     );
     Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(defaultSegment)), result1);
 
-    final SegmentPublishResult result2 = coordinator.announceHistoricalSegments(
+    final SegmentPublishResult result2 = coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment2),
         new ObjectMetadata(ImmutableMap.of("foo", "qux")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
@@ -751,7 +751,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSimpleUsedList() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
@@ -767,8 +767,8 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testMultiIntervalUsedList() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
-    coordinator.announceHistoricalSegments(ImmutableSet.of(defaultSegment3));
+    coordinator.commitSegments(SEGMENTS);
+    coordinator.commitSegments(ImmutableSet.of(defaultSegment3));
 
     Assertions.assertThat(
         coordinator.retrieveUsedSegmentsForIntervals(
@@ -810,7 +810,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSimpleUnusedList() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertEquals(
         SEGMENTS,
@@ -826,7 +826,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSimpleUnusedListWithLimit() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     int limit = SEGMENTS.size() - 1;
     Set<DataSegment> retreivedUnusedSegments = ImmutableSet.copyOf(
@@ -843,7 +843,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedOverlapLow() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Set<DataSegment> actualSegments = ImmutableSet.copyOf(
         coordinator.retrieveUsedSegmentsForInterval(
             defaultSegment.getDataSource(),
@@ -861,7 +861,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedOverlapHigh() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
@@ -877,7 +877,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedOutOfBoundsLow() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertTrue(
         coordinator.retrieveUsedSegmentsForInterval(
             defaultSegment.getDataSource(),
@@ -891,7 +891,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedOutOfBoundsHigh() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertTrue(
         coordinator.retrieveUsedSegmentsForInterval(
             defaultSegment.getDataSource(),
@@ -904,7 +904,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedWithinBoundsEnd() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
@@ -920,7 +920,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedOverlapEnd() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     Assert.assertEquals(
         SEGMENTS,
         ImmutableSet.copyOf(
@@ -937,7 +937,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedOverlapLow() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
@@ -953,7 +953,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedUnderlapLow() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
@@ -967,7 +967,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedUnderlapHigh() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
@@ -980,7 +980,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedOverlapHigh() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertTrue(
         coordinator.retrieveUnusedSegmentsForInterval(
@@ -993,7 +993,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedBigOverlap() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertEquals(
         SEGMENTS,
@@ -1009,7 +1009,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedLowRange() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertEquals(
         SEGMENTS,
@@ -1034,7 +1034,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUnusedHighRange() throws IOException
   {
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
     markAllSegmentsUnused();
     Assert.assertEquals(
         SEGMENTS,
@@ -1059,7 +1059,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedHugeTimeRangeEternityFilter() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             hugeTimeRangeSegment1,
             hugeTimeRangeSegment2,
@@ -1082,7 +1082,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedHugeTimeRangeTrickyFilter1() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             hugeTimeRangeSegment1,
             hugeTimeRangeSegment2,
@@ -1105,7 +1105,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testUsedHugeTimeRangeTrickyFilter2() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             hugeTimeRangeSegment1,
             hugeTimeRangeSegment2,
@@ -1129,7 +1129,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testEternitySegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             eternitySegment
         )
@@ -1150,7 +1150,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testEternityMultipleSegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             numberedSegment0of0,
             eternitySegment
@@ -1172,7 +1172,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testFirstHalfEternitySegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             firstHalfEternityRangeSegment
         )
@@ -1193,7 +1193,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testFirstHalfEternityMultipleSegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             numberedSegment0of0,
             firstHalfEternityRangeSegment
@@ -1215,7 +1215,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSecondHalfEternitySegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             secondHalfEternityRangeSegment
         )
@@ -1238,7 +1238,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testLargeIntervalWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             hugeTimeRangeSegment4
         )
@@ -1259,7 +1259,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testSecondHalfEternityMultipleSegmentWithStringComparison() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         ImmutableSet.of(
             numberedSegment0of0,
             secondHalfEternityRangeSegment
@@ -1281,7 +1281,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testDeleteDataSourceMetadata() throws IOException
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -1302,7 +1302,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   public void testDeleteSegmentsInMetaDataStorage() throws IOException
   {
     // Published segments to MetaDataStorage
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
 
     // check segments Published
     Assert.assertEquals(
@@ -1335,7 +1335,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   public void testUpdateSegmentsInMetaDataStorage() throws IOException
   {
     // Published segments to MetaDataStorage
-    coordinator.announceHistoricalSegments(SEGMENTS);
+    coordinator.commitSegments(SEGMENTS);
 
     // check segments Published
     Assert.assertEquals(
@@ -1397,7 +1397,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
 
   private void additionalNumberedShardTest(Set<DataSegment> segments) throws IOException
   {
-    coordinator.announceHistoricalSegments(segments);
+    coordinator.commitSegments(segments);
 
     for (DataSegment segment : segments) {
       Assert.assertArrayEquals(
@@ -1989,7 +1989,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
               10L
           )
       );
-      final Set<DataSegment> announced = coordinator.announceHistoricalSegments(toBeAnnounced);
+      final Set<DataSegment> announced = coordinator.commitSegments(toBeAnnounced);
 
       Assert.assertEquals(toBeAnnounced, announced);
     }
@@ -2042,7 +2042,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     Assert.assertEquals(0, shardSpec.getNumCorePartitions());
     Assert.assertEquals(5, shardSpec.getNumBuckets());
 
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         Collections.singleton(
             new DataSegment(
                 id.getDataSource(),
@@ -2073,7 +2073,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     Assert.assertEquals(0, shardSpec.getNumCorePartitions());
     Assert.assertEquals(5, shardSpec.getNumBuckets());
 
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegments(
         Collections.singleton(
             new DataSegment(
                 id.getDataSource(),
@@ -2135,7 +2135,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
           )
       );
     }
-    coordinator.announceHistoricalSegments(originalSegments);
+    coordinator.commitSegments(originalSegments);
     final SegmentIdWithShardSpec id = coordinator.allocatePendingSegment(
         datasource,
         "seq",
@@ -2180,7 +2180,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
           )
       );
     }
-    coordinator.announceHistoricalSegments(originalSegments);
+    coordinator.commitSegments(originalSegments);
     final SegmentIdWithShardSpec id = coordinator.allocatePendingSegment(
         datasource,
         "seq",
@@ -2196,7 +2196,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testRemoveDataSourceMetadataOlderThanDatasourceActiveShouldNotBeDeleted() throws Exception
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -2224,7 +2224,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testRemoveDataSourceMetadataOlderThanDatasourceNotActiveAndOlderThanTimeShouldBeDeleted() throws Exception
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -2249,7 +2249,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   public void testRemoveDataSourceMetadataOlderThanDatasourceNotActiveButNotOlderThanTimeShouldNotBeDeleted()
       throws Exception
   {
-    coordinator.announceHistoricalSegments(
+    coordinator.commitSegmentsAndMetadata(
         ImmutableSet.of(defaultSegment),
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "bar"))
@@ -2278,7 +2278,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testMarkSegmentsAsUnusedWithinIntervalOneYear() throws IOException
   {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(existingSegment1, existingSegment2));
+    coordinator.commitSegments(ImmutableSet.of(existingSegment1, existingSegment2));
 
     // interval covers existingSegment1 and partially overlaps existingSegment2,
     // only existingSegment1 will be dropped
@@ -2310,7 +2310,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
   @Test
   public void testMarkSegmentsAsUnusedWithinIntervalTwoYears() throws IOException
   {
-    coordinator.announceHistoricalSegments(ImmutableSet.of(existingSegment1, existingSegment2));
+    coordinator.commitSegments(ImmutableSet.of(existingSegment1, existingSegment2));
 
     // interval covers existingSegment1 and partially overlaps existingSegment2,
     // only existingSegment1 will be dropped


### PR DESCRIPTION
This PR pulls out some changes from #14407 to simplify that PR

### Changes
- Rename `IndexerMetadataStorageCoordinator.announceHistoricalSegments` to `commitSegments`
- Rename the overloaded method to `commitSegmentsAndMetadata`
- Fix some typos