### PR TITLE
Add a TaskReport for "kill" tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
@@ -22,29 +22,25 @@ package org.apache.druid.indexing.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Objects;
-
-public class IngestionStatsAndErrorsTaskReport implements TaskReport
+public class KillTaskReport implements TaskReport
 {
-  public static final String REPORT_KEY = "ingestionStatsAndErrors";
+  public static final String REPORT_KEY = "killUnusedStats";
 
-  @JsonProperty
   private final String taskId;
-
-  @JsonProperty
-  private final IngestionStatsAndErrorsTaskReportData payload;
+  private final Stats stats;
 
   @JsonCreator
-  public IngestionStatsAndErrorsTaskReport(
+  public KillTaskReport(
       @JsonProperty("taskId") String taskId,
-      @JsonProperty("payload") IngestionStatsAndErrorsTaskReportData payload
+      @JsonProperty("payload") Stats stats
   )
   {
     this.taskId = taskId;
-    this.payload = payload;
+    this.stats = stats;
   }
 
   @Override
+  @JsonProperty
   public String getTaskId()
   {
     return taskId;
@@ -57,37 +53,46 @@ public class IngestionStatsAndErrorsTaskReport implements TaskReport
   }
 
   @Override
+  @JsonProperty
   public Object getPayload()
   {
-    return payload;
+    return stats;
   }
 
-  @Override
-  public boolean equals(Object o)
+  public static class Stats
   {
-    if (this == o) {
-      return true;
+    private final int numSegmentsKilled;
+    private final int numBatchesProcessed;
+    private final int numSegmentsMarkedAsUnused;
+
+    @JsonCreator
+    public Stats(
+        @JsonProperty("numSegmentsKilled") int numSegmentsKilled,
+        @JsonProperty("numBatchesProcessed") int numBatchesProcessed,
+        @JsonProperty("numSegmentsMarkedAsUnused") int numSegmentsMarkedAsUnused
+    )
+    {
+      this.numSegmentsKilled = numSegmentsKilled;
+      this.numBatchesProcessed = numBatchesProcessed;
+      this.numSegmentsMarkedAsUnused = numSegmentsMarkedAsUnused;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
+
+    @JsonProperty
+    public int getNumSegmentsKilled()
+    {
+      return numSegmentsKilled;
     }
-    IngestionStatsAndErrorsTaskReport that = (IngestionStatsAndErrorsTaskReport) o;
-    return Objects.equals(getTaskId(), that.getTaskId()) &&
-           Objects.equals(getPayload(), that.getPayload());
-  }
 
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(getTaskId(), getPayload());
-  }
+    @JsonProperty
+    public int getNumBatchesProcessed()
+    {
+      return numBatchesProcessed;
+    }
 
-  @Override
-  public String toString()
-  {
-    return "IngestionStatsAndErrorsTaskReport{" +
-           "taskId='" + taskId + '\'' +
-           ", payload=" + payload +
-           '}';
+    @JsonProperty
+    public int getNumSegmentsMarkedAsUnused()
+    {
+      return numSegmentsMarkedAsUnused;
+    }
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
@@ -22,6 +22,8 @@ package org.apache.druid.indexing.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class KillTaskReport implements TaskReport
 {
   public static final String REPORT_KEY = "killUnusedSegments";
@@ -93,6 +95,37 @@ public class KillTaskReport implements TaskReport
     public int getNumSegmentsMarkedAsUnused()
     {
       return numSegmentsMarkedAsUnused;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Stats stats = (Stats) o;
+      return numSegmentsKilled == stats.numSegmentsKilled
+             && numBatchesProcessed == stats.numBatchesProcessed
+             && numSegmentsMarkedAsUnused == stats.numSegmentsMarkedAsUnused;
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(numSegmentsKilled, numBatchesProcessed, numSegmentsMarkedAsUnused);
+    }
+
+    @Override
+    public String toString()
+    {
+      return "Stats{" +
+             "numSegmentsKilled=" + numSegmentsKilled +
+             ", numBatchesProcessed=" + numBatchesProcessed +
+             ", numSegmentsMarkedAsUnused=" + numSegmentsMarkedAsUnused +
+             '}';
     }
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 public class KillTaskReport implements TaskReport
@@ -65,13 +66,13 @@ public class KillTaskReport implements TaskReport
   {
     private final int numSegmentsKilled;
     private final int numBatchesProcessed;
-    private final int numSegmentsMarkedAsUnused;
+    private final Integer numSegmentsMarkedAsUnused;
 
     @JsonCreator
     public Stats(
         @JsonProperty("numSegmentsKilled") int numSegmentsKilled,
         @JsonProperty("numBatchesProcessed") int numBatchesProcessed,
-        @JsonProperty("numSegmentsMarkedAsUnused") int numSegmentsMarkedAsUnused
+        @JsonProperty("numSegmentsMarkedAsUnused") @Nullable Integer numSegmentsMarkedAsUnused
     )
     {
       this.numSegmentsKilled = numSegmentsKilled;
@@ -91,8 +92,9 @@ public class KillTaskReport implements TaskReport
       return numBatchesProcessed;
     }
 
+    @Nullable
     @JsonProperty
-    public int getNumSegmentsMarkedAsUnused()
+    public Integer getNumSegmentsMarkedAsUnused()
     {
       return numSegmentsMarkedAsUnused;
     }
@@ -106,10 +108,10 @@ public class KillTaskReport implements TaskReport
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      Stats stats = (Stats) o;
-      return numSegmentsKilled == stats.numSegmentsKilled
-             && numBatchesProcessed == stats.numBatchesProcessed
-             && numSegmentsMarkedAsUnused == stats.numSegmentsMarkedAsUnused;
+      Stats that = (Stats) o;
+      return numSegmentsKilled == that.numSegmentsKilled
+             && numBatchesProcessed == that.numBatchesProcessed
+             && Objects.equals(this.numSegmentsMarkedAsUnused, that.numSegmentsMarkedAsUnused);
     }
 
     @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/KillTaskReport.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class KillTaskReport implements TaskReport
 {
-  public static final String REPORT_KEY = "killUnusedStats";
+  public static final String REPORT_KEY = "killUnusedSegments";
 
   private final String taskId;
   private final Stats stats;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskReport.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskReport.java
@@ -31,7 +31,8 @@ import java.util.Map;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(value = {
-    @JsonSubTypes.Type(name = "ingestionStatsAndErrors", value = IngestionStatsAndErrorsTaskReport.class)
+    @JsonSubTypes.Type(name = "ingestionStatsAndErrors", value = IngestionStatsAndErrorsTaskReport.class),
+    @JsonSubTypes.Type(name = KillTaskReport.REPORT_KEY, value = KillTaskReport.class)
 })
 public interface TaskReport
 {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -24,12 +24,13 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.client.indexing.ClientKillUnusedSegmentsTaskQuery;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexing.common.KillTaskReport;
 import org.apache.druid.indexing.common.TaskLock;
+import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.MarkSegmentsAsUnusedAction;
 import org.apache.druid.indexing.common.actions.RetrieveUnusedSegmentsAction;
@@ -46,7 +47,6 @@ import org.joda.time.Interval;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -61,6 +61,8 @@ import java.util.stream.Collectors;
  * The client representation of this task is {@link ClientKillUnusedSegmentsTaskQuery}.
  * JSON serialization fields of this class must correspond to those of {@link
  * ClientKillUnusedSegmentsTaskQuery}, except for "id" and "context" fields.
+ * <p>
+ * The field {@link #isMarkAsUnused()} is now deprecated.
  */
 public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 {
@@ -77,18 +79,18 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
    */
   private static final int DEFAULT_SEGMENT_NUKE_BATCH_SIZE = 100;
 
+  @Deprecated
   private final boolean markAsUnused;
   /**
    * Split processing to try and keep each nuke operation relatively short, in the case that either
    * the database or the storage layer is particularly slow.
    */
   private final int batchSize;
+
+  /**
+   * Maximum number of segments that can be killed.
+   */
   @Nullable private final Integer limit;
-
-
-  // counters included primarily for testing
-  private int numSegmentsKilled = 0;
-  private long numBatchesProcessed = 0;
 
   @JsonCreator
   public KillUnusedSegmentsTask(
@@ -109,22 +111,26 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
     );
     this.markAsUnused = markAsUnused != null && markAsUnused;
     this.batchSize = (batchSize != null) ? batchSize : DEFAULT_SEGMENT_NUKE_BATCH_SIZE;
-    Preconditions.checkArgument(this.batchSize > 0, "batchSize should be greater than zero");
-    if (null != limit && limit <= 0) {
-      throw InvalidInput.exception(
-          "limit [%d] is invalid. It must be a positive integer.",
-          limit
-      );
+    if (this.batchSize <= 0) {
+      throw InvalidInput.exception("batchSize[%d] must be a positive integer.", limit);
     }
-    if (limit != null && markAsUnused != null && markAsUnused) {
-      throw InvalidInput.exception(
-          "limit cannot be provided with markAsUnused.",
-          limit
-      );
+    if (limit != null && limit <= 0) {
+      throw InvalidInput.exception("Limit[%d] must be a positive integer.", limit);
+    }
+    if (limit != null && Boolean.TRUE.equals(markAsUnused)) {
+      throw InvalidInput.exception("Limit cannot be provided when markAsUnused is enabled.");
     }
     this.limit = limit;
   }
 
+  /**
+   * This field has been deprecated as "kill" tasks should not be responsible for
+   * marking segments as unused. Instead, users should call the Coordinator API
+   * {@code /{dataSourceName}/markUnused} to explicitly mark segments as unused.
+   * Segments may also be marked unused by the Coordinator if they become overshadowed
+   * or have a {@code DropRule} applied to them.
+   */
+  @Deprecated
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_DEFAULT)
   public boolean isMarkAsUnused()
@@ -160,30 +166,22 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
     return ImmutableSet.of();
   }
 
-  @JsonIgnore
-  @VisibleForTesting
-  long getNumBatchesProcessed()
-  {
-    return numBatchesProcessed;
-  }
-
-  @JsonIgnore
-  @VisibleForTesting
-  long getNumSegmentsKilled()
-  {
-    return numSegmentsKilled;
-  }
-
   @Override
   public TaskStatus runTask(TaskToolbox toolbox) throws Exception
   {
     final NavigableMap<DateTime, List<TaskLock>> taskLockMap = getTaskLockMap(toolbox.getTaskActionClient());
 
+    // Track stats for reporting
+    int numSegmentsKilled = 0;
+    int numBatchesProcessed = 0;
+    final int numSegmentsMarkedAsUnused;
     if (markAsUnused) {
-      int numMarked = toolbox.getTaskActionClient().submit(
+      numSegmentsMarkedAsUnused = toolbox.getTaskActionClient().submit(
           new MarkSegmentsAsUnusedAction(getDataSource(), getInterval())
       );
-      LOG.info("Marked %d segments as unused.", numMarked);
+      LOG.info("Marked [%d] segments as unused.", numSegmentsMarkedAsUnused);
+    } else {
+      numSegmentsMarkedAsUnused = 0;
     }
 
     // List unused segments
@@ -194,7 +192,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
         "Starting kill with batchSize[%d], up to limit[%d] segments will be deleted%s",
         batchSize,
         limit,
-        numTotalBatches != null ? StringUtils.format(" in([%d] batches]).", numTotalBatches) : "."
+        numTotalBatches != null ? StringUtils.format(" in [%d] batches.", numTotalBatches) : "."
     );
     do {
       if (nextBatchSize <= 0) {
@@ -229,16 +227,21 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
       nextBatchSize = computeNextBatchSize(numSegmentsKilled);
     } while (unusedSegments.size() != 0 && (null == numTotalBatches || numBatchesProcessed < numTotalBatches));
 
-    LOG.info("Finished kill task[%s] for dataSource[%s] and interval[%s]. Deleted total [%d] unused segments "
-             + "in [%d] batches.",
-        getId(),
-        getDataSource(),
-        getInterval(),
-        numSegmentsKilled,
-        numBatchesProcessed
+    final String taskId = getId();
+    LOG.info(
+        "Finished kill task[%s] for dataSource[%s] and interval[%s]."
+        + " Deleted total [%d] unused segments in [%d] batches.",
+        taskId, getDataSource(), getInterval(), numSegmentsKilled, numBatchesProcessed
     );
 
-    return TaskStatus.success(getId());
+    final KillTaskReport.Stats stats =
+        new KillTaskReport.Stats(numSegmentsKilled, numBatchesProcessed, numSegmentsMarkedAsUnused);
+    toolbox.getTaskReportFileWriter().write(
+        taskId,
+        TaskReport.buildTaskReports(new KillTaskReport(taskId, stats))
+    );
+
+    return TaskStatus.success(taskId);
   }
 
   @JsonIgnore

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -104,7 +104,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     );
 
     KillTaskReport.Stats stats = getReportedStats();
-    Assert.assertEquals(2L, stats.getNumBatchesProcessed());
+    Assert.assertEquals(2, stats.getNumBatchesProcessed());
     Assert.assertEquals(1, stats.getNumSegmentsKilled());
   }
 
@@ -379,11 +379,11 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
       Object payload = getObjectMapper().readValue(
           taskRunner.getTaskReportsFile(),
           new TypeReference<Map<String, TaskReport>>() { }
-      ).get(KillTaskReport.REPORT_KEY);
+      ).get(KillTaskReport.REPORT_KEY).getPayload();
       return getObjectMapper().convertValue(payload, KillTaskReport.Stats.class);
     }
     catch (Exception e) {
-      throw new ISE("Error while reading task report");
+      throw new ISE(e, "Error while reading task report");
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -19,12 +19,15 @@
 
 package org.apache.druid.indexing.common.task;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexing.common.KillTaskReport;
+import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.overlord.Segments;
-import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.assertj.core.api.Assertions;
@@ -35,13 +38,14 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 {
   private static final String DATA_SOURCE = "dataSource";
 
-  private TaskRunner taskRunner;
+  private TestTaskRunner taskRunner;
 
   @Before
   public void setup()
@@ -99,8 +103,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
 
-    Assert.assertEquals(2L, task.getNumBatchesProcessed());
-    Assert.assertEquals(1, task.getNumSegmentsKilled());
+    KillTaskReport.Stats stats = getReportedStats();
+    Assert.assertEquals(2L, stats.getNumBatchesProcessed());
+    Assert.assertEquals(1, stats.getNumSegmentsKilled());
   }
 
 
@@ -148,8 +153,10 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         newSegment(Intervals.of("2019-01-01/2019-02-01"), version),
         newSegment(Intervals.of("2019-04-01/2019-05-01"), version)
     );
-    Assert.assertEquals(2L, task.getNumBatchesProcessed());
-    Assert.assertEquals(1, task.getNumSegmentsKilled());
+
+    KillTaskReport.Stats stats = getReportedStats();
+    Assert.assertEquals(2L, stats.getNumBatchesProcessed());
+    Assert.assertEquals(1, stats.getNumSegmentsKilled());
   }
 
   @Test
@@ -209,8 +216,10 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"));
 
     Assert.assertEquals(Collections.emptyList(), unusedSegments);
-    Assert.assertEquals(4L, task.getNumBatchesProcessed());
-    Assert.assertEquals(4, task.getNumSegmentsKilled());
+
+    KillTaskReport.Stats stats = getReportedStats();
+    Assert.assertEquals(4L, stats.getNumBatchesProcessed());
+    Assert.assertEquals(4, stats.getNumSegmentsKilled());
   }
 
   @Test
@@ -246,8 +255,10 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(DATA_SOURCE, Intervals.of("2019/2020"));
 
     Assert.assertEquals(Collections.emptyList(), unusedSegments);
-    Assert.assertEquals(3L, task.getNumBatchesProcessed());
-    Assert.assertEquals(4, task.getNumSegmentsKilled());
+
+    KillTaskReport.Stats stats = getReportedStats();
+    Assert.assertEquals(3L, stats.getNumBatchesProcessed());
+    Assert.assertEquals(4, stats.getNumSegmentsKilled());
   }
 
   @Test
@@ -360,6 +371,20 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             10
         );
     Assert.assertEquals(2, (int) task.getNumTotalBatches());
+  }
+
+  private KillTaskReport.Stats getReportedStats()
+  {
+    try {
+      Object payload = getObjectMapper().readValue(
+          taskRunner.getTaskReportsFile(),
+          new TypeReference<Map<String, TaskReport>>() { }
+      ).get(KillTaskReport.REPORT_KEY);
+      return getObjectMapper().convertValue(payload, KillTaskReport.Stats.class);
+    }
+    catch (Exception e) {
+      throw new ISE("Error while reading task report");
+    }
   }
 
   private static DataSegment newSegment(Interval interval, String version)

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientKillUnusedSegmentsTaskQuery.java
@@ -25,7 +25,6 @@ import com.google.common.base.Preconditions;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
-
 import java.util.Objects;
 
 /**
@@ -90,6 +89,14 @@ public class ClientKillUnusedSegmentsTaskQuery implements ClientTaskQuery
     return interval;
   }
 
+  /**
+   * This field has been deprecated as "kill" tasks should not be responsible for
+   * marking segments as unused. Instead, users should call the Coordinator API
+   * {@code /{dataSourceName}/markUnused} to explicitly mark segments as unused.
+   * Segments may also be marked unused by the Coordinator if they become overshadowed
+   * or have a {@code DropRule} applied to them.
+   */
+  @Deprecated
   @JsonProperty
   public Boolean getMarkAsUnused()
   {


### PR DESCRIPTION
### Changes
- Add `KillTaskReport` that contains stats for `numSegmentsKilled`, `numBatchesProcessed`, `numSegmentsMarkedAsUnused`
- Fix bug where exception message had no formatter but was was still being passed some args.
- Add some comments regarding deprecation of `markAsUnused` flag.

### Release note

Kill tasks that delete unused segments now publish a task report containing kill stats such as `numSegmentsKilled`, `numBatchesProcessed`, `numSegmentsMarkedAsUnused`.

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
