### PR TITLE
Support getTaskLocation for mixed task runner

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
@@ -276,4 +276,17 @@ public class KubernetesAndWorkerTaskRunner implements TaskLogStreamer, WorkerTas
     }
     return Math.max(0, k8sCapacity) + Math.max(0, workerCapacity);
   }
+
+  // Worker task runners do not implement these methods
+  @Override
+  public void updateStatus(Task task, TaskStatus status)
+  {
+    kubernetesTaskRunner.updateStatus(task, status);
+  }
+
+  @Override
+  public void updateLocation(Task task, TaskLocation location)
+  {
+    kubernetesTaskRunner.updateLocation(task, location);
+  }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.druid.indexer.RunnerTaskState;
+import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
@@ -232,6 +233,16 @@ public class KubernetesAndWorkerTaskRunner implements TaskLogStreamer, WorkerTas
     return Optional.absent();
   }
 
+  @Override
+  public TaskLocation getTaskLocation(String taskId)
+  {
+    TaskLocation taskLocation = kubernetesTaskRunner.getTaskLocation(taskId);
+    if (taskLocation == null || taskLocation.equals(TaskLocation.unknown())) {
+      return workerTaskRunner.getTaskLocation(taskId);
+    }
+    return taskLocation;
+  }
+  
   @Nullable
   @Override
   public RunnerTaskState getRunnerTaskState(String taskId)

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
@@ -323,4 +323,22 @@ public class KubernetesAndWorkerTaskRunnerTest extends EasyMockSupport
     Assert.assertEquals(workerTaskLocation, runner.getTaskLocation(ID));
     verifyAll();
   }
+
+  @Test
+  public void test_updateStatus()
+  {
+    kubernetesTaskRunner.updateStatus(task, TaskStatus.running(ID));
+    replayAll();
+    runner.updateStatus(task, TaskStatus.running(ID));
+    verifyAll();
+  }
+
+  @Test
+  public void test_updateLocation()
+  {
+    kubernetesTaskRunner.updateLocation(task, TaskLocation.unknown());
+    replayAll();
+    runner.updateLocation(task, TaskLocation.unknown());
+    verifyAll();
+  }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Futures;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.indexer.RunnerTaskState;
+import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
@@ -298,6 +299,28 @@ public class KubernetesAndWorkerTaskRunnerTest extends EasyMockSupport
     EasyMock.expect(workerTaskRunner.restore()).andReturn(ImmutableList.of());
     replayAll();
     Assert.assertEquals(0, runner.restore().size());
+    verifyAll();
+  }
+
+  @Test
+  public void test_getTaskLocation_kubernetes()
+  {
+    TaskLocation kubernetesTaskLocation = TaskLocation.create("host", 0, 0, false);
+    EasyMock.expect(kubernetesTaskRunner.getTaskLocation(ID)).andReturn(kubernetesTaskLocation);
+    replayAll();
+    Assert.assertEquals(kubernetesTaskLocation, runner.getTaskLocation(ID));
+    verifyAll();
+  }
+
+  @Test
+  public void test_getTaskLocation_worker()
+  {
+    TaskLocation workerTaskLocation = TaskLocation.create("host", 0, 0, false);
+    EasyMock.expect(kubernetesTaskRunner.getTaskLocation(ID)).andReturn(TaskLocation.unknown());
+    EasyMock.expect(workerTaskRunner.getTaskLocation(ID)).andReturn(workerTaskLocation);
+
+    replayAll();
+    Assert.assertEquals(workerTaskLocation, runner.getTaskLocation(ID));
     verifyAll();
   }
 }


### PR DESCRIPTION
### Description
The KubernetesAndWorkerTaskRunner currently doesn't implement getTaskLocation, so tasks run by it will show a unknown TaskLocation in the druid console after a task has completed.

#### Release note
Fix bug in KubernetesAndWorkerTaskRunner that manifests as missing information in the druid Web Console.

##### Key changed/added classes in this PR
 * `KubernetesAndWorkerTaskRunner`


- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
