### PR TITLE
Add read timeout for getting records when sampling a stream

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -198,7 +198,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, 5_000,null, null),
+        new SamplerConfig(5, 5_000, 5_000, null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );
@@ -416,7 +416,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, 5_000,  null, null),
+        new SamplerConfig(5, 5_000, 5_000, null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         OBJECT_MAPPER
     );

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -198,7 +198,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, null, null),
+        new SamplerConfig(5, 5_000, 5_000,null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );
@@ -251,7 +251,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, null, null),
+        new SamplerConfig(5, 5_000, 5_000, null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );
@@ -313,7 +313,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, null, null),
+        new SamplerConfig(5, 5_000, 5_000, null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );
@@ -416,7 +416,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, 5_000, null, null),
+        new SamplerConfig(5, 5_000, 5_000,  null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         OBJECT_MAPPER
     );
@@ -600,7 +600,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );
@@ -656,7 +656,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(OBJECT_MAPPER),
         OBJECT_MAPPER
     );

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -166,7 +166,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     KinesisSamplerSpec samplerSpec = new TestableKinesisSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         null
     );
@@ -244,7 +244,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     KinesisSamplerSpec samplerSpec = new TestableKinesisSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         null
     );
@@ -297,7 +297,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     KinesisSamplerSpec samplerSpec = new TestableKinesisSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null,  null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         null
     );

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -297,7 +297,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     KinesisSamplerSpec samplerSpec = new TestableKinesisSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null,  null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(new DefaultObjectMapper()),
         null
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
@@ -34,7 +34,7 @@ public class SamplerConfig
 
   private final int numRows;
   private final int timeoutMs;
-  private final int nextRecordTimeoutMs;
+  private final Integer readTimeoutMs;
   private final long maxBytesInMemory;
   private final long maxClientResponseBytes;
 
@@ -42,18 +42,22 @@ public class SamplerConfig
   public SamplerConfig(
       @JsonProperty("numRows") @Nullable Integer numRows,
       @JsonProperty("timeoutMs") @Nullable Integer timeoutMs,
-      @JsonProperty("nextRecordTimeoutMs") @Nullable Integer nextRecordTimeoutMs,
+      @JsonProperty("readTimeoutMs") @Nullable Integer readTimeoutMs,
       @JsonProperty("maxBytesInMemory") @Nullable HumanReadableBytes maxBytesInMemory,
       @JsonProperty("maxClientResponseBytes") @Nullable HumanReadableBytes maxClientResponseBytes
   )
   {
     this.numRows = numRows != null ? numRows : DEFAULT_NUM_ROWS;
     this.timeoutMs = timeoutMs != null ? timeoutMs : DEFAULT_TIMEOUT_MS;
-    this.nextRecordTimeoutMs = nextRecordTimeoutMs != null ? nextRecordTimeoutMs : this.timeoutMs;
+    this.readTimeoutMs = readTimeoutMs;
     this.maxBytesInMemory = maxBytesInMemory != null ? maxBytesInMemory.getBytes() : Long.MAX_VALUE;
     this.maxClientResponseBytes = maxClientResponseBytes != null ? maxClientResponseBytes.getBytes() : 0;
 
     Preconditions.checkArgument(this.numRows <= MAX_NUM_ROWS, "numRows must be <= %s", MAX_NUM_ROWS);
+    Preconditions.checkArgument(
+        this.readTimeoutMs != null && this.readTimeoutMs <= this.timeoutMs,
+        "readTimeoutMs must be <= timeoutMs"
+    );
   }
 
   /**
@@ -92,9 +96,10 @@ public class SamplerConfig
    *
    * @return timeout in milliseconds
    */
-  public int getNextRecordTimeoutMs()
+  @Nullable
+  public Integer getReadTimeoutMs()
   {
-    return nextRecordTimeoutMs;
+    return readTimeoutMs;
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
@@ -55,7 +55,7 @@ public class SamplerConfig
 
     Preconditions.checkArgument(this.numRows <= MAX_NUM_ROWS, "numRows must be <= %s", MAX_NUM_ROWS);
     Preconditions.checkArgument(
-        this.readTimeoutMs != null && this.readTimeoutMs <= this.timeoutMs,
+        this.readTimeoutMs == null || this.readTimeoutMs <= this.timeoutMs,
         "readTimeoutMs must be <= timeoutMs"
     );
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/SamplerConfig.java
@@ -34,6 +34,7 @@ public class SamplerConfig
 
   private final int numRows;
   private final int timeoutMs;
+  private final int nextRecordTimeoutMs;
   private final long maxBytesInMemory;
   private final long maxClientResponseBytes;
 
@@ -41,12 +42,14 @@ public class SamplerConfig
   public SamplerConfig(
       @JsonProperty("numRows") @Nullable Integer numRows,
       @JsonProperty("timeoutMs") @Nullable Integer timeoutMs,
+      @JsonProperty("nextRecordTimeoutMs") @Nullable Integer nextRecordTimeoutMs,
       @JsonProperty("maxBytesInMemory") @Nullable HumanReadableBytes maxBytesInMemory,
       @JsonProperty("maxClientResponseBytes") @Nullable HumanReadableBytes maxClientResponseBytes
   )
   {
     this.numRows = numRows != null ? numRows : DEFAULT_NUM_ROWS;
     this.timeoutMs = timeoutMs != null ? timeoutMs : DEFAULT_TIMEOUT_MS;
+    this.nextRecordTimeoutMs = nextRecordTimeoutMs != null ? nextRecordTimeoutMs : this.timeoutMs;
     this.maxBytesInMemory = maxBytesInMemory != null ? maxBytesInMemory.getBytes() : Long.MAX_VALUE;
     this.maxClientResponseBytes = maxClientResponseBytes != null ? maxClientResponseBytes.getBytes() : 0;
 
@@ -84,6 +87,17 @@ public class SamplerConfig
   }
 
   /**
+   * Time to wait in milliseconds for the next record before closing the sampler and returning the data which has
+   * already been read. This timeout is only used once we have read at least one record from the input source.
+   *
+   * @return timeout in milliseconds
+   */
+  public int getNextRecordTimeoutMs()
+  {
+    return nextRecordTimeoutMs;
+  }
+
+  /**
    * Maximum number of bytes in memory that the {@link org.apache.druid.segment.incremental.IncrementalIndex} used by
    * {@link InputSourceSampler#sample(org.apache.druid.data.input.InputSource, org.apache.druid.data.input.InputFormat, org.apache.druid.segment.indexing.DataSchema, SamplerConfig)}
    * will be allowed to accumulate before aborting sampling. Particularly useful for limiting footprint of sample
@@ -111,6 +125,6 @@ public class SamplerConfig
 
   public static SamplerConfig empty()
   {
-    return new SamplerConfig(null, null, null, null);
+    return new SamplerConfig(null, null, null, null, null);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSource.java
@@ -168,7 +168,7 @@ public class RecordSupplierInputSource<PartitionIdType, SequenceOffsetType, Reco
             }
             if (nextRecordTerminationTime != null && currentTime > nextRecordTerminationTime) {
               LOG.info(
-                  "Configured sampler poll timeout [%s] has been exceeded, returning without a bytesIterator.",
+                  "Configured sampler next record timeout [%s] has been exceeded, returning without a bytesIterator.",
                   nextRecordTimeoutMs
               );
               bytesIterator = null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -106,7 +106,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
           recordSupplier,
           ioConfig.isUseEarliestSequenceNumber(),
           samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs(),
-          samplerConfig.getNextRecordTimeoutMs() <= 0 ? null : samplerConfig.getNextRecordTimeoutMs()
+          samplerConfig.getReadTimeoutMs()
       );
       inputFormat = Preconditions.checkNotNull(
           ioConfig.getInputFormat(),
@@ -190,9 +190,7 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
               samplerConfig.getTimeoutMs() <= 0
                   ? null
                   : samplerConfig.getTimeoutMs(),
-              samplerConfig.getNextRecordTimeoutMs() <= 0
-                  ? null
-                  : samplerConfig.getNextRecordTimeoutMs()
+              samplerConfig.getReadTimeoutMs()
           );
       this.entityIterator = inputSource.createEntityIterator();
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpec.java
@@ -105,7 +105,8 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
           ioConfig.getStream(),
           recordSupplier,
           ioConfig.isUseEarliestSequenceNumber(),
-          samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs()
+          samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs(),
+          samplerConfig.getNextRecordTimeoutMs() <= 0 ? null : samplerConfig.getNextRecordTimeoutMs()
       );
       inputFormat = Preconditions.checkNotNull(
           ioConfig.getInputFormat(),
@@ -181,12 +182,18 @@ public abstract class SeekableStreamSamplerSpec<PartitionIdType, SequenceOffsetT
         ((StringInputRowParser) parser).startFileFromBeginning();
       }
 
-      RecordSupplierInputSource<PartitionIdType, SequenceOffsetType, RecordType> inputSource = new RecordSupplierInputSource<>(
-          ioConfig.getStream(),
-          createRecordSupplier(),
-          ioConfig.isUseEarliestSequenceNumber(),
-          samplerConfig.getTimeoutMs() <= 0 ? null : samplerConfig.getTimeoutMs()
-      );
+      RecordSupplierInputSource<PartitionIdType, SequenceOffsetType, RecordType> inputSource =
+          new RecordSupplierInputSource<>(
+              ioConfig.getStream(),
+              createRecordSupplier(),
+              ioConfig.isUseEarliestSequenceNumber(),
+              samplerConfig.getTimeoutMs() <= 0
+                  ? null
+                  : samplerConfig.getTimeoutMs(),
+              samplerConfig.getNextRecordTimeoutMs() <= 0
+                  ? null
+                  : samplerConfig.getNextRecordTimeoutMs()
+          );
       this.entityIterator = inputSource.createEntityIterator();
     }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/InputSourceSamplerTest.java
@@ -246,7 +246,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
         inputSource,
         createInputFormat(),
         null,
-        new SamplerConfig(3, null, null, null)
+        new SamplerConfig(3, null, null, null, null)
     );
 
     Assert.assertEquals(3, response.getNumRowsRead());
@@ -1228,10 +1228,10 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
     );
 
     SamplerResponse response = inputSourceSampler.sample(
-        new RecordSupplierInputSource("topicName", new TestRecordSupplier(jsonBlockList), true, 3000),
+        new RecordSupplierInputSource("topicName", new TestRecordSupplier(jsonBlockList), true, 3000, 3000),
         createInputFormat(),
         dataSchema,
-        new SamplerConfig(200, 3000/*default timeout is 10s, shorten it to speed up*/, null, null)
+        new SamplerConfig(200, 3000/*default timeout is 10s, shorten it to speed up*/, 3000, null, null)
     );
 
     //
@@ -1353,7 +1353,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
         inputSource,
         inputFormat,
         dataSchema,
-        new SamplerConfig(4, null, null, null)
+        new SamplerConfig(4, null, null, null, null)
     );
 
     Assert.assertEquals(4, response.getNumRowsRead());
@@ -1388,7 +1388,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
         inputSource,
         inputFormat,
         dataSchema,
-        new SamplerConfig(null, null, HumanReadableBytes.valueOf(256), null)
+        new SamplerConfig(null, null, null, HumanReadableBytes.valueOf(256), null)
     );
 
     Assert.assertEquals(4, response.getNumRowsRead());
@@ -1422,7 +1422,7 @@ public class InputSourceSamplerTest extends InitializedNullHandlingTest
         inputSource,
         inputFormat,
         dataSchema,
-        new SamplerConfig(null, null, null, HumanReadableBytes.valueOf(300))
+        new SamplerConfig(null, null, null, null, HumanReadableBytes.valueOf(300))
     );
 
     Assert.assertEquals(4, response.getNumRowsRead());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -76,7 +76,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   public void testRead() throws IOException
   {
     final RandomCsvSupplier supplier = new RandomCsvSupplier();
-    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, null);
+    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, null, null);
     final List<String> colNames = IntStream.range(0, NUM_COLS)
                                            .mapToObj(i -> StringUtils.format("col_%d", i))
                                            .collect(Collectors.toList());
@@ -110,7 +110,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   public void testReadTimeout() throws IOException
   {
     final RandomCsvSupplier supplier = new RandomCsvSupplier();
-    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, -1000);
+    final InputSource inputSource = new RecordSupplierInputSource<>("topic", supplier, false, -1000, -1000);
     final List<String> colNames = IntStream.range(0, NUM_COLS)
                                            .mapToObj(i -> StringUtils.format("col_%d", i))
                                            .collect(Collectors.toList());
@@ -147,7 +147,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
     //noinspection ResultOfObjectAllocationIgnored
     final SamplerException exception = Assert.assertThrows(
         SamplerException.class,
-        () -> new RecordSupplierInputSource<>("test-stream", supplier, false, null)
+        () -> new RecordSupplierInputSource<>("test-stream", supplier, false, null, null)
     );
     Assert.assertEquals(
         "Exception while seeking to the [latest] offset of partitions in topic [test-stream]: Something bad happened",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -139,7 +139,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testNextRecordTimeoutExceeded() throws IOException
+  public void testReadTimeoutExceeded() throws IOException
   {
     int numRecordsPerPoll = 1;
     final RandomCsvSupplier supplier = new RandomCsvSupplier(numRecordsPerPoll);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpecTest.java
@@ -174,7 +174,7 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
 
     SeekableStreamSamplerSpec samplerSpec = new TestableSeekableStreamSamplerSpec(
         supervisorSpec,
-        new SamplerConfig(5, null, null, null),
+        new SamplerConfig(5, null, null, null, null),
         new InputSourceSampler(new DefaultObjectMapper())
     );
 


### PR DESCRIPTION
### Description

Previously, when sampling streaming data, the sampler would wait `timeoutMs` for `numRows` to be returned. If the stream has less rows than `numRows`, the sampler would wait the full `timeoutMs` period. In some cases, initially connecting to a given stream to sample may take a considerable amount of time, but reading subsequent records thereafter is a much faster operation. For these cases, this PR adds a new sampler config property `readTimeoutMs`, which if specified, causes the sampler to return after this period of time if no further records are found between the last record found, or `timeoutMs`, whichever comes first.  The new `readTimeoutMs` is only applied once some records have been read from the stream during sampling. For example if a stream has only 1 record in it at a given time, and `timeoutMs` is configured as `15000` miliseconds and `readTimeoutMs` is configured as `2000` milliseconds while `numRows` is configured as `500`, then assuming the first record is read quickly, the sampler will return after roughly `2000` milliseconds, whereas previously it would have returned after the full `15000` millesecond `timeoutMs` config value.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
