### PR TITLE
(WIP) Wait for initialization during KubernetesTaskRunner startup

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -318,7 +318,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   public void start()
   {
     log.info("Starting K8sTaskRunner...");
-    // Load tasks fromcom.google.common.util.concurrent.Futures create futurewa previously running jobs and wait for their statuses to be updated asynchronously.
+    // Load tasks from previously running jobs and wait for their statuses to be updated asynchronously.
     for (Job job : client.getPeonJobs()) {
       try {
         joinAsync(adapter.toTask(job));
@@ -359,13 +359,13 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
             return pendingWorkItems;
           },
           e -> e instanceof ISE,
-          6,
-          6
+          5,
+          5
 
       );
     }
     catch (Exception e) {
-      log.error("Kubernetes took too long to initialize, continuing startup.", e);
+      log.info("Kubernetes took too long to initialize, continuing startup. %s", e);
     }
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -231,7 +231,6 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
     Assert.assertEquals(0, runner.tasks.size());
   }
 
-
   @Test
   public void test_streamTaskLog_withoutExistingTask_returnsEmptyOptional()
   {


### PR DESCRIPTION
This fix attempts to bring the KubernetesTaskRunner more into line with the HttpRemoteTaskRunner (https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java#L560) w.r.t startup initialization.

Right now when the overlord becomes a leader using the KubernetesTaskRunner it adds all of the running tasks to its mapping, but doesn't wait for the underlying thread pool to finish syncing state from Kubernetes. This change attempts to do this (although it doesn't fail if it is unable to completely finish syncing)
### Description
Best-effort attempt to sync state from Kubernetes completely before becoming the overlord leader when running mm-less ingestion.

In the start() method, after adding all the jobs in kubernetes to the tasks map, try to wait for the underlying thread pool to finish syncing state from K8s. 

#### Release note
Improvments to overlord lifecycle when running mm-less ingestion

##### Key changed/added classes in this PR
 * `KubernetesTaskRunner`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
