### PR TITLE
Fix uploading IT docker logs to GHA artifacts

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -137,6 +137,7 @@ jobs:
       - name: Collect docker logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
+          mkdir docker-logs
           for c in $(docker ps -a --format="{{.Names}}")
           do
             docker logs $c > ./docker-logs/$c.log
@@ -156,8 +157,7 @@ jobs:
       - name: Collect service logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
-          docker cp middlemanager:/shared/logs/ ./service-logs
-          tar cvzf ./service-logs.tgz ./service-logs
+          tar cvzf ./service-logs.tgz ~/shared/logs
 
       - name: Upload Druid service logs to GitHub
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Collect docker logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
+          mkdir docker-logs
           for c in $(docker ps -a --format="{{.Names}}")
           do
             docker logs $c > ./docker-logs/$c.log
@@ -110,8 +111,7 @@ jobs:
       - name: Collect service logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
-          docker cp druid-middlemanager:/shared/logs/ ./service-logs
-          tar cvzf ./service-logs.tgz ./service-logs
+          tar cvzf ./service-logs.tgz ./shared/logs
 
       - name: Upload Druid service logs to GitHub
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}


### PR DESCRIPTION
- Fixes `Collect Docker logs on failure` step in Integration tests GHA workflow - https://github.com/apache/druid/actions/runs/6321037668/job/17165721727
- Collects service logs from the local `~/shared/logs` directory instead of a docker container. 