### PR TITLE
Build reliablity fixes

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml) }}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Maven build
         if: steps.maven-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml)}}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml) }}
 
       - name: Maven build
         if: steps.maven-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -159,6 +159,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml)}}
 
       - name: Maven build
         if: steps.maven-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml)}}
 
       - name: Cache targets
         id: target

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml) }}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache targets
         id: target

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml)}}
+          restore-keys: setup-java-Linux-maven-${{ hashFiles(**/pom.xml) }}
 
       - name: Cache targets
         id: target

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/DatasourceOptimizerTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.client.BrokerServerView;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.selector.HighestPriorityTierSelectorStrategy;
 import org.apache.druid.client.selector.RandomServerSelectorStrategy;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.curator.CuratorTestBase;
 import org.apache.druid.indexing.materializedview.DerivativeDataSourceMetadata;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -72,6 +73,10 @@ import java.util.concurrent.TimeUnit;
 
 public class DatasourceOptimizerTest extends CuratorTestBase
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   @Rule
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
   private DerivativeDataSourceManager derivativesManager;
@@ -142,7 +147,7 @@ public class DatasourceOptimizerTest extends CuratorTestBase
     Set<String> metrics = Sets.newHashSet("cost");
     DerivativeDataSourceMetadata metadata = new DerivativeDataSourceMetadata(baseDataSource, dims, metrics);
     metadataStorageCoordinator.insertDataSourceMetadata(dataSource, metadata);
-    // insert base datasource segments 
+    // insert base datasource segments
     List<Boolean> baseResult = Lists.transform(
         ImmutableList.of(
             "2011-04-01/2011-04-02",

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.MapBasedRow;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
@@ -55,6 +56,10 @@ import java.util.stream.Collectors;
 
 public class MaterializedViewQueryQueryToolChestTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final ObjectMapper JSON_MAPPER = new DefaultObjectMapper();
 
   @Test
@@ -244,7 +249,5 @@ public class MaterializedViewQueryQueryToolChestTest
         ));
 
     Assert.assertEquals(realQuery, materializedViewQueryQueryToolChest.getRealQuery(materializedViewQuery));
-    
   }
-  
 }

--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.Query;
@@ -45,6 +46,10 @@ import java.io.IOException;
 
 public class MaterializedViewQueryTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final ObjectMapper JSON_MAPPER = TestHelper.makeJsonMapper();
   private DataSourceOptimizer optimizer;
 

--- a/integration-tests/script/copy_resources_template.sh
+++ b/integration-tests/script/copy_resources_template.sh
@@ -30,7 +30,7 @@ cp -R docker $SHARED_DIR/docker
 
 pushd ../
 rm -rf distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin
-mvn -Pskip-static-checks,skip-tests -T1C -Danimal.sniffer.skip=true -Dcheckstyle.skip=true -Dweb.console.skip=true -Dcyclonedx.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true install -Pintegration-test
+mvn -B -Pskip-static-checks,skip-tests -Danimal.sniffer.skip=true -Dcheckstyle.skip=true -Dweb.console.skip=true -Dcyclonedx.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true install -Pintegration-test
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/bin $SHARED_DIR/docker/bin
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions

--- a/integration-tests/script/copy_resources_template.sh
+++ b/integration-tests/script/copy_resources_template.sh
@@ -30,7 +30,8 @@ cp -R docker $SHARED_DIR/docker
 
 pushd ../
 rm -rf distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin
-mvn -B -Pskip-static-checks,skip-tests -Danimal.sniffer.skip=true -Dcheckstyle.skip=true -Dweb.console.skip=true -Dcyclonedx.skip=true -Denforcer.skip=true -Dforbiddenapis.skip=true -Dmaven.javadoc.skip=true -Dpmd.skip=true -Dspotbugs.skip=true install -Pintegration-test
+# using parallel build here may not yield significant speedups
+mvn -B -Pskip-static-checks,skip-tests -Dweb.console.skip=true install -Pintegration-test
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/bin $SHARED_DIR/docker/bin
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/lib $SHARED_DIR/docker/lib
 mv distribution/target/apache-druid-$DRUID_VERSION-integration-test-bin/extensions $SHARED_DIR/docker/extensions

--- a/it.sh
+++ b/it.sh
@@ -232,7 +232,7 @@ case $CMD in
     mvn -q clean install dependency:go-offline -P dist $MAVEN_IGNORE
     ;;
   "build" )
-    mvn -B clean install -P dist $MAVEN_IGNORE $*
+    mvn -B clean install -P dist $MAVEN_IGNORE -T1.0C $*
     ;;
   "dist" )
     mvn -B install -P dist $MAVEN_IGNORE -pl :distribution

--- a/it.sh
+++ b/it.sh
@@ -232,17 +232,17 @@ case $CMD in
     mvn -q clean install dependency:go-offline -P dist $MAVEN_IGNORE
     ;;
   "build" )
-    mvn clean install -P dist $MAVEN_IGNORE -T1.0C $*
+    mvn -B clean install -P dist $MAVEN_IGNORE $*
     ;;
   "dist" )
-    mvn install -P dist $MAVEN_IGNORE -pl :distribution
+    mvn -B install -P dist $MAVEN_IGNORE -pl :distribution
     ;;
   "tools" )
-    mvn install -pl :druid-it-tools
+    mvn -B install -pl :druid-it-tools
     ;;
   "image" )
     cd $DRUID_DEV/integration-tests-ex/image
-    mvn install -P test-image $MAVEN_IGNORE
+    mvn -B install -P test-image $MAVEN_IGNORE
     ;;
   "gen")
     # Generate the docker-compose.yaml files. Mostly for debugging
@@ -264,7 +264,7 @@ case $CMD in
   "run" )
     require_category
     reuse_override
-    mvn $TEST_OPTIONS -P IT-$CATEGORY -pl $MAVEN_PROJECT
+    mvn -B $TEST_OPTIONS -P IT-$CATEGORY -pl $MAVEN_PROJECT
     ;;
   "test" )
     require_category
@@ -275,7 +275,7 @@ case $CMD in
     # Run the test. On failure, still shut down the cluster.
     # Return Maven's return code as the script's return code.
     set +e
-    mvn $TEST_OPTIONS -P IT-$CATEGORY -pl $MAVEN_PROJECT
+    mvn -B $TEST_OPTIONS -P IT-$CATEGORY -pl $MAVEN_PROJECT
     RESULT=$?
     set -e
     $IT_CASES_DIR/cluster.sh down $CATEGORY

--- a/pom.xml
+++ b/pom.xml
@@ -2106,6 +2106,7 @@
             <maven.javadoc.skip>true</maven.javadoc.skip>
             <pmd.skip>true</pmd.skip>
             <spotbugs.skip>true</spotbugs.skip>
+            <maven.gitcommitid.skip>true</maven.gitcommitid.skip>
           </properties>
         </profile>
         <profile>

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
@@ -258,8 +258,8 @@ public class CalciteSelectQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  // Test that the integers are getting correctly casted after being passed through a function
-  // when not selecting from a table
+  // Test that the integers are getting correctly casted after being passed through a function when not selecting from
+  // a table
   @Test
   public void testDruidLogicalValuesRule()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
@@ -258,8 +258,8 @@ public class CalciteSelectQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  // Test that the integers are getting correctly casted after being passed through a function when not selecting from
-  // a table
+  // Test that the integers are getting correctly casted after being passed through a function
+  // when not selecting from a table
   @Test
   public void testDruidLogicalValuesRule()
   {


### PR DESCRIPTION
* disable parallel builds in CI - could potentially fix the shader issue by making the build more reliable
* possibly enable m2 artifact restoration for integration test builds
* enable batch mode `-B` (disables download progress)
* fix one test missing `NullHandling.init`