### PR TITLE
Debug ITWikipediaQueryTest 

### DIFF
--- a/integration-tests/docker/environment-configs/historical
+++ b/integration-tests/docker/environment-configs/historical
@@ -21,7 +21,7 @@ DRUID_SERVICE=historical
 DRUID_LOG_PATH=/shared/logs/historical.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx512m -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx512m -Xms512m -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/shared/logs -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
 
 # Druid configs
 druid_host=druid-historical


### PR DESCRIPTION
This test has been failing lately with following exception. 

```
Error:  before(org.apache.druid.tests.query.ITWikipediaQueryTest)  Time elapsed: 182.3 s  <<< FAILURE!
org.apache.druid.java.util.common.ISE: Error while querying [http://127.0.0.1:8081/druid/coordinator/v1/lookups/config] status [500 Internal Server Error] content [{"error":"given update for lookup [__default]:[wiki-simple] can't replace existing spec [LookupExtractorFactoryContainer{version='v1', lookupExtractorFactory={type=cachedNamespace, extractionNamespace={type=uri, uri=file:/shared/wikiticker-it/wiki-simple-lookup.json, namespaceParseSpec={format=simpleJson}, pollPeriod=PT10S}, firstCacheTimeout=0}}]."}]
	at org.apache.druid.tests.query.ITWikipediaQueryTest.before(ITWikipediaQueryTest.java:78)
```

It seems that the historical is going out of memory causing this failure. 

Trying to take historical heap dump when it goes out of memory. 