### PR TITLE
Fix missing format strings in calls to DruidException.build 

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -217,7 +217,7 @@ public class SqlStatementResource
       return buildNonOkResponse(
           DruidException.forPersona(DruidException.Persona.DEVELOPER)
                         .ofCategory(DruidException.Category.UNCATEGORIZED)
-                        .build(e.getMessage())
+                        .build("%s", e.getMessage())
       );
     }
     finally {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
@@ -170,7 +170,7 @@ public class SqlTaskResource
           sqlQueryId,
           DruidException.forPersona(DruidException.Persona.DEVELOPER)
                         .ofCategory(DruidException.Category.UNCATEGORIZED)
-                        .build(e.getMessage())
+                        .build("%s", e.getMessage())
       );
     }
     finally {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
@@ -234,7 +234,7 @@ public class SqlStatementResourceHelper
           null,
           DruidException.forPersona(DruidException.Persona.DEVELOPER)
                         .ofCategory(DruidException.Category.UNCATEGORIZED)
-                        .build(taskResponse.getStatus().getErrorMsg()).toErrorResponse()
+                        .build("%s", taskResponse.getStatus().getErrorMsg()).toErrorResponse()
       ));
     }
 

--- a/processing/src/main/java/org/apache/druid/error/ErrorResponse.java
+++ b/processing/src/main/java/org/apache/druid/error/ErrorResponse.java
@@ -204,7 +204,7 @@ public class ErrorResponse
             {
               return bob.forPersona(cause.getTargetPersona())
                         .ofCategory(cause.getCategory())
-                        .build(cause, cause.getMessage())
+                        .build(cause, "%s", cause.getMessage())
                         .withContext(cause.getContext());
             }
           }

--- a/processing/src/main/java/org/apache/druid/error/QueryExceptionCompat.java
+++ b/processing/src/main/java/org/apache/druid/error/QueryExceptionCompat.java
@@ -47,7 +47,7 @@ public class QueryExceptionCompat extends DruidException.Failure
   {
     return bob.forPersona(DruidException.Persona.OPERATOR)
               .ofCategory(convertFailType(exception.getFailType()))
-              .build(exception, exception.getMessage())
+              .build(exception, "%s", exception.getMessage())
               .withContext("host", exception.getHost())
               .withContext("errorClass", exception.getErrorClass())
               .withContext("legacyErrorCode", exception.getErrorCode());

--- a/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
@@ -373,16 +373,24 @@ public class StringUtils
     if (formatArgs == null || formatArgs.length == 0) {
       return message;
     }
+    if (message == null) {
+      return compactFormatArgs("", formatArgs);
+    }
     try {
       return String.format(Locale.ENGLISH, message, formatArgs);
     }
     catch (IllegalFormatException e) {
-      StringBuilder bob = new StringBuilder(message);
-      for (Object formatArg : formatArgs) {
-        bob.append("; ").append(formatArg);
-      }
-      return bob.toString();
+      return compactFormatArgs(message, formatArgs);
     }
+  }
+
+  private static String compactFormatArgs(String message, Object... formatArgs)
+  {
+    StringBuilder bob = new StringBuilder(message);
+    for (Object formatArg : formatArgs) {
+      bob.append("; ").append(formatArg);
+    }
+    return bob.toString();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/StringUtils.java
@@ -373,24 +373,16 @@ public class StringUtils
     if (formatArgs == null || formatArgs.length == 0) {
       return message;
     }
-    if (message == null) {
-      return compactFormatArgs("", formatArgs);
-    }
     try {
       return String.format(Locale.ENGLISH, message, formatArgs);
     }
     catch (IllegalFormatException e) {
-      return compactFormatArgs(message, formatArgs);
+      StringBuilder bob = new StringBuilder(message);
+      for (Object formatArg : formatArgs) {
+        bob.append("; ").append(formatArg);
+      }
+      return bob.toString();
     }
-  }
-
-  private static String compactFormatArgs(String message, Object... formatArgs)
-  {
-    StringBuilder bob = new StringBuilder(message);
-    for (Object formatArg : formatArgs) {
-      bob.append("; ").append(formatArg);
-    }
-    return bob.toString();
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
+++ b/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
@@ -131,7 +131,7 @@ public class ErrorResponseTest
             "TIMEOUT",
 
             "errorMessage",
-            null
+            "null"
         )
     );
   }

--- a/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
+++ b/processing/src/test/java/org/apache/druid/error/ErrorResponseTest.java
@@ -107,4 +107,32 @@ public class ErrorResponseTest
             .expectMessageIs("Query did not complete within configured timeout period. You can increase query timeout or tune the performance of query.")
     );
   }
+  @Test
+  public void testQueryExceptionCompatWithNullMessage()
+  {
+    ErrorResponse response = new ErrorResponse(DruidException.fromFailure(new QueryExceptionCompat(new QueryTimeoutException(
+        null,
+        "hostname"
+    ))));
+    final Map<String, Object> asMap = response.getAsMap();
+    MatcherAssert.assertThat(
+        asMap,
+        DruidMatchers.mapMatcher(
+            "error",
+            "Query timeout",
+
+            "errorCode",
+            "legacyQueryException",
+
+            "persona",
+            "OPERATOR",
+
+            "category",
+            "TIMEOUT",
+
+            "errorMessage",
+            null
+        )
+    );
+  }
 }

--- a/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
@@ -387,10 +387,10 @@ public class StringUtilsTest
     }
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test()
   public void testNonStrictFormatWithNullMessage()
   {
-    StringUtils.nonStrictFormat(null, 1, 2);
+    Assert.assertThrows(NullPointerException.class, () -> StringUtils.nonStrictFormat(null, 1, 2));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
@@ -386,11 +386,19 @@ public class StringUtilsTest
       }
     }
   }
-  @Test
+
+  @Test(expected = NullPointerException.class)
   public void testNonStrictFormatWithNullMessage()
   {
-    Assert.assertEquals("; 1; 2", StringUtils.nonStrictFormat(null, 1, 2));
-    Assert.assertEquals(null, StringUtils.nonStrictFormat(null));
-    Assert.assertEquals("", StringUtils.nonStrictFormat("", 1));
+    StringUtils.nonStrictFormat(null, 1, 2);
+  }
+
+  @Test
+  public void testNonStrictFormatWithStringContainingPercent()
+  {
+    Assert.assertEquals(
+        "some string containing % %s %d %f",
+        StringUtils.nonStrictFormat("%s", "some string containing % %s %d %f")
+    );
   }
 }

--- a/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/StringUtilsTest.java
@@ -386,4 +386,11 @@ public class StringUtilsTest
       }
     }
   }
+  @Test
+  public void testNonStrictFormatWithNullMessage()
+  {
+    Assert.assertEquals("; 1; 2", StringUtils.nonStrictFormat(null, 1, 2));
+    Assert.assertEquals(null, StringUtils.nonStrictFormat(null));
+    Assert.assertEquals("", StringUtils.nonStrictFormat("", 1));
+  }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -345,7 +345,7 @@ public class DruidPlanner implements Closeable
           return DruidException.forPersona(DruidException.Persona.USER)
                                .ofCategory(DruidException.Category.INVALID_INPUT)
                                .withErrorCode("invalidInput")
-                               .build(inner, inner.getMessage()).withContext("sourceType", "sql");
+                               .build(inner, "%s", inner.getMessage()).withContext("sourceType", "sql");
         } else {
           final String theUnexpectedToken = getUnexpectedTokenString(parseException);
 
@@ -390,14 +390,14 @@ public class DruidPlanner implements Closeable
     catch (RelOptPlanner.CannotPlanException inner) {
       return DruidException.forPersona(DruidException.Persona.USER)
                            .ofCategory(DruidException.Category.INVALID_INPUT)
-                           .build(inner, inner.getMessage());
+                           .build(inner, "%s", inner.getMessage());
     }
     catch (Exception inner) {
       // Anything else. Should not get here. Anything else should already have
       // been translated to a DruidException unless it is an unexpected exception.
       return DruidException.forPersona(DruidException.Persona.ADMIN)
                            .ofCategory(DruidException.Category.UNCATEGORIZED)
-                           .build(inner, inner.getMessage());
+                           .build(inner, "%s", inner.getMessage());
     }
   }
 


### PR DESCRIPTION
Fixes #15055 

### Description
PR fix exception eating duck and helps to surface the original exception, 
  
 `String.format(Locale.ENGLISH, null, 1); or  String.format(Locale.ENGLISH, null);`
    
throws NPE and I safeguarding the nonStrictFormat function with null check. 
    
```
Exception in thread "main" java.lang.NullPointerException
	at java.util.regex.Matcher.getTextLength(Matcher.java:1283)
	at java.util.regex.Matcher.reset(Matcher.java:309)
	at java.util.regex.Matcher.<init>(Matcher.java:229)
	at java.util.regex.Pattern.matcher(Pattern.java:1093)
	at java.util.Formatter.parse(Formatter.java:2547)
	at java.util.Formatter.format(Formatter.java:2501)
	at java.util.Formatter.format(Formatter.java:2455)
	at java.lang.String.format(String.java:2981)
```
#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...




This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
