### PR TITLE
Add query id to processing pool thread name.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -74,7 +74,7 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
 
     final Thread currThread = setName ? Thread.currentThread() : null;
     final String currThreadName = setName ? currThread.getName() : null;
-    final String newName = setName ? query.getType() + "_" + query.getDataSource() + "_" + query.getIntervals() : null;
+    final String newName = setName ? "processing_" + query.getId() : null;
 
     final Sequence<T> baseSequence;
 

--- a/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -74,7 +74,7 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
 
     final Thread currThread = setName ? Thread.currentThread() : null;
     final String currThreadName = setName ? currThread.getName() : null;
-    final String newName = setName ? "processing_" + query.getId() : null;
+    final String newName = setName ? "processing_" + query.getDataSource().getTableNames() + "_" + query.getId() : null;
 
     final Sequence<T> baseSequence;
 

--- a/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/spec/SpecificSegmentQueryRunner.java
@@ -74,7 +74,7 @@ public class SpecificSegmentQueryRunner<T> implements QueryRunner<T>
 
     final Thread currThread = setName ? Thread.currentThread() : null;
     final String currThreadName = setName ? currThread.getName() : null;
-    final String newName = setName ? "processing_" + query.getDataSource().getTableNames() + "_" + query.getId() : null;
+    final String newName = setName ? "processing_" + query.getId() : null;
 
     final Sequence<T> baseSequence;
 


### PR DESCRIPTION
I was looking through some stack traces of the historical and I found some processing pool threads which were stuck due to : https://github.com/apache/druid/issues/14514. 

If we had query id in the thread name of the processing pool, it would have easier to locate the initial query which caused the historical to be stuck. 

This patch changes the thread name from `query.getType() + "_" + query.getDataSource() + "_" + query.getIntervals()` to ` query.getId()` in the processing pool of the indexers/peons/historicals copying the same trick from how we rename jetty threads on the broker. 