### PR TITLE
Getting Zookeeper as a repository from Bitnami.

### DIFF
--- a/helm/druid/Chart.yaml
+++ b/helm/druid/Chart.yaml
@@ -19,8 +19,8 @@ description: Apache Druid is a high performance real-time analytics database.
 name: druid
 dependencies:
   - name: zookeeper
-    version: 2.1.4
-    repository: https://charts.helm.sh/incubator
+    version: 11.1.0
+    repository: https://charts.bitnami.com/bitnami
     condition: zookeeper.enabled
   - name: mysql
     version: 1.6.4


### PR DESCRIPTION
Getting Zookeeper from Bitnami as repository and thus solving the Zookeeper error.

Error:
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: resource mapping not found for name: "druid-zookeeper" namespace: "" from "": no matches for kind "PodDisruptionBudget" in version "policy/v1beta1" ensure CRDs are installed first

After:
NAME: druid
LAST DEPLOYED: Sat Sep 30 08:44:16 2023
NAMESPACE: druid
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES: