### PR TITLE
Document the allowed range of announcer maxBytesPerNode

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -757,7 +757,7 @@ In current Druid, multiple data segments may be announced under the same Znode.
 |Property|Description|Default|
 |--------|-----------|-------|
 |`druid.announcer.segmentsPerNode`|Each Znode contains info for up to this many segments.|50|
-|`druid.announcer.maxBytesPerNode`|Max byte size for Znode.|524288|
+|`druid.announcer.maxBytesPerNode`|Max byte size for Znode. Allowed range is [1024, 1048576].|524288|
 |`druid.announcer.skipDimensionsAndMetrics`|Skip Dimensions and Metrics list from segment announcements. NOTE: Enabling this will also remove the dimensions and metrics list from Coordinator and Broker endpoints.|false|
 |`druid.announcer.skipLoadSpec`|Skip segment LoadSpec from segment announcements. NOTE: Enabling this will also remove the loadspec from Coordinator and Broker endpoints.|false|
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
The Batch Data Segment Announcer has a configurable parameter `druid.announcer.maxBytesPerNode`, which controls the maximum ZNode size in bytes. The default value is documented, but the upper limit of 1MB (set [here](https://github.com/apache/druid/blob/07c28f17ca6020c1cc0fa954d19b9b0cc8d32c1b/server/src/main/java/org/apache/druid/server/initialization/BatchDataSegmentAnnouncerConfig.java)) is not. When deploying with a value above that limit, the process crashes, since the configuration is considered invalid. This PR documents the allowed range.


#### Release note
Documented the allowed range of the batch segment announcer's maximum ZNode size.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
