### PR TITLE
urlencode nested serializer temp file names so they dont explode stuff

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
@@ -99,7 +99,7 @@ public final class DictionaryIdLookup implements Closeable
       // for strings because of this. if other type dictionary writers could potentially use multiple internal files
       // in the future, we should transition them to using this approach as well (or build a combination smoosher and
       // mapper so that we can have a mutable smoosh)
-      File stringSmoosh = FileUtils.createTempDir(name + "__stringTempSmoosh");
+      File stringSmoosh = FileUtils.createTempDir(StringUtils.urlEncode(name) + "__stringTempSmoosh");
       final String fileName = NestedCommonFormatColumnSerializer.getInternalFileName(
           name,
           NestedCommonFormatColumnSerializer.STRING_DICTIONARY_FILE_NAME
@@ -135,7 +135,9 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupLong(@Nullable Long value)
   {
     if (longDictionary == null) {
-      Path longFile = makeTempFile(name + NestedCommonFormatColumnSerializer.LONG_DICTIONARY_FILE_NAME);
+      final Path longFile = makeTempFile(
+          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.LONG_DICTIONARY_FILE_NAME
+      );
       longBuffer = mapWriter(longFile, longDictionaryWriter);
       longDictionary = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES).get();
       // reset position
@@ -151,7 +153,9 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupDouble(@Nullable Double value)
   {
     if (doubleDictionary == null) {
-      Path doubleFile = makeTempFile(name + NestedCommonFormatColumnSerializer.DOUBLE_DICTIONARY_FILE_NAME);
+      final Path doubleFile = makeTempFile(
+          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.DOUBLE_DICTIONARY_FILE_NAME
+      );
       doubleBuffer = mapWriter(doubleFile, doubleDictionaryWriter);
       doubleDictionary = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES).get();
       // reset position
@@ -167,7 +171,9 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupArray(@Nullable int[] value)
   {
     if (arrayDictionary == null) {
-      Path arrayFile = makeTempFile(name + NestedCommonFormatColumnSerializer.ARRAY_DICTIONARY_FILE_NAME);
+      final Path arrayFile = makeTempFile(
+          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.ARRAY_DICTIONARY_FILE_NAME
+      );
       arrayBuffer = mapWriter(arrayFile, arrayDictionaryWriter);
       arrayDictionary = FrontCodedIntArrayIndexed.read(arrayBuffer, ByteOrder.nativeOrder()).get();
       // reset position

--- a/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
@@ -135,9 +135,7 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupLong(@Nullable Long value)
   {
     if (longDictionary == null) {
-      final Path longFile = makeTempFile(
-          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.LONG_DICTIONARY_FILE_NAME
-      );
+      final Path longFile = makeTempFile(name + NestedCommonFormatColumnSerializer.LONG_DICTIONARY_FILE_NAME);
       longBuffer = mapWriter(longFile, longDictionaryWriter);
       longDictionary = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES).get();
       // reset position
@@ -153,11 +151,14 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupDouble(@Nullable Double value)
   {
     if (doubleDictionary == null) {
-      final Path doubleFile = makeTempFile(
-          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.DOUBLE_DICTIONARY_FILE_NAME
-      );
+      final Path doubleFile = makeTempFile(name + NestedCommonFormatColumnSerializer.DOUBLE_DICTIONARY_FILE_NAME);
       doubleBuffer = mapWriter(doubleFile, doubleDictionaryWriter);
-      doubleDictionary = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES).get();
+      doubleDictionary = FixedIndexed.read(
+          doubleBuffer,
+          TypeStrategies.DOUBLE,
+          ByteOrder.nativeOrder(),
+          Double.BYTES
+      ).get();
       // reset position
       doubleBuffer.position(0);
     }
@@ -171,9 +172,7 @@ public final class DictionaryIdLookup implements Closeable
   public int lookupArray(@Nullable int[] value)
   {
     if (arrayDictionary == null) {
-      final Path arrayFile = makeTempFile(
-          StringUtils.urlEncode(name) + NestedCommonFormatColumnSerializer.ARRAY_DICTIONARY_FILE_NAME
-      );
+      final Path arrayFile = makeTempFile(name + NestedCommonFormatColumnSerializer.ARRAY_DICTIONARY_FILE_NAME);
       arrayBuffer = mapWriter(arrayFile, arrayDictionaryWriter);
       arrayDictionary = FrontCodedIntArrayIndexed.read(arrayBuffer, ByteOrder.nativeOrder()).get();
       // reset position
@@ -245,7 +244,7 @@ public final class DictionaryIdLookup implements Closeable
   private Path makeTempFile(String name)
   {
     try {
-      return Files.createTempFile(name, ".tmp");
+      return Files.createTempFile(StringUtils.urlEncode(name), null);
     }
     catch (IOException e) {
       throw new RuntimeException(e);

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -171,7 +171,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
   @Before
   public void setup() throws IOException
   {
-    final String fileNameBase = "test";
+    final String fileNameBase = "test/column";
     final String arrayFileNameBase = "array";
     fileMapper = smooshify(fileNameBase, tempFolder.newFolder(), data);
     baseBuffer = fileMapper.mapFile(fileNameBase);


### PR DESCRIPTION
### Description
Fixes a bug caused by #14919, which was just using the column name as part of a temp file name, which.. isn't very cool, my bad. Switched to use `StringUtils.urlEncode` so that ugly chars don't explode stuff. The modified test fails without the changes in this PR.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
