### PR TITLE
Fix path of druid service IT logs during artifacts creation

### DIFF
--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Collect service logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
-          tar cvzf ./service-logs.tgz ./shared/logs
+          tar cvzf ./service-logs.tgz ~/shared/logs
 
       - name: Upload Druid service logs to GitHub
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}


### PR DESCRIPTION
Earlier PR - https://github.com/apache/druid/pull/15046 introduced a small error in the path of service logs while uploading to GHA artifacts. This PR fixes it.