### PR TITLE
Fix IndexerWorkerClient#fetchChannelData when response has data and error.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFileHttpResponseHandler.java
@@ -21,6 +21,7 @@ package org.apache.druid.frame.file;
 
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.channel.ReadableByteChunksFrameChannel;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.http.client.response.ClientResponse;
@@ -49,11 +50,20 @@ public class FrameFileHttpResponseHandler implements HttpResponseHandler<FrameFi
   public static final String HEADER_LAST_FETCH_NAME = "X-Druid-Frame-Last-Fetch";
   public static final String HEADER_LAST_FETCH_VALUE = "yes";
 
+  /**
+   * Channel to write to.
+   */
   private final ReadableByteChunksFrameChannel channel;
+
+  /**
+   * Starting offset for this handler.
+   */
+  private final long startOffset;
 
   public FrameFileHttpResponseHandler(final ReadableByteChunksFrameChannel channel)
   {
     this.channel = Preconditions.checkNotNull(channel, "channel");
+    this.startOffset = channel.getBytesAdded();
   }
 
   @Override
@@ -114,20 +124,34 @@ public class FrameFileHttpResponseHandler implements HttpResponseHandler<FrameFi
       return ClientResponse.finished(clientResponseObj);
     }
 
-    final byte[] chunk = new byte[content.readableBytes()];
-    content.getBytes(content.readerIndex(), chunk);
+    final byte[] chunk;
+    final int chunkSize = content.readableBytes();
 
-    try {
-      final ListenableFuture<?> backpressureFuture = channel.addChunk(chunk);
+    // Potentially skip some of this chunk, if the relevant bytes have already been read by the handler. This can
+    // happen if a request reads some data, then fails with a retryable I/O error, and then is retried. The retry
+    // will re-read some data that has already been added to the channel, so we need to skip it.
+    final long readByThisHandler = channel.getBytesAdded() - startOffset;
+    final long readByThisRequest = clientResponseObj.getBytesRead(); // Prior to the current chunk
+    final long toSkip = readByThisHandler - readByThisRequest;
 
-      if (backpressureFuture != null) {
-        clientResponseObj.setBackpressureFuture(backpressureFuture);
+    clientResponseObj.addBytesRead(chunkSize);
+
+    if (toSkip < 0) {
+      throw DruidException.defensive("Expected toSkip[%d] to be nonnegative", toSkip);
+    } else if (toSkip < chunkSize) {
+      chunk = new byte[chunkSize - (int) toSkip];
+      content.getBytes(content.readerIndex() + (int) toSkip, chunk);
+
+      try {
+        final ListenableFuture<?> backpressureFuture = channel.addChunk(chunk);
+
+        if (backpressureFuture != null) {
+          clientResponseObj.setBackpressureFuture(backpressureFuture);
+        }
       }
-
-      clientResponseObj.addBytesRead(chunk.length);
-    }
-    catch (Exception e) {
-      clientResponseObj.exceptionCaught(e);
+      catch (Exception e) {
+        clientResponseObj.exceptionCaught(e);
+      }
     }
 
     return ClientResponse.unfinished(clientResponseObj);

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
@@ -74,6 +74,9 @@ public class FrameFilePartialFetch
     return exceptionCaught != null;
   }
 
+  /**
+   * Number of bytes read so far by this request.
+   */
   public long getBytesRead()
   {
     return bytesRead;
@@ -110,6 +113,9 @@ public class FrameFilePartialFetch
     }
   }
 
+  /**
+   * Increment the value returned by {@link #getBytesRead()}. Called whenever a chunk of data is read from the response.
+   */
   void addBytesRead(final long n)
   {
     bytesRead += n;

--- a/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
+++ b/processing/src/main/java/org/apache/druid/frame/file/FrameFilePartialFetch.java
@@ -74,6 +74,11 @@ public class FrameFilePartialFetch
     return exceptionCaught != null;
   }
 
+  public long getBytesRead()
+  {
+    return bytesRead;
+  }
+
   /**
    * Future that resolves when it is a good time to request the next chunk of the frame file.
    *


### PR DESCRIPTION
When a channel data response from a worker includes some data and then some I/O error, then when the call is retried, we will re-read the set of data that was read by the previous connection and add it to the local channel again. This causes the local channel to become corrupted. The patch fixes this case by skipping data that has already been read.