### PR TITLE
Remediate ingestion failures when number of segments in time period is larger than 32767

### DIFF
--- a/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -418,9 +418,9 @@ class OvershadowableManager<T extends Overshadowable<T>>
       TreeMap<RootPartitionRange, Short2ObjectSortedMap<AtomicUpdateGroup<T>>> stateMap
   )
   {
-    final RootPartitionRange lowFench = new RootPartitionRange(partitionId, partitionId);
+    final RootPartitionRange lowFence = new RootPartitionRange(partitionId, partitionId);
     final RootPartitionRange highFence = new RootPartitionRange(Short.MAX_VALUE, Short.MAX_VALUE);
-    return stateMap.subMap(lowFench, false, highFence, false).entrySet().iterator();
+    return stateMap.subMap(lowFence, false, highFence, false).entrySet().iterator();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -420,6 +420,7 @@ class OvershadowableManager<T extends Overshadowable<T>>
       TreeMap<RootPartitionRange, Short2ObjectSortedMap<AtomicUpdateGroup<T>>> stateMap
   )
   {
+    // remediate submap `fromKey > toKey` issue when partitionId overflows
     final short partitionIdLowFence = partitionId < 0 ? Short.MAX_VALUE : partitionId;
     final RootPartitionRange lowFence = new RootPartitionRange(partitionIdLowFence, partitionIdLowFence);
     final RootPartitionRange highFence = new RootPartitionRange(Short.MAX_VALUE, Short.MAX_VALUE);

--- a/processing/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -163,6 +163,36 @@ public class OvershadowableManagerTest
         Collections.emptyList(),
         overshadowedGroups
     );
+
+  }
+
+  @Test
+  public void testHandleOutOfRangeFindOvershadowedBy()
+  {
+    final List<PartitionChunk<OvershadowableInteger>> expectedOvershadowedChunks = new ArrayList<>();
+    PartitionChunk<OvershadowableInteger> chunk = newNonRootChunk(32001, 32003, 1, 1);
+    manager.addChunk(chunk);
+    expectedOvershadowedChunks.add(chunk);
+    manager.addChunk(newNonRootChunk(32001, 32005, 2, 1));
+    manager.addChunk(newNonRootChunk(32767, 32768, 3, 1));
+    manager.addChunk(newNonRootChunk(32768, 32769, 3, 1));
+
+    List<AtomicUpdateGroup<OvershadowableInteger>> overshadowedGroups = manager.findOvershadowedBy(
+            RootPartitionRange.of(32000, 32767),
+            (short) 4,
+            State.OVERSHADOWED
+    );
+    Assert.assertEquals(
+            expectedOvershadowedChunks.stream().map(AtomicUpdateGroup::new).collect(Collectors.toList()),
+            overshadowedGroups
+    );
+
+    overshadowedGroups = manager.findOvershadowedBy(
+            RootPartitionRange.of(32769, 32769),
+            (short) 10,
+            State.VISIBLE
+    );
+    Assert.assertTrue(overshadowedGroups.isEmpty());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -163,7 +163,6 @@ public class OvershadowableManagerTest
         Collections.emptyList(),
         overshadowedGroups
     );
-
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/15091.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
This PR is attempting to remediate the exception `java.lang.IllegalArgumentException: fromKey > toKey
` when number of segments is larger than Java Short.MAX_VALUE 32767, without fully context on why we set a limit on number of segments in time period to be within range of Java Short, this is what I believe that could make ingestion keep going
I can send a different PR if it is appropriate to change the number of segments to be in range of Int intead of Short, which requires larger scope of changes.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->


<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug 
https://github.com/apache/druid/issues/15091.
#### Renamed the class 
None
#### Added a forbidden-apis entry ...
None
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 


If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Prevent ingestion failures when number of segments in time period exceeds 32767

<hr>

##### Key changed/added classes in this PR
 * `OvershadowableManager`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
