### PR TITLE
Fix monomorphic processing code running on JDK8 since it references a non-existing method

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
@@ -95,7 +95,7 @@ public class DefineClassUtils
   }
 
   /**
-   * "Compile" a MethodHandle that is equilavent to:
+   * "Compile" a MethodHandle that is equivalent to:
    *
    *  Class<?> defineClass(Class targetClass, byte[] byteCode, String className) {
    *    return Unsafe.defineClass(
@@ -147,7 +147,7 @@ public class DefineClassUtils
     //   defineClass(className, byteCode, 0, length, targetClass)
     defineClass = MethodHandles.insertArguments(defineClass, 2, (int) 0);
 
-    // JDK8 does not implement MethodHandles.arrayLength so we have to roll our own
+    // JDK8 does not implement MethodHandles.arrayLength, so we have to roll our own
     MethodHandle arrayLength = lookup.findStatic(
         lookup.lookupClass(),
         "getArrayLength",
@@ -169,6 +169,11 @@ public class DefineClassUtils
     );
 
     return defineClass;
+  }
+
+  static int getArrayLength(byte[] bytes)
+  {
+    return bytes.length;
   }
 
   public static Class defineClass(

--- a/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
@@ -171,6 +171,11 @@ public class DefineClassUtils
     return defineClass;
   }
 
+  /**
+   * This method is referenced in Java 8 using method handle, therefore it is not actually unused, and shouldn't be
+   * removed (till Java 8 is supported)
+   */
+  // noinspection unused
   static int getArrayLength(byte[] bytes)
   {
     return bytes.length;

--- a/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
@@ -175,7 +175,7 @@ public class DefineClassUtils
    * This method is referenced in Java 8 using method handle, therefore it is not actually unused, and shouldn't be
    * removed (till Java 8 is supported)
    */
-  // noinspection unused
+  //noinspection unused
   static int getArrayLength(byte[] bytes)
   {
     return bytes.length;

--- a/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/DefineClassUtils.java
@@ -175,7 +175,7 @@ public class DefineClassUtils
    * This method is referenced in Java 8 using method handle, therefore it is not actually unused, and shouldn't be
    * removed (till Java 8 is supported)
    */
-  //noinspection unused
+  @SuppressWarnings("unused") // method is referenced and used in defineClassJava8
   static int getArrayLength(byte[] bytes)
   {
     return bytes.length;


### PR DESCRIPTION
### Description

Code relying on monomorphic processing on JDK8 doesn't work correctly, since it tries to reference `getArrayLength` using method handles, which might have been accidentally removed [here](https://github.com/apache/druid/commit/614205f3bcd366315432fe7bb12c9fdb7f68987c#diff-392e011ac9959032a65e99e559d5bbd2e5bd7ee3ac484c2ac4ffc35a12cbc4b0) since it seems unused. This PR adds the method back as is.


<hr>

##### Key changed/added classes in this PR
 * `DefineClassUtils`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
