### PR TITLE
MSQ writes out string arrays instead of MVDs by default

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2005,7 +2005,8 @@ public class ControllerImpl implements Controller
                 DimensionSchemaUtils.createDimensionSchema(
                     outputColumnName,
                     type,
-                    MultiStageQueryContext.useAutoColumnSchemas(query.context())
+                    MultiStageQueryContext.useAutoColumnSchemas(query.context()),
+                    MultiStageQueryContext.isIngestStringArraysAsMVDs(query.context())
                 )
             );
           } else if (!isRollupQuery) {
@@ -2054,7 +2055,8 @@ public class ControllerImpl implements Controller
           DimensionSchemaUtils.createDimensionSchema(
               outputColumn,
               type,
-              MultiStageQueryContext.useAutoColumnSchemas(context)
+              MultiStageQueryContext.useAutoColumnSchemas(context),
+              MultiStageQueryContext.isIngestStringArraysAsMVDs(context)
           )
       );
     }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -118,11 +118,9 @@ public class ExternalInputSliceReader implements InputSliceReader
         new DimensionsSpec(
             signature.getColumnNames().stream().map(
                 column ->
-                    DimensionSchemaUtils.createDimensionSchema(
+                    DimensionSchemaUtils.createDimensionSchemaForExtern(
                         column,
-                        signature.getColumnType(column).orElse(null),
-                        false,
-                        false
+                        signature.getColumnType(column).orElse(null)
                     )
             ).collect(Collectors.toList())
         ),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -121,6 +121,7 @@ public class ExternalInputSliceReader implements InputSliceReader
                     DimensionSchemaUtils.createDimensionSchema(
                         column,
                         signature.getColumnType(column).orElse(null),
+                        false,
                         false
                     )
             ).collect(Collectors.toList())

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/ArrayIngestMode.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/ArrayIngestMode.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.util;
+
+/**
+ * Values that the query context flag 'arrayIngestMode' can take to specify the behaviour of ingestion of arrays via
+ * MSQ's INSERT queries
+ */
+public enum ArrayIngestMode
+{
+  /**
+   * Disables the ingestion of arrays via MSQ's INSERT queries.
+   */
+  NONE,
+
+  /**
+   * String arrays are ingested as MVDs. This is to preserve the legacy behaviour of Druid and will be removed in the
+   * future, since MVDs are not true array types and the behaviour is incorrect.
+   * This also disables the ingestion of numeric arrays
+   */
+  MVD,
+
+  /**
+   * Allows numeric and string arrays to be ingested as arrays. This should be the preferred method of ingestion,
+   * unless bound by compatibility reasons to use 'mvd'
+   */
+  ARRAY
+}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
@@ -24,7 +24,9 @@ import org.apache.druid.data.input.impl.DoubleDimensionSchema;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.column.ColumnCapabilities;
@@ -40,11 +42,26 @@ import javax.annotation.Nullable;
  */
 public class DimensionSchemaUtils
 {
+
+  /**
+   * Creates a dimension schema for creating {@link org.apache.druid.data.input.InputSourceReader}.
+   */
+  public static DimensionSchema createDimensionSchemaForExtern(final String column, @Nullable final ColumnType type)
+  {
+    return createDimensionSchema(
+        column,
+        type,
+        false,
+        // Least restrictive mode since we do not have any type restrictions while reading the extern files.
+        ArrayIngestMode.ARRAY
+    );
+  }
+
   public static DimensionSchema createDimensionSchema(
       final String column,
       @Nullable final ColumnType type,
       boolean useAutoType,
-      boolean writeStringArraysAsMVDs
+      ArrayIngestMode arrayIngestMode
   )
   {
     if (useAutoType) {
@@ -75,15 +92,33 @@ public class DimensionSchemaUtils
         case ARRAY:
           switch (type.getElementType().getType()) {
             case STRING:
-              if (writeStringArraysAsMVDs) {
+              if (arrayIngestMode == ArrayIngestMode.NONE) {
+                throw InvalidInput.exception(
+                    "String arrays can not be ingested when '%s' is set to '%s'. Either set '%s' in query context "
+                    + "to 'array' to ingest the string array as an array, or set it to 'mvd' to ingest the string array "
+                    + "as MVD (which is legacy behaviour and not recommmended)",
+                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
+                    StringUtils.toLowerCase(arrayIngestMode.name()),
+                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE
+                );
+              } else if (arrayIngestMode == ArrayIngestMode.MVD) {
                 return new StringDimensionSchema(column, DimensionSchema.MultiValueHandling.ARRAY, null);
-              } else {
+              } else if (arrayIngestMode == ArrayIngestMode.ARRAY) {
                 return new AutoTypeColumnSchema(column);
               }
             case LONG:
             case FLOAT:
             case DOUBLE:
-              return new AutoTypeColumnSchema(column);
+              if (arrayIngestMode == ArrayIngestMode.ARRAY) {
+                return new AutoTypeColumnSchema(column);
+              } else {
+                throw InvalidInput.exception(
+                    "Numeric arrays can only be ingested when '%s' is set to 'array' in the MSQ query's context. "
+                    + "Current value of the parameter [%s]",
+                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
+                    StringUtils.toLowerCase(arrayIngestMode.name())
+                );
+              }
             default:
               throw new ISE("Cannot create dimension for type [%s]", type.toString());
           }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
@@ -103,7 +103,8 @@ public class DimensionSchemaUtils
                 );
               } else if (arrayIngestMode == ArrayIngestMode.MVD) {
                 return new StringDimensionSchema(column, DimensionSchema.MultiValueHandling.ARRAY, null);
-              } else if (arrayIngestMode == ArrayIngestMode.ARRAY) {
+              } else {
+                // arrayIngestMode == ArrayIngestMode.ARRAY would be true
                 return new AutoTypeColumnSchema(column);
               }
             case LONG:

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
@@ -90,38 +90,38 @@ public class DimensionSchemaUtils
         case DOUBLE:
           return new DoubleDimensionSchema(column);
         case ARRAY:
-          switch (type.getElementType().getType()) {
-            case STRING:
-              if (arrayIngestMode == ArrayIngestMode.NONE) {
-                throw InvalidInput.exception(
-                    "String arrays can not be ingested when '%s' is set to '%s'. Either set '%s' in query context "
-                    + "to 'array' to ingest the string array as an array, or set it to 'mvd' to ingest the string array "
-                    + "as MVD (which is legacy behaviour and not recommmended)",
-                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
-                    StringUtils.toLowerCase(arrayIngestMode.name()),
-                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE
-                );
-              } else if (arrayIngestMode == ArrayIngestMode.MVD) {
-                return new StringDimensionSchema(column, DimensionSchema.MultiValueHandling.ARRAY, null);
-              } else {
-                // arrayIngestMode == ArrayIngestMode.ARRAY would be true
-                return new AutoTypeColumnSchema(column);
-              }
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-              if (arrayIngestMode == ArrayIngestMode.ARRAY) {
-                return new AutoTypeColumnSchema(column);
-              } else {
-                throw InvalidInput.exception(
-                    "Numeric arrays can only be ingested when '%s' is set to 'array' in the MSQ query's context. "
-                    + "Current value of the parameter [%s]",
-                    MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
-                    StringUtils.toLowerCase(arrayIngestMode.name())
-                );
-              }
-            default:
-              throw new ISE("Cannot create dimension for type [%s]", type.toString());
+          ValueType elementType = type.getElementType().getType();
+          if (elementType == ValueType.STRING) {
+            if (arrayIngestMode == ArrayIngestMode.NONE) {
+              throw InvalidInput.exception(
+                  "String arrays can not be ingested when '%s' is set to '%s'. Either set '%s' in query context "
+                  + "to 'array' to ingest the string array as an array, or set it to 'mvd' to ingest the string array "
+                  + "as MVD (which is legacy behaviour and not recommmended)",
+                  MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
+                  StringUtils.toLowerCase(arrayIngestMode.name()),
+                  MultiStageQueryContext.CTX_ARRAY_INGEST_MODE
+              );
+            } else if (arrayIngestMode == ArrayIngestMode.MVD) {
+              return new StringDimensionSchema(column, DimensionSchema.MultiValueHandling.ARRAY, null);
+            } else {
+              // arrayIngestMode == ArrayIngestMode.ARRAY would be true
+              return new AutoTypeColumnSchema(column);
+            }
+          } else if (elementType == ValueType.LONG
+                     || elementType == ValueType.FLOAT
+                     || elementType == ValueType.DOUBLE) {
+            if (arrayIngestMode == ArrayIngestMode.ARRAY) {
+              return new AutoTypeColumnSchema(column);
+            } else {
+              throw InvalidInput.exception(
+                  "Numeric arrays can only be ingested when '%s' is set to 'array' in the MSQ query's context. "
+                  + "Current value of the parameter [%s]",
+                  MultiStageQueryContext.CTX_ARRAY_INGEST_MODE,
+                  StringUtils.toLowerCase(arrayIngestMode.name())
+              );
+            }
+          } else {
+            throw new ISE("Cannot create dimension for type [%s]", type.toString());
           }
         default:
           final ColumnCapabilities capabilities = ColumnCapabilitiesImpl.createDefault().setType(type);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/DimensionSchemaUtils.java
@@ -83,12 +83,16 @@ public class DimensionSchemaUtils
       switch (type.getType()) {
         case STRING:
           return new StringDimensionSchema(column);
+
         case LONG:
           return new LongDimensionSchema(column);
+
         case FLOAT:
           return new FloatDimensionSchema(column);
+
         case DOUBLE:
           return new DoubleDimensionSchema(column);
+
         case ARRAY:
           ValueType elementType = type.getElementType().getType();
           if (elementType == ValueType.STRING) {
@@ -107,9 +111,8 @@ public class DimensionSchemaUtils
               // arrayIngestMode == ArrayIngestMode.ARRAY would be true
               return new AutoTypeColumnSchema(column);
             }
-          } else if (elementType == ValueType.LONG
-                     || elementType == ValueType.FLOAT
-                     || elementType == ValueType.DOUBLE) {
+          } else if (elementType.isNumeric()) {
+            // ValueType == LONG || ValueType == FLOAT || ValueType == DOUBLE
             if (arrayIngestMode == ArrayIngestMode.ARRAY) {
               return new AutoTypeColumnSchema(column);
             } else {
@@ -123,6 +126,7 @@ public class DimensionSchemaUtils
           } else {
             throw new ISE("Cannot create dimension for type [%s]", type.toString());
           }
+
         default:
           final ColumnCapabilities capabilities = ColumnCapabilitiesImpl.createDefault().setType(type);
           return DimensionHandlerUtils.getHandlerFromCapabilities(column, capabilities, null)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -73,10 +73,10 @@ import java.util.stream.Collectors;
  * {@link org.apache.druid.segment.AutoTypeColumnSchema} for all 'standard' type columns during segment generation,
  * see {@link DimensionSchemaUtils#createDimensionSchema} for more details.
  *
- * <li><b>ingestStringArraysAsMVDs</b>: Flag to ingest the string arrays using string dimension handlers, which generates
- * MVDs instead of {@code ARRAY<STRING>}. The flag is undocumented, and provided to preserve legacy behaviour.
- * see {@link DimensionSchemaUtils#createDimensionSchema} for more details.
- *
+ * <li><b>arrayIngestMode</b>: Tri-state query context that controls the behaviour and support of arrays that are
+ * ingested via MSQ. If set to 'none', arrays are not allowed to be ingested in MSQ. If set to 'array', array types
+ * can be ingested as expected. If set to 'mvd', numeric arrays can not be ingested, and string arrays will be
+ * ingested as MVDs (this is kept for legacy purpose).
  * </ol>
  **/
 public class MultiStageQueryContext
@@ -127,8 +127,8 @@ public class MultiStageQueryContext
   public static final String CTX_USE_AUTO_SCHEMAS = "useAutoColumnSchemas";
   public static final boolean DEFAULT_USE_AUTO_SCHEMAS = false;
 
-  public static final String CTX_INGEST_STRING_ARRAYS_AS_MVDS = "ingestStringArraysAsMVDs";
-  public static final boolean DEFAULT_INGEST_STRING_ARRAYS_AS_MVDS = false;
+  public static final String CTX_ARRAY_INGEST_MODE = "arrayIngestMode";
+  public static final ArrayIngestMode DEFAULT_ARRAY_INGEST_MODE = ArrayIngestMode.NONE;
 
 
   private static final Pattern LOOKS_LIKE_JSON_ARRAY = Pattern.compile("^\\s*\\[.*", Pattern.DOTALL);
@@ -255,9 +255,9 @@ public class MultiStageQueryContext
     return queryContext.getBoolean(CTX_USE_AUTO_SCHEMAS, DEFAULT_USE_AUTO_SCHEMAS);
   }
 
-  public static boolean isIngestStringArraysAsMVDs(final QueryContext queryContext)
+  public static ArrayIngestMode getArrayIngestMode(final QueryContext queryContext)
   {
-    return queryContext.getBoolean(CTX_INGEST_STRING_ARRAYS_AS_MVDS, DEFAULT_INGEST_STRING_ARRAYS_AS_MVDS);
+    return queryContext.getEnum(CTX_ARRAY_INGEST_MODE, ArrayIngestMode.class, DEFAULT_ARRAY_INGEST_MODE);
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -128,7 +128,7 @@ public class MultiStageQueryContext
   public static final boolean DEFAULT_USE_AUTO_SCHEMAS = false;
 
   public static final String CTX_ARRAY_INGEST_MODE = "arrayIngestMode";
-  public static final ArrayIngestMode DEFAULT_ARRAY_INGEST_MODE = ArrayIngestMode.NONE;
+  public static final ArrayIngestMode DEFAULT_ARRAY_INGEST_MODE = ArrayIngestMode.MVD;
 
 
   private static final Pattern LOOKS_LIKE_JSON_ARRAY = Pattern.compile("^\\s*\\[.*", Pattern.DOTALL);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -73,6 +73,10 @@ import java.util.stream.Collectors;
  * {@link org.apache.druid.segment.AutoTypeColumnSchema} for all 'standard' type columns during segment generation,
  * see {@link DimensionSchemaUtils#createDimensionSchema} for more details.
  *
+ * <li><b>ingestStringArraysAsMVDs</b>: Flag to ingest the string arrays using string dimension handlers, which generates
+ * MVDs instead of {@code ARRAY<STRING>}. The flag is undocumented, and provided to preserve legacy behaviour.
+ * see {@link DimensionSchemaUtils#createDimensionSchema} for more details.
+ *
  * </ol>
  **/
 public class MultiStageQueryContext
@@ -121,6 +125,11 @@ public class MultiStageQueryContext
   public static final String CTX_INDEX_SPEC = "indexSpec";
 
   public static final String CTX_USE_AUTO_SCHEMAS = "useAutoColumnSchemas";
+  public static final boolean DEFAULT_USE_AUTO_SCHEMAS = false;
+
+  public static final String CTX_INGEST_STRING_ARRAYS_AS_MVDS = "ingestStringArraysAsMVDs";
+  public static final boolean DEFAULT_INGEST_STRING_ARRAYS_AS_MVDS = false;
+
 
   private static final Pattern LOOKS_LIKE_JSON_ARRAY = Pattern.compile("^\\s*\\[.*", Pattern.DOTALL);
 
@@ -243,7 +252,12 @@ public class MultiStageQueryContext
 
   public static boolean useAutoColumnSchemas(final QueryContext queryContext)
   {
-    return queryContext.getBoolean(CTX_USE_AUTO_SCHEMAS, false);
+    return queryContext.getBoolean(CTX_USE_AUTO_SCHEMAS, DEFAULT_USE_AUTO_SCHEMAS);
+  }
+
+  public static boolean isIngestStringArraysAsMVDs(final QueryContext queryContext)
+  {
+    return queryContext.getBoolean(CTX_INGEST_STRING_ARRAYS_AS_MVDS, DEFAULT_INGEST_STRING_ARRAYS_AS_MVDS);
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysInsertTest.java
@@ -1,0 +1,543 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.exec;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.msq.test.MSQTestBase;
+import org.apache.druid.msq.util.MultiStageQueryContext;
+import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.utils.CompressionUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests the MSQ ingestion with arrays
+ */
+@RunWith(Parameterized.class)
+public class MSQArraysInsertTest extends MSQTestBase
+{
+
+  @Parameterized.Parameters(name = "{index}:with context {0}")
+  public static Collection<Object[]> data()
+  {
+    Object[][] data = new Object[][]{
+        {DEFAULT, DEFAULT_MSQ_CONTEXT},
+        {DURABLE_STORAGE, DURABLE_STORAGE_MSQ_CONTEXT},
+        {FAULT_TOLERANCE, FAULT_TOLERANCE_MSQ_CONTEXT},
+        {PARALLEL_MERGE, PARALLEL_MERGE_MSQ_CONTEXT}
+    };
+    return Arrays.asList(data);
+  }
+
+  @Parameterized.Parameter(0)
+  public String contextName;
+
+  @Parameterized.Parameter(1)
+  public Map<String, Object> context;
+
+  @Test
+  public void testInsertOnFoo1WithMultiValueToArrayGroupBy()
+  {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .add("dim3", ColumnType.STRING_ARRAY).build();
+
+    testIngestQuery().setSql(
+                         "INSERT INTO foo1 SELECT MV_TO_ARRAY(dim3) AS dim3 FROM foo GROUP BY 1 PARTITIONED BY ALL TIME")
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(rowSignature)
+                     .setQueryContext(context)
+                     .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
+                     .setExpectedResultRows(expectedMultiValueFooRowsToArray())
+                     .verifyResults();
+  }
+
+  @Test
+  public void testInsertArraysAutoType() throws IOException
+  {
+    List<Object[]> expectedRows = Arrays.asList(
+        new Object[]{1672531200000L, null, null, null},
+        new Object[]{1672531200000L, null, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
+        new Object[]{1672531200000L, new Object[]{"d", "e"}, new Object[]{1L, 4L}, new Object[]{2.2, 3.3, 4.0}},
+        new Object[]{1672531200000L, new Object[]{"a", "b"}, null, null},
+        new Object[]{1672531200000L, new Object[]{"a", "b"}, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
+        new Object[]{1672531200000L, new Object[]{"b", "c"}, new Object[]{1L, 2L, 3L, 4L}, new Object[]{1.1, 3.3}},
+        new Object[]{1672531200000L, new Object[]{"a", "b", "c"}, new Object[]{2L, 3L}, new Object[]{3.3, 4.4, 5.5}},
+        new Object[]{1672617600000L, null, null, null},
+        new Object[]{1672617600000L, null, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
+        new Object[]{1672617600000L, new Object[]{"d", "e"}, new Object[]{1L, 4L}, new Object[]{2.2, 3.3, 4.0}},
+        new Object[]{1672617600000L, new Object[]{"a", "b"}, null, null},
+        new Object[]{1672617600000L, new Object[]{"a", "b"}, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
+        new Object[]{1672617600000L, new Object[]{"b", "c"}, new Object[]{1L, 2L, 3L, 4L}, new Object[]{1.1, 3.3}},
+        new Object[]{1672617600000L, new Object[]{"a", "b", "c"}, new Object[]{2L, 3L}, new Object[]{3.3, 4.4, 5.5}}
+    );
+
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .add("arrayString", ColumnType.STRING_ARRAY)
+                                            .add("arrayLong", ColumnType.LONG_ARRAY)
+                                            .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
+                                            .build();
+
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(MultiStageQueryContext.CTX_USE_AUTO_SCHEMAS, true);
+
+    final File tmpFile = temporaryFolder.newFile();
+    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
+                                                                .getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
+    final InputStream decompressing = CompressionUtils.decompress(
+        resourceStream,
+        NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+    );
+    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    decompressing.close();
+
+    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
+
+    testIngestQuery().setSql(" INSERT INTO foo1 SELECT\n"
+                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
+                             + "  arrayString,\n"
+                             + "  arrayLong,\n"
+                             + "  arrayDouble\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"arrayString\", \"type\": \"COMPLEX<json>\"}, {\"name\": \"arrayLong\", \"type\": \"COMPLEX<json>\"}, {\"name\": \"arrayDouble\", \"type\": \"COMPLEX<json>\"}]'\n"
+                             + "  )\n"
+                             + ") PARTITIONED BY ALL")
+                     .setQueryContext(adjustedContext)
+                     .setExpectedResultRows(expectedRows)
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(rowSignature)
+                     .verifyResults();
+  }
+
+  @Test
+  public void testInsertArraysWithStringArraysAsMVDs() throws IOException
+  {
+    List<Object[]> expectedRows = Arrays.asList(
+        new Object[]{
+            1672531200000L,
+            null,
+            null,
+            new Object[]{1L, 2L, 3L},
+            new Object[]{},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            null
+        },
+        new Object[]{
+            1672531200000L,
+            null,
+            Arrays.asList("a", "b"),
+            null,
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{null}
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b"),
+            null,
+            null,
+            new Object[]{null, 2L, 9L},
+            null,
+            new Object[]{999.0d, 5.5d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b"),
+            Arrays.asList("a", "b"),
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1L, null, 3L},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{1.1d, 2.2d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(null, "b"),
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{3.3d, 4.4d, 5.5d},
+            new Object[]{999.0d, null, 5.5d}
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("b", "c"),
+            Arrays.asList("d", null, "b"),
+            new Object[]{1L, 2L, 3L, 4L},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1.1d, 3.3d},
+            new Object[]{null, 2.2d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("d", "e"),
+            Arrays.asList("b", "b"),
+            new Object[]{1L, 4L},
+            new Object[]{1L},
+            new Object[]{2.2d, 3.3d, 4.0d},
+            null
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            null,
+            new Object[]{1L, 2L, 3L},
+            null,
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{}
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            Arrays.asList("a", "b"),
+            null,
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{null, 1.1d}
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b"),
+            null,
+            null,
+            new Object[]{null, 2L, 9L},
+            null,
+            new Object[]{999.0d, 5.5d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b"),
+            Collections.emptyList(),
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1L, null, 3L},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{1.1d, 2.2d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(null, "b"),
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{3.3d, 4.4d, 5.5d},
+            new Object[]{999.0d, null, 5.5d}
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("b", "c"),
+            Arrays.asList("d", null, "b"),
+            new Object[]{1L, 2L, 3L, 4L},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1.1d, 3.3d},
+            new Object[]{null, 2.2d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("d", "e"),
+            Arrays.asList("b", "b"),
+            new Object[]{1L, 4L},
+            new Object[]{null},
+            new Object[]{2.2d, 3.3d, 4.0},
+            null
+        }
+    );
+
+    RowSignature rowSignatureWithoutTimeAndStringColumns =
+        RowSignature.builder()
+                    .add("arrayLong", ColumnType.LONG_ARRAY)
+                    .add("arrayLongNulls", ColumnType.LONG_ARRAY)
+                    .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
+                    .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
+                    .build();
+
+
+    RowSignature fileSignature = RowSignature.builder()
+                                             .add("timestamp", ColumnType.STRING)
+                                             .add("arrayString", ColumnType.STRING_ARRAY)
+                                             .add("arrayStringNulls", ColumnType.STRING_ARRAY)
+                                             .addAll(rowSignatureWithoutTimeAndStringColumns)
+                                             .build();
+
+    // MSQ writes strings instead of string arrays
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .add("arrayString", ColumnType.STRING)
+                                            .add("arrayStringNulls", ColumnType.STRING)
+                                            .addAll(rowSignatureWithoutTimeAndStringColumns)
+                                            .build();
+
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(MultiStageQueryContext.CTX_INGEST_STRING_ARRAYS_AS_MVDS, true);
+
+    final File tmpFile = temporaryFolder.newFile();
+    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
+                                                                .getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
+    final InputStream decompressing = CompressionUtils.decompress(
+        resourceStream,
+        NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+    );
+    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    decompressing.close();
+
+    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
+
+    testIngestQuery().setSql(" INSERT INTO foo1 SELECT\n"
+                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
+                             + "  arrayString,\n"
+                             + "  arrayStringNulls,\n"
+                             + "  arrayLong,\n"
+                             + "  arrayLongNulls,\n"
+                             + "  arrayDouble,\n"
+                             + "  arrayDoubleNulls\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '" + queryFramework().queryJsonMapper().writeValueAsString(fileSignature) + "'\n"
+                             + "  )\n"
+                             + ") PARTITIONED BY ALL")
+                     .setQueryContext(adjustedContext)
+                     .setExpectedResultRows(expectedRows)
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(rowSignature)
+                     .verifyResults();
+  }
+
+  @Test
+  public void testInsertArrays() throws IOException
+  {
+    final List<Object[]> expectedRows = Arrays.asList(
+        new Object[]{
+            1672531200000L,
+            null,
+            null,
+            new Object[]{1L, 2L, 3L},
+            new Object[]{},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            null
+        },
+        new Object[]{
+            1672531200000L,
+            null,
+            new Object[]{"a", "b"},
+            null,
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{null}
+        },
+        new Object[]{
+            1672531200000L,
+            new Object[]{"d", "e"},
+            new Object[]{"b", "b"},
+            new Object[]{1L, 4L},
+            new Object[]{1L},
+            new Object[]{2.2d, 3.3d, 4.0d},
+            null
+        },
+        new Object[]{
+            1672531200000L,
+            new Object[]{"a", "b"},
+            null,
+            null,
+            new Object[]{null, 2L, 9L},
+            null,
+            new Object[]{999.0d, 5.5d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            new Object[]{"a", "b"},
+            new Object[]{"a", "b"},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1L, null, 3L},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{1.1d, 2.2d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            new Object[]{"b", "c"},
+            new Object[]{"d", null, "b"},
+            new Object[]{1L, 2L, 3L, 4L},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1.1d, 3.3d},
+            new Object[]{null, 2.2d, null}
+        },
+        new Object[]{
+            1672531200000L,
+            new Object[]{"a", "b", "c"},
+            new Object[]{null, "b"},
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{3.3d, 4.4d, 5.5d},
+            new Object[]{999.0d, null, 5.5d}
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            null,
+            new Object[]{1L, 2L, 3L},
+            null,
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{}
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            new Object[]{"a", "b"},
+            null,
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{null, 1.1d}
+        },
+        new Object[]{
+            1672617600000L,
+            new Object[]{"d", "e"},
+            new Object[]{"b", "b"},
+            new Object[]{1L, 4L},
+            new Object[]{null},
+            new Object[]{2.2d, 3.3d, 4.0},
+            null
+        },
+        new Object[]{
+            1672617600000L,
+            new Object[]{"a", "b"},
+            new Object[]{null},
+            null,
+            new Object[]{null, 2L, 9L},
+            null,
+            new Object[]{999.0d, 5.5d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            new Object[]{"a", "b"},
+            new Object[]{},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1L, null, 3L},
+            new Object[]{1.1d, 2.2d, 3.3d},
+            new Object[]{1.1d, 2.2d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            new Object[]{"b", "c"},
+            new Object[]{"d", null, "b"},
+            new Object[]{1L, 2L, 3L, 4L},
+            new Object[]{1L, 2L, 3L},
+            new Object[]{1.1d, 3.3d},
+            new Object[]{null, 2.2d, null}
+        },
+        new Object[]{
+            1672617600000L,
+            new Object[]{"a", "b", "c"},
+            new Object[]{null, "b"},
+            new Object[]{2L, 3L},
+            null,
+            new Object[]{3.3d, 4.4d, 5.5d},
+            new Object[]{999.0d, null, 5.5d}
+        }
+    );
+
+    RowSignature rowSignatureWithoutTimeColumn =
+        RowSignature.builder()
+                    .add("arrayString", ColumnType.STRING_ARRAY)
+                    .add("arrayStringNulls", ColumnType.STRING_ARRAY)
+                    .add("arrayLong", ColumnType.LONG_ARRAY)
+                    .add("arrayLongNulls", ColumnType.LONG_ARRAY)
+                    .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
+                    .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
+                    .build();
+
+
+    RowSignature fileSignature = RowSignature.builder()
+                                             .add("timestamp", ColumnType.STRING)
+                                             .addAll(rowSignatureWithoutTimeColumn)
+                                             .build();
+
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .addAll(rowSignatureWithoutTimeColumn)
+                                            .build();
+
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+
+    final File tmpFile = temporaryFolder.newFile();
+    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
+                                                                .getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
+    final InputStream decompressing = CompressionUtils.decompress(
+        resourceStream,
+        NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+    );
+    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    decompressing.close();
+
+    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
+
+    testIngestQuery().setSql(" INSERT INTO foo1 SELECT\n"
+                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
+                             + "  arrayString,\n"
+                             + "  arrayStringNulls,\n"
+                             + "  arrayLong,\n"
+                             + "  arrayLongNulls,\n"
+                             + "  arrayDouble,\n"
+                             + "  arrayDoubleNulls\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '" + queryFramework().queryJsonMapper().writeValueAsString(fileSignature) + "'\n"
+                             + "  )\n"
+                             + ") PARTITIONED BY ALL")
+                     .setQueryContext(adjustedContext)
+                     .setExpectedResultRows(expectedRows)
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(rowSignature)
+                     .verifyResults();
+  }
+
+  private List<Object[]> expectedMultiValueFooRowsToArray()
+  {
+    ImmutableList.Builder<Object[]> expectedRowsBuilder = ImmutableList.builder();
+    expectedRowsBuilder.add(new Object[]{0L, null});
+    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"a", "b"}});
+    expectedRowsBuilder.add(new Object[]{0L, new Object[]{""}});
+    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"b", "c"}});
+    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"d"}});
+    return expectedRowsBuilder.build();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -21,15 +21,30 @@ package org.apache.druid.msq.exec;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.LocalInputSource;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.msq.indexing.MSQSpec;
+import org.apache.druid.msq.indexing.MSQTuningConfig;
+import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
+import org.apache.druid.sql.calcite.external.ExternalDataSource;
+import org.apache.druid.sql.calcite.filtration.Filtration;
+import org.apache.druid.sql.calcite.planner.ColumnMapping;
+import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CompressionUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
+import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -38,6 +53,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,10 +62,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Tests the MSQ ingestion with arrays
+ * Tests INSERT and SELECT behaviour of MSQ with arrays and MVDs
  */
 @RunWith(Parameterized.class)
-public class MSQArraysInsertTest extends MSQTestBase
+public class MSQArraysTest extends MSQTestBase
 {
 
   @Parameterized.Parameters(name = "{index}:with context {0}")
@@ -70,23 +86,53 @@ public class MSQArraysInsertTest extends MSQTestBase
   @Parameterized.Parameter(1)
   public Map<String, Object> context;
 
+  /**
+   * Tests the behaviour of INSERT query when arrayIngestMode is set to none (default) and the user tries to ingest
+   * string arrays
+   */
+  @Test
+  public void testInsertStringArrayWithDefaultContext()
+  {
+    testIngestQuery().setSql(
+                         "INSERT INTO foo1 SELECT MV_TO_ARRAY(dim3) AS dim3 FROM foo GROUP BY 1 PARTITIONED BY ALL TIME")
+                     .setQueryContext(context)
+                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
+                         CoreMatchers.instanceOf(ISE.class),
+                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             "String arrays can not be ingested when 'arrayIngestMode' is set to 'none'"))
+                     ))
+                     .verifyExecutionError();
+  }
+
+
+  /**
+   * Tests the behaviour of INSERT query when arrayIngestMode is set to mvd and the only array type to be
+   * ingested is string array
+   */
   @Test
   public void testInsertOnFoo1WithMultiValueToArrayGroupBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
-                                            .add("dim3", ColumnType.STRING_ARRAY).build();
+                                            .add("dim3", ColumnType.STRING)
+                                            .build();
+
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(MultiStageQueryContext.CTX_ARRAY_INGEST_MODE, "mvd");
 
     testIngestQuery().setSql(
                          "INSERT INTO foo1 SELECT MV_TO_ARRAY(dim3) AS dim3 FROM foo GROUP BY 1 PARTITIONED BY ALL TIME")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(adjustedContext)
                      .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
                      .setExpectedResultRows(expectedMultiValueFooRowsToArray())
                      .verifyResults();
   }
 
+  /**
+   * Tests the INSERT query when 'auto' type is set
+   */
   @Test
   public void testInsertArraysAutoType() throws IOException
   {
@@ -148,138 +194,13 @@ public class MSQArraysInsertTest extends MSQTestBase
                      .verifyResults();
   }
 
+  /**
+   * Tests the behaviour of INSERT query when arrayIngestMode is set to mvd and the user tries to ingest numeric array
+   * types as well
+   */
   @Test
   public void testInsertArraysWithStringArraysAsMVDs() throws IOException
   {
-    List<Object[]> expectedRows = Arrays.asList(
-        new Object[]{
-            1672531200000L,
-            null,
-            null,
-            new Object[]{1L, 2L, 3L},
-            new Object[]{},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            null
-        },
-        new Object[]{
-            1672531200000L,
-            null,
-            Arrays.asList("a", "b"),
-            null,
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b"),
-            null,
-            null,
-            new Object[]{null, 2L, 9L},
-            null,
-            new Object[]{999.0d, 5.5d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b"),
-            Arrays.asList("a", "b"),
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1L, null, 3L},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{1.1d, 2.2d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b", "c"),
-            Arrays.asList(null, "b"),
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{3.3d, 4.4d, 5.5d},
-            new Object[]{999.0d, null, 5.5d}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("b", "c"),
-            Arrays.asList("d", null, "b"),
-            new Object[]{1L, 2L, 3L, 4L},
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1.1d, 3.3d},
-            new Object[]{null, 2.2d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("d", "e"),
-            Arrays.asList("b", "b"),
-            new Object[]{1L, 4L},
-            new Object[]{1L},
-            new Object[]{2.2d, 3.3d, 4.0d},
-            null
-        },
-        new Object[]{
-            1672617600000L,
-            null,
-            null,
-            new Object[]{1L, 2L, 3L},
-            null,
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{}
-        },
-        new Object[]{
-            1672617600000L,
-            null,
-            Arrays.asList("a", "b"),
-            null,
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{null, 1.1d}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b"),
-            null,
-            null,
-            new Object[]{null, 2L, 9L},
-            null,
-            new Object[]{999.0d, 5.5d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b"),
-            Collections.emptyList(),
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1L, null, 3L},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{1.1d, 2.2d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b", "c"),
-            Arrays.asList(null, "b"),
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{3.3d, 4.4d, 5.5d},
-            new Object[]{999.0d, null, 5.5d}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("b", "c"),
-            Arrays.asList("d", null, "b"),
-            new Object[]{1L, 2L, 3L, 4L},
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1.1d, 3.3d},
-            new Object[]{null, 2.2d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("d", "e"),
-            Arrays.asList("b", "b"),
-            new Object[]{1L, 4L},
-            new Object[]{null},
-            new Object[]{2.2d, 3.3d, 4.0},
-            null
-        }
-    );
-
     RowSignature rowSignatureWithoutTimeAndStringColumns =
         RowSignature.builder()
                     .add("arrayLong", ColumnType.LONG_ARRAY)
@@ -296,16 +217,8 @@ public class MSQArraysInsertTest extends MSQTestBase
                                              .addAll(rowSignatureWithoutTimeAndStringColumns)
                                              .build();
 
-    // MSQ writes strings instead of string arrays
-    RowSignature rowSignature = RowSignature.builder()
-                                            .add("__time", ColumnType.LONG)
-                                            .add("arrayString", ColumnType.STRING)
-                                            .add("arrayStringNulls", ColumnType.STRING)
-                                            .addAll(rowSignatureWithoutTimeAndStringColumns)
-                                            .build();
-
     final Map<String, Object> adjustedContext = new HashMap<>(context);
-    adjustedContext.put(MultiStageQueryContext.CTX_INGEST_STRING_ARRAYS_AS_MVDS, true);
+    adjustedContext.put(MultiStageQueryContext.CTX_ARRAY_INGEST_MODE, "mvd");
 
     final File tmpFile = temporaryFolder.newFile();
     final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
@@ -335,14 +248,20 @@ public class MSQArraysInsertTest extends MSQTestBase
                              + "  )\n"
                              + ") PARTITIONED BY ALL")
                      .setQueryContext(adjustedContext)
-                     .setExpectedResultRows(expectedRows)
-                     .setExpectedDataSource("foo1")
-                     .setExpectedRowSignature(rowSignature)
-                     .verifyResults();
+                     .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
+                         CoreMatchers.instanceOf(ISE.class),
+                         ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             "Numeric arrays can only be ingested when"))
+                     ))
+                     .verifyExecutionError();
   }
 
+  /**
+   * Tests the behaviour of INSERT query when arrayIngestMode is set to array and the user tries to ingest all
+   * array types
+   */
   @Test
-  public void testInsertArrays() throws IOException
+  public void testInsertArraysAsArrays() throws IOException
   {
     final List<Object[]> expectedRows = Arrays.asList(
         new Object[]{
@@ -483,7 +402,6 @@ public class MSQArraysInsertTest extends MSQTestBase
                     .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
                     .build();
 
-
     RowSignature fileSignature = RowSignature.builder()
                                              .add("timestamp", ColumnType.STRING)
                                              .addAll(rowSignatureWithoutTimeColumn)
@@ -495,6 +413,7 @@ public class MSQArraysInsertTest extends MSQTestBase
                                             .build();
 
     final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(MultiStageQueryContext.CTX_ARRAY_INGEST_MODE, "array");
 
     final File tmpFile = temporaryFolder.newFile();
     final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
@@ -530,14 +449,276 @@ public class MSQArraysInsertTest extends MSQTestBase
                      .verifyResults();
   }
 
+  @Test
+  public void testSelectOnArraysWithArrayIngestModeAsNone() throws IOException
+  {
+    testSelectOnArrays("none");
+  }
+
+  @Test
+  public void testSelectOnArraysWithArrayIngestModeAsMVD() throws IOException
+  {
+    testSelectOnArrays("mvd");
+  }
+
+  @Test
+  public void testSelectOnArraysWithArrayIngestModeAsArray() throws IOException
+  {
+    testSelectOnArrays("array");
+  }
+
+  public void testSelectOnArrays(String arrayIngestMode) throws IOException
+  {
+    final List<Object[]> expectedRows = Arrays.asList(
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b"),
+            Arrays.asList("a", "b"),
+            Arrays.asList(1L, 2L, 3L),
+            Arrays.asList(1L, null, 3L),
+            Arrays.asList(1.1d, 2.2d, 3.3d),
+            Arrays.asList(1.1d, 2.2d, null)
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(null, "b"),
+            Arrays.asList(2L, 3L),
+            null,
+            Arrays.asList(3.3d, 4.4d, 5.5d),
+            Arrays.asList(999.0d, null, 5.5d),
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("b", "c"),
+            Arrays.asList("d", null, "b"),
+            Arrays.asList(1L, 2L, 3L, 4L),
+            Arrays.asList(1L, 2L, 3L),
+            Arrays.asList(1.1d, 3.3d),
+            Arrays.asList(null, 2.2d, null)
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("d", "e"),
+            Arrays.asList("b", "b"),
+            Arrays.asList(1L, 4L),
+            Collections.singletonList(1L),
+            Arrays.asList(2.2d, 3.3d, 4.0d),
+            null
+        },
+        new Object[]{
+            1672531200000L,
+            null,
+            null,
+            Arrays.asList(1L, 2L, 3L),
+            Collections.emptyList(),
+            Arrays.asList(1.1d, 2.2d, 3.3d),
+            null
+        },
+        new Object[]{
+            1672531200000L,
+            Arrays.asList("a", "b"),
+            null,
+            null,
+            Arrays.asList(null, 2L, 9L),
+            null,
+            Arrays.asList(999.0d, 5.5d, null)
+        },
+        new Object[]{
+            1672531200000L,
+            null,
+            Arrays.asList("a", "b"),
+            null,
+            Arrays.asList(2L, 3L),
+            null,
+            Collections.singletonList(null)
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b"),
+            Collections.emptyList(),
+            Arrays.asList(1L, 2L, 3L),
+            Arrays.asList(1L, null, 3L),
+            Arrays.asList(1.1d, 2.2d, 3.3d),
+            Arrays.asList(1.1d, 2.2d, null)
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b", "c"),
+            Arrays.asList(null, "b"),
+            Arrays.asList(2L, 3L),
+            null,
+            Arrays.asList(3.3d, 4.4d, 5.5d),
+            Arrays.asList(999.0d, null, 5.5d)
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("b", "c"),
+            Arrays.asList("d", null, "b"),
+            Arrays.asList(1L, 2L, 3L, 4L),
+            Arrays.asList(1L, 2L, 3L),
+            Arrays.asList(1.1d, 3.3d),
+            Arrays.asList(null, 2.2d, null)
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("d", "e"),
+            Arrays.asList("b", "b"),
+            Arrays.asList(1L, 4L),
+            Collections.singletonList(null),
+            Arrays.asList(2.2d, 3.3d, 4.0),
+            null
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            null,
+            Arrays.asList(1L, 2L, 3L),
+            null,
+            Arrays.asList(1.1d, 2.2d, 3.3d),
+            Collections.emptyList()
+        },
+        new Object[]{
+            1672617600000L,
+            Arrays.asList("a", "b"),
+            Collections.singletonList(null),
+            null,
+            Arrays.asList(null, 2L, 9L),
+            null,
+            Arrays.asList(999.0d, 5.5d, null)
+        },
+        new Object[]{
+            1672617600000L,
+            null,
+            Arrays.asList("a", "b"),
+            null,
+            Arrays.asList(2L, 3L),
+            null,
+            Arrays.asList(null, 1.1d),
+        }
+    );
+
+    RowSignature rowSignatureWithoutTimeColumn =
+        RowSignature.builder()
+                    .add("arrayString", ColumnType.STRING_ARRAY)
+                    .add("arrayStringNulls", ColumnType.STRING_ARRAY)
+                    .add("arrayLong", ColumnType.LONG_ARRAY)
+                    .add("arrayLongNulls", ColumnType.LONG_ARRAY)
+                    .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
+                    .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
+                    .build();
+
+    RowSignature fileSignature = RowSignature.builder()
+                                             .add("timestamp", ColumnType.STRING)
+                                             .addAll(rowSignatureWithoutTimeColumn)
+                                             .build();
+
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .addAll(rowSignatureWithoutTimeColumn)
+                                            .build();
+
+    RowSignature scanSignature = RowSignature.builder()
+                                             .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
+                                             .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
+                                             .add("arrayLong", ColumnType.LONG_ARRAY)
+                                             .add("arrayLongNulls", ColumnType.LONG_ARRAY)
+                                             .add("arrayString", ColumnType.STRING_ARRAY)
+                                             .add("arrayStringNulls", ColumnType.STRING_ARRAY)
+                                             .add("v0", ColumnType.LONG)
+                                             .build();
+
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(MultiStageQueryContext.CTX_ARRAY_INGEST_MODE, arrayIngestMode);
+
+    final File tmpFile = temporaryFolder.newFile();
+    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader()
+                                                                .getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
+    final InputStream decompressing = CompressionUtils.decompress(
+        resourceStream,
+        NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+    );
+    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    decompressing.close();
+
+    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
+
+    Query<?> expectedQuery = newScanQueryBuilder()
+        .dataSource(new ExternalDataSource(
+            new LocalInputSource(null, null, ImmutableList.of(tmpFile)),
+            new JsonInputFormat(null, null, null, null, null),
+            fileSignature
+        ))
+        .intervals(querySegmentSpec(Filtration.eternity()))
+        .columns(
+            "arrayDouble",
+            "arrayDoubleNulls",
+            "arrayLong",
+            "arrayLongNulls",
+            "arrayString",
+            "arrayStringNulls",
+            "v0"
+        )
+        .virtualColumns(new ExpressionVirtualColumn(
+            "v0",
+            "timestamp_parse(\"timestamp\",null,'UTC')",
+            ColumnType.LONG,
+            TestExprMacroTable.INSTANCE
+        ))
+        .context(defaultScanQueryContext(adjustedContext, scanSignature))
+        .build();
+
+    testSelectQuery().setSql("SELECT\n"
+                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
+                             + "  arrayString,\n"
+                             + "  arrayStringNulls,\n"
+                             + "  arrayLong,\n"
+                             + "  arrayLongNulls,\n"
+                             + "  arrayDouble,\n"
+                             + "  arrayDoubleNulls\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '" + queryFramework().queryJsonMapper().writeValueAsString(fileSignature) + "'\n"
+                             + "  )\n"
+                             + ")")
+                     .setQueryContext(adjustedContext)
+                     .setExpectedMSQSpec(MSQSpec
+                                             .builder()
+                                             .query(expectedQuery)
+                                             .columnMappings(new ColumnMappings(ImmutableList.of(
+                                                 new ColumnMapping("v0", "__time"),
+                                                 new ColumnMapping("arrayString", "arrayString"),
+                                                 new ColumnMapping("arrayStringNulls", "arrayStringNulls"),
+                                                 new ColumnMapping("arrayLong", "arrayLong"),
+                                                 new ColumnMapping("arrayLongNulls", "arrayLongNulls"),
+                                                 new ColumnMapping("arrayDouble", "arrayDouble"),
+                                                 new ColumnMapping("arrayDoubleNulls", "arrayDoubleNulls")
+                                             )))
+                                             .tuningConfig(MSQTuningConfig.defaultConfig())
+                                             .destination(TaskReportMSQDestination.INSTANCE)
+                                             .build()
+                     )
+                     .setExpectedRowSignature(rowSignature)
+                     .setExpectedResultRows(expectedRows)
+                     .verifyResults();
+  }
+
+
   private List<Object[]> expectedMultiValueFooRowsToArray()
   {
-    ImmutableList.Builder<Object[]> expectedRowsBuilder = ImmutableList.builder();
-    expectedRowsBuilder.add(new Object[]{0L, null});
-    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"a", "b"}});
-    expectedRowsBuilder.add(new Object[]{0L, new Object[]{""}});
-    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"b", "c"}});
-    expectedRowsBuilder.add(new Object[]{0L, new Object[]{"d"}});
-    return expectedRowsBuilder.build();
+    List<Object[]> expectedRows = new ArrayList<>();
+    expectedRows.add(new Object[]{0L, null});
+    if (!useDefault) {
+      expectedRows.add(new Object[]{0L, ""});
+    }
+
+    expectedRows.addAll(ImmutableList.of(
+        new Object[]{0L, ImmutableList.of("a", "b")},
+        new Object[]{0L, ImmutableList.of("b", "c")},
+        new Object[]{0L, "d"}
+    ));
+    return expectedRows;
   }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQInsertTest.java
@@ -38,7 +38,6 @@ import org.apache.druid.msq.test.CounterSnapshotMatcher;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestFileUtils;
 import org.apache.druid.msq.util.MultiStageQueryContext;
-import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
@@ -46,7 +45,6 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.timeline.SegmentId;
-import org.apache.druid.utils.CompressionUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
@@ -54,16 +52,11 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -735,22 +728,6 @@ public class MSQInsertTest extends MSQTestBase
   }
 
 
-  @Test
-  public void testInsertOnFoo1WithMultiValueToArrayGroupBy()
-  {
-    RowSignature rowSignature = RowSignature.builder()
-                                            .add("__time", ColumnType.LONG)
-                                            .add("dim3", ColumnType.STRING).build();
-
-    testIngestQuery().setSql(
-                         "INSERT INTO foo1 SELECT MV_TO_ARRAY(dim3) AS dim3 FROM foo GROUP BY 1 PARTITIONED BY ALL TIME")
-                     .setExpectedDataSource("foo1")
-                     .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
-                     .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
-                     .setExpectedResultRows(expectedMultiValueFooRowsToArray())
-                     .verifyResults();
-  }
 
   @Test
   public void testInsertOnFoo1WithAutoTypeArrayGroupBy()
@@ -1407,251 +1384,6 @@ public class MSQInsertTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @Test
-  public void testInsertArraysAutoType() throws IOException
-  {
-    List<Object[]> expectedRows = Arrays.asList(
-        new Object[]{1672531200000L, null, null, null},
-        new Object[]{1672531200000L, null, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
-        new Object[]{1672531200000L, new Object[]{"d", "e"}, new Object[]{1L, 4L}, new Object[]{2.2, 3.3, 4.0}},
-        new Object[]{1672531200000L, new Object[]{"a", "b"}, null, null},
-        new Object[]{1672531200000L, new Object[]{"a", "b"}, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
-        new Object[]{1672531200000L, new Object[]{"b", "c"}, new Object[]{1L, 2L, 3L, 4L}, new Object[]{1.1, 3.3}},
-        new Object[]{1672531200000L, new Object[]{"a", "b", "c"}, new Object[]{2L, 3L}, new Object[]{3.3, 4.4, 5.5}},
-        new Object[]{1672617600000L, null, null, null},
-        new Object[]{1672617600000L, null, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
-        new Object[]{1672617600000L, new Object[]{"d", "e"}, new Object[]{1L, 4L}, new Object[]{2.2, 3.3, 4.0}},
-        new Object[]{1672617600000L, new Object[]{"a", "b"}, null, null},
-        new Object[]{1672617600000L, new Object[]{"a", "b"}, new Object[]{1L, 2L, 3L}, new Object[]{1.1, 2.2, 3.3}},
-        new Object[]{1672617600000L, new Object[]{"b", "c"}, new Object[]{1L, 2L, 3L, 4L}, new Object[]{1.1, 3.3}},
-        new Object[]{1672617600000L, new Object[]{"a", "b", "c"}, new Object[]{2L, 3L}, new Object[]{3.3, 4.4, 5.5}}
-    );
-
-    RowSignature rowSignature = RowSignature.builder()
-                                            .add("__time", ColumnType.LONG)
-                                            .add("arrayString", ColumnType.STRING_ARRAY)
-                                            .add("arrayLong", ColumnType.LONG_ARRAY)
-                                            .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
-                                            .build();
-
-    final Map<String, Object> adjustedContext = new HashMap<>(context);
-    adjustedContext.put(MultiStageQueryContext.CTX_USE_AUTO_SCHEMAS, true);
-
-    final File tmpFile = temporaryFolder.newFile();
-    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader().getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
-    final InputStream decompressing = CompressionUtils.decompress(resourceStream, NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
-    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-    decompressing.close();
-
-    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
-
-    testIngestQuery().setSql(" INSERT INTO foo1 SELECT\n"
-                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
-                             + "  arrayString,\n"
-                             + "  arrayLong,\n"
-                             + "  arrayDouble\n"
-                             + "FROM TABLE(\n"
-                             + "  EXTERN(\n"
-                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
-                             + "    '{\"type\": \"json\"}',\n"
-                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"arrayString\", \"type\": \"COMPLEX<json>\"}, {\"name\": \"arrayLong\", \"type\": \"COMPLEX<json>\"}, {\"name\": \"arrayDouble\", \"type\": \"COMPLEX<json>\"}]'\n"
-                             + "  )\n"
-                             + ") PARTITIONED BY day")
-                     .setQueryContext(adjustedContext)
-                     .setExpectedResultRows(expectedRows)
-                     .setExpectedDataSource("foo1")
-                     .setExpectedRowSignature(rowSignature)
-                     .verifyResults();
-  }
-
-  @Test
-  public void testInsertArrays() throws IOException
-  {
-    List<Object[]> expectedRows = Arrays.asList(
-        new Object[]{
-            1672531200000L,
-            null,
-            null,
-            new Object[]{1L, 2L, 3L},
-            new Object[]{},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            null
-        },
-        new Object[]{
-            1672531200000L,
-            null,
-            Arrays.asList("a", "b"),
-            null,
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b"),
-            null,
-            null,
-            new Object[]{null, 2L, 9L},
-            null,
-            new Object[]{999.0d, 5.5d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b"),
-            Arrays.asList("a", "b"),
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1L, null, 3L},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{1.1d, 2.2d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("a", "b", "c"),
-            Arrays.asList(null, "b"),
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{3.3d, 4.4d, 5.5d},
-            new Object[]{999.0d, null, 5.5d}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("b", "c"),
-            Arrays.asList("d", null, "b"),
-            new Object[]{1L, 2L, 3L, 4L},
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1.1d, 3.3d},
-            new Object[]{null, 2.2d, null}
-        },
-        new Object[]{
-            1672531200000L,
-            Arrays.asList("d", "e"),
-            Arrays.asList("b", "b"),
-            new Object[]{1L, 4L},
-            new Object[]{1L},
-            new Object[]{2.2d, 3.3d, 4.0d},
-            null
-        },
-        new Object[]{
-            1672617600000L,
-            null,
-            null,
-            new Object[]{1L, 2L, 3L},
-            null,
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{}
-        },
-        new Object[]{
-            1672617600000L,
-            null,
-            Arrays.asList("a", "b"),
-            null,
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{null, 1.1d}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b"),
-            null,
-            null,
-            new Object[]{null, 2L, 9L},
-            null,
-            new Object[]{999.0d, 5.5d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b"),
-            Collections.emptyList(),
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1L, null, 3L},
-            new Object[]{1.1d, 2.2d, 3.3d},
-            new Object[]{1.1d, 2.2d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("a", "b", "c"),
-            Arrays.asList(null, "b"),
-            new Object[]{2L, 3L},
-            null,
-            new Object[]{3.3d, 4.4d, 5.5d},
-            new Object[]{999.0d, null, 5.5d}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("b", "c"),
-            Arrays.asList("d", null, "b"),
-            new Object[]{1L, 2L, 3L, 4L},
-            new Object[]{1L, 2L, 3L},
-            new Object[]{1.1d, 3.3d},
-            new Object[]{null, 2.2d, null}
-        },
-        new Object[]{
-            1672617600000L,
-            Arrays.asList("d", "e"),
-            Arrays.asList("b", "b"),
-            new Object[]{1L, 4L},
-            new Object[]{null},
-            new Object[]{2.2d, 3.3d, 4.0},
-            null
-        }
-    );
-
-    RowSignature rowSignatureWithoutTimeAndStringColumns =
-        RowSignature.builder()
-                    .add("arrayLong", ColumnType.LONG_ARRAY)
-                    .add("arrayLongNulls", ColumnType.LONG_ARRAY)
-                    .add("arrayDouble", ColumnType.DOUBLE_ARRAY)
-                    .add("arrayDoubleNulls", ColumnType.DOUBLE_ARRAY)
-                    .build();
-
-
-    RowSignature fileSignature = RowSignature.builder()
-                                             .add("timestamp", ColumnType.STRING)
-                                             .add("arrayString", ColumnType.STRING_ARRAY)
-                                             .add("arrayStringNulls", ColumnType.STRING_ARRAY)
-                                             .addAll(rowSignatureWithoutTimeAndStringColumns)
-                                             .build();
-
-    // MSQ writes strings instead of string arrays
-    RowSignature rowSignature = RowSignature.builder()
-                                            .add("__time", ColumnType.LONG)
-                                            .add("arrayString", ColumnType.STRING)
-                                            .add("arrayStringNulls", ColumnType.STRING)
-                                            .addAll(rowSignatureWithoutTimeAndStringColumns)
-                                            .build();
-
-    final Map<String, Object> adjustedContext = new HashMap<>(context);
-    final File tmpFile = temporaryFolder.newFile();
-    final InputStream resourceStream = NestedDataTestUtils.class.getClassLoader().getResourceAsStream(NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
-    final InputStream decompressing = CompressionUtils.decompress(resourceStream, NestedDataTestUtils.ARRAY_TYPES_DATA_FILE);
-    Files.copy(decompressing, tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-    decompressing.close();
-
-    final String toReadFileNameAsJson = queryFramework().queryJsonMapper().writeValueAsString(tmpFile);
-
-    testIngestQuery().setSql(" INSERT INTO foo1 SELECT\n"
-                             + "  TIME_PARSE(\"timestamp\") as __time,\n"
-                             + "  arrayString,\n"
-                             + "  arrayStringNulls,\n"
-                             + "  arrayLong,\n"
-                             + "  arrayLongNulls,\n"
-                             + "  arrayDouble,\n"
-                             + "  arrayDoubleNulls\n"
-                             + "FROM TABLE(\n"
-                             + "  EXTERN(\n"
-                             + "    '{ \"files\": [" + toReadFileNameAsJson + "],\"type\":\"local\"}',\n"
-                             + "    '{\"type\": \"json\"}',\n"
-                             + "    '" + queryFramework().queryJsonMapper().writeValueAsString(fileSignature) + "'\n"
-                             + "  )\n"
-                             + ") PARTITIONED BY day")
-                     .setQueryContext(adjustedContext)
-                     .setExpectedResultRows(expectedRows)
-                     .setExpectedDataSource("foo1")
-                     .setExpectedRowSignature(rowSignature)
-                     .verifyResults();
-  }
-
-  @Nonnull
   private List<Object[]> expectedFooRows()
   {
     List<Object[]> expectedRows = new ArrayList<>();
@@ -1668,7 +1400,6 @@ public class MSQInsertTest extends MSQTestBase
     return expectedRows;
   }
 
-  @Nonnull
   private List<Object[]> expectedFooRowsWithAggregatedComplexColumn()
   {
     List<Object[]> expectedRows = new ArrayList<>();
@@ -1687,7 +1418,6 @@ public class MSQInsertTest extends MSQTestBase
     return expectedRows;
   }
 
-  @Nonnull
   private List<Object[]> expectedMultiValueFooRows()
   {
     List<Object[]> expectedRows = new ArrayList<>();
@@ -1704,24 +1434,6 @@ public class MSQInsertTest extends MSQTestBase
     return expectedRows;
   }
 
-  @Nonnull
-  private List<Object[]> expectedMultiValueFooRowsToArray()
-  {
-    List<Object[]> expectedRows = new ArrayList<>();
-    expectedRows.add(new Object[]{0L, null});
-    if (!useDefault) {
-      expectedRows.add(new Object[]{0L, ""});
-    }
-
-    expectedRows.addAll(ImmutableList.of(
-        new Object[]{0L, ImmutableList.of("a", "b")},
-        new Object[]{0L, ImmutableList.of("b", "c")},
-        new Object[]{0L, "d"}
-    ));
-    return expectedRows;
-  }
-
-  @Nonnull
   private List<Object[]> expectedMultiValueFooRowsGroupBy()
   {
     List<Object[]> expectedRows = new ArrayList<>();
@@ -1737,7 +1449,6 @@ public class MSQInsertTest extends MSQTestBase
     return expectedRows;
   }
 
-  @Nonnull
   private Set<SegmentId> expectedFooSegments()
   {
     Set<SegmentId> expectedSegments = new TreeSet<>();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -39,10 +39,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_ARRAY_INGEST_MODE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_DURABLE_SHUFFLE_STORAGE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FAULT_TOLERANCE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS;
-import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_INGEST_STRING_ARRAYS_AS_MVDS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_NUM_TASKS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MSQ_MODE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_ROWS_IN_MEMORY;
@@ -216,16 +216,34 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void isIngestStringArraysAsMVDs_unset_returnsDefaultValue()
+  public void arrayIngestMode_unset_returnsDefaultValue()
   {
-    Assert.assertFalse(MultiStageQueryContext.isIngestStringArraysAsMVDs(QueryContext.empty()));
+    Assert.assertEquals(ArrayIngestMode.NONE, MultiStageQueryContext.getArrayIngestMode(QueryContext.empty()));
   }
 
   @Test
-  public void isIngestStringArraysAsMVDs_set_returnsCorrectValue()
+  public void arrayIngestMode_set_returnsCorrectValue()
   {
-    Map<String, Object> propertyMap = ImmutableMap.of(CTX_INGEST_STRING_ARRAYS_AS_MVDS, true);
-    Assert.assertTrue(MultiStageQueryContext.isIngestStringArraysAsMVDs(QueryContext.of(propertyMap)));
+    Assert.assertEquals(
+        ArrayIngestMode.NONE,
+        MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "none")))
+    );
+
+    Assert.assertEquals(
+        ArrayIngestMode.MVD,
+        MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "mvd")))
+    );
+
+    Assert.assertEquals(
+        ArrayIngestMode.ARRAY,
+        MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "array")))
+    );
+
+    Assert.assertThrows(
+        BadQueryContextException.class,
+        () ->
+            MultiStageQueryContext.getArrayIngestMode(QueryContext.of(ImmutableMap.of(CTX_ARRAY_INGEST_MODE, "dummy")))
+    );
   }
 
   @Test

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -218,7 +218,7 @@ public class MultiStageQueryContextTest
   @Test
   public void arrayIngestMode_unset_returnsDefaultValue()
   {
-    Assert.assertEquals(ArrayIngestMode.NONE, MultiStageQueryContext.getArrayIngestMode(QueryContext.empty()));
+    Assert.assertEquals(ArrayIngestMode.MVD, MultiStageQueryContext.getArrayIngestMode(QueryContext.empty()));
   }
 
   @Test

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_DURABLE_SHUFFLE_STORAGE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FAULT_TOLERANCE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS;
+import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_INGEST_STRING_ARRAYS_AS_MVDS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_NUM_TASKS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MSQ_MODE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_ROWS_IN_MEMORY;
@@ -54,46 +55,46 @@ import static org.apache.druid.msq.util.MultiStageQueryContext.DEFAULT_MAX_NUM_T
 public class MultiStageQueryContextTest
 {
   @Test
-  public void isDurableShuffleStorageEnabled_noParameterSetReturnsDefaultValue()
+  public void isDurableShuffleStorageEnabled_unset_returnsDefaultValue()
   {
     Assert.assertFalse(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.empty()));
   }
 
   @Test
-  public void isDurableShuffleStorageEnabled_parameterSetReturnsCorrectValue()
+  public void isDurableShuffleStorageEnabled_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_DURABLE_SHUFFLE_STORAGE, "true");
     Assert.assertTrue(MultiStageQueryContext.isDurableStorageEnabled(QueryContext.of(propertyMap)));
   }
 
   @Test
-  public void isFaultToleranceEnabled_noParameterSetReturnsDefaultValue()
+  public void isFaultToleranceEnabled_unset_returnsDefaultValue()
   {
     Assert.assertFalse(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.empty()));
   }
 
   @Test
-  public void isFaultToleranceEnabled_parameterSetReturnsCorrectValue()
+  public void isFaultToleranceEnabled_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_FAULT_TOLERANCE, "true");
     Assert.assertTrue(MultiStageQueryContext.isFaultToleranceEnabled(QueryContext.of(propertyMap)));
   }
 
   @Test
-  public void isFinalizeAggregations_noParameterSetReturnsDefaultValue()
+  public void isFinalizeAggregations_unset_returnsDefaultValue()
   {
     Assert.assertTrue(MultiStageQueryContext.isFinalizeAggregations(QueryContext.empty()));
   }
 
   @Test
-  public void isFinalizeAggregations_parameterSetReturnsCorrectValue()
+  public void isFinalizeAggregations_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_FINALIZE_AGGREGATIONS, "false");
     Assert.assertFalse(MultiStageQueryContext.isFinalizeAggregations(QueryContext.of(propertyMap)));
   }
 
   @Test
-  public void getAssignmentStrategy_noParameterSetReturnsDefaultValue()
+  public void getAssignmentStrategy_unset_returnsDefaultValue()
   {
     Assert.assertEquals(
         WorkerAssignmentStrategy.MAX,
@@ -102,7 +103,7 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void testGetMaxInputBytesPerWorker()
+  public void getMaxInputBytesPerWorker_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(MultiStageQueryContext.CTX_MAX_INPUT_BYTES_PER_WORKER, 1024);
 
@@ -112,7 +113,7 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void getAssignmentStrategy_parameterSetReturnsCorrectValue()
+  public void getAssignmentStrategy_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_TASK_ASSIGNMENT_STRATEGY, "AUTO");
     Assert.assertEquals(
@@ -122,27 +123,20 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void getMaxNumTasks_noParameterSetReturnsDefaultValue()
+  public void getMaxNumTasks_unset_returnsDefaultValue()
   {
     Assert.assertEquals(DEFAULT_MAX_NUM_TASKS, MultiStageQueryContext.getMaxNumTasks(QueryContext.empty()));
   }
 
   @Test
-  public void getMaxNumTasks_parameterSetReturnsCorrectValue()
+  public void getMaxNumTasks_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_NUM_TASKS, 101);
     Assert.assertEquals(101, MultiStageQueryContext.getMaxNumTasks(QueryContext.of(propertyMap)));
   }
 
   @Test
-  public void getMaxNumTasks_legacyParameterSetReturnsCorrectValue()
-  {
-    Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_NUM_TASKS, 101);
-    Assert.assertEquals(101, MultiStageQueryContext.getMaxNumTasks(QueryContext.of(propertyMap)));
-  }
-
-  @Test
-  public void getRowsPerSegment_noParameterSetReturnsDefaultValue()
+  public void getRowsPerSegment_unset_returnsDefaultValue()
   {
     Assert.assertEquals(
         MultiStageQueryContext.DEFAULT_ROWS_PER_SEGMENT,
@@ -151,14 +145,14 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void getRowsPerSegment_parameterSetReturnsCorrectValue()
+  public void getRowsPerSegment_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_ROWS_PER_SEGMENT, 10);
     Assert.assertEquals(10, MultiStageQueryContext.getRowsPerSegment(QueryContext.of(propertyMap)));
   }
 
   @Test
-  public void getRowsInMemory_noParameterSetReturnsDefaultValue()
+  public void getRowsInMemory_unset_returnsDefaultValue()
   {
     Assert.assertEquals(
         MultiStageQueryContext.DEFAULT_ROWS_IN_MEMORY,
@@ -167,10 +161,71 @@ public class MultiStageQueryContextTest
   }
 
   @Test
-  public void getRowsInMemory_parameterSetReturnsCorrectValue()
+  public void getRowsInMemory_set_returnsCorrectValue()
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_ROWS_IN_MEMORY, 10);
     Assert.assertEquals(10, MultiStageQueryContext.getRowsInMemory(QueryContext.of(propertyMap)));
+  }
+
+  @Test
+  public void getSortOrder_unset_returnsDefaultValue()
+  {
+    Assert.assertEquals(Collections.emptyList(), MultiStageQueryContext.getSortOrder(QueryContext.empty()));
+  }
+
+  @Test
+  public void getSortOrder_set_returnsCorrectValue()
+  {
+    Map<String, Object> propertyMap = ImmutableMap.of(CTX_SORT_ORDER, "a, b,\"c,d\"");
+    Assert.assertEquals(
+        ImmutableList.of("a", "b", "c,d"),
+        MultiStageQueryContext.getSortOrder(QueryContext.of(propertyMap))
+    );
+  }
+
+  @Test
+  public void getMSQMode_unset_returnsDefaultValue()
+  {
+    Assert.assertEquals("strict", MultiStageQueryContext.getMSQMode(QueryContext.empty()));
+  }
+
+  @Test
+  public void getMSQMode_set_returnsCorrectValue()
+  {
+    Map<String, Object> propertyMap = ImmutableMap.of(CTX_MSQ_MODE, "nonStrict");
+    Assert.assertEquals("nonStrict", MultiStageQueryContext.getMSQMode(QueryContext.of(propertyMap)));
+  }
+
+  @Test
+  public void getSelectDestination_unset_returnsDefaultValue()
+  {
+    Assert.assertEquals(MSQSelectDestination.TASKREPORT, MultiStageQueryContext.getSelectDestination(QueryContext.empty()));
+  }
+
+  @Test
+  public void useAutoColumnSchemes_unset_returnsDefaultValue()
+  {
+    Assert.assertFalse(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.empty()));
+  }
+
+  @Test
+  public void useAutoColumnSchemes_set_returnsCorrectValue()
+  {
+    Map<String, Object> propertyMap = ImmutableMap.of(CTX_USE_AUTO_SCHEMAS, true);
+    Assert.assertTrue(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.of(propertyMap)));
+  }
+
+  @Test
+  public void isIngestStringArraysAsMVDs_unset_returnsDefaultValue()
+  {
+    Assert.assertFalse(MultiStageQueryContext.isIngestStringArraysAsMVDs(QueryContext.empty()));
+  }
+
+  @Test
+  public void isIngestStringArraysAsMVDs_set_returnsCorrectValue()
+  {
+    Map<String, Object> propertyMap = ImmutableMap.of(CTX_INGEST_STRING_ARRAYS_AS_MVDS, true);
+    Assert.assertTrue(MultiStageQueryContext.isIngestStringArraysAsMVDs(QueryContext.of(propertyMap)));
   }
 
   @Test
@@ -219,48 +274,6 @@ public class MultiStageQueryContextTest
         ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
             "Expected key [indexSpec] to be an indexSpec, but got [{]"))
     );
-  }
-
-  @Test
-  public void getSortOrderNoParameterSetReturnsDefaultValue()
-  {
-    Assert.assertEquals(Collections.emptyList(), MultiStageQueryContext.getSortOrder(QueryContext.empty()));
-  }
-
-  @Test
-  public void getSortOrderParameterSetReturnsCorrectValue()
-  {
-    Map<String, Object> propertyMap = ImmutableMap.of(CTX_SORT_ORDER, "a, b,\"c,d\"");
-    Assert.assertEquals(
-        ImmutableList.of("a", "b", "c,d"),
-        MultiStageQueryContext.getSortOrder(QueryContext.of(propertyMap))
-    );
-  }
-
-  @Test
-  public void getMSQModeNoParameterSetReturnsDefaultValue()
-  {
-    Assert.assertEquals("strict", MultiStageQueryContext.getMSQMode(QueryContext.empty()));
-  }
-
-  @Test
-  public void getMSQModeParameterSetReturnsCorrectValue()
-  {
-    Map<String, Object> propertyMap = ImmutableMap.of(CTX_MSQ_MODE, "nonStrict");
-    Assert.assertEquals("nonStrict", MultiStageQueryContext.getMSQMode(QueryContext.of(propertyMap)));
-  }
-
-  @Test
-  public void limitSelectResultReturnsDefaultValue()
-  {
-    Assert.assertEquals(MSQSelectDestination.TASKREPORT, MultiStageQueryContext.getSelectDestination(QueryContext.empty()));
-  }
-
-  @Test
-  public void testUseAutoSchemas()
-  {
-    Map<String, Object> propertyMap = ImmutableMap.of(CTX_USE_AUTO_SCHEMAS, true);
-    Assert.assertTrue(MultiStageQueryContext.useAutoColumnSchemas(QueryContext.of(propertyMap)));
   }
 
   private static List<String> decodeSortOrder(@Nullable final String input)


### PR DESCRIPTION
### Description

MSQ uses the string dimension schema for `ARRAY<STRING>` typed columns, which creates MVDs instead of string arrays as required. Therefore someone trying to ingest columns of type `ARRAY<STRING>` from an external data source or another data source would get `STRING` columns in the newly generated segments.

This patch changes the following:
1. Use auto dimension schema to ingest the `ARRAY<STRING>` columns, which will create columns with the desired type.
2. Add an undocumented flag `ingestStringArraysAsMVDs` to preserve the legacy behavior. 
3. Create `MSQArraysInsertTest` and refactor some of the tests in `MSQInsertTest`.

**NOTE:** This is a user-facing change that changes how string arrays are ingested in MSQ. 


#### Release note
(TO BE UPDATED)

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
