### PR TITLE
Fixing old function used

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
@@ -33,7 +33,7 @@ public class CalciteSysQueryTest extends BaseCalciteQueryTest
   @Test
   public void testTasksSum()
   {
-    notMsqCompatible();
+    msqIncompatible();
 
     testBuilder()
         .sql("select datasource, sum(duration) from sys.tasks group by datasource")
@@ -50,7 +50,7 @@ public class CalciteSysQueryTest extends BaseCalciteQueryTest
   @Test
   public void testTasksSumOver()
   {
-    notMsqCompatible();
+    msqIncompatible();
 
     testBuilder()
         .sql("select datasource, sum(duration) over () from sys.tasks group by datasource")


### PR DESCRIPTION
The master broke in https://github.com/apache/druid/pull/15070 as the function notMsqCompatible() is renamed to msqIncompatible() in #14900 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
