### PR TITLE
Fix the build for #15013.: Lookup jitter upstream build fix

### DIFF
--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -352,7 +352,7 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 |`filter`|The filter to use when selecting lookups, this is used to create a where clause on lookup population|No|No Filter|
 |`tsColumn`| The column in `table` which contains when the key was updated|No|Not used|
 |`pollPeriod`|How often to poll the DB|No|0 (only once)|
-|`jitterSeconds`| How much jitter to add (in seconds) as a delay, used to distribute db load more evenly|No|0
+|`jitterSeconds`| How much jitter to add (in seconds) up to maximum as a delay (actual value will be used as random from 0 to `jitterSeconds`), used to distribute db load more evenly|No|0|
 |`maxHeapPercentage`|The maximum percentage of heap size that the lookup should consume. If the lookup grows beyond this size, warning messages will be logged in the respective service logs.|No|10% of JVM heap size|
 
 ```json

--- a/docs/development/extensions-core/lookups-cached-global.md
+++ b/docs/development/extensions-core/lookups-cached-global.md
@@ -352,6 +352,7 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
 |`filter`|The filter to use when selecting lookups, this is used to create a where clause on lookup population|No|No Filter|
 |`tsColumn`| The column in `table` which contains when the key was updated|No|Not used|
 |`pollPeriod`|How often to poll the DB|No|0 (only once)|
+|`jitterSeconds`| How much jitter to add (in seconds) as a delay, used to distribute db load more evenly|No|0
 |`maxHeapPercentage`|The maximum percentage of heap size that the lookup should consume. If the lookup grows beyond this size, warning messages will be logged in the respective service logs.|No|10% of JVM heap size|
 
 ```json
@@ -367,6 +368,7 @@ The JDBC lookups will poll a database to populate its local cache. If the `tsCol
   "valueColumn":"the_new_dim_value",
   "tsColumn":"timestamp_column",
   "pollPeriod":600000,
+  "jitterSeconds": 120,
   "maxHeapPercentage": 10
 }
 ```

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/ExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/ExtractionNamespace.java
@@ -41,4 +41,12 @@ public interface ExtractionNamespace
   {
     return -1L;
   }
+
+  // For larger clusters, when they all startup at the same time and have lookups in the db,
+  // it overwhelms the database, this allows implementations to introduce a jitter, which
+  // should spread out the load.
+  default long getJitter()
+  {
+    return 0;
+  }
 }

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/ExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/ExtractionNamespace.java
@@ -45,7 +45,7 @@ public interface ExtractionNamespace
   // For larger clusters, when they all startup at the same time and have lookups in the db,
   // it overwhelms the database, this allows implementations to introduce a jitter, which
   // should spread out the load.
-  default long getJitter()
+  default long getJitterMills()
   {
     return 0;
   }

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  *
@@ -173,8 +173,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
     if (jitterSeconds == 0) {
       return jitterSeconds;
     }
-    Random r = new Random();
-    return 1000L * r.nextInt(jitterSeconds + 1);
+    return 1000L * ThreadLocalRandom.current().nextInt(jitterSeconds + 1);
   }
 
   @Override

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
+import java.util.Random;
 
 /**
  *
@@ -61,6 +62,8 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
   private final Period pollPeriod;
   @JsonProperty
   private final long maxHeapPercentage;
+  @JsonProperty
+  private final int jitterSeconds;
 
   @JsonCreator
   public JdbcExtractionNamespace(
@@ -73,6 +76,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
       @JsonProperty(value = "filter") @Nullable final String filter,
       @Min(0) @JsonProperty(value = "pollPeriod") @Nullable final Period pollPeriod,
       @JsonProperty(value = "maxHeapPercentage") @Nullable final Long maxHeapPercentage,
+      @JsonProperty(value = "jitterSeconds") @Nullable Integer jitterSeconds,
       @JacksonInject JdbcAccessSecurityConfig securityConfig
   )
   {
@@ -95,6 +99,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
     } else {
       this.pollPeriod = pollPeriod;
     }
+    this.jitterSeconds = jitterSeconds == null ? 0 : jitterSeconds;
     this.maxHeapPercentage = maxHeapPercentage == null ? DEFAULT_MAX_HEAP_PERCENTAGE : maxHeapPercentage;
   }
 
@@ -160,6 +165,16 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
   public long getMaxHeapPercentage()
   {
     return maxHeapPercentage;
+  }
+
+  @Override
+  public long getJitter()
+  {
+    if (jitterSeconds == 0) {
+      return jitterSeconds;
+    }
+    Random r = new Random();
+    return 1000L * r.nextInt(jitterSeconds + 1);
   }
 
   @Override

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespace.java
@@ -168,7 +168,7 @@ public class JdbcExtractionNamespace implements ExtractionNamespace
   }
 
   @Override
-  public long getJitter()
+  public long getJitterMills()
   {
     if (jitterSeconds == 0) {
       return jitterSeconds;

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
@@ -180,9 +180,9 @@ public final class CacheScheduler
       final long updateMs = namespace.getPollMs();
       Runnable command = this::updateCache;
       if (updateMs > 0) {
-        return cacheManager.scheduledExecutorService().scheduleAtFixedRate(command, namespace.getJitter(), updateMs, TimeUnit.MILLISECONDS);
+        return cacheManager.scheduledExecutorService().scheduleAtFixedRate(command, namespace.getJitterMills(), updateMs, TimeUnit.MILLISECONDS);
       } else {
-        return cacheManager.scheduledExecutorService().schedule(command, namespace.getJitter(), TimeUnit.MILLISECONDS);
+        return cacheManager.scheduledExecutorService().schedule(command, namespace.getJitterMills(), TimeUnit.MILLISECONDS);
       }
     }
 

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/CacheScheduler.java
@@ -180,9 +180,9 @@ public final class CacheScheduler
       final long updateMs = namespace.getPollMs();
       Runnable command = this::updateCache;
       if (updateMs > 0) {
-        return cacheManager.scheduledExecutorService().scheduleAtFixedRate(command, 0, updateMs, TimeUnit.MILLISECONDS);
+        return cacheManager.scheduledExecutorService().scheduleAtFixedRate(command, namespace.getJitter(), updateMs, TimeUnit.MILLISECONDS);
       } else {
-        return cacheManager.scheduledExecutorService().schedule(command, 0, TimeUnit.MILLISECONDS);
+        return cacheManager.scheduledExecutorService().schedule(command, namespace.getJitter(), TimeUnit.MILLISECONDS);
       }
     }
 

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
@@ -63,7 +63,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
-          new JdbcAccessSecurityConfig()
+          0, new JdbcAccessSecurityConfig()
           {
             @Override
             public Set<String> getAllowedProperties()
@@ -101,6 +101,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -137,6 +138,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -175,6 +177,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -217,6 +220,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -255,6 +259,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           10L,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -291,7 +296,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
-          new JdbcAccessSecurityConfig()
+          0, new JdbcAccessSecurityConfig()
           {
             @Override
             public Set<String> getAllowedProperties()
@@ -329,6 +334,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -373,6 +379,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override
@@ -415,6 +422,7 @@ public class JdbcExtractionNamespaceUrlCheckTest
           "some filter",
           new Period(10),
           null,
+          0,
           new JdbcAccessSecurityConfig()
           {
             @Override

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
@@ -137,6 +137,7 @@ public class JdbcCacheGeneratorTest
         "filter",
         Period.ZERO,
         null,
+        0,
         new JdbcAccessSecurityConfig()
     );
   }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
@@ -458,6 +458,7 @@ public class CacheSchedulerTest
         "some filter",
         new Period(10_000),
         null,
+        0,
         new JdbcAccessSecurityConfig()
         {
           @Override

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -63,9 +63,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 /**
  *
  */
@@ -419,9 +416,9 @@ public class JdbcExtractionNamespaceTest
         120,
         new JdbcAccessSecurityConfig()
     );
-    long jitter = extractionNamespace.getJitter();
+    long jitter = extractionNamespace.getJitterMills();
     // jitter will be a random value between 0 and 120 seconds.
-    assertTrue(jitter >= 0 && jitter <= 120000);
+    Assert.assertTrue(jitter >= 0 && jitter <= 120000);
   }
 
   @Test
@@ -439,9 +436,9 @@ public class JdbcExtractionNamespaceTest
         null,
         new JdbcAccessSecurityConfig()
     );
-    long jitter = extractionNamespace.getJitter();
+    long jitter = extractionNamespace.getJitterMills();
     // jitter will be a random value between 0 and 120 seconds.
-    assertEquals(0, extractionNamespace.getJitter());
+    Assert.assertEquals(0, extractionNamespace.getJitterMills());
   }
 
   @Test(timeout = 60_000L)
@@ -540,7 +537,7 @@ public class JdbcExtractionNamespaceTest
       log.debug("Waiting for updateLock");
       updateLock.lockInterruptibly();
       try {
-        assertTrue("Failed waiting for update", System.currentTimeMillis() - startTime < timeout);
+        Assert.assertTrue("Failed waiting for update", System.currentTimeMillis() - startTime < timeout);
         post = updates.get();
       }
       finally {

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -436,7 +436,6 @@ public class JdbcExtractionNamespaceTest
         null,
         new JdbcAccessSecurityConfig()
     );
-    long jitter = extractionNamespace.getJitterMills();
     // jitter will be a random value between 0 and 120 seconds.
     Assert.assertEquals(0, extractionNamespace.getJitterMills());
   }


### PR DESCRIPTION

Fix the build for https://github.com/apache/druid/pull/15013. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
