### PR TITLE
run some integration tests with Java 21

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup java
-        run: export JAVA_HOME=$JAVA_HOME_8_X64
+      - name: setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
 
       - name: Cache Maven m2 repository
         id: maven

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -77,9 +77,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup java
-        run: |
-          echo "JAVA_HOME=$JAVA_HOME_${{ inputs.build_jdk }}_X64" >> $GITHUB_ENV
+      - name: setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ inputs.build_jdk }}
+          distribution: 'zulu'
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -62,9 +62,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup java
-        run: |
-          echo "JAVA_HOME=$JAVA_HOME_${{ inputs.runtime_jdk }}_X64" >> $GITHUB_ENV
+      - name: setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ inputs.runtime_jdk }}
+          distribution: 'zulu'
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 17]
+        jdk: [8, 17, 21]
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -150,8 +150,11 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v3
 
-      - name: Setup java
-        run: export JAVA_HOME=$JAVA_HOME_8_X64
+      - name: setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'zulu'
 
       # the build step produces SNAPSHOT artifacts into the local maven repository,
       # we include github.sha in the cache key to make it specific to that build/jdk

--- a/examples/bin/run-java
+++ b/examples/bin/run-java
@@ -24,7 +24,7 @@ if [ -z "$JAVA_BIN" ]; then
   exit 1
 fi
 
-JAVA_MAJOR="$("$JAVA_BIN" -version 2>&1 | sed -n -E 's/.* version "([^."]*).*/\1/p')"
+JAVA_MAJOR="$("$JAVA_BIN" -version 2>&1 | sed -n -E 's/.* version "([^."-]*).*/\1/p')"
 
 if [ "$JAVA_MAJOR" != "" ] && [ "$JAVA_MAJOR" -ge "11" ]
 then

--- a/integration-tests/script/docker_build_containers.sh
+++ b/integration-tests/script/docker_build_containers.sh
@@ -26,21 +26,18 @@ then
 else
   echo "\$DRUID_INTEGRATION_TEST_JVM_RUNTIME is set with value ${DRUID_INTEGRATION_TEST_JVM_RUNTIME}"
   case "${DRUID_INTEGRATION_TEST_JVM_RUNTIME}" in
-  8)
-    echo "Build druid-cluster with Java 8"
-    docker build -t druid/cluster --build-arg JDK_VERSION=8-slim-buster --build-arg ZK_VERSION --build-arg KAFKA_VERSION --build-arg CONFLUENT_VERSION --build-arg MYSQL_VERSION --build-arg MARIA_VERSION --build-arg MYSQL_DRIVER_CLASSNAME --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
-    ;;
-  11)
-    echo "Build druid-cluster with Java 11"
-    docker build -t druid/cluster --build-arg JDK_VERSION=11-slim-buster --build-arg ZK_VERSION --build-arg KAFKA_VERSION --build-arg CONFLUENT_VERSION --build-arg MYSQL_VERSION --build-arg MARIA_VERSION --build-arg MYSQL_DRIVER_CLASSNAME --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
-    ;;
-  15)
-    echo "Build druid-cluster with Java 15"
-    docker build -t druid/cluster --build-arg JDK_VERSION=15-slim-buster --build-arg ZK_VERSION --build-arg KAFKA_VERSION --build-arg CONFLUENT_VERSION --build-arg MYSQL_VERSION --build-arg MARIA_VERSION --build-arg MYSQL_DRIVER_CLASSNAME --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
-    ;;
-  17)
-    echo "Build druid-cluster with Java 17"
-    docker build -t druid/cluster --build-arg JDK_VERSION=17-slim-buster --build-arg ZK_VERSION --build-arg KAFKA_VERSION --build-arg CONFLUENT_VERSION --build-arg MYSQL_VERSION --build-arg MARIA_VERSION --build-arg MYSQL_DRIVER_CLASSNAME --build-arg APACHE_ARCHIVE_MIRROR_HOST $SHARED_DIR/docker
+  8 | 11 | 17 | 21)
+    echo "Build druid-cluster with Java $DRUID_INTEGRATION_TEST_JVM_RUNTIME"
+    docker build -t druid/cluster \
+      --build-arg JDK_VERSION=$DRUID_INTEGRATION_TEST_JVM_RUNTIME-slim-buster \
+      --build-arg ZK_VERSION \
+      --build-arg KAFKA_VERSION \
+      --build-arg CONFLUENT_VERSION \
+      --build-arg MYSQL_VERSION \
+      --build-arg MARIA_VERSION \
+      --build-arg MYSQL_DRIVER_CLASSNAME \
+      --build-arg APACHE_ARCHIVE_MIRROR_HOST \
+      $SHARED_DIR/docker
     ;;
   *)
     echo "Invalid JVM Runtime given. Stopping"


### PR DESCRIPTION
* add Java 21 to the integration test matrix for all integration tests already running with Java 17
* use setup-java everywhere for consistency, since Java 21 is not built into the runner image
* remove Java 15 from docker_build_containers script
* simplify docker_build_containers script
* fix run-java script to support early-access Java versions (e.g. reporting as `21-ea`), since our
  base image openjdk:21-slim-buster is still an early-access version