### PR TITLE
remove unsafe use of maven dependency caching, and cache deps explicitly

### DIFF
--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -47,7 +47,7 @@ on:
         default: com.mysql.jdbc.Driver
 
 env:
-  MVN: mvn --no-snapshot-updates
+  MVN: mvn -B --no-transfer-progress --no-snapshot-updates
   MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
   MAVEN_SKIP_TESTS: -P skip-tests
   DOCKER_IP: 127.0.0.1  # for integration tests

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -40,7 +40,7 @@ on:
         value: ${{ jobs.unit-tests.outputs.coverage_failure }}
 
 env:
-  MVN: mvn -B
+  MVN: mvn -B --no-transfer-progress
   MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
   MAVEN_SKIP_TESTS: -P skip-tests
   MAVEN_OPTS: -Xmx3500m

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -139,7 +139,7 @@ jobs:
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     runs-on: ubuntu-22.04
     env:
-      MVN: mvn --no-snapshot-updates
+      MVN: mvn -B --no-transfer-progress --no-snapshot-updates
       MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
       CONFIG_FILE: k8s_run_config_file.json
       IT_TEST: -Dit.test=ITNestedQueryPushDownTest

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -164,7 +164,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Maven build
         if: steps.maven-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -164,6 +164,11 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}
+          # fallback cache entries to restore from. 'depsonly' keys are safe to
+          # restore since they don't contain any artifacts created by mvn install
+          restore-keys: |
+            maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
+            maven-${{ runner.os }}-depsonly-
 
       - name: Maven build
         if: steps.maven-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -188,7 +188,9 @@ jobs:
 
       # restore maven dependencies only. 'depsonly' keys are safe to restore
       # since they don't contain any artifacts created by mvn install
-      - uses: actions/cache@v3
+      # do not save cache since this step only runs web-console and as such
+      # does not populate most dependencies in the maven repository.
+      - uses: actions/cache/restore@v3
         with:
           key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -185,8 +185,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-          # cache is safe use here since we don't call mvn install
-          cache: 'maven'
+
+      # restore maven dependencies only. 'depsonly' keys are safe to restore
+      # since they don't contain any artifacts created by mvn install
+      - uses: actions/cache@v3
+        with:
+          key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-${{ runner.os }}-depsonly-
 
       - name: setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -55,9 +55,12 @@ jobs:
       - name: maven cache dependencies
         run: ${MVN} dependency:resolve dependency:resolve-plugins
 
+      # Create a cache entry for dependencies only. This cache entry must
+      # never include any artifacts written to the local repo by mvn install.
       - uses: actions/cache/save@v3
         with:
-          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
 
       - name: packaging check
         run: |
@@ -130,6 +133,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
+
+      - uses: actions/cache/restore@v3
+        with:
+          key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          # fallback cache entries to restore from. 'depsonly' keys are safe to
+          # restore since they don't contain any artifacts created by mvn install
+          restore-keys: |
+            maven-${{ runner.os }}-depsonly-
 
       - name: maven install
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+          # cache is safe use here since we don't call mvn install
           cache: 'maven'
 
       - name: setup node

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -124,7 +124,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '8'
-          cache: 'maven'
 
       - name: maven install
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -51,7 +51,13 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-          cache: 'maven'
+
+      - name: maven cache dependencies
+        run: ${MVN} dependency:resolve dependency:resolve-plugins
+
+      - uses: actions/cache/save@v3
+        with:
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
 
       - name: packaging check
         run: |

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
-      - name: maven cache dependencies
+      - name: cache maven dependencies
         run: ${MVN} dependency:resolve dependency:resolve-plugins
 
       # Create a cache entry for dependencies only. This cache entry must

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MVN: mvn -B
+  MVN: mvn -B --no-transfer-progress
   MAVEN_SKIP: -P skip-static-checks -Dweb.console.skip=true -Dmaven.javadoc.skip=true
   MAVEN_SKIP_TESTS: -P skip-tests
   MAVEN_OPTS: -Xmx3000m

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -134,12 +134,12 @@ jobs:
           distribution: 'zulu'
           java-version: '8'
 
+      # restore maven dependencies only. 'depsonly' keys are safe to restore
+      # since they don't contain any artifacts created by mvn install
       - uses: actions/cache/restore@v3
         with:
           key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
           path: ~/.m2/repository
-          # fallback cache entries to restore from. 'depsonly' keys are safe to
-          # restore since they don't contain any artifacts created by mvn install
           restore-keys: |
             maven-${{ runner.os }}-depsonly-
 

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -52,8 +52,20 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
-      - name: cache maven dependencies
-        run: ${MVN} dependency:resolve dependency:resolve-plugins
+      - name: restore maven dependencies
+      # restore maven dependencies only. 'depsonly' keys are safe to restore
+      # since they don't contain any artifacts created by mvn install
+      - uses: actions/cache/restore@v3
+        with:
+          key: maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
+          path: ~/.m2/repository
+          restore-keys: |
+            maven-${{ runner.os }}-depsonly-
+
+      - name: compile and cache maven dependencies
+        # run maven compile step to cache all shared maven dependencies
+        # maven install will be run in a subsequent step to avoid polluting the global maven cache
+        run: ${MVN} clean test-compile --fail-at-end -pl '!benchmarks, !distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false
 
       # Create a cache entry for dependencies only. This cache entry must
       # never include any artifacts written to the local repo by mvn install.
@@ -65,7 +77,7 @@ jobs:
       - name: packaging check
         run: |
           ./.github/scripts/setup_generate_license.sh
-          ${MVN} clean install -Prat --fail-at-end \
+          ${MVN} install -Prat --fail-at-end \
           -pl '!benchmarks, !distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C
           ${MVN} install -Prat -Pdist -Pbundle-contrib-exts --fail-at-end \
           -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS} -Dweb.console.skip=false -T1C

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
-          restore-keys: setup-java-Linux-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Cache targets
         id: target

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
+          # fallback cache entries to restore from. 'depsonly' keys are safe to
+          # restore since they don't contain any artifacts created by mvn install
+          restore-keys: |
+            maven-${{ runner.os }}-depsonly-${{ hashFiles('**/pom.xml') }}
+            maven-${{ runner.os }}-depsonly-
 
       - name: Cache targets
         id: target


### PR DESCRIPTION
Fix unsafe usage of maven dependency caching in `actions/setup-java`,
and replace with explicit save/restore of maven dependencies only without relying on `mvn install`.

Using the the setup-java maven cache is not safe for steps calling `mvn install`,
since setup-java cache keys are only based on the pom hashfiles whereas
mvn install causes artifacts specific to that commit to end up into the local maven repository.

This disables the use of the setup-java maven cache for all steps.

This also removes references to polluted setup-java cache keys, which we were referencing as fall-back
 cache using `restore-keys:` in some integration and unit tests.

Instead, to avoid pulling dependencies all the time, maven dependencies are first resolved explicitly
using `maven compile / test-compile`, and then cached/restored explicitly or used as fallback for
cache misses with explicit commit tags.