### PR TITLE
Fix compilation failure in master

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteUnionQueryMSQTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteUnionQueryMSQTest.java
@@ -95,7 +95,8 @@ public class CalciteUnionQueryMSQTest extends CalciteUnionQueryTest
         queryJsonMapper,
         injector,
         new MSQTestTaskActionClient(queryJsonMapper),
-        workerMemoryParameters
+        workerMemoryParameters,
+        ImmutableList.of()
     );
     return new MSQTaskSqlEngine(indexingServiceClient, queryJsonMapper);
   }


### PR DESCRIPTION
### Description

Fixes the compilation failure in master due to merging https://github.com/apache/druid/pull/14981.
The build began before the https://github.com/apache/druid/pull/15024 was merged into the master, therefore it was green in the PR but broke due to incompatible signatures in the method which the latter PR modified and the former used. 

<hr>