### PR TITLE
Ability to send task types to k8s or worker task runner

### DIFF
--- a/docs/development/extensions-contrib/k8s-jobs.md
+++ b/docs/development/extensions-contrib/k8s-jobs.md
@@ -286,4 +286,4 @@ To do this, set the following property.
 |--------|-----------------|-----------|-------|--------|
 |`druid.indexer.runner.k8sAndWorker.workerTaskRunnerType`|`String`|Determines whether the `httpRemote` or the `remote` task runner should be used in addition to the Kubernetes task runner.|`httpRemote`|No|
 |`druid.indexer.runner.k8sAndWorker.sendAllTasksToWorkerTaskRunner`|`boolean`| Whether to send all the tasks to the worker task runner. If this is set to false all tasks will be sent to Kubernetes|`false`|No|
-
+|`druid.indexer.runner.k8sAndWorker.taskTypeToWorkerTaskRunnerOverrides`|`Map<String, Boolean>`|Json key value pairs of task types and a boolean for whether or not the task should be sent to the worker task runner. If the task type is not in this list, tasks will be assigned to a worker based on the `sendAllTasksToWorkerTaskRunner` config. Example: `{'index_kafka': true}`|`{}`|No|

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
@@ -101,7 +101,7 @@ public class KubernetesAndWorkerTaskRunner implements TaskLogStreamer, WorkerTas
   @Override
   public ListenableFuture<TaskStatus> run(Task task)
   {
-    if (kubernetesAndWorkerTaskRunnerConfig.isSendAllTasksToWorkerTaskRunner()) {
+    if (kubernetesAndWorkerTaskRunnerConfig.isSendTaskTypeToWorkerTaskRunner(task.getType())) {
       return workerTaskRunner.run(task);
     } else {
       return kubernetesTaskRunner.run(task);

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfig.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfig.java
@@ -20,6 +20,7 @@
 package org.apache.druid.k8s.overlord;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.ObjectUtils;
@@ -27,6 +28,8 @@ import org.apache.druid.indexing.overlord.RemoteTaskRunnerFactory;
 import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerFactory;
 
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.Map;
 
 public class KubernetesAndWorkerTaskRunnerConfig
 {
@@ -45,10 +48,15 @@ public class KubernetesAndWorkerTaskRunnerConfig
   @NotNull
   private final boolean sendAllTasksToWorkerTaskRunner;
 
+  @JsonProperty
+  @NotNull
+  private final Map<String, Boolean> taskTypeToWorkerTaskRunnerOverrides;
+
   @JsonCreator
   public KubernetesAndWorkerTaskRunnerConfig(
       @JsonProperty("workerTaskRunnerType") String workerTaskRunnerType,
-      @JsonProperty("sendAllTasksToWorkerTaskRunner") Boolean sendAllTasksToWorkerTaskRunner
+      @JsonProperty("sendAllTasksToWorkerTaskRunner") Boolean sendAllTasksToWorkerTaskRunner,
+      @JsonProperty("taskTypeToWorkerTaskRunnerOverrides") Map<String, Boolean> taskTypeToWorkerTaskRunnerOverrides
   )
   {
     this.workerTaskRunnerType = ObjectUtils.defaultIfNull(
@@ -66,16 +74,34 @@ public class KubernetesAndWorkerTaskRunnerConfig
         sendAllTasksToWorkerTaskRunner,
         false
     );
+    this.taskTypeToWorkerTaskRunnerOverrides = ObjectUtils.defaultIfNull(
+        taskTypeToWorkerTaskRunnerOverrides,
+        Collections.emptyMap()
+    );
   }
 
+  @JsonProperty
   public String getWorkerTaskRunnerType()
   {
     return workerTaskRunnerType;
   }
 
+  @JsonProperty
   public boolean isSendAllTasksToWorkerTaskRunner()
   {
     return sendAllTasksToWorkerTaskRunner;
+  }
+
+  @JsonProperty
+  public Map<String, Boolean> getTaskTypeToWorkerTaskRunnerOverrides()
+  {
+    return taskTypeToWorkerTaskRunnerOverrides;
+  }
+
+  @JsonIgnore
+  public boolean isSendTaskTypeToWorkerTaskRunner(String taskType)
+  {
+    return taskTypeToWorkerTaskRunnerOverrides.getOrDefault(taskType, sendAllTasksToWorkerTaskRunner);
   }
 
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfigTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfigTest.java
@@ -47,9 +47,10 @@ public class KubernetesAndWorkerTaskRunnerConfigTest
   @Test
   public void test_withDefaults()
   {
-    KubernetesAndWorkerTaskRunnerConfig config = new KubernetesAndWorkerTaskRunnerConfig(null, null);
+    KubernetesAndWorkerTaskRunnerConfig config = new KubernetesAndWorkerTaskRunnerConfig(null, null, null);
 
     Assert.assertEquals(HttpRemoteTaskRunnerFactory.TYPE_NAME, config.getWorkerTaskRunnerType());
     Assert.assertFalse(config.isSendAllTasksToWorkerTaskRunner());
+    Assert.assertTrue(config.getTaskTypeToWorkerTaskRunnerOverrides().isEmpty());
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerFactoryTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerFactoryTest.java
@@ -45,7 +45,7 @@ public class KubernetesAndWorkerTaskRunnerFactoryTest extends EasyMockSupport
         kubernetesTaskRunnerFactory,
         httpRemoteTaskRunnerFactory,
         remoteTaskRunnerFactory,
-        new KubernetesAndWorkerTaskRunnerConfig(null, null)
+        new KubernetesAndWorkerTaskRunnerConfig(null, null, null)
     );
 
     EasyMock.expect(httpRemoteTaskRunnerFactory.build()).andReturn(null);
@@ -63,7 +63,7 @@ public class KubernetesAndWorkerTaskRunnerFactoryTest extends EasyMockSupport
         kubernetesTaskRunnerFactory,
         httpRemoteTaskRunnerFactory,
         remoteTaskRunnerFactory,
-        new KubernetesAndWorkerTaskRunnerConfig("remote", null)
+        new KubernetesAndWorkerTaskRunnerConfig("remote", null, null)
     );
 
     EasyMock.expect(remoteTaskRunnerFactory.build()).andReturn(null);
@@ -81,7 +81,7 @@ public class KubernetesAndWorkerTaskRunnerFactoryTest extends EasyMockSupport
         kubernetesTaskRunnerFactory,
         httpRemoteTaskRunnerFactory,
         remoteTaskRunnerFactory,
-        new KubernetesAndWorkerTaskRunnerConfig("noop", null)
+        new KubernetesAndWorkerTaskRunnerConfig("noop", null, null)
     );
 
     EasyMock.expect(remoteTaskRunnerFactory.build()).andReturn(null);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
@@ -41,6 +41,8 @@ import java.util.UUID;
  */
 public class NoopTask extends AbstractTask
 {
+  public static final String TYPE = "noop";
+
   private static final int DEFAULT_RUN_TIME = 2500;
 
   @JsonIgnore
@@ -70,7 +72,7 @@ public class NoopTask extends AbstractTask
   @Override
   public String getType()
   {
-    return "noop";
+    return TYPE;
   }
 
   @Nonnull


### PR DESCRIPTION
### Description

Follow on to #14918

Some cluster administrators may want to send particular tasks to the worker task runner instead of k8sTaskRunner, as the task startup time is usually faster on the worker task runner system.

An example use case is high throughput streaming ingestion where a long pod startup time can result in user visible lag. To get around this, an administrator could configure the cluster to have enough idle capacity to reasonably handle the high throughput stream and configure all other tasks to be handled by the k8s task runner while the streaming tasks are handled by the worker task runner.

The other idea I explored was implementing something like `WorkerSelectStrategy` for the `KubernetesAndWorkerTaskRunner` to provide more flexibility. But I was not certain whether or not the added complexity of this implementation was worth it, so I went with the simpler approach

#### Release note

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
