### PR TITLE
Added concurrent compaction switches

### DIFF
--- a/web-console/src/components/auto-form/auto-form.tsx
+++ b/web-console/src/components/auto-form/auto-form.tsx
@@ -72,6 +72,10 @@ export interface Field<M> {
   hide?: Functor<M, boolean>;
   hideInMore?: Functor<M, boolean>;
   valueAdjustment?: (value: any) => any;
+  /**
+   * An optional callback to transform the value before it is set on the input
+   */
+  adjustValue?: (value: any) => any;
   adjustment?: (model: Partial<M>, oldModel: Partial<M>) => Partial<M>;
   issueWithValue?: (value: any) => string | undefined;
 
@@ -378,12 +382,14 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
     const disabled = AutoForm.evaluateFunctor(field.disabled, model, false);
     const intent = required && modelValue == null ? AutoForm.REQUIRED_INTENT : undefined;
 
+    const adjustedValue = field.adjustValue ? field.adjustValue(shownValue) : shownValue;
+
     return (
       <ButtonGroup large={large}>
         <Button
           intent={intent}
           disabled={disabled}
-          active={shownValue === false}
+          active={adjustedValue === false}
           onClick={() => {
             this.fieldChange(field, false);
             if (onFinalize) onFinalize();
@@ -394,7 +400,7 @@ export class AutoForm<T extends Record<string, any>> extends React.PureComponent
         <Button
           intent={intent}
           disabled={disabled}
-          active={shownValue === true}
+          active={adjustedValue === true}
           onClick={() => {
             this.fieldChange(field, true);
             if (onFinalize) onFinalize();

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -342,7 +342,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
               Allows or forbids concurrent compactions.
             </p>,
             "label": "Allow concurrent compactions (experimental)",
-            "name": "taskLockType",
+            "name": "taskContext.taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
           },
@@ -735,7 +735,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
               Allows or forbids concurrent compactions.
             </p>,
             "label": "Allow concurrent compactions (experimental)",
-            "name": "taskLockType",
+            "name": "taskContext.taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
           },
@@ -1128,7 +1128,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
               Allows or forbids concurrent compactions.
             </p>,
             "label": "Allow concurrent compactions (experimental)",
-            "name": "taskLockType",
+            "name": "taskContext.taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
           },
@@ -1521,7 +1521,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
               Allows or forbids concurrent compactions.
             </p>,
             "label": "Allow concurrent compactions (experimental)",
-            "name": "taskLockType",
+            "name": "taskContext.taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
           },

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -341,7 +341,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             "info": <p>
               Allows or forbids concurrent compactions.
             </p>,
-            "label": "Allow concurrent append tasks",
+            "label": "Allow concurrent compactions (experimental)",
             "name": "taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
@@ -734,7 +734,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             "info": <p>
               Allows or forbids concurrent compactions.
             </p>,
-            "label": "Allow concurrent append tasks",
+            "label": "Allow concurrent compactions (experimental)",
             "name": "taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
@@ -1127,7 +1127,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             "info": <p>
               Allows or forbids concurrent compactions.
             </p>,
-            "label": "Allow concurrent append tasks",
+            "label": "Allow concurrent compactions (experimental)",
             "name": "taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],
@@ -1520,7 +1520,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             "info": <p>
               Allows or forbids concurrent compactions.
             </p>,
-            "label": "Allow concurrent append tasks",
+            "label": "Allow concurrent compactions (experimental)",
             "name": "taskLockType",
             "type": "boolean",
             "valueAdjustment": [Function],

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -335,6 +335,17 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             "name": "tuningConfig.splitHintSpec.maxNumFiles",
             "type": "number",
           },
+          Object {
+            "adjustValue": [Function],
+            "defaultValue": undefined,
+            "info": <p>
+              Allows or forbids concurrent compactions.
+            </p>,
+            "label": "Allow concurrent append tasks",
+            "name": "taskLockType",
+            "type": "boolean",
+            "valueAdjustment": [Function],
+          },
         ]
       }
       model={
@@ -716,6 +727,17 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             "min": 1,
             "name": "tuningConfig.splitHintSpec.maxNumFiles",
             "type": "number",
+          },
+          Object {
+            "adjustValue": [Function],
+            "defaultValue": undefined,
+            "info": <p>
+              Allows or forbids concurrent compactions.
+            </p>,
+            "label": "Allow concurrent append tasks",
+            "name": "taskLockType",
+            "type": "boolean",
+            "valueAdjustment": [Function],
           },
         ]
       }
@@ -1099,6 +1121,17 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             "name": "tuningConfig.splitHintSpec.maxNumFiles",
             "type": "number",
           },
+          Object {
+            "adjustValue": [Function],
+            "defaultValue": undefined,
+            "info": <p>
+              Allows or forbids concurrent compactions.
+            </p>,
+            "label": "Allow concurrent append tasks",
+            "name": "taskLockType",
+            "type": "boolean",
+            "valueAdjustment": [Function],
+          },
         ]
       }
       model={
@@ -1480,6 +1513,17 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             "min": 1,
             "name": "tuningConfig.splitHintSpec.maxNumFiles",
             "type": "number",
+          },
+          Object {
+            "adjustValue": [Function],
+            "defaultValue": undefined,
+            "info": <p>
+              Allows or forbids concurrent compactions.
+            </p>,
+            "label": "Allow concurrent append tasks",
+            "name": "taskLockType",
+            "type": "boolean",
+            "valueAdjustment": [Function],
           },
         ]
       }

--- a/web-console/src/druid-models/compaction-config/compaction-config.tsx
+++ b/web-console/src/druid-models/compaction-config/compaction-config.tsx
@@ -357,7 +357,7 @@ export const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
   {
     name: 'taskLockType',
     type: 'boolean',
-    label: 'Allow concurrent append tasks',
+    label: 'Allow concurrent compactions (experimental)',
     defaultValue: undefined,
     valueAdjustment: v => (v ? 'REPLACE' : undefined),
     adjustValue: v => v === 'REPLACE',

--- a/web-console/src/druid-models/compaction-config/compaction-config.tsx
+++ b/web-console/src/druid-models/compaction-config/compaction-config.tsx
@@ -355,7 +355,7 @@ export const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
     ),
   },
   {
-    name: 'taskLockType',
+    name: 'taskContext.taskLockType',
     type: 'boolean',
     label: 'Allow concurrent compactions (experimental)',
     defaultValue: undefined,

--- a/web-console/src/druid-models/compaction-config/compaction-config.tsx
+++ b/web-console/src/druid-models/compaction-config/compaction-config.tsx
@@ -354,4 +354,13 @@ export const COMPACTION_CONFIG_FIELDS: Field<CompactionConfig>[] = [
       </>
     ),
   },
+  {
+    name: 'taskLockType',
+    type: 'boolean',
+    label: 'Allow concurrent append tasks',
+    defaultValue: undefined,
+    valueAdjustment: v => (v ? 'REPLACE' : undefined),
+    adjustValue: v => v === 'REPLACE',
+    info: <p>Allows or forbids concurrent compactions.</p>,
+  },
 ];

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -72,6 +72,7 @@ const CURRENT_YEAR = new Date().getUTCFullYear();
 export interface IngestionSpec {
   readonly type: IngestionType;
   readonly spec: IngestionSpecInner;
+  readonly context?: { taskLockType?: 'APPEND' | 'REPLACE' };
 }
 
 export interface IngestionSpecInner {
@@ -344,6 +345,11 @@ export function normalizeSpec(spec: Partial<IngestionSpec>): IngestionSpec {
   spec = deepSetIfUnset(spec, 'type', specType);
   spec = deepSetIfUnset(spec, 'spec.ioConfig.type', specType);
   spec = deepSetIfUnset(spec, 'spec.tuningConfig.type', specType);
+
+  if (spec.context?.taskLockType !== undefined) {
+    spec.context.taskLockType = spec.spec?.ioConfig.appendToExisting ? 'APPEND' : 'REPLACE';
+  }
+
   return spec as IngestionSpec;
 }
 

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3134,6 +3134,8 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
     const { spec } = this.state;
     const parallel = deepGet(spec, 'spec.tuningConfig.maxNumConcurrentSubTasks') > 1;
 
+    const appendToExisting = spec.spec?.ioConfig.appendToExisting;
+
     return (
       <>
         <div className="main">
@@ -3168,6 +3170,15 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                     appending to the segment set instead of replacing it.
                   </>
                 ),
+              },
+              {
+                name: 'context.taskLockType',
+                type: 'boolean',
+                label: `Allow concurrent ${appendToExisting ? 'append' : 'replace'} tasks`,
+                defaultValue: undefined,
+                valueAdjustment: v => (v ? (appendToExisting ? 'APPEND' : 'REPLACE') : undefined),
+                adjustValue: v => v === (appendToExisting ? 'APPEND' : 'REPLACE'),
+                info: <p>Allows or forbids concurrent compactions.</p>,
               },
             ]}
             model={spec}

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3174,11 +3174,13 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
               {
                 name: 'context.taskLockType',
                 type: 'boolean',
-                label: `Allow concurrent ${appendToExisting ? 'append' : 'replace'} tasks`,
+                label: `Allow concurrent ${
+                  appendToExisting ? 'append' : 'replace'
+                } tasks (experimental)`,
                 defaultValue: undefined,
                 valueAdjustment: v => (v ? (appendToExisting ? 'APPEND' : 'REPLACE') : undefined),
                 adjustValue: v => v === (appendToExisting ? 'APPEND' : 'REPLACE'),
-                info: <p>Allows or forbids concurrent compactions.</p>,
+                info: <p>Allows or forbids concurrent tasks.</p>,
               },
             ]}
             model={spec}


### PR DESCRIPTION
This PR adds checkboxes in two places:
 - in the classic batch ingestion wizard
<img width="1504" alt="image" src="https://github.com/apache/druid/assets/1224709/e6b149fc-75f8-430a-b732-8cc248df9e3f">

 - in the compaction configuration UI
<img width="1504" alt="image" src="https://github.com/apache/druid/assets/1224709/c2693c14-ea7a-483d-a76c-521a46b2ecfc">

These both set the `context.taskLockType` accordingly, to either `'APPEND'`, `'REPLACE'` or `undefined` based on the checkbox state and the current spec.