### PR TITLE
fix debugging and running with intellij runConfiguration

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -207,6 +207,10 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi</artifactId>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.apache.druid</groupId>
@@ -220,11 +224,6 @@
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Using Intellij runConfiguration to run or debug with a `druid-services` entrypoint was broken recently, launching immediately fails with the following error:
 
```
Exception 'java.lang.NoClassDefFoundError' occurred in thread 'main' at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:108)
Exception in thread "main" java.lang.NoClassDefFoundError: org/skife/jdbi/v2/TransactionCallback
	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3373)
	at java.base/java.lang.Class.getDeclaredConstructors(Class.java:2555)
	at com.google.inject.spi.InjectionPoint.forConstructorOf(InjectionPoint.java:245)
	at com.google.inject.internal.ConstructorBindingImpl.create(ConstructorBindingImpl.java:100)
	at com.google.inject.internal.InjectorImpl.createUninitializedBinding(InjectorImpl.java:661)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:885)
	at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:808)
	at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:285)
	at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:217)
	at com.google.inject.internal.InjectorImpl.getInternalFactory(InjectorImpl.java:893)
	at com.google.inject.internal.FactoryProxy.notify(FactoryProxy.java:46)
	at com.google.inject.internal.ProcessedBindingData.runCreationListeners(ProcessedBindingData.java:50)
	at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:134)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
	at com.google.inject.Guice.createInjector(Guice.java:99)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.apache.druid.initialization.ExtensionInjectorBuilder.build(ExtensionInjectorBuilder.java:49)
	at org.apache.druid.initialization.ServerInjectorBuilder.build(ServerInjectorBuilder.java:118)
	at org.apache.druid.initialization.ServerInjectorBuilder.makeServerInjector(ServerInjectorBuilder.java:73)
	at org.apache.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:85)
	at org.apache.druid.cli.ServerRunnable.run(ServerRunnable.java:62)
	at org.apache.druid.cli.Main.main(Main.java:112)
Caused by: java.lang.ClassNotFoundException: org.skife.jdbi.v2.TransactionCallback
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 24 more
```

I tracked it down to https://github.com/apache/druid/pull/14407/files#diff-2512fca4701f37cc8f13c0775edbffbca17c81c1c306a1ede8fefa2aff325654R225-R229, which added jdbi explicitly as `test` scoped to `druid-services`. For whatever reason, this causes it to no longer appear in the classpath of the launched process via runConfiguration, but removing test scope seems to fix everything.