### PR TITLE
Prepare 28.0.0 branch for the release

### DIFF
--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -362,7 +362,7 @@ exports[`HeaderBar matches snapshot 1`] = `
           <Blueprint4.MenuItem
             active={false}
             disabled={false}
-            href="https://druid.apache.org/docs/latest"
+            href="https://druid.apache.org/docs/28.0.0"
             icon="th"
             multiline={false}
             popoverProps={Object {}}

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
             Druid uses rules to determine what data should be retained in the cluster. The rules are evaluated in order from top to bottom. For more information please refer to the
              
             <a
-              href="https://druid.apache.org/docs/latest/operations/rule-configuration.html"
+              href="https://druid.apache.org/docs/28.0.0/operations/rule-configuration.html"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/web-console/src/links.ts
+++ b/web-console/src/links.ts
@@ -19,7 +19,7 @@
 import hasOwnProp from 'has-own-prop';
 
 // This is set to the latest available version and should be updated to the next version before release
-const DRUID_DOCS_VERSION = 'latest';
+const DRUID_DOCS_VERSION = '28.0.0';
 
 function fillVersion(str: string): string {
   return str.replace(/\{\{VERSION}}/g, DRUID_DOCS_VERSION);

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
   >
     <React.Fragment>
       <Memo(ExternalLink)
-        href="https://druid.apache.org/docs/latest/multi-stage-query/reference.html#error_TooManyWarnings"
+        href="https://druid.apache.org/docs/28.0.0/multi-stage-query/reference.html#error_TooManyWarnings"
       >
         TooManyWarnings
       </Memo(ExternalLink)>


### PR DESCRIPTION
Updates the links in the `links.ts` and related files to 28.0.0

It is done as a part of [Preparing the release branch](https://github.com/apache/druid/blob/master/distribution/asf-release-process-guide.md#preparing-the-release-branch) and analogous to https://github.com/apache/druid/pull/14569