### PR TITLE
docs: remove experimental note from unnest docs

### DIFF
--- a/docs/querying/datasource.md
+++ b/docs/querying/datasource.md
@@ -401,11 +401,6 @@ future versions:
 
 ### `unnest`
 
-:::info
- The unnest datasource is [experimental](../development/experimental.md). Its API and behavior are subject
- to change in future releases. It is not recommended to use this feature in production at this time.
-:::
-
 Use the `unnest` datasource to unnest a column with multiple values in an array.
 For example, you have a source column that looks like this:
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -87,11 +87,6 @@ documentation.
 
 ## UNNEST
 
-:::info
- The UNNEST SQL function is [experimental](../development/experimental.md). Its API and behavior are subject
- to change in future releases. It is not recommended to use this feature in production at this time.
-:::
-
 The UNNEST clause unnests array values. It's the SQL equivalent to the [unnest datasource](./datasource.md#unnest). The source for UNNEST can be an array or an input that's been transformed into an array, such as with helper functions like MV_TO_ARRAY or ARRAY.
 
 The following is the general syntax for UNNEST, specifically a query that returns the column that gets unnested:

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -105,7 +105,6 @@ SELECT column_alias_name FROM datasource CROSS JOIN UNNEST(source_expression1) A
 
 Keep the following things in mind when writing your query:
 
-- You must include the context parameter `"enableUnnest": true`.
 - You can unnest multiple source expressions in a single query.
 - Notice the CROSS JOIN between the datasource and the UNNEST function. This is needed in most cases of the UNNEST function. Specifically, it is not needed when you're unnesting an inline array since the array itself is the datasource.
 - If you view the native explanation of a SQL UNNEST, you'll notice that Druid uses `j0.unnest` as a virtual column to perform the unnest. An underscore is added for each unnest, so you may notice virtual columns named `_j0.unnest` or `__j0.unnest`.

--- a/docs/tutorials/tutorial-unnest-arrays.md
+++ b/docs/tutorials/tutorial-unnest-arrays.md
@@ -161,12 +161,6 @@ The following is the general syntax for UNNEST:
 SELECT column_alias_name FROM datasource CROSS JOIN UNNEST(source_expression) AS table_alias_name(column_alias_name)
 ```
 
-In addition, you must supply the following context parameter:
-
-```json
-"enableUnnest": "true"
-```
-
 For more information about the syntax, see [UNNEST](../querying/sql.md#unnest).
 
 ### Unnest a single source expression in a datasource
@@ -640,7 +634,6 @@ The following Scan query unnests the column `dim3` into `d3` and a virtual colum
   ],
   "legacy": false,
   "context": {
-    "enableUnnest": "true",
     "queryId": "2618b9ce-6c0d-414e-b88d-16fb59b9c481",
     "sqlOuterLimit": 1001,
     "sqlQueryId": "2618b9ce-6c0d-414e-b88d-16fb59b9c481",

--- a/docs/tutorials/tutorial-unnest-arrays.md
+++ b/docs/tutorials/tutorial-unnest-arrays.md
@@ -30,11 +30,6 @@ import TabItem from '@theme/TabItem';
  If you're looking for information about how to unnest `COMPLEX<json>` columns, see [Nested columns](../querying/nested-columns.md).
 :::
 
-:::info
- The unnest datasource and UNNEST SQL function are [experimental](../development/experimental.md). Their API and behavior are subject
- to change in future releases. It is not recommended to use this feature in production at this time.
-:::
-
 This tutorial demonstrates how to use the unnest datasource to unnest a column that has data stored in arrays. For example, if you have a column named `dim3` with values like `[a,b]` or `[c,d,f]`, the unnest datasource can output the data to a new column with individual rows that contain single values like `a` and `b`. When doing this, be mindful of the following:
 
 - Unnesting data can dramatically increase the total number of rows.


### PR DESCRIPTION
Removes the experimental blurb from the unnest docs

This PR has:

- [x] been self-reviewed.
