### PR TITLE
Fix expression result writing of arrays in Hadoop Ingestion

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -25,6 +25,7 @@ import com.google.common.primitives.Longs;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.math.expr.Evals;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -72,7 +73,7 @@ public final class Rows
       // convert byte[] to base64 encoded string
       return Collections.singletonList(StringUtils.encodeBase64String((byte[]) inputValue));
     } else if (inputValue instanceof Object[]) {
-      return Arrays.stream((Object[]) inputValue).map(String::valueOf).collect(Collectors.toList());
+      return Arrays.stream((Object[]) inputValue).map(Evals::asString).collect(Collectors.toList());
     } else {
       return Collections.singletonList(String.valueOf(inputValue));
     }

--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +71,8 @@ public final class Rows
     } else if (inputValue instanceof byte[]) {
       // convert byte[] to base64 encoded string
       return Collections.singletonList(StringUtils.encodeBase64String((byte[]) inputValue));
+    } else if (inputValue instanceof Object[]) {
+      return Arrays.stream((Object[]) inputValue).map(String::valueOf).collect(Collectors.toList());
     } else {
       return Collections.singletonList(String.valueOf(inputValue));
     }

--- a/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
@@ -31,7 +31,6 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
-import org.apache.druid.segment.virtual.ExpressionSelectors;
 
 import java.util.List;
 import java.util.Objects;
@@ -111,9 +110,7 @@ public class ExpressionTransform implements Transform
     public List<String> evalDimension(Row row)
     {
       try {
-        return Rows.objectToStrings(
-            ExpressionSelectors.coerceEvalToObjectOrList(expr.eval(InputBindings.forRow(row)))
-        );
+        return Rows.objectToStrings(expr.eval(InputBindings.forRow(row)).valueOrDefault());
       }
       catch (Throwable t) {
         throw new ISE(t, "Could not transform dimension value for %s reason: %s", name, t.getMessage());

--- a/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
@@ -100,11 +100,7 @@ public class ExpressionTransform implements Transform
     public Object eval(final Row row)
     {
       try {
-        Object result = expr.eval(InputBindings.forRow(row)).valueOrDefault();
-        if (result != null && result.getClass().isArray()) {
-          return Rows.objectToStrings(result);
-        }
-        return result;
+        return expr.eval(InputBindings.forRow(row)).valueOrDefault();
       }
       catch (Throwable t) {
         throw new ISE(t, "Could not transform value for %s reason: %s", name, t.getMessage());

--- a/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
+++ b/processing/src/main/java/org/apache/druid/segment/transform/ExpressionTransform.java
@@ -100,7 +100,11 @@ public class ExpressionTransform implements Transform
     public Object eval(final Row row)
     {
       try {
-        return expr.eval(InputBindings.forRow(row)).valueOrDefault();
+        Object result = expr.eval(InputBindings.forRow(row)).valueOrDefault();
+        if (result != null && result.getClass().isArray()) {
+          return Rows.objectToStrings(result);
+        }
+        return result;
       }
       catch (Throwable t) {
         throw new ISE(t, "Could not transform value for %s reason: %s", name, t.getMessage());

--- a/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
@@ -455,7 +455,10 @@ public class TransformerTest extends InitializedNullHandlingTest
     final Transformer transformer = new Transformer(
         new TransformSpec(
             null,
-            ImmutableList.of(new ExpressionTransform("dim", "array_slice(dim, 0, 5)", TestExprMacroTable.INSTANCE))
+            ImmutableList.of(
+                new ExpressionTransform("dim", "array_slice(dim, 0, 5)", TestExprMacroTable.INSTANCE),
+                new ExpressionTransform("dim1", "array_slice(dim, 0, 1)", TestExprMacroTable.INSTANCE)
+            )
         )
     );
     final List<String> dimList = ImmutableList.of("a", "b", "c", "d", "e", "f", "g");
@@ -514,5 +517,6 @@ public class TransformerTest extends InitializedNullHandlingTest
     });
     Assert.assertEquals(actualTranformedRow.getDimension("dim"), dimList.subList(0, 5));
     Assert.assertArrayEquals(dimList.subList(0, 5).toArray(), (Object[]) actualTranformedRow.getRaw("dim"));
+    Assert.assertArrayEquals(new Object[]{"a"}, actualTranformedRow.getDimension("dim1").toArray());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
@@ -513,6 +513,6 @@ public class TransformerTest extends InitializedNullHandlingTest
       }
     });
     Assert.assertEquals(actualTranformedRow.getDimension("dim"), dimList.subList(0, 5));
-    Assert.assertEquals(actualTranformedRow.getRaw("dim"), dimList.subList(0, 5));
+    Assert.assertArrayEquals(dimList.subList(0, 5).toArray(), (Object[]) actualTranformedRow.getRaw("dim"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
@@ -389,7 +389,7 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertNotNull(actual);
     Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) actual.getRaw("dim"));
-    Assert.assertEquals(Arrays.asList("1", "2", "null", "3"), actual.getDimension("dim"));
+    Assert.assertArrayEquals(new String[]{"1", "2", null, "3"}, actual.getDimension("dim").toArray());
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
@@ -416,9 +416,9 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertEquals(2.3, (Double) raw[1], 0.00001);
     Assert.assertNull(raw[2]);
     Assert.assertEquals(3.4, (Double) raw[3], 0.00001);
-    Assert.assertEquals(
-        Arrays.asList("1.2000000476837158", "2.299999952316284", "null", "3.4000000953674316"),
-        actual.getDimension("dim")
+    Assert.assertArrayEquals(
+        new String[]{"1.2000000476837158", "2.299999952316284", null, "3.4000000953674316"},
+        actual.getDimension("dim").toArray()
     );
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
@@ -445,7 +445,7 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertEquals(2.3, (Double) raw[1], 0.0);
     Assert.assertNull(raw[2]);
     Assert.assertEquals(3.4, (Double) raw[3], 0.0);
-    Assert.assertEquals(Arrays.asList("1.2", "2.3", "null", "3.4"), actual.getDimension("dim"));
+    Assert.assertArrayEquals(new String[]{"1.2", "2.3", null, "3.4"}, actual.getDimension("dim").toArray());
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 


### PR DESCRIPTION

Fixes #15100.



### Description
This PR fixes the bug in Hadoop ingestion which writes arrays as objects.toString as result of transform expressions. Found the case that we were not handing the expression results correctly when we get result as Array from array_slice expression. 

Also found another bug while testing this that Complex /json column ingestion does not work with index_hadoop. 

 ```
       "transforms": [
          {
            "type": "expression",
            "name": "dimT",
            "expression": "array_slice(dim2, 0, 2)"
          }
        ]
```

<img width="672" alt="Screenshot 2023-10-12 at 1 54 25 PM" src="https://github.com/apache/druid/assets/4935454/e4abbb32-22fe-4b2d-8d37-7c8d0d094fcd">

verified the change with local hadoop ingestion, 
Fixed: 
<img width="584" alt="Screenshot 2023-10-12 at 1 57 45 PM" src="https://github.com/apache/druid/assets/4935454/eaf25ec7-5a64-4a1c-98e9-9e31ed4c5029">


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
