### PR TITLE
Upgrade Jetty & Netty4 dependencies

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1289,7 +1289,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.94.Final
+version: 4.1.100.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec
@@ -2060,7 +2060,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.51.v20230217
+version: 9.4.53.v20231009
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <guava.version>31.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.12.7</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
@@ -103,7 +103,7 @@
         <mysql.version>5.1.49</mysql.version>
         <mariadb.version>2.7.3</mariadb.version>
         <netty3.version>3.10.6.Final</netty3.version>
-        <netty4.version>4.1.94.Final</netty4.version>
+        <netty4.version>4.1.100.Final</netty4.version>
         <postgresql.version>42.6.0</postgresql.version>
         <protobuf.version>3.24.0</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>


### PR DESCRIPTION
- Update `jetty` dependencies version to `9.4.53.v20231009`
- Update `netty4` dependencies version to `4.1.100.Final` to resolve CVE-2023-4586 (Netty-handler does not validate host names by default)