### PR TITLE
Add AWS connector

### DIFF
--- a/extensions-core/druid-aws-rds-extensions/pom.xml
+++ b/extensions-core/druid-aws-rds-extensions/pom.xml
@@ -47,6 +47,10 @@
       <version>${aws.sdk.version}</version>
     </dependency>
     <dependency>
+      <groupId>software.aws.rds</groupId>
+      <artifactId>aws-mysql-jdbc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,11 @@
                 <version>${aws.sdk.version}</version>
             </dependency>
             <dependency>
+                <groupId>software.aws.rds</groupId>
+                <artifactId>aws-mysql-jdbc</artifactId>
+                <version>1.1.10</version>
+            </dependency>
+            <dependency>
                 <groupId>com.ning</groupId>
                 <artifactId>compress-lzf</artifactId>
                 <version>1.0.4</version>


### PR DESCRIPTION
### Description
Add the aws-jdbc connector jar to the aws-rds extension to support  jdbc:mysql:aws url strings for e.g. Amazon Aurora


The connector is documented here: https://github.com/awslabs/aws-mysql-jdbc

#### Release note
Add support for using the AWS JDBC Connector
##### Key changed/added classes in this PR
pom.xml


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
