### PR TITLE
fix issue with SQL boolean constants not respecting nulls when strict booleans and sql compatible null handling are enabled

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
@@ -25,6 +25,7 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.InvalidSqlInput;
 import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.InlineDataSource;
@@ -121,7 +122,7 @@ public class DruidLogicalValuesRule extends RelOptRule
         }
         return ((Number) RexLiteral.value(literal)).longValue();
       case BOOLEAN:
-        if (ExpressionProcessing.useStrictBooleans() && literal.isNull()) {
+        if (ExpressionProcessing.useStrictBooleans() && NullHandling.sqlCompatible() && literal.isNull()) {
           return null;
         }
         return literal.isAlwaysTrue() ? 1L : 0L;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
@@ -26,6 +26,7 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.druid.error.InvalidSqlInput;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.planner.Calcites;
@@ -120,6 +121,9 @@ public class DruidLogicalValuesRule extends RelOptRule
         }
         return ((Number) RexLiteral.value(literal)).longValue();
       case BOOLEAN:
+        if (ExpressionProcessing.useStrictBooleans() && literal.isNull()) {
+          return null;
+        }
         return literal.isAlwaysTrue() ? 1L : 0L;
       case TIMESTAMP:
       case DATE:

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.math.expr.ExpressionProcessing;
@@ -145,18 +146,13 @@ public class DruidLogicalValuesRuleTest
     {
       RexLiteral literal = REX_BUILDER.makeLiteral(null, REX_BUILDER.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN));
 
-      try {
-        ExpressionProcessing.initializeForStrictBooleansTests(true);
+      if (NullHandling.sqlCompatible() && ExpressionProcessing.useStrictBooleans()) {
         final Object fromLiteral = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
         Assert.assertNull(fromLiteral);
-
-        ExpressionProcessing.initializeForStrictBooleansTests(false);
+      } else {
         final Object fromLiteralNonStrict = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
         Assert.assertSame(Long.class, fromLiteralNonStrict.getClass());
         Assert.assertEquals(0L, fromLiteralNonStrict);
-      }
-      finally {
-        ExpressionProcessing.initializeForTests();
       }
     }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
@@ -30,6 +30,7 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.sql.calcite.planner.DruidTypeSystem;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -137,6 +138,26 @@ public class DruidLogicalValuesRuleTest
       final Object fromLiteral = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
       Assert.assertSame(Long.class, fromLiteral.getClass());
       Assert.assertEquals(0L, fromLiteral);
+    }
+
+    @Test
+    public void testGetValueFromNullBooleanLiteral()
+    {
+      RexLiteral literal = REX_BUILDER.makeLiteral(null, REX_BUILDER.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN));
+
+      try {
+        ExpressionProcessing.initializeForStrictBooleansTests(true);
+        final Object fromLiteral = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
+        Assert.assertNull(fromLiteral);
+
+        ExpressionProcessing.initializeForStrictBooleansTests(false);
+        final Object fromLiteralNonStrict = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
+        Assert.assertSame(Long.class, fromLiteralNonStrict.getClass());
+        Assert.assertEquals(0L, fromLiteralNonStrict);
+      }
+      finally {
+        ExpressionProcessing.initializeForTests();
+      }
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes an issue semi related to #15058, but this dealing specifically with boolean constant expressions, where boolean constants in the SQL layer were effectively not allowed to be null.

The result was incorrect behavior from a query like:

<img width="673" alt="Screenshot 2023-10-10 at 11 40 15 PM" src="https://github.com/apache/druid/assets/1577461/87102b23-0da9-4a9d-a281-df866c1a4d9c">
 
even if `druid.expressions.useStrictBooleans` was set to true and `druid.generic.useDefaultValueForNull` set to false. I've modified `DruidLogicalValuesRule` to check for null values on BOOLEAN types, but only if `druid.expressions.useStrictBooleans=true` and `druid.generic.useDefaultValueForNull=false`, resulting in the previous query now producing correct results:

<img width="654" alt="Screenshot 2023-10-10 at 11 38 12 PM" src="https://github.com/apache/druid/assets/1577461/a8058faa-a67f-4cf4-94fb-e4d6b9eea7b3">


This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
