### PR TITLE
[Backport] fix issue with SQL boolean constants not respecting nulls when strict booleans and sql compatible null handling are enabled

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRule.java
@@ -25,7 +25,9 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexLiteral;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.InvalidSqlInput;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.planner.Calcites;
@@ -120,6 +122,9 @@ public class DruidLogicalValuesRule extends RelOptRule
         }
         return ((Number) RexLiteral.value(literal)).longValue();
       case BOOLEAN:
+        if (ExpressionProcessing.useStrictBooleans() && NullHandling.sqlCompatible() && literal.isNull()) {
+          return null;
+        }
         return literal.isAlwaysTrue() ? 1L : 0L;
       case TIMESTAMP:
       case DATE:

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/DruidLogicalValuesRuleTest.java
@@ -28,8 +28,10 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.sql.calcite.planner.DruidTypeSystem;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -137,6 +139,21 @@ public class DruidLogicalValuesRuleTest
       final Object fromLiteral = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
       Assert.assertSame(Long.class, fromLiteral.getClass());
       Assert.assertEquals(0L, fromLiteral);
+    }
+
+    @Test
+    public void testGetValueFromNullBooleanLiteral()
+    {
+      RexLiteral literal = REX_BUILDER.makeLiteral(null, REX_BUILDER.getTypeFactory().createSqlType(SqlTypeName.BOOLEAN));
+
+      if (NullHandling.sqlCompatible() && ExpressionProcessing.useStrictBooleans()) {
+        final Object fromLiteral = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
+        Assert.assertNull(fromLiteral);
+      } else {
+        final Object fromLiteralNonStrict = DruidLogicalValuesRule.getValueFromLiteral(literal, DEFAULT_CONTEXT);
+        Assert.assertSame(Long.class, fromLiteralNonStrict.getClass());
+        Assert.assertEquals(0L, fromLiteralNonStrict);
+      }
     }
 
     @Test


### PR DESCRIPTION
Backport of #15135 to 28.0.0.