### PR TITLE
Handle status failures for streaming supervisors

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2113,13 +2113,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     for (int i = 0; i < results.size(); i++) {
       String taskId = futureTaskIds.get(i);
       if (results.get(i).isError() || results.get(i).valueOrThrow() == null) {
-        log.info("Task [%s] failed to respond, might need to kill it.", taskId);
-        Optional<TaskStatus> killTaskStatus = taskStorage.getStatus(taskId);
-        if (killTaskStatus.isPresent() && !killTaskStatus.get().isComplete()) {
-          // If the task completed while we were failing to chat with it, don't do anything.
-          log.info("Task [%s] failed to return status, killing task", taskId);
-          killTask(taskId, "Task [%s] failed to return status, killing task", taskId);
-        }
+        killTask(taskId, "Task [%s] failed to return status, killing task", taskId);
       } else if (Boolean.valueOf(false).equals(results.get(i).valueOrThrow())) {
         // "return false" above means that we want to stop the task.
         stopFutures.add(stopTask(taskId, false));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1978,7 +1978,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                       final Map<PartitionIdType, SequenceOffsetType> publishingTaskEndOffsets = pair.rhs;
 
                       try {
-                        log.info("Task [%s], status [%s]", taskId, status);
+                        log.debug("Task [%s], status [%s]", taskId, status);
                         if (status == SeekableStreamIndexTaskRunner.Status.PUBLISHING) {
                           seekableStreamIndexTask.getIOConfig()
                                                  .getStartSequenceNumbers()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2108,6 +2108,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
 
     List<Either<Throwable, Boolean>> results = coalesceAndAwait(futures);
+    
     final List<ListenableFuture<Void>> stopFutures = new ArrayList<>();
     for (int i = 0; i < results.size(); i++) {
       String taskId = futureTaskIds.get(i);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2108,7 +2108,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
 
     List<Either<Throwable, Boolean>> results = coalesceAndAwait(futures);
-    
+
     final List<ListenableFuture<Void>> stopFutures = new ArrayList<>();
     for (int i = 0; i < results.size(); i++) {
       String taskId = futureTaskIds.get(i);

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResource.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResource.java
@@ -74,6 +74,7 @@ public class ChatHandlerResource
       return handler.get();
     }
 
+    // Return HTTP 503 so SpecificTaskRetryPolicy retries in case the handler is not registered yet or has been registered before shutdown.
     throw new ServiceUnavailableException(StringUtils.format("Can't find chatHandler for handler[%s]", handlerId));
   }
 }

--- a/server/src/main/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResource.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResource.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.initialization.jetty.BadRequestException;
+import org.apache.druid.server.initialization.jetty.ServiceUnavailableException;
 import org.apache.druid.server.metrics.DataSourceTaskIdHolder;
 
 import javax.ws.rs.Path;
@@ -73,6 +74,6 @@ public class ChatHandlerResource
       return handler.get();
     }
 
-    throw new BadRequestException(StringUtils.format("Can't find chatHandler for handler[%s]", handlerId));
+    throw new ServiceUnavailableException(StringUtils.format("Can't find chatHandler for handler[%s]", handlerId));
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResourceTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/firehose/ChatHandlerResourceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.druid.segment.realtime.firehose;
+
+import com.google.common.base.Optional;
+import org.apache.druid.server.initialization.jetty.ServiceUnavailableException;
+import org.apache.druid.server.metrics.DataSourceTaskIdHolder;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(EasyMockRunner.class)
+public class ChatHandlerResourceTest extends EasyMockSupport
+{
+
+  @Mock
+  ChatHandlerProvider handlers;
+  @Mock
+  DataSourceTaskIdHolder dataSourceTaskIdHolder;
+  ChatHandlerResource chatHandlerResource;
+
+  @Test
+  public void test_noHandlerFound()
+  {
+    String handlerId = "handlerId";
+    EasyMock.expect(dataSourceTaskIdHolder.getTaskId()).andReturn(null);
+    EasyMock.expect(handlers.get(handlerId)).andReturn(Optional.absent());
+
+    replayAll();
+    chatHandlerResource = new ChatHandlerResource(handlers, dataSourceTaskIdHolder);
+    Assert.assertThrows(ServiceUnavailableException.class, () -> chatHandlerResource.doTaskChat(handlerId, null));
+    verifyAll();
+  }
+}


### PR DESCRIPTION
Currently it's possible for there to be unnecessary task failures during streaming ingestion after tasks are launched and after tasks finish handoff (right before exit).

The errors occur when a peon is running (e.g. the jetty server is responding), but there is no chat handler registered for the task. SeekableStreamIndexTaskRunner is responsible for registering and deregistering the chat handler, but this is technically not synced up exactly with when the jetty server starts.

If the chat handler is not registered, the ChatHandlerResource throws a 400 (non-retryable) error. IMO this error should be a ServiceUnavailable error because the resource is per task,  so a missing handler indicates that the task is setting up or tearing down and can be retried.

If this ChatHandlerResource throws a 400 in response to a supervisor's getStatusAsync call, the supervisor will attempt to kill the task even though it may be in the process of starting up or shutting down successfully. The task will fail with "Task [%s] failed to return status, killing task", even though it may have been able to run successfully.

Updating the errror code from 400 -> 503 directly fixes the issue during startup, since the supervisor will retry the 503 error according to its retryPolicy and will eventually succeed when the task comes up.

For the case where a task is shutting down, the client will continue retrying the 503 exceptions (either from the ChatHandlerResource or from when Jetty itself has been torn down) (https://github.com/apache/druid/blob/0a27a7a7ca1561630730c9288e5b36ead1268aed/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java#L115). Eventually the task will be reported by the task runner as exited and this will be reflected in taskStorage. The client getStatusAsync call will stop retrying at this point and the future will fail (https://github.com/apache/druid/blob/0a27a7a7ca1561630730c9288e5b36ead1268aed/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClientAsyncImpl.java#L661).

To handle this case, I added code in the supervisor logic to check taskStorage before killing a unresponsive task. If the task has been marked as complete in taskStorage, we can conclude that we were trying to contact a task that was in the process of cleaning up and we don't need to do anything else.

#### Release note
Cleanup race condition that can occur at high streaming concurrency.


<hr>

##### Key changed/added classes in this PR
 * `SeekableStreamSupervisor`
 * `ChatHandlerResource`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.


I tested this quite a bit in a test environment with quite a few supervisors (300). I am not sure how to go about writing a integration test to test this logic though, open to any suggestions.