### PR TITLE
Optimize the reading of numerical frame arrays in MSQ 

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/field/DoubleArrayFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/DoubleArrayFieldReader.java
@@ -37,6 +37,7 @@ public class DoubleArrayFieldReader extends NumericArrayFieldReader
   {
     return new NumericArrayFieldSelector<Double>(memory, fieldPointer)
     {
+      private static final int FIELD_SIZE = Byte.BYTES + Double.BYTES;
       final SettableFieldPointer fieldPointer = new SettableFieldPointer();
       final ColumnValueSelector<?> columnValueSelector =
           DoubleFieldReader.forArray().makeColumnValueSelector(memory, fieldPointer);
@@ -45,7 +46,7 @@ public class DoubleArrayFieldReader extends NumericArrayFieldReader
       @Override
       public Double getIndividualValueAtMemory(long position)
       {
-        fieldPointer.setPosition(position);
+        fieldPointer.setPositionAndLength(position, FIELD_SIZE);
         if (columnValueSelector.isNull()) {
           return null;
         }
@@ -55,7 +56,7 @@ public class DoubleArrayFieldReader extends NumericArrayFieldReader
       @Override
       public int getIndividualFieldSize()
       {
-        return Byte.BYTES + Double.BYTES;
+        return FIELD_SIZE;
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/frame/field/FloatArrayFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/FloatArrayFieldReader.java
@@ -37,6 +37,7 @@ public class FloatArrayFieldReader extends NumericArrayFieldReader
   {
     return new NumericArrayFieldSelector<Float>(memory, fieldPointer)
     {
+      private static final int FIELD_SIZE = Byte.BYTES + Float.BYTES;
       final SettableFieldPointer fieldPointer = new SettableFieldPointer();
       final ColumnValueSelector<?> columnValueSelector =
           FloatFieldReader.forArray().makeColumnValueSelector(memory, fieldPointer);
@@ -45,7 +46,7 @@ public class FloatArrayFieldReader extends NumericArrayFieldReader
       @Override
       public Float getIndividualValueAtMemory(long position)
       {
-        fieldPointer.setPosition(position);
+        fieldPointer.setPositionAndLength(position, FIELD_SIZE);
         if (columnValueSelector.isNull()) {
           return null;
         }
@@ -55,7 +56,7 @@ public class FloatArrayFieldReader extends NumericArrayFieldReader
       @Override
       public int getIndividualFieldSize()
       {
-        return Byte.BYTES + Float.BYTES;
+        return FIELD_SIZE;
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/frame/field/LongArrayFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/LongArrayFieldReader.java
@@ -37,6 +37,7 @@ public class LongArrayFieldReader extends NumericArrayFieldReader
   {
     return new NumericArrayFieldSelector<Long>(memory, fieldPointer)
     {
+      private static final int FIELD_SIZE = Byte.BYTES + Long.BYTES;
       final SettableFieldPointer fieldPointer = new SettableFieldPointer();
       final ColumnValueSelector<?> columnValueSelector =
           LongFieldReader.forArray().makeColumnValueSelector(memory, fieldPointer);
@@ -45,7 +46,7 @@ public class LongArrayFieldReader extends NumericArrayFieldReader
       @Override
       public Long getIndividualValueAtMemory(long position)
       {
-        fieldPointer.setPosition(position);
+        fieldPointer.setPositionAndLength(position, FIELD_SIZE);
         if (columnValueSelector.isNull()) {
           return null;
         }
@@ -55,7 +56,7 @@ public class LongArrayFieldReader extends NumericArrayFieldReader
       @Override
       public int getIndividualFieldSize()
       {
-        return Byte.BYTES + Long.BYTES;
+        return FIELD_SIZE;
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/frame/field/ReadableFieldPointer.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/ReadableFieldPointer.java
@@ -31,4 +31,9 @@ public interface ReadableFieldPointer
    * Starting position of the field.
    */
   long position();
+
+  /**
+   * Length of the field.
+   */
+  long length();
 }

--- a/processing/src/main/java/org/apache/druid/frame/field/SettableFieldPointer.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/SettableFieldPointer.java
@@ -20,21 +20,31 @@
 package org.apache.druid.frame.field;
 
 /**
- * A simple {@link ReadableFieldPointer} that returns the position that was set on its object.
+ * A simple {@link ReadableFieldPointer} that returns the position and the length that was set on its object.
  */
 public class SettableFieldPointer implements ReadableFieldPointer
 {
-
   long position = 0;
+  long length = -1;
 
-  public void setPosition(long position)
+  /**
+   * Sets the position and the length to be returned when interface's methods are called.
+   */
+  public void setPositionAndLength(long position, long length)
   {
     this.position = position;
+    this.length = length;
   }
 
   @Override
   public long position()
   {
     return position;
+  }
+
+  @Override
+  public long length()
+  {
+    return length;
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/segment/row/ReadableFrameRowPointer.java
+++ b/processing/src/main/java/org/apache/druid/frame/segment/row/ReadableFrameRowPointer.java
@@ -30,7 +30,13 @@ import org.apache.druid.frame.write.RowBasedFrameWriter;
  */
 public interface ReadableFrameRowPointer
 {
+  /**
+   * Position of the start of the row relative to the start of the Frame
+   */
   long position();
 
+  /**
+   * Length of the row (in bytes)
+   */
   long length();
 }

--- a/processing/src/test/java/org/apache/druid/frame/field/ComplexFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/ComplexFieldReaderTest.java
@@ -123,7 +123,7 @@ public class ComplexFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(null);
 
     final ColumnValueSelector<?> readSelector =
-        new ComplexFieldReader(SERDE).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new ComplexFieldReader(SERDE).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertNull(readSelector.getObject());
   }
@@ -134,7 +134,7 @@ public class ComplexFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory("foo");
 
     final ColumnValueSelector<?> readSelector =
-        new ComplexFieldReader(SERDE).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new ComplexFieldReader(SERDE).makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals("foo", readSelector.getObject());
   }

--- a/processing/src/test/java/org/apache/druid/frame/field/ConstantFieldPointer.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/ConstantFieldPointer.java
@@ -22,15 +22,23 @@ package org.apache.druid.frame.field;
 public class ConstantFieldPointer implements ReadableFieldPointer
 {
   private final long position;
+  private final long length;
 
-  public ConstantFieldPointer(long position)
+  public ConstantFieldPointer(long position, long length)
   {
     this.position = position;
+    this.length = length;
   }
 
   @Override
   public long position()
   {
     return position;
+  }
+
+  @Override
+  public long length()
+  {
+    return length;
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/field/DoubleArrayFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/DoubleArrayFieldReaderTest.java
@@ -149,10 +149,13 @@ public class DoubleArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_null()
   {
-    writeToMemory(null, MEMORY_POSITION);
+    long sz = writeToMemory(null, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new DoubleArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new DoubleArrayFieldReader().makeColumnValueSelector(
+            memory,
+            new ConstantFieldPointer(MEMORY_POSITION, sz)
+        );
 
     Assert.assertTrue(readSelector.isNull());
   }
@@ -160,10 +163,14 @@ public class DoubleArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_aValue()
   {
-    writeToMemory(DOUBLES_ARRAY_1, MEMORY_POSITION);
+    long sz = writeToMemory(DOUBLES_ARRAY_1, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new DoubleArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new DoubleArrayFieldReader()
+            .makeColumnValueSelector(
+                memory,
+                new ConstantFieldPointer(MEMORY_POSITION, sz)
+            );
 
     assertResults(DOUBLES_LIST_1, readSelector.getObject());
   }
@@ -172,15 +179,15 @@ public class DoubleArrayFieldReaderTest extends InitializedNullHandlingTest
   public void test_makeColumnValueSelector_multipleValues()
   {
     long sz = writeToMemory(DOUBLES_ARRAY_1, MEMORY_POSITION);
-    writeToMemory(DOUBLES_ARRAY_2, MEMORY_POSITION + sz);
-    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz));
-
+    long sz2 = writeToMemory(DOUBLES_ARRAY_2, MEMORY_POSITION + sz);
+    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(
+        ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz),
+        ImmutableList.of(sz, sz2)
+    );
 
     final ColumnValueSelector<?> readSelector = new DoubleArrayFieldReader().makeColumnValueSelector(memory, pointer);
-
     pointer.setPointer(0);
     assertResults(DOUBLES_LIST_1, readSelector.getObject());
-
     pointer.setPointer(1);
     assertResults(DOUBLES_LIST_2, readSelector.getObject());
   }
@@ -188,10 +195,11 @@ public class DoubleArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_emptyArray()
   {
-    writeToMemory(new Object[]{}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new DoubleArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new DoubleArrayFieldReader()
+            .makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(Collections.emptyList(), readSelector.getObject());
   }
@@ -199,10 +207,13 @@ public class DoubleArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_arrayWithSingleNullElement()
   {
-    writeToMemory(new Object[]{null}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{null}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new DoubleArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new DoubleArrayFieldReader().makeColumnValueSelector(
+            memory,
+            new ConstantFieldPointer(MEMORY_POSITION, sz)
+        );
 
     assertResults(Collections.singletonList(null), readSelector.getObject());
   }

--- a/processing/src/test/java/org/apache/druid/frame/field/DoubleFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/DoubleFieldReaderTest.java
@@ -89,7 +89,7 @@ public class DoubleFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultDoubleValue());
 
     final ColumnValueSelector<?> readSelector =
-        DoubleFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        DoubleFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(!NullHandling.replaceWithDefault(), readSelector.isNull());
 
@@ -104,7 +104,7 @@ public class DoubleFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5.1d);
 
     final ColumnValueSelector<?> readSelector =
-        DoubleFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        DoubleFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(5.1d, readSelector.getObject());
   }
@@ -115,7 +115,8 @@ public class DoubleFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultDoubleValue());
 
     final DimensionSelector readSelector =
-        DoubleFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        DoubleFieldReader.forPrimitive()
+                         .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -149,7 +150,8 @@ public class DoubleFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5.1d);
 
     final DimensionSelector readSelector =
-        DoubleFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        DoubleFieldReader.forPrimitive()
+                         .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -178,7 +180,7 @@ public class DoubleFieldReaderTest extends InitializedNullHandlingTest
     final DimensionSelector readSelector =
         DoubleFieldReader.forPrimitive().makeDimensionSelector(
             memory,
-            new ConstantFieldPointer(MEMORY_POSITION),
+            new ConstantFieldPointer(MEMORY_POSITION, -1),
             new SubstringDimExtractionFn(1, null)
         );
 

--- a/processing/src/test/java/org/apache/druid/frame/field/FloatArrayFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/FloatArrayFieldReaderTest.java
@@ -150,10 +150,10 @@ public class FloatArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_null()
   {
-    writeToMemory(null, MEMORY_POSITION);
+    long sz = writeToMemory(null, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     Assert.assertTrue(readSelector.isNull());
   }
@@ -161,10 +161,10 @@ public class FloatArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_aValue()
   {
-    writeToMemory(FLOATS_ARRAY_1, MEMORY_POSITION);
+    long sz = writeToMemory(FLOATS_ARRAY_1, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(FLOATS_LIST_1, readSelector.getObject());
   }
@@ -173,15 +173,15 @@ public class FloatArrayFieldReaderTest extends InitializedNullHandlingTest
   public void test_makeColumnValueSelector_multipleValues()
   {
     long sz = writeToMemory(FLOATS_ARRAY_1, MEMORY_POSITION);
-    writeToMemory(FLOATS_ARRAY_2, MEMORY_POSITION + sz);
-    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz));
-
+    long sz2 = writeToMemory(FLOATS_ARRAY_2, MEMORY_POSITION + sz);
+    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(
+        ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz),
+        ImmutableList.of(sz, sz2)
+    );
 
     final ColumnValueSelector<?> readSelector = new FloatArrayFieldReader().makeColumnValueSelector(memory, pointer);
-
     pointer.setPointer(0);
     assertResults(FLOATS_LIST_1, readSelector.getObject());
-
     pointer.setPointer(1);
     assertResults(FLOATS_LIST_2, readSelector.getObject());
   }
@@ -189,10 +189,10 @@ public class FloatArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_emptyArray()
   {
-    writeToMemory(new Object[]{}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(Collections.emptyList(), readSelector.getObject());
   }
@@ -200,10 +200,10 @@ public class FloatArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_arrayWithSingleNullElement()
   {
-    writeToMemory(new Object[]{null}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{null}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new FloatArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(Collections.singletonList(null), readSelector.getObject());
   }

--- a/processing/src/test/java/org/apache/druid/frame/field/FloatFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/FloatFieldReaderTest.java
@@ -89,7 +89,7 @@ public class FloatFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultFloatValue());
 
     final ColumnValueSelector<?> readSelector =
-        FloatFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        FloatFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(!NullHandling.replaceWithDefault(), readSelector.isNull());
 
@@ -104,7 +104,7 @@ public class FloatFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5.1f);
 
     final ColumnValueSelector<?> readSelector =
-        FloatFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        FloatFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(5.1f, readSelector.getObject());
   }
@@ -115,7 +115,8 @@ public class FloatFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultFloatValue());
 
     final DimensionSelector readSelector =
-        FloatFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        FloatFieldReader.forPrimitive()
+                        .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -149,7 +150,8 @@ public class FloatFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5.1f);
 
     final DimensionSelector readSelector =
-        FloatFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        FloatFieldReader.forPrimitive()
+                        .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -178,7 +180,7 @@ public class FloatFieldReaderTest extends InitializedNullHandlingTest
     final DimensionSelector readSelector =
         FloatFieldReader.forPrimitive().makeDimensionSelector(
             memory,
-            new ConstantFieldPointer(MEMORY_POSITION),
+            new ConstantFieldPointer(MEMORY_POSITION, -1),
             new SubstringDimExtractionFn(1, null)
         );
 

--- a/processing/src/test/java/org/apache/druid/frame/field/IndexArrayFieldPointer.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/IndexArrayFieldPointer.java
@@ -30,11 +30,13 @@ import java.util.List;
 public class IndexArrayFieldPointer implements ReadableFieldPointer
 {
   private final LongArrayList indices;
+  private final LongArrayList lengths;
   private int pointer = 0;
 
-  public IndexArrayFieldPointer(final List<Long> indices)
+  public IndexArrayFieldPointer(final List<Long> indices, final List<Long> lengths)
   {
     this.indices = new LongArrayList(indices);
+    this.lengths = new LongArrayList(lengths);
   }
 
   private int numIndices()
@@ -52,5 +54,11 @@ public class IndexArrayFieldPointer implements ReadableFieldPointer
   public long position()
   {
     return indices.getLong(pointer);
+  }
+
+  @Override
+  public long length()
+  {
+    return lengths.getLong(pointer);
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/field/LongArrayFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/LongArrayFieldReaderTest.java
@@ -126,10 +126,10 @@ public class LongArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_null()
   {
-    writeToMemory(null, MEMORY_POSITION);
+    long sz = writeToMemory(null, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     Assert.assertTrue(readSelector.isNull());
   }
@@ -137,10 +137,10 @@ public class LongArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_aValue()
   {
-    writeToMemory(LONGS_ARRAY_1, MEMORY_POSITION);
+    long sz = writeToMemory(LONGS_ARRAY_1, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(LONGS_LIST_1, readSelector.getObject());
   }
@@ -149,15 +149,15 @@ public class LongArrayFieldReaderTest extends InitializedNullHandlingTest
   public void test_makeColumnValueSelector_multipleValues()
   {
     long sz = writeToMemory(LONGS_ARRAY_1, MEMORY_POSITION);
-    writeToMemory(LONGS_ARRAY_2, MEMORY_POSITION + sz);
-    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz));
-
+    long sz2 = writeToMemory(LONGS_ARRAY_2, MEMORY_POSITION + sz);
+    IndexArrayFieldPointer pointer = new IndexArrayFieldPointer(
+        ImmutableList.of(MEMORY_POSITION, MEMORY_POSITION + sz),
+        ImmutableList.of(sz, sz2)
+    );
 
     final ColumnValueSelector<?> readSelector = new LongArrayFieldReader().makeColumnValueSelector(memory, pointer);
-
     pointer.setPointer(0);
     assertResults(LONGS_LIST_1, readSelector.getObject());
-
     pointer.setPointer(1);
     assertResults(LONGS_LIST_2, readSelector.getObject());
   }
@@ -165,10 +165,10 @@ public class LongArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_emptyArray()
   {
-    writeToMemory(new Object[]{}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(Collections.emptyList(), readSelector.getObject());
   }
@@ -176,10 +176,10 @@ public class LongArrayFieldReaderTest extends InitializedNullHandlingTest
   @Test
   public void test_makeColumnValueSelector_arrayWithSingleNullElement()
   {
-    writeToMemory(new Object[]{null}, MEMORY_POSITION);
+    long sz = writeToMemory(new Object[]{null}, MEMORY_POSITION);
 
     final ColumnValueSelector<?> readSelector =
-        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new LongArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, sz));
 
     assertResults(Collections.singletonList(null), readSelector.getObject());
   }

--- a/processing/src/test/java/org/apache/druid/frame/field/LongFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/LongFieldReaderTest.java
@@ -89,7 +89,7 @@ public class LongFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultLongValue());
 
     final ColumnValueSelector<?> readSelector =
-        LongFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        LongFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(!NullHandling.replaceWithDefault(), readSelector.isNull());
 
@@ -104,7 +104,7 @@ public class LongFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5L);
 
     final ColumnValueSelector<?> readSelector =
-        LongFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        LongFieldReader.forPrimitive().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(5L, readSelector.getObject());
   }
@@ -115,7 +115,8 @@ public class LongFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(NullHandling.defaultLongValue());
 
     final DimensionSelector readSelector =
-        LongFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        LongFieldReader.forPrimitive()
+                       .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -149,7 +150,8 @@ public class LongFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(5L);
 
     final DimensionSelector readSelector =
-        LongFieldReader.forPrimitive().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        LongFieldReader.forPrimitive()
+                       .makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -178,7 +180,7 @@ public class LongFieldReaderTest extends InitializedNullHandlingTest
     final DimensionSelector readSelector =
         LongFieldReader.forPrimitive().makeDimensionSelector(
             memory,
-            new ConstantFieldPointer(MEMORY_POSITION),
+            new ConstantFieldPointer(MEMORY_POSITION, -1),
             new SubstringDimExtractionFn(1, null)
         );
 

--- a/processing/src/test/java/org/apache/druid/frame/field/StringArrayFieldWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringArrayFieldWriterTest.java
@@ -140,7 +140,7 @@ public class StringArrayFieldWriterTest extends InitializedNullHandlingTest
 
     final FieldReader fieldReader = FieldReaders.create("columnNameDoesntMatterHere", ColumnType.STRING_ARRAY);
     final ColumnValueSelector<?> selector =
-        fieldReader.makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        fieldReader.makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     final Object o = selector.getObject();
     //noinspection rawtypes,unchecked

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
@@ -143,9 +143,9 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(Collections.singletonList("foo"));
 
     final ColumnValueSelector<?> readSelector =
-        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
     final ColumnValueSelector<?> readSelectorAsArray =
-        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals("foo", readSelector.getObject());
     Assert.assertArrayEquals(new Object[]{"foo"}, (Object[]) readSelectorAsArray.getObject());
@@ -157,9 +157,9 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(ImmutableList.of("foo", "bar"));
 
     final ColumnValueSelector<?> readSelector =
-        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
     final ColumnValueSelector<?> readSelectorAsArray =
-        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertEquals(ImmutableList.of("foo", "bar"), readSelector.getObject());
     Assert.assertArrayEquals(new Object[]{"foo", "bar"}, (Object[]) readSelectorAsArray.getObject());
@@ -171,9 +171,9 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(Collections.singletonList(null));
 
     final ColumnValueSelector<?> readSelector =
-        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
     final ColumnValueSelector<?> readSelectorAsArray =
-        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertNull(readSelector.getObject());
     Assert.assertArrayEquals(new Object[]{null}, (Object[]) readSelectorAsArray.getObject());
@@ -185,9 +185,9 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(Collections.emptyList());
 
     final ColumnValueSelector<?> readSelector =
-        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
     final ColumnValueSelector<?> readSelectorAsArray =
-        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        new StringArrayFieldReader().makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     Assert.assertNull(readSelector.getObject());
     Assert.assertArrayEquals(ObjectArrays.EMPTY_ARRAY, (Object[]) readSelectorAsArray.getObject());
@@ -200,7 +200,11 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
 
     final IllegalStateException e = Assert.assertThrows(
         IllegalStateException.class,
-        () -> new StringArrayFieldReader().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null)
+        () -> new StringArrayFieldReader().makeDimensionSelector(
+            memory,
+            new ConstantFieldPointer(MEMORY_POSITION, -1),
+            null
+        )
     );
 
     MatcherAssert.assertThat(
@@ -215,7 +219,7 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     writeToMemory(ImmutableList.of("foo", "bar"));
 
     final DimensionSelector readSelector =
-        new StringFieldReader().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION), null);
+        new StringFieldReader().makeDimensionSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1), null);
 
     // Data retrieval tests.
     final IndexedInts row = readSelector.getRow();
@@ -247,7 +251,7 @@ public class StringFieldReaderTest extends InitializedNullHandlingTest
     final DimensionSelector readSelector =
         new StringFieldReader().makeDimensionSelector(
             memory,
-            new ConstantFieldPointer(MEMORY_POSITION),
+            new ConstantFieldPointer(MEMORY_POSITION, -1),
             new SubstringDimExtractionFn(1, null)
         );
 

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldWriterTest.java
@@ -184,7 +184,7 @@ public class StringFieldWriterTest extends InitializedNullHandlingTest
 
     final FieldReader fieldReader = FieldReaders.create("columnNameDoesntMatterHere", ColumnType.STRING_ARRAY);
     final ColumnValueSelector<?> selector =
-        fieldReader.makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION));
+        fieldReader.makeColumnValueSelector(memory, new ConstantFieldPointer(MEMORY_POSITION, -1));
 
     return (Object[]) selector.getObject();
   }


### PR DESCRIPTION
### Description

Currently, MSQ adds the numbers from the array field and adds it to a `List` and converts this list to `Object[]` while returning it from the column value selector.
This patch optimizes this sequence by directly creating the `Object[]`. To do so, it requires the number of elements present in the array, which it gets by introducing `ReadableFieldPointer#length()` method.

No additional tests are required since the current reading and writing tests would handle the new codepaths

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
