### PR TITLE
Enhance json parser error logging to better track Istio Proxy error message

### DIFF
--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -185,6 +185,12 @@ public class JsonParserIterator<T> implements CloseableIterator<T>
         } else if (nextToken == JsonToken.START_OBJECT) {
           throw convertException(jp.getCodec().readValue(jp, QueryException.class));
         } else {
+          if (nextToken == JsonToken.VALUE_STRING) {
+            LOG.error(
+                "Next Token value is of type VALUE_STRING with content [%s], not as expected START_ARRAY",
+                jp.getText()
+            );
+          }
           throw convertException(
               new IAE("Next token wasn't a START_ARRAY, was[%s] from url[%s]", jp.getCurrentToken(), url)
           );

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -185,14 +185,15 @@ public class JsonParserIterator<T> implements CloseableIterator<T>
         } else if (nextToken == JsonToken.START_OBJECT) {
           throw convertException(jp.getCodec().readValue(jp, QueryException.class));
         } else {
-          if (nextToken == JsonToken.VALUE_STRING) {
-            LOG.error(
-                "Next Token value is of type VALUE_STRING with content [%s], not as expected START_ARRAY",
-                jp.getText()
-            );
-          }
+          String errMsg = jp.getValueAsString();
+          errMsg = errMsg.substring(0, Math.min(errMsg.length(), 192));
           throw convertException(
-              new IAE("Next token wasn't a START_ARRAY, was[%s] from url[%s]", jp.getCurrentToken(), url)
+              new IAE(
+                  "Next token wasn't a START_ARRAY, was[%s] from url[%s] with value[%s]",
+                  jp.getCurrentToken(),
+                  url,
+                  errMsg
+              )
           );
         }
       }

--- a/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
+++ b/server/src/main/java/org/apache/druid/client/JsonParserIterator.java
@@ -186,7 +186,9 @@ public class JsonParserIterator<T> implements CloseableIterator<T>
           throw convertException(jp.getCodec().readValue(jp, QueryException.class));
         } else {
           String errMsg = jp.getValueAsString();
-          errMsg = errMsg.substring(0, Math.min(errMsg.length(), 192));
+          if (errMsg != null) {
+            errMsg = errMsg.substring(0, Math.min(errMsg.length(), 192));
+          }
           throw convertException(
               new IAE(
                   "Next token wasn't a START_ARRAY, was[%s] from url[%s] with value[%s]",

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -321,16 +321,16 @@ public class JsonParserIteratorTest
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private String meshErrMsg = "pstream connect error or disconnect/reset before header";
+    private String errorMessage = "pstream connect error or disconnect/reset before header";
+    private String nullErrMsg = null;
 
     @Test
-    public void testMeshProxyError()
-        throws JsonProcessingException
+    public void testNullErrorMsg() throws JsonProcessingException
     {
       JsonParserIterator<Object> iterator = new JsonParserIterator<>(
           JAVA_TYPE,
           Futures.immediateFuture(
-              mockMeshProxyResponse(meshErrMsg)
+              mockMeshProxyResponse(nullErrMsg)
           ),
           URL,
           null,
@@ -339,7 +339,26 @@ public class JsonParserIteratorTest
       );
 
       expectedException.expect(QueryInterruptedException.class);
-      expectedException.expectMessage(meshErrMsg);
+      expectedException.expectMessage("");
+      iterator.hasNext();
+    }
+
+    @Test
+    public void testParsingError() throws JsonProcessingException
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFuture(
+              mockMeshProxyResponse(errorMessage)
+          ),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage(errorMessage);
       iterator.hasNext();
     }
   }

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -330,7 +330,7 @@ public class JsonParserIteratorTest
       JsonParserIterator<Object> iterator = new JsonParserIterator<>(
           JAVA_TYPE,
           Futures.immediateFuture(
-              mockMeshProxyResponse(nullErrMsg)
+              mockErrorResponse(nullErrMsg)
           ),
           URL,
           null,
@@ -349,7 +349,7 @@ public class JsonParserIteratorTest
       JsonParserIterator<Object> iterator = new JsonParserIterator<>(
           JAVA_TYPE,
           Futures.immediateFuture(
-              mockMeshProxyResponse(errorMessage)
+              mockErrorResponse(errorMessage)
           ),
           URL,
           null,
@@ -368,7 +368,7 @@ public class JsonParserIteratorTest
     return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(e));
   }
 
-  private static InputStream mockMeshProxyResponse(String errMsg) throws JsonProcessingException
+  private static InputStream mockErrorResponse(String errMsg) throws JsonProcessingException
   {
     return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(errMsg));
   }

--- a/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/client/JsonParserIteratorTest.java
@@ -316,8 +316,41 @@ public class JsonParserIteratorTest
     }
   }
 
+  public static class IAEExceptionConversionTest
+  {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private String meshErrMsg = "pstream connect error or disconnect/reset before header";
+
+    @Test
+    public void testMeshProxyError()
+        throws JsonProcessingException
+    {
+      JsonParserIterator<Object> iterator = new JsonParserIterator<>(
+          JAVA_TYPE,
+          Futures.immediateFuture(
+              mockMeshProxyResponse(meshErrMsg)
+          ),
+          URL,
+          null,
+          HOST,
+          OBJECT_MAPPER
+      );
+
+      expectedException.expect(QueryInterruptedException.class);
+      expectedException.expectMessage(meshErrMsg);
+      iterator.hasNext();
+    }
+  }
+
   private static InputStream mockErrorResponse(Exception e) throws JsonProcessingException
   {
     return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(e));
+  }
+
+  private static InputStream mockMeshProxyResponse(String errMsg) throws JsonProcessingException
+  {
+    return new ByteArrayInputStream(OBJECT_MAPPER.writeValueAsBytes(errMsg));
   }
 }


### PR DESCRIPTION

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->
Currently the inter Druid communication via rest endpoints is based on json formatted payload. Upon parsing error, there is only a generic exception stating expected json token type and current json token type. There is no detailed error log about the content of the payload causing the violation. 

In the micro-service world, the trend is to deploy the Druid servers in k8 with the mesh network. Often the istio proxy or other proxies is used to intercept the network connection between Druid servers. The proxy may give error messages for various reasons. These error messages are not expected by the json parser. The generic error message from Druid can be very misleading as the user may think the message is based on the response from the other Druid server. 

For example, this is an example of mysterious error message

```
QueryInterruptedException{msg=Next token wasn't a START_ARRAY, was[VALUE_STRING] from url[http://xxxxx:8088/druid/v2/], code=Unknown exception, class=org.apache.druid.java.util.common.IAE, host=xxxxx:8088}"
```

While the context of the message is the following from the proxy when it can't tunnel the network connection.

```
pstream connect error or disconnect/reset before header
```

So this very simple PR is just to enhance the logging and get the real underlying message printed out. This would save a lot of head scratching time if Druid is deployed with mesh network. 


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>
Improved: enhanced the json parser unexpected token logging with the context of the expected VALUE_STRING token. This way, it is easier to track to mesh/proxy network error messages, instead misleading user to track the Druid server rest endpoint responses.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
