### PR TITLE
Cast the values read in the EXTERN function to the type in the row signature 

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
@@ -45,13 +45,13 @@ public class ExternalSegment extends RowBasedSegment<InputRow>
 {
 
   private final InputSource inputSource;
+  private final RowSignature signature;
   public static final String SEGMENT_ID = "__external";
 
   /**
    * @param inputSource       {@link InputSource} that the segment is a representation of
    * @param reader            reader to read the external input source
-   * @param inputStats        input stats
-   * @param warningCounters   warning counters tracking the warnings generated while reading the external source
+   * @param inputStats        input stats * @param warningCounters   warning counters tracking the warnings generated while reading the external source
    * @param warningPublisher  publisher to report the warnings generated
    * @param channelCounters   channel counters to increment as we read through the files/units of the external source
    * @param signature         signature of the external source
@@ -145,6 +145,7 @@ public class ExternalSegment extends RowBasedSegment<InputRow>
         signature
     );
     this.inputSource = inputSource;
+    this.signature = signature;
   }
 
   /**
@@ -153,5 +154,13 @@ public class ExternalSegment extends RowBasedSegment<InputRow>
   public InputSource externalInputSource()
   {
     return inputSource;
+  }
+
+  /**
+   * Returns the signature of the external input source
+   */
+  public RowSignature signature()
+  {
+    return signature;
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
@@ -51,7 +51,8 @@ public class ExternalSegment extends RowBasedSegment<InputRow>
   /**
    * @param inputSource       {@link InputSource} that the segment is a representation of
    * @param reader            reader to read the external input source
-   * @param inputStats        input stats * @param warningCounters   warning counters tracking the warnings generated while reading the external source
+   * @param inputStats        input stats
+   * @param warningCounters   warning counters tracking the warnings generated while reading the external source
    * @param warningPublisher  publisher to report the warnings generated
    * @param channelCounters   channel counters to increment as we read through the files/units of the external source
    * @param signature         signature of the external source

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ExternalColumnSelectorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ExternalColumnSelectorFactory.java
@@ -73,6 +73,7 @@ public class ExternalColumnSelectorFactory implements ColumnSelectorFactory
     return new DimensionSelector()
     {
       final DimensionSelector delegateDimensionSelector = delegate.makeDimensionSelector(dimensionSpec);
+      final ExpressionType expressionType = ExpressionType.fromColumnType(dimensionSpec.getOutputType());
 
       @Override
       public IndexedInts getRow()
@@ -103,7 +104,6 @@ public class ExternalColumnSelectorFactory implements ColumnSelectorFactory
       public Object getObject()
       {
         try {
-          ExpressionType expressionType = ExpressionType.fromColumnType(dimensionSpec.getOutputType());
           if (expressionType == null) {
             return delegateDimensionSelector.getObject();
           }
@@ -154,6 +154,9 @@ public class ExternalColumnSelectorFactory implements ColumnSelectorFactory
     return new ColumnValueSelector()
     {
       final ColumnValueSelector delegateColumnValueSelector = delegate.makeColumnValueSelector(columnName);
+      final ExpressionType expressionType = ExpressionType.fromColumnType(
+          rowSignature.getColumnType(columnName).orElse(null)
+      );
 
       @Override
       public double getDouble()
@@ -205,9 +208,6 @@ public class ExternalColumnSelectorFactory implements ColumnSelectorFactory
       public Object getObject()
       {
         try {
-          ExpressionType expressionType = ExpressionType.fromColumnType(rowSignature
-                                                                            .getColumnType(columnName)
-                                                                            .orElse(null));
           if (expressionType == null) {
             return delegateColumnValueSelector.getObject();
           }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
@@ -392,6 +392,7 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
       return new ExternalColumnSelectorFactory(
           baseColumnSelectorFactory,
           ((ExternalSegment) segment).externalInputSource(),
+          ((ExternalSegment) segment).signature(),
           cursorOffset
       );
     }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -905,6 +905,53 @@ public class MSQArraysTest extends MSQTestBase
                      .verifyResults();
   }
 
+  @Test
+  public void testScanExternArrayWithNonConvertibleType()
+  {
+    final List<Object[]> expectedRows = Collections.singletonList(
+        new Object[]{Arrays.asList(null, null)}
+    );
+
+    RowSignature scanSignature = RowSignature.builder()
+                                             .add("a_bool", ColumnType.LONG_ARRAY)
+                                             .build();
+
+    Query<?> expectedQuery = newScanQueryBuilder()
+        .dataSource(
+            new ExternalDataSource(
+                new InlineInputSource("{\"a_bool\":[\"Test\",\"Test2\"]}"),
+                new JsonInputFormat(null, null, null, null, null),
+                scanSignature
+            )
+        )
+        .intervals(querySegmentSpec(Filtration.eternity()))
+        .columns("a_bool")
+        .context(defaultScanQueryContext(context, scanSignature))
+        .build();
+
+    testSelectQuery().setSql("SELECT a_bool FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{\"type\": \"inline\", \"data\":\"{\\\"a_bool\\\":[\\\"Test\\\",\\\"Test2\\\"]}\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"a_bool\", \"type\": \"ARRAY<LONG>\"}]'\n"
+                             + "  )\n"
+                             + ")")
+                     .setQueryContext(context)
+                     .setExpectedMSQSpec(MSQSpec
+                                             .builder()
+                                             .query(expectedQuery)
+                                             .columnMappings(new ColumnMappings(ImmutableList.of(
+                                                 new ColumnMapping("a_bool", "a_bool")
+                                             )))
+                                             .tuningConfig(MSQTuningConfig.defaultConfig())
+                                             .destination(TaskReportMSQDestination.INSTANCE)
+                                             .build()
+                     )
+                     .setExpectedRowSignature(scanSignature)
+                     .setExpectedResultRows(expectedRows)
+                     .verifyResults();
+  }
+
   private List<Object[]> expectedMultiValueFooRowsToArray()
   {
     List<Object[]> expectedRows = new ArrayList<>();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.DataSource;
-import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.expression.TestExprMacroTable;

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQArraysTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.msq.exec;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.java.util.common.ISE;
@@ -31,6 +32,7 @@ import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.DataSource;
+import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.NestedDataTestUtils;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.expression.TestExprMacroTable;
@@ -853,6 +855,53 @@ public class MSQArraysTest extends MSQTestBase
                                              .build()
                      )
                      .setExpectedRowSignature(rowSignature)
+                     .setExpectedResultRows(expectedRows)
+                     .verifyResults();
+  }
+
+  @Test
+  public void testScanExternBooleanArray()
+  {
+    final List<Object[]> expectedRows = Collections.singletonList(
+        new Object[]{Arrays.asList(1L, 0L, null)}
+    );
+
+    RowSignature scanSignature = RowSignature.builder()
+                                             .add("a_bool", ColumnType.LONG_ARRAY)
+                                             .build();
+
+    Query<?> expectedQuery = newScanQueryBuilder()
+        .dataSource(
+            new ExternalDataSource(
+                new InlineInputSource("{\"a_bool\":[true,false,null]}"),
+                new JsonInputFormat(null, null, null, null, null),
+                scanSignature
+            )
+        )
+        .intervals(querySegmentSpec(Filtration.eternity()))
+        .columns("a_bool")
+        .context(defaultScanQueryContext(context, scanSignature))
+        .build();
+
+    testSelectQuery().setSql("SELECT a_bool FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{\"type\": \"inline\", \"data\":\"{\\\"a_bool\\\":[true,false,null]}\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"a_bool\", \"type\": \"ARRAY<LONG>\"}]'\n"
+                             + "  )\n"
+                             + ")")
+                     .setQueryContext(context)
+                     .setExpectedMSQSpec(MSQSpec
+                                             .builder()
+                                             .query(expectedQuery)
+                                             .columnMappings(new ColumnMappings(ImmutableList.of(
+                                                 new ColumnMapping("a_bool", "a_bool")
+                                             )))
+                                             .tuningConfig(MSQTuningConfig.defaultConfig())
+                                             .destination(TaskReportMSQDestination.INSTANCE)
+                                             .build()
+                     )
+                     .setExpectedRowSignature(scanSignature)
                      .setExpectedResultRows(expectedRows)
                      .verifyResults();
   }


### PR DESCRIPTION
### Description

Currently, when reading values from an external data source (`EXTERN`), we don't cast the values to the signature passed by the user. This can cause an issue when reading values that are not casted by the underlying selectors. 

For example, when reading a boolean array [true, false], we may run into a bug where the array is not casted to `ARRAY<LONG>` (internal representation for boolean) by the underlying selector, we pass it to methods assuming the `getObject()` returns a valid array type (Object[] with long values). Therefore it's important to cast the externally read values to the row signature passed by the user. This PR addresses the issue and preserves the type that is entered by the user in the query, regardless of what gets read. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
