### PR TITLE
Rename windowing option

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -80,7 +80,7 @@ public class PlannerContext
   /**
    * Undocumented context key, used to enable window functions.
    */
-  public static final String CTX_ENABLE_WINDOW_FNS = "windowsAreForClosers";
+  public static final String CTX_ENABLE_WINDOW_FNS = "enableWindowing";
 
   public static final String CTX_SQL_USE_BOUNDS_AND_SELECTORS = "sqlUseBoundAndSelectors";
   public static final boolean DEFAULT_SQL_USE_BOUNDS_AND_SELECTORS = NullHandling.replaceWithDefault();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -477,7 +477,6 @@ public class DrillWindowQueryTest extends BaseCalciteQueryTest
           .skipVectorize(true)
           .queryContext(ImmutableMap.of(
               PlannerContext.CTX_ENABLE_WINDOW_FNS, true,
-              "windowsAllTheWayDown", true,
               QueryContexts.ENABLE_DEBUG, true)
               )
           .sql(testCase.getQueryString())


### PR DESCRIPTION
Renames the windowing related feature enabler context parameter to `enableWindowing`