### PR TITLE
preserve Rows.objectToStrings behavior of translating null into "null" inside of lists and arrays

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -60,7 +60,11 @@ public final class Rows
   }
 
   /**
-   * Convert an object to a list of strings.
+   * Convert an object to a list of strings. This function translates single value nulls into an empty list, and any
+   * nulls inside of a list or array into the string "null". Do not use this method if you don't want this behavior,
+   * but note that many implementations of {@link InputRow#getDimension(String)} do use this method, so it is
+   * recommended to use {@link InputRow#getRaw(String)} if you want the actual value without this coercion. For legacy
+   * reasons, some stuff counts on this incorrect behavior, (such as {@link Rows#toGroupKey(long, InputRow)}).
    */
   public static List<String> objectToStrings(final Object inputValue)
   {

--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -25,7 +25,6 @@ import com.google.common.primitives.Longs;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.math.expr.Evals;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;

--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -73,7 +73,7 @@ public final class Rows
       // convert byte[] to base64 encoded string
       return Collections.singletonList(StringUtils.encodeBase64String((byte[]) inputValue));
     } else if (inputValue instanceof Object[]) {
-      return Arrays.stream((Object[]) inputValue).map(Evals::asString).collect(Collectors.toList());
+      return Arrays.stream((Object[]) inputValue).map(String::valueOf).collect(Collectors.toList());
     } else {
       return Collections.singletonList(String.valueOf(inputValue));
     }

--- a/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
@@ -389,7 +389,7 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertNotNull(actual);
     Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) actual.getRaw("dim"));
-    Assert.assertArrayEquals(new String[]{"1", "2", null, "3"}, actual.getDimension("dim").toArray());
+    Assert.assertEquals(ImmutableList.of("1", "2", "null", "3"), actual.getDimension("dim"));
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
@@ -416,9 +416,9 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertEquals(2.3, (Double) raw[1], 0.00001);
     Assert.assertNull(raw[2]);
     Assert.assertEquals(3.4, (Double) raw[3], 0.00001);
-    Assert.assertArrayEquals(
-        new String[]{"1.2000000476837158", "2.299999952316284", null, "3.4000000953674316"},
-        actual.getDimension("dim").toArray()
+    Assert.assertEquals(
+        ImmutableList.of("1.2000000476837158", "2.299999952316284", "null", "3.4000000953674316"),
+        actual.getDimension("dim")
     );
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
@@ -445,12 +445,12 @@ public class TransformerTest extends InitializedNullHandlingTest
     Assert.assertEquals(2.3, (Double) raw[1], 0.0);
     Assert.assertNull(raw[2]);
     Assert.assertEquals(3.4, (Double) raw[3], 0.0);
-    Assert.assertArrayEquals(new String[]{"1.2", "2.3", null, "3.4"}, actual.getDimension("dim").toArray());
+    Assert.assertEquals(ImmutableList.of("1.2", "2.3", "null", "3.4"), actual.getDimension("dim"));
     Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
-  public void testTransformWithExpr()
+  public void testTransformWithArrayExpr()
   {
     final Transformer transformer = new Transformer(
         new TransformSpec(
@@ -517,6 +517,6 @@ public class TransformerTest extends InitializedNullHandlingTest
     });
     Assert.assertEquals(actualTranformedRow.getDimension("dim"), dimList.subList(0, 5));
     Assert.assertArrayEquals(dimList.subList(0, 5).toArray(), (Object[]) actualTranformedRow.getRaw("dim"));
-    Assert.assertArrayEquals(new Object[]{"a"}, actualTranformedRow.getDimension("dim1").toArray());
+    Assert.assertEquals(ImmutableList.of("a"), actualTranformedRow.getDimension("dim1"));
   }
 }


### PR DESCRIPTION
### Description

Follow up to #15127, where I incorrectly advised during review to make arrays not translate `null` into `"null"` in `Rows.objectToStrings`, but forgot that stuff was counting on this behavior (however incorrect it may be).

`Rows.toGroupKey` copies the output of `getDimension` into an `ImmutableSortedSet`, so this change can cause ingestion tasks with null array elements to fail with an error like:

```
java.lang.NullPointerException: at index 0
	at com.google.common.collect.ObjectArrays.checkElementNotNull(ObjectArrays.java:229) ~[guava-31.1-jre.jar:?]
	at com.google.common.collect.ObjectArrays.checkElementsNotNull(ObjectArrays.java:219) ~[guava-31.1-jre.jar:?]
	at com.google.common.collect.ImmutableSortedSet.construct(ImmutableSortedSet.java:372) ~[guava-31.1-jre.jar:?]
	at com.google.common.collect.ImmutableSortedSet.copyOf(ImmutableSortedSet.java:309) ~[guava-31.1-jre.jar:?]
	at com.google.common.collect.ImmutableSortedSet.copyOf(ImmutableSortedSet.java:329) ~[guava-31.1-jre.jar:?]
	at com.google.common.collect.ImmutableSortedSet.copyOf(ImmutableSortedSet.java:250) ~[guava-31.1-jre.jar:?]
	at org.apache.druid.data.input.Rows.toGroupKey(Rows.java:54) ~[classes/:?]
	at org.apache.druid.indexing.common.task.batch.parallel.PartialDimensionDistributionTask$DedupInputRowFilter.accept(PartialDimensionDistributionTask.java:402) ~[classes/:?]
```

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
