### PR TITLE
fix incorrect unnest dimension cursor value matcher implementation

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
@@ -126,13 +126,21 @@ public class UnnestDimensionCursor implements Cursor
                 @Override
                 public boolean matches(boolean includeUnknown)
                 {
-                  return includeUnknown;
+                  // don't match anything, except for null values when includeUnknown is true
+                  if (includeUnknown) {
+                    if (indexedIntsForCurrentRow == null || indexedIntsForCurrentRow.size() <= 0) {
+                      return true;
+                    }
+                    final int rowId = indexedIntsForCurrentRow.get(index);
+                    return lookupName(rowId) == null;
+                  }
+                  return false;
                 }
 
                 @Override
                 public void inspectRuntimeShape(RuntimeShapeInspector inspector)
                 {
-
+                  inspector.visit("selector", dimSelector);
                 }
               };
             }
@@ -155,7 +163,7 @@ public class UnnestDimensionCursor implements Cursor
               @Override
               public void inspectRuntimeShape(RuntimeShapeInspector inspector)
               {
-                dimSelector.inspectRuntimeShape(inspector);
+                inspector.visit("selector", dimSelector);
               }
             };
           }

--- a/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
@@ -40,6 +40,8 @@ import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.ExtractionDimensionSpec;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.extraction.StringFormatExtractionFn;
+import org.apache.druid.query.filter.EqualityFilter;
+import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.TestHelper;
@@ -702,6 +704,229 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
 
     return GroupByQueryRunnerTestHelper.runQuery(factory, queryRunner, query);
+  }
+
+  @Test
+  public void testGroupByOnUnnestedFilterMatch()
+  {
+    cannotVectorize();
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST,
+            "\"" + QueryRunnerTestHelper.PLACEMENTISH_DIMENSION + "\"",
+            null,
+            ExprMacroTable.nil()
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setDimensions(
+            new DefaultDimensionSpec(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, "alias0")
+        )
+        .setDimFilter(
+            new EqualityFilter(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, ColumnType.STRING, "a", null)
+        )
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .addOrderByColumn("alias0", OrderByColumnSpec.Direction.ASCENDING)
+        .build();
+
+    // Total rows should add up to 26 * 2 = 52
+    // 26 rows and each has 2 entries in the column to be unnested
+    List<ResultRow> expectedResults = Collections.singletonList(
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "a",
+            "rows", 2L
+        )
+    );
+
+    Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
+  }
+
+  @Test
+  public void testGroupByOnUnnestedNotFilterMatch()
+  {
+    cannotVectorize();
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST,
+            "\"" + QueryRunnerTestHelper.PLACEMENTISH_DIMENSION + "\"",
+            null,
+            ExprMacroTable.nil()
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setDimensions(
+            new DefaultDimensionSpec(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, "alias0")
+        )
+        .setDimFilter(
+            NotDimFilter.of(new EqualityFilter(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, ColumnType.STRING, "a", null))
+        )
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .addOrderByColumn("alias0", OrderByColumnSpec.Direction.ASCENDING)
+        .build();
+
+    List<ResultRow> expectedResults = Arrays.asList(
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "b",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "e",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "h",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "m",
+            "rows", 6L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "n",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "p",
+            "rows", 6L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "preferred",
+            "rows", 26L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "t",
+            "rows", 4L
+        )
+    );
+
+    Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
+  }
+
+  @Test
+  public void testGroupByOnUnnestedNotFilterMatchNonexistentValue()
+  {
+    cannotVectorize();
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST,
+            "\"" + QueryRunnerTestHelper.PLACEMENTISH_DIMENSION + "\"",
+            null,
+            ExprMacroTable.nil()
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
+        .setDimensions(
+            new DefaultDimensionSpec(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, "alias0")
+        )
+        .setDimFilter(
+            NotDimFilter.of(new EqualityFilter(QueryRunnerTestHelper.PLACEMENTISH_DIMENSION_UNNEST, ColumnType.STRING, "noexist", null))
+        )
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .addOrderByColumn("alias0", OrderByColumnSpec.Direction.ASCENDING)
+        .build();
+
+    // Total rows should add up to 26 * 2 = 52
+    // 26 rows and each has 2 entries in the column to be unnested
+    List<ResultRow> expectedResults = Arrays.asList(
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "a",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "b",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "e",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "h",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "m",
+            "rows", 6L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "n",
+            "rows", 2L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "p",
+            "rows", 6L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "preferred",
+            "rows", 26L
+        ),
+        makeRow(
+            query,
+            "2011-04-01",
+            "alias0", "t",
+            "rows", 4L
+        )
+    );
+
+    Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
   private Map<String, Object> makeContext()

--- a/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
@@ -709,6 +709,7 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByOnUnnestedFilterMatch()
   {
+    // testGroupByOnUnnestedColumn but with filter to match single value
     cannotVectorize();
 
     final DataSource unnestDataSource = UnnestDataSource.create(
@@ -736,8 +737,6 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
         .addOrderByColumn("alias0", OrderByColumnSpec.Direction.ASCENDING)
         .build();
 
-    // Total rows should add up to 26 * 2 = 52
-    // 26 rows and each has 2 entries in the column to be unnested
     List<ResultRow> expectedResults = Collections.singletonList(
         makeRow(
             query,
@@ -754,6 +753,7 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByOnUnnestedNotFilterMatch()
   {
+    // testGroupByOnUnnestedColumn but with negated filter to match everything except 1 value
     cannotVectorize();
 
     final DataSource unnestDataSource = UnnestDataSource.create(
@@ -839,6 +839,7 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByOnUnnestedNotFilterMatchNonexistentValue()
   {
+    // testGroupByOnUnnestedColumn but with negated filter on nonexistent value to still match everything
     cannotVectorize();
 
     final DataSource unnestDataSource = UnnestDataSource.create(
@@ -866,8 +867,6 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
         .addOrderByColumn("alias0", OrderByColumnSpec.Direction.ASCENDING)
         .build();
 
-    // Total rows should add up to 26 * 2 = 52
-    // 26 rows and each has 2 entries in the column to be unnested
     List<ResultRow> expectedResults = Arrays.asList(
         makeRow(
             query,

--- a/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestStorageAdapterTest.java
@@ -300,12 +300,6 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     });
   }
 
-  private static void assertColumnReadsIdentifier(final VirtualColumn column, final String identifier)
-  {
-    MatcherAssert.assertThat(column, CoreMatchers.instanceOf(ExpressionVirtualColumn.class));
-    Assert.assertEquals("\"" + identifier + "\"", ((ExpressionVirtualColumn) column).getExpression());
-  }
-
   @Test
   public void test_pushdown_or_filters_unnested_and_original_dimension_with_unnest_adapters()
   {
@@ -350,6 +344,7 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
       return null;
     });
   }
+
   @Test
   public void test_nested_filters_unnested_and_original_dimension_with_unnest_adapters()
   {
@@ -483,7 +478,6 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
         "(unnested-multi-string1 = 3 || (newcol = 2 && multi-string1 = 2 && unnested-multi-string1 = 1))"
     );
   }
-
   @Test
   public void test_nested_filters_unnested_and_topLevelAND3filtersInORWithNestedOrs()
   {
@@ -734,6 +728,78 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
     });
   }
 
+  @Test
+  public void testUnnestValueMatcherValueExist()
+  {
+
+    Sequence<Cursor> cursorSequence = UNNEST_STORAGE_ADAPTER.makeCursors(
+        null,
+        UNNEST_STORAGE_ADAPTER.getInterval(),
+        VirtualColumns.EMPTY,
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    cursorSequence.accumulate(null, (accumulated, cursor) -> {
+      ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+
+      DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(OUTPUT_COLUMN_NAME));
+      int count = 0;
+      while (!cursor.isDone()) {
+        Object dimSelectorVal = dimSelector.getObject();
+        if (dimSelectorVal == null) {
+          Assert.assertNull(dimSelectorVal);
+        }
+        cursor.advance();
+        count++;
+      }
+        /*
+      each row has 8 entries.
+      unnest 2 rows -> 16 rows after unnest
+       */
+      Assert.assertEquals(count, 16);
+      return null;
+    });
+
+  }
+
+  @Test
+  public void testUnnestValueMatcherValueNotExistExist()
+  {
+
+    Sequence<Cursor> cursorSequence = UNNEST_STORAGE_ADAPTER.makeCursors(
+        null,
+        UNNEST_STORAGE_ADAPTER.getInterval(),
+        VirtualColumns.EMPTY,
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    cursorSequence.accumulate(null, (accumulated, cursor) -> {
+      ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
+
+      DimensionSelector dimSelector = factory.makeDimensionSelector(DefaultDimensionSpec.of(OUTPUT_COLUMN_NAME));
+      int count = 0;
+      while (!cursor.isDone()) {
+        Object dimSelectorVal = dimSelector.getObject();
+        if (dimSelectorVal == null) {
+          Assert.assertNull(dimSelectorVal);
+        }
+        cursor.advance();
+        count++;
+      }
+        /*
+      each row has 8 entries.
+      unnest 2 rows -> 16 rows after unnest
+       */
+      Assert.assertEquals(count, 16);
+      return null;
+    });
+
+  }
+
   public void testComputeBaseAndPostUnnestFilters(
       Filter testQueryFilter,
       String expectedBasePushDown,
@@ -776,6 +842,12 @@ public class UnnestStorageAdapterTest extends InitializedNullHandlingTest
         expectedPostUnnest,
         actualPostUnnestFilter == null ? "" : actualPostUnnestFilter.toString()
     );
+  }
+
+  private static void assertColumnReadsIdentifier(final VirtualColumn column, final String identifier)
+  {
+    MatcherAssert.assertThat(column, CoreMatchers.instanceOf(ExpressionVirtualColumn.class));
+    Assert.assertEquals("\"" + identifier + "\"", ((ExpressionVirtualColumn) column).getExpression());
   }
 }
 


### PR DESCRIPTION
### Description
Fixes an issue from #15058 with value matchers created by `UnnestDimensionCursor` for matches against non-existent values, which I forgot to update to match only null rows whenever `includeUnknown` is set to true. I checked around and didn't notice any other implementations with this issue, the problem was that it was treating the case as a non-existent column instead of an always false matcher that should only match null rows when `includeUnknown` is true, and so instead would effectively match nothing when used with a not filter. Added tests cover the case.
This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
