### PR TITLE
Fix GHA Revised ITs workflow service logs path

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Collect service logs on failure
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}
         run: |
-          tar cvzf ./service-logs.tgz ~/shared/logs
+          tar cvzf ./service-logs.tgz integration-tests-ex/cases/target/${{ inputs.it }}/logs
 
       - name: Upload Druid service logs to GitHub
         if: ${{ failure() && steps.run-it.conclusion == 'failure' }}


### PR DESCRIPTION
Fixes path of Druid service logs collection on Revised ITs failure as per docs - https://github.com/apache/druid/blob/a8febd457ceb184870dfbb11f6fe82b02dd1242d/integration-tests-ex/docs/quickstart.md?plain=1#L133