### PR TITLE
Proper default for taskLockType in streaming ingestion

### DIFF
--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3177,7 +3177,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 label: `Allow concurrent ${
                   appendToExisting ? 'append' : 'replace'
                 } tasks (experimental)`,
-                defaultValue: undefined,
+                defaultValue: isStreamingSpec(spec) ? true : undefined,
                 valueAdjustment: v => (v ? (appendToExisting ? 'APPEND' : 'REPLACE') : undefined),
                 adjustValue: v => v === (appendToExisting ? 'APPEND' : 'REPLACE'),
                 info: <p>Allows or forbids concurrent tasks.</p>,

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3177,9 +3177,25 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 label: `Allow concurrent ${
                   appendToExisting ? 'append' : 'replace'
                 } tasks (experimental)`,
-                defaultValue: isStreamingSpec(spec) ? true : undefined,
-                valueAdjustment: v => (v ? (appendToExisting ? 'APPEND' : 'REPLACE') : undefined),
-                adjustValue: v => v === (appendToExisting ? 'APPEND' : 'REPLACE'),
+                defaultValue: undefined,
+                valueAdjustment: v => {
+                  if (!v) return undefined;
+
+                  if (isStreamingSpec(spec)) {
+                    return 'APPEND';
+                  } else {
+                    return appendToExisting ? 'APPEND' : 'REPLACE';
+                  }
+                },
+                adjustValue: v => {
+                  if (v === undefined) return false;
+
+                  if (isStreamingSpec(spec)) {
+                    return v === 'APPEND';
+                  }
+
+                  return v === (appendToExisting ? 'APPEND' : 'REPLACE');
+                },
                 info: <p>Allows or forbids concurrent tasks.</p>,
               },
             ]}


### PR DESCRIPTION
Accounts for the fact that we're looking at a streaming spec or a batch spec to set the `taskLockType`.