### PR TITLE
Refactored Test Cases in UpdateStatusActionTest.java

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.common.actions;
 
 
+
 import com.google.common.base.Optional;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.NoopTask;
@@ -55,9 +56,8 @@ public class UpdateStatusActionTest
   {
     UpdateStatusAction action = new UpdateStatusAction("failure");
     Task task = NoopTask.create();
-    TaskActionToolbox toolbox = mock(TaskActionToolbox.class);
     TaskRunner runner = mock(TaskRunner.class);
-    when(toolbox.getTaskRunner()).thenReturn(Optional.of(runner));
+    TaskActionToolbox toolbox = CreateMockTaskActionToolbox(Optional.of(runner));
     action.perform(task, toolbox);
     verify(runner, times(1)).updateStatus(eq(task), eq(TaskStatus.failure(task.getId(), "Error with task")));
   }
@@ -67,10 +67,14 @@ public class UpdateStatusActionTest
   {
     UpdateStatusAction action = new UpdateStatusAction("successful");
     Task task = NoopTask.create();
-    TaskActionToolbox toolbox = mock(TaskActionToolbox.class);
+    TaskActionToolbox toolbox = CreateMockTaskActionToolbox(Optional.absent());
     TaskRunner runner = mock(TaskRunner.class);
-    when(toolbox.getTaskRunner()).thenReturn(Optional.absent());
     action.perform(task, toolbox);
     verify(runner, never()).updateStatus(any(), any());
+  }
+  TaskActionToolbox CreateMockTaskActionToolbox(Optional<TaskRunner> taskRunner){
+    TaskActionToolbox toolbox = mock(TaskActionToolbox.class);
+    when(toolbox.getTaskRunner()).thenReturn(taskRunner);
+    return toolbox;
   }
 }


### PR DESCRIPTION
Related to #15164 

### Description

Implemented a similar refactoring approach as described in issue #15164. Introduced a helper method `CreateMockTaskActionToolbox` to reuse the creation of `TaskActionToolbox` mocks. This reduces code redundancy and improves test readability.

### Key changed/added classes in this PR

* Refactored test methods in the `UpdateStatusActionTest.java`.
* Introduced `CreateMockTaskActionToolbox` method.


##### Key changed/added methods in this PR
 * `CreateMockTaskActionToolbox`

---

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
