### PR TITLE
Suppress CVE's in master

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -266,6 +266,8 @@ def build_compatible_license_names():
     compatible_licenses['Eclipse Public License - Version 1.0'] = 'Eclipse Public License 1.0'
     compatible_licenses['Eclipse Public License, Version 1.0'] = 'Eclipse Public License 1.0'
     compatible_licenses['Eclipse Public License v1.0'] = 'Eclipse Public License 1.0'
+    compatible_licenses['Eclipse Public License - v1.0'] = 'Eclipse Public License 1.0'
+    compatible_licenses['Eclipse Public License - v 1.0'] = 'Eclipse Public License 1.0'
     compatible_licenses['EPL 1.0'] = 'Eclipse Public License 1.0'
 
     compatible_licenses['Eclipse Public License 2.0'] = 'Eclipse Public License 2.0'

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -807,18 +807,13 @@
 
   <!-- CVE-2022-4244 is affecting plexus-utils package, plexus-interpolation is wrongly matched - https://github.com/jeremylong/DependencyCheck/issues/5973 -->
   <suppress base="true">
-    <notes><![CDATA[
-   FP per issue #5973
-   ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-interpolation@.*$</packageUrl>
     <cve>CVE-2022-4244</cve>
   </suppress>
 
-  <!-- CVE-2023-5072 has a too broad CPE that flags all versions of json-java - https://github.com/jeremylong/DependencyCheck/issues/5991 -->
+  <!-- CVE-2023-5072 has a too broad CPE that seems to be flagging dependencies like json-*. Neither Druid nor any of its
+    ~ transitive dependency use json-java which contains the vulnerability-->
   <suppress base="true">
-    <notes><![CDATA[
-   FP per issue #5991
-   ]]></notes>
     <cve>CVE-2023-5072</cve>
   </suppress>
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -829,4 +829,14 @@
     ]]></notes>
     <cve>CVE-2023-44981</cve>
   </suppress>
+
+  <!--
+   ~ Hostname verification is disabled by default in Netty 4.x, therefore the version that Druid is using gets flagged,
+   ~ however Druid enables it in ChannelResourceFactory therefore this is a false positive-->
+  <suppress>
+    <notes><![CDATA[
+      file name: netty-transport-4.1.100.Final.jar
+    ]]></notes>
+    <cve>CVE-2023-4586</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -759,6 +759,7 @@
     <cve>CVE-2023-1370</cve>
     <cve>CVE-2023-37475</cve> <!-- Suppressing since CVE wrongly linked to apache:avro project - https://github.com/jeremylong/DependencyCheck/issues/5843 -->
     <cve>CVE-2023-39410</cve> <!-- This seems to be a legitimate vulnerability. But there is no fix as of yet in Hadoop repo -->
+    <cve>CVE-2023-44487</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
   </suppress>
   <suppress>
     <!-- from extensions using hadoop-client-api, these dependencies are shaded in the jar -->
@@ -766,6 +767,7 @@
      file name: hadoop-client-api-3.3.6.jar: jquery.dataTables.min.js (pkg:javascript/jquery.datatables@1.10.18)
      ]]></notes>
     <vulnerabilityName>prototype pollution</vulnerabilityName>
+    <cve>CVE-2020-28458</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -810,5 +812,26 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-interpolation@.*$</packageUrl>
     <cve>CVE-2022-4244</cve>
+  </suppress>
+
+  <!-- CVE-2023-5072 has a too broad CPE that flags all versions of json-java - https://github.com/jeremylong/DependencyCheck/issues/5991 -->
+  <suppress base="true">
+    <notes><![CDATA[
+   FP per issue #5991
+   ]]></notes>
+    <cve>CVE-2023-5072</cve>
+  </suppress>
+
+  <!--
+    ~ CVE-2023-44981 seems to affect Zookeeper servers. While we ship with a previous version of the Zookeeper, Druid only
+    ~ only uses the client classes of the Zookeeper. We do use the older version in the quickstart & example docker file,
+    ~ however in production it is recomended to use your own Zookeeper server with the CVE patched up, which the Druid's
+    ~ older ZK library is still compatible with.
+    -->
+  <suppress>
+    <notes><![CDATA[
+      file name: zookeeper-3.5.10.jar
+    ]]></notes>
+    <cve>CVE-2023-44981</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
This PR suppresses the following CVE's

* CVE-2023-44487 - Suppressing the CVE since it hasn't been fixed in the latest version of Hadoop
* CVE-2020-28458 - Pretty old CVE that was suppressed using` <vulnerabilityName>` already, however, it was popping up while trying to build the artifact.
* CVE-2023-5072 - Affects `json-java` that neither Druid nor any of its dependency is using (verified using `mvn dependency:tree`. False positive, looks like the CPE identifier is too generic that it is flagging JARs with json- in their name
* CVE-2023-44981 - Genuine CVE, this should be resolved once we upgrade ZK, since the ZK version Druid is using doesn't have a patch for this CVE. This seems to affect ZK servers, and Druid uses that in quickstart/docker-compose. In production, users are supposed to use their own ZK (containing a later & patched version of ZK), with which the client libraries Druid is using would be compatible.