### PR TITLE
Updating plugin which has fix for corrupt nodejs pkg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1809,7 +1809,7 @@
               <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.14.0</version>
+                <version>1.14.2</version>
               </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
### Description
Build fix for corrupt nodejs package error. https://github.com/eirslett/frontend-maven-plugin/pull/1118  is merged and released new version.

```
Error:  The archive file /home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz is corrupted and will be deleted. Please try the build again.
Error:  Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.11.3:install-node-and-npm (install-node-and-npm) on project web-console: Could not extract the Node archive: Could not extract archive: '/home/runner/.m2/repository/com/github/eirslett/node/16.17.0/node-16.17.0-linux-x64.tar.gz': EOFException -> [Help 1]
Error:  
```

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
