### PR TITLE
Fix dockerfile for druid image

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plu
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && mv /opt/apache-druid-${VERSION} /opt/druid
 
-FROM alpine as bash-static
+FROM alpine:3 as bash-static
 ARG TARGETARCH
 #
 # Download bash-static binary to execute scripts that require bash.

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JDK_VERSION=11
+ARG JDK_VERSION=17
 
 # The platform is explicitly specified as x64 to build the Druid distribution.
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
@@ -66,9 +66,9 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
     echo "Downloading bash-static from ${BASH_URL}" \
     && wget ${BASH_URL} -O /bin/bash
 
-FROM busybox:1.34.1-glibc as busybox
+FROM busybox:1.35.0-glibc as busybox
 
-FROM gcr.io/distroless/java$JDK_VERSION-debian11
+FROM gcr.io/distroless/java$JDK_VERSION-debian12
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
 COPY --from=busybox /bin/busybox /busybox/busybox

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -49,17 +49,8 @@ RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plu
  && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
  && mv /opt/apache-druid-${VERSION} /opt/druid
 
-FROM busybox:1.34.1-glibc as busybox
-
-FROM gcr.io/distroless/java$JDK_VERSION-debian11
-LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
-
-COPY --from=busybox /bin/busybox /busybox/busybox
-RUN ["/busybox/busybox", "--install", "/bin"]
-
-# Predefined builtin arg, see: https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+FROM alpine as bash-static
 ARG TARGETARCH
-
 #
 # Download bash-static binary to execute scripts that require bash.
 # Although bash-static supports multiple platforms, but there's no need for us to support all those platform, amd64 and arm64 are enough.
@@ -73,11 +64,23 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
       echo "Unsupported architecture ($TARGETARCH)" && exit 1; \
     fi; \
     echo "Downloading bash-static from ${BASH_URL}" \
-    && wget ${BASH_URL} -O /bin/bash \
-    && chmod 755 /bin/bash
+    && wget ${BASH_URL} -O /bin/bash
+
+FROM busybox:1.34.1-glibc as busybox
+
+FROM gcr.io/distroless/java$JDK_VERSION-debian11
+LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
+
+COPY --from=busybox /bin/busybox /busybox/busybox
+RUN ["/busybox/busybox", "--install", "/bin"]
+
 
 RUN addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid
+
+
+COPY --from=bash-static /bin/bash /bin/bash
+RUN chmod 755 /bin/bash
 
 COPY --chown=druid:druid --from=builder /opt /opt
 COPY distribution/docker/druid.sh /druid.sh


### PR DESCRIPTION
Fixes docker image build issues with apache/druid.

### Description
Currently, trying to build the docker image fails with the following error when trying to grab the static bash utils.
```
#16 0.263 wget: note: TLS certificate validation not implemented
#16 0.297 wget: TLS error from peer (alert code 80): 80
#16 0.297 wget: error getting response: Connection reset by peer
```

This seems to be caused by a SSL validation issue in busybox (it seems to happen for github.com but not google.com). I thought this might be fixed by moving to busybox 1.35.0, but I got the same error.

To get this working, I moved the wget commands to another setup layer and copied the file into the distroless build.

It seems like it would be better to switch to busybox 1.35.0 anyways (there is a critical CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-48174), although we technically just use the image for the setup tools, not sure if the CVE actually affects us), but the issue with switching to busybox 1.35.0 is that we get the build errors that were described in this pr: https://github.com/apache/druid/pull/14518

This can be remediated by also upgrading the distroless image to debian12, but there is no java11-debian12 distroless image, only a java17-debian12 image.

As far as I know druid supports java17 as a target now so maybe this would be okay? I can make that change if people think it makes sense.

I tested the new image and it ran fine.

#### Release note
Fix druid docker image

##### Key changed/added classes in this PR
 * `distribution/docker/Dockerfile`

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
