### PR TITLE
Fixed flaky test testDateHandling in TimestampsParquetReaderTest.java with ObjectMapper

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -194,17 +194,6 @@
           <version>${hadoop.compile.version}</version>
           <scope>runtime</scope>
         </dependency>
-        <dependency>
-          <groupId>org.json</groupId>
-          <artifactId>json</artifactId>
-          <version>20210307</version>
-        </dependency>
-        <dependency>
-          <groupId>org.skyscreamer</groupId>
-          <artifactId>jsonassert</artifactId>
-          <version>1.5.1</version>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
       <properties>
         <parquet.version>1.13.0</parquet.version>

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -194,6 +194,17 @@
           <version>${hadoop.compile.version}</version>
           <scope>runtime</scope>
         </dependency>
+        <dependency>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+          <version>20210307</version>
+        </dependency>
+        <dependency>
+          <groupId>org.skyscreamer</groupId>
+          <artifactId>jsonassert</artifactId>
+          <version>1.5.1</version>
+          <scope>test</scope>
+        </dependency>
       </dependencies>
       <properties>
         <parquet.version>1.13.0</parquet.version>

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -28,14 +28,13 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
-
-import org.json.JSONException;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Duplicate of {@link TimestampsParquetInputTest} but for {@link ParquetReader} instead of Hadoop
@@ -95,10 +94,11 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
     try {
-        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
-        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } catch (JSONException jse) {
-        Assert.fail("Not comparing JSON strings. Error: " + jse.getMessage());
+      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
+      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
+    } 
+    catch (JSONException jse) {
+      throw new RuntimeException(jse);
     }
   }
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -28,10 +29,8 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
@@ -84,6 +83,8 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
         schemaAsDate,
         JSONPathSpec.DEFAULT
     );
+    ObjectMapper objectMapperString = new ObjectMapper();
+    ObjectMapper objectMapperDate = new ObjectMapper();
     List<InputRowListPlusRawValues> sampledAsString = sampleAllRows(readerAsString);
     List<InputRowListPlusRawValues> sampledAsDate = sampleAllRows(readerAsDate);
     final String expectedJson = "{\n"
@@ -93,13 +94,8 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    try {
-      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
-      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } 
-    catch (JSONException jse) {
-      throw new RuntimeException(jse);
-    }
+    Assert.assertEquals(objectMapperString.readTree(expectedJson), objectMapperString.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues())));
+    Assert.assertEquals(objectMapperDate.readTree(expectedJson), objectMapperDate.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -94,11 +94,11 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    try{
+    try {
         JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
         JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
-    } catch (JSONException jse){
-        Assert.fail("Not comparing JSON strings");
+    } catch (JSONException jse) {
+        Assert.fail("Not comparing JSON strings. Error: " + jse.getMessage());
     }
   }
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -34,6 +34,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 /**
  * Duplicate of {@link TimestampsParquetInputTest} but for {@link ParquetReader} instead of Hadoop
  */
@@ -91,8 +94,12 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    try{
+        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()), false);
+        JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()), false);
+    } catch (JSONException jse){
+        Assert.fail("Not comparing JSON strings");
+    }
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed flaky test testDateHandling in TimestampsParquetReaderTest.java with ObjectMapper


https://github.com/apache/druid/blob/e2fde8c516e418e4d9711c8490b54318cdd2ccf7/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java#L43


**Steps to Reproduce:**
1.  Install the package
    ```
    mvn install -pl extensions-core/parquet-extensions -am -DskipTests
    ```
2. Run the test in regular runs
     ```
    mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
    ```
3. The test failed by running the test with Non-Dex tool.
    ```
    mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dcheckstyle.skip -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
    ```
The following error is noticed:
```console
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.204 s <<< FAILURE! -- in org.apache.druid.data.input.parquet.TimestampsParquetReaderTest
[ERROR] org.apache.druid.data.input.parquet.TimestampsParquetReaderTest.testDateHandling -- Time elapsed: 0.188 s <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<... : "2017-06-18",
  "[timestamp_as_timestamp" : 1497702471815,
  "timestamp_as_string" : "2017-06-17 14:27:51.815",
  "idx" : 1,
  "date_as_date" : 1497744000000]
}> but was:<... : "2017-06-18",
  "[idx" : 1,
  "timestamp_as_timestamp" : 1497702471815,
  "date_as_date" : 1497744000000,
  "timestamp_as_string" : "2017-06-17 14:27:51.815"]
}>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at org.apache.druid.data.input.parquet.TimestampsParquetReaderTest.testDateHandling(TimestampsParquetReaderTest.java:99)
```

**Reason of flakiness:**
The test checks the equality of two JSON strings. The data reading method used `createReader()` in the test do not retrieve data in a consistent order, which can possibly lead to different JSON representations of the same data during test runs.

**Changes:**
- Imported `fasterxml.jackson` package, and changed from using standard assertion method `Assert` to using `JSONNode` and `ObjectMapper`, which parse two JSON strings and convert them to a tree structure and each node in the trees are compared. Thus, the order of the elements in JSON strings is deterministic and the test passes.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fixed: `TimestampsParquetReaderTest.testDateHandling` test no longer fail when running with the NonDex tool.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.