### PR TITLE
Better logging in ServiceClientImpl

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -66,9 +66,7 @@ public class IndexerControllerContext implements ControllerContext
     this.injector = injector;
     this.clientFactory = clientFactory;
     this.overlordClient = overlordClient;
-    this.workerManager = new IndexerWorkerManagerClient(
-        overlordClient.withRetryPolicy(StandardRetryPolicy.unlimitedWithoutRetryLogging())
-    );
+    this.workerManager = new IndexerWorkerManagerClient(overlordClient);
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -37,6 +37,7 @@ import org.apache.druid.msq.indexing.client.ControllerChatHandler;
 import org.apache.druid.msq.indexing.client.IndexerWorkerClient;
 import org.apache.druid.msq.indexing.client.IndexerWorkerManagerClient;
 import org.apache.druid.rpc.ServiceClientFactory;
+import org.apache.druid.rpc.StandardRetryPolicy;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.segment.realtime.firehose.ChatHandler;
 import org.apache.druid.server.DruidNode;
@@ -65,7 +66,9 @@ public class IndexerControllerContext implements ControllerContext
     this.injector = injector;
     this.clientFactory = clientFactory;
     this.overlordClient = overlordClient;
-    this.workerManager = new IndexerWorkerManagerClient(overlordClient);
+    this.workerManager = new IndexerWorkerManagerClient(
+        overlordClient.withRetryPolicy(StandardRetryPolicy.unlimitedWithoutRetryLogging())
+    );
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -37,7 +37,6 @@ import org.apache.druid.msq.indexing.client.ControllerChatHandler;
 import org.apache.druid.msq.indexing.client.IndexerWorkerClient;
 import org.apache.druid.msq.indexing.client.IndexerWorkerManagerClient;
 import org.apache.druid.rpc.ServiceClientFactory;
-import org.apache.druid.rpc.StandardRetryPolicy;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.segment.realtime.firehose.ChatHandler;
 import org.apache.druid.server.DruidNode;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/client/IndexerWorkerClient.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/client/IndexerWorkerClient.java
@@ -301,7 +301,7 @@ public class IndexerWorkerClient implements WorkerClient
             final ServiceClient client = clientFactory.makeClient(
                 id,
                 locator,
-                new SpecificTaskRetryPolicy(workerTaskId, StandardRetryPolicy.unlimited())
+                new SpecificTaskRetryPolicy(workerTaskId, StandardRetryPolicy.unlimitedWithoutRetryLogging())
             );
             return Pair.of(client, locator);
           }

--- a/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
@@ -222,10 +222,10 @@ public class ServiceClientImpl implements ServiceClient
 
                       if (retryPolicy.retryLoggable(t)) {
                         // log as INFO level if the retry is loggable
-                        log.info(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
+                        log.noStackTrace().info(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
                       } else if (log.isDebugEnabled()) {
                         // log as DEBUG level if the debug log is enabled
-                        log.debug(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
+                        log.noStackTrace().debug(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
                       } else {
                         // If none of the above is valid, we log the error message every tenth time we retry. It seems like
                         // a good balance between making the logs not too verbose when the retry is due to the same cause
@@ -286,9 +286,9 @@ public class ServiceClientImpl implements ServiceClient
                   // if the HttpClient encounters an exception in the midst of response processing).
                   final long backoffMs = computeBackoffMs(retryPolicy, attemptNumber);
                   if (retryPolicy.retryLoggable(null)) {
-                    log.info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
+                    log.noStackTrace().info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
                   } else if (log.isDebugEnabled()) {
-                    log.debug(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
+                    log.noStackTrace().debug(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
                   } else {
                     if (nextAttemptNumber > 0 && nextAttemptNumber % 10 == 0) {
                       log.noStackTrace().info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));

--- a/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
@@ -220,12 +220,16 @@ public class ServiceClientImpl implements ServiceClient
                     if (shouldTry(nextAttemptNumber) && retryPolicy.retryThrowable(t)) {
                       final long backoffMs = computeBackoffMs(retryPolicy, attemptNumber);
 
-                      if (log.isDebugEnabled()) {
+                      if (retryPolicy.retryLoggable(t)) {
+                        // log as INFO level if the retry is loggable
+                        log.info(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
+                      } else if (log.isDebugEnabled()) {
+                        // log as DEBUG level if the debug log is enabled
                         log.debug(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
                       } else {
-                        // We don't really need to log every retry attempt as the request handler might be starting up.
-                        // Also, we might be retrying for the same exception, and therefore we can omit the cause of retry
-                        // per retry while logging
+                        // If none of the above is valid, we log the error message every tenth time we retry. It seems like
+                        // a good balance between making the logs not too verbose when the retry is due to the same cause
+                        // and enriching logs with useful information, if we keep retrying due to the same reason
                         if (nextAttemptNumber > 0 && nextAttemptNumber % 10 == 0) {
                           log.noStackTrace().info(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
                         }
@@ -281,12 +285,13 @@ public class ServiceClientImpl implements ServiceClient
                   // Retryable server response (or null errorHolder, which means null result, which can happen
                   // if the HttpClient encounters an exception in the midst of response processing).
                   final long backoffMs = computeBackoffMs(retryPolicy, attemptNumber);
-                  if (log.isDebugEnabled()) {
+                  if (retryPolicy.retryLoggable(null)) {
+                    log.info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
+                  } else if (log.isDebugEnabled()) {
                     log.debug(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
                   } else {
-                    // If we are retrying the connection, then we can omit the reason for retrying per retry
                     if (nextAttemptNumber > 0 && nextAttemptNumber % 10 == 0) {
-                      log.info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
+                      log.noStackTrace().info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
                     }
                   }
                   connectExec.schedule(

--- a/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceClientImpl.java
@@ -220,7 +220,7 @@ public class ServiceClientImpl implements ServiceClient
                     if (shouldTry(nextAttemptNumber) && retryPolicy.retryThrowable(t)) {
                       final long backoffMs = computeBackoffMs(retryPolicy, attemptNumber);
 
-                      if (retryPolicy.retryLoggable(t)) {
+                      if (retryPolicy.retryLoggable()) {
                         // log as INFO level if the retry is loggable
                         log.noStackTrace().info(t, buildErrorMessage(request, null, backoffMs, nextAttemptNumber));
                       } else if (log.isDebugEnabled()) {
@@ -285,7 +285,7 @@ public class ServiceClientImpl implements ServiceClient
                   // Retryable server response (or null errorHolder, which means null result, which can happen
                   // if the HttpClient encounters an exception in the midst of response processing).
                   final long backoffMs = computeBackoffMs(retryPolicy, attemptNumber);
-                  if (retryPolicy.retryLoggable(null)) {
+                  if (retryPolicy.retryLoggable()) {
                     log.noStackTrace().info(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));
                   } else if (log.isDebugEnabled()) {
                     log.noStackTrace().debug(buildErrorMessage(request, errorHolder, backoffMs, nextAttemptNumber));

--- a/server/src/main/java/org/apache/druid/rpc/ServiceRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceRetryPolicy.java
@@ -21,8 +21,6 @@ package org.apache.druid.rpc;
 
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
-import javax.annotation.Nullable;
-
 /**
  * Used by {@link ServiceClient} to decide whether to retry requests.
  */
@@ -59,7 +57,7 @@ public interface ServiceRetryPolicy
   /**
    * Returns whether to log the cause of failure before retrying
    */
-  boolean retryLoggable(@Nullable Throwable t);
+  boolean retryLoggable();
 
   /**
    * Returns whether service-not-available, i.e. empty {@link ServiceLocations#getLocations()}, can be retried.

--- a/server/src/main/java/org/apache/druid/rpc/ServiceRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceRetryPolicy.java
@@ -21,6 +21,8 @@ package org.apache.druid.rpc;
 
 import org.jboss.netty.handler.codec.http.HttpResponse;
 
+import javax.annotation.Nullable;
+
 /**
  * Used by {@link ServiceClient} to decide whether to retry requests.
  */
@@ -53,6 +55,11 @@ public interface ServiceRetryPolicy
    * Returns whether the given exception can be retried.
    */
   boolean retryThrowable(Throwable t);
+
+  /**
+   * Returns whether to log the cause of failure before retrying
+   */
+  boolean retryLoggable(@Nullable Throwable t);
 
   /**
    * Returns whether service-not-available, i.e. empty {@link ServiceLocations#getLocations()}, can be retried.

--- a/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
@@ -24,6 +24,7 @@ import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
@@ -44,6 +45,9 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
   private static final int MAX_ATTEMPTS_ABOUT_AN_HOUR = 125;
 
   private static final StandardRetryPolicy DEFAULT_UNLIMITED_POLICY = new Builder().maxAttempts(UNLIMITED).build();
+  private static final StandardRetryPolicy DEFAULT_UNLIMITED_POLICY_NO_RETRY_LOG = new Builder().maxAttempts(UNLIMITED)
+                                                                                                .retryLoggable(false)
+                                                                                                .build();
   private static final StandardRetryPolicy DEFAULT_ABOUT_AN_HOUR_POLICY =
       new Builder().maxAttempts(MAX_ATTEMPTS_ABOUT_AN_HOUR).build();
   private static final StandardRetryPolicy DEFAULT_NO_RETRIES_POLICY = new Builder().maxAttempts(1).build();
@@ -52,13 +56,21 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
   private final long minWaitMillis;
   private final long maxWaitMillis;
   private final boolean retryNotAvailable;
+  private final boolean retryLoggable;
 
-  private StandardRetryPolicy(long maxAttempts, long minWaitMillis, long maxWaitMillis, boolean retryNotAvailable)
+  private StandardRetryPolicy(
+      long maxAttempts,
+      long minWaitMillis,
+      long maxWaitMillis,
+      boolean retryNotAvailable,
+      boolean retryLoggable
+  )
   {
     this.maxAttempts = maxAttempts;
     this.minWaitMillis = minWaitMillis;
     this.maxWaitMillis = maxWaitMillis;
     this.retryNotAvailable = retryNotAvailable;
+    this.retryLoggable = retryLoggable;
 
     if (maxAttempts == 0) {
       throw new IAE("maxAttempts must be positive (limited) or negative (unlimited); cannot be zero.");
@@ -77,6 +89,14 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
   public static StandardRetryPolicy unlimited()
   {
     return DEFAULT_UNLIMITED_POLICY;
+  }
+
+  /**
+   * Standard unlimited retry policy along with muted the logging for the retries.
+   */
+  public static StandardRetryPolicy unlimitedWithoutRetryLogging()
+  {
+    return DEFAULT_UNLIMITED_POLICY_NO_RETRY_LOG;
   }
 
   /**
@@ -136,6 +156,12 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
   }
 
   @Override
+  public boolean retryLoggable(@Nullable Throwable t)
+  {
+    return retryLoggable;
+  }
+
+  @Override
   public boolean retryNotAvailable()
   {
     return retryNotAvailable;
@@ -147,6 +173,7 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
     private long minWaitMillis = DEFAULT_MIN_WAIT_MS;
     private long maxWaitMillis = DEFAULT_MAX_WAIT_MS;
     private boolean retryNotAvailable = true;
+    private boolean retryLoggable = true;
 
     public Builder maxAttempts(final long maxAttempts)
     {
@@ -172,9 +199,15 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
       return this;
     }
 
+    public Builder retryLoggable(final boolean retryLoggable)
+    {
+      this.retryLoggable = retryLoggable;
+      return this;
+    }
+
     public StandardRetryPolicy build()
     {
-      return new StandardRetryPolicy(maxAttempts, minWaitMillis, maxWaitMillis, retryNotAvailable);
+      return new StandardRetryPolicy(maxAttempts, minWaitMillis, maxWaitMillis, retryNotAvailable, retryLoggable);
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/StandardRetryPolicy.java
@@ -24,7 +24,6 @@ import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
@@ -156,7 +155,7 @@ public class StandardRetryPolicy implements ServiceRetryPolicy
   }
 
   @Override
-  public boolean retryLoggable(@Nullable Throwable t)
+  public boolean retryLoggable()
   {
     return retryLoggable;
   }

--- a/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
@@ -82,7 +82,7 @@ public class SpecificTaskRetryPolicy implements ServiceRetryPolicy
   @Override
   public boolean retryLoggable(@Nullable Throwable t)
   {
-    return true;
+    return baseRetryPolicy.retryLoggable(t);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
@@ -27,8 +27,6 @@ import org.apache.druid.segment.realtime.firehose.ChatHandlerResource;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.annotation.Nullable;
-
 /**
  * Retry policy for tasks. Meant to be used together with {@link SpecificTaskServiceLocator}.
  *
@@ -80,9 +78,9 @@ public class SpecificTaskRetryPolicy implements ServiceRetryPolicy
   }
 
   @Override
-  public boolean retryLoggable(@Nullable Throwable t)
+  public boolean retryLoggable()
   {
-    return baseRetryPolicy.retryLoggable(t);
+    return baseRetryPolicy.retryLoggable();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/SpecificTaskRetryPolicy.java
@@ -27,6 +27,8 @@ import org.apache.druid.segment.realtime.firehose.ChatHandlerResource;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
+import javax.annotation.Nullable;
+
 /**
  * Retry policy for tasks. Meant to be used together with {@link SpecificTaskServiceLocator}.
  *
@@ -75,6 +77,12 @@ public class SpecificTaskRetryPolicy implements ServiceRetryPolicy
   public boolean retryThrowable(final Throwable t)
   {
     return StandardRetryPolicy.unlimited().retryThrowable(t);
+  }
+
+  @Override
+  public boolean retryLoggable(@Nullable Throwable t)
+  {
+    return true;
   }
 
   @Override


### PR DESCRIPTION
### Description

ServiceClientImpl logs the cause of every retry, even though we are retrying the connection attempt. This leads to slight pollution in the logs because a lot of the time, the reason for retrying is the same. This is seen primarily in MSQ, when the worker task hasn't launched yet however controller attempts to connect to the worker task, which can lead to scary-looking messages (with `INFO` log level), even though they are normal.
This PR changes the logging logic to log every 10 (arbitrary number) retries instead of every retry, to reduce the pollution of the logs. 
Note: If there are no retries left, the client returns an exception, which would get thrown up by the caller, and therefore this change doesn't hide any important information. 

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
