### PR TITLE
Fix error assuming a Complex Type that is a Number is a double

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/filter/PredicateValueMatcherFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/PredicateValueMatcherFactory.java
@@ -189,7 +189,7 @@ public class PredicateValueMatcherFactory implements ColumnProcessorFactory<Valu
             return getFloatPredicate().applyFloat((float) rowValue);
           } else if (rowValue instanceof Number) {
             // Double or some other non-int, non-long, non-float number.
-            return getDoublePredicate().applyDouble((double) rowValue);
+            return getDoublePredicate().applyDouble(((Number) rowValue).doubleValue());
           } else if (rowValue instanceof Object[]) {
             return getArrayPredicate().apply((Object[]) rowValue);
           } else {

--- a/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
@@ -165,22 +165,26 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
             Number.class,
             ImmutableList.of(new Number() {
               @Override
-              public int intValue() {
+              public int intValue()
+              {
                 return num.intValue();
               }
 
               @Override
-              public long longValue() {
+              public long longValue()
+              {
                 return num.longValue();
               }
 
               @Override
-              public float floatValue() {
+              public float floatValue()
+              {
                 return num.floatValue();
               }
 
               @Override
-              public double doubleValue() {
+              public double doubleValue()
+              {
                 return num;
               }
             }),
@@ -199,22 +203,26 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
             Double.class,
             ImmutableList.of(new Number() {
               @Override
-              public int intValue() {
+              public int intValue()
+              {
                 return num.intValue();
               }
 
               @Override
-              public long longValue() {
+              public long longValue()
+              {
                 return num.longValue();
               }
 
               @Override
-              public float floatValue() {
+              public float floatValue()
+              {
                 return num.floatValue();
               }
 
               @Override
-              public double doubleValue() {
+              public double doubleValue()
+              {
                 return num;
               }
             }),

--- a/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
@@ -158,6 +158,74 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
   }
 
   @Test
+  public void testNumberProcessorMatchingValue()
+  {
+    Double num = 2.;
+    final TestColumnValueSelector<Number> columnValueSelector = TestColumnValueSelector.of(
+            Number.class,
+            ImmutableList.of(new Number() {
+              @Override
+              public int intValue() {
+                return num.intValue();
+              }
+
+              @Override
+              public long longValue() {
+                return num.longValue();
+              }
+
+              @Override
+              public float floatValue() {
+                return num.floatValue();
+              }
+
+              @Override
+              public double doubleValue() {
+                return num;
+              }
+            }),
+            DateTimes.nowUtc()
+    );
+    columnValueSelector.advance();
+    final ValueMatcher matcher = forSelector("2").makeComplexProcessor(columnValueSelector);
+    Assert.assertTrue(matcher.matches(false));
+  }
+
+  @Test
+  public void testNumberProcessorNotMatchingValue()
+  {
+    Double num = 2.;
+    final TestColumnValueSelector<Double> columnValueSelector = TestColumnValueSelector.of(
+            Double.class,
+            ImmutableList.of(new Number() {
+              @Override
+              public int intValue() {
+                return num.intValue();
+              }
+
+              @Override
+              public long longValue() {
+                return num.longValue();
+              }
+
+              @Override
+              public float floatValue() {
+                return num.floatValue();
+              }
+
+              @Override
+              public double doubleValue() {
+                return num;
+              }
+            }),
+            DateTimes.nowUtc()
+    );
+    columnValueSelector.advance();
+    final ValueMatcher matcher = forSelector("5").makeComplexProcessor(columnValueSelector);
+    Assert.assertFalse(matcher.matches(false));
+  }
+
+  @Test
   public void testLongProcessorMatchingValue()
   {
     final TestColumnValueSelector<Long> columnValueSelector = TestColumnValueSelector.of(


### PR DESCRIPTION
In the case where a complex type is a number, it may not be castable to double. It can safely be case as Number first to get to the doubleValue.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
