### PR TITLE
Fix k8s task runner failure reporting

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
@@ -37,6 +37,7 @@ public class UpdateStatusAction implements TaskAction<Void>
   @JsonIgnore
   private final TaskStatus statusFull;
 
+  @Deprecated
   public UpdateStatusAction(
       String status
   )
@@ -98,7 +99,7 @@ public class UpdateStatusAction implements TaskAction<Void>
   {
     return "UpdateStatusAction{" +
            "status=" + status +
-           "statusFull=" + statusFull +
+           ", statusFull=" + statusFull +
            '}';
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
@@ -34,13 +34,23 @@ public class UpdateStatusAction implements TaskAction<Void>
 {
   @JsonIgnore
   private final String status;
+  private final TaskStatus statusFull;
+
+  public UpdateStatusAction(
+      String status
+  )
+  {
+    this(status, null);
+  }
 
   @JsonCreator
   public UpdateStatusAction(
-      @JsonProperty("status") String status
+      @JsonProperty("status") String status,
+      @JsonProperty("statusFull") TaskStatus statusFull
   )
   {
     this.status = status;
+    this.statusFull = statusFull;
   }
 
 
@@ -48,6 +58,12 @@ public class UpdateStatusAction implements TaskAction<Void>
   public String getStatus()
   {
     return status;
+  }
+
+  @JsonProperty
+  public TaskStatus getStatusFull()
+  {
+    return statusFull;
   }
 
   @Override
@@ -63,9 +79,8 @@ public class UpdateStatusAction implements TaskAction<Void>
   {
     Optional<TaskRunner> taskRunner = toolbox.getTaskRunner();
     if (taskRunner.isPresent()) {
-      TaskStatus result = "successful".equals(status)
-                          ? TaskStatus.success(task.getId())
-                          : TaskStatus.failure(task.getId(), "Error with task");
+      // Fall back to checking status instead of statusFull for backwards compatibility
+      TaskStatus result = statusFull != null ? statusFull : "successful".equals(status) ? TaskStatus.success(task.getId()) : TaskStatus.failure(task.getId(), "Error with task");
       taskRunner.get().updateStatus(task, result);
     }
     return null;
@@ -82,6 +97,7 @@ public class UpdateStatusAction implements TaskAction<Void>
   {
     return "UpdateStatusAction{" +
            "status=" + status +
+           "statusFull=" + statusFull +
            '}';
   }
 
@@ -95,12 +111,12 @@ public class UpdateStatusAction implements TaskAction<Void>
       return false;
     }
     UpdateStatusAction that = (UpdateStatusAction) o;
-    return Objects.equals(status, that.status);
+    return Objects.equals(status, that.status) && Objects.equals(statusFull, that.statusFull);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(status);
+    return Objects.hash(status, statusFull);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/UpdateStatusAction.java
@@ -34,6 +34,7 @@ public class UpdateStatusAction implements TaskAction<Void>
 {
   @JsonIgnore
   private final String status;
+  @JsonIgnore
   private final TaskStatus statusFull;
 
   public UpdateStatusAction(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -159,12 +159,13 @@ public abstract class AbstractTask implements Task
   @Override
   public final TaskStatus run(TaskToolbox taskToolbox) throws Exception
   {
-    TaskStatus taskStatus = TaskStatus.running(getId());
+    TaskStatus taskStatus = null;
     try {
       cleanupCompletionLatch = new CountDownLatch(1);
       String errorMessage = setup(taskToolbox);
       if (org.apache.commons.lang3.StringUtils.isNotBlank(errorMessage)) {
-        return TaskStatus.failure(getId(), errorMessage);
+        taskStatus = TaskStatus.failure(getId(), errorMessage);
+        return taskStatus;
       }
       taskStatus = runTask(taskToolbox);
       return taskStatus;
@@ -186,7 +187,7 @@ public abstract class AbstractTask implements Task
   public abstract TaskStatus runTask(TaskToolbox taskToolbox) throws Exception;
 
   @Override
-  public void cleanUp(TaskToolbox toolbox, TaskStatus taskStatus) throws Exception
+  public void cleanUp(TaskToolbox toolbox, @Nullable TaskStatus taskStatus) throws Exception
   {
     // clear any interrupted status to ensure subsequent cleanup proceeds without interruption.
     Thread.interrupted();
@@ -196,11 +197,11 @@ public abstract class AbstractTask implements Task
       return;
     }
 
+    TaskStatus taskStatusToReport = taskStatus == null
+        ? TaskStatus.failure(id, "Task failed to run")
+        : taskStatus;
     // report back to the overlord
-    UpdateStatusAction status = new UpdateStatusAction("successful");
-    if (taskStatus.isFailure()) {
-      status = new UpdateStatusAction("failure");
-    }
+    UpdateStatusAction status = new UpdateStatusAction("", taskStatus);
     toolbox.getTaskActionClient().submit(status);
 
     if (reportsFile != null && reportsFile.exists()) {
@@ -211,7 +212,7 @@ public abstract class AbstractTask implements Task
     }
 
     if (statusFile != null) {
-      toolbox.getJsonMapper().writeValue(statusFile, taskStatus);
+      toolbox.getJsonMapper().writeValue(statusFile, taskStatusToReport);
       toolbox.getTaskLogPusher().pushTaskStatus(id, statusFile);
       Files.deleteIfExists(statusFile.toPath());
       log.debug("Pushed task status");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -201,7 +201,7 @@ public abstract class AbstractTask implements Task
         ? TaskStatus.failure(id, "Task failed to run")
         : taskStatus;
     // report back to the overlord
-    UpdateStatusAction status = new UpdateStatusAction("", taskStatus);
+    UpdateStatusAction status = new UpdateStatusAction("", taskStatusToReport);
     toolbox.getTaskActionClient().submit(status);
 
     if (reportsFile != null && reportsFile.exists()) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -37,6 +38,8 @@ import static org.mockito.Mockito.when;
 
 public class UpdateStatusActionTest
 {
+
+  private static final String ID = "id";
 
   @Test
   public void testActionCallsTaskRunner()
@@ -78,12 +81,20 @@ public class UpdateStatusActionTest
   @Test
   public void testNoTaskRunner()
   {
-    UpdateStatusAction action = new UpdateStatusAction("successful");
+    UpdateStatusAction action = new UpdateStatusAction("", TaskStatus.success(ID));
     Task task = NoopTask.create();
     TaskActionToolbox toolbox = mock(TaskActionToolbox.class);
     TaskRunner runner = mock(TaskRunner.class);
     when(toolbox.getTaskRunner()).thenReturn(Optional.absent());
     action.perform(task, toolbox);
     verify(runner, never()).updateStatus(any(), any());
+  }
+
+  @Test
+  public void testEquals()
+  {
+    UpdateStatusAction one = new UpdateStatusAction("", TaskStatus.failure(ID, "error"));
+    UpdateStatusAction two = new UpdateStatusAction("", TaskStatus.failure(ID, "error"));
+    Assert.assertEquals(one, two);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
@@ -63,6 +63,19 @@ public class UpdateStatusActionTest
   }
 
   @Test
+  public void testTaskStatusFull()
+  {
+    Task task = NoopTask.create();
+    TaskActionToolbox toolbox = mock(TaskActionToolbox.class);
+    TaskRunner runner = mock(TaskRunner.class);
+    when(toolbox.getTaskRunner()).thenReturn(Optional.of(runner));
+    TaskStatus taskStatus = TaskStatus.failure(task.getId(), "custom error message");
+    UpdateStatusAction action = new UpdateStatusAction("failure", taskStatus);
+    action.perform(task, toolbox);
+    verify(runner, times(1)).updateStatus(eq(task), eq(taskStatus));
+  }
+
+  @Test
   public void testNoTaskRunner()
   {
     UpdateStatusAction action = new UpdateStatusAction("successful");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -182,18 +182,93 @@ public class AbstractTaskTest
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
     when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
 
+    TaskStatus taskStatus = TaskStatus.failure("myId", "failed");
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
     {
       @Override
       public TaskStatus runTask(TaskToolbox toolbox)
       {
-        return TaskStatus.failure("myId", "failed");
+        return taskStatus;
       }
     };
     task.run(toolbox);
-    UpdateStatusAction action = new UpdateStatusAction("failure");
+    UpdateStatusAction action = new UpdateStatusAction("", taskStatus);
     verify(taskActionClient).submit(eq(action));
   }
+
+  @Test
+  public void testNullStackStatusGetsReportedCorrectly() throws Exception
+  {
+    TaskToolbox toolbox = mock(TaskToolbox.class);
+    when(toolbox.getAttemptId()).thenReturn("1");
+
+    DruidNode node = new DruidNode("foo", "foo", false, 1, 2, true, true);
+    when(toolbox.getTaskExecutorNode()).thenReturn(node);
+
+    TaskLogPusher pusher = mock(TaskLogPusher.class);
+    when(toolbox.getTaskLogPusher()).thenReturn(pusher);
+
+    TaskConfig config = mock(TaskConfig.class);
+    when(config.isEncapsulatedTask()).thenReturn(true);
+    File folder = temporaryFolder.newFolder();
+    when(config.getTaskDir(eq("myID"))).thenReturn(folder);
+    when(toolbox.getConfig()).thenReturn(config);
+    when(toolbox.getJsonMapper()).thenReturn(objectMapper);
+
+    TaskActionClient taskActionClient = mock(TaskActionClient.class);
+    when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
+    when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
+    AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
+    {
+      @Nullable
+      @Override
+      public TaskStatus runTask(TaskToolbox toolbox)
+      {
+        // Simulate the scenario where taskStatus is never set and cleanUp is called with null.
+        return null;
+      }
+    };
+    task.run(toolbox);
+    UpdateStatusAction action = new UpdateStatusAction("", TaskStatus.failure(task.getId(), "Task failed to run"));
+    verify(taskActionClient).submit(eq(action));
+  }
+
+  @Test
+  public void testSetupFailsGetsReportedCorrectly() throws Exception
+  {
+    TaskToolbox toolbox = mock(TaskToolbox.class);
+    when(toolbox.getAttemptId()).thenReturn("1");
+
+    DruidNode node = new DruidNode("foo", "foo", false, 1, 2, true, true);
+    when(toolbox.getTaskExecutorNode()).thenReturn(node);
+
+    TaskLogPusher pusher = mock(TaskLogPusher.class);
+    when(toolbox.getTaskLogPusher()).thenReturn(pusher);
+
+    TaskConfig config = mock(TaskConfig.class);
+    when(config.isEncapsulatedTask()).thenReturn(true);
+    File folder = temporaryFolder.newFolder();
+    when(config.getTaskDir(eq("myID"))).thenReturn(folder);
+    when(toolbox.getConfig()).thenReturn(config);
+    when(toolbox.getJsonMapper()).thenReturn(objectMapper);
+
+    TaskActionClient taskActionClient = mock(TaskActionClient.class);
+    when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
+    when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
+    AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
+    {
+      @Nullable
+      @Override
+      public String setup(TaskToolbox toolbox)
+      {
+        return "setup error";
+      }
+    };
+    task.run(toolbox);
+    UpdateStatusAction action = new UpdateStatusAction("", TaskStatus.failure(task.getId(), "setup error"));
+    verify(taskActionClient).submit(eq(action));
+  }
+
 
   @Test
   public void testBatchIOConfigAppend()


### PR DESCRIPTION
Fixes a couple bugs with some of the AbstractTask.run implementation that was added to support mmless ingestion..

### Description
If a task in mmless ingestion fails during setup(), then cleanup is called with taskStatus=TaskStatus.running(getId()) because of a error in the logic. This can cause issues because then the overlord will think the task is running when in reality it has exited.

Separately, as a part of https://github.com/apache/druid/commit/dc0b163e192545c802b7fe2b3271e035cc1e70ff, mmless ingestion will normally report the status to the overlord in the UpdateStatusAction api call, with the deep storage status.json being just a backup option. When this status is reported, the error message is dropped because UpdateStateAction only takes in a string instead of a TaskStatus object. To fix this, I added a TaskStatus field to the UpdateStatusAction (i left the string value in for backwards compatibility).

#### Release note
Fix some error reporting with mmless ingestion

##### Key changed/added classes in this PR
 * `AbstractTask`
 * `UpdateStatusAction`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
