### PR TITLE
Fix flaky tests in ParserTest.java

### DIFF
--- a/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -38,6 +38,7 @@ import org.junit.rules.ExpectedException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -820,7 +821,7 @@ public class ParserTest extends InitializedNullHandlingTest
     }
     final Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Assert.assertEquals(expression, expected, parsed.toString());
-    Assert.assertEquals(expression, identifiers, deets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), deets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, deets.getScalarVariables());
     Assert.assertEquals(expression, arrays, deets.getArrayVariables());
 
@@ -828,7 +829,7 @@ public class ParserTest extends InitializedNullHandlingTest
     final Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Assert.assertEquals(parsed.stringify(), roundTrip.stringify());
     final Expr.BindingAnalysis roundTripDeets = roundTrip.analyzeInputs();
-    Assert.assertEquals(expression, identifiers, roundTripDeets.getRequiredBindingsList());
+    Assert.assertEquals(expression, new HashSet<>(identifiers), roundTripDeets.getRequiredBindings());
     Assert.assertEquals(expression, scalars, roundTripDeets.getScalarVariables());
     Assert.assertEquals(expression, arrays, roundTripDeets.getArrayVariables());
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #15288, #15289, #15290, #15291, #15292, #15293

These flaky tests have been found using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Plugin.
PR made in collaboration with @deekshacheruku

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the following flaky tests:
1. org.apache.druid.math.expr.ParserTest#testApplyFunctions
2. org.apache.druid.math.expr.ParserTest#testSimpleMultiplicativeOp1
3. org.apache.druid.math.expr.ParserTest#testFunctions
4. org.apache.druid.math.expr.ParserTest#testSimpleLogicalOps1
5. org.apache.druid.math.expr.ParserTest#testSimpleAdditivityOp1
6. org.apache.druid.math.expr.ParserTest#testSimpleAdditivityOp2

#### Problem:
The above mentioned tests have been reported as flaky (tests assuming deterministic implementation of a non-deterministic specification ) when ran against the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 
The tests contain assertions ([Assertion 1](https://github.com/apache/druid/blob/fb260f3e412522a4993d43209b2bc20cb3dae80c/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L823C1-L824C1) & [Assertion 2](https://github.com/apache/druid/blob/fb260f3e412522a4993d43209b2bc20cb3dae80c/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java#L831)) that compare an ArrayList created from a HashSet using the ArrayList() constructor with another List. However, HashSet does not guarantee the ordering of elements and thus resulting in these flaky tests that assume deterministic implementation of HashSet. Thus, when the NonDex tool shuffles the HashSet elements, it results in the test failures:


```
[ERROR] org.apache.druid.math.expr.ParserTest.testApplyFunctions
[ERROR]   Run 1: ParserTest.testApplyFunctions:521->validateParser:823 x + map((x) -> x + 1, y) expected:<[x, y]> but was:<[y, x]>

[ERROR] org.apache.druid.math.expr.ParserTest.testFunctions
[ERROR]   Run 1: ParserTest.testFunctions:453->validateParser:799->validateParser:831 if(cond,then,else) expected:<[then, cond, else]> but was:<[then, else, cond]>

[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp1
[ERROR]   Run 1: ParserTest.testSimpleAdditivityOp1:180->validateParser:799->validateParser:831 x-y expected:<[x, y]> but was:<[y, x]>

[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleAdditivityOp2
[ERROR]   Run 1: ParserTest.testSimpleAdditivityOp2:186->validateParser:799->validateParser:823 x+y+z expected:<[x, y, z]> but was:<[z, x, y]>

[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleLogicalOps1
[ERROR]   Run 1: ParserTest.testSimpleLogicalOps1:165->validateParser:799->validateParser:831 x>y expected:<[x, y]> but was:<[y, x]>

[ERROR] org.apache.druid.math.expr.ParserTest.testSimpleMultiplicativeOp1
[ERROR]   Run 1: ParserTest.testSimpleMultiplicativeOp1:197->validateParser:799->validateParser:823 x*y expected:<[x, y]> but was:<[y, x]>

[ERROR] Tests run: 35, Failures: 6, Errors: 0, Skipped: 0

```

To reproduce run:
```
mvn -pl processing edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.math.expr.ParserTestx
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

#### Fix:
Used the existing method which returns a set (getRequiredBindings() instead of getRequiredBindingsList()) and compare it with identifiers converted to a HashSet.

#### Additional information on alternate solution:
I tried another approach, where I made a code change to use LinkedHashSet which preserves the order of elements instead of HashSet. (The code change can be found in this [draft PR](https://github.com/yashdeep97/druid/pull/1/files))
However, I noticed for some tests, the order of elements in the expected outputs was different from the order of insertion in the LinkedHashSet being created. Which makes me think that the developers created the expected values based on the most probable order rather than the order of insertion. Hence, I believe it would be safe to use getRequiredBindings and compare the sets without making tests weaker.
<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.math.expr.ParserTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
