### PR TITLE
support non-constant expressions for path arguments for json_value and json_query

### DIFF
--- a/docs/querying/math-expr.md
+++ b/docs/querying/math-expr.md
@@ -235,7 +235,7 @@ JSON functions provide facilities to extract, transform, and create `COMPLEX<jso
 
 | function | description |
 |---|---|
-| json_value(expr, path[, type]) | Extract a Druid literal (`STRING`, `LONG`, `DOUBLE`) value from `expr` using JSONPath syntax of `path`. The optional `type` argument can be set to `'LONG'`,`'DOUBLE'` or `'STRING'` to cast values to that type. |
+| json_value(expr, path[, type]) | Extract a Druid literal (`STRING`, `LONG`, `DOUBLE`, `ARRAY<STRING>`, `ARRAY<LONG>`, or `ARRAY<DOUBLE>`) value from `expr` using JSONPath syntax of `path`. The optional `type` argument can be set to `'LONG'`,`'DOUBLE'`, `'STRING'`, `'ARRAY<LONG>'`, `'ARRAY<DOUBLE>'`, or `'ARRAY<STRING>'` to cast values to that type. |
 | json_query(expr, path) | Extract a `COMPLEX<json>` value from `expr` using JSONPath syntax of `path` |
 | json_object(expr1, expr2[, expr3, expr4 ...]) | Construct a `COMPLEX<json>` with alternating 'key' and 'value' arguments|
 | parse_json(expr) | Deserialize a JSON `STRING` into a `COMPLEX<json>`. If the input is not a `STRING` or it is invalid JSON, this function will result in an error.|

--- a/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
@@ -272,6 +272,11 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
     eval = expr.eval(inputBindings);
     Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
     Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+
+    expr = Parser.parse("json_value(nester, array_offset(json_paths(nester), 0))", MACRO_TABLE);
+    eval = expr.eval(inputBindings);
+    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
   }
 
   @Test
@@ -316,6 +321,11 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
     expr = Parser.parse("json_query(long, '$')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
     Assert.assertEquals(1234L, eval.value());
+    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+
+    expr = Parser.parse("json_query(nester, array_offset(json_paths(nester), 0))", MACRO_TABLE);
+    eval = expr.eval(inputBindings);
+    Assert.assertEquals(NESTER.get("x"), eval.value());
     Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -199,9 +199,10 @@ public class NestedDataOperatorConversions
 
       final Expr pathExpr = plannerContext.parseExpression(druidExpressions.get(1).getExpression());
       if (!pathExpr.isLiteral()) {
-        return null;
+        // if path argument is not constant, just use a pure expression
+        return DruidExpression.ofFunctionCall(ColumnType.NESTED_DATA, "json_query", druidExpressions);
       }
-      // pre-normalize path so that the same expressions with different jq syntax are collapsed
+      // pre-normalize path so that the same expressions with different json path syntax are collapsed
       final String path = (String) pathExpr.eval(InputBindings.nilBindings()).value();
       final List<NestedPathPart> parts = extractNestedPathParts(call, path);
       final String jsonPath = NestedPathFinder.toNormalizedJsonPath(parts);
@@ -353,9 +354,17 @@ public class NestedDataOperatorConversions
 
       final Expr pathExpr = plannerContext.parseExpression(druidExpressions.get(1).getExpression());
       if (!pathExpr.isLiteral()) {
-        return null;
+        // if path argument is not constant, just use a pure expression
+        return DruidExpression.ofFunctionCall(
+            druidType,
+            "json_value",
+            ImmutableList.<DruidExpression>builder()
+                         .addAll(druidExpressions)
+                         .add(DruidExpression.ofStringLiteral(druidType.asTypeString()))
+                         .build()
+        );
       }
-      // pre-normalize path so that the same expressions with different jq syntax are collapsed
+      // pre-normalize path so that the same expressions with different json path syntax are collapsed
       final String path = (String) pathExpr.eval(InputBindings.nilBindings()).value();
 
       final List<NestedPathPart> parts = extractNestedPathParts(call, path);
@@ -477,7 +486,7 @@ public class NestedDataOperatorConversions
       if (!pathExpr.isLiteral()) {
         return null;
       }
-      // pre-normalize path so that the same expressions with different jq syntax are collapsed
+      // pre-normalize path so that the same expressions with different json path syntax are collapsed
       final String path = (String) pathExpr.eval(InputBindings.nilBindings()).value();
       final List<NestedPathPart> parts;
       try {
@@ -645,7 +654,7 @@ public class NestedDataOperatorConversions
       if (!pathExpr.isLiteral()) {
         return null;
       }
-      // pre-normalize path so that the same expressions with different jq syntax are collapsed
+      // pre-normalize path so that the same expressions with different json path syntax are collapsed
       final String path = (String) pathExpr.eval(InputBindings.nilBindings()).value();
       final List<NestedPathPart> parts = extractNestedPathParts(call, path);
       final String jsonPath = NestedPathFinder.toNormalizedJsonPath(parts);


### PR DESCRIPTION
### Description
This PR adds support for using expressions to compute the json path argument for `JSON_VALUE` and `JSON_QUERY` functions. Note that when using a path expression that isn't a constant, Druid cannot take advantage of the specialized virtual column typically used, and so must fall back to a pure expression virtual column to compute the values from the 'raw' json blob, which will be much less performant than if the path is constant and known up front.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
