### PR TITLE
allow compaction to work with spatial dimensions

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment;
 
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionSchema.MultiValueHandling;
+import org.apache.druid.data.input.impl.NewSpatialDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.io.Closer;
@@ -31,6 +32,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableDimensionValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.util.Collections;
 import java.util.Comparator;
 
 public class StringDimensionHandler implements DimensionHandler<Integer, int[], String>
@@ -124,6 +126,9 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   @Override
   public DimensionSchema getDimensionSchema(ColumnCapabilities capabilities)
   {
+    if (hasSpatialIndexes) {
+      return new NewSpatialDimensionSchema(dimensionName, Collections.singletonList(dimensionName));
+    }
     return new StringDimensionSchema(dimensionName, multiValueHandling, hasBitmapIndexes);
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/DimensionHandlerUtilsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/DimensionHandlerUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DoubleDimensionSchema;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
+import org.apache.druid.data.input.impl.NewSpatialDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.column.ColumnCapabilities;
@@ -113,6 +114,24 @@ public class DimensionHandlerUtilsTest extends InitializedNullHandlingTest
     );
     Assert.assertTrue(stringHandler instanceof StringDimensionHandler);
     Assert.assertTrue(stringHandler.getDimensionSchema(stringCapabilities) instanceof StringDimensionSchema);
+  }
+
+  @Test
+  public void testGetHandlerFromStringCapabilitiesSpatialIndexes()
+  {
+    ColumnCapabilities stringCapabilities = ColumnCapabilitiesImpl.createSimpleSingleValueStringColumnCapabilities()
+                                                                  .setHasBitmapIndexes(true)
+                                                                  .setDictionaryEncoded(true)
+                                                                  .setDictionaryValuesUnique(true)
+                                                                  .setDictionaryValuesUnique(true)
+                                                                  .setHasSpatialIndexes(true);
+    DimensionHandler spatialHandler = DimensionHandlerUtils.getHandlerFromCapabilities(
+        DIM_NAME,
+        stringCapabilities,
+        DimensionSchema.MultiValueHandling.SORTED_SET
+    );
+    Assert.assertTrue(spatialHandler instanceof StringDimensionHandler);
+    Assert.assertTrue(spatialHandler.getDimensionSchema(stringCapabilities) instanceof NewSpatialDimensionSchema);
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR fixes auto-compaction to properly preserve spatial dimensions. Prior to this fix, spatial dimensions would be rewritten into regular string dimensions, losing their spatial indexes.

I went back and tested stuff versions over the last few years, and all of them had this flaw, at least for as far back as I went. It seems plausible that auto compaction has never supported spatial dimensions - which isn't particularly surprising since they are not commonly used afaik, at least I haven't seen them much, and are not supported in SQL.

I personally think spatial dimensions would be a lot better suited to be modernized as a complex dimension instead of piggy-backing off of strings, but that said, using compaction on them shouldn't destroy them if you went to the trouble of creating them in the first place. 


<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
