### PR TITLE
 Suppress CVE's in master

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -840,4 +840,11 @@
     ]]></notes>
     <cve>CVE-2023-4586</cve>
   </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+      file name: jose4j-0.7.3.jar
+    ]]></notes>
+    <cve>CVE-2023-31582</cve>
+  </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -760,6 +760,7 @@
     <cve>CVE-2023-37475</cve> <!-- Suppressing since CVE wrongly linked to apache:avro project - https://github.com/jeremylong/DependencyCheck/issues/5843 -->
     <cve>CVE-2023-39410</cve> <!-- This seems to be a legitimate vulnerability. But there is no fix as of yet in Hadoop repo -->
     <cve>CVE-2023-44487</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
+    <cve>CVE-2023-36478</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
   </suppress>
   <suppress>
     <!-- from extensions using hadoop-client-api, these dependencies are shaded in the jar -->


### PR DESCRIPTION
This PR suppresses the following CVE's

* CVE-2023-36478 - Suppressing the CVE since it hasn't been fixed in the latest version of Hadoop