### PR TITLE
docs: suggest metadata store with instant ADD COLUMN semantics

### DIFF
--- a/docs/design/metadata-storage.md
+++ b/docs/design/metadata-storage.md
@@ -44,7 +44,9 @@ See [Metadata storage configuration](../configuration/index.md#metadata-storage)
 
 ## Available metadata stores
 
-Druid supports Derby, MySQL, and PostgreSQL for storing metadata. 
+Druid supports Derby, MySQL, and PostgreSQL for storing metadata.
+
+To avoid issues with upgrades that require scehma changes to a large metadata table, chose a metadata store version that supports instant ADD COLUMN semantics.
 
 ### Derby
 

--- a/docs/design/metadata-storage.md
+++ b/docs/design/metadata-storage.md
@@ -46,7 +46,17 @@ See [Metadata storage configuration](../configuration/index.md#metadata-storage)
 
 Druid supports Derby, MySQL, and PostgreSQL for storing metadata.
 
-To avoid issues with upgrades that require scehma changes to a large metadata table, chose a metadata store version that supports instant ADD COLUMN semantics.
+To avoid issues with upgrades that require scehma changes to a large metadata table, consider a metadata store version that supports instant ADD COLUMN semantics.
+See the database-specific docs for guidance on versions.
+
+### MySQL
+
+See [mysql-metadata-storage extension documentation](../development/extensions-core/mysql.md).
+
+### PostgreSQL
+
+See [postgresql-metadata-storage](../development/extensions-core/postgresql.md).
+
 
 ### Derby
 
@@ -60,14 +70,6 @@ Configure metadata storage with Derby by setting the following properties in you
 druid.metadata.storage.type=derby
 druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527//opt/var/druid_state/derby;create=true
 ```
-
-### MySQL
-
-See [mysql-metadata-storage extension documentation](../development/extensions-core/mysql.md).
-
-### PostgreSQL
-
-See [postgresql-metadata-storage](../development/extensions-core/postgresql.md).
 
 ## Adding custom DBCP properties
 

--- a/docs/design/metadata-storage.md
+++ b/docs/design/metadata-storage.md
@@ -46,7 +46,7 @@ See [Metadata storage configuration](../configuration/index.md#metadata-storage)
 
 Druid supports Derby, MySQL, and PostgreSQL for storing metadata.
 
-To avoid issues with upgrades that require scehma changes to a large metadata table, consider a metadata store version that supports instant ADD COLUMN semantics.
+To avoid issues with upgrades that require schema changes to a large metadata table, consider a metadata store version that supports instant ADD COLUMN semantics.
 See the database-specific docs for guidance on versions.
 
 ### MySQL

--- a/docs/development/extensions-core/mysql.md
+++ b/docs/development/extensions-core/mysql.md
@@ -61,7 +61,7 @@ Depending on the MariaDB client library version, the connector supports both `jd
 
 ## Setting up MySQL
 
-To avoid issues with upgrades that require scehma changes to a large metadata table, chose a MySQL version that supports instant ADD COLUMN semantics. For example, MySQL 8.
+To avoid issues with upgrades that require schema changes to a large metadata table, chose a MySQL version that supports instant ADD COLUMN semantics. For example, MySQL 8.
 
 1. Install MySQL
 

--- a/docs/development/extensions-core/mysql.md
+++ b/docs/development/extensions-core/mysql.md
@@ -61,7 +61,7 @@ Depending on the MariaDB client library version, the connector supports both `jd
 
 ## Setting up MySQL
 
-To avoid issues with upgrades that require schema changes to a large metadata table, chose a MySQL version that supports instant ADD COLUMN semantics. For example, MySQL 8.
+To avoid issues with upgrades that require schema changes to a large metadata table, consider a MySQL version that supports instant ADD COLUMN semantics. For example, MySQL 8.
 
 1. Install MySQL
 

--- a/docs/development/extensions-core/mysql.md
+++ b/docs/development/extensions-core/mysql.md
@@ -61,6 +61,8 @@ Depending on the MariaDB client library version, the connector supports both `jd
 
 ## Setting up MySQL
 
+To avoid issues with upgrades that require scehma changes to a large metadata table, chose a MySQL version that supports instant ADD COLUMN semantics. For example, MySQL 8.
+
 1. Install MySQL
 
   Use your favorite package manager to install mysql, e.g.:

--- a/docs/development/extensions-core/postgresql.md
+++ b/docs/development/extensions-core/postgresql.md
@@ -27,7 +27,7 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 
 ## Setting up PostgreSQL
 
-To avoid issues with upgrades that require schema changes to a large metadata table, chose a PostgreSQL version that supports instant ADD COLUMN semantics.
+To avoid issues with upgrades that require schema changes to a large metadata table, consider a PostgreSQL version that supports instant ADD COLUMN semantics.
 
 1. Install PostgreSQL
 

--- a/docs/development/extensions-core/postgresql.md
+++ b/docs/development/extensions-core/postgresql.md
@@ -27,6 +27,9 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 
 ## Setting up PostgreSQL
 
+To avoid issues with upgrades that require scehma changes to a large metadata table, chose a PostreSQL version that supports instant ADD COLUMN semantics.
+For example, any currently supported version of PostgreSQL, version 11 or later.
+
 1. Install PostgreSQL
 
   Use your favorite package manager to install PostgreSQL, e.g.:

--- a/docs/development/extensions-core/postgresql.md
+++ b/docs/development/extensions-core/postgresql.md
@@ -27,7 +27,7 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 
 ## Setting up PostgreSQL
 
-To avoid issues with upgrades that require scehma changes to a large metadata table, chose a PostreSQL version that supports instant ADD COLUMN semantics.
+To avoid issues with upgrades that require schema changes to a large metadata table, chose a PostgreSQL version that supports instant ADD COLUMN semantics.
 For example, any currently supported version of PostgreSQL, version 11 or later.
 
 1. Install PostgreSQL

--- a/docs/development/extensions-core/postgresql.md
+++ b/docs/development/extensions-core/postgresql.md
@@ -28,7 +28,6 @@ To use this Apache Druid extension, [include](../../configuration/extensions.md#
 ## Setting up PostgreSQL
 
 To avoid issues with upgrades that require schema changes to a large metadata table, chose a PostgreSQL version that supports instant ADD COLUMN semantics.
-For example, any currently supported version of PostgreSQL, version 11 or later.
 
 1. Install PostgreSQL
 


### PR DESCRIPTION
Suggests opting for a metadata store with instant ADD COLUMN semantics to avoid issues with future upgrades.


This PR has:

- [ x] been self-reviewed.