### PR TITLE
Increase historical heap for standard IT

### DIFF
--- a/integration-tests/docker/environment-configs/historical
+++ b/integration-tests/docker/environment-configs/historical
@@ -21,7 +21,7 @@ DRUID_SERVICE=historical
 DRUID_LOG_PATH=/shared/logs/historical.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx512m -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx700m -Xms700m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
 
 # Druid configs
 druid_host=druid-historical

--- a/integration-tests/docker/environment-configs/historical
+++ b/integration-tests/docker/environment-configs/historical
@@ -21,6 +21,8 @@ DRUID_SERVICE=historical
 DRUID_LOG_PATH=/shared/logs/historical.log
 
 # JAVA OPTS
+# Query IT often fails with historical server running out of memory (OOM).
+# Until the issue is resolved, heap size for historical server is increased from 512m to 700m.
 SERVICE_DRUID_JAVA_OPTS=-server -Xmx700m -Xms700m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
 
 # Druid configs


### PR DESCRIPTION
Lately, Query IT has been failing due to historical server running out of memory (OOM). 
We are investigating the historical heap dump from the test. Until the issue is resolved, we are increasing the heap size of historical server. 



