### PR TITLE
Web console: fix ingest datasource detection falling over on paren

### DIFF
--- a/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.spec.ts
@@ -487,6 +487,18 @@ describe('WorkbenchQuery', () => {
       expect(workbenchQuery.changeEngine('sql-native').getIngestDatasource()).toBeUndefined();
     });
 
+    it('works with INSERT (unparsable with paren)', () => {
+      const sql = sane`
+        -- Some comment
+        INSERT into trips2
+        (SELECT TIME_PARSE(pickup_datetime) AS __time,
+      `;
+
+      const workbenchQuery = WorkbenchQuery.blank().changeQueryString(sql);
+      expect(workbenchQuery.getIngestDatasource()).toEqual('trips2');
+      expect(workbenchQuery.changeEngine('sql-native').getIngestDatasource()).toBeUndefined();
+    });
+
     it('works with REPLACE', () => {
       const sql = sane`
         REPLACE INTO trips2 OVERWRITE ALL

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -226,7 +226,7 @@ export class WorkbenchQuery {
 
     const queryStartingWithInsertOrReplace = queryFragment.substring(matchInsertReplaceIndex);
 
-    const matchEnd = queryStartingWithInsertOrReplace.match(/\b(?:SELECT|WITH)\b|$/i);
+    const matchEnd = queryStartingWithInsertOrReplace.match(/\(|\b(?:SELECT|WITH)\b|$/i);
     const fragmentQuery = SqlQuery.maybeParse(
       queryStartingWithInsertOrReplace.substring(0, matchEnd?.index) + ' SELECT * FROM t',
     );


### PR DESCRIPTION
Make the "ingest data source" detection code more robust. Right now it falls over is the inner SELECT query is in parens `()`. See test.