### PR TITLE
Fixed flaky tests in CompatParquetReaderTest.java with ObjectMapper

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -88,22 +89,21 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT,
         false
     );
+    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapperBinary = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     List<InputRowListPlusRawValues> sampledAsBinary = sampleAllRows(readerNotAsString);
     final String expectedJson = "{\n"
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
 
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(
-        expectedJsonBinary,
-        DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
-    );
+    Assert.assertEquals(objectMapperBinary.readTree(expectedJsonBinary), objectMapperBinary.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())));
   }
 
 
@@ -245,6 +245,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
+    ObjectMapper objectMapper = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     final String expectedJson = "{\n"
                                 + "  \"enumColumn\" : \"SPADES\",\n"
@@ -305,7 +306,8 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+
   }
 
   @Test
@@ -377,6 +379,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
+    ObjectMapper objectMapper = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     final String expectedJson = "{\n"
                                 + "  \"primitive\" : 2,\n"
@@ -385,7 +388,8 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+
   }
 
   @Test
@@ -424,6 +428,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
+    ObjectMapper objectMapper = new ObjectMapper();
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     final String expectedJson = "{\n"
                                 + "  \"optionalMessage\" : null,\n"
@@ -435,6 +440,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed flaky tests in CompatParquetReaderTest.java with ObjectMapper

https://github.com/apache/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java#L43

Test: `testBinaryAsString`, `testParquetThriftCompat`, `testReadNestedArrayStruct`, `testProtoStructWithArray`

**Steps to Reproduce:**
1. Clone the repo
   ```
   git clone git clone https://github.com/apache/druid.git
   ```
2.  Install the package
    ```
    mvn install -pl extensions-core/parquet-extensions -am -DskipTests
    ```
3. Run the test in regular runs
     ```
    mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.CompatParquetReaderTest#testname
    ```
4. The test failed by running the test with Non-Dex tool.
    ```
    mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dcheckstyle.skip -Dtest=org.apache.druid.data.input.parquet.CompatParquetReaderTest#testname
    ```
The following is an example error message from `testReadNestedArrayStruct`
```console
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.732 s <<< FAILURE! -- in org.apache.druid.data.input.parquet.CompatParquetReaderTest
[ERROR] org.apache.druid.data.input.parquet.CompatParquetReaderTest.testReadNestedArrayStruct -- Time elapsed: 0.052 s <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<{
  "[primitive" : 2,
  "myComplex" : [ {
    "id" : 1,
    "repeatedMessage" : [ 3 ]
  } ]]
}> but was:<{
  "[myComplex" : [ {
    "id" : 1,
    "repeatedMessage" : [ 3 ]
  } ],
  "primitive" : 2]
}>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at org.apache.druid.data.input.parquet.CompatParquetReaderTest.testReadNestedArrayStruct(CompatParquetReaderTest.java:392)
```
**Reason of flakiness:**
These tests check the equality of two JSON strings. The data reading methods used `createReader()` in those tests do not retrieve data in a consistent order, which can possibly lead to different JSON representations of the same data during test runs.

**Changes:**
- Imported `fasterxml.jackson` package, and changed from using standard assertion method `Assert` to using `JSONNode` and `ObjectMapper`, which parse two JSON strings and convert them to a tree structure and each node in the trees are compared. Thus, the order of the elements in JSON strings is deterministic and the test passes.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fixed: `CompatParquetReaderTest` tests no longer fail when running with the NonDex tool.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.