### PR TITLE
Bump Jedis version to 5.0.2

### DIFF
--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.9.0</version>
+            <version>5.0.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -104,9 +104,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fiftyonred</groupId>
-            <artifactId>mock-jedis</artifactId>
-            <version>0.4.0</version>
+            <groupId>com.github.fppt</groupId>
+            <artifactId>jedis-mock</artifactId>
+            <version>1.0.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -125,6 +125,37 @@
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>redis-extension</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.commons:commons-pool2</include>
+                                    <include>redis.clients:jedis</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons.pool2</pattern>
+                                    <shadedPattern>org.apache.druid.redis.shaded.org.apache.commons.pool2</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>redis.clients.jedis</pattern>
+                                    <shadedPattern>org.apache.druid.redis.shaded.redis.clients.jedis</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheFactory.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.client.cache;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.druid.java.util.common.IAE;
+import redis.clients.jedis.ConnectionPoolConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
@@ -59,7 +60,7 @@ public class RedisCacheFactory
                                        return new HostAndPort(hostAndPort.substring(0, index), port);
                                      }).collect(Collectors.toSet());
 
-      JedisPoolConfig poolConfig = new JedisPoolConfig();
+      ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
       poolConfig.setMaxTotal(config.getMaxTotalConnections());
       poolConfig.setMaxIdle(config.getMaxIdleConnections());
       poolConfig.setMinIdle(config.getMinIdleConnections());

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisClusterCache.java
@@ -21,9 +21,8 @@ package org.apache.druid.client.cache;
 
 import org.apache.druid.java.util.common.Pair;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.util.JedisClusterCRC16;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -110,10 +109,6 @@ public class RedisClusterCache extends AbstractRedisCache
   @Override
   protected void cleanup()
   {
-    try {
-      cluster.close();
-    }
-    catch (IOException ignored) {
-    }
+    cluster.close();
   }
 }


### PR DESCRIPTION
### Description

Currently, the redis-cache extension uses Jedis 2.9.0, which was released over seven years ago and [is no longer listed in the official support matrix](https://github.com/redis/jedis#supported-redis-versions). This patch upgrades it to ensure the compatibility with the recent version of Redis and make future upgrades easier, including:

* Upgrade Jedis to v5.0.2, the latest version at this writing, and address the API changes and dependency version mismatch.

* Replace mock-jedis with jedis-mock, since the former has not been actively maintained any longer and not compatible with recent versions of Jedis.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
