### PR TITLE
Fix for segment/count Metric Not Emitting with Statsd-emitter

### DIFF
--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -107,8 +107,10 @@ For metrics which are emitted from multiple services with different dimensions, 
 the service name. For example:
 
 ```json
-"coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
-"historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }
+"druid/coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+"druid/historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }
 ```
+
+Please note that the Coordinator service name can be customized via the `druid.selectors.coordinator.serviceName` configuration setting. It is essential to ensure that this name matches the service name prefix used in the metric configuration.
  
 For most use cases, the default mapping is sufficient.

--- a/docs/development/extensions-contrib/prometheus.md
+++ b/docs/development/extensions-contrib/prometheus.md
@@ -110,7 +110,5 @@ the service name. For example:
 "druid/coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
 "druid/historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }
 ```
-
-Please note that the Coordinator service name can be customized via the `druid.selectors.coordinator.serviceName` configuration setting. It is essential to ensure that this name matches the service name prefix used in the metric configuration.
  
 For most use cases, the default mapping is sufficient.

--- a/docs/development/extensions-contrib/statsd.md
+++ b/docs/development/extensions-contrib/statsd.md
@@ -65,7 +65,9 @@ e.g.
 For metrics which are emitted from multiple services with different dimensions, the metric name is prefixed with
 the service name.
 e.g.
-`"coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
- "historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }`
- 
+`"druid/coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+ "druid/historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }`
+
+Please note that the Coordinator service name can be customized via the `druid.selectors.coordinator.serviceName` configuration setting. It is essential to ensure that this name matches the service name prefix used in the metric configuration.
+
 For most use-cases, the default mapping is sufficient.

--- a/docs/development/extensions-contrib/statsd.md
+++ b/docs/development/extensions-contrib/statsd.md
@@ -68,6 +68,4 @@ e.g.
 `"druid/coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
  "druid/historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" }`
 
-Please note that the Coordinator service name can be customized via the `druid.selectors.coordinator.serviceName` configuration setting. It is essential to ensure that this name matches the service name prefix used in the metric configuration.
-
 For most use-cases, the default mapping is sufficient.

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -138,8 +138,8 @@
   "sys/storage/used" : { "dimensions" : ["fsDirName"], "type" : "gauge"},
   "sys/cpu" : { "dimensions" : ["cpuName", "cpuTime"], "type" : "gauge"},
 
-  "coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
-  "historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" },
+  "druid/coordinator-segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "druid/historical-segment/count" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge" },
 
   "jetty/numOpenConnections": { "dimensions" : [], "type" : "gauge" },
   "jetty/threadPool/total": { "dimensions" : [], "type" : "gauge" },


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

This pull request resolves a bug where the `segment/count` metric was not being emitted as expected when using the Statsd-emitter. The issue was traced to a discrepancy in the `serviceName` used within the metric name. While the Statsd-emitter was correctly appending the serviceName to the metric name, the configured metric name within the Statsd-emitter did not include the correct serviceName. This mismatch led to a failure during the metric name comparison check, resulting in the segment/count metric not being reported. The configuration has been corrected to include the appropriate serviceName, ensuring that the segment/count metric is now emitted correctly for each service.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
