### PR TITLE
Web console: use is not distinct from

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4987,7 +4987,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.21.1
+version: 0.21.4
 
 ---
 

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -14,7 +14,7 @@
         "@blueprintjs/datetime2": "^0.9.35",
         "@blueprintjs/icons": "^4.16.0",
         "@blueprintjs/popover2": "^1.14.9",
-        "@druid-toolkit/query": "^0.21.1",
+        "@druid-toolkit/query": "^0.21.4",
         "@druid-toolkit/visuals-core": "^0.3.3",
         "@druid-toolkit/visuals-react": "^0.3.3",
         "ace-builds": "~1.4.14",
@@ -2344,9 +2344,9 @@
       }
     },
     "node_modules/@druid-toolkit/query": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.21.1.tgz",
-      "integrity": "sha512-p9bE0mlE0Lv6w1HOOr6m/NB1l4oQy0ew6HFa3hSZ1T/qlDx8CPT5MXRRhruEmgtneZx4UrN6RqFULJNFVv+aWg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.21.4.tgz",
+      "integrity": "sha512-rZYRrtahy68ZMp3XDWa2Z3Pa28yiQMgDVHbB7ZAqynNFbKOgqS1j08LS122CRmNrvpAUyzwCnMj3Og4BvWeq1Q==",
       "dependencies": {
         "tslib": "^2.5.2"
       }
@@ -26105,9 +26105,9 @@
       "dev": true
     },
     "@druid-toolkit/query": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.21.1.tgz",
-      "integrity": "sha512-p9bE0mlE0Lv6w1HOOr6m/NB1l4oQy0ew6HFa3hSZ1T/qlDx8CPT5MXRRhruEmgtneZx4UrN6RqFULJNFVv+aWg==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.21.4.tgz",
+      "integrity": "sha512-rZYRrtahy68ZMp3XDWa2Z3Pa28yiQMgDVHbB7ZAqynNFbKOgqS1j08LS122CRmNrvpAUyzwCnMj3Og4BvWeq1Q==",
       "requires": {
         "tslib": "^2.5.2"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -68,7 +68,7 @@
     "@blueprintjs/datetime2": "^0.9.35",
     "@blueprintjs/icons": "^4.16.0",
     "@blueprintjs/popover2": "^1.14.9",
-    "@druid-toolkit/query": "^0.21.1",
+    "@druid-toolkit/query": "^0.21.4",
     "@druid-toolkit/visuals-core": "^0.3.3",
     "@druid-toolkit/visuals-react": "^0.3.3",
     "ace-builds": "~1.4.14",


### PR DESCRIPTION
Use `IS NOT DISTINCT FROM` (added in https://github.com/apache/druid/pull/14976) where appropriate instead of hacky cast-based workaround.