### PR TITLE
Optimize mark segments as unused

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -141,6 +141,10 @@ public class SqlSegmentsMetadataQuery
   /**
    * Marks the provided segments as either used or unused.
    *
+   * For better performance, please try to
+   * 1) ensure that the caller passes only used segments to this method when marking them as unused.
+   * 2) Similarly, please try to call this method only on unused segments when marking segments as used with this method.
+   *
    * Returns the number of segments actually modified.
    */
   public int markSegments(final Collection<SegmentId> segmentIds, final boolean used)
@@ -176,7 +180,7 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
-   * Marks all segments for a datasource unused that are *fully contained by* a particular interval.
+   * Marks all used segments that are *fully contained by* a particular interval as unused.
    *
    * Returns the number of segments actually modified.
    */
@@ -186,7 +190,8 @@ public class SqlSegmentsMetadataQuery
       return handle
           .createStatement(
               StringUtils.format(
-                  "UPDATE %s SET used=:used, used_status_last_updated = :used_status_last_updated WHERE dataSource = :dataSource",
+                  "UPDATE %s SET used=:used, used_status_last_updated = :used_status_last_updated "
+                  + "WHERE dataSource = :dataSource AND used = true",
                   dbTables.getSegmentsTable()
               )
           )
@@ -202,7 +207,8 @@ public class SqlSegmentsMetadataQuery
       return handle
           .createStatement(
               StringUtils.format(
-                  "UPDATE %s SET used=:used, used_status_last_updated = :used_status_last_updated WHERE dataSource = :dataSource AND %s",
+                  "UPDATE %s SET used=:used, used_status_last_updated = :used_status_last_updated "
+                  + "WHERE dataSource = :dataSource AND used = true AND %s",
                   dbTables.getSegmentsTable(),
                   IntervalMode.CONTAINS.makeSqlCondition(connector.getQuoteString(), ":start", ":end")
               )


### PR DESCRIPTION
Currently marking segments as unused modifies `used` and `used_status_last_updated` for every segment and this can be inefficient when kill is enabled after there are a lot of accumulated unused segments. This could potentially time out as well causing KillTask failures.

This PR helps mitigate the issue by modifying only those rows which have used = true when marking them unused.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
