### PR TITLE
Document Nuances in SegmentMetadataCache Behaviour

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -90,9 +90,18 @@ import java.util.stream.StreamSupport;
  * An abstract class that listens for segment change events and caches segment metadata. It periodically refreshes
  * the segments, by fetching their metadata which includes schema information from sources like
  * data nodes, tasks, metadata database and builds table schema.
- *
- * <p>This class has an abstract method {@link #refresh(Set, Set)} which the child class must override
- * with the logic to build and cache table schema.</p>
+ * <p>
+ * At startup, the cache awaits the initialization of the timeline.
+ * If the cahce uses a segment metadata query to fetch segment schema,
+ * it attempts to refresh segments in batches of {@code MAX_SEGMENTS_PER_QUERY} for each datasource.
+ * Once all datasources have undergone this process, the initial schema of each datasource is constructed,
+ * and the cache is marked as initialized.
+ * Subsequently, the cache continues to periodically refresh segments and update the datasource schema.
+ * It is also important to note that a failure in segment refresh results in pausing the refresh work,
+ * and the process is resumed in the next refresh cycle.
+ * <p>
+ * This class has an abstract method {@link #refresh(Set, Set)} which the child class must override
+ * with the logic to build and cache table schema.
  *
  * @param <T> The type of information associated with the data source, which must extend {@link DataSourceInformation}.
  */

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -92,7 +92,7 @@ import java.util.stream.StreamSupport;
  * data nodes, tasks, metadata database and builds table schema.
  * <p>
  * At startup, the cache awaits the initialization of the timeline.
- * If the cahce uses a segment metadata query to fetch segment schema,
+ * If the cache uses a segment metadata query to fetch segment schema,
  * it attempts to refresh segments in batches of {@code MAX_SEGMENTS_PER_QUERY} for each datasource.
  * Once all datasources have undergone this process, the initial schema of each datasource is constructed,
  * and the cache is marked as initialized.

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -93,7 +93,7 @@ import java.util.stream.StreamSupport;
  * <p>
  * At startup, the cache awaits the initialization of the timeline.
  * If the cache uses a segment metadata query to fetch segment schema,
- * it attempts to refresh segments in batches of {@code MAX_SEGMENTS_PER_QUERY} for each datasource.
+ * it attempts to refresh a maximum of {@code MAX_SEGMENTS_PER_QUERY} segments for each datasource.
  * Once all datasources have undergone this process, the initial schema of each datasource is constructed,
  * and the cache is marked as initialized.
  * Subsequently, the cache continues to periodically refresh segments and update the datasource schema.

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -92,8 +92,8 @@ import java.util.stream.StreamSupport;
  * data nodes, tasks, metadata database and builds table schema.
  * <p>
  * At startup, the cache awaits the initialization of the timeline.
- * If the cache uses a segment metadata query to fetch segment schema,
- * it attempts to refresh a maximum of {@code MAX_SEGMENTS_PER_QUERY} segments for each datasource.
+ * If the cache employs a segment metadata query to retrieve segment schema, it attempts to refresh a maximum
+ * of {@code MAX_SEGMENTS_PER_QUERY} segments for each datasource in each refresh cycle.
  * Once all datasources have undergone this process, the initial schema of each datasource is constructed,
  * and the cache is marked as initialized.
  * Subsequently, the cache continues to periodically refresh segments and update the datasource schema.


### PR DESCRIPTION
This change documents the behaviour of SegmentMetadataCache when it uses segment metadata query to 
fetch segment schema.