### PR TITLE
Fix cancellation bug in MSQ.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernel.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernel.java
@@ -664,21 +664,23 @@ public class ControllerQueryKernel
    */
   public List<WorkOrder> getWorkInCaseWorkerEligibleForRetryElseThrow(int workerNumber, MSQFault msqFault)
   {
+    if (isRetriableFault(msqFault)) {
+      return getWorkInCaseWorkerEligibleForRetry(workerNumber);
+    } else {
+      throw new MSQException(msqFault);
+    }
+  }
 
+  public static boolean isRetriableFault(MSQFault msqFault)
+  {
     final String errorCode;
     if (msqFault instanceof WorkerFailedFault) {
       errorCode = MSQFaultUtils.getErrorCodeFromMessage((((WorkerFailedFault) msqFault).getErrorMsg()));
     } else {
       errorCode = msqFault.getErrorCode();
     }
-
-    log.info("Parsed out errorCode[%s] to check eligibility for retry", errorCode);
-
-    if (RETRIABLE_ERROR_CODES.contains(errorCode)) {
-      return getWorkInCaseWorkerEligibleForRetry(workerNumber);
-    } else {
-      throw new MSQException(msqFault);
-    }
+    log.debug("Parsed out errorCode[%s] to check eligibility for retry", errorCode);
+    return RETRIABLE_ERROR_CODES.contains(errorCode);
   }
 
   /**


### PR DESCRIPTION
Saw bug where MSQ controller task would continue to hold the task slot even after cancel was issued. 
This was due to a deadlock created on work launch. The main thread was waiting for tasks to spawn and the cancel thread was waiting for tasks to finish. 
The fix was to instruct the `MSQWorkerTaskLauncher` thread to stop creating new tasks which would enable the main thread to unblock and release the slot. 

Also short circuited the taskRetriable condition. Now the check is run in the `MSQWorkerTaskLauncher` thread as opposed to the main event thread loop. This will result in faster task failure in case the task is deemed to be non retriable. 


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
