### PR TITLE
Addressing a Flaky test in `testAPIs()`

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -66,6 +66,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -337,11 +338,14 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         .stream()
         .filter(entry -> !runningSpecs.containsKey(entry.getKey()))
         .map(entry -> entry.getValue().getSpec())
+        .sorted(Comparator.comparing(SubTaskSpec::getId))
         .collect(Collectors.toList());
 
     response = task.getCompleteSubTaskSpecs(newRequest());
     Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(completeSubTaskSpecs, response.getEntity());
+    List<SubTaskSpec<SinglePhaseSubTask>> actual = (List<SubTaskSpec<SinglePhaseSubTask>>) response.getEntity();
+    actual.sort(Comparator.comparing(SubTaskSpec::getId));
+    Assert.assertEquals(completeSubTaskSpecs, actual);
 
     // subTaskSpec
     final String subTaskId = runningSpecs.keySet().iterator().next();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Issue Description

This PR intends to fix a flaky test identified in `org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest.testAPIs`.

- In the `checkState()` method, The use of `entrySet()` does not guarantee the order of elements will be saved in `completeSubTaskSpecs`.
- As a result, the assertion between `completeSubTaskSpecs` and `response.getEntity()` can fail if the order in which elements are stored in `response`.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->
### Patch Description:
- In order to eliminate the non-determinism introduced by `entrySet()`, we can sort `expectedSubTaskStateResponses` using the id.
- In `response`, there is no guarantee that the order of elements will be maintained.
- Thus, we introduce a sorting using `Id` and save it in an `actual` list.
- In the assertion, we compare the two sorted entities to ensure that the expected elements are present and remove the emphasis on receiving elements in the correct order.

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->
I used a tool called [NonDex](https://github.com/TestingResearchIllinois/NonDex) to confirm the presence of flakiness.

### Steps to verify using NonDex:
1. Run `mvn -pl indexing-service edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest#testAPIs`.
2. This execution will throw the following error in a few shuffles:

  ```
  [ERROR] Failures: 
[ERROR] org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest.testAPIs
[ERROR]   Run 1: ParallelIndexSupervisorTaskResourceTest.testAPIs:215->checkState:344 expected:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5f3e180f, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@6c3b6532, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@30a49557, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@72919b7, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@28f8973d, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@1fdd65e5, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@b475564, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@446c111a, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@284137d5]> but was:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@6c3b6532, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@28f8973d, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@72919b7, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@30a49557, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@284137d5, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@446c111a, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5f3e180f, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@1fdd65e5, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@b475564]>
[ERROR]   Run 2: ParallelIndexSupervisorTaskResourceTest.testAPIs:199->checkState:344 expected:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@558c4386, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@51b3cdef]> but was:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@51b3cdef, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@558c4386]>
[ERROR]   Run 3: ParallelIndexSupervisorTaskResourceTest.testAPIs:215->checkState:344 expected:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@7f4a3c6f, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@7b75a75e, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@3e773654, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@21847108, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@f838813, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@599a91ea, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5e58c91b, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5cd6ffe9, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@4f063770]> but was:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@7b75a75e, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@7f4a3c6f, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@4f063770, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@21847108, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@3e773654, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5cd6ffe9, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@f838813, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5e58c91b, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@599a91ea]>
[ERROR]   Run 4: ParallelIndexSupervisorTaskResourceTest.testAPIs:199->checkState:344 expected:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@167c287, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5585673]> but was:<[org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@5585673, org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest$TestSubTaskSpec@167c287]>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
  ```
  
With the patch, `mvn -pl indexing-service edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskResourceTest#testAPIs -DnondexRuns=100` can be executed to check the resilience of the patch across multiple shuffles.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Addressed a minor flakiness in `testAPIs()`.
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.