### PR TITLE
Fetch active task payloads from memory

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -947,6 +947,25 @@ public class TaskQueue
     return stats;
   }
 
+  public Optional<Task> getTask(String id)
+  {
+    Task activeTask;
+
+    giant.lock();
+    try {
+      activeTask = tasks.get(id);
+    }
+    finally {
+      giant.unlock();
+    }
+
+    if (activeTask == null) {
+      return taskStorage.getTask(id);
+    } else {
+      return Optional.of(activeTask);
+    }
+  }
+
   @VisibleForTesting
   List<Task> getTasks()
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -947,22 +947,14 @@ public class TaskQueue
     return stats;
   }
 
-  public Optional<Task> getTask(String id)
+  public Optional<Task> getActiveTask(String id)
   {
-    Task activeTask;
-
     giant.lock();
     try {
-      activeTask = tasks.get(id);
+      return Optional.fromNullable(tasks.get(id));
     }
     finally {
       giant.unlock();
-    }
-
-    if (activeTask == null) {
-      return taskStorage.getTask(id);
-    } else {
-      return Optional.of(activeTask);
     }
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -104,7 +104,14 @@ public class TaskStorageQueryAdapter
 
   public Optional<Task> getTask(final String taskid)
   {
-    return storage.getTask(taskid);
+    // Try to fetch active task from memory
+    final Task activeTask = taskLockbox.getActiveTask(taskid);
+    if (activeTask != null) {
+      return Optional.of(activeTask);
+    } else {
+      // fallback to db
+      return storage.getTask(taskid);
+    }
   }
 
   public Optional<TaskStatus> getStatus(final String taskid)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -48,12 +48,14 @@ public class TaskStorageQueryAdapter
 {
   private final TaskStorage storage;
   private final TaskLockbox taskLockbox;
+  private final Optional<TaskQueue> taskQueue;
 
   @Inject
-  public TaskStorageQueryAdapter(TaskStorage storage, TaskLockbox taskLockbox)
+  public TaskStorageQueryAdapter(TaskStorage storage, TaskLockbox taskLockbox, TaskMaster taskMaster)
   {
     this.storage = storage;
     this.taskLockbox = taskLockbox;
+    this.taskQueue = taskMaster.getTaskQueue();
   }
 
   public List<Task> getActiveTasks()
@@ -104,12 +106,9 @@ public class TaskStorageQueryAdapter
 
   public Optional<Task> getTask(final String taskid)
   {
-    // Try to fetch active task from memory
-    final Task activeTask = taskLockbox.getActiveTask(taskid);
-    if (activeTask != null) {
-      return Optional.of(activeTask);
+    if (taskQueue.isPresent()) {
+      return taskQueue.get().getTask(taskid);
     } else {
-      // fallback to db
       return storage.getTask(taskid);
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -107,10 +107,12 @@ public class TaskStorageQueryAdapter
   public Optional<Task> getTask(final String taskid)
   {
     if (taskQueue.isPresent()) {
-      return taskQueue.get().getTask(taskid);
-    } else {
-      return storage.getTask(taskid);
+      Optional<Task> activeTask = taskQueue.get().getActiveTask(taskid);
+      if (activeTask.isPresent()) {
+        return activeTask;
+      }
     }
+    return storage.getTask(taskid);
   }
 
   public Optional<TaskStatus> getStatus(final String taskid)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -482,7 +482,10 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
       default:
         throw new RE("Unknown task storage type [%s]", taskStorageType);
     }
-    tsqa = new TaskStorageQueryAdapter(taskStorage, taskLockbox);
+    TaskMaster taskMaster = EasyMock.createMock(TaskMaster.class);
+    EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.absent()).anyTimes();
+    EasyMock.replay(taskMaster);
+    tsqa = new TaskStorageQueryAdapter(taskStorage, taskLockbox, taskMaster);
     return taskStorage;
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -257,7 +257,7 @@ public class OverlordTest
     Assert.assertEquals(taskMaster.getCurrentLeader(), druidNode.getHostAndPort());
     Assert.assertEquals(Optional.absent(), taskMaster.getRedirectLocation());
 
-    final TaskStorageQueryAdapter taskStorageQueryAdapter = new TaskStorageQueryAdapter(taskStorage, taskLockbox);
+    final TaskStorageQueryAdapter taskStorageQueryAdapter = new TaskStorageQueryAdapter(taskStorage, taskLockbox, taskMaster);
     final WorkerTaskRunnerQueryAdapter workerTaskRunnerQueryAdapter = new WorkerTaskRunnerQueryAdapter(taskMaster, null);
     // Test Overlord resource stuff
     overlordResource = new OverlordResource(


### PR DESCRIPTION
The TaskQueue maintains a map of active task ids to tasks, which can be utilized to get active task payloads, before falling back to the metadata store.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
