### PR TITLE
Make `numCorePartitions` as 0 for tombstones

### DIFF
--- a/processing/src/main/java/org/apache/druid/timeline/partition/TombstoneShardSpec.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/TombstoneShardSpec.java
@@ -69,7 +69,7 @@ public class TombstoneShardSpec implements ShardSpec
   @JsonProperty("partitions")
   public int getNumCorePartitions()
   {
-    return 1;
+    return 0;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/timeline/partition/TombstoneShardSpec.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/TombstoneShardSpec.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A shard spec to represent tombstones. Its partition number is always zero and contains 1 core partitions.
+ * A shard spec to represent tombstones. Its partition number is always zero and contains zero core partitions as it
+ * contains no data. This allows other shard types appending to an existing {@link TombstoneShardSpec} to exist independently
+ * in the timeline even if the {@link TombstoneShardSpec} is dropped.
  */
 public class TombstoneShardSpec implements ShardSpec
 {
@@ -88,8 +90,8 @@ public class TombstoneShardSpec implements ShardSpec
   public String toString()
   {
     return "TombstoneShardSpec{" +
-           "partitionNum=" + 0 +
-           ", partitions=" + 1 +
+           "partitionNum=" + getPartitionNum() +
+           ", partitions=" + getNumCorePartitions() +
            '}';
   }
 

--- a/processing/src/test/java/org/apache/druid/timeline/partition/TombstoneShardSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/partition/TombstoneShardSpecTest.java
@@ -60,7 +60,7 @@ public class TombstoneShardSpecTest
   @Test
   public void getNumCorePartitions()
   {
-    assertEquals(1, tombstoneShardSpec.getNumCorePartitions());
+    assertEquals(0, tombstoneShardSpec.getNumCorePartitions());
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -2961,25 +2961,18 @@ public class IndexerSQLMetadataStorageCoordinatorTest
     Assert.assertEquals(dataSegment, segmentTimeline.lookup(interval).get(0).getObject().getChunk(1).getObject());
   }
 
-  /**
-   * This tests the behavior of "old generation" tombstones with 1 core partition.
-   */
   @Test
   public void testTimelineWith1CorePartitionTombstone() throws IOException
   {
+    // Register the old generation tombstone spec for this test.
+    mapper.registerSubtypes(TombstoneShardSpecWith1CorePartition.class);
+
     final Interval interval = Intervals.of("2020/2021");
     // Create and commit an old generation tombstone with 1 core partition
     final DataSegment tombstoneSegment = createSegment(
         interval,
         "version",
-        new TombstoneShardSpec() {
-          @Override
-          @JsonProperty("partitions")
-          public int getNumCorePartitions()
-          {
-            return 1;
-          }
-        }
+        new TombstoneShardSpecWith1CorePartition()
     );
 
     final Set<DataSegment> tombstones = new HashSet<>(Collections.singleton(tombstoneSegment));
@@ -3074,5 +3067,18 @@ public class IndexerSQLMetadataStorageCoordinatorTest
           }
         }
     );
+  }
+
+  /**
+   * This test-only shard type is to test the behavior of "old generation" tombstones with 1 core partition.
+   */
+  private static class TombstoneShardSpecWith1CorePartition extends TombstoneShardSpec
+  {
+    @Override
+    @JsonProperty("partitions")
+    public int getNumCorePartitions()
+    {
+      return 1;
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

This PR changes the core partitions for tombstones to 0, so they can exist independently if they're deleted or marked as unused without affecting availability of other appended segments in the same co-partition space. This is particularly important in the following scenarios:
1. Concurrent replace and append to a datasource containing tombstones and data segments in the same time chunk (also, related coordinator duty: https://github.com/apache/druid/pull/15281)
2. If a user drops a tombstone segment and there are other data segments appended to it, the data segments should still be available


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Tombstone segments have 0 core partitions. This means they can be dropped or removed independently without affecting availability of other appended segments in the same co-partition space. Note that removing tombstones with 1 core partition (prior to this change) that contain appended segments in the partition space can make the appended segments unavailable.

<hr>

##### Key changed/added classes in this PR
 * `TombstoneShardSpec.java`
 * `IndexerSQLMetadataStorageCoordinatorTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
