### PR TITLE
fix physical memory detection on OSX

### DIFF
--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -362,7 +362,7 @@ def get_physical_memory_linux():
 
 def get_physical_memory_osx():
     p1 = subprocess.Popen(['sysctl', '-a'], stdout=subprocess.PIPE)
-    p2 = subprocess.check_output(['grep', 'hw.memsize'], stdin=p1.stdout)
+    p2 = subprocess.check_output(['grep', 'hw.memsize:'], stdin=p1.stdout)
     p2 = p2.decode('utf-8')
     fields = p2.split(':')
 
@@ -394,7 +394,7 @@ def convert_total_memory_string(memory):
             physical_memory = get_physical_memory()
 
             if physical_memory is None:
-                raise ValueError('Please specify memory argument')
+                raise ValueError('Could not automatically determine memory size. Please explitly specify the memory argument as --memory=<integer_value><m/g>')
 
             return physical_memory
         elif memory.endswith(MEM_MB_SUFFIX):

--- a/examples/bin/start-druid-main.py
+++ b/examples/bin/start-druid-main.py
@@ -394,7 +394,7 @@ def convert_total_memory_string(memory):
             physical_memory = get_physical_memory()
 
             if physical_memory is None:
-                raise ValueError('Could not automatically determine memory size. Please explitly specify the memory argument as --memory=<integer_value><m/g>')
+                raise ValueError('Could not automatically determine memory size. Please explicitly specify the memory argument as --memory=<integer_value><m/g>')
 
             return physical_memory
         elif memory.endswith(MEM_MB_SUFFIX):


### PR DESCRIPTION
I just upgraded my Mac to MacOS Sonoma and I am unable to start Druid with `bin/start-druid`

![image](https://github.com/apache/druid/assets/177816/6e3ccb40-73aa-40c8-90d0-ace790c3bde6)

This is due to the fact that the starter script can not detect the physical memory on my machine.
The physical memory is detected by doing `sysctl -a | grep hw.memsize` which for me now returns 2 values:

![image](https://github.com/apache/druid/assets/177816/3332eee4-c399-45b2-9682-2a37ead38acb)

I am guessing that "hw.memsize_usable" was added in MacOS Sonoma as previously it worked.

The script then does a `split(':')` which for me produces `['hw.memsize', ' 68719476736\nhw.memsize_usable', ' 68719476736\n']`

and the `[1]` index can not be parsed as a number.

I am fixing this by instead greping for `sysctl -a | grep hw.memsize:` the added `:` means that it should only match one line and is generally more robust.

I also rewrote the error message to be better, the original `Please specify memory argument` was accurate but confused me.