### PR TITLE
resolve multiple CVEs

### DIFF
--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -20,6 +20,7 @@ import os
 import sys
 from html.parser import HTMLParser
 import argparse
+#import json
 
 class DependencyReportParser(HTMLParser):
     # This class parses the given html file to find all dependency reports under "Project dependencies"
@@ -202,8 +203,20 @@ class DependencyReportParser(HTMLParser):
 
     def set_license(self, data):
         if data.upper().find("GPL") < 0:
-            if self.license != 'Apache License version 2.0':
-                self.license = self.compatible_license_names[data]
+            # Check if the license assosciated with the component is acccepted
+            # set_license() will pick the first acceptable license
+            # this fixes issue where a multi-licensed component
+            # could override accepted license with not accepted one
+            # e.g., EPL / GPL for logback-core
+            if self.license not in self.compatible_license_names:
+                try:
+                    self.license = self.compatible_license_names[data]
+                except:
+                    print("Unsupported license: " + data)
+                    print("For:" +  self.group_id + " "  + self.artifact_id + " in: "+ self.druid_module_name)
+                    sys.exit(1)
+            else:
+                print(self.group_id + " "  + self.artifact_id + " in: " + self.druid_module_name + " with: " + self.license + " ignoring " + data)
 
 
 def print_log_to_stderr(string):

--- a/distribution/bin/check-licenses.py
+++ b/distribution/bin/check-licenses.py
@@ -211,10 +211,9 @@ class DependencyReportParser(HTMLParser):
             if self.license not in self.compatible_license_names:
                 try:
                     self.license = self.compatible_license_names[data]
-                except:
+                except KeyError:
                     print("Unsupported license: " + data)
                     print("For:" +  self.group_id + " "  + self.artifact_id + " in: "+ self.druid_module_name)
-                    sys.exit(1)
             else:
                 print(self.group_id + " "  + self.artifact_id + " in: " + self.druid_module_name + " with: " + self.license + " ignoring " + data)
 

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
-    <confluent.version>5.5.12</confluent.version>
+    <confluent.version>6.2.12</confluent.version>
   </properties>
 
   <repositories>

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -133,6 +133,10 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -41,6 +41,11 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>6.4.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bundle</artifactId>
+                <version>${aws.sdk.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -37,16 +37,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.elasticsearch</groupId>
-                <artifactId>elasticsearch</artifactId>
-                <version>7.17.15</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>elasticsearch-rest-client</artifactId>
-                <version>7.17.15</version>
-            </dependency>
-            <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
                 <version>6.4.0</version>

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -34,6 +34,25 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>7.17.15</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>7.17.15</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>6.4.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>19.0.0</kubernetes.client.version>
+    <kubernetes.client.version>16.0.3</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -68,6 +68,7 @@
       <version>${kubernetes.client.version}</version>
     </dependency>
 
+
     <!-- Tests -->
     <dependency>
       <groupId>junit</groupId>
@@ -125,6 +126,18 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+        <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-dependency-plugin</artifactId>
+              <version>3.1.1</version>
+              <configuration>
+                <ignoredDependencies>io.kubernetes:client-java-api-fluent:jar:19.0.0</ignoredDependencies>
+              </configuration>
+          </plugin>
+        </plugins>
+  </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -80,18 +80,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Version override to address CVE-2020-28052 -->
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-ext-jdk18on</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
     <!-- others -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -67,11 +67,6 @@
       <artifactId>client-java-api</artifactId>
       <version>${kubernetes.client.version}</version>
     </dependency>
-    <dependency>
-    <groupId>io.kubernetes</groupId>
-    <artifactId>client-java-api-fluent</artifactId>
-    <version>${kubernetes.client.version}</version>
-  </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>client-java-api</artifactId>
       <version>${kubernetes.client.version}</version>
     </dependency>
+    <dependency>
+    <groupId>io.kubernetes</groupId>
+    <artifactId>client-java-api-fluent</artifactId>
+    <version>${kubernetes.client.version}</version>
+  </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>16.0.3</kubernetes.client.version>
+    <kubernetes.client.version>11.0.4</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>11.0.4</kubernetes.client.version>
+    <kubernetes.client.version>19.0.0</kubernetes.client.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <kubernetes.client.version>11.0.4</kubernetes.client.version>
+    <kubernetes.client.version>19.0.0</kubernetes.client.version>
   </properties>
 
   <dependencies>
@@ -83,12 +83,12 @@
     <!-- Version override to address CVE-2020-28052 -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-ext-jdk15on</artifactId>
+      <artifactId>bcprov-ext-jdk18on</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -65,7 +65,7 @@ public class DefaultK8sApiClient implements K8sApiClient
   public void patchPod(String podName, String podNamespace, String jsonPatchStr)
   {
     try {
-      coreV1Api.patchNamespacedPod(podName, podNamespace, new V1Patch(jsonPatchStr), "true", null, null, null);
+      coreV1Api.patchNamespacedPod(podName, podNamespace, new V1Patch(jsonPatchStr), "true", null, null, null, false);
     }
     catch (ApiException ex) {
       throw new RE(ex, "Failed to patch pod[%s/%s], code[%d], error[%s].", podNamespace, podName, ex.getCode(), ex.getResponseBody());
@@ -80,7 +80,7 @@ public class DefaultK8sApiClient implements K8sApiClient
   )
   {
     try {
-      V1PodList podList = coreV1Api.listNamespacedPod(podNamespace, null, null, null, null, labelSelector, 0, null, null, null, null);
+      V1PodList podList = coreV1Api.listNamespacedPod(podNamespace, null, null, null, null, labelSelector, 0, null, null, null, null, false);
       Preconditions.checkState(podList != null, "WTH: NULL podList");
 
       Map<String, DiscoveryDruidNode> allNodes = new HashMap();
@@ -114,7 +114,7 @@ public class DefaultK8sApiClient implements K8sApiClient
           Watch.createWatch(
               realK8sClient,
               coreV1Api.listNamespacedPodCall(namespace, null, true, null, null,
-                                              labelSelector, null, lastKnownResourceVersion, null, 0, true, null
+                                              labelSelector, null, lastKnownResourceVersion, null, false, 0, true, null
               ),
               new TypeReference<Watch.Response<V1Pod>>()
               {

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -114,7 +114,7 @@ public class DefaultK8sApiClient implements K8sApiClient
           Watch.createWatch(
               realK8sClient,
               coreV1Api.listNamespacedPodCall(namespace, null, true, null, null,
-                                              labelSelector, null, lastKnownResourceVersion, null, false, 0, true, null
+                                              labelSelector, null, lastKnownResourceVersion, null, true, 0, true, null
               ),
               new TypeReference<Watch.Response<V1Pod>>()
               {

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -884,26 +884,44 @@ license_name: Apache License version 2.0
 version: 19.0.0
 libraries:
   - io.kubernetes: client-java
-
----
-
-name: kubernetes official java client api
-license_category: binary
-module: extensions/druid-kubernetes-extensions
-license_name: Apache License version 2.0
-version: 19.0.0
-libraries:
   - io.kubernetes: client-java-api
+  - io.kubernetes: client-java-extended
+  - io.kubernetes: client-java-extended
+  - io.kubernetes: client-java-api-fluent
+  - io.kubernetes: client-java-proto
 
 ---
 
-name: kubernetes official java client extended
+name: Jetbrains Annotations
 license_category: binary
-module: extensions/druid-kubernetes-extensions
+module: extensions/kubernetes-extensions
 license_name: Apache License version 2.0
-version: 19.0.0
+version: 13.0.0
 libraries:
-  - io.kubernetes: client-java-extended
+  - org.jetbrains: annotations
+
+---
+
+name: Jetbrains stdlib
+license_category: binary
+module: extensions/kubernetes-extensions
+license_name: Apache License version 2.0
+version: 1.4.32
+libraries:
+  - org.jetbrains.kotlin: kotlin-stdlib
+  - org.jetbrains.kotlin: kotlin-stdlib-common
+
+
+---
+
+name: Jetbrains  jdk7 jdk 8
+license_category: binary
+module: extensions/kubernetes-extensions
+license_name: Apache License version 2.0
+version: 1.6.20
+libraries:
+  - org.jetbrains.kotlin: kotlin-stdlib-jdk7
+  - org.jetbrains.kotlin: kotlin-stdlib-jdk8
 
 ---
 
@@ -917,13 +935,18 @@ libraries:
 
 ---
 
-name: io.prometheus simpleclient_common
+name: io.prometheus
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.9.0
+version: 0.16.0
 libraries:
+  - io.prometheus: simpleclient
   - io.prometheus: simpleclient_common
+  - io.prometheus: simpleclient_httpserver
+  - io.prometheus: simpleclient_tracer_common
+  - io.prometheus: simpleclient_tracer_otel
+  - io.prometheus: simpleclient_tracer_otel_agent
 
 ---
 
@@ -951,10 +974,10 @@ name: com.squareup.okio okio
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 1.17.2
+version: 3.2.0
 libraries:
   - com.squareup.okio: okio
-
+  - com.squareup.okio: okio-jvm
 ---
 
 name: io.gsonfire gson-fire
@@ -971,7 +994,7 @@ name: io.swagger swagger-annotations
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 1.6.2
+version: 1.6.11
 libraries:
   - io.swagger: swagger-annotations
 
@@ -984,16 +1007,6 @@ license_name: Apache License version 2.0
 version: 2.8.6
 libraries:
   - com.google.code.gson: gson
-
----
-
-name: io.prometheus simpleclient_httpserver
-license_category: binary
-module: extensions/druid-kubernetes-extensions
-license_name: Apache License version 2.0
-version: 0.9.0
-libraries:
-  - io.prometheus: simpleclient_httpserver
 
 ---
 
@@ -1021,19 +1034,10 @@ name: com.squareup.okhttp3 okhttp
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 3.14.9
+version: 4.11.0
 libraries:
   - com.squareup.okhttp3: okhttp
-
----
-
-name: io.prometheus simpleclient
-license_category: binary
-module: extensions/druid-kubernetes-extensions
-license_name: Apache License version 2.0
-version: 0.9.0
-libraries:
-  - io.prometheus: simpleclient
+  - com.squareup.okhttp3: logging-interceptor
 
 ---
 
@@ -1061,7 +1065,7 @@ name: com.flipkart.zjsonpatch zjsonpatch
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.4.11
+version: 0.4.14
 libraries:
   - com.flipkart.zjsonpatch: zjsonpatch
 
@@ -1177,21 +1181,11 @@ libraries:
 
 ---
 
-name: com.squareup.okhttp3 logging-interceptor
-license_category: binary
-module: extensions/druid-kubernetes-extensions
-license_name: Apache License version 2.0
-version: 3.14.9
-libraries:
-  - com.squareup.okhttp3: logging-interceptor
-
----
-
 name: com.github.vladimir-bukhtoyarov bucket4j-core
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 4.10.0
+version: 7.6.0
 libraries:
   - com.github.vladimir-bukhtoyarov: bucket4j-core
 
@@ -2010,7 +2004,7 @@ name: Apache Yetus Audience Annotations Component
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 0.5.0
+version: 0.12.0
 libraries:
   - org.apache.yetus: audience-annotations
 notices:
@@ -2061,6 +2055,17 @@ notice: |
 
   For additional credits (generally to people who reported problems)
   see CREDITS file.
+
+---
+
+name: ch.qos.logback
+license_category: binary
+module: core
+license_name: Eclipse Public License 1.0
+version: 1.2.10
+libraries:
+  - ch.qos.logback: logback-classic
+  - ch.qos.logback: logback-core
 
 ---
 
@@ -2989,7 +2994,7 @@ notices:
 name: JTS
 license_category: binary
 module: java-core
-license_name: Eclipse Distribution License 1.0
+license_name: Eclipse Public License 2.0
 version: 1.19.0
 libraries:
   - org.locationtech.jts: jts-core
@@ -2997,9 +3002,9 @@ libraries:
 notices:
   - jts-core: |
       The JTS Topology Suite is a Java library for creating and manipulating vector geometry.
-      Eclipse Distribution License 1.0
+      Eclipse Public License 2.0
   - jts-io-common: |
-      Eclipse Distribution License 1.0
+      Eclipse Public License 2.0
 ---
 
 name: Apache Avro
@@ -3214,7 +3219,7 @@ libraries:
 ---
 
 name: Kafka clients
-version: 5.5.12-ccs
+version: 6.2.12-ccs
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3223,7 +3228,7 @@ libraries:
 
 ---
 name: Kafka-schema-registry-client
-version: 5.5.12
+version: 6.2.12
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3677,6 +3682,16 @@ license_category: binary
 module: extensions/protobuf-extensions
 license_name: Apache License version 2.0
 version: 2.8.9
+libraries:
+  - com.google.code.gson: gson
+
+---
+
+name: Gson
+license_category: binary
+module: extensions/kubernetes-extensions
+license_name: Apache License version 2.0
+version: 2.10.1
 libraries:
   - com.google.code.gson: gson
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -365,7 +365,7 @@ name: Guava
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 32.1.3-jre
+version: 32.0.1-jre
 libraries:
   - com.google.guava: guava
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -881,7 +881,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 19.0.0
+version: 11.0.4
 libraries:
   - io.kubernetes: client-java
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -896,7 +896,7 @@ name: Jetbrains Annotations
 license_category: binary
 module: extensions/kubernetes-extensions
 license_name: Apache License version 2.0
-version: 13.0.0
+version: 13.0
 libraries:
   - org.jetbrains: annotations
 
@@ -993,6 +993,16 @@ libraries:
 name: io.swagger swagger-annotations
 license_category: binary
 module: extensions/druid-kubernetes-extensions
+license_name: Apache License version 2.0
+version: 1.6.2
+libraries:
+  - io.swagger: swagger-annotations
+
+---
+
+name: io.swagger swagger-annotations
+license_category: binary
+module: extensions/protobuf-extensions
 license_name: Apache License version 2.0
 version: 1.6.11
 libraries:
@@ -2005,6 +2015,19 @@ license_category: binary
 module: java-core
 license_name: Apache License version 2.0
 version: 0.12.0
+libraries:
+  - org.apache.yetus: audience-annotations
+notices:
+  - audience-annotations: |
+      Apache Yetus - Audience Annotations
+      Copyright 2015-2017 The Apache Software Foundation
+---
+
+name: Apache Yetus Audience Annotations Component
+license_category: binary
+module: java-core
+license_name: Apache License version 2.0
+version: 0.5.0
 libraries:
   - org.apache.yetus: audience-annotations
 notices:
@@ -4741,7 +4764,7 @@ libraries:
 
 ---
 
-name: Apache Lucene 
+name: Apache Lucene
 license_category: binary
 version: 8.4.0
 module: druid-ranger-security
@@ -4777,7 +4800,7 @@ libraries:
 
 name: Elastic Search
 license_category: binary
-version: 7.10.2
+version: 7.17.15
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:
@@ -4835,7 +4858,7 @@ libraries:
 
 name: Woodstox
 license_category: binary
-version: 6.2.4
+version: 6.4.0
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -289,7 +289,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7.20221012
+version: 2.12.7.1
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -655,7 +655,7 @@ name: Apache Commons Compress
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.23.0
+version: 1.24.0
 libraries:
   - org.apache.commons: commons-compress
 notices:
@@ -891,7 +891,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 16.0.3
+version: 11.0.4
 libraries:
   - io.kubernetes: client-java-api
 
@@ -901,7 +901,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 19.0.0
+version: 11.0.4
 libraries:
   - io.kubernetes: client-java-extended
 
@@ -1124,6 +1124,46 @@ license_name: MIT License
 version: "1.77"
 libraries:
   - org.bouncycastle: bcutil-jdk18on
+
+---
+
+name: org.bouncycastle bcprov-jdk15on
+license_category: binary
+module: extensions/druid-kubernetes-extensions
+license_name: MIT License
+version: "1.70"
+libraries:
+  - org.bouncycastle: bcprov-jdk15on
+
+---
+
+name: org.bouncycastle bcprov-ext-jdk15on
+license_category: binary
+module: extensions/druid-kubernetes-extensions
+license_name: MIT License
+version: "1.70"
+libraries:
+  - org.bouncycastle: bcprov-ext-jdk15on
+
+---
+
+name: org.bouncycastle bcpkix-jdk15on
+license_category: binary
+module: extensions/druid-kubernetes-extensions
+license_name: MIT License
+version: "1.70"
+libraries:
+  - org.bouncycastle: bcpkix-jdk15on
+
+---
+
+name: org.bouncycastle bcutil-jdk15on
+license_category: binary
+module: extensions/druid-kubernetes-extensions
+license_name: MIT License
+version: "1.70"
+libraries:
+  - org.bouncycastle: bcutil-jdk15on
 
 ---
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -365,7 +365,7 @@ name: Guava
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 32.0.1-jre
+version: 31.1-jre
 libraries:
   - com.google.guava: guava
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -199,6 +199,7 @@ libraries:
   - com.amazonaws: aws-java-sdk-sts
   - com.amazonaws: aws-java-sdk-rds
   - com.amazonaws: jmespath-java
+  - com.amazonaws: aws-java-sdk-bundle
 notice: |
   AWS SDK for Java
   Copyright 2010-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -289,7 +289,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7
+version: 2.12.7.20221012
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -364,7 +364,7 @@ name: Guava
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 31.1-jre
+version: 32.1.3-jre
 libraries:
   - com.google.guava: guava
 
@@ -791,7 +791,7 @@ name: DropWizard Metrics Core
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.2.19
+version: 4.2.22
 libraries:
   - io.dropwizard.metrics: metrics-core
 
@@ -881,7 +881,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java
 
@@ -891,7 +891,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java-api
 
@@ -901,7 +901,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java-extended
 
@@ -1001,7 +1001,7 @@ name: org.bitbucket.b_c jose4j
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.7.3
+version: 0.9.3
 libraries:
   - org.bitbucket.b_c: jose4j
 
@@ -1087,43 +1087,43 @@ libraries:
 
 ---
 
-name: org.bouncycastle bcprov-jdk15on
+name: org.bouncycastle bcprov-jdk18on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: "1.70"
+version: "1.77"
 libraries:
-  - org.bouncycastle: bcprov-jdk15on
+  - org.bouncycastle: bcprov-jdk18on
 
 ---
 
-name: org.bouncycastle bcprov-ext-jdk15on
+name: org.bouncycastle bcprov-ext-jdk18on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: "1.70"
+version: "1.77"
 libraries:
-  - org.bouncycastle: bcprov-ext-jdk15on
+  - org.bouncycastle: bcprov-ext-jdk18on
 
 ---
 
-name: org.bouncycastle bcpkix-jdk15on
+name: org.bouncycastle bcpkix-jdk18on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: "1.70"
+version: "1.77"
 libraries:
-  - org.bouncycastle: bcpkix-jdk15on
+  - org.bouncycastle: bcpkix-jdk18on
 
 ---
 
-name: org.bouncycastle bcutil-jdk15on
+name: org.bouncycastle bcutil-jdk18on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: "1.70"
+version: "1.77"
 libraries:
-  - org.bouncycastle: bcutil-jdk15on
+  - org.bouncycastle: bcutil-jdk18on
 
 ---
 
@@ -3345,7 +3345,7 @@ name: Apache Avro
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
-version: 1.11.1
+version: 1.11.3
 libraries:
   - org.apache.avro: avro
   - org.apache.avro: avro-mapred

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -891,7 +891,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 19.0.0
+version: 16.0.3
 libraries:
   - io.kubernetes: client-java-api
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4800,7 +4800,7 @@ libraries:
 
 name: Elastic Search
 license_category: binary
-version: 7.17.15
+version: 7.10.2
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -881,7 +881,7 @@ name: kubernetes official java client
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java
 
@@ -891,7 +891,7 @@ name: kubernetes official java client api
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java-api
 
@@ -901,7 +901,7 @@ name: kubernetes official java client extended
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 11.0.4
+version: 19.0.0
 libraries:
   - io.kubernetes: client-java-extended
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -62,7 +62,6 @@
     <!-- This CVE affects the server -->
     <cve>CVE-2021-3563</cve>
   </suppress>
-
   <suppress>
     <notes><![CDATA[
      file name: json-path-2.3.0.jar
@@ -70,34 +69,6 @@
     <packageUrl regex="true">^pkg:maven/net\.minidev/json\-path@.*$</packageUrl>
     <cve>CVE-2022-45688</cve>
   </suppress>
-
-  <suppress>
-    <!--
-      the suppressions here aren't currently applicable, but can be resolved once we update the version
-      -->
-    <notes><![CDATA[
-   file name: jackson-databind-2.10.5.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <!-- CVE-2022-42003 and CVE-2022-42004 are related to UNWRAP_SINGLE_VALUE_ARRAYS which we do not use
-    https://nvd.nist.gov/vuln/detail/CVE-2022-42003
-    https://nvd.nist.gov/vuln/detail/CVE-2022-42004
-     -->
-    <cve>CVE-2022-42003</cve>
-    <cve>CVE-2022-42004</cve>
-  </suppress>
-
-
-  <suppress>
-    <!-- Not much for us to do as a user of the client lib, and no patch is available,
-     see https://github.com/kubernetes/kubernetes/issues/97076 -->
-    <notes><![CDATA[
-   file name: client-java-10.0.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java.*@10.0.1$</packageUrl>
-    <cve>CVE-2020-8554</cve>
-  </suppress>
-
   <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->
   <suppress>
     <!--

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -87,15 +87,6 @@
     <cve>CVE-2022-42004</cve>
   </suppress>
 
-  <suppress>
-    <!-- Pulled in by io.kubernetes:client-java and kafka_2.13 but not fixed in either place yet -->
-    <!-- jose4j before v0.9.3 allows attackers to set a low iteration count of 1000 or less -->
-    <notes><![CDATA[
-    file name: jose4j-0.7.3.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.bitbucket\.b_c/jose4j@.*$</packageUrl>
-    <cve>CVE-2023-31582</cve>
-  </suppress>
 
   <suppress>
     <!-- Not much for us to do as a user of the client lib, and no patch is available,
@@ -769,7 +760,7 @@
     <cve>CVE-2023-37475</cve> <!-- Suppressing since CVE wrongly linked to apache:avro project - https://github.com/jeremylong/DependencyCheck/issues/5843 -->
     <cve>CVE-2023-39410</cve> <!-- This seems to be a legitimate vulnerability. But there is no fix as of yet in Hadoop repo -->
     <cve>CVE-2023-44487</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
-    <cve>CVE-2023-36478</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
+    <cve>CVE-2023-36478</cve> <!-- Fixed version of jetty is in use, but dependency check identifies pom -->
   </suppress>
   <suppress>
     <!-- from extensions using hadoop-client-api, these dependencies are shaded in the jar -->
@@ -854,5 +845,47 @@
       file name: jackson-databind-2.12.7.1.jar
      ]]></notes>
     <cve>CVE-2023-35116</cve>
+  </suppress>
+
+  <!-- False positives introduced in ranger 2.4 -->
+  <suppress>
+    <notes><![CDATA[
+      file name: kafka-clients-2.8.1.jar
+     ]]></notes>
+    <cve>CVE-2023-25194</cve>
+  </suppress>
+    <suppress>
+    <notes><![CDATA[
+      file name: spatial4j-0.7.jar
+     ]]></notes>
+    <cve>CVE-2014-125074</cve>
+  </suppress>
+    <suppress>
+    <notes><![CDATA[
+      file name: woodstox-core-6.4.0.jar
+     ]]></notes>
+    <cve>CVE-2023-34411</cve>
+  </suppress>
+  <!-- This is the last version of Elasticsearch code distributed under Apache 2 license -->
+  </suppress>
+    <suppress>
+    <notes><![CDATA[
+      file name: elasticsearch-rest-client-7.10.2.jar
+     ]]></notes>
+    <cve>CVE-2021-22145</cve>
+  </suppress>
+
+  </suppress>
+    <suppress>
+    <notes><![CDATA[
+      file name: elasticsearch-*7.10.2.jar
+     ]]></notes>
+    <cve>CVE-2023-31418</cve>
+    <cve>CVE-2021-22134</cve>
+    <cve>CVE-2021-22135</cve>
+    <cve>CVE-2021-22144</cve>
+    <cve>CVE-2023-31417</cve>
+    <cve>CVE-2023-31419</cve>
+    <cve>CVE-2023-46673</cve>
   </suppress>
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -791,7 +791,7 @@
 
   <suppress>
     <notes><![CDATA[
-      file name: okio-1.17.2.jar, okio-1.15.0.jar
+      file name: okio-1.17.2.jar, okio-1.15.0.jar okio-3.2.0.jar
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@1..*$</packageUrl>
     <cve>CVE-2023-3635</cve>  <!-- Suppressed since okio requests in Druid are internal, and not user-facing -->

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -793,7 +793,6 @@
     <notes><![CDATA[
       file name: okio-1.17.2.jar, okio-1.15.0.jar okio-3.2.0.jar
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio@1..*$</packageUrl>
     <cve>CVE-2023-3635</cve>  <!-- Suppressed since okio requests in Druid are internal, and not user-facing -->
   </suppress>
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -760,6 +760,7 @@
     <cve>CVE-2023-37475</cve> <!-- Suppressing since CVE wrongly linked to apache:avro project - https://github.com/jeremylong/DependencyCheck/issues/5843 -->
     <cve>CVE-2023-39410</cve> <!-- This seems to be a legitimate vulnerability. But there is no fix as of yet in Hadoop repo -->
     <cve>CVE-2023-44487</cve> <!-- Occurs in the version of Hadoop used by Jetty, but it hasn't been fixed by Hadoop yet-->
+    <cve>CVE-2023-36478</cve> <!-- Fixed version of jetty is in use, but dependency check identifies pom -->
   </suppress>
   <suppress>
     <!-- from extensions using hadoop-client-api, these dependencies are shaded in the jar -->

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -18,8 +18,161 @@
   ~ under the License.
   -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress>
+    <!-- druid-indexing-hadoop.jar is mistaken for hadoop -->
+    <notes><![CDATA[
+   file name: org.apache.druid:druid-indexing-hadoop
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.druid/druid\-indexing\-hadoop@.*$</packageUrl>
+    <cve>CVE-2012-4449</cve>
+    <cve>CVE-2017-3162</cve>
+    <cve>CVE-2018-8009</cve>
+    <cve>CVE-2022-26612</cve>
+  </suppress>
+  <suppress>
+    <!-- druid-processing.jar is mistaken for org.processing:processing -->
+    <notes><![CDATA[
+   file name: org.apache.druid:druid-processing
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.druid/druid\-processing@.*$</packageUrl>
+    <cve>CVE-2018-1000840</cve>
+  </suppress>
+  <suppress>
+    <!-- These CVEs are for the python SDK, but Druid uses the Java SDK -->
+    <notes><![CDATA[
+   file name: openstack-swift
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-swift@.*$</packageUrl>
+    <cve>CVE-2013-7109</cve>
+    <cve>CVE-2016-0737</cve>
+    <cve>CVE-2016-0738</cve>
+    <cve>CVE-2017-16613</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: openstack-keystone-1.9.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-keystone@.*$</packageUrl>
+    <!-- These CVEs are for the python SDK, but Druid uses the Java SDK -->
+    <cve>CVE-2015-7546</cve>
+    <cve>CVE-2020-12689</cve>
+    <cve>CVE-2020-12690</cve>
+    <cve>CVE-2020-12691</cve>
+
+    <!-- This CVE affects the server -->
+    <cve>CVE-2021-3563</cve>
+  </suppress>
+
+  <suppress>
+    <notes><![CDATA[
+     file name: json-path-2.3.0.jar
+     ]]></notes>
+    <packageUrl regex="true">^pkg:maven/net\.minidev/json\-path@.*$</packageUrl>
+    <cve>CVE-2022-45688</cve>
+  </suppress>
+
+  <suppress>
+    <!--
+      the suppressions here aren't currently applicable, but can be resolved once we update the version
+      -->
+    <notes><![CDATA[
+   file name: jackson-databind-2.10.5.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <!-- CVE-2022-42003 and CVE-2022-42004 are related to UNWRAP_SINGLE_VALUE_ARRAYS which we do not use
+    https://nvd.nist.gov/vuln/detail/CVE-2022-42003
+    https://nvd.nist.gov/vuln/detail/CVE-2022-42004
+     -->
+    <cve>CVE-2022-42003</cve>
+    <cve>CVE-2022-42004</cve>
+  </suppress>
 
 
+  <suppress>
+    <!-- Not much for us to do as a user of the client lib, and no patch is available,
+     see https://github.com/kubernetes/kubernetes/issues/97076 -->
+    <notes><![CDATA[
+   file name: client-java-10.0.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io\.kubernetes/client\-java.*@10.0.1$</packageUrl>
+    <cve>CVE-2020-8554</cve>
+  </suppress>
+
+  <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->
+  <suppress>
+    <!--
+      ~ TODO: Fix by updating hibernate-validator.
+
+      ~ Note hibernate-validator:5.3.1 introduces a change that requires an EL implementation to be in the classpath:
+      ~ https://developer.jboss.org/wiki/HibernateValidatorMigrationGuide#jive_content_id_531Final
+      ~
+      ~ For example, updating hibernate-validator causes hadoop ingestion tasks to fail:
+      ~
+      ~   Error: com.google.inject.CreationException: Unable to create injector, see the following errors:
+      ~
+      ~   1) An exception was caught and reported. Message: HV000183: Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath, or use ParameterMessageInterpolator instead
+      ~     at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
+      ~
+      ~   2) No implementation for javax.validation.Validator was bound.
+      ~     at org.apache.druid.guice.ConfigModule.configure(ConfigModule.java:39)
+      ~
+      ~   2 errors
+      ~       at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
+      ~       at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
+      ~       at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
+      ~       at com.google.inject.Guice.createInjector(Guice.java:99)
+      ~       at com.google.inject.Guice.createInjector(Guice.java:73)
+      ~       at org.apache.druid.guice.GuiceInjectors.makeStartupInjector(GuiceInjectors.java:56)
+      ~       at org.apache.druid.indexer.HadoopDruidIndexerConfig.<clinit>(HadoopDruidIndexerConfig.java:102)
+      ~       at org.apache.druid.indexer.HadoopDruidIndexerMapper.setup(HadoopDruidIndexerMapper.java:53)
+      ~       at org.apache.druid.indexer.DetermineHashedPartitionsJob$DetermineCardinalityMapper.setup(DetermineHashedPartitionsJob.java:279)
+      ~       at org.apache.druid.indexer.DetermineHashedPartitionsJob$DetermineCardinalityMapper.run(DetermineHashedPartitionsJob.java:334)
+      ~       at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
+      ~       at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
+      ~       at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:175)
+      ~       at java.security.AccessController.doPrivileged(Native Method)
+      ~       at javax.security.auth.Subject.doAs(Subject.java:422)
+      ~       at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1844)
+      ~       at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:169)
+      ~   Caused by: javax.validation.ValidationException: HV000183: Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath, or use ParameterMessageInterpolator instead
+      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.buildExpressionFactory(ResourceBundleMessageInterpolator.java:102)
+      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.<init>(ResourceBundleMessageInterpolator.java:45)
+      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getDefaultMessageInterpolator(ConfigurationImpl.java:423)
+      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getDefaultMessageInterpolatorConfiguredWithClassLoader(ConfigurationImpl.java:575)
+      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getMessageInterpolator(ConfigurationImpl.java:364)
+      ~       at org.hibernate.validator.internal.engine.ValidatorFactoryImpl.<init>(ValidatorFactoryImpl.java:148)
+      ~       at org.hibernate.validator.HibernateValidator.buildValidatorFactory(HibernateValidator.java:38)
+      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.buildValidatorFactory(ConfigurationImpl.java:331)
+      ~       at javax.validation.Validation.buildDefaultValidatorFactory(Validation.java:110)
+      ~       at org.apache.druid.guice.ConfigModule.configure(ConfigModule.java:39)
+      ~       at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
+      ~       at com.google.inject.spi.Elements.getElements(Elements.java:110)
+      ~       at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
+      ~       at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
+      ~       ... 14 more
+      ~   Caused by: java.lang.NoSuchMethodError: javax.el.ExpressionFactory.newInstance()Ljavax/el/ExpressionFactory;
+      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.buildExpressionFactory(ResourceBundleMessageInterpolator.java:98)
+      ~       ... 27 more
+      -->
+    <notes><![CDATA[
+   file name: hibernate-validator-5.3.6.Final.jar
+   file name: hibernate-validator-5.2.5.Final.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-validator@.*$</packageUrl>
+    <cve>CVE-2017-7536</cve>
+    <cve>CVE-2019-10219</cve> <!-- We don't use SafeHtml validator annotation https://nvd.nist.gov/vuln/detail/CVE-2019-10219 -->
+    <cve>CVE-2019-14900</cve> <!-- Not applicable to hibernate validator https://github.com/hibernate/hibernate-orm/pull/3438 -->
+    <cve>CVE-2020-10693</cve> <!-- We don't take user input in constraint violation message https://hibernate.atlassian.net/browse/HV-1774 -->
+    <cve>CVE-2020-25638</cve>
+  </suppress>
+  <suppress>
+    <!-- TODO: Fix by updating curator-x-discovery to > 4.2.0 and updating hadoop -->
+    <notes><![CDATA[
+   file name: jackson-mapper-asl-1.9.13.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@1.9.13$</packageUrl>
+    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-mapper-asl:1.9.13 ince it is via curator-x-discovery -->
+  </suppress>
   <suppress>
     <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
     <notes><![CDATA[
@@ -40,7 +193,44 @@
     <cve>CVE-2022-41881</cve>
     <cve>CVE-2023-34462</cve>	<!-- Suppressed since netty requests in Druid are internal, and not user-facing -->
   </suppress>
-
+  <suppress>
+    <!-- TODO: Fix by upgrading hadoop-auth version -->
+    <notes><![CDATA[
+   file name: nimbus-jose-jwt-4.41.1.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.nimbusds/nimbus\-jose\-jwt@4.41.1$</packageUrl>
+    <cve>CVE-2019-17195</cve>
+  </suppress>
+  <suppress>
+    <!-- This CVE is a false positive. The CVE is not for apacheds-i18n -->
+    <notes><![CDATA[
+   file name: apacheds-i18n-2.0.0-M15.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@.*$</packageUrl>
+    <cve>CVE-2020-7791</cve>
+  </suppress>
+  <suppress>
+      <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
+      <notes><![CDATA[
+   file name: libthrift-0.6.1.jar
+   ]]></notes>
+      <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@0.6.1$</packageUrl>
+      <cve>CVE-2016-5397</cve>
+      <cve>CVE-2018-1320</cve>
+      <cve>CVE-2019-0205</cve>
+  </suppress>
+  <suppress>
+    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage     -->
+    <notes><![CDATA[
+    file name: jettison-1.*.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@1.*$</packageUrl>
+    <cve>CVE-2022-40149</cve>
+    <cve>CVE-2022-40150</cve>
+    <cve>CVE-2022-45685</cve>
+    <cve>CVE-2022-45693</cve>
+    <cve>CVE-2023-1436</cve>
+  </suppress>
   <suppress>
     <!-- We need to wait for 17.0.0 of https://github.com/kubernetes-client/java/releases -->
     <!-- We need to update several other components to move to Snakeyaml 2.0 to address CVE-2022-1471 -->
@@ -52,6 +242,13 @@
     <!-- false positive -->
     <cve>CVE-2023-2251</cve>
     <cve>CVE-2022-3064</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: htrace-core4-4.0.1-incubating.jar (shaded: com.fasterxml.jackson.core:jackson-annotations:2.4.0)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@2.4.0$</packageUrl>
+    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-annotations:2.4.0 since it is via htrace-core4 -->
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -646,8 +843,7 @@
   <suppress>
     <notes><![CDATA[
       file name: jackson-databind-2.12.7.1.jar
-    ]]></notes>
+     ]]></notes>
     <cve>CVE-2023-35116</cve>
   </suppress>
-
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -18,132 +18,8 @@
   ~ under the License.
   -->
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress>
-    <!-- druid-indexing-hadoop.jar is mistaken for hadoop -->
-    <notes><![CDATA[
-   file name: org.apache.druid:druid-indexing-hadoop
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.druid/druid\-indexing\-hadoop@.*$</packageUrl>
-    <cve>CVE-2012-4449</cve>
-    <cve>CVE-2017-3162</cve>
-    <cve>CVE-2018-8009</cve>
-    <cve>CVE-2022-26612</cve>
-  </suppress>
-  <suppress>
-    <!-- druid-processing.jar is mistaken for org.processing:processing -->
-    <notes><![CDATA[
-   file name: org.apache.druid:druid-processing
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.druid/druid\-processing@.*$</packageUrl>
-    <cve>CVE-2018-1000840</cve>
-  </suppress>
-  <suppress>
-    <!-- These CVEs are for the python SDK, but Druid uses the Java SDK -->
-    <notes><![CDATA[
-   file name: openstack-swift
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-swift@.*$</packageUrl>
-    <cve>CVE-2013-7109</cve>
-    <cve>CVE-2016-0737</cve>
-    <cve>CVE-2016-0738</cve>
-    <cve>CVE-2017-16613</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: openstack-keystone-1.9.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.jclouds\.api/openstack\-keystone@.*$</packageUrl>
-    <!-- These CVEs are for the python SDK, but Druid uses the Java SDK -->
-    <cve>CVE-2015-7546</cve>
-    <cve>CVE-2020-12689</cve>
-    <cve>CVE-2020-12690</cve>
-    <cve>CVE-2020-12691</cve>
 
-    <!-- This CVE affects the server -->
-    <cve>CVE-2021-3563</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-     file name: json-path-2.3.0.jar
-     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.minidev/json\-path@.*$</packageUrl>
-    <cve>CVE-2022-45688</cve>
-  </suppress>
-  <!-- FIXME: These are suppressed so that CI can enforce that no new vulnerable dependencies are added. -->
-  <suppress>
-    <!--
-      ~ TODO: Fix by updating hibernate-validator.
 
-      ~ Note hibernate-validator:5.3.1 introduces a change that requires an EL implementation to be in the classpath:
-      ~ https://developer.jboss.org/wiki/HibernateValidatorMigrationGuide#jive_content_id_531Final
-      ~
-      ~ For example, updating hibernate-validator causes hadoop ingestion tasks to fail:
-      ~
-      ~   Error: com.google.inject.CreationException: Unable to create injector, see the following errors:
-      ~
-      ~   1) An exception was caught and reported. Message: HV000183: Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath, or use ParameterMessageInterpolator instead
-      ~     at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
-      ~
-      ~   2) No implementation for javax.validation.Validator was bound.
-      ~     at org.apache.druid.guice.ConfigModule.configure(ConfigModule.java:39)
-      ~
-      ~   2 errors
-      ~       at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:470)
-      ~       at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
-      ~       at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
-      ~       at com.google.inject.Guice.createInjector(Guice.java:99)
-      ~       at com.google.inject.Guice.createInjector(Guice.java:73)
-      ~       at org.apache.druid.guice.GuiceInjectors.makeStartupInjector(GuiceInjectors.java:56)
-      ~       at org.apache.druid.indexer.HadoopDruidIndexerConfig.<clinit>(HadoopDruidIndexerConfig.java:102)
-      ~       at org.apache.druid.indexer.HadoopDruidIndexerMapper.setup(HadoopDruidIndexerMapper.java:53)
-      ~       at org.apache.druid.indexer.DetermineHashedPartitionsJob$DetermineCardinalityMapper.setup(DetermineHashedPartitionsJob.java:279)
-      ~       at org.apache.druid.indexer.DetermineHashedPartitionsJob$DetermineCardinalityMapper.run(DetermineHashedPartitionsJob.java:334)
-      ~       at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:787)
-      ~       at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
-      ~       at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:175)
-      ~       at java.security.AccessController.doPrivileged(Native Method)
-      ~       at javax.security.auth.Subject.doAs(Subject.java:422)
-      ~       at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1844)
-      ~       at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:169)
-      ~   Caused by: javax.validation.ValidationException: HV000183: Unable to initialize 'javax.el.ExpressionFactory'. Check that you have the EL dependencies on the classpath, or use ParameterMessageInterpolator instead
-      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.buildExpressionFactory(ResourceBundleMessageInterpolator.java:102)
-      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.<init>(ResourceBundleMessageInterpolator.java:45)
-      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getDefaultMessageInterpolator(ConfigurationImpl.java:423)
-      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getDefaultMessageInterpolatorConfiguredWithClassLoader(ConfigurationImpl.java:575)
-      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.getMessageInterpolator(ConfigurationImpl.java:364)
-      ~       at org.hibernate.validator.internal.engine.ValidatorFactoryImpl.<init>(ValidatorFactoryImpl.java:148)
-      ~       at org.hibernate.validator.HibernateValidator.buildValidatorFactory(HibernateValidator.java:38)
-      ~       at org.hibernate.validator.internal.engine.ConfigurationImpl.buildValidatorFactory(ConfigurationImpl.java:331)
-      ~       at javax.validation.Validation.buildDefaultValidatorFactory(Validation.java:110)
-      ~       at org.apache.druid.guice.ConfigModule.configure(ConfigModule.java:39)
-      ~       at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:340)
-      ~       at com.google.inject.spi.Elements.getElements(Elements.java:110)
-      ~       at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:138)
-      ~       at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
-      ~       ... 14 more
-      ~   Caused by: java.lang.NoSuchMethodError: javax.el.ExpressionFactory.newInstance()Ljavax/el/ExpressionFactory;
-      ~       at org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator.buildExpressionFactory(ResourceBundleMessageInterpolator.java:98)
-      ~       ... 27 more
-      -->
-    <notes><![CDATA[
-   file name: hibernate-validator-5.3.6.Final.jar
-   file name: hibernate-validator-5.2.5.Final.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-validator@.*$</packageUrl>
-    <cve>CVE-2017-7536</cve>
-    <cve>CVE-2019-10219</cve> <!-- We don't use SafeHtml validator annotation https://nvd.nist.gov/vuln/detail/CVE-2019-10219 -->
-    <cve>CVE-2019-14900</cve> <!-- Not applicable to hibernate validator https://github.com/hibernate/hibernate-orm/pull/3438 -->
-    <cve>CVE-2020-10693</cve> <!-- We don't take user input in constraint violation message https://hibernate.atlassian.net/browse/HV-1774 -->
-    <cve>CVE-2020-25638</cve>
-  </suppress>
-  <suppress>
-    <!-- TODO: Fix by updating curator-x-discovery to > 4.2.0 and updating hadoop -->
-    <notes><![CDATA[
-   file name: jackson-mapper-asl-1.9.13.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@1.9.13$</packageUrl>
-    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-mapper-asl:1.9.13 ince it is via curator-x-discovery -->
-  </suppress>
   <suppress>
     <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
     <notes><![CDATA[
@@ -164,44 +40,7 @@
     <cve>CVE-2022-41881</cve>
     <cve>CVE-2023-34462</cve>	<!-- Suppressed since netty requests in Druid are internal, and not user-facing -->
   </suppress>
-  <suppress>
-    <!-- TODO: Fix by upgrading hadoop-auth version -->
-    <notes><![CDATA[
-   file name: nimbus-jose-jwt-4.41.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.nimbusds/nimbus\-jose\-jwt@4.41.1$</packageUrl>
-    <cve>CVE-2019-17195</cve>
-  </suppress>
-  <suppress>
-    <!-- This CVE is a false positive. The CVE is not for apacheds-i18n -->
-    <notes><![CDATA[
-   file name: apacheds-i18n-2.0.0-M15.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.directory\.server/apacheds\-i18n@.*$</packageUrl>
-    <cve>CVE-2020-7791</cve>
-  </suppress>
-  <suppress>
-      <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
-      <notes><![CDATA[
-   file name: libthrift-0.6.1.jar
-   ]]></notes>
-      <packageUrl regex="true">^pkg:maven/org\.apache\.thrift/libthrift@0.6.1$</packageUrl>
-      <cve>CVE-2016-5397</cve>
-      <cve>CVE-2018-1320</cve>
-      <cve>CVE-2019-0205</cve>
-  </suppress>
-  <suppress>
-    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage     -->
-    <notes><![CDATA[
-    file name: jettison-1.*.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@1.*$</packageUrl>
-    <cve>CVE-2022-40149</cve>
-    <cve>CVE-2022-40150</cve>
-    <cve>CVE-2022-45685</cve>
-    <cve>CVE-2022-45693</cve>
-    <cve>CVE-2023-1436</cve>
-  </suppress>
+
   <suppress>
     <!-- We need to wait for 17.0.0 of https://github.com/kubernetes-client/java/releases -->
     <!-- We need to update several other components to move to Snakeyaml 2.0 to address CVE-2022-1471 -->
@@ -213,13 +52,6 @@
     <!-- false positive -->
     <cve>CVE-2023-2251</cve>
     <cve>CVE-2022-3064</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: htrace-core4-4.0.1-incubating.jar (shaded: com.fasterxml.jackson.core:jackson-annotations:2.4.0)
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-annotations@2.4.0$</packageUrl>
-    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-annotations:2.4.0 since it is via htrace-core4 -->
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -810,4 +642,12 @@
     ]]></notes>
     <cve>CVE-2023-4586</cve>
   </suppress>
+  <!-- Disputed CVE -->
+  <suppress>
+    <notes><![CDATA[
+      file name: jackson-databind-2.12.7.1.jar
+    ]]></notes>
+    <cve>CVE-2023-35116</cve>
+  </suppress>
+
 </suppressions>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -854,29 +854,26 @@
      ]]></notes>
     <cve>CVE-2023-25194</cve>
   </suppress>
-    <suppress>
+  <suppress>
     <notes><![CDATA[
       file name: spatial4j-0.7.jar
      ]]></notes>
     <cve>CVE-2014-125074</cve>
   </suppress>
-    <suppress>
+  <suppress>
     <notes><![CDATA[
       file name: woodstox-core-6.4.0.jar
      ]]></notes>
     <cve>CVE-2023-34411</cve>
   </suppress>
   <!-- This is the last version of Elasticsearch code distributed under Apache 2 license -->
-  </suppress>
-    <suppress>
+  <suppress>
     <notes><![CDATA[
       file name: elasticsearch-rest-client-7.10.2.jar
      ]]></notes>
     <cve>CVE-2021-22145</cve>
   </suppress>
-
-  </suppress>
-    <suppress>
+  <suppress>
     <notes><![CDATA[
       file name: elasticsearch-*7.10.2.jar
      ]]></notes>

--- a/pom.xml
+++ b/pom.xml
@@ -371,26 +371,6 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.70</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-ext-jdk15on</artifactId>
-                <version>1.70</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>1.70</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk15on</artifactId>
-                <version>1.70</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>1.77</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -359,16 +359,36 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>1.33</version>
             </dependency>
-<dependency>
-    <groupId>org.apache.ant</groupId>
-    <artifactId>ant</artifactId>
-    <version>1.10.14</version>
-</dependency>
-<dependency>
-    <groupId>org.bitbucket.b_c</groupId>
-    <artifactId>jose4j</artifactId>
-    <version>0.9.3</version>
-</dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>1.10.14</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>0.9.3</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>1.70</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-ext-jdk15on</artifactId>
+                <version>1.70</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk15on</artifactId>
+                <version>1.70</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk15on</artifactId>
+                <version>1.70</version>
+            </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -355,6 +355,11 @@
                 <version>2.4.11</version>
             </dependency>
             <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.33</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>1.10.14</version>

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
+                <version>2.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.ant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
-        <zookeeper.version>3.5.10</zookeeper.version>
+        <zookeeper.version>3.8.3</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -355,11 +355,6 @@
                 <version>2.4.11</version>
             </dependency>
             <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>2.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>1.10.14</version>

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,11 @@
                 <version>1.77</version>
             </dependency>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>1.4.32</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
         <scala.library.version>2.13.11</scala.library.version>
         <avatica.version>1.23.0</avatica.version>
-        <avro.version>1.11.1</avro.version>
+        <avro.version>1.11.3</avro.version>
         <!-- When updating Calcite, also propagate updates to these files which we've copied and modified:
              default_config.fmpp
           -->
@@ -89,15 +89,15 @@
         <datasketches.version>4.2.0</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
-        <dropwizard.metrics.version>4.2.19</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>
         <errorprone.version>2.20.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>31.1-jre</guava.version>
+        <guava.version>32.1.3-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.12.7</jackson.version>
+        <jackson.version>2.12.7.20221012</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>
@@ -359,25 +359,35 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>1.33</version>
             </dependency>
+<dependency>
+    <groupId>org.apache.ant</groupId>
+    <artifactId>ant</artifactId>
+    <version>1.10.14</version>
+</dependency>
+<dependency>
+    <groupId>org.bitbucket.b_c</groupId>
+    <artifactId>jose4j</artifactId>
+    <version>0.9.3</version>
+</dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.77</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-ext-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcprov-ext-jdk18on</artifactId>
+                <version>1.77</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.77</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk15on</artifactId>
-                <version>1.70</version>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>1.77</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
@@ -541,7 +551,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
+                <version>1.24.0</version>
             </dependency>
             <dependency>
                 <groupId>org.tukaani</groupId>
@@ -1063,7 +1073,7 @@
             <dependency>
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java-bom</artifactId>
-                <version>3.2.13</version>
+                <version>3.3.4</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>
         <errorprone.version>2.20.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>32.1.3-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.53.v20231009</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>
         <errorprone.version>2.20.0</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>32.0.1-jre</guava.version>
+        <guava.version>31.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.53.v20231009</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.5.10</zookeeper.version>
         <checkerframework.version>2.5.7</checkerframework.version>
         <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -283,7 +283,7 @@ public class SqlSegmentsMetadataManagerTest
     Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getDataSourcesSnapshot();
     Assert.assertEquals(
-        ImmutableList.of("wikipedia3", "wikipedia", "wikipedia2"),
+        ImmutableList.of("wikipedia2", "wikipedia3", "wikipedia"),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
                            .map(ImmutableDruidDataSource::getName)

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -282,8 +282,11 @@ public class SqlSegmentsMetadataManagerTest
     Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
     Assert.assertTrue(sqlSegmentsMetadataManager.getLatestDatabasePoll() instanceof SqlSegmentsMetadataManager.PeriodicDatabasePoll);
     dataSourcesSnapshot = sqlSegmentsMetadataManager.getDataSourcesSnapshot();
+    // This test is guava version sensitive when upgrading to guava > 32
+    // the order changes to
+    //  ImmutableList.of("wikipedia2", "wikipedia3", "wikipedia"),
     Assert.assertEquals(
-        ImmutableList.of("wikipedia2", "wikipedia3", "wikipedia"),
+        ImmutableList.of("wikipedia3", "wikipedia", "wikipedia2"),
         dataSourcesSnapshot.getDataSourcesWithAllUsedSegments()
                            .stream()
                            .map(ImmutableDruidDataSource::getName)


### PR DESCRIPTION
Fixes # Multiple CVEs in dependencies. .

### Description

Update multiple dependencies to clear CVEs
Update docker-java-bom to 3.3.4 and 
kubernetes-client to 19.0.0  to move away from bcprov-jdk15 to address: CVE-2023-33201
Update dropwizard-metrics to 4.2.22 to address CVE-2023-46120  in com.rabbitmq:amqp-client                   
Update avro to 1.11.3 to resolve CVE-2023-39410 
Update jackson-databind to 2.12.7.1 to resolve CVE-2022-42003 CVE-2022-42004
Update ant to 1.10.14 to resolve CVE-2020-11979  CVE-2020-1945  CVE-2021-36373   CVE-2021-36374 
Update comomons-compress to resolve CVE-2023-42503  
Update jose4j to 0.9.3 to resolve CVE-2023-31582  GHSA-jgvc-jfgh-rjvv 
Update kotlin-stdlib to 1.4.21 to resolve CVE-2020-29582 
Update kafka-client-schema-registry to 6.2.12 
Update woodstox-core to 6.4.0 to address CVE-2022-40152
Update aws-java-sdk-bundle to 1.12.497 to remove CVE regressions introduced by ranger update

- updated licenses and suppressions. 
- update license checker to provide more verbose information when license is not found

This PR has:

- [ x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
