### PR TITLE
Fix missing task failure error message on Overlord caused by MessageBodyWriter not found error on Middle Manager

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
@@ -206,11 +206,16 @@ public class TaskManagementResource
   @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
   public Response assignTask(Task task)
   {
+    // Sometimes assignTask API can fail when the supplied task arg can't be interpreted due to some missing extension(s).
+    // In such cases, the call produces an error response without entering the function.
+    // @Produces helps to correctly write back this error response as JSON which otherwise ends up in an empty response
+    // message due to "MessageBodyWriter not found for SingletonImmutableBiMap" error.
+    // Ref: https://github.com/apache/druid/pull/15412.
     try {
       workerTaskManager.assignTask(task);
       return Response.ok().build();
     }
-    catch (RuntimeException ex) {
+    catch (Exception ex) {
       return Response.serverError().entity(ex.getMessage()).build();
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
@@ -203,6 +203,7 @@ public class TaskManagementResource
   @POST
   @Path("/assignTask")
   @Consumes({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
+  @Produces({MediaType.APPLICATION_JSON, SmileMediaTypes.APPLICATION_JACKSON_SMILE})
   public Response assignTask(Task task)
   {
     try {


### PR DESCRIPTION
Fixes missing task failure error message on Overlord. 

The error message was missing since `TaskManagementResource#assignTask` API wasn't annotated with `@Produces(MediaType.APPLICATION_JSON)` resulting in the response being treated as `application/octet-stream`, that in turn lead to `MessageBodyWriter not found` error on the middle manager. The exception is not logged on the middle manager itself since it happens even before entering the `assignTask` function -- while mapping arg `Task` -> `MSQControllerTask`. 

Resolution is to add `@Produces` annotation to `TaskManagementResource#assignTask`

Updated error message on Overlord:

> org.apache.druid.java.util.common.RE: Failed to assign task[query-50594440-9720-451b-b5c1-76a3d3ff6ffe] to worker[localhost:8091]. Response Code[400] and Message[{"error":"Please make sure to load all the necessary extensions and jars with type 'query_controller'. Could not resolve type id 'query_controller' as a subtype of `org.apache.druid.indexing.common.task.Task` known type ids = [archive, compact, index, index_hadoop, index_kafka, index_parallel, index_realtime, index_realtime_appenderator, index_sub, kill, move, noop, partial_dimension_cardinality, partial_dimension_distribution, partial_index_generate, partial_index_generic_merge, partial_range_index_generate, restore, single_phase_sub_task]\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: -1, column: 10]"}]. Retrying...
