### PR TITLE
Fix flaky tests in multiple modules due to non-deterministic specification of HashSet and JSON objects

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/BaseParquetReaderTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 class BaseParquetReaderTest extends InitializedNullHandlingTest
 {
   ObjectWriter DEFAULT_JSON_WRITER = new ObjectMapper().writerWithDefaultPrettyPrinter();
+  protected final ObjectMapper objectMapper = new ObjectMapper();
 
   InputEntityReader createReader(String parquetFile, InputRowSchema schema, JSONPathSpec flattenSpec)
   {

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.parquet;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -43,8 +42,6 @@ import java.util.List;
  */
 public class CompatParquetReaderTest extends BaseParquetReaderTest
 {
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-  
   @Test
   public void testBinaryAsString() throws IOException
   {
@@ -97,12 +94,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
-                                + "}"; 
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJsonBinary), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())));
+                                + "}";
+    Assert.assertEquals(
+        objectMapper.readTree(expectedJsonBinary), 
+        objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())));
   }
 
   @Test
@@ -303,7 +302,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -382,7 +381,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -432,6 +431,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(objectMapper.readTree(expectedJson), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -141,7 +141,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -340,7 +340,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -42,6 +43,8 @@ import java.util.List;
  */
 public class CompatParquetReaderTest extends BaseParquetReaderTest
 {
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  
   @Test
   public void testBinaryAsString() throws IOException
   {
@@ -94,18 +97,13 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
-                                + "}";
-    Assert.assertEquals(
-        expectedJsonBinary,
-        DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
-    );
+                                + "}"; 
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJsonBinary), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())));
   }
-
 
   @Test
   public void testParquet1217() throws IOException
@@ -143,7 +141,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -305,7 +303,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -342,9 +340,8 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
-
 
   @Test
   public void testReadNestedArrayStruct() throws IOException
@@ -385,7 +382,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -435,6 +432,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -205,8 +206,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper mapper = new ObjectMapper();
 
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(mapper.readTree(FLAT_JSON), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.parquet;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -94,7 +93,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -127,7 +126,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -168,7 +167,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -205,10 +204,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         schema,
         flattenSpec
     );
-    List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper mapper = new ObjectMapper();
 
-    Assert.assertEquals(mapper.readTree(FLAT_JSON), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    Assert.assertEquals(objectMapper.readTree(FLAT_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
 
@@ -245,7 +243,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(NESTED_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -278,7 +276,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(NESTED_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -321,7 +319,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(NESTED_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -362,7 +360,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(objectMapper.readTree(NESTED_JSON), objectMapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.parquet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputRow;
@@ -39,6 +40,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 
 public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
@@ -218,7 +220,7 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(ImmutableList.of("nestedData", "dim1", "metric1"), rows.get(0).getDimensions());
+    Assert.assertEquals(ImmutableSet.of("nestedData", "dim1", "metric1"), new HashSet<>(rows.get(0).getDimensions()));
     Assert.assertEquals(FlattenSpecParquetInputTest.TS1, rows.get(0).getTimestamp().toString());
     Assert.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
     Assert.assertEquals("d1v1", rows.get(0).getRaw("dim1"));

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -91,8 +92,9 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    ObjectMapper mapper = new ObjectMapper();
+    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues())));
+    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -39,6 +40,8 @@ import java.util.List;
  */
 public class WikiParquetReaderTest extends BaseParquetReaderTest
 {
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
   @Test
   public void testWiki() throws IOException
   {
@@ -77,7 +80,7 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"user\" : \"nuclear\",\n"
                                 + "  \"timestamp\" : \"2013-08-31T01:02:33Z\"\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
@@ -99,6 +99,6 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"foo\" : \"baz\",\n"
                                 + "  \"time\" : 1678853101621\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -82,6 +82,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1193,11 +1194,11 @@ public class TaskLockboxTest
     Assert.assertEquals(2, lockedIntervals.size());
 
     Assert.assertEquals(
-        Arrays.asList(
+        new HashSet<>(Arrays.asList(
             Intervals.of("2017-01-01/2017-02-01"),
             Intervals.of("2017-04-01/2017-05-01")
-        ),
-        lockedIntervals.get(task1.getDataSource())
+        )),
+        new HashSet<>(lockedIntervals.get(task1.getDataSource()))
     );
 
     Assert.assertEquals(

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
@@ -177,14 +177,13 @@ public class ParametrizedUriEmitterTest
           {
             Assert.assertEquals("http://example.com/val1/val2", request.getUrl());
             Assert.assertEquals(
-                StringUtils.format(
+                JSON_MAPPER.readTree(StringUtils.format(
                     "[%s,%s]\n",
                     JSON_MAPPER.writeValueAsString(events.get(0)),
                     JSON_MAPPER.writeValueAsString(events.get(1))
-                ),
-                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                )),
+                JSON_MAPPER.readTree(StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString())
             );
-
             return GoHandlers.immediateFuture(EmitterTest.okResponse());
           }
         }.times(1)

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -408,8 +408,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     for (int i = 0; i < data.size(); i++) {
       Map row = data.get(i);
       Assert.assertEquals(
-          JSON_MAPPER.writeValueAsString(row),
-          JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject()))
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(row)),
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject())))
       );
 
       testPath(row, i, "v", vSelector, vDimSelector, vValueIndex, vPredicateIndex, vNulls, null);
@@ -539,8 +539,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     while (offset.withinBounds()) {
       Map row = arrayTestData.get(rowCounter);
       Assert.assertEquals(
-          JSON_MAPPER.writeValueAsString(row),
-          JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject()))
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(row)),
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject())))
       );
 
       Object[] s = (Object[]) row.get("s");
@@ -595,8 +595,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
 
         Map row = arrayTestData.get(rowCounter);
         Assert.assertEquals(
-            JSON_MAPPER.writeValueAsString(row),
-            JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i]))
+            JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(row)),
+            JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i])))
         );
         Object[] s = (Object[]) row.get("s");
         Object[] l = (Object[]) row.get("l");
@@ -644,8 +644,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       for (int i = 0; i < bitmapVectorOffset.getCurrentVectorSize(); i++, rowCounter += 2) {
         Map row = arrayTestData.get(rowCounter);
         Assert.assertEquals(
-            JSON_MAPPER.writeValueAsString(row),
-            JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i]))
+            JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(row)),
+            JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i])))
         );
         Object[] s = (Object[]) row.get("s");
         Object[] l = (Object[]) row.get("l");

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4Test.java
@@ -413,8 +413,8 @@ public class NestedDataColumnSupplierV4Test extends InitializedNullHandlingTest
     for (int i = 0; i < data.size(); i++) {
       Map row = data.get(i);
       Assert.assertEquals(
-          JSON_MAPPER.writeValueAsString(row),
-          JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject()))
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(row)),
+          JSON_MAPPER.readTree(JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject())))
       );
       testPath(row, i, "v", vSelector, vDimSelector, vValueIndex, vPredicateIndex, vNulls, null);
       testPath(row, i, "x", xSelector, xDimSelector, xValueIndex, xPredicateIndex, xNulls, ColumnType.LONG);

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -61,6 +61,7 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.HashSet;
 
 public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
 {
@@ -734,10 +735,10 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
   @Test
   public void testRequiredColumns()
   {
-    Assert.assertEquals(ImmutableList.of("x", "y"), X_PLUS_Y.requiredColumns());
+    Assert.assertEquals(new HashSet<>(ImmutableList.of("x", "y")), new HashSet<>(X_PLUS_Y.requiredColumns()));
     Assert.assertEquals(ImmutableList.of(), CONSTANT_LIKE.requiredColumns());
     Assert.assertEquals(ImmutableList.of("z"), Z_LIKE.requiredColumns());
-    Assert.assertEquals(ImmutableList.of("x", "z"), Z_CONCAT_X.requiredColumns());
+    Assert.assertEquals(new HashSet<>(ImmutableList.of("x", "z")), new HashSet<>(Z_CONCAT_X.requiredColumns()));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/discovery/BaseNodeRoleWatcherTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/BaseNodeRoleWatcherTest.java
@@ -128,7 +128,7 @@ public class BaseNodeRoleWatcherTest
   private void assertListener(TestListener listener, boolean nodeViewInitialized, List<DiscoveryDruidNode> nodesAdded, List<DiscoveryDruidNode> nodesRemoved)
   {
     Assert.assertEquals(nodeViewInitialized, listener.nodeViewInitialized.get());
-    Assert.assertEquals(nodesAdded, listener.nodesAddedList);
+    Assert.assertEquals(new HashSet<>(nodesAdded), new HashSet<>(listener.nodesAddedList));
     Assert.assertEquals(nodesRemoved, listener.nodesRemovedList);
   }
 

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
@@ -64,6 +64,6 @@ public class SupervisorStatusTest
     Assert.assertEquals("wikipedia", deserialized.getId());
     final String serialized = mapper.writeValueAsString(deserialized);
     Assert.assertTrue(serialized.contains("\"source\""));
-    Assert.assertEquals(json, serialized);
+    Assert.assertEquals(mapper.readTree(json), mapper.readTree(serialized));
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
@@ -78,7 +78,7 @@ public class SqlEntityTest
     String expectedJson = mapper.writeValueAsString(
         Collections.singletonList(((MapBasedInputRow) expectedRow).getEvent())
     );
-    Assert.assertEquals(actualJson, expectedJson);
+    Assert.assertEquals(mapper.readTree(actualJson), mapper.readTree(expectedJson));
     testUtils.dropTable(TABLE_NAME_1);
   }
 

--- a/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -55,6 +55,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -367,18 +368,18 @@ public class TieredBrokerHostSelectorTest
   {
     Assert.assertEquals(
         ImmutableMap.of(
-            "mediumBroker", ImmutableList.of(),
-            "coldBroker", ImmutableList.of("coldHost1:8080", "coldHost2:8080"),
-            "hotBroker", ImmutableList.of("hotHost:8080")
+            "mediumBroker", ImmutableSet.of(),
+            "coldBroker", ImmutableSet.of("coldHost1:8080", "coldHost2:8080"),
+            "hotBroker", ImmutableSet.of("hotHost:8080")
         ),
         Maps.transformValues(
             brokerSelector.getAllBrokers(),
-            new Function<List<Server>, List<String>>()
+            new Function<List<Server>, HashSet<String>>()
             {
               @Override
-              public List<String> apply(@Nullable List<Server> servers)
+              public HashSet<String> apply(@Nullable List<Server> servers)
               {
-                return Lists.transform(servers, server -> server.getHost());
+                return new HashSet<>(Lists.transform(servers, server -> server.getHost()));
               }
             }
         )


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

I found some flaky tests using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Plugin for maven in various modules.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the following flaky tests:
#### `processing` module:
1. org.apache.druid.segment.nested.NestedDataColumnSupplierV4Test#testBasicFunctionality
2. org.apache.druid.segment.nested.NestedDataColumnSupplierV4Test#testConcurrency
3. org.apache.druid.segment.nested.NestedDataColumnSupplierTest#testBasicFunctionality
4. org.apache.druid.segment.nested.NestedDataColumnSupplierTest#testArrayFunctionality
5. org.apache.druid.segment.nested.NestedDataColumnSupplierTest#testConcurrency
6. org.apache.druid.segment.virtual.ExpressionVirtualColumnTest#testRequiredColumns
7. org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest#testEmitterWithParametrizedUriExtractor

#### `services` module:
8. org.apache.druid.server.router.TieredBrokerHostSelectorTest#testGetAllBrokers

#### `indexing-service` module:
9. org.apache.druid.indexing.overlord.TaskLockboxTest#testGetLockedIntervals

#### `extensions-core/parquet-extensions` module:
10. org.apache.druid.data.input.parquet.WikiParquetReaderTest#testUint32Datatype
11. org.apache.druid.data.input.parquet.WikiParquetReaderTest#testWiki
12. org.apache.druid.data.input.parquet.NestedColumnParquetReaderTest#testNestedColumnSchemalessNestedTestFile
13. org.apache.druid.data.input.parquet.CompatParquetReaderTest#testBinaryAsString
14. org.apache.druid.data.input.parquet.CompatParquetReaderTest#testParquetThriftCompat
15. org.apache.druid.data.input.parquet.CompatParquetReaderTest#testReadNestedArrayStruct
16. org.apache.druid.data.input.parquet.CompatParquetReaderTest#testProtoStructWithArray
17. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1FlattenSelectListItem
18. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1NoFlattenSpec
19. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Autodiscover
20. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testFlat1Flatten
21. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1NoFlattenSpec
22. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1Autodiscover
23. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1Flatten
24. org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1FlattenSelectListItem
25. org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling

#### `server` module:
26. org.apache.druid.discovery.BaseNodeRoleWatcherTest#testGeneralUseSimulation
27. org.apache.druid.indexing.overlord.supervisor.SupervisorStatusTest#testJsonAttr
28. org.apache.druid.metadata.input.SqlEntityTest#testExecuteQuery


#### Problem:
The above mentioned tests have been reported as flaky (tests assuming deterministic implementation of a non-deterministic specification ) when ran against the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 
The tests contain assertions that compare strings created from JSON objects and lists created from HashSets and HashMaps.

However, HashSet does not guarantee the ordering of elements and thus resulting in these flaky tests that assume deterministic implementation of HashSet. Also, some tests check for a specific ordering of elements in JSON strings. JSON objects are equal even if the ordering of the elements in the JSON strings are not equal. This results in flakiness as the Jackson ObjectMapper does not guarantee consistent ordering of the JSON keys.

Thus, when the NonDex tool shuffles the HashSet elements and the JSON keys, it results in test failures:
Errors can be found in this Github issue: https://github.com/apache/druid/issues/15471

To reproduce run:
```
mvn -pl <module_name> edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<test_name>
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

#### Fix:
For the tests failing due to inequality in ordering of objects in lists that were created from HashSets or HashMaps, first convert the arraylists to hashSets and then compare the 2 HashSets using assertEquals().

For all the tests failing due to inequality in ordering of keys in JSON strings, first create the JSON node trees and then compare the two trees using assertEquals().

Made these fixes in collaboration with - @same8891, @Rette66, @prathyushreddylpr,  @lxb007981

##### Key changed/added classes in this PR
 * `org.apache.druid.segment.nested.NestedDataColumnSupplierV4Test`
 * `org.apache.druid.segment.nested.NestedDataColumnSupplierTest`
 * `org.apache.druid.segment.virtual.ExpressionVirtualColumnTest`
 * `org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest`
 * `org.apache.druid.server.router.TieredBrokerHostSelectorTest`
 * `org.apache.druid.indexing.overlord.TaskLockboxTest`
 * `org.apache.druid.data.input.parquet.WikiParquetReaderTest`
 * `org.apache.druid.data.input.parquet.NestedColumnParquetReaderTest`
 * `org.apache.druid.data.input.parquet.CompatParquetReaderTest`
 * `org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest`
 * `org.apache.druid.data.input.parquet.TimestampsParquetReaderTest`
 * `org.apache.druid.discovery.BaseNodeRoleWatcherTest`
 * `org.apache.druid.indexing.overlord.supervisor.SupervisorStatusTest`
 * `org.apache.druid.metadata.input.SqlEntityTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
