### PR TITLE
Changing the queryFrameWork in Calcite*Tests may have sideeffects

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -116,6 +116,7 @@ import org.joda.time.chrono.ISOChronology;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
@@ -629,8 +630,11 @@ public class BaseCalciteQueryTest extends CalciteTestBase
     return queryLogHook = new QueryLogHook(() -> queryFramework().queryJsonMapper());
   }
 
+  @ClassRule
+  public static SqlTestFrameworkConfig .ClassRule queryFrameworkClassRule = new SqlTestFrameworkConfig .ClassRule();
+
   @Rule
-  public SqlTestFrameworkRule queryFrameworkRule = new SqlTestFrameworkRule(this);
+  public SqlTestFrameworkConfig.SqlTestFrameworkRule queryFrameworkRule = queryFrameworkClassRule.methodRule(this);
 
   public SqlTestFramework queryFramework()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.guice.DruidInjectorBuilder;
 import org.apache.druid.hll.VersionOneHyperLogLogCollector;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.io.Closer;
@@ -74,7 +73,6 @@ import org.apache.druid.query.scan.ScanQuery;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.spec.QuerySegmentSpec;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
-import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -115,8 +113,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.ExpectedException;
@@ -284,11 +282,8 @@ public class BaseCalciteQueryTest extends CalciteTestBase
 
   public static final Map<String, Object> OUTER_LIMIT_CONTEXT = new HashMap<>(QUERY_CONTEXT_DEFAULT);
 
-  public static int minTopNThreshold = TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD;
-
   @Nullable
   public final SqlEngine engine0;
-  private static SqlTestFramework queryFramework;
   final boolean useDefault = NullHandling.replaceWithDefault();
 
   @Rule(order = 1)
@@ -613,26 +608,6 @@ public class BaseCalciteQueryTest extends CalciteTestBase
                                         .legacy(false);
   }
 
-  @BeforeClass
-  public static void setUpClass()
-  {
-    resetFramework();
-  }
-
-  @AfterClass
-  public static void tearDownClass()
-  {
-    resetFramework();
-  }
-
-  protected static void resetFramework()
-  {
-    if (queryFramework != null) {
-      queryFramework.close();
-    }
-    queryFramework = null;
-  }
-
   protected static DruidExceptionMatcher invalidSqlIs(String s)
   {
     return DruidExceptionMatcher.invalidSqlInput().expectMessageIs(s);
@@ -654,42 +629,20 @@ public class BaseCalciteQueryTest extends CalciteTestBase
     return queryLogHook = new QueryLogHook(() -> queryFramework().queryJsonMapper());
   }
 
+  @Rule
+  public SqlTestFrameworkRule queryFrameworkRule = new SqlTestFrameworkRule(this);
+
   public SqlTestFramework queryFramework()
   {
-    if (queryFramework == null) {
-      createFramework(0);
-    }
-    return queryFramework;
+    return queryFrameworkRule.get();
   }
 
-  /**
-   * Creates the query planning/execution framework. The logic is somewhat
-   * round-about: the builder creates the structure, but delegates back to
-   * this class for the parts that the Calcite tests customize. This class,
-   * in turn, delegates back to a standard class to create components. However,
-   * subclasses do override each method to customize components for specific
-   * tests.
-   */
-  private void createFramework(int mergeBufferCount)
+  @Before
+  public void before() throws Exception
   {
-    resetFramework();
-    try {
-      baseComponentSupplier = new StandardComponentSupplier(
-          temporaryFolder.newFolder()
-      );
-    }
-    catch (IOException e) {
-      throw new RE(e);
-    }
-    SqlTestFramework.Builder builder = new SqlTestFramework.Builder(this)
-        .minTopNThreshold(minTopNThreshold)
-        .mergeBufferCount(mergeBufferCount);
-    configureBuilder(builder);
-    queryFramework = builder.build();
-  }
-
-  protected void configureBuilder(Builder builder)
-  {
+    baseComponentSupplier = new StandardComponentSupplier(
+        temporaryFolder.newFolder()
+    );
   }
 
   @Override
@@ -1431,7 +1384,8 @@ public class BaseCalciteQueryTest extends CalciteTestBase
    */
   protected void requireMergeBuffers(int numMergeBuffers)
   {
-    createFramework(numMergeBuffers);
+    throw new RuntimeException();
+//    createFramework(numMergeBuffers);
   }
 
   protected Map<String, Object> withTimestampResultContext(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteJoinQueryTest.java
@@ -125,10 +125,11 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
     this.sortBasedJoin = sortBasedJoin;
   }
 
+  @SqlTestFrameworkConfig(minTopNThreshold = 1)
   @Test
   public void testInnerJoinWithLimitAndAlias()
   {
-    minTopNThreshold = 1;
+
     Map<String, Object> context = new HashMap<>(QUERY_CONTEXT_DEFAULT);
     context.put(PlannerConfig.CTX_KEY_USE_APPROXIMATE_TOPN, false);
     testQuery(
@@ -183,12 +184,12 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
   }
 
 
+  // Adjust topN threshold, so that the topN engine keeps only 1 slot for aggregates, which should be enough
+  // to compute the query with limit 1.
+  @SqlTestFrameworkConfig(minTopNThreshold = 1)
   @Test
   public void testExactTopNOnInnerJoinWithLimit()
   {
-    // Adjust topN threshold, so that the topN engine keeps only 1 slot for aggregates, which should be enough
-    // to compute the query with limit 1.
-    minTopNThreshold = 1;
     Map<String, Object> context = new HashMap<>(QUERY_CONTEXT_DEFAULT);
     context.put(PlannerConfig.CTX_KEY_USE_APPROXIMATE_TOPN, false);
     testQuery(
@@ -5625,10 +5626,10 @@ public class CalciteJoinQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(minTopNThreshold = 1)
   @Test
   public void testJoinWithAliasAndOrderByNoGroupBy()
   {
-    minTopNThreshold = 1;
     Map<String, Object> context = new HashMap<>(QUERY_CONTEXT_DEFAULT);
     context.put(PlannerConfig.CTX_KEY_USE_APPROXIMATE_TOPN, false);
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -5719,6 +5719,11 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testMergeBufferSettingHasSideEffect() {
+    requireMergeBuffers(1);
+  }
+
+  @Test
   public void testCountStarWithTimeMillisecondFilters()
   {
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -2479,6 +2479,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testExactCountDistinctWithFilter()
   {
@@ -2501,8 +2502,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
             ImmutableList.of()
         )
     );
-
-    requireMergeBuffers(3);
 
     if (NullHandling.sqlCompatible()) {
       // Cannot vectorize due to "istrue" operator.
@@ -3242,6 +3241,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
    * This test case should be in {@link CalciteUnionQueryTest}. However, there's a bug in the test framework that
    * doesn't reset framework once the merge buffers
    */
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @NotYetSupported
   @Test
   public void testUnionAllSameTableThreeTimes()
@@ -3286,6 +3286,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @NotYetSupported(Modes.NOT_ENOUGH_RULES)
   @Test
   public void testExactCountDistinctUsingSubqueryOnUnionAllTables()
@@ -5719,11 +5720,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testMergeBufferSettingHasSideEffect() {
-    requireMergeBuffers(1);
-  }
-
-  @Test
   public void testCountStarWithTimeMillisecondFilters()
   {
     testQuery(
@@ -6581,11 +6577,11 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 4)
   @Test
   public void testMultipleExactCountDistinctWithGroupingUsingGroupingSets()
   {
     msqIncompatible();
-    requireMergeBuffers(4);
     testQuery(
         PLANNER_CONFIG_NO_HLL.withOverrides(
             ImmutableMap.of(
@@ -6845,10 +6841,10 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testDoubleNestedGroupBy()
   {
-    requireMergeBuffers(3);
     testQuery(
         "SELECT SUM(cnt), COUNT(*) FROM (\n"
         + "  SELECT dim2, SUM(t1.cnt) cnt FROM (\n"
@@ -6900,6 +6896,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testDoubleNestedGroupBy2()
   {
@@ -8195,13 +8192,13 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testQueryWithSelectProjectAndIdentityProjectDoesNotRename()
   {
     msqIncompatible();
     cannotVectorize();
     skipVectorize();
-    requireMergeBuffers(3);
     testQuery(
         PLANNER_CONFIG_NO_HLL.withOverrides(
             ImmutableMap.of(
@@ -10237,6 +10234,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSets()
   {
@@ -10302,11 +10300,11 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingAggregatorDifferentOrder()
   {
     msqIncompatible();
-    requireMergeBuffers(3);
 
     testQuery(
         "SELECT dim2, gran, SUM(cnt), GROUPING(gran, dim2)\n"
@@ -10572,6 +10570,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupByCube()
   {
@@ -10634,6 +10633,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithDummyDimension()
   {
@@ -10696,6 +10696,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsNoSuperset()
   {
@@ -10753,6 +10754,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithOrderByDimension()
   {
@@ -10824,6 +10826,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithOrderByAggregator()
   {
@@ -10893,6 +10896,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithOrderByAggregatorWithLimit()
   {
@@ -12487,6 +12491,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithLimit()
   {
@@ -12552,6 +12557,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testGroupingSetsWithLimitOrderByGran()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import org.apache.druid.query.topn.TopNQueryConfig;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD})
+  public @interface SqlTestFrameworkConfig
+  {
+    int numMergeBuffers() default 0;
+    int minTopNThreshold() default TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD;
+ }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
@@ -20,16 +20,93 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.query.topn.TopNQueryConfig;
+import org.apache.druid.sql.calcite.util.SqlTestFramework;
+import org.apache.druid.sql.calcite.util.SqlTestFramework.QueryComponentSupplier;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
 
 @Retention(RetentionPolicy.RUNTIME)
-  @Target({ElementType.METHOD})
-  public @interface SqlTestFrameworkConfig
+@Target({ElementType.METHOD})
+public @interface SqlTestFrameworkConfig
+{
+  int numMergeBuffers() default 0;
+
+  int minTopNThreshold() default TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD;
+
+  public static class ClassRule extends ExternalResource
   {
-    int numMergeBuffers() default 0;
-    int minTopNThreshold() default TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD;
- }
+
+    Map<SqlTestFrameworkConfig, SqlTestFramework> frameworkMap = new HashMap<SqlTestFrameworkConfig, SqlTestFramework>();
+
+    public SqlTestFrameworkRule methodRule(BaseCalciteQueryTest testHost)
+    {
+      return new SqlTestFrameworkRule(this, testHost);
+    }
+
+    @Override
+    protected void after()
+    {
+      for (SqlTestFramework f : frameworkMap.values()) {
+        f.close();
+      }
+      frameworkMap.clear();
+    }
+  }
+
+  public static class SqlTestFrameworkRule implements TestRule
+  {
+    private SqlTestFrameworkConfig config;
+    private ClassRule classRule;
+    private QueryComponentSupplier testHost;
+
+    public SqlTestFrameworkRule(ClassRule classRule, QueryComponentSupplier testHost)
+    {
+      this.classRule = classRule;
+      this.testHost = testHost;
+    }
+
+    @SqlTestFrameworkConfig
+    public SqlTestFrameworkConfig defaultConfig()
+    {
+      try {
+        return getClass()
+            .getMethod("defaultConfig")
+            .getAnnotation(SqlTestFrameworkConfig.class);
+      } catch (NoSuchMethodException | SecurityException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description)
+    {
+      config = description.getAnnotation(SqlTestFrameworkConfig.class);
+      if (config == null) {
+        config = defaultConfig();
+      }
+      return base;
+    }
+
+    public SqlTestFramework get()
+    {
+      return classRule.frameworkMap.computeIfAbsent(config, this::createFramework);
+    }
+
+    private SqlTestFramework createFramework(SqlTestFrameworkConfig config)
+    {
+      SqlTestFramework.Builder builder = new SqlTestFramework.Builder(testHost)
+          .minTopNThreshold(config.minTopNThreshold())
+          .mergeBufferCount(config.numMergeBuffers());
+      return builder.build();
+    }
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkRule.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkRule.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import org.apache.druid.sql.calcite.util.SqlTestFramework;
+import org.apache.druid.sql.calcite.util.SqlTestFramework.QueryComponentSupplier;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SqlTestFrameworkRule implements TestRule
+{
+  private SqlTestFrameworkConfig config;
+  Map<SqlTestFrameworkConfig, SqlTestFramework> frameworkMap = new HashMap<SqlTestFrameworkConfig, SqlTestFramework>();
+  private QueryComponentSupplier testHost;
+
+  public SqlTestFrameworkRule(QueryComponentSupplier host)
+  {
+    testHost = host;
+    System.out.println("Asd");
+  }
+
+  @SqlTestFrameworkConfig
+  public SqlTestFrameworkConfig defaultConfig()
+  {
+    try {
+      return getClass()
+          .getMethod("defaultConfig")
+          .getAnnotation(SqlTestFrameworkConfig.class);
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description)
+  {
+    config = description.getAnnotation(SqlTestFrameworkConfig.class);
+    if (config == null) {
+      config = defaultConfig();
+    }
+    return base;
+  }
+
+  public SqlTestFramework get()
+  {
+    return    frameworkMap .computeIfAbsent(config, this::createFramework);
+  }
+
+  private SqlTestFramework createFramework(SqlTestFrameworkConfig config)
+  {
+    SqlTestFramework.Builder builder = new SqlTestFramework.Builder(testHost)
+        .minTopNThreshold(config.minTopNThreshold())
+        .mergeBufferCount(config.numMergeBuffers());
+    return builder.build();
+  }
+
+
+}


### PR DESCRIPTION
* changes how its configured a bit to use an annotation instead of methods
* framework is cached - not thrown away; this makes it run a bit faster 16s vs 20s for CQT
* annotated cases which were using more merge buffers due to the fact that the framework was not reset to the default for every testcase (#15427)

Fixes #15427. 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
