### PR TITLE
update confluent's dependencies to common, supported version

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
-    <confluent.version>5.5.12</confluent.version>
+    <confluent.version>6.2.12</confluent.version>
   </properties>
 
   <repositories>

--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -35,7 +35,6 @@
 
   <properties>
     <schemarepo.version>0.1.3</schemarepo.version>
-    <confluent.version>6.2.12</confluent.version>
   </properties>
 
   <repositories>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <confluent.version>6.0.1</confluent.version>
+    <confluent.version>6.2.12</confluent.version>
     <commons-io.version>2.11.0</commons-io.version>
   </properties>
 

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -35,7 +35,6 @@
   </parent>
 
   <properties>
-    <confluent.version>6.2.12</confluent.version>
     <commons-io.version>2.11.0</commons-io.version>
   </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -363,7 +363,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
-            <version>5.5.12</version>
+            <version>6.2.12</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-provider</artifactId>
-            <version>5.5.12</version>
+            <version>6.2.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -592,7 +592,7 @@
                                         <DRUID_INTEGRATION_TEST_INDEXER>${it.indexer}</DRUID_INTEGRATION_TEST_INDEXER>
                                         <MYSQL_VERSION>${mysql.version}</MYSQL_VERSION>
                                         <MARIA_VERSION>2.7.3</MARIA_VERSION>
-                                        <CONFLUENT_VERSION>5.5.1</CONFLUENT_VERSION>
+                                        <CONFLUENT_VERSION>6.2.12</CONFLUENT_VERSION>
                                         <KAFKA_VERSION>${apache.kafka.version}</KAFKA_VERSION>
                                         <ZK_VERSION>${zookeeper.version}</ZK_VERSION>
                                         <HADOOP_VERSION>${hadoop.compile.version}</HADOOP_VERSION>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3184,7 +3184,7 @@ libraries:
 ---
 
 name: Kafka clients
-version: 5.5.12-ccs
+version: 7.5.1-ccs
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3193,7 +3193,7 @@ libraries:
 
 ---
 name: Kafka-schema-registry-client
-version: 6.2.12
+version: 7.5.1
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3316,7 +3316,7 @@ libraries:
 ---
 
 name: Kafka Schema Registry Client 6.0.1
-version: 6.2.12
+version: 7.5.1
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
@@ -3327,7 +3327,7 @@ libraries:
 ---
 
 name: Confluent Kafka Client
-version: 6.2.12-ccs
+version: 7.5.1-ccs
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3322,6 +3322,7 @@ module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
 libraries:
   - io.swagger: swagger-annotations
+  - io.swagger.core.v3: swagger-annotations
 
 ---
 
@@ -3343,6 +3344,18 @@ module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
 libraries:
   - org.apache.kafka: kafka-clients
+
+
+---
+
+name: swagger-annotations
+version: 2.1.10
+license_category: binary
+module: extensions/druid-avro-extensions
+license_name: Apache License version 2.0
+libraries:
+  - io.swagger: swagger-annotations
+  - io.swagger.core.v3: swagger-annotations
 
 ---
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3315,6 +3315,16 @@ libraries:
 
 ---
 
+name: swagger-annotations
+version: 2.1.10
+license_category: binary
+module: extensions/druid-avro-extensions
+license_name: Apache License version 2.0
+libraries:
+  - io.swagger: swagger-annotations
+
+---
+
 name: Kafka Schema Registry Client 6.0.1
 version: 7.5.1
 license_category: binary

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3193,7 +3193,7 @@ libraries:
 
 ---
 name: Kafka-schema-registry-client
-version: 5.5.12
+version: 6.2.12
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3316,7 +3316,7 @@ libraries:
 ---
 
 name: Kafka Schema Registry Client 6.0.1
-version: 6.0.1
+version: 6.2.12
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
@@ -3327,7 +3327,7 @@ libraries:
 ---
 
 name: Confluent Kafka Client
-version: 6.0.1-ccs
+version: 6.2.12-ccs
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
@@ -4686,7 +4686,7 @@ libraries:
 
 ---
 
-name: Apache Lucene 
+name: Apache Lucene
 license_category: binary
 version: 8.4.0
 module: druid-ranger-security

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3184,7 +3184,7 @@ libraries:
 ---
 
 name: Kafka clients
-version: 7.0.11-ccs
+version: 6.2.12-ccs
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3193,7 +3193,7 @@ libraries:
 
 ---
 name: Kafka-schema-registry-client
-version: 7.0.11
+version: 6.2.12
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3327,7 +3327,7 @@ libraries:
 ---
 
 name: Kafka Schema Registry Client
-version: 7.0.11
+version: 6.2.12
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
@@ -3338,7 +3338,7 @@ libraries:
 ---
 
 name: Confluent Kafka Client
-version: 7.0.11-ccs
+version: 6.2.12-ccs
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3184,7 +3184,7 @@ libraries:
 ---
 
 name: Kafka clients
-version: 7.5.1-ccs
+version: 7.0.11-ccs
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3193,7 +3193,7 @@ libraries:
 
 ---
 name: Kafka-schema-registry-client
-version: 7.5.1
+version: 7.0.11
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0
@@ -3326,8 +3326,8 @@ libraries:
 
 ---
 
-name: Kafka Schema Registry Client 6.0.1
-version: 7.5.1
+name: Kafka Schema Registry Client
+version: 7.0.11
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
@@ -3338,7 +3338,7 @@ libraries:
 ---
 
 name: Confluent Kafka Client
-version: 7.5.1-ccs
+version: 7.0.11-ccs
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
              default_config.fmpp
           -->
         <calcite.version>1.35.0</calcite.version>
+        <confluent.version>7.5.1</confluent.version>
         <datasketches.version>4.2.0</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
              default_config.fmpp
           -->
         <calcite.version>1.35.0</calcite.version>
-        <confluent.version>7.0.11</confluent.version>
+        <confluent.version>6.2.12</confluent.version>
         <datasketches.version>4.2.0</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
              default_config.fmpp
           -->
         <calcite.version>1.35.0</calcite.version>
-        <confluent.version>7.5.1</confluent.version>
+        <confluent.version>7.0.11</confluent.version>
         <datasketches.version>4.2.0</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
@@ -250,6 +250,14 @@
         <repository>
             <id>sigar</id>
             <url>https://repository.mulesoft.org/nexus/content/repositories/public</url>
+            <snapshots>
+               <enabled>false</enabled>
+            </snapshots>
+        </repository>
+
+        <repository>
+            <id>cflt-public</id>
+            <url>https://packages.confluent.io/maven/</url>
             <snapshots>
                <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
### Description
Update io.confluent.* dependencies to common, updated version 6.2.12 
currently used versions are EOL 


This PR has:

- [x ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
