### PR TITLE
remove unnecessary elasticsearch dependencies to fix CVE regressions

### DIFF
--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -34,6 +34,21 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>6.4.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bundle</artifactId>
+                <version>${aws.sdk.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>
@@ -133,6 +148,18 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch.client</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch.plugin</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -144,13 +171,19 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch.client</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch.plugin</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>${apache.ranger.gson.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4597,7 +4597,7 @@ libraries:
 
 name: com.amazonaws aws-java-sdk-bundle
 license_category: binary
-version: 1.12.125
+version: 1.12.497
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:
@@ -4676,17 +4676,7 @@ libraries:
 
 ---
 
-name: org.elasticsearch securesm
-license_category: binary
-version: 2.1.9
-module: druid-ranger-security
-license_name: Creative Commons CC0
-libraries:
-  - org.hdrhistogram: HdrHistogram
-
----
-
-name: Apache Lucene 
+name: Apache Lucene
 license_category: binary
 version: 8.4.0
 module: druid-ranger-security
@@ -4707,38 +4697,6 @@ libraries:
   - org.apache.lucene: lucene-spatial-extras
   - org.apache.lucene: lucene-spatial3d
   - org.apache.lucene: lucene-suggest
-
----
-
-name: org.elasticsearch securesm
-license_category: binary
-version: 1.2
-module: druid-ranger-security
-license_name: Apache License version 2.0
-libraries:
-  - org.elasticsearch: securesm
-
----
-
-name: Elastic Search
-license_category: binary
-version: 7.10.2
-module: druid-ranger-security
-license_name: Apache License version 2.0
-libraries:
-  - org.elasticsearch: elasticsearch
-  - org.elasticsearch: elasticsearch-cli
-  - org.elasticsearch: elasticsearch-core
-  - org.elasticsearch: elasticsearch-geo
-  - org.elasticsearch: elasticsearch-secure-sm
-  - org.elasticsearch: elasticsearch-x-content
-  - org.elasticsearch.client: elasticsearch-rest-client
-  - org.elasticsearch.client: elasticsearch-rest-high-level-client
-  - org.elasticsearch.plugin: aggs-matrix-stats-client
-  - org.elasticsearch.plugin: lang-mustache-client
-  - org.elasticsearch.plugin: mapper-extras-client
-  - org.elasticsearch.plugin: parent-join-client
-  - org.elasticsearch.plugin: rank-eval-client
 
 ---
 
@@ -4780,7 +4738,7 @@ libraries:
 
 name: Woodstox
 license_category: binary
-version: 6.2.4
+version: 6.4.0
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:


### PR DESCRIPTION
### Description
Recent upgrade of ranger introduced CVE regressions due to outdated elasticsearch components. 
Druid-ranger-plugin does not elasticsearch components , and they have been explicitly removed. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
