### PR TITLE
Web console: better management proxy detection

### DIFF
--- a/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
@@ -109,7 +109,7 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
           MODIFIED_PATH_ATTRIBUTE,
           request.getRequestURI().substring(ARBITRARY_OVERLORD_BASE_PATH.length())
       );
-    } else if (requestURI.equals(ENABLED_PATH)) {
+    } else if (ENABLED_PATH.equals(requestURI)) {
       handleEnabledRequest(response);
       return;
     } else {

--- a/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
@@ -63,6 +63,9 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
   private static final String ARBITRARY_COORDINATOR_BASE_PATH = "/proxy/coordinator";
   private static final String ARBITRARY_OVERLORD_BASE_PATH = "/proxy/overlord";
 
+  // This path is used to check if the managment proxy is enabled, it simply returns {"enabled":true}
+  private static final String ENABLED_PATH = "/proxy/enabled";
+
   private final ObjectMapper jsonMapper;
   private final Provider<HttpClient> httpClientProvider;
   private final DruidHttpClientConfig httpClientConfig;
@@ -106,6 +109,9 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
           MODIFIED_PATH_ATTRIBUTE,
           request.getRequestURI().substring(ARBITRARY_OVERLORD_BASE_PATH.length())
       );
+    } else if (requestURI.equals(ENABLED_PATH)) {
+      handleEnabledRequest(response);
+      return;
     } else {
       handleBadRequest(response, StringUtils.format("Unsupported proxy destination [%s]", request.getRequestURI()));
       return;
@@ -185,6 +191,16 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
       response.resetBuffer();
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       jsonMapper.writeValue(response.getOutputStream(), ImmutableMap.of("error", errorMessage));
+    }
+    response.flushBuffer();
+  }
+
+  private void handleEnabledRequest(HttpServletResponse response) throws IOException
+  {
+    if (!response.isCommitted()) {
+      response.resetBuffer();
+      response.setStatus(HttpServletResponse.SC_OK);
+      jsonMapper.writeValue(response.getOutputStream(), ImmutableMap.of("enabled", true));
     }
     response.flushBuffer();
   }

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -318,6 +318,18 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
   }
 
   @Test
+  public void testProxyEnebledCheck() throws Exception
+  {
+    HttpURLConnection connection = ((HttpURLConnection)
+        new URL(StringUtils.format("http://localhost:%d/proxy/enabled", port)).openConnection());
+    connection.setRequestMethod("GET");
+
+    Assert.assertEquals(200, connection.getResponseCode());
+    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
+    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+  }
+
+  @Test
   public void testBadProxyDestination() throws Exception
   {
     HttpURLConnection connection = ((HttpURLConnection)

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -326,7 +326,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     Assert.assertEquals(200, connection.getResponseCode());
     byte[] bytes = new byte[connection.getContentLength()];
-    connection.getInputStream().read(bytes);
+    Assert.assertEquals(connection.getInputStream().read(bytes), connection.getContentLength());
     Assert.assertEquals(ImmutableMap.of("enabled", true), new ObjectMapper().readValue(bytes, Map.class));
     Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
     Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -327,7 +327,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     Assert.assertEquals(200, connection.getResponseCode());
     byte[] bytes = new byte[connection.getContentLength()];
     connection.getInputStream().read(bytes);
-    Assert.assertEquals(ImmutableMap.of("enabled", true), new DefaultObjectMapper().readValue(bytes, Map.class));
+    Assert.assertEquals(ImmutableMap.of("enabled", true), new ObjectMapper().readValue(bytes, Map.class));
     Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
     Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
   }

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -325,6 +325,9 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
     connection.setRequestMethod("GET");
 
     Assert.assertEquals(200, connection.getResponseCode());
+    byte[] bytes = new byte[connection.getContentLength()];
+    connection.getInputStream().read(bytes);
+    Assert.assertEquals(ImmutableMap.of("enabled", true), new DefaultObjectMapper().readValue(bytes, Map.class));
     Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
     Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
   }

--- a/web-console/src/helpers/capabilities.ts
+++ b/web-console/src/helpers/capabilities.ts
@@ -102,11 +102,13 @@ export class Capabilities {
 
   static async detectManagementProxy(): Promise<boolean> {
     try {
-      await Api.instance.get(`/proxy/coordinator/status?capabilities`, {
+      await Api.instance.get(`/proxy/enabled?capabilities`, {
         timeout: Capabilities.STATUS_TIMEOUT,
       });
     } catch (e) {
-      return false;
+      const { response } = e;
+      // If we detect error code 400 the management proxy is enabled but just does not know about the recently added /proxy/enabled route so treat this as a win.
+      return response.status === 400;
     }
 
     return true;


### PR DESCRIPTION
This PR tries to address a UX confusion where the console goes into "no management proxy mode" when in-fact the coordinator leader can simply not be determined in a transitive state. This is because right now the console relies on havign `/proxy/coordinator/status` return 200 to know that the management proxy is enabled. But that call might fail even when the management proxy is on.

In this PR I add a `/proxy/enabled` endpoint that simply returns `{"enabled":true}` and retool the console to use that route instead. Also I allow for a code 400 to indicate that the management proxy is running.