### PR TITLE
Propagate Intervals.of() error message to user

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.common;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -39,7 +40,12 @@ public final class Intervals
 
   public static Interval of(String interval)
   {
-    return new Interval(interval, ISOChronology.getInstanceUTC());
+    try {
+      return new Interval(interval, ISOChronology.getInstanceUTC());
+    }
+    catch (IllegalArgumentException e) {
+      throw InvalidInput.exception(e, "Bad Interval[%s]: [%s]", interval, e.getMessage());
+    }
   }
 
   public static Interval of(String format, Object... formatArgs)

--- a/processing/src/test/java/org/apache/druid/java/util/common/IntervalsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/IntervalsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.java.util.common;
 
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -78,4 +79,11 @@ public class IntervalsTest
     );
   }
 
+  @Test
+  public void testInvalidInterval()
+  {
+    DruidExceptionMatcher.invalidInput().assertThrowsAndMatches(
+        () -> Intervals.of("invalid string")
+    );
+  }
 }

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -697,25 +697,6 @@ public class SqlSegmentsMetadataManagerTest
     );
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testMarkAsUsedNonOvershadowedSegmentsInIntervalWithInvalidInterval() throws IOException
-  {
-    sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-
-    final String newDataSource = "wikipedia2";
-    final DataSegment newSegment1 = createNewSegment1(newDataSource);
-
-    final DataSegment newSegment2 = createNewSegment2(newDataSource);
-
-    publish(newSegment1, false);
-    publish(newSegment2, false);
-    // invalid interval start > end
-    final Interval theInterval = Intervals.of("2017-10-22T00:00:00.000/2017-10-02T00:00:00.000");
-    sqlSegmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(newDataSource, theInterval);
-  }
-
   @Test
   public void testMarkAsUsedNonOvershadowedSegmentsInIntervalWithOverlappingInterval() throws IOException
   {
@@ -831,25 +812,6 @@ public class SqlSegmentsMetadataManagerTest
         ImmutableSet.of(segment1, segment2, newSegment3),
         ImmutableSet.copyOf(sqlSegmentsMetadataManager.iterateAllUsedSegments())
     );
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testMarkAsUnusedSegmentsInIntervalWithInvalidInterval() throws IOException
-  {
-    sqlSegmentsMetadataManager.startPollingDatabasePeriodically();
-    sqlSegmentsMetadataManager.poll();
-    Assert.assertTrue(sqlSegmentsMetadataManager.isPollingDatabasePeriodically());
-
-    final String newDataSource = "wikipedia2";
-    final DataSegment newSegment1 = createNewSegment1(newDataSource);
-
-    final DataSegment newSegment2 = createNewSegment2(newDataSource);
-
-    publisher.publishSegment(newSegment1);
-    publisher.publishSegment(newSegment2);
-    // invalid interval start > end
-    final Interval theInterval = Intervals.of("2017-10-22T00:00:00.000/2017-10-02T00:00:00.000");
-    sqlSegmentsMetadataManager.markAsUnusedSegmentsInInterval(newDataSource, theInterval);
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.client.SegmentLoadInfo;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.metadata.MetadataRuleManager;
 import org.apache.druid.metadata.SegmentsMetadataManager;
@@ -611,19 +612,9 @@ public class DataSourcesResourceTest
     EasyMock.replay(overlordClient, server);
     DataSourcesResource dataSourcesResource =
         new DataSourcesResource(inventoryView, null, null, overlordClient, null, null, auditManager);
-    try {
-      Response response =
-          dataSourcesResource.markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", "true", "???", request);
-      // 400 (Bad Request) or an IllegalArgumentException is expected.
-      Assert.assertEquals(400, response.getStatus());
-      Assert.assertNotNull(response.getEntity());
-      Assert.assertTrue(response.getEntity().toString().contains("java.lang.IllegalArgumentException"));
-    }
-    catch (IllegalArgumentException ignore) {
-      // expected
-    }
-
-    EasyMock.verify(overlordClient, server);
+    DruidExceptionMatcher.invalidInput().assertThrowsAndMatches(
+        () -> dataSourcesResource.markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", "true", "???", request)
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description

In SQL, when specifying an interval, eg '2020-01-01T:00:00:00Z/2021-01-01T00:00:00Z', errors in the string are not shown to the user. It gives an unknown error and no useful information.

This propagates any errors from Intervals.of() properly by catching and throwing the proper exception

#### Release note
-Improve error message on interval construction in SQL statements

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
