### PR TITLE
Web console: fix tab duplication

### DIFF
--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -200,11 +200,13 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
               {RuleUtil.hasIncludeFuture(rule) && (
                 <Switch
                   className="include-future"
-                  checked={rule.includeFuture || false}
+                  checked={RuleUtil.getIncludeFuture(rule)}
                   label="Include future"
                   disabled={disabled}
                   onChange={() => {
-                    onChange?.(RuleUtil.changeIncludeFuture(rule, !rule.includeFuture));
+                    onChange?.(
+                      RuleUtil.changeIncludeFuture(rule, !RuleUtil.getIncludeFuture(rule)),
+                    );
                   }}
                 />
               )}

--- a/web-console/src/druid-models/execution/execution.ts
+++ b/web-console/src/druid-models/execution/execution.ts
@@ -21,6 +21,7 @@ import { Column, QueryResult, SqlExpression, SqlQuery, SqlWithQuery } from '@dru
 import {
   deepGet,
   deleteKeys,
+  formatDuration,
   formatInteger,
   nonEmptyArray,
   oneOf,
@@ -563,7 +564,7 @@ export class Execution {
         break;
 
       case 'SUCCESS':
-        label = 'Segments loaded successfully in ' + segmentStatus.duration + 'ms.';
+        label = `Segments loaded successfully in ${formatDuration(segmentStatus.duration)}`;
         break;
 
       default:

--- a/web-console/src/utils/load-rule.ts
+++ b/web-console/src/utils/load-rule.ts
@@ -57,8 +57,9 @@ export class RuleUtil {
   static ruleToString(rule: Rule): string {
     const params: string[] = [];
 
-    if (RuleUtil.hasPeriod(rule))
-      params.push(`${rule.period}${rule.includeFuture ? '+future' : ''}`);
+    if (RuleUtil.hasPeriod(rule)) {
+      params.push(`${rule.period}${RuleUtil.getIncludeFuture(rule) ? '+future' : ''}`);
+    }
     if (RuleUtil.hasInterval(rule)) params.push(rule.interval || '?');
     if (RuleUtil.canHaveTieredReplicants(rule)) params.push(`${RuleUtil.totalReplicas(rule)}x`);
 
@@ -69,20 +70,21 @@ export class RuleUtil {
     const newRule = deepSet(rule, 'type', type);
 
     if (RuleUtil.hasPeriod(newRule)) {
-      if (!newRule.period) newRule.period = 'P1M';
+      newRule.period ??= 'P1M';
+      newRule.includeFuture ??= true;
     } else {
       delete newRule.period;
       delete newRule.includeFuture;
     }
 
     if (RuleUtil.hasInterval(newRule)) {
-      if (!newRule.interval) newRule.interval = '2010-01-01/2020-01-01';
+      newRule.interval ??= '2010-01-01/2020-01-01';
     } else {
       delete newRule.interval;
     }
 
     if (RuleUtil.canHaveTieredReplicants(newRule)) {
-      if (!newRule.tieredReplicants) newRule.tieredReplicants = { _default_tier: 2 };
+      newRule.tieredReplicants ??= { _default_tier: 2 };
     } else {
       delete newRule.tieredReplicants;
     }
@@ -100,6 +102,10 @@ export class RuleUtil {
 
   static hasIncludeFuture(rule: Rule): boolean {
     return RuleUtil.hasPeriod(rule) && rule.type !== 'dropBeforeByPeriod';
+  }
+
+  static getIncludeFuture(rule: Rule): boolean {
+    return rule.includeFuture ?? true;
   }
 
   static changeIncludeFuture(rule: Rule, includeFuture: boolean): Rule {

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -496,7 +496,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
                           const newTabEntry: TabEntry = {
                             id,
                             tabName: tabEntry.tabName + ' (copy)',
-                            query: tabEntry.query,
+                            query: tabEntry.query.changeLastExecution(undefined),
                           };
                           this.handleQueriesChange(
                             tabEntries.slice(0, i + 1).concat(newTabEntry, tabEntries.slice(i + 1)),


### PR DESCRIPTION
Fix bug where a duplicated tab reattaches to the same running query as the original.
Also fixes a place where the duration is not formatted.