### PR TITLE
add supported array column type support to EXTEND operator

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/JsonInputFormat.java
@@ -215,4 +215,16 @@ public class JsonInputFormat extends NestedInputFormat
         useJsonNodeReader
     );
   }
+
+  @Override
+  public String toString()
+  {
+    return "JsonInputFormat{" +
+           "featureSpec=" + featureSpec +
+           ", keepNullColumns=" + keepNullColumns +
+           ", lineSplittable=" + lineSplittable +
+           ", assumeNewlineDelimited=" + assumeNewlineDelimited +
+           ", useJsonNodeReader=" + useJsonNodeReader +
+           '}';
+  }
 }

--- a/server/src/main/java/org/apache/druid/catalog/model/Columns.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/Columns.java
@@ -38,6 +38,10 @@ public class Columns
   public static final String BIGINT = "BIGINT";
   public static final String FLOAT = "FLOAT";
   public static final String DOUBLE = "DOUBLE";
+  public static final String VARCHAR_ARRAY = "VARCHAR ARRAY";
+  public static final String BIGINT_ARRAY = "BIGINT ARRAY";
+  public static final String FLOAT_ARRAY = "FLOAT ARRAY";
+  public static final String DOUBLE_ARRAY = "DOUBLE ARRAY";
   public static final String TIMESTAMP = "TIMESTAMP";
 
   public static final Set<String> NUMERIC_TYPES =
@@ -52,6 +56,10 @@ public class Columns
         .put(FLOAT, ColumnType.FLOAT)
         .put(DOUBLE, ColumnType.DOUBLE)
         .put(VARCHAR, ColumnType.STRING)
+        .put(VARCHAR_ARRAY, ColumnType.STRING_ARRAY)
+        .put(BIGINT_ARRAY, ColumnType.LONG_ARRAY)
+        .put(FLOAT_ARRAY, ColumnType.FLOAT_ARRAY)
+        .put(DOUBLE_ARRAY, ColumnType.DOUBLE_ARRAY)
         .build();
 
   public static final Map<ColumnType, String> DRUID_TO_SQL_TYPES =
@@ -60,6 +68,10 @@ public class Columns
       .put(ColumnType.FLOAT, FLOAT)
       .put(ColumnType.DOUBLE, DOUBLE)
       .put(ColumnType.STRING, VARCHAR)
+      .put(ColumnType.STRING_ARRAY, VARCHAR_ARRAY)
+      .put(ColumnType.LONG_ARRAY, BIGINT_ARRAY)
+      .put(ColumnType.FLOAT_ARRAY, FLOAT_ARRAY)
+      .put(ColumnType.DOUBLE_ARRAY, DOUBLE_ARRAY)
       .build();
 
   private Columns()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/ExtendOperator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/ExtendOperator.java
@@ -70,14 +70,14 @@ public class ExtendOperator extends SqlInternalOperator
   @Override
   public SqlNode rewriteCall(SqlValidator validator, SqlCall call)
   {
-    SqlBasicCall tableOpCall = (SqlBasicCall) call.operand(0);
+    SqlBasicCall tableOpCall = call.operand(0);
     if (!(tableOpCall.getOperator() instanceof SqlCollectionTableOperator)) {
       throw new ISE("First argument to EXTEND must be TABLE");
     }
 
     // The table function must be a Druid-defined table macro function
     // which is aware of the EXTEND schema.
-    SqlBasicCall tableFnCall = (SqlBasicCall) tableOpCall.operand(0);
+    SqlBasicCall tableFnCall = tableOpCall.operand(0);
     if (!(tableFnCall.getOperator() instanceof SchemaAwareUserDefinedTableMacro)) {
       // May be an unresolved function.
       throw new IAE(
@@ -89,7 +89,7 @@ public class ExtendOperator extends SqlInternalOperator
     // Move the schema from the second operand of EXTEND into a member
     // function of a shim table macro.
     SchemaAwareUserDefinedTableMacro tableFn = (SchemaAwareUserDefinedTableMacro) tableFnCall.getOperator();
-    SqlNodeList schema = (SqlNodeList) call.operand(1);
+    SqlNodeList schema = call.operand(1);
     SqlCall newCall = tableFn.rewriteCall(tableFnCall, schema);
 
     // Create a new TABLE(table_fn) node to replace the EXTEND node. After this,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/Externals.java
@@ -292,6 +292,8 @@ public class Externals
       case FLOAT:
       case REAL:
         return SqlType.FLOAT.name();
+      case ARRAY:
+        return convertType(name, dataType.getComponentTypeSpec()) + " " + SqlType.ARRAY.name();
       default:
         throw unsupportedType(name, dataType);
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/table/RowSignatures.java
@@ -151,6 +151,9 @@ public class RowSignatures
               case DOUBLE:
                 type = Calcites.createSqlArrayTypeWithNullability(typeFactory, SqlTypeName.DOUBLE, nullNumeric);
                 break;
+              case FLOAT:
+                type = Calcites.createSqlArrayTypeWithNullability(typeFactory, SqlTypeName.FLOAT, nullNumeric);
+                break;
               default:
                 throw new ISE("valueType[%s] not translatable", columnType);
             }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -399,13 +399,7 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
             SystemFields.none(),
             new HttpInputSourceConfig(null)
         ),
-        new JsonInputFormat(
-            null,
-            null,
-            null,
-            null,
-            null
-        ),
+        new JsonInputFormat(null, null, null, null, null),
         RowSignature.builder()
                     .add("x", ColumnType.STRING)
                     .add("y", ColumnType.STRING)


### PR DESCRIPTION
### Description
Allows using types like `VARCHAR ARRAY` and `BIGINT ARRAY` with the `EXTEND` operator. 

For example,
```
EXTEND (a VARCHAR ARRAY, b BIGINT ARRAY, c VARCHAR)
```
specifies an extern input with native druid input types `ARRAY<STRING>`, `ARRAY<LONG>` and `STRING`.

I went ahead and mapped `FLOAT ARRAY` to `ARRAY<FLOAT>` even though these will be stored as `ARRAY<DOUBLE>` if using `"arrayIngestMode":"array"`. Alternatively I suppose it could be an error?

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
