### PR TITLE
Upgrade Jackson and Google GSON to address CVEs

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -248,7 +248,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7
+version: 2.12.7.1
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -289,7 +289,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7
+version: 2.12.7.1
 libraries:
   - com.fasterxml.jackson.core: jackson-databind
 notice: |
@@ -3216,7 +3216,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.12.7
+version: 2.12.7.1
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -248,7 +248,7 @@ name: Jackson
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.12.7.1
+version: 2.12.7
 libraries:
   - com.fasterxml.jackson.core: jackson-annotations
   - com.fasterxml.jackson.core: jackson-core
@@ -2500,7 +2500,7 @@ name: Gson
 license_category: binary
 module: hadoop-client
 license_name: Apache License version 2.0
-version: 2.2.4
+version: 2.10.1
 libraries:
   - com.google.code.gson: gson
 
@@ -3216,7 +3216,7 @@ libraries:
 ---
 
 name: Jackson Dataformat Yaml
-version: 2.12.7.1
+version: 2.12.7
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Apache License version 2.0

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -72,6 +72,16 @@
   </suppress>
 
   <suppress>
+    <!-- Pulled in by io.kubernetes:client-java and kafka_2.13 but not fixed in either place yet -->
+    <!-- jose4j before v0.9.3 allows attackers to set a low iteration count of 1000 or less -->
+    <notes><![CDATA[
+    file name: jose4j-0.7.3.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.bitbucket\.b_c/jose4j@.*$</packageUrl>
+    <cve>CVE-2023-31582</cve>
+  </suppress>
+
+  <suppress>
     <!-- Not much for us to do as a user of the client lib, and no patch is available,
      see https://github.com/kubernetes/kubernetes/issues/97076 -->
     <notes><![CDATA[

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -72,32 +72,6 @@
   </suppress>
 
   <suppress>
-    <!--
-      the suppressions here aren't currently applicable, but can be resolved once we update the version
-      -->
-    <notes><![CDATA[
-   file name: jackson-databind-2.10.5.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-    <!-- CVE-2022-42003 and CVE-2022-42004 are related to UNWRAP_SINGLE_VALUE_ARRAYS which we do not use
-    https://nvd.nist.gov/vuln/detail/CVE-2022-42003
-    https://nvd.nist.gov/vuln/detail/CVE-2022-42004
-     -->
-    <cve>CVE-2022-42003</cve>
-    <cve>CVE-2022-42004</cve>
-  </suppress>
-
-  <suppress>
-    <!-- Pulled in by io.kubernetes:client-java and kafka_2.13 but not fixed in either place yet -->
-    <!-- jose4j before v0.9.3 allows attackers to set a low iteration count of 1000 or less -->
-    <notes><![CDATA[
-    file name: jose4j-0.7.3.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.bitbucket\.b_c/jose4j@.*$</packageUrl>
-    <cve>CVE-2023-31582</cve>
-  </suppress>
-
-  <suppress>
     <!-- Not much for us to do as a user of the client lib, and no patch is available,
      see https://github.com/kubernetes/kubernetes/issues/97076 -->
     <notes><![CDATA[

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.12.7</jackson.version>
+        <jackson.version>2.12.7.20221012</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <apache.curator.version>5.5.0</apache.curator.version>
         <apache.kafka.version>3.6.0</apache.kafka.version>
         <apache.ranger.version>2.4.0</apache.ranger.version>
-        <apache.ranger.gson.version>2.2.4</apache.ranger.gson.version>
+        <apache.ranger.gson.version>2.10.1</apache.ranger.gson.version>
         <scala.library.version>2.13.11</scala.library.version>
         <avatica.version>1.23.0</avatica.version>
         <avro.version>1.11.3</avro.version>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
- Upgrade Jackson to version 2.12.7.1 to address [CVE-2022-42003](https://github.com/advisories/GHSA-jjjh-jjxp-wpff), [CVE-2022-42004](https://github.com/advisories/GHSA-rgv9-q543-rqg4) which affects `jackson-databind`.
- Upgrade `com.google.code.gson:gson` from 2.2.4 to the latest version (2.10.1) since 2.2.4 is affected by [CVE-2022-25647](https://github.com/advisories/GHSA-4jrv-ppp4-jm57).

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
