### PR TITLE
Add a limit to intervals that Granularity.getIterable can return

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/timeline/VersionedIntervalTimelineBenchmark.java
@@ -89,7 +89,7 @@ public class VersionedIntervalTimelineBenchmark
     final int numCompactedSegments =
         (int) (numInitialRootGenSegmentsPerInterval * COMPACTED_SEGMENTS_RATIO_TO_INITIAL_SEGMENTS);
 
-    intervals = Lists.newArrayList(segmentGranularity.getDefaultGranularity().getIterable(TOTAL_INTERVAL));
+    intervals = Lists.newArrayList(segmentGranularity.getDefaultGranularity().getIterable(TOTAL_INTERVAL, 365));
     segments = new ArrayList<>(intervals.size() * numInitialRootGenSegmentsPerInterval);
     Map<Interval, Integer> nextRootGenPartitionIds = Maps.newHashMapWithExpectedSize(intervals.size());
     Map<Interval, Integer> nextNonRootGenPartitionIds = Maps.newHashMapWithExpectedSize(intervals.size());

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/path/GranularityPathSpec.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/path/GranularityPathSpec.java
@@ -112,7 +112,7 @@ public class GranularityPathSpec implements PathSpec
   {
     final Set<Interval> intervals = new TreeSet<>(Comparators.intervalsByStartThenEnd());
     for (Interval inputInterval : config.getInputIntervals()) {
-      for (Interval interval : dataGranularity.getIterable(inputInterval)) {
+      for (Interval interval : dataGranularity.getIterable(inputInterval, 365)) {
         intervals.add(trim(inputInterval, interval));
       }
     }

--- a/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/coordinator/duty/ITAutoCompactionTest.java
@@ -672,7 +672,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
 
       List<String> expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -698,7 +698,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
           coordinator.getSegmentIntervals(fullDatasourceName);
       expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsAfterYEARCompactionButBeforeMONTHCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -781,7 +781,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
 
       List<String> expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -807,7 +807,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
           coordinator.getSegmentIntervals(fullDatasourceName);
       expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsAfterYEARCompactionButBeforeMONTHCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -866,7 +866,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
 
       List<String> expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -888,7 +888,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       // Hence, all three segments are available and the expected intervals are combined from the DAY and YEAR segment granularities
       // (which are 2013-08-31 to 2013-09-01, 2013-09-01 to 2013-09-02 and 2013-01-01 to 2014-01-01)
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -923,7 +923,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
 
       List<String> expectedIntervalAfterCompaction = new ArrayList<>();
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -1021,7 +1021,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       // We will still have one visible segment with interval of 2013-01-01/2014-01-01 (compacted with YEAR)
       // and four overshadowed segments
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -1054,7 +1054,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       // and one segment with interval of 2013-09-01/2013-10-01 (compacted with MONTH)
       // plus ten tombstones for the remaining months, thus expecting 12 intervals...
       for (String interval : intervalsAfterYEARButBeforeMONTHCompaction) {
-        for (Interval newinterval : Granularities.MONTH.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : Granularities.MONTH.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -1084,7 +1084,7 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       List<String> expectedIntervalAfterCompaction = new ArrayList<>();
       // We wil have one segment with interval of 2013-01-01/2014-01-01 (compacted with YEAR)
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : newGranularity.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
@@ -1112,14 +1112,14 @@ public class ITAutoCompactionTest extends AbstractIndexerTest
       // Since dropExisting is set to false...
       // We wil have one segment with interval of 2013-01-01/2014-01-01 (compacted with YEAR) from before the compaction
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : Granularities.YEAR.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : Granularities.YEAR.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }
       // one segments with interval of 2013-09-01/2013-10-01 (compacted with MONTH)
       // and one segments with interval of 2013-10-01/2013-11-01 (compacted with MONTH)
       for (String interval : intervalsBeforeCompaction) {
-        for (Interval newinterval : Granularities.MONTH.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : Granularities.MONTH.getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           expectedIntervalAfterCompaction.add(newinterval.toString());
         }
       }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
@@ -208,7 +208,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
       if (newSegmentGranularity != null) {
         List<String> newIntervals = new ArrayList<>();
         for (String interval : expectedIntervalAfterCompaction) {
-          for (Interval newinterval : newSegmentGranularity.getDefaultGranularity().getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+          for (Interval newinterval : newSegmentGranularity.getDefaultGranularity().getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
             newIntervals.add(newinterval.toString());
           }
         }

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
@@ -159,7 +159,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
 
       List<String> newIntervals = new ArrayList<>();
       for (String interval : expectedIntervalAfterCompaction) {
-        for (Interval newinterval : GranularityType.YEAR.getDefaultGranularity().getIterable(new Interval(interval, ISOChronology.getInstanceUTC()))) {
+        for (Interval newinterval : GranularityType.YEAR.getDefaultGranularity().getIterable(new Interval(interval, ISOChronology.getInstanceUTC()), 365)) {
           newIntervals.add(newinterval.toString());
         }
       }

--- a/processing/src/main/java/org/apache/druid/java/util/common/granularity/AllGranularity.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/granularity/AllGranularity.java
@@ -90,7 +90,7 @@ public class AllGranularity extends Granularity
   }
 
   @Override
-  public Iterable<Interval> getIterable(Interval input)
+  public Iterable<Interval> getIterable(Interval input, int limit)
   {
     return ImmutableList.of(input);
   }

--- a/processing/src/main/java/org/apache/druid/java/util/common/granularity/IntervalsByGranularity.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/granularity/IntervalsByGranularity.java
@@ -69,7 +69,7 @@ public class IntervalsByGranularity
       // Thus dups can be created given the right conditions....
       final SettableSupplier<Interval> previous = new SettableSupplier<>();
       return FluentIterable.from(sortedNonOverlappingIntervals)
-                           .transformAndConcat(granularity::getIterable)
+                           .transformAndConcat(input -> granularity.getIterable(input, 1))
                            .filter(interval -> {
                              if (previous.get() != null && previous.get().equals(interval)) {
                                return false;

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQuery.java
@@ -758,7 +758,7 @@ public class GroupByQuery extends BaseQuery<ResultRow>
         return null;
       }
       final DateTime timeStart = intervals.get(0).getStart();
-      return granularity.getIterable(new Interval(timeStart, timeStart.plus(1))).iterator().next().getStart();
+      return granularity.getIterable(new Interval(timeStart, timeStart.plus(1)), 1).iterator().next().getStart();
     } else {
       return null;
     }

--- a/processing/src/main/java/org/apache/druid/query/vector/VectorCursorGranularizer.java
+++ b/processing/src/main/java/org/apache/druid/query/vector/VectorCursorGranularizer.java
@@ -86,7 +86,7 @@ public class VectorCursorGranularizer
       return null;
     }
 
-    final Iterable<Interval> bucketIterable = granularity.getIterable(clippedQueryInterval);
+    final Iterable<Interval> bucketIterable = granularity.getIterable(clippedQueryInterval, 10_000);
     final Interval firstBucket = granularity.bucket(clippedQueryInterval.getStart());
 
     final VectorValueSelector timeSelector;

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorSequenceBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorSequenceBuilder.java
@@ -119,7 +119,7 @@ public class QueryableIndexCursorSequenceBuilder
 
     final NumericColumn timestamps = (NumericColumn) columnCache.getColumn(ColumnHolder.TIME_COLUMN_NAME);
 
-    Iterable<Interval> iterable = gran.getIterable(interval);
+    Iterable<Interval> iterable = gran.getIterable(interval, 10_000);
     if (descending) {
       iterable = Lists.reverse(ImmutableList.copyOf(iterable));
     }

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedStorageAdapter.java
@@ -197,7 +197,7 @@ public class RowBasedStorageAdapter<RowType> implements StorageAdapter
         rowAdapter
     );
 
-    final Iterable<Interval> bucketIntervals = gran.getIterable(actualInterval);
+    final Iterable<Interval> bucketIntervals = gran.getIterable(actualInterval, 10_000);
 
     return Sequences.simple(
         Iterables.transform(

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapter.java
@@ -279,7 +279,7 @@ public class IncrementalIndexStorageAdapter implements StorageAdapter
       return Sequences.empty();
     }
     final Interval actualInterval = interval.overlap(dataInterval);
-    Iterable<Interval> intervals = gran.getIterable(actualInterval);
+    Iterable<Interval> intervals = gran.getIterable(actualInterval, 10_000);
     if (descending) {
       intervals = Lists.reverse(ImmutableList.copyOf(intervals));
     }

--- a/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/granularity/QueryGranularityTest.java
@@ -58,7 +58,7 @@ public class QueryGranularityTest
   @Test
   public void testIterableNone()
   {
-    final Iterator<Interval> iterator = Granularities.NONE.getIterable(Intervals.utc(0, 1000)).iterator();
+    final Iterator<Interval> iterator = Granularities.NONE.getIterable(Intervals.utc(0, 1000), 10_000).iterator();
     int count = 0;
     while (iterator.hasNext()) {
       Assert.assertEquals(count, iterator.next().getStartMillis());
@@ -77,7 +77,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T09:39:00.000Z"),
             DateTimes.of("2011-01-01T09:40:00.000Z")
         ),
-        Granularities.MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.THREE)))
+        Granularities.MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.THREE)), 10_000)
     );
   }
 
@@ -93,7 +93,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T09:40:00.000Z"),
             DateTimes.of("2011-01-01T09:41:00.000Z")
         ),
-        Granularities.MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.THREE)))
+        Granularities.MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.THREE)), 10_000)
     );
   }
 
@@ -108,7 +108,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T09:45:00.000Z"),
             DateTimes.of("2011-01-01T10:00:00.000Z")
         ),
-        Granularities.FIFTEEN_MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.minutes(45))))
+        Granularities.FIFTEEN_MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.minutes(45))), 10_000)
     );
   }
 
@@ -124,7 +124,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T10:00:00.000Z"),
             DateTimes.of("2011-01-01T10:15:00.000Z")
         ),
-        Granularities.FIFTEEN_MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.minutes(45))))
+        Granularities.FIFTEEN_MINUTE.getIterable(new Interval(baseTime, baseTime.plus(Minutes.minutes(45))), 10_000)
     );
   }
 
@@ -138,7 +138,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T09:00:00.000Z"),
             DateTimes.of("2011-01-01T10:00:00.000Z"),
             DateTimes.of("2011-01-01T11:00:00.000Z")
-        ), Granularities.HOUR.getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(3))))
+        ), Granularities.HOUR.getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(3))), 10_000)
     );
   }
 
@@ -153,7 +153,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-01T10:00:00.000Z"),
             DateTimes.of("2011-01-01T11:00:00.000Z"),
             DateTimes.of("2011-01-01T12:00:00.000Z")
-        ), Granularities.HOUR.getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(3))))
+        ), Granularities.HOUR.getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(3))), 10_000)
     );
   }
 
@@ -168,7 +168,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-02T00:00:00.000Z"),
             DateTimes.of("2011-01-03T00:00:00.000Z")
         ),
-        Granularities.DAY.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))))
+        Granularities.DAY.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))), 10_000)
     );
   }
 
@@ -184,7 +184,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-03T00:00:00.000Z"),
             DateTimes.of("2011-01-04T00:00:00.000Z")
         ),
-        Granularities.DAY.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))))
+        Granularities.DAY.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))), 10_000)
     );
   }
 
@@ -199,7 +199,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-10T00:00:00.000Z"),
             DateTimes.of("2011-01-17T00:00:00.000Z")
         ),
-        Granularities.WEEK.getIterable(new Interval(baseTime, baseTime.plus(Weeks.THREE)))
+        Granularities.WEEK.getIterable(new Interval(baseTime, baseTime.plus(Weeks.THREE)), 10_000)
     );
   }
 
@@ -215,7 +215,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-01-10T00:00:00.000Z"),
             DateTimes.of("2011-01-17T00:00:00.000Z")
         ),
-        Granularities.WEEK.getIterable(new Interval(baseTime, baseTime.plus(Weeks.THREE)))
+        Granularities.WEEK.getIterable(new Interval(baseTime, baseTime.plus(Weeks.THREE)), 10_000)
     );
   }
 
@@ -230,7 +230,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-02-01T00:00:00.000Z"),
             DateTimes.of("2011-03-01T00:00:00.000Z")
         ),
-        Granularities.MONTH.getIterable(new Interval(baseTime, baseTime.plus(Months.THREE)))
+        Granularities.MONTH.getIterable(new Interval(baseTime, baseTime.plus(Months.THREE)), 10_000)
     );
   }
 
@@ -246,7 +246,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-03-01T00:00:00.000Z"),
             DateTimes.of("2011-04-01T00:00:00.000Z")
         ),
-        Granularities.MONTH.getIterable(new Interval(baseTime, baseTime.plus(Months.THREE)))
+        Granularities.MONTH.getIterable(new Interval(baseTime, baseTime.plus(Months.THREE)), 10_000)
     );
   }
 
@@ -261,7 +261,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-04-01T00:00:00.000Z"),
             DateTimes.of("2011-07-01T00:00:00.000Z")
         ),
-        Granularities.QUARTER.getIterable(new Interval(baseTime, baseTime.plus(Months.NINE)))
+        Granularities.QUARTER.getIterable(new Interval(baseTime, baseTime.plus(Months.NINE)), 10_000)
     );
   }
 
@@ -277,7 +277,7 @@ public class QueryGranularityTest
             DateTimes.of("2011-07-01T00:00:00.000Z"),
             DateTimes.of("2011-10-01T00:00:00.000Z")
         ),
-        Granularities.QUARTER.getIterable(new Interval(baseTime, baseTime.plus(Months.NINE)))
+        Granularities.QUARTER.getIterable(new Interval(baseTime, baseTime.plus(Months.NINE)), 10_000)
     );
   }
 
@@ -292,7 +292,7 @@ public class QueryGranularityTest
             DateTimes.of("2012-01-01T00:00:00.000Z"),
             DateTimes.of("2013-01-01T00:00:00.000Z")
         ),
-        Granularities.YEAR.getIterable(new Interval(baseTime, baseTime.plus(Years.THREE)))
+        Granularities.YEAR.getIterable(new Interval(baseTime, baseTime.plus(Years.THREE)), 10_000)
     );
   }
 
@@ -308,7 +308,7 @@ public class QueryGranularityTest
             DateTimes.of("2013-01-01T00:00:00.000Z"),
             DateTimes.of("2014-01-01T00:00:00.000Z")
         ),
-        Granularities.YEAR.getIterable(new Interval(baseTime, baseTime.plus(Years.THREE)))
+        Granularities.YEAR.getIterable(new Interval(baseTime, baseTime.plus(Years.THREE)), 10_000)
     );
   }
 
@@ -324,7 +324,7 @@ public class QueryGranularityTest
             new DateTime("2012-11-06T00:00:00.000-08:00", tz)
         ),
         new PeriodGranularity(new Period("P1D"), null, tz)
-            .getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))))
+            .getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))), 10_000)
     );
 
     assertSameInterval(
@@ -336,7 +336,7 @@ public class QueryGranularityTest
             new DateTime("2012-11-04T03:00:00.000-08:00", tz)
         ),
         new PeriodGranularity(new Period("PT1H"), null, tz)
-            .getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(5))))
+            .getIterable(new Interval(baseTime, baseTime.plus(Hours.hours(5))), 10_000)
     );
 
     final PeriodGranularity hour = new PeriodGranularity(new Period("PT1H"), null, tz);
@@ -458,7 +458,7 @@ public class QueryGranularityTest
             new DateTime("2013-02-01T00:00:00.000-08:00", tz)
         ),
         new PeriodGranularity(new Period("P1M"), null, tz)
-            .getIterable(new Interval(baseTime, baseTime.plus(Months.months(3))))
+            .getIterable(new Interval(baseTime, baseTime.plus(Months.months(3))), 10_000)
     );
   }
 
@@ -475,7 +475,7 @@ public class QueryGranularityTest
             new DateTime("2012-11-19T00:00:00.000-08:00", tz)
         ),
         new PeriodGranularity(new Period("P1W"), null, tz)
-            .getIterable(new Interval(baseTime, baseTime.plus(Weeks.weeks(3))))
+            .getIterable(new Interval(baseTime, baseTime.plus(Weeks.weeks(3))), 10_000)
     );
 
     assertSameInterval(
@@ -485,7 +485,7 @@ public class QueryGranularityTest
             new DateTime("2012-11-17T10:00:00.000-08:00", tz)
         ),
         new PeriodGranularity(new Period("P1W"), baseTime, tz)
-            .getIterable(new Interval(baseTime, baseTime.plus(Weeks.weeks(3))))
+            .getIterable(new Interval(baseTime, baseTime.plus(Weeks.weeks(3))), 10_000)
     );
   }
 
@@ -794,7 +794,7 @@ public class QueryGranularityTest
 
     assertSameInterval(
         Collections.singletonList(baseTime),
-        Granularities.ALL.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))))
+        Granularities.ALL.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))), 10_000)
     );
   }
 
@@ -805,7 +805,7 @@ public class QueryGranularityTest
 
     assertSameInterval(
         Collections.singletonList(baseTime),
-        Granularities.ALL.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))))
+        Granularities.ALL.getIterable(new Interval(baseTime, baseTime.plus(Days.days(3))), 10_000)
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/java/util/common/GranularityTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/GranularityTest.java
@@ -847,7 +847,7 @@ public class GranularityTest
     DateTime start = DateTimes.of("2011-01-01T00:00:00");
     DateTime end = DateTimes.of("2011-01-14T00:00:00");
 
-    Iterator<Interval> intervals = DAY.getIterable(new Interval(start, end)).iterator();
+    Iterator<Interval> intervals = DAY.getIterable(new Interval(start, end), Integer.MAX_VALUE).iterator();
 
     Assert.assertEquals(Intervals.of("2011-01-01/P1d"), intervals.next());
     Assert.assertEquals(Intervals.of("2011-01-02/P1d"), intervals.next());
@@ -863,12 +863,23 @@ public class GranularityTest
     Assert.assertEquals(Intervals.of("2011-01-12/P1d"), intervals.next());
     Assert.assertEquals(Intervals.of("2011-01-13/P1d"), intervals.next());
 
-    try {
-      intervals.next();
-    }
-    catch (NoSuchElementException e) {
-      Assert.assertTrue(true);
-    }
+    Assert.assertThrows(NoSuchElementException.class, intervals::next);
+  }
+
+  @Test
+  public void testGetIterableWithLimit()
+  {
+    DateTime start = DateTimes.of("2011-01-01T00:00:00");
+    DateTime end = DateTimes.of("2011-01-14T00:00:00");
+
+    Iterator<Interval> intervals = DAY.getIterable(new Interval(start, end), 3).iterator();
+
+    Assert.assertEquals(Intervals.of("2011-01-01/P1d"), intervals.next());
+    Assert.assertEquals(Intervals.of("2011-01-02/P1d"), intervals.next());
+    Assert.assertEquals(Intervals.of("2011-01-03/P1d"), intervals.next());
+
+    Assert.assertThrows(IllegalArgumentException.class, intervals::next);
+
   }
 
   @Test
@@ -928,7 +939,8 @@ public class GranularityTest
         new Interval(
             new DateTime("2017-10-14", saoPaulo),
             new DateTime("2017-10-17", saoPaulo)
-        )
+        ),
+        Integer.MAX_VALUE
     );
 
     // Similar to what query engines do: call granularity.bucketStart on the datetimes returned by their cursors.

--- a/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/TimeseriesQueryRunnerTest.java
@@ -925,7 +925,8 @@ public class TimeseriesQueryRunnerTest extends InitializedNullHandlingTest
 
     List<Result<TimeseriesResultValue>> lotsOfZeroes = new ArrayList<>();
     final Iterable<Interval> iterable = Granularities.HOUR.getIterable(
-        new Interval(DateTimes.of("2011-04-14T01"), DateTimes.of("2011-04-15"))
+        new Interval(DateTimes.of("2011-04-14T01"), DateTimes.of("2011-04-15")),
+        Integer.MAX_VALUE
     );
     Map noRowsResult = new HashMap<>();
     noRowsResult.put("rows", 0L);

--- a/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpec.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/ClientCompactionIntervalSpec.java
@@ -69,7 +69,7 @@ public class ClientCompactionIntervalSpec
       // If the compaction task's interval is 2015-02-01/2015-03-01, then the compacted segment would cause existing data
       // from 2015-01-26 to 2015-02-01 and 2015-03-01 to 2015-03-02 to be lost. Hence, in this case,
       // we must adjust the compaction task interval to 2015-01-26/2015-03-02
-      interval = JodaUtils.umbrellaInterval(segmentGranularity.getIterable(interval));
+      interval = JodaUtils.umbrellaInterval(segmentGranularity.getIterable(interval, 365));
       LOGGER.info(
           "Interval adjusted to %s in compaction task for datasource %s with configured segmentGranularity %s",
           interval,

--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -111,13 +111,21 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
             // For example, if the original is interval of 2020-01-28/2020-02-03 with WEEK granularity
             // and the configuredSegmentGranularity is MONTH, the segment will be split to two segments
             // of 2020-01/2020-02 and 2020-02/2020-03.
-            if (Intervals.ETERNITY.equals(segment.getInterval())) {
-              // This is to prevent the coordinator from crashing as raised in https://github.com/apache/druid/issues/13208
-              log.warn("Cannot compact datasource[%s] with ALL granularity", dataSource);
-              return;
+            try {
+              for (Interval interval : configuredSegmentGranularity.getIterable(segment.getInterval(), 365)) {
+                intervalToPartitionMap.computeIfAbsent(interval, k -> new HashSet<>()).add(segment);
+              }
             }
-            for (Interval interval : configuredSegmentGranularity.getIterable(segment.getInterval())) {
-              intervalToPartitionMap.computeIfAbsent(interval, k -> new HashSet<>()).add(segment);
+            catch (IllegalStateException ise) {
+              log.warn(
+                  "Cannot compact datasource[%s] granularity [%s] is too fine-grained for "
+                  + "interval [%s] of segment [%s]. Try manual compaction instead.",
+                  dataSource,
+                  configuredSegmentGranularity,
+                  segment.getInterval(),
+                  segment.getId()
+              );
+              return;
             }
           }
           for (Map.Entry<Interval, Set<DataSegment>> partitionsPerInterval : intervalToPartitionMap.entrySet()) {


### PR DESCRIPTION
This method has been problematic in the past, where a not-so-careful invocation can lead to the iterator generating an excessive number of intervals. This, in turn, can either lead to heavy CPU usage or heavy memory pressure. In discussions with @imply-cheddar / @cheddar, we settled on this approach where the code forces the caller to specify a limit.  If exceeded, the iterator will throw an error but at least will keep services resilient. 

The PR is a draft as I still need to determine the correct limit in various places. 

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
