### PR TITLE
Add null check for VarianceAggregatorCollector

### DIFF
--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollector.java
@@ -91,8 +91,11 @@ public class VarianceAggregatorCollector
     this.sum += other.sum;
   }
 
-  static Object combineValues(Object lhs, @Nullable Object rhs)
+  static Object combineValues(@Nullable Object lhs, @Nullable Object rhs)
   {
+    if (lhs == null) {
+      return rhs;
+    }
     ((VarianceAggregatorCollector) lhs).fold((VarianceAggregatorCollector) rhs);
     return lhs;
   }

--- a/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
+++ b/extensions-core/stats/src/test/java/org/apache/druid/query/aggregation/variance/VarianceAggregatorCollectorTest.java
@@ -173,6 +173,14 @@ public class VarianceAggregatorCollectorTest extends InitializedNullHandlingTest
     Assert.assertEquals(0, VarianceAggregatorCollector.COMPARATOR.compare(v1, v2));
   }
 
+  @Test
+  public void testNullCollectors()
+  {
+    VarianceAggregatorCollector collector =
+        (VarianceAggregatorCollector) VarianceAggregatorCollector.combineValues(null, null);
+    Assert.assertNull(collector);
+  }
+
   private static class FloatHandOver extends TestFloatColumnSelector
   {
     float v;


### PR DESCRIPTION
Adds a null check while combining VarianceAggregatorCollectors.

- Fix a NPE that could occur while combining VarianceAggregatorCollectors.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
