### PR TITLE
Prepare for 28.0.1 release

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/druid:28.0.0
+    image: apache/druid:28.0.1
     container_name: coordinator
     volumes:
       - druid_shared:/opt/shared
@@ -67,7 +67,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:28.0.0
+    image: apache/druid:28.0.1
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -83,7 +83,7 @@ services:
       - environment
 
   historical:
-    image: apache/druid:28.0.0
+    image: apache/druid:28.0.1
     container_name: historical
     volumes:
       - druid_shared:/opt/shared
@@ -100,7 +100,7 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:28.0.0
+    image: apache/druid:28.0.1
     container_name: middlemanager
     volumes:
       - druid_shared:/opt/shared
@@ -118,7 +118,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:28.0.0
+    image: apache/druid:28.0.1
     container_name: router
     volumes:
       - router_var:/opt/druid/var

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-console",
-  "version": "28.0.0",
+  "version": "28.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "web-console",
-      "version": "28.0.0",
+      "version": "28.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@blueprintjs/core": "^4.20.1",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-console",
-  "version": "28.0.0",
+  "version": "28.0.1",
   "description": "A web console for Apache Druid",
   "author": "Apache Druid Developers <dev@druid.apache.org>",
   "license": "Apache-2.0",

--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -362,7 +362,7 @@ exports[`HeaderBar matches snapshot 1`] = `
           <Blueprint4.MenuItem
             active={false}
             disabled={false}
-            href="https://druid.apache.org/docs/28.0.0"
+            href="https://druid.apache.org/docs/28.0.1"
             icon="th"
             multiline={false}
             popoverProps={Object {}}

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -64,7 +64,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
             Druid uses rules to determine what data should be retained in the cluster. The rules are evaluated in order from top to bottom. For more information please refer to the
              
             <a
-              href="https://druid.apache.org/docs/28.0.0/operations/rule-configuration.html"
+              href="https://druid.apache.org/docs/28.0.1/operations/rule-configuration.html"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/web-console/src/links.ts
+++ b/web-console/src/links.ts
@@ -19,7 +19,7 @@
 import hasOwnProp from 'has-own-prop';
 
 // This is set to the latest available version and should be updated to the next version before release
-const DRUID_DOCS_VERSION = '28.0.0';
+const DRUID_DOCS_VERSION = '28.0.1';
 
 function fillVersion(str: string): string {
   return str.replace(/\{\{VERSION}}/g, DRUID_DOCS_VERSION);

--- a/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-error-pane/__snapshots__/execution-error-pane.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`ExecutionErrorPane matches snapshot 1`] = `
   >
     <React.Fragment>
       <Memo(ExternalLink)
-        href="https://druid.apache.org/docs/28.0.0/multi-stage-query/reference.html#error_TooManyWarnings"
+        href="https://druid.apache.org/docs/28.0.1/multi-stage-query/reference.html#error_TooManyWarnings"
       >
         TooManyWarnings
       </Memo(ExternalLink)>

--- a/web-console/unified-console.html
+++ b/web-console/unified-console.html
@@ -71,6 +71,6 @@
       };
     </script>
     <script src="console-config.js"></script>
-    <script src="public/web-console-28.0.0.js"></script>
+    <script src="public/web-console-28.0.1.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Prepares the 28.0.1 branch for release.

Note: This doesn't update the POMs to 28.0.1-SNAPSHOT, since that won't be needed anyway. Also, Druid 24.0.1 & 24.0.2 patches didn't update the POMs, so it should be okay. 