### PR TITLE
Suppress CVE-2022-46337 related to Derby 

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -825,4 +825,12 @@
     ]]></notes>
     <cve>CVE-2023-4586</cve>
   </suppress>
+
+  <!--
+    ~ CVE-2022-46337 applies to configurations using authentication for Derby and is not applicable to Druid. Also, Derby isn't a suggested
+    ~ metadata store for production clusters.
+    -->
+  <suppress>
+    <cve>CVE-2022-46337</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppresses CVE-2022-46337, because Druid doesn't use authentication for Derby, therefore, the CVE doesn't apply to Druid. Also, using Derby as a metadata store for Druid in production clusters isn't advisable. 