### PR TITLE
Allow for kafka emitter producer secrets to be masked in logs 

### DIFF
--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -115,6 +115,7 @@ public class KafkaEmitter implements Emitter
       props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
       props.put(ProducerConfig.RETRIES_CONFIG, DEFAULT_RETRIES);
       props.putAll(config.getKafkaProducerConfig());
+      props.putAll(config.getKafkaProducerSecrets().getConfig());
 
       return new KafkaProducer<>(props);
     }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -75,7 +75,7 @@ public class KafkaEmitterConfig
   private final String clusterName;
   @JsonProperty("producer.config")
   private final Map<String, String> kafkaProducerConfig;
-  @JsonProperty("producer.secrets.config")
+  @JsonProperty("producer.hiddenProperties")
   private final DynamicConfigProvider<String> kafkaProducerSecrets;
 
   @JsonCreator
@@ -88,7 +88,7 @@ public class KafkaEmitterConfig
       @Nullable @JsonProperty("segmentMetadata.topic") String segmentMetadataTopic,
       @JsonProperty("clusterName") String clusterName,
       @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig,
-      @JsonProperty("producer.secrets.config") @Nullable DynamicConfigProvider<String> kafkaProducerSecrets
+      @JsonProperty("producer.hiddenProperties") @Nullable DynamicConfigProvider<String> kafkaProducerSecrets
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "druid.emitter.kafka.bootstrap.servers can not be null");
@@ -243,7 +243,7 @@ public class KafkaEmitterConfig
            ", segmentMetadata.topic='" + segmentMetadataTopic + '\'' +
            ", clusterName='" + clusterName + '\'' +
            ", producer.config=" + kafkaProducerConfig + '\'' +
-           ", producer.secrets.config=" + kafkaProducerSecrets +
+           ", producer.hiddenProperties=" + kafkaProducerSecrets +
            '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterConfig.java
@@ -26,6 +26,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.metadata.MapStringDynamicConfigProvider;
 import org.apache.kafka.clients.producer.ProducerConfig;
 
 import javax.annotation.Nullable;
@@ -73,6 +75,8 @@ public class KafkaEmitterConfig
   private final String clusterName;
   @JsonProperty("producer.config")
   private final Map<String, String> kafkaProducerConfig;
+  @JsonProperty("producer.secrets.config")
+  private final DynamicConfigProvider<String> kafkaProducerSecrets;
 
   @JsonCreator
   public KafkaEmitterConfig(
@@ -83,7 +87,8 @@ public class KafkaEmitterConfig
       @Nullable @JsonProperty("request.topic") String requestTopic,
       @Nullable @JsonProperty("segmentMetadata.topic") String segmentMetadataTopic,
       @JsonProperty("clusterName") String clusterName,
-      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig
+      @JsonProperty("producer.config") @Nullable Map<String, String> kafkaProducerConfig,
+      @JsonProperty("producer.secrets.config") @Nullable DynamicConfigProvider<String> kafkaProducerSecrets
   )
   {
     this.bootstrapServers = Preconditions.checkNotNull(bootstrapServers, "druid.emitter.kafka.bootstrap.servers can not be null");
@@ -94,6 +99,7 @@ public class KafkaEmitterConfig
     this.segmentMetadataTopic = this.eventTypes.contains(EventType.SEGMENT_METADATA) ? Preconditions.checkNotNull(segmentMetadataTopic, "druid.emitter.kafka.segmentMetadata.topic can not be null") : null;
     this.clusterName = clusterName;
     this.kafkaProducerConfig = kafkaProducerConfig == null ? ImmutableMap.of() : kafkaProducerConfig;
+    this.kafkaProducerSecrets = kafkaProducerSecrets == null ? new MapStringDynamicConfigProvider(ImmutableMap.of()) : kafkaProducerSecrets;
   }
 
   private Set<EventType> maybeUpdateEventTypes(Set<EventType> eventTypes, String requestTopic)
@@ -159,6 +165,12 @@ public class KafkaEmitterConfig
     return kafkaProducerConfig;
   }
 
+  @JsonProperty
+  public DynamicConfigProvider<String> getKafkaProducerSecrets()
+  {
+    return kafkaProducerSecrets;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -198,7 +210,10 @@ public class KafkaEmitterConfig
     if (getClusterName() != null ? !getClusterName().equals(that.getClusterName()) : that.getClusterName() != null) {
       return false;
     }
-    return getKafkaProducerConfig().equals(that.getKafkaProducerConfig());
+    if (!getKafkaProducerConfig().equals(that.getKafkaProducerConfig())) {
+      return false;
+    }
+    return getKafkaProducerSecrets().getConfig().equals(that.getKafkaProducerSecrets().getConfig());
   }
 
   @Override
@@ -212,6 +227,7 @@ public class KafkaEmitterConfig
     result = 31 * result + (getSegmentMetadataTopic() != null ? getSegmentMetadataTopic().hashCode() : 0);
     result = 31 * result + (getClusterName() != null ? getClusterName().hashCode() : 0);
     result = 31 * result + getKafkaProducerConfig().hashCode();
+    result = 31 * result + getKafkaProducerSecrets().getConfig().hashCode();
     return result;
   }
 
@@ -226,7 +242,8 @@ public class KafkaEmitterConfig
            ", request.topic='" + requestTopic + '\'' +
            ", segmentMetadata.topic='" + segmentMetadataTopic + '\'' +
            ", clusterName='" + clusterName + '\'' +
-           ", Producer.config=" + kafkaProducerConfig +
+           ", producer.config=" + kafkaProducerConfig + '\'' +
+           ", producer.secrets.config=" + kafkaProducerSecrets +
            '}';
   }
 }

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -60,7 +60,7 @@ public class KafkaEmitterConfigTest
         "clusterNameTest",
         ImmutableMap.<String, String>builder()
                     .put("testKey", "testValue").build(),
-       DEFAULT_PRODUCER_SECRETS
+        DEFAULT_PRODUCER_SECRETS
     );
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -25,48 +25,67 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.metadata.DynamicConfigProvider;
+import org.apache.druid.metadata.MapStringDynamicConfigProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
 public class KafkaEmitterConfigTest
 {
-  private ObjectMapper mapper = new DefaultObjectMapper();
+  private static final DynamicConfigProvider<String> DEFAULT_PRODUCER_SECRETS = new MapStringDynamicConfigProvider(
+      ImmutableMap.of("testSecretKey", "testSecretValue"));
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
 
   @Before
   public void setUp()
   {
-    mapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
+    MAPPER.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
   }
 
   @Test
   public void testSerDeserKafkaEmitterConfig() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
-        "alertTest", "requestTest", "metadataTest",
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build()
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "hostname",
+        null,
+        "metricTest",
+        "alertTest",
+        "requestTest",
+        "metadataTest",
+        "clusterNameTest",
+        ImmutableMap.<String, String>builder()
+                    .put("testKey", "testValue").build(),
+       DEFAULT_PRODUCER_SECRETS
     );
-    String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
-    KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
-        .readValue(kafkaEmitterConfigString);
+    String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
     Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
   @Test
   public void testSerDeserKafkaEmitterConfigNullRequestTopic() throws IOException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", null, "metricTest",
-        "alertTest", null, "metadataTest",
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build()
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "hostname",
+        null,
+        "metricTest",
+        "alertTest",
+        null,
+        "metadataTest",
+        "clusterNameTest",
+        ImmutableMap.<String, String>builder()
+                    .put("testKey", "testValue").build(),
+        DEFAULT_PRODUCER_SECRETS
     );
-    String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
-    KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
-        .readValue(kafkaEmitterConfigString);
+    String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
     Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
@@ -75,27 +94,34 @@ public class KafkaEmitterConfigTest
   {
     Set<KafkaEmitterConfig.EventType> eventTypeSet = new HashSet<KafkaEmitterConfig.EventType>();
     eventTypeSet.add(KafkaEmitterConfig.EventType.SEGMENT_METADATA);
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("hostname", eventTypeSet, null,
-        null, null, "metadataTest",
-        "clusterNameTest", ImmutableMap.<String, String>builder()
-        .put("testKey", "testValue").build()
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "hostname",
+        eventTypeSet,
+        null,
+        null,
+        null,
+        "metadataTest",
+        "clusterNameTest",
+        ImmutableMap.<String, String>builder()
+                    .put("testKey", "testValue").build(),
+        DEFAULT_PRODUCER_SECRETS
     );
-    String kafkaEmitterConfigString = mapper.writeValueAsString(kafkaEmitterConfig);
-    KafkaEmitterConfig kafkaEmitterConfigExpected = mapper.readerFor(KafkaEmitterConfig.class)
-        .readValue(kafkaEmitterConfigString);
+    String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
     Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
   @Test
-  public void testSerDeNotRequiredKafkaProducerConfig()
+  public void testSerDeNotRequiredKafkaProducerConfigOrKafkaSecretProducer()
   {
     KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", null, "metricTest",
-        "alertTest", null, "metadataTest",
-        "clusterNameTest", null
+                                                                   "alertTest", null, "metadataTest",
+                                                                   "clusterNameTest", null, null
     );
     try {
       @SuppressWarnings("unused")
-      KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, mapper);
+      KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, MAPPER);
     }
     catch (NullPointerException e) {
       Assert.fail();
@@ -105,9 +131,18 @@ public class KafkaEmitterConfigTest
   @Test
   public void testDeserializeEventTypesWithDifferentCase() throws JsonProcessingException
   {
-    Assert.assertEquals(KafkaEmitterConfig.EventType.SEGMENT_METADATA, mapper.readValue("\"segment_metadata\"", KafkaEmitterConfig.EventType.class));
-    Assert.assertEquals(KafkaEmitterConfig.EventType.ALERTS, mapper.readValue("\"alerts\"", KafkaEmitterConfig.EventType.class));
-    Assert.assertThrows(ValueInstantiationException.class, () -> mapper.readValue("\"segmentMetadata\"", KafkaEmitterConfig.EventType.class));
+    Assert.assertEquals(
+        KafkaEmitterConfig.EventType.SEGMENT_METADATA,
+        MAPPER.readValue("\"segment_metadata\"", KafkaEmitterConfig.EventType.class)
+    );
+    Assert.assertEquals(
+        KafkaEmitterConfig.EventType.ALERTS,
+        MAPPER.readValue("\"alerts\"", KafkaEmitterConfig.EventType.class)
+    );
+    Assert.assertThrows(
+        ValueInstantiationException.class,
+        () -> MAPPER.readValue("\"segmentMetadata\"", KafkaEmitterConfig.EventType.class)
+    );
   }
 
   @Test

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -106,7 +106,7 @@ public class KafkaEmitterTest
     ObjectMapper mapper = new ObjectMapper();
     mapper.registerModule(new JodaModule());
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
-        new KafkaEmitterConfig("", eventsType, "metrics", "alerts", requestTopic, "metadata", "test-cluster", null),
+        new KafkaEmitterConfig("", eventsType, "metrics", "alerts", requestTopic, "metadata", "test-cluster", null, null),
         mapper
     )
     {

--- a/processing/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
+++ b/processing/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java
@@ -38,9 +38,7 @@ public class DynamicConfigProviderUtils
         }
       }
       Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(dynamicConfigProviderKey), mapper);
-      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-        newConfig.put(entry.getKey(), entry.getValue());
-      }
+      newConfig.putAll(dynamicConfig);
     }
     return newConfig;
   }
@@ -55,9 +53,7 @@ public class DynamicConfigProviderUtils
         }
       }
       Map<String, String> dynamicConfig = extraConfigFromProvider(config.get(dynamicConfigProviderKey), mapper);
-      for (Map.Entry<String, String> entry : dynamicConfig.entrySet()) {
-        newConfig.put(entry.getKey(), entry.getValue());
-      }
+      newConfig.putAll(dynamicConfig);
     }
     return newConfig;
   }


### PR DESCRIPTION
This change will allow for kafka producer config values that should be secrets to not show up in the logs. This will enhance the security of the people who use the kafka emitter to use this if they want to. This is opt in and will not affect prior configs for this emitter

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes an issue where kafka producer configs that would be used for securing the producer to the kafka topic would be logged in plaintext.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

add a new config option to the kafka emitter config that will leverage [DynamicConfigProvider.java](https://github.com/apache/druid/blob/71036551b15033a134be4a55ccd1e6c651a53d70/processing/src/main/java/org/apache/druid/metadata/DynamicConfigProvider.java#L37) to mask a map of configs for the kafka producer.

If there are duplicate keys in the secrets config and the not masked config the secrets config value will be the one used.

for example the `runtime.properties` for the the config can look like this when leveraging the [MapStringDynamicConfigProvider.java](https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/metadata/MapStringDynamicConfigProvider.java#L28)

```java.properties
druid.emitter.kafka.producer.config={"sasl.mechanism": "PLAIN", "security.protocol": "SASL_SSL"}
druid.emitter.ikafka.producer.secrets.config={"config":{"sasl.jaas.config": "org.apache.kafka.common.security.plain.PlainLoginModule required username=\\"KV...NI\\" password=\\"gA3...n6a/\\";"}}
```

also made minor change to [DynamicConfigProviderUtils](https://github.com/apache/druid/blob/ddd2299272fab5d6e1fcace796f42c9a5050e1be/processing/src/main/java/org/apache/druid/utils/DynamicConfigProviderUtils.java#L29) to use putAll instead of iterating and putting in that class.


how the properties now look in the logs
```
2023-12-05T15:58:28,661 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter: kafka
2023-12-05T15:58:28,661 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter.kafka.bootstrap.servers: localhost:9092
2023-12-05T15:58:28,662 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter.kafka.event.types: ["metrics"]
2023-12-05T15:58:28,662 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter.kafka.metric.topic: test_12_4_23
2023-12-05T15:58:28,662 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter.kafka.producer.config: {"sasl.mechanism": "PLAIN", "security.protocol": "SASL_SSL"}
2023-12-05T15:58:28,662 INFO [main] org.apache.druid.cli.CliPeon - * druid.emitter.kafka.producer.secrets.config: <masked>
```

3 test cases:
Tested this with valid config and secret value so it's masked. Worked fine
Tested this with the secrets left in the normal producer config and no line for the secrets config. Worked fine
Tested this with the secrets left in the normal producer config and the mapString was empty. Worked fine.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `KafkaEmitterConfig`
 * `KafkaEmitter`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
