### PR TITLE
add gson to dependencyManagement

### DIFF
--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -191,7 +191,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <scope>compile</scope>
-            <version>${gson.version}</version>
         </dependency>
 
         <!-- Tests -->

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -190,7 +190,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <scope>compile</scope>
         </dependency>
 
         <!-- Tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -413,6 +413,7 @@
             </dependency>
             <!-- Transitive dependency of kubernetes-client-java in kubernetes-extension,
             schema-repo in avro-extensions, and com.google.caliper:caliper in druid-server
+            and direct dependency of druid-ranger
               -->
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -418,7 +418,6 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <scope>compile</scope>
                 <version>${gson.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <apache.kafka.version>3.6.0</apache.kafka.version>
         <apache.ranger.version>2.4.0</apache.ranger.version>
         <gson.version>2.10.1</gson.version>
-        <apache.ranger.gson.version>2.10.1</apache.ranger.gson.version>
         <scala.library.version>2.13.11</scala.library.version>
         <avatica.version>1.23.0</avatica.version>
         <avro.version>1.11.3</avro.version>
@@ -411,6 +410,15 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>1.6.10</version>
+            </dependency>
+            <!-- Transitive dependency of kubernetes-client-java in kubernetes-extension,
+            schema-repo in avro-extensions, and com.google.caliper:caliper in druid-server
+              -->
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <scope>compile</scope>
+                <version>${gson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
### Description
This change completes the change introduced in https://github.com/apache/druid/pull/15461
and unifies the version of gson dependency used between all the modules. 
gson is used by kubernetes-extension, avro-extensions, ranger-security, and as a test dependency in several core modules. 
Change was green in local build and test, now for integration tests. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
