### PR TITLE
Lookup on incomplete partition set in SegmentMetadataQuerySegmentWalker

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/metadata/SegmentMetadataQuerySegmentWalker.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/SegmentMetadataQuerySegmentWalker.java
@@ -201,7 +201,7 @@ public class SegmentMetadataQuerySegmentWalker implements QuerySegmentWalker
   )
   {
     final Function<Interval, List<TimelineObjectHolder<String, SegmentLoadInfo>>> lookupFn
-        = timeline::lookup;
+        = timeline::lookupWithIncompletePartitions;
 
     final List<Interval> intervals = query.getIntervals();
     List<TimelineObjectHolder<String, SegmentLoadInfo>> timelineObjectHolders =


### PR DESCRIPTION
### Description 

With `CentralizedDatasourceSchema` (https://github.com/apache/druid/issues/14989) feature enabled, metadata for appended segments was not being refreshed. This caused `numRows` to be 0 for the new segments and would probably cause the datasource schema to not include columns from the new segments. 

### Analysis 
The problem turned out in the new QuerySegmentWalker implementation in the Coordinator. It first finds the segment to be queried in the Coordinator timeline. Then it creates a new timeline of the segments present in the timeline.  
The problem was that it is looking up complete partition set in the new timeline. Since the appended segments by themselves do not make a complete partition set, no SegmentMetadataQuery were executed. 

### Fix
The fix is to lookup incomplete partition set in the new timeline. It is consistent with the logic in `CachingClusteredClient` for querying specific segments (https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java#L429). 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
