### PR TITLE
Fix NullFilter getDimensionRangeSet.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/NullFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/NullFilter.java
@@ -114,6 +114,10 @@ public class NullFilter extends AbstractOptimizableDimFilter implements Filter
   @Override
   public RangeSet<String> getDimensionRangeSet(String dimension)
   {
+    if (!Objects.equals(getColumn(), dimension)) {
+      return null;
+    }
+
     RangeSet<String> retSet = TreeRangeSet.create();
     // Nulls are less than empty String in segments
     retSet.add(Range.lessThan(""));

--- a/processing/src/test/java/org/apache/druid/segment/filter/NullFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/NullFilterTests.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -41,6 +43,7 @@ import org.junit.runners.Parameterized;
 
 import java.io.Closeable;
 import java.util.Arrays;
+import java.util.Collections;
 
 @RunWith(Enclosed.class)
 public class NullFilterTests
@@ -310,6 +313,19 @@ public class NullFilterTests
 
   public static class NullFilterNonParameterizedTest
   {
+    @Test
+    public void testGetDimensionRangeSet()
+    {
+      final NullFilter filter = new NullFilter("x", null);
+
+      Assert.assertEquals(
+          TreeRangeSet.create(Collections.singleton(Range.lessThan(""))),
+          filter.getDimensionRangeSet("x")
+      );
+
+      Assert.assertNull(filter.getDimensionRangeSet("y"));
+    }
+
     @Test
     public void testSerde() throws JsonProcessingException
     {


### PR DESCRIPTION
It wasn't checking the column name, so it would return a domain regardless of the input column. This means that null filters on datasources with range partitioning could lead to excessive pruning of segments, and therefore missing results.

The null filter was introduced in #14542, meaning this query correctness bug has existed since 27.0. It will likely be more commonly hit in 28.0 because the null handling mode is on by default (and therefore this filter is generated by SQL planning by default) since #14792.