### PR TITLE
Trace origin sql of No Such Connection failures

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidConnection.java
@@ -31,6 +31,7 @@ import org.apache.druid.sql.avatica.DruidJdbcResultSet.ResultFetcherFactory;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
@@ -110,11 +111,11 @@ public class DruidConnection
       if (statements.containsKey(statementId)) {
         // Will only happen if statementCounter rolls over before old statements are cleaned up. If this
         // ever happens then something fishy is going on, because we shouldn't have billions of statements.
-        throw DruidMeta.logFailure(new ISE("Uh oh, too many statements"));
+        throw DruidMeta.logFailure(new ISE("Uh oh, too many statements"), Optional.empty());
       }
 
       if (statements.size() >= maxStatements) {
-        throw DruidMeta.logFailure(new ISE("Too many open statements, limit is %,d", maxStatements));
+        throw DruidMeta.logFailure(new ISE("Too many open statements, limit is %,d", maxStatements), Optional.empty());
       }
 
       @SuppressWarnings("GuardedBy")
@@ -145,11 +146,11 @@ public class DruidConnection
       if (statements.containsKey(statementId)) {
         // Will only happen if statementCounter rolls over before old statements are cleaned up. If this
         // ever happens then something fishy is going on, because we shouldn't have billions of statements.
-        throw DruidMeta.logFailure(new ISE("Uh oh, too many statements"));
+        throw DruidMeta.logFailure(new ISE("Uh oh, too many statements"), Optional.empty());
       }
 
       if (statements.size() >= maxStatements) {
-        throw DruidMeta.logFailure(new ISE("Too many open statements, limit is %,d", maxStatements));
+        throw DruidMeta.logFailure(new ISE("Too many open statements, limit is %,d", maxStatements), Optional.empty());
       }
 
       @SuppressWarnings("GuardedBy")

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -35,6 +35,7 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -341,7 +342,7 @@ public class DruidJdbcResultSet implements Closeable
 
   private RuntimeException closeAndPropagateThrowable(Throwable t)
   {
-    DruidMeta.logFailure(t);
+    DruidMeta.logFailure(t, Optional.ofNullable(stmt.query() != null ? stmt.query().sql() : null));
     // Report a failure so that the failure is logged.
     stmt.reporter().failed(t);
     try {


### PR DESCRIPTION
### Description
After updating avatica client, it mandatory to set transparent_reconnection flag in jdbc uri to make sure that client does reconnect, ideally we should be see no such connection only from connectionSync request, if client is not setting flag then we see it from prepare phase itself that seems like a gap. This PR prints associated sql if it fails from prepare or prepareAndExecute  avatica calls. It can help to trace the origin of client and fix it.

```
org.apache.calcite.avatica.NoSuchConnectionException: null
	at org.apache.druid.sql.avatica.DruidMeta.getDruidConnection(DruidMeta.java:845) ~[druid-sql.jar]
	at org.apache.druid.sql.avatica.DruidMeta.prepare(DruidMeta.java:274) ~[druid-sql.jar]
	at org.apache.calcite.avatica.remote.LocalService.apply(LocalService.java:201) ~[avatica-core-1.23.0.jar:1.23.0]
	at org.apache.calcite.avatica.remote.Service$PrepareRequest.accept(Service.java:1240) ~[avatica-core-1.23.0.jar:1.23.0]
	at org.apache.calcite.avatica.remote.Service$PrepareRequest.accept(Service.java:1211) ~[avatica-core-1.23.0.jar:1.23.0]
```

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
