### PR TITLE
Add null checks for HllSketchHolder

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -173,6 +173,8 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
       public void fold(final ColumnValueSelector selector)
       {
         final HllSketchHolder sketchHolder = (HllSketchHolder) selector.getObject();
+        // sketchHolder can be null here, if the sketch is empty. This is an optimisation done by
+        // HllSketchHolderObjectStrategy. If the holder is null, this should be a no-op.
         if (sketchHolder != null) {
           union.update(sketchHolder.getSketch());
         }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactory.java
@@ -172,8 +172,10 @@ public abstract class HllSketchAggregatorFactory extends AggregatorFactory
       @Override
       public void fold(final ColumnValueSelector selector)
       {
-        final HllSketchHolder sketch = (HllSketchHolder) selector.getObject();
-        union.update(sketch.getSketch());
+        final HllSketchHolder sketchHolder = (HllSketchHolder) selector.getObject();
+        if (sketchHolder != null) {
+          union.update(sketchHolder.getSketch());
+        }
       }
 
       @Nullable

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
@@ -27,8 +27,6 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 
-import javax.validation.constraints.NotNull;
-
 public class HllSketchHolder
 {
   public static HllSketchHolder fromObj(Object obj)
@@ -145,7 +143,7 @@ public class HllSketchHolder
   }
 
   @SuppressWarnings("VariableNotUsedInsideIf")
-  public HllSketchHolder merge(@NotNull HllSketchHolder other)
+  public HllSketchHolder merge(HllSketchHolder other)
   {
     // It appears like we could make this code cleaner by checking for other.union first and then delegating to add
     // if it's not.  But, we check ourselves first because callers would tend to expect that the object they are

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolder.java
@@ -27,6 +27,8 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 
+import javax.validation.constraints.NotNull;
+
 public class HllSketchHolder
 {
   public static HllSketchHolder fromObj(Object obj)
@@ -143,7 +145,7 @@ public class HllSketchHolder
   }
 
   @SuppressWarnings("VariableNotUsedInsideIf")
-  public HllSketchHolder merge(HllSketchHolder other)
+  public HllSketchHolder merge(@NotNull HllSketchHolder other)
   {
     // It appears like we could make this code cleaner by checking for other.union first and then delegating to add
     // if it's not.  But, we check ourselves first because callers would tend to expect that the object they are

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategy.java
@@ -45,6 +45,7 @@ public class HllSketchHolderObjectStrategy implements ObjectStrategy<HllSketchHo
     return HllSketchAggregatorFactory.COMPARATOR.compare(sketch1, sketch2);
   }
 
+  @Nullable
   @Override
   public HllSketchHolder fromByteBuffer(final ByteBuffer buf, final int size)
   {

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -24,10 +24,12 @@ import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.aggregation.AggregateCombiner;
 import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.BufferAggregator;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
@@ -346,6 +348,22 @@ public class HllSketchAggregatorFactoryTest
                     .build(),
         new TimeseriesQueryQueryToolChest().resultArraySignature(query)
     );
+  }
+
+  @Test
+  public void testFoldWithNullObject()
+  {
+    TestHllSketchAggregatorFactory factory = new TestHllSketchAggregatorFactory(
+        NAME,
+        FIELD_NAME,
+        LG_K,
+        TGT_HLL_TYPE,
+        STRING_ENCODING,
+        !ROUND
+    );
+    AggregateCombiner aggregateCombiner = factory.makeAggregateCombiner();
+    TestObjectColumnSelector objectColumnSelector = new TestObjectColumnSelector(new Object[] {null});
+    aggregateCombiner.fold(objectColumnSelector);
   }
 
   private static boolean isToStringField(Field field)


### PR DESCRIPTION
Fixes a potential NPE which could occur while folding the HllSketchAggregator. If the sketch is null, druid could return a null HllSketchHolder object. Adding a null check here could help here

- Resolves a null pointer exception in `HllSketchAggregatorFactory`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
