### PR TITLE
fix array presenting columns to not match single element arrays to scalars for equality

### DIFF
--- a/docs/ingestion/schema-design.md
+++ b/docs/ingestion/schema-design.md
@@ -263,12 +263,17 @@ native boolean types, Druid ingests these values as longs if `druid.expressions.
 the [array functions](../querying/sql-array-functions.md) or [UNNEST](../querying/sql-functions.md#unnest). Nested
 columns can be queried with the [JSON functions](../querying/sql-json-functions.md).
 
-Mixed type columns are stored in the _least_ restrictive type that can represent all values in the column. For example:
+Mixed type columns follow the same rules for schema differences between segments, and present as the _least_ restrictive
+type that can represent all values in the column. For example:
 
 - Mixed numeric columns are `DOUBLE`
 - If there are any strings present, then the column is a `STRING`
 - If there are arrays, then the column becomes an array with the least restrictive element type
 - Any nested data or arrays of nested data become `COMPLEX<json>` nested columns.
+
+Grouping, filtering, and aggregating mixed type values will handle these columns as if all values are represented as the
+least restrictive type. The exception to this is the scan query, which will return the values in their original mixed
+types, but any downstream operations on these values will still coerce them to the common type.
 
 If you're already using string-based schema discovery and want to migrate, see [Migrating to type-aware schema discovery](#migrating-to-type-aware-schema-discovery).
 

--- a/processing/src/main/java/org/apache/druid/query/filter/EqualityFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/EqualityFilter.java
@@ -392,6 +392,9 @@ public class EqualityFilter extends AbstractOptimizableDimFilter implements Filt
     @Override
     public Predicate<Object[]> makeArrayPredicate(@Nullable TypeSignature<ValueType> arrayType)
     {
+      if (!matchValue.isArray()) {
+        return Predicates.alwaysFalse();
+      }
       if (arrayType == null) {
         // fall back to per row detection if input array type is unknown
         return typeDetectingArrayPredicateSupplier.get();

--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnAndIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnAndIndexSupplier.java
@@ -320,6 +320,9 @@ public class VariantColumnAndIndexSupplier implements Supplier<NestedCommonForma
     @Override
     public BitmapColumnIndex forValue(@Nonnull Object value, TypeSignature<ValueType> valueType)
     {
+      if (!valueType.isArray()) {
+        return new AllFalseBitmapColumnIndex(bitmapFactory, nullValueBitmap);
+      }
       final ExprEval<?> eval = ExprEval.ofType(ExpressionType.fromColumnTypeStrict(valueType), value);
       final ExprEval<?> castForComparison = ExprEval.castForEqualityComparison(
           eval,

--- a/processing/src/test/java/org/apache/druid/query/timeseries/NestedDataTimeseriesQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeseries/NestedDataTimeseriesQueryTest.java
@@ -488,7 +488,6 @@ public class NestedDataTimeseriesQueryTest extends InitializedNullHandlingTest
                                   .intervals(Collections.singletonList(Intervals.ETERNITY))
                                   .filters(
                                       new AndDimFilter(
-                                          new EqualityFilter("variantWithArrays", ColumnType.STRING, "1", null),
                                           new EqualityFilter("v0", ColumnType.STRING, "1", null)
                                       )
                                   )
@@ -524,7 +523,6 @@ public class NestedDataTimeseriesQueryTest extends InitializedNullHandlingTest
                                   .intervals(Collections.singletonList(Intervals.ETERNITY))
                                   .filters(
                                       new AndDimFilter(
-                                          new EqualityFilter("variantWithArrays", ColumnType.DOUBLE, 3.0, null),
                                           new EqualityFilter("v0", ColumnType.DOUBLE, 3.0, null)
                                       )
                                   )


### PR DESCRIPTION
### Description
The equality filter allows automatic coercion of scalar typed columns to array columns to help assist schema migration between mvds and arrays, as well as scalars to arrays, where the scalar inputs are treated as single element arrays for the purposes of matching.

However, this had an unintended side-effect of allowing the reverse that impacts only native queries, allowing using an equality filter with a scalar match value to match single element arrays of array columns, which is pretty strange (and json_value using SQL).

This PR modifies the equality filter (and array indexes) to no longer allow matching single element arrays in columns with scalar values, while preserving the opposite, where scalar columns can match single element arrays.

This has a side-effect that strictly impacts native query equality filter on mixed type 'auto' columns which contain arrays, that they must now be interacted with as their presenting type, so if any rows are arrays, e.g. the segment metadata and information_schema reports the type as some array type, then the native queries must also filter as if they are some array type. This does not impact SQL, which already has this limitation due to how the type presents itself, and again only impacts mixed type 'auto' columns.

#### Release note
Native query `equals` filter on mixed type 'auto' columns which contain arrays must now be filtered as their presenting type, so if any rows are arrays (e.g. the segment metadata and information_schema reports the type as some array type), then the native queries must also filter as if they are some array type. This does not impact SQL, which already has this limitation due to how the type presents itself, and again only impacts mixed type 'auto' columns which contain both scalars and arrays.

<hr>

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
