### PR TITLE
Bump up max heap memory for unit tests from 1.5 GB to 2 GB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1725,7 +1725,9 @@
                             @{jacocoArgLine}
                             ${jdk.strong.encapsulation.argLine}
                             ${jdk.security.manager.allow.argLine}
-                            -Xmx1500m
+                            <!-- Bump up memory from 1.5 GB to 2 GB. This is particularly needed for JDK 17 where
+                            we have jfr profiler enabled which adds additional memory pressure. -->
+                            -Xmx2048m
                             -XX:MaxDirectMemorySize=2500m
                             -XX:+ExitOnOutOfMemoryError
                             -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
This PR bumps up the max heap memory for unit tests from 1.5 GB to 2 GB. 

### Why?
While looking into https://github.com/apache/druid/pull/15495, I noticed that the MSQ Controller tests were consistently failing only in jdk 17 (e.g., [job-19381423068](https://github.com/apache/druid/actions/runs/7117839945/job/19381423068) and [job-19393777007]( https://github.com/apache/druid/actions/runs/7122105769/job/19393777007)). This is partly precipitated by the fact that jdk 17 tests have jfr profiling enabled. 

Analyzing the heap dump from [job-7122105769](https://github.com/apache/druid/actions/runs/7122105769), it seems that the [ClusterByStatisticsCollectorImplTest.java](https://github.com/apache/druid/blob/master/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java#L100) is probably taking up too much memory with 1M rows and the jfr profiler contributes to about 6% of the strong reachable objects.


Unit tests and CI succeeded after the heap size increase: https://github.com/apache/druid/pull/15495/commits/c8f92d79bedaadebf7179f6b42b4308b6fb123d1


OOM stacktrace from the heap dump:

```
main  Runnable <--- OutOfMemoryError happened in this thread Thread ID: 1
  java.lang.OutOfMemoryError.<init>(OutOfMemoryError.java:48)
  java.nio.HeapByteBuffer.<init>(HeapByteBuffer.java:64)
  java.nio.ByteBuffer.allocate(ByteBuffer.java:363)
  org.apache.druid.frame.allocation.HeapMemoryAllocator$1.<init>(HeapMemoryAllocator.java:63)
  org.apache.druid.frame.allocation.HeapMemoryAllocator.allocate(HeapMemoryAllocator.java:59)
  org.apache.druid.frame.allocation.AppendableMemory.reserveAdditional(AppendableMemory.java:139)
  org.apache.druid.frame.write.RowBasedFrameWriter.writeDataUsingFieldWriters(RowBasedFrameWriter.java:275)
  org.apache.druid.frame.write.RowBasedFrameWriter.writeData(RowBasedFrameWriter.java:246)
  org.apache.druid.frame.write.RowBasedFrameWriter.addSelection(RowBasedFrameWriter.java:122)
  org.apache.druid.frame.key.KeyTestUtils.createKey(KeyTestUtils.java:104)
  org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImplTest.createKey(ClusterByStatisticsCollectorImplTest.java:659)
  org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImplTest.lambda$test_clusterByX_unique$0(ClusterByStatisticsCollectorImplTest.java:107)
  org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImplTest$$Lambda$2714+0x00007fa380e5e248.apply()
  java.util.stream.LongPipeline$1$1.accept(LongPipeline.java:177)
  java.util.stream.Streams$RangeLongSpliterator.tryAdvance(Streams.java:207)
  java.util.Spliterator$OfLong.tryAdvance(Spliterator.java:752)
  java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:292)
  java.util.stream.StreamSpliterators$WrappingSpliterator$$Lambda$389+0x00007fa3804c7398.getAsBoolean()
  java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
  java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
  java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:298)
  java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
  com.google.common.collect.Iterators.addAll(Iterators.java:365)
  com.google.common.collect.Lists.newArrayList(Lists.java:146)
  com.google.common.collect.Lists.newArrayList(Lists.java:132)
  org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImplTest.doTest(ClusterByStatisticsCollectorImplTest.java:572)
  org.apache.druid.msq.statistics.ClusterByStatisticsCollectorImplTest.test_clusterByX_unique(ClusterByStatisticsCollectorImplTest.java:113)
```


<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.