### PR TITLE
Add better error messages for using OVERWRITE with INSERT statments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <avro.version>1.11.3</avro.version>
         <!-- When updating Calcite, also propagate updates to these files which we've copied and modified:
              default_config.fmpp
+             sql/src/main/codegen/includes/*
           -->
         <calcite.version>1.35.0</calcite.version>
         <confluent.version>6.2.12</confluent.version>

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -19,7 +19,7 @@
 
 /**
  * Parses an INSERT statement. This function is copied from SqlInsert in core/src/main/codegen/templates/Parser.jj,
- * with some minor custom changes.
+ * with some changes to allow a custom error message if an OVERWRITE clause is present.
  */
 SqlNode DruidSqlInsert() :
 {

--- a/sql/src/main/codegen/includes/insert.ftl
+++ b/sql/src/main/codegen/includes/insert.ftl
@@ -17,6 +17,63 @@
  * under the License.
  */
 
+/**
+ * Parses an INSERT statement. This function is copied from SqlInsert in core/src/main/codegen/templates/Parser.jj,
+ * with some minor custom changes.
+ */
+SqlNode DruidSqlInsert() :
+{
+    final List<SqlLiteral> keywords = new ArrayList<SqlLiteral>();
+    final SqlNodeList keywordList;
+    final SqlIdentifier tableName;
+    SqlNode tableRef;
+    SqlNode source;
+    final SqlNodeList columnList;
+    final Span s;
+    final Pair<SqlNodeList, SqlNodeList> p;
+}
+{
+    (
+        <INSERT>
+    |
+        <UPSERT> { keywords.add(SqlInsertKeyword.UPSERT.symbol(getPos())); }
+    )
+    { s = span(); }
+    SqlInsertKeywords(keywords) {
+        keywordList = new SqlNodeList(keywords, s.addAll(keywords).pos());
+    }
+    <INTO> tableName = CompoundTableIdentifier()
+    ( tableRef = TableHints(tableName) | { tableRef = tableName; } )
+    [ LOOKAHEAD(5) tableRef = ExtendTable(tableRef) ]
+    (
+        LOOKAHEAD(2)
+        p = ParenthesizedCompoundIdentifierList() {
+            if (p.right.size() > 0) {
+                tableRef = extend(tableRef, p.right);
+            }
+            if (p.left.size() > 0) {
+                columnList = p.left;
+            } else {
+                columnList = null;
+            }
+        }
+    |   { columnList = null; }
+    )
+    (
+    <OVERWRITE>
+    {
+        throw org.apache.druid.sql.calcite.parser.DruidSqlParserUtils.problemParsing(
+            "An OVERWRITE clause is not allowed with INSERT statements. Use REPLACE statements if overwriting existing segments is required or remove the OVERWRITE clause."
+        );
+    }
+    |
+    source = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
+        return new SqlInsert(s.end(source), keywordList, tableRef, source,
+            columnList);
+    }
+    )
+}
+
 // Using fully qualified name for Pair class, since Calcite also has a same class name being used in the Parser.jj
 SqlNode DruidSqlInsertEof() :
 {
@@ -25,7 +82,7 @@ SqlNode DruidSqlInsertEof() :
   SqlNodeList clusteredBy = null;
 }
 {
-  insertNode = SqlInsert()
+  insertNode = DruidSqlInsert()
   // PARTITIONED BY is necessary, but is kept optional in the grammar. It is asserted that it is not missing in the
   // DruidSqlInsert constructor so that we can return a custom error message.
   [

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -1419,6 +1419,15 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
   }
 
   @Test
+  public void testInsertWithOverwriteClause()
+  {
+    testIngestionQuery()
+        .sql("INSERT INTO dst OVERWRITE ALL SELECT * FROM foo PARTITIONED BY ALL TIME")
+        .expectValidationError(DruidException.class, "An OVERWRITE clause is not allowed with INSERT statements. Use REPLACE statements if overwriting existing segments is required or remove the OVERWRITE clause.")
+        .verify();
+  }
+
+  @Test
   public void testInsertFromExternalProjectSort()
   {
     // INSERT with a particular column ordering.


### PR DESCRIPTION
Currently, REPLACE statements require an `OVERWRITE WHERE` clause. Using this clause with an insert statement, however, throws the cryptic error
```
Unable to parse the SQL, unrecognized error from calcite: [Non-query expression encountered in illegal context]
```
This PR changes this to be a more user-friendly error message instead.
```
An OVERWRITE clause is not allowed with INSERT statements. Use REPLACE statements if overwriting existing segments is required or remove the OVERWRITE clause.
```

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
