### PR TITLE
Suppress CVE-2022-46337 and CVEs below score of 9 for the patch branch

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -847,4 +847,12 @@
     ]]></notes>
     <cve>CVE-2023-31582</cve>
   </suppress>
+
+  <!--
+  ~ CVE-2022-46337 applies to configurations using authentication for Derby and is not applicable to Druid. Also, Derby isn't a suggested
+  ~ metadata store for production clusters.
+  -->
+  <suppress>
+    <cve>CVE-2022-46337</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -1630,7 +1630,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>7.4.4</version>
                 <configuration>
-                    <failBuildOnCVSS>7</failBuildOnCVSS>
+                    <failBuildOnCVSS>9</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->
                     <!-- For node analysis info, see https://github.com/jeremylong/DependencyCheck/issues/2482#issuecomment-603755623 -->


### PR DESCRIPTION
Suppress CVE-2022-46337 and CVEs below the score of 9 for the patch branch to ensure that the build process goes smoothly since this is a patch release on top of 28.0.0. 

CVE-2022-46337 has a high CVSS score (>9), however, it is suppressed in the master branch since it doesn't apply to Druid, but the [patch](https://github.com/apache/druid/pull/15447) couldn't be backported cleanly