### PR TITLE
allow array_to_mv to support expression inputs

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -3231,14 +3231,6 @@ public interface Function extends NamedFunction
     public void validateArguments(List<Expr> args)
     {
       validationHelperCheckArgumentCount(args, 1);
-      IdentifierExpr expr = args.get(0).getIdentifierExprIfIdentifierExpr();
-
-      if (expr == null) {
-        throw validationFailed(
-            "argument %s should be an identifier expression. Use array() instead",
-            args.get(0).toString()
-        );
-      }
     }
 
     @Nullable

--- a/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -1163,6 +1163,13 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertArrayExpr("array_to_mv(a)", new String[]{"foo", "bar", "baz", "foobar"});
     assertArrayExpr("array_to_mv(b)", new String[]{"1", "2", "3", "4", "5"});
     assertArrayExpr("array_to_mv(c)", new String[]{"3.1", "4.2", "5.3"});
+    assertArrayExpr("array_to_mv(array(y,z))", new String[]{"2", "3"});
+    // array type is determined by the first array type
+    assertArrayExpr("array_to_mv(array_concat(b,c))", new String[]{"1", "2", "3", "4", "5", "3", "4", "5"});
+    assertArrayExpr(
+        "array_to_mv(array_concat(c,b))",
+        new String[]{"3.1", "4.2", "5.3", "1.0", "2.0", "3.0", "4.0", "5.0"}
+    );
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayToMultiValueStringOperatorConversion.java
@@ -45,6 +45,4 @@ public class ArrayToMultiValueStringOperatorConversion extends DirectOperatorCon
   {
     super(SQL_FUNCTION, "array_to_mv");
   }
-
-
 }


### PR DESCRIPTION
### Description
Lifts validation restrictions on `ARRAY_TO_MV` function, used to coerce array types into native multi-value string dimensions to accept any type of expression. This should open up the flexibility of creating multi-value dimensions with MSQ  to make it easier to still create multi-value dimensions with `"arrayIngestMode":"array"`.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
