### PR TITLE
split jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jetty.version>9.4.53.v20231009</jetty.version>
         <jersey.version>1.19.4</jersey.version>
-        <jackson.version>2.12.7.20221012</jackson.version>
+        <jackson.version>2.15.3</jackson.version>
+        <core.jackson.version>2.12.7.20221012</core.jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
         <log4j.version>2.18.0</log4j.version>
         <mysql.version>5.1.49</mysql.version>
@@ -363,11 +364,7 @@
                 <artifactId>json-smart</artifactId>
                 <version>2.4.11</version>
             </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
-            </dependency>
+
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -39,6 +39,17 @@
     <ipaddress.version>5.3.4</ipaddress.version>
     <oshi.version>6.4.4</oshi.version>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+          <groupId>com.fasterxml.jackson</groupId>
+          <artifactId>jackson-bom</artifactId>
+          <version>${core.jackson.version}</version>
+          <scope>import</scope>
+          <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -31,6 +31,18 @@
         <version>29.0.0-SNAPSHOT</version>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson</groupId>
+            <artifactId>jackson-bom</artifactId>
+            <version>${core.jackson.version}</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -29,6 +29,17 @@
         <artifactId>druid</artifactId>
         <version>29.0.0-SNAPSHOT</version>
     </parent>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${core.jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
### Description
Allow for bringing two separate versions of jackson dependencies. 
1. for druid processing / core that requires jackson 2.12
2. for the remaining modules bring in updated 2.15 version

This change should hopefully help us move away from Snakeyaml 1.x in compile scope and keep it only as a test dependency. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
