### PR TITLE
update core Apache Kafka dependencies to 3.6.1

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3054,7 +3054,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 3.6.0
+version: 3.6.1
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3912,7 +3912,7 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 3.6.0
+version: 3.6.1
 libraries:
   - org.apache.kafka: kafka-clients
 notices:

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>5.5.0</apache.curator.version>
-        <apache.kafka.version>3.6.0</apache.kafka.version>
+        <apache.kafka.version>3.6.1</apache.kafka.version>
         <apache.ranger.version>2.4.0</apache.ranger.version>
         <gson.version>2.10.1</gson.version>
         <scala.library.version>2.13.11</scala.library.version>


### PR DESCRIPTION
Release notes: https://downloads.apache.org/kafka/3.6.1/RELEASE_NOTES.html
