### PR TITLE
remove references to non-existent website maven module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2129,7 +2129,6 @@
                                 <exclude>.github/workflows/codeql.yml</exclude>
                                 <exclude>.github/workflows/codeql-config.yml</exclude>
                                 <exclude>git.version</exclude>
-                                <exclude>website/node_modules/**</exclude>
                                 <exclude>src/**/*.snap</exclude>
                                 <exclude>examples/conf/**</exclude>
                                 <exclude>.asf.yaml</exclude>
@@ -2175,12 +2174,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-          <id>website-docs</id>
-          <modules>
-            <module>website</module>
-          </modules>
         </profile>
         <profile>
           <id>skip-static-checks</id>


### PR DESCRIPTION
The website pom was removed as part of https://github.com/apache/druid/pull/14411
so we no longer need to reference it as a module and the profile can be removed.

Dependabot is currently failing trying to look for this module, so removing it should also fix dependency updates.