### PR TITLE
Skip compaction for datasources with partial-eternity segments

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -113,7 +113,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
             if (Intervals.ETERNITY.getStart().equals(segment.getInterval().getStart())
                 || Intervals.ETERNITY.getEnd().equals(segment.getInterval().getEnd())) {
               // This is to prevent the coordinator from crashing as raised in https://github.com/apache/druid/issues/13208
-              log.warn("Cannot compact datasource[%s] containing segments with partial-ETERNITY segments", dataSource);
+              log.warn("Cannot compact datasource[%s] containing segments with partial-ETERNITY intervals", dataSource);
               return;
             }
             for (Interval interval : configuredSegmentGranularity.getIterable(segment.getInterval())) {

--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -110,9 +110,10 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
             // For example, if the original is interval of 2020-01-28/2020-02-03 with WEEK granularity
             // and the configuredSegmentGranularity is MONTH, the segment will be split to two segments
             // of 2020-01/2020-02 and 2020-02/2020-03.
-            if (Intervals.ETERNITY.equals(segment.getInterval())) {
+            if (Intervals.ETERNITY.getStart().equals(segment.getInterval().getStart())
+                || Intervals.ETERNITY.getEnd().equals(segment.getInterval().getEnd())) {
               // This is to prevent the coordinator from crashing as raised in https://github.com/apache/druid/issues/13208
-              log.warn("Cannot compact datasource[%s] with ALL granularity", dataSource);
+              log.warn("Cannot compact datasource[%s] containing segments with partial-ETERNITY segments", dataSource);
               return;
             }
             for (Interval interval : configuredSegmentGranularity.getIterable(segment.getInterval())) {
@@ -429,8 +430,9 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     final List<Interval> searchIntervals = new ArrayList<>();
 
     for (Interval lookupInterval : filteredInterval) {
-      if (Intervals.ETERNITY.equals(lookupInterval)) {
-        log.warn("Cannot compact datasource[%s] since interval is ETERNITY.", dataSourceName);
+      if (Intervals.ETERNITY.getStart().equals(lookupInterval.getStart())
+          || Intervals.ETERNITY.getEnd().equals(lookupInterval.getEnd())) {
+        log.warn("Cannot compact datasource[%s] since interval start or end coincides with ETERNITY.", dataSourceName);
         return Collections.emptyList();
       }
       final List<DataSegment> segments = timeline

--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -432,7 +432,7 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     for (Interval lookupInterval : filteredInterval) {
       if (Intervals.ETERNITY.getStart().equals(lookupInterval.getStart())
           || Intervals.ETERNITY.getEnd().equals(lookupInterval.getEnd())) {
-        log.warn("Cannot compact datasource[%s] since interval start or end coincides with ETERNITY.", dataSourceName);
+        log.warn("Cannot compact datasource[%s] since interval[%s] coincides with ETERNITY.", dataSourceName, lookupInterval);
         return Collections.emptyList();
       }
       final List<DataSegment> segments = timeline

--- a/server/src/test/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstPolicyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstPolicyTest.java
@@ -1637,6 +1637,70 @@ public class NewestSegmentFirstPolicyTest
   }
 
   @Test
+  public void testSkipFirstHalfEternityToDefault()
+  {
+    CompactionSegmentIterator iterator = policy.reset(
+        ImmutableMap.of(DATA_SOURCE,
+                        createCompactionConfig(10000,
+                                               new Period("P0D"),
+                                               null
+                        )
+        ),
+        ImmutableMap.of(
+            DATA_SOURCE,
+            SegmentTimeline.forSegments(ImmutableSet.of(
+                                            new DataSegment(
+                                                DATA_SOURCE,
+                                                new Interval(DateTimes.MIN, DateTimes.of("2024-01-01")),
+                                                "0",
+                                                new HashMap<>(),
+                                                new ArrayList<>(),
+                                                new ArrayList<>(),
+                                                new NumberedShardSpec(0, 0),
+                                                0,
+                                                100)
+                                        )
+            )
+        ),
+        Collections.emptyMap()
+    );
+
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  public void testSkipSecondHalfOfEternityToDefault()
+  {
+    CompactionSegmentIterator iterator = policy.reset(
+        ImmutableMap.of(DATA_SOURCE,
+                        createCompactionConfig(10000,
+                                               new Period("P0D"),
+                                               null
+                        )
+        ),
+        ImmutableMap.of(
+            DATA_SOURCE,
+            SegmentTimeline.forSegments(ImmutableSet.of(
+                                            new DataSegment(
+                                                DATA_SOURCE,
+                                                new Interval(DateTimes.of("2024-01-01"), DateTimes.MAX),
+                                                "0",
+                                                new HashMap<>(),
+                                                new ArrayList<>(),
+                                                new ArrayList<>(),
+                                                new NumberedShardSpec(0, 0),
+                                                0,
+                                                100)
+                                        )
+            )
+        ),
+        Collections.emptyMap()
+    );
+
+    Assert.assertFalse(iterator.hasNext());
+  }
+
+  @Test
   public void testSkipAllToAllGranularity()
   {
     CompactionSegmentIterator iterator = policy.reset(


### PR DESCRIPTION
This PR builds on https://github.com/apache/druid/pull/13304 to skip compaction for datasources with segments that have their interval start or end coinciding with Eternity interval end-points.

This is needed in order to prevent an issue similar to #13208 as the Coordinator tries to iterate over a large number of intervals when trying to compact an interval with infinite start or end.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
