### PR TITLE
unpin snakeyaml, add suppressions and licenses

### DIFF
--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -35,6 +35,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- snakeyaml explicitly pinned to version 1.33 as it is
+            a transitive dependency of:
+            com.netflix.astyanax:astyanax:jar -> g.apache.cassandra:cassandra-all:jar
+            please remove this pin after the update of astyanax, see comment below
+             -->
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>

--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -33,6 +33,16 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.33</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.druid</groupId>

--- a/extensions-contrib/kubernetes-overlord-extensions/pom.xml
+++ b/extensions-contrib/kubernetes-overlord-extensions/pom.xml
@@ -36,6 +36,9 @@
 
   <dependencyManagement>
       <dependencies>
+            <!-- snakeyaml explicitly pinned to version 1.33 as it is
+             a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.12.7
+             please remove this pin, after updating jackson-dataform-yaml to version > 2.14.3  / 2.15.0 -->
           <dependency>
               <groupId>org.yaml</groupId>
               <artifactId>snakeyaml</artifactId>

--- a/extensions-contrib/kubernetes-overlord-extensions/pom.xml
+++ b/extensions-contrib/kubernetes-overlord-extensions/pom.xml
@@ -34,6 +34,15 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
+  <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>org.yaml</groupId>
+              <artifactId>snakeyaml</artifactId>
+              <version>1.33</version>
+          </dependency>
+      </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -43,6 +43,16 @@
         <hadoop.s3.impl>org.apache.hadoop.fs.s3a.S3AFileSystem</hadoop.s3.impl>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>1.33</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -45,6 +45,9 @@
 
     <dependencyManagement>
         <dependencies>
+             <!-- snakeyaml explicitly pinned to version 1.33 as it is
+             a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml 2.12.7
+             please remove this pin, after updating jackson-dataform-yaml to version > 2.14.3  / 2.15.0 -->
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2876,7 +2876,7 @@ libraries:
 
 name: org.yaml snakeyaml
 license_category: binary
-module: extensions/druid-kubernetes-extensions
+module: extensions/druid-protobuf-extensions
 license_name: Apache License version 2.0
 version: 2.0
 libraries:

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1022,7 +1022,7 @@ name: org.yaml snakeyaml
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 1.33
+version: 2.2
 libraries:
   - org.yaml: snakeyaml
 
@@ -2871,6 +2871,18 @@ license_name: Apache License version 2.0
 libraries:
   - io.confluent: kafka-schema-registry-client
   - io.confluent: common-utils
+
+---
+
+name: org.yaml snakeyaml
+license_category: binary
+module: extensions/druid-kubernetes-extensions
+license_name: Apache License version 2.0
+version: 2.0
+libraries:
+  - org.yaml: snakeyaml
+
+
 
 ---
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -275,14 +275,40 @@
   </suppress>
 
   <suppress>
-    <!-- We need to wait for 17.0.0 of https://github.com/kubernetes-client/java/releases -->
-    <!-- We need to update several other components to move to Snakeyaml 2.0 to address CVE-2022-1471 -->
-    <!-- Snakeyaml 1.33 added to dependencyManagement in main pom file -->
+    <!-- The main use of snakeyaml in Druid is coming in test scope from:
+     com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.7
+     (version 1.27)
+     The contrib extension: druid-cassandra-storage uses version 1.6 in compile
+     scope
+     The integration tests use version 1.27 in compile scope.
+     Previous pinning of version to 1.33 forced the usage of the version across
+     all the modules, downgrading the version for some of them.
+     The removal of the pin in the main POM allows the modules choose which version
+     to be used, enabling the users to disable contrib extensions and use the
+     CVE free version of Snakeyaml in core extensions.
+      -->
+
     <notes><![CDATA[
-    file name: snakeyaml-1.33.jar
+    file name:  snakeyaml-1.27.jar
     ]]></notes>
+    <!-- Snakeyaml is used only in test scope in Druid core with trusted inputs -->
     <cve>CVE-2022-1471</cve>
+    <cve>CVE-2022-25857</cve>
     <!-- false positive -->
+    <cve>CVE-2023-2251</cve>
+    <cve>CVE-2022-3064</cve>
+  </suppress>
+
+  <suppress>
+    <!-- This is for contrib extension for which dependency-check is disabled
+    restoring this data for accuracy -->
+    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
+    <notes><![CDATA[
+    file name: snakeyaml-1.6.jar
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@1.6$</packageUrl>
+    <cve>CVE-2017-18640</cve>
+    <cve>CVE-2022-25857</cve>
     <cve>CVE-2023-2251</cve>
     <cve>CVE-2022-3064</cve>
   </suppress>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -289,7 +289,7 @@
       -->
 
     <notes><![CDATA[
-    file name:  snakeyaml-1.27.jar
+    file name: snakeyaml-1.27.jar snakeyaml-1.33.jar
     ]]></notes>
     <!-- Snakeyaml is used only in test scope in Druid core with trusted inputs -->
     <cve>CVE-2022-1471</cve>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -293,22 +293,7 @@
     ]]></notes>
     <!-- Snakeyaml is used only in test scope in Druid core with trusted inputs -->
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2022-25857</cve>
     <!-- false positive -->
-    <cve>CVE-2023-2251</cve>
-    <cve>CVE-2022-3064</cve>
-  </suppress>
-
-  <suppress>
-    <!-- This is for contrib extension for which dependency-check is disabled
-    restoring this data for accuracy -->
-    <!-- TODO: Fix by using com.datastax.oss:java-driver-core instead of com.netflix.astyanax:astyanax in extensions-contrib/cassandra-storage -->
-    <notes><![CDATA[
-    file name: snakeyaml-1.6.jar
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@1.6$</packageUrl>
-    <cve>CVE-2017-18640</cve>
-    <cve>CVE-2022-25857</cve>
     <cve>CVE-2023-2251</cve>
     <cve>CVE-2022-3064</cve>
   </suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -364,11 +364,6 @@
                 <artifactId>json-smart</artifactId>
                 <version>2.4.11</version>
             </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
-            </dependency>
 
             <!-- transitive dependency of testng
             this would be resolved by updating


### PR DESCRIPTION
### Description
This removes the pin of the Snakeyaml introduced in: 
https://github.com/apache/druid/pull/14519
After the updates of io.kubernetes.java-client and io.confluent.kafka-clients, the only uses of the Snakeyaml 1.x are:
- in test scope, transitive dependency of jackson-dataformat-yaml:jar:2.12.7
- in compile scope in contrib extension druid-cassandra-storage
- in compile scope in it-tests. 

With the dependency version un-pinned, io.kubernetes.java-client and io.confluent.kafka-clients bring Snakeyaml versions 2.0 and 2.2, consequently allowing to build a Druid distribution without the contrib-extension and free of vulnerable Snakeyaml versions. 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
