### PR TITLE
add support for ColumnConfig skipValueRangeIndexScale and skipValueRangeIndexScale to traditional string columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/serde/StringUtf8ColumnIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/StringUtf8ColumnIndexSupplier.java
@@ -62,6 +62,10 @@ public class StringUtf8ColumnIndexSupplier<TIndexed extends Indexed<ByteBuffer>>
   private final ColumnConfig columnConfig;
   private final int numRows;
 
+  /**
+   * Legacy constructor which always uses bitmap indexes, sparing no expense (ignores the configurable range and
+   * predicate indexes thresholds on {@link ColumnConfig}, in favor of using {@link ColumnConfig#ALWAYS_USE_INDEXES}).
+   */
   public StringUtf8ColumnIndexSupplier(
       BitmapFactory bitmapFactory,
       Supplier<TIndexed> utf8Dictionary,
@@ -77,7 +81,7 @@ public class StringUtf8ColumnIndexSupplier<TIndexed extends Indexed<ByteBuffer>>
           Supplier<TIndexed> utf8Dictionary,
           @Nullable GenericIndexed<ImmutableBitmap> bitmaps,
           @Nullable ImmutableRTree indexedTree,
-          @Nullable ColumnConfig columnConfig,
+          ColumnConfig columnConfig,
           int numRows
   )
   {


### PR DESCRIPTION
### Description
Adds the enhancements from #13977 to traditional string columns to improve performance of filter processing by allowing obviously expensive bitmap operations to be skipped. While I haven't run the benchmarks, I assume a similar improvement for string columns that are not created with the 'auto' indexer as were seen in #13977. Previously this performance enhancement was only available for 'auto' and 'json' columns.

This is related to #15550 to help replace the 'auto' search strategy.

I've not documented the configs behind this yet in this PR because I'm still thinking on how to frame what these configs do in an understandable manner without requiring deep knowledge of how query processing actually works. For the most part these settings should probably not be tweaked by users, but will try to think of something and add docs in a follow-up PR.

#### Release note
String columns created with the 'string' column indexer now have an enhancement for filter match processing that was previously only available to columns created by the 'auto' indexer, and will automatically skip obviously expensive index computation for filters which would require a very large number of bitmap operations. This should improve performance, particularly when filter clauses contain a mix of simple and complex filters since it allows the complex filters. Previously Druid would always utilize indexes if they were available, and this behavior can be returned by setting `druid.processing.skipValuePredicateIndexScale` and `druid.processing.skipValueRangeIndexScale` to `1.0`.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
