### PR TITLE
Update labeler GHA to v5 

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -32,6 +32,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Currently the auto-labeler bot sometimes removes labels manually added by maintainers. For example:

<img width="974" alt="CleanShot 2023-12-13 at 23 30 13@2x" src="https://github.com/apache/druid/assets/8687261/0127499a-b6e5-479e-b682-d3149705af87">

The behavior seems to be fixed in `v5` where the bot doesn't spuriously remove labels when `sync-label` is set to false (the default). See https://github.com/actions/labeler/releases/tag/v5.0.0 for some details.

This PR has:

- [x] been self-reviewed.
