### PR TITLE
Update labeler configuration for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -21,47 +21,71 @@
 # Pull Request Labeler GitHub Action Configuration: https://github.com/marketplace/actions/labeler
 
 'Area - Batch Ingestion':
-  - 'indexing-hadoop/**'
-  - 'extensions-core/multi-stage-query/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'indexing-hadoop/**'
+      - 'extensions-core/multi-stage-query/**'
 
 'Area - Dependencies':
-  - '**/pom.xml'
-  - 'licenses.yaml'
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/pom.xml'
+      - 'licenses.yaml'
 
 'Area - Documentation':
-  - 'docs/**/*'
-  - 'website/**'
-  - 'examples/quickstart/jupyter-notebooks/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**/*'
+      - 'website/**'
+      - 'examples/quickstart/jupyter-notebooks/**'
 
 'Area - Ingestion':
-  - 'indexing-service/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'indexing-service/**'
 
 'Area - Lookups':
-  - 'extensions-core/lookups-cached-global/**'
-  - 'extensions-core/lookups-cached-single/**'
-  - 'extensions-core/kafka-extraction-namespace/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'extensions-core/lookups-cached-global/**'
+      - 'extensions-core/lookups-cached-single/**'
+      - 'extensions-core/kafka-extraction-namespace/**'
 
 'Area - Metrics/Event Emitting':
-  - 'processing/src/main/java/org/apache/druid/java/util/metrics/**'
-  - 'processing/src/main/java/org/apache/druid/java/util/emitter/**'
-  - 'extensions-contrib/*-emitter/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'processing/src/main/java/org/apache/druid/java/util/metrics/**'
+      - 'processing/src/main/java/org/apache/druid/java/util/emitter/**'
+      - 'extensions-contrib/*-emitter/**'
 
 'Area - MSQ':
-  - 'extensions-core/multi-stage-query/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'extensions-core/multi-stage-query/**'
 
 'Area - Querying':
-  - 'sql/**'
-  - 'extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'sql/**'
+      - 'extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/**'
 
 'Area - Segment Format and Ser/De':
-  - 'processing/src/main/java/org/apache/druid/segment/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'processing/src/main/java/org/apache/druid/segment/**'
 
 'Area - Streaming Ingestion':
-  - 'extensions-core/kafka-indexing-service/**'
-  - 'extensions-core/kinesis-indexing-service/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'extensions-core/kafka-indexing-service/**'
+      - 'extensions-core/kinesis-indexing-service/**'
 
 'Area - Web Console':
-  - 'web-console/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'web-console/**'
 
 'Kubernetes':
-  - 'extensions-contrib/kubernetes-overlord-extensions/**'
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'extensions-contrib/kubernetes-overlord-extensions/**'


### PR DESCRIPTION
After https://github.com/apache/druid/pull/15558,  @LakshSingla noticed this error in one of his jobs - https://github.com/apache/druid/actions/runs/7212566265/job/19650514677?pr=15559. 

> The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: Error: found unexpected type for label 'Area - Batch Ingestion' (should be array of config options)
Error: found unexpected type for label 'Area - Batch Ingestion' (should be array of config options)

The issue seems related to: https://github.com/actions/labeler/issues/712. This PR updates the labeler configuration format to be compatible with v5.

As with GitHub actions, we'd have to test this by merging the PR and then a follow-up PR should succeed as the workflow is run from the base branch, master in this case. If it doesn't succeed, we can perhaps revert the version back to v4.

This PR has:

- [x] been self-reviewed.

