### PR TITLE
Detect `EXPLAIN PLAN` queries in web-console and run them individually

### DIFF
--- a/web-console/src/utils/sql.spec.ts
+++ b/web-console/src/utils/sql.spec.ts
@@ -351,5 +351,237 @@ describe('sql', () => {
         ]
       `);
     });
+
+    it('works with explain plan query', () => {
+      const text = sane`
+        EXPLAIN PLAN FOR
+        INSERT INTO "wikipedia"
+        WITH "ext" AS (
+          SELECT *
+          FROM TABLE(
+            EXTERN(
+              '{"type":"http","uris":["https://druid.apache.org/data/wikipedia.json.gz"]}',
+              '{"type":"json"}'
+            )
+          ) EXTEND ("isRobot" VARCHAR, "channel" VARCHAR, "timestamp" VARCHAR)
+        )
+        SELECT
+          TIME_PARSE("timestamp") AS "__time",
+          "isRobot",
+          "channel"
+        FROM "ext"
+        PARTITIONED BY DAY
+        CLUSTERED BY "channel"
+      `;
+
+      const found = findAllSqlQueriesInText(text);
+
+      expect(found).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "endOffset": 404,
+            "endRowColumn": Object {
+              "column": 22,
+              "row": 17,
+            },
+            "sql": "EXPLAIN PLAN FOR
+        INSERT INTO \\"wikipedia\\"
+        WITH \\"ext\\" AS (
+          SELECT *
+          FROM TABLE(
+            EXTERN(
+              '{\\"type\\":\\"http\\",\\"uris\\":[\\"https://druid.apache.org/data/wikipedia.json.gz\\"]}',
+              '{\\"type\\":\\"json\\"}'
+            )
+          ) EXTEND (\\"isRobot\\" VARCHAR, \\"channel\\" VARCHAR, \\"timestamp\\" VARCHAR)
+        )
+        SELECT
+          TIME_PARSE(\\"timestamp\\") AS \\"__time\\",
+          \\"isRobot\\",
+          \\"channel\\"
+        FROM \\"ext\\"
+        PARTITIONED BY DAY
+        CLUSTERED BY \\"channel\\"",
+            "startOffset": 0,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 0,
+            },
+          },
+          Object {
+            "endOffset": 404,
+            "endRowColumn": Object {
+              "column": 22,
+              "row": 17,
+            },
+            "sql": "INSERT INTO \\"wikipedia\\"
+        WITH \\"ext\\" AS (
+          SELECT *
+          FROM TABLE(
+            EXTERN(
+              '{\\"type\\":\\"http\\",\\"uris\\":[\\"https://druid.apache.org/data/wikipedia.json.gz\\"]}',
+              '{\\"type\\":\\"json\\"}'
+            )
+          ) EXTEND (\\"isRobot\\" VARCHAR, \\"channel\\" VARCHAR, \\"timestamp\\" VARCHAR)
+        )
+        SELECT
+          TIME_PARSE(\\"timestamp\\") AS \\"__time\\",
+          \\"isRobot\\",
+          \\"channel\\"
+        FROM \\"ext\\"
+        PARTITIONED BY DAY
+        CLUSTERED BY \\"channel\\"",
+            "startOffset": 17,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 1,
+            },
+          },
+          Object {
+            "endOffset": 362,
+            "endRowColumn": Object {
+              "column": 10,
+              "row": 15,
+            },
+            "sql": "WITH \\"ext\\" AS (
+          SELECT *
+          FROM TABLE(
+            EXTERN(
+              '{\\"type\\":\\"http\\",\\"uris\\":[\\"https://druid.apache.org/data/wikipedia.json.gz\\"]}',
+              '{\\"type\\":\\"json\\"}'
+            )
+          ) EXTEND (\\"isRobot\\" VARCHAR, \\"channel\\" VARCHAR, \\"timestamp\\" VARCHAR)
+        )
+        SELECT
+          TIME_PARSE(\\"timestamp\\") AS \\"__time\\",
+          \\"isRobot\\",
+          \\"channel\\"
+        FROM \\"ext\\"",
+            "startOffset": 41,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 2,
+            },
+          },
+          Object {
+            "endOffset": 278,
+            "endRowColumn": Object {
+              "column": 70,
+              "row": 9,
+            },
+            "sql": "SELECT *
+          FROM TABLE(
+            EXTERN(
+              '{\\"type\\":\\"http\\",\\"uris\\":[\\"https://druid.apache.org/data/wikipedia.json.gz\\"]}',
+              '{\\"type\\":\\"json\\"}'
+            )
+          ) EXTEND (\\"isRobot\\" VARCHAR, \\"channel\\" VARCHAR, \\"timestamp\\" VARCHAR)",
+            "startOffset": 59,
+            "startRowColumn": Object {
+              "column": 2,
+              "row": 3,
+            },
+          },
+          Object {
+            "endOffset": 362,
+            "endRowColumn": Object {
+              "column": 10,
+              "row": 15,
+            },
+            "sql": "SELECT
+          TIME_PARSE(\\"timestamp\\") AS \\"__time\\",
+          \\"isRobot\\",
+          \\"channel\\"
+        FROM \\"ext\\"",
+            "startOffset": 281,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 11,
+            },
+          },
+        ]
+      `);
+    });
+
+    it('works with multiple explain plan queries', () => {
+      const text = sane`
+        EXPLAIN PLAN FOR
+        SELECT *
+        FROM wikipedia
+
+        EXPLAIN PLAN FOR
+        SELECT *
+        FROM w2
+        LIMIT 5
+
+      `;
+
+      const found = findAllSqlQueriesInText(text);
+
+      expect(found).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "endOffset": 40,
+            "endRowColumn": Object {
+              "column": 14,
+              "row": 2,
+            },
+            "sql": "EXPLAIN PLAN FOR
+        SELECT *
+        FROM wikipedia",
+            "startOffset": 0,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 0,
+            },
+          },
+          Object {
+            "endOffset": 40,
+            "endRowColumn": Object {
+              "column": 14,
+              "row": 2,
+            },
+            "sql": "SELECT *
+        FROM wikipedia",
+            "startOffset": 17,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 1,
+            },
+          },
+          Object {
+            "endOffset": 83,
+            "endRowColumn": Object {
+              "column": 7,
+              "row": 7,
+            },
+            "sql": "EXPLAIN PLAN FOR
+        SELECT *
+        FROM w2
+        LIMIT 5",
+            "startOffset": 42,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 4,
+            },
+          },
+          Object {
+            "endOffset": 83,
+            "endRowColumn": Object {
+              "column": 7,
+              "row": 7,
+            },
+            "sql": "SELECT *
+        FROM w2
+        LIMIT 5",
+            "startOffset": 59,
+            "startRowColumn": Object {
+              "column": 0,
+              "row": 5,
+            },
+          },
+        ]
+      `);
+    });
   });
 });

--- a/web-console/src/utils/sql.ts
+++ b/web-console/src/utils/sql.ts
@@ -123,7 +123,7 @@ export function findAllSqlQueriesInText(text: string): QuerySlice[] {
   let offset = 0;
   let m: RegExpExecArray | null = null;
   do {
-    m = /SELECT|WITH|INSERT|REPLACE/i.exec(remainingText);
+    m = /SELECT|WITH|INSERT|REPLACE|EXPLAIN/i.exec(remainingText);
     if (m) {
       const sql = findSqlQueryPrefix(remainingText.slice(m.index));
       const advanceBy = m.index + m[0].length; // Skip the initial word


### PR DESCRIPTION
Building on top of https://github.com/apache/druid/pull/14801. With this patch, the web-console can now detect multiple `EXPLAIN PLAN` queries in the workbench and run them individually.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->
<img width="812" alt="CleanShot 2023-12-15 at 07 36 07@2x" src="https://github.com/apache/druid/assets/8687261/a179b08c-b4bd-4bcd-8207-86e570647cdc">

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
