### PR TITLE
fix some null handling bugs with vector expression processors

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/DoubleOutLongsInFunctionVectorValueProcessor.java
@@ -45,7 +45,7 @@ public abstract class DoubleOutLongsInFunctionVectorValueProcessor
   @Override
   public ExpressionType getOutputType()
   {
-    return ExpressionType.LONG;
+    return ExpressionType.DOUBLE;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/VectorProcessors.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/VectorProcessors.java
@@ -544,9 +544,11 @@ public class VectorProcessors
                 outputNulls[i] = rightNulls[i];
               } else {
                 output[i] = rightInput[i];
+                outputNulls[i] = false;
               }
             } else {
               output[i] = leftInput[i];
+              outputNulls[i] = false;
             }
           }
 
@@ -580,9 +582,11 @@ public class VectorProcessors
                 outputNulls[i] = rightNulls[i];
               } else {
                 output[i] = rightInput[i];
+                outputNulls[i] = false;
               }
             } else {
               output[i] = leftInput[i];
+              outputNulls[i] = false;
             }
           }
 
@@ -744,6 +748,7 @@ public class VectorProcessors
               }
             }
             output[i] = Evals.asLong(Evals.asBoolean(leftInput[i]) || Evals.asBoolean(rightInput[i]));
+            outputNulls[i] = false;
           }
 
           @Override
@@ -793,6 +798,7 @@ public class VectorProcessors
               }
             }
             output[i] = Evals.asLong(Evals.asBoolean(leftInput[i]) || Evals.asBoolean(rightInput[i]));
+            outputNulls[i] = false;
           }
 
           @Override
@@ -839,6 +845,7 @@ public class VectorProcessors
               return;
             }
             output[i] = Evals.asLong(Evals.asBoolean((String) leftInput[i]) || Evals.asBoolean((String) rightInput[i]));
+            outputNulls[i] = false;
           }
 
           @Override
@@ -907,6 +914,7 @@ public class VectorProcessors
               }
             }
             output[i] = Evals.asLong(Evals.asBoolean(leftInput[i]) && Evals.asBoolean(rightInput[i]));
+            outputNulls[i] = false;
           }
 
           @Override
@@ -916,7 +924,7 @@ public class VectorProcessors
           }
         },
         () -> new BivariateFunctionVectorProcessor<double[], double[], long[]>(
-            ExpressionType.DOUBLE,
+            ExpressionType.LONG,
             left.asVectorProcessor(inputTypes),
             right.asVectorProcessor(inputTypes)
         )
@@ -956,6 +964,7 @@ public class VectorProcessors
               }
             }
             output[i] = Evals.asLong(Evals.asBoolean(leftInput[i]) && Evals.asBoolean(rightInput[i]));
+            outputNulls[i] = false;
           }
 
           @Override
@@ -965,7 +974,7 @@ public class VectorProcessors
           }
         },
         () -> new BivariateFunctionVectorProcessor<Object[], Object[], long[]>(
-            ExpressionType.STRING,
+            ExpressionType.LONG,
             left.asVectorProcessor(inputTypes),
             right.asVectorProcessor(inputTypes)
         )
@@ -1004,6 +1013,7 @@ public class VectorProcessors
             output[i] = Evals.asLong(
                 Evals.asBoolean((String) leftInput[i]) && Evals.asBoolean((String) rightInput[i])
             );
+            outputNulls[i] = false;
           }
 
           @Override

--- a/processing/src/test/java/org/apache/druid/query/expression/VectorExpressionsSanityTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/VectorExpressionsSanityTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.query.expression;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
@@ -62,13 +61,8 @@ public class VectorExpressionsSanityTest extends InitializedNullHandlingTest
   static void testExpression(String expr, Expr parsed, Map<String, ExpressionType> types)
   {
     log.debug("[%s]", expr);
-    NonnullPair<Expr.ObjectBinding[], Expr.VectorInputBinding> bindings;
-    for (int iterations = 0; iterations < NUM_ITERATIONS; iterations++) {
-      bindings = VectorExprSanityTest.makeRandomizedBindings(VECTOR_SIZE, types);
-      VectorExprSanityTest.testExpressionWithBindings(expr, parsed, bindings);
-    }
-    bindings = VectorExprSanityTest.makeSequentialBinding(VECTOR_SIZE, types);
-    VectorExprSanityTest.testExpressionWithBindings(expr, parsed, bindings);
+    VectorExprSanityTest.testExpression(expr, parsed, types, NUM_ITERATIONS);
+    VectorExprSanityTest.testSequentialBinding(expr, parsed, types);
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixes some bugs with `and`/`or`/ and numeric `nvl` not clearing out stale 'null' vectors for vector expression processing causing rows to incorrectly be considered as null. The tests that should have caught this were actually hiding this bug by making a new binding and processor for every iteration instead of re-using the processor for a bunch of different bindings, so the problem never was hit because the vectors were not being re-used.

I also stumbled across a couple small bugs with expression vector processor output types, which I have also fixed.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
