### PR TITLE
Register first lookup immediately, regardless of the cache status.

### DIFF
--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -668,7 +668,11 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
           e -> true,
           startRetries
       );
-      if (lookupExtractorFactoryContainer.getLookupExtractorFactory().isInitialized()) {
+      /*
+       if new container is initailized then add it to manager to start serving immediately.
+       if old container is null then it is fresh load, we can skip waiting for initialization and add the container to registry first. Esp for MSQ workers.
+       */
+      if (old == null || lookupExtractorFactoryContainer.getLookupExtractorFactory().isInitialized()) {
         old = lookupMap.put(lookupName, lookupExtractorFactoryContainer);
         LOG.debug("Loaded lookup [%s] with spec [%s].", lookupName, lookupExtractorFactoryContainer);
         manager.dropContainer(old, lookupName);


### PR DESCRIPTION
### Description
In case of the first version of the lookup, we can skip waiting for initialization where it is good or bad configuration and just load it as it is. Esp for MSQ workers, it get spin off for each tasks, and issues loadNotice with no previous lookup version.
For first lookup, it get registered immediately regardless of the cache status. For subsequent version of the lookup, we make sure that new lookup come up before we kill the existing good lookup.

In subsequent version of the same lookup, we always make sure that we wait until new lookup config is loaded with cache before we kill the old working lookup.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
