### PR TITLE
Reverse lookup fixes and enhancements.

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.k8s.overlord;
 
-import com.google.api.client.util.Lists;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.k8s.overlord.taskadapter;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.google.api.client.util.Joiner;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;

--- a/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
+++ b/extensions-core/druid-bloom-filter/src/main/java/org/apache/druid/query/filter/BloomDimFilter.java
@@ -84,13 +84,6 @@ public class BloomDimFilter extends AbstractOptimizableDimFilter implements DimF
         .build();
   }
 
-
-  @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
   @Override
   public Filter toFilter()
   {

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -20,8 +20,8 @@
 package org.apache.druid.query.lookup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.lookup;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
@@ -261,7 +262,10 @@ public class TestKafkaExtractionCluster
 
       log.info("-------------------------     Checking baz bat     -------------------------------");
       Assert.assertEquals("bat", factory.get().apply("baz"));
-      Assert.assertEquals(Collections.singletonList("baz"), factory.get().unapply("bat"));
+      Assert.assertEquals(
+          Collections.singletonList("baz"),
+          Lists.newArrayList(factory.get().unapplyAll(Collections.singleton("bat")))
+      );
     }
   }
 
@@ -365,10 +369,10 @@ public class TestKafkaExtractionCluster
   {
     final LookupExtractor extractor = factory.get();
 
-    while (!expected.equals(extractor.unapply(key))) {
+    while (!expected.equals(Lists.newArrayList(extractor.unapplyAll(Collections.singleton(key))))) {
       Thread.sleep(100);
     }
 
-    Assert.assertEquals("update check", expected, extractor.unapply(key));
+    Assert.assertEquals("update check", expected, Lists.newArrayList(extractor.unapplyAll(Collections.singleton(key))));
   }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.server.lookup;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.server.lookup.cache.loading.LoadingCache;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -87,7 +88,10 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
             .andReturn(Collections.singletonList("key"))
             .once();
     EasyMock.replay(reverseLookupCache);
-    Assert.assertEquals(ImmutableMap.of("value", Collections.singletonList("key")), loadingLookup.unapplyAll(ImmutableSet.of("value")));
+    Assert.assertEquals(
+        Collections.singletonList("key"),
+        Lists.newArrayList(loadingLookup.unapplyAll(ImmutableSet.of("value")))
+    );
     EasyMock.verify(reverseLookupCache);
   }
 

--- a/processing/src/main/java/org/apache/druid/common/config/NullHandling.java
+++ b/processing/src/main/java/org/apache/druid/common/config/NullHandling.java
@@ -23,8 +23,15 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import org.apache.druid.math.expr.ExpressionProcessing;
+import org.apache.druid.query.BitmapResultFactory;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.ValueMatcher;
+import org.apache.druid.query.filter.vector.ReadableVectorMatch;
+import org.apache.druid.query.filter.vector.VectorValueMatcher;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.Indexed;
+import org.apache.druid.segment.filter.NotFilter;
+import org.apache.druid.segment.index.BitmapColumnIndex;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -72,7 +79,11 @@ public class NullHandling
   }
 
   @VisibleForTesting
-  public static void initializeForTestsWithValues(Boolean useDefForNull, Boolean useThreeValueLogic, Boolean ignoreNullForString)
+  public static void initializeForTestsWithValues(
+      Boolean useDefForNull,
+      Boolean useThreeValueLogic,
+      Boolean ignoreNullForString
+  )
   {
     INSTANCE = new NullValueHandlingConfig(useDefForNull, useThreeValueLogic, ignoreNullForString);
   }
@@ -106,6 +117,16 @@ public class NullHandling
     return !replaceWithDefault();
   }
 
+  /**
+   * Whether filtering uses 3-valued logic. Used primarily by {@link NotFilter} to invert matches in a SQL compliant
+   * manner. When this is set, an "includeUnknown" parameter can be activated in various classes related to filtering;
+   * see below for references.
+   *
+   * @see ValueMatcher#matches(boolean) includeUnknown parameter
+   * @see VectorValueMatcher#match(ReadableVectorMatch, boolean) includeUnknown parameter
+   * @see BitmapColumnIndex#computeBitmapResult(BitmapResultFactory, boolean) includeUnknown parameter
+   * @see DimFilter#optimize(boolean) mayIncludeUnknown parameter
+   */
   public static boolean useThreeValueLogic()
   {
     return NullHandling.sqlCompatible() &&

--- a/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.lookup.LookupExtractor;
@@ -33,10 +34,10 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @JsonTypeName("map")
 public class MapLookupExtractor extends LookupExtractor
@@ -111,18 +112,21 @@ public class MapLookupExtractor extends LookupExtractor
   @Override
   public List<String> unapply(@Nullable final String value)
   {
-    String valueToLookup = NullHandling.nullToEmptyIfNeeded(value);
-    if (valueToLookup == null) {
-      // valueToLookup is null only for SQL Compatible Null Behavior
-      // otherwise null will be replaced with empty string in nullToEmptyIfNeeded above.
-      // null value maps to empty list when SQL Compatible
-      return Collections.emptyList();
-    }
-    return map.entrySet()
-              .stream()
-              .filter(entry -> entry.getValue().equals(valueToLookup))
-              .map(entry -> entry.getKey())
-              .collect(Collectors.toList());
+    // Not needed, since we override unapplyAll.
+    throw new UnsupportedOperationException();
+  }
+
+  @Nullable
+  @Override
+  public Iterator<String> unapplyAll(Set<String> values)
+  {
+    return Iterators.transform(
+        Iterators.filter(
+            map.entrySet().iterator(),
+            entry -> values.contains(NullHandling.emptyToNullIfNeeded(entry.getValue()))
+        ),
+        Map.Entry::getKey
+    );
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/MapLookupExtractor.java
@@ -123,7 +123,14 @@ public class MapLookupExtractor extends LookupExtractor
     return Iterators.transform(
         Iterators.filter(
             map.entrySet().iterator(),
-            entry -> values.contains(NullHandling.emptyToNullIfNeeded(entry.getValue()))
+            entry -> {
+              if (entry.getKey() == null && NullHandling.sqlCompatible()) {
+                // apply always maps null to null in SQL-compatible mode.
+                return values.contains(null);
+              } else {
+                return values.contains(NullHandling.emptyToNullIfNeeded(entry.getValue()));
+              }
+            }
         ),
         Map.Entry::getKey
     );

--- a/processing/src/main/java/org/apache/druid/query/filter/ArrayContainsElementFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ArrayContainsElementFilter.java
@@ -122,12 +122,6 @@ public class ArrayContainsElementFilter extends AbstractOptimizableDimFilter imp
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return this;

--- a/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/BoundDimFilter.java
@@ -253,12 +253,6 @@ public class BoundDimFilter extends AbstractOptimizableDimFilter implements DimF
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new BoundFilter(this);

--- a/processing/src/main/java/org/apache/druid/query/filter/ColumnComparisonDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ColumnComparisonDimFilter.java
@@ -60,12 +60,6 @@ public class ColumnComparisonDimFilter extends AbstractOptimizableDimFilter impl
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new ColumnComparisonFilter(dimensions);

--- a/processing/src/main/java/org/apache/druid/query/filter/DimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/DimFilter.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.filter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.RangeSet;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Cacheable;
 import org.apache.druid.query.extraction.ExtractionFn;
 
@@ -59,10 +60,12 @@ import java.util.Set;
 public interface DimFilter extends Cacheable
 {
   /**
-   * @return Returns an optimized filter.
-   * returning the same filter can be a straightforward default implementation.
+   * Returns an optimized version of this filter.
+   *
+   * @param mayIncludeUnknown whether the optimized filter may need to operate in "includeUnknown" mode.
+   *                          See {@link NullHandling#useThreeValueLogic()}.
    */
-  DimFilter optimize();
+  DimFilter optimize(boolean mayIncludeUnknown);
 
   /**
    * @return Return a Filter that implements this DimFilter, after applying optimizations to this DimFilter.
@@ -73,8 +76,11 @@ public interface DimFilter extends Cacheable
    * The Filter returned by this method across multiple calls must be the same object: parts of the query stack
    * compare Filters, and returning the same object allows these checks to avoid deep comparisons.
    * (see {@link org.apache.druid.segment.join.HashJoinSegmentStorageAdapter#makeCursors for an example}
+   *
+   * @param mayIncludeUnknown whether the optimized filter may need to operate in "includeUnknown" mode.
+   *                          See {@link NullHandling#useThreeValueLogic()}.
    */
-  Filter toOptimizedFilter();
+  Filter toOptimizedFilter(boolean mayIncludeUnknown);
 
   /**
    * Returns a Filter that implements this DimFilter. This does not generally involve optimizing the DimFilter,

--- a/processing/src/main/java/org/apache/druid/query/filter/DimFilters.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/DimFilters.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
+ *
  */
 public class DimFilters
 {
@@ -60,9 +61,9 @@ public class DimFilters
     return new NotDimFilter(filter);
   }
 
-  public static List<DimFilter> optimize(List<DimFilter> filters)
+  public static List<DimFilter> optimize(List<DimFilter> filters, boolean mayIncludeUnknown)
   {
-    return filterNulls(Lists.transform(filters, DimFilter::optimize));
+    return filterNulls(Lists.transform(filters, filter -> filter.optimize(mayIncludeUnknown)));
   }
 
   public static List<DimFilter> filterNulls(List<DimFilter> optimized)

--- a/processing/src/main/java/org/apache/druid/query/filter/EqualityFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/EqualityFilter.java
@@ -125,12 +125,6 @@ public class EqualityFilter extends AbstractOptimizableDimFilter implements Filt
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return this;

--- a/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ExpressionDimFilter.java
@@ -105,12 +105,6 @@ public class ExpressionDimFilter extends AbstractOptimizableDimFilter implements
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new ExpressionFilter(parsed, filterTuning);

--- a/processing/src/main/java/org/apache/druid/query/filter/ExtractionDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ExtractionDimFilter.java
@@ -95,9 +95,9 @@ public class ExtractionDimFilter extends AbstractOptimizableDimFilter implements
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
-    return new SelectorDimFilter(dimension, value, extractionFn).optimize();
+    return new SelectorDimFilter(dimension, value, extractionFn).optimize(mayIncludeUnknown);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/FalseDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/FalseDimFilter.java
@@ -45,12 +45,6 @@ public class FalseDimFilter extends AbstractOptimizableDimFilter implements DimF
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return FalseFilter.instance();

--- a/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/InDimFilter.java
@@ -32,8 +32,10 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ForwardingSortedSet;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
@@ -67,6 +69,8 @@ import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -75,7 +79,11 @@ import java.util.TreeSet;
 
 public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
 {
-  // Values can contain `null` object. Values are sorted (nulls-first).
+  /**
+   * Values matched by this filter. Values are sorted (nulls-first). Values can contain `null` in SQL-compatible null
+   * handling mode. When {@link NullHandling#replaceWithDefault()}, the values set does not contain empty string.
+   * (It may contain null.)
+   */
   private final ValuesSet values;
   // Computed eagerly, not lazily, because lazy computations would block all processing threads for a given query.
   private final SortedSet<ByteBuffer> valuesUtf8;
@@ -171,13 +179,6 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     Preconditions.checkNotNull(values, "values cannot be null");
 
     this.values = values;
-
-    if (!NullHandling.sqlCompatible() && values.contains("")) {
-      // In non-SQL-compatible mode, empty strings must be converted to nulls for the filter.
-      this.values.remove("");
-      this.values.add(null);
-    }
-
     this.valuesUtf8 = this.values.toUtf8();
     this.dimension = Preconditions.checkNotNull(dimension, "dimension cannot be null");
     this.extractionFn = extractionFn;
@@ -227,22 +228,32 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
-    InDimFilter inFilter = optimizeLookup();
+    final ExtractionFn newExtractionFn;
+    ValuesSet newValues = optimizeLookup(this, mayIncludeUnknown);
 
-    if (inFilter.values.isEmpty()) {
-      return FalseDimFilter.instance();
+    if (newValues == null) {
+      newValues = values;
+      newExtractionFn = extractionFn;
+    } else {
+      newExtractionFn = null;
     }
-    if (inFilter.values.size() == 1) {
+
+    if (newValues.isEmpty()) {
+      return FalseDimFilter.instance();
+    } else if (newValues.size() == 1) {
       return new SelectorDimFilter(
-          inFilter.dimension,
-          inFilter.values.iterator().next(),
-          inFilter.getExtractionFn(),
+          dimension,
+          newValues.iterator().next(),
+          newExtractionFn,
           filterTuning
       );
+    } else if (newValues == values) {
+      return this;
+    } else {
+      return new InDimFilter(dimension, newValues, newExtractionFn, filterTuning);
     }
-    return inFilter;
   }
 
   @Override
@@ -420,41 +431,107 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
         .build();
   }
 
-  private InDimFilter optimizeLookup()
+  /**
+   * If the provided "in" filter uses a {@link LookupExtractionFn} that can be reversed, then return the matching
+   * set of keys as a {@link ValuesSet}. Otherwise return null.
+   *
+   * @param inFilter          in filter
+   * @param mayIncludeUnknown same as the argument to {@link #optimize(boolean)}
+   */
+  @Nullable
+  static ValuesSet optimizeLookup(final InDimFilter inFilter, final boolean mayIncludeUnknown)
   {
-    if (extractionFn instanceof LookupExtractionFn
-        && ((LookupExtractionFn) extractionFn).isOptimize()) {
-      LookupExtractionFn exFn = (LookupExtractionFn) extractionFn;
-      LookupExtractor lookup = exFn.getLookup();
+    final LookupExtractionFn exFn;
 
-      final ValuesSet keys = new ValuesSet();
-      for (String value : values) {
+    if (inFilter.getExtractionFn() instanceof LookupExtractionFn) {
+      exFn = (LookupExtractionFn) inFilter.getExtractionFn();
+    } else {
+      // Not a lookup extractionFn.
+      return null;
+    }
 
-        // We cannot do an unapply()-based optimization if the selector value
-        // and the replaceMissingValuesWith value are the same, since we have to match on
-        // all values that are not present in the lookup.
-        final String convertedValue = NullHandling.emptyToNullIfNeeded(value);
-        if (!exFn.isRetainMissingValue() && Objects.equals(convertedValue, exFn.getReplaceMissingValueWith())) {
-          return this;
-        }
-        keys.addAll(lookup.unapply(convertedValue));
+    if (!exFn.isOptimize()) {
+      return null;
+    }
 
-        // If retainMissingValues is true and the selector value is not in the lookup map,
-        // there may be row values that match the selector value but are not included
-        // in the lookup map. Match on the selector value as well.
-        // If the selector value is overwritten in the lookup map, don't add selector value to keys.
-        if (exFn.isRetainMissingValue() && NullHandling.isNullOrEquivalent(lookup.apply(convertedValue))) {
-          keys.add(convertedValue);
+    if (!exFn.isInjective()
+        && !exFn.isRetainMissingValue()
+        && inFilter.values.contains(NullHandling.emptyToNullIfNeeded(exFn.getReplaceMissingValueWith()))) {
+      // We cannot do an unapply()-based optimization when the original filter is configured to match on values that are
+      // not present in the lookup key set. This would require creating a filter like "NOT IN (lookup key set)", which
+      // we aren't willing to do, since it requires iterating the entire lookup and may be prohibitively large.
+      return null;
+    }
+
+    final LookupExtractor lookup = exFn.getLookup();
+
+    if (mayIncludeUnknown && !inFilter.values.contains(null)) {
+      // We need to return an optimized filter that works as expected when run in includeUnknown mode, which means
+      // it must be able to match in scenarios where the original filter's extractionFn returns null. This is generally
+      // impractical, because it leads to needing to match the complement of the lookup key set. However, it's
+      // manageable if a lookup has no null values, and is either injective (one-to-one) or is being queried with a
+      // nonnull replaceMissingValueWith. In these cases, the extractionFn can't return null, so there isn't anything
+      // to worry about.
+
+      boolean ok = false;
+
+      if (!NullHandling.isNullOrEquivalent(exFn.getReplaceMissingValueWith()) || exFn.isInjective()) {
+        final Iterator<String> keysWithNullValues = lookup.unapplyAll(Collections.singleton(null));
+        if (keysWithNullValues != null) {
+          if (!keysWithNullValues.hasNext()) {
+            ok = true;
+          } else {
+            final String nullUnapplied = keysWithNullValues.next();
+            if (!keysWithNullValues.hasNext() && nullUnapplied == null) {
+              ok = true;
+            }
+          }
         }
       }
 
-      if (keys.isEmpty()) {
-        return this;
-      } else {
-        return new InDimFilter(dimension, keys, null, filterTuning);
+      if (!ok) {
+        return null;
       }
     }
-    return this;
+
+    final Set<String> valuesToUnapply;
+    if (!NullHandling.isNullOrEquivalent(exFn.getReplaceMissingValueWith())
+        && inFilter.values.contains(exFn.getReplaceMissingValueWith())) {
+      // When matching against replaceMissingValueWith, this filter matches null values.
+      valuesToUnapply = Sets.union(inFilter.values, Collections.singleton(null));
+    } else {
+      valuesToUnapply = inFilter.values;
+    }
+
+    final ValuesSet unapplied = new ValuesSet();
+    final Iterator<String> keysIterator = lookup.unapplyAll(valuesToUnapply);
+    if (keysIterator == null) {
+      // unapply not supported by this lookup implementation.
+      return null;
+    }
+
+    Iterators.addAll(unapplied, keysIterator);
+
+    // In SQL-compatible null handling mode, lookup of null is always "replaceMissingValueWith", regardless of contents
+    // of the lookup. So, if we're matching against "replaceMissingValueWith", we need to include null in the
+    // unapplied set.
+    if (NullHandling.sqlCompatible() && inFilter.values.contains(exFn.getReplaceMissingValueWith())) {
+      unapplied.add(null);
+    }
+
+    // If retainMissingValues is true and the selector value is not in the lookup map,
+    // there may be row values that match the selector value but are not included
+    // in the lookup map. Match on the selector value as well.
+    // If the selector value is overwritten in the lookup map, don't add selector value to keys.
+    if (exFn.isRetainMissingValue()) {
+      for (final String value : inFilter.values) {
+        if (NullHandling.isNullOrEquivalent(lookup.apply(NullHandling.emptyToNullIfNeeded(value)))) {
+          unapplied.add(value);
+        }
+      }
+    }
+
+    return unapplied;
   }
 
   @SuppressWarnings("ReturnValueIgnored")
@@ -660,16 +737,20 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
 
     /**
      * Create a ValuesSet from another Collection. The Collection will be reused if it is a {@link SortedSet} with
-     * the {@link Comparators#naturalNullsFirst()} comparator.
+     * the {@link Comparators#naturalNullsFirst()} comparator, and doesn't contain empty string in
+     * {@link NullHandling#replaceWithDefault()} mode.
      */
     private ValuesSet(final Collection<String> values)
     {
-      if (values instanceof SortedSet && Comparators.naturalNullsFirst()
-                                                    .equals(((SortedSet<String>) values).comparator())) {
+      if (values instanceof SortedSet
+          && Comparators.naturalNullsFirst().equals(((SortedSet<String>) values).comparator())
+          && !(NullHandling.replaceWithDefault() && values.contains(""))) {
         this.values = (SortedSet<String>) values;
       } else {
         this.values = new TreeSet<>(Comparators.naturalNullsFirst());
-        this.values.addAll(values);
+        for (String value : values) {
+          this.values.add(NullHandling.emptyToNullIfNeeded(value));
+        }
       }
     }
 
@@ -682,15 +763,28 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
     }
 
     /**
-     * Creates a ValuesSet wrapping the provided single value.
+     * Creates a ValuesSet wrapping the provided single value, with {@link NullHandling#emptyToNullIfNeeded(String)}
+     * applied.
      *
      * @throws IllegalStateException if the provided collection cannot be wrapped since it has the wrong comparator
      */
     public static ValuesSet of(@Nullable final String value)
     {
       final ValuesSet retVal = ValuesSet.create();
-      retVal.add(value);
+      retVal.add(NullHandling.emptyToNullIfNeeded(value));
       return retVal;
+    }
+
+    /**
+     * Creates a ValuesSet copying the provided iterator, with {@link NullHandling#emptyToNullIfNeeded(String)} applied.
+     */
+    public static ValuesSet copyOf(final Iterator<String> values)
+    {
+      final TreeSet<String> copyOfValues = new TreeSet<>(Comparators.naturalNullsFirst());
+      while (values.hasNext()) {
+        copyOfValues.add(NullHandling.emptyToNullIfNeeded(values.next()));
+      }
+      return new ValuesSet(copyOfValues);
     }
 
     /**
@@ -698,9 +792,7 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
      */
     public static ValuesSet copyOf(final Collection<String> values)
     {
-      final TreeSet<String> copyOfValues = new TreeSet<>(Comparators.naturalNullsFirst());
-      copyOfValues.addAll(values);
-      return new ValuesSet(copyOfValues);
+      return copyOf(values.iterator());
     }
 
     public SortedSet<ByteBuffer> toUtf8()
@@ -716,6 +808,19 @@ public class InDimFilter extends AbstractOptimizableDimFilter implements Filter
       }
 
       return valuesUtf8;
+    }
+
+    @Override
+    public boolean add(String s)
+    {
+      // In non-SQL-compatible mode, empty strings must be converted to nulls for the filter.
+      return delegate().add(NullHandling.emptyToNullIfNeeded(s));
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends String> other)
+    {
+      return standardAddAll(other);
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/IntervalDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/IntervalDimFilter.java
@@ -131,12 +131,6 @@ public class IntervalDimFilter extends AbstractOptimizableDimFilter implements D
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return convertedFilter.toFilter();

--- a/processing/src/main/java/org/apache/druid/query/filter/IsFalseDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/IsFalseDimFilter.java
@@ -38,8 +38,8 @@ public class IsFalseDimFilter extends IsBooleanDimFilter
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
-    return new IsFalseDimFilter(getField().optimize());
+    return new IsFalseDimFilter(getField().optimize(mayIncludeUnknown));
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/filter/IsTrueDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/IsTrueDimFilter.java
@@ -38,8 +38,8 @@ public class IsTrueDimFilter extends IsBooleanDimFilter
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
-    return new IsTrueDimFilter(getField().optimize());
+    return new IsTrueDimFilter(getField().optimize(mayIncludeUnknown));
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/JavaScriptDimFilter.java
@@ -139,12 +139,6 @@ public class JavaScriptDimFilter extends AbstractOptimizableDimFilter implements
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     JavaScriptPredicateFactory predicateFactory = getPredicateFactory();

--- a/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
@@ -146,12 +146,6 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new LikeFilter(dimension, extractionFn, likeMatcher, filterTuning);

--- a/processing/src/main/java/org/apache/druid/query/filter/NotDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/NotDimFilter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.RangeSet;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.segment.filter.NotFilter;
 
 import java.nio.ByteBuffer;
@@ -67,9 +68,9 @@ public class NotDimFilter extends AbstractOptimizableDimFilter implements DimFil
 
   @SuppressWarnings("ObjectEquality")
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
-    final DimFilter optimized = this.getField().optimize();
+    final DimFilter optimized = this.getField().optimize(!mayIncludeUnknown && NullHandling.useThreeValueLogic());
     if (optimized == FalseDimFilter.instance()) {
       return TrueDimFilter.instance();
     } else if (optimized == TrueDimFilter.instance()) {

--- a/processing/src/main/java/org/apache/druid/query/filter/NullFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/NullFilter.java
@@ -98,12 +98,6 @@ public class NullFilter extends AbstractOptimizableDimFilter implements Filter
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return this;

--- a/processing/src/main/java/org/apache/druid/query/filter/OrDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/OrDimFilter.java
@@ -78,12 +78,12 @@ public class OrDimFilter extends AbstractOptimizableDimFilter implements DimFilt
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
     // This method optimizes children, but doesn't do any special AND-related stuff like flattening or duplicate
     // removal. That will happen in "toFilter", which allows us to share code with Filters.or(...).
 
-    final List<DimFilter> newFields = DimFilters.optimize(fields);
+    final List<DimFilter> newFields = DimFilters.optimize(fields, mayIncludeUnknown);
 
     if (newFields.size() == 1) {
       return newFields.get(0);
@@ -95,7 +95,13 @@ public class OrDimFilter extends AbstractOptimizableDimFilter implements DimFilt
   @Override
   public Filter toFilter()
   {
-    return Filters.or(Filters.toFilters(fields));
+    final List<Filter> filters = new ArrayList<>(fields.size());
+
+    for (final DimFilter field : fields) {
+      filters.add(field.toFilter());
+    }
+
+    return Filters.or(filters);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/RangeFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/RangeFilter.java
@@ -261,12 +261,6 @@ public class RangeFilter extends AbstractOptimizableDimFilter implements Filter
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return this;

--- a/processing/src/main/java/org/apache/druid/query/filter/RegexDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/RegexDimFilter.java
@@ -117,12 +117,6 @@ public class RegexDimFilter extends AbstractOptimizableDimFilter implements DimF
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new RegexFilter(dimension, compiledPattern, extractionFn, filterTuning);

--- a/processing/src/main/java/org/apache/druid/query/filter/SearchQueryDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/SearchQueryDimFilter.java
@@ -117,12 +117,6 @@ public class SearchQueryDimFilter extends AbstractOptimizableDimFilter implement
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return new SearchQueryFilter(dimension, query, extractionFn, filterTuning);

--- a/processing/src/main/java/org/apache/druid/query/filter/SelectorDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/SelectorDimFilter.java
@@ -94,11 +94,11 @@ public class SelectorDimFilter extends AbstractOptimizableDimFilter implements D
   }
 
   @Override
-  public DimFilter optimize()
+  public DimFilter optimize(final boolean mayIncludeUnknown)
   {
     final InDimFilter.ValuesSet valuesSet = new InDimFilter.ValuesSet();
     valuesSet.add(value);
-    return new InDimFilter(dimension, valuesSet, extractionFn, filterTuning).optimize();
+    return new InDimFilter(dimension, valuesSet, extractionFn, filterTuning).optimize(mayIncludeUnknown);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/SpatialDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/SpatialDimFilter.java
@@ -79,12 +79,6 @@ public class SpatialDimFilter extends AbstractOptimizableDimFilter implements Di
                      .array();
   }
 
-  @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
   @JsonProperty
   public String getDimension()
   {

--- a/processing/src/main/java/org/apache/druid/query/filter/TrueDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/TrueDimFilter.java
@@ -49,12 +49,6 @@ public class TrueDimFilter extends AbstractOptimizableDimFilter implements DimFi
   }
 
   @Override
-  public DimFilter optimize()
-  {
-    return this;
-  }
-
-  @Override
   public Filter toFilter()
   {
     return TrueFilter.instance();

--- a/processing/src/main/java/org/apache/druid/query/filter/ValueMatcher.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/ValueMatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.filter;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.monomorphicprocessing.CalledFromHotLoop;
 import org.apache.druid.query.monomorphicprocessing.HotLoopCallee;
 
@@ -35,10 +36,9 @@ public interface ValueMatcher extends HotLoopCallee
    * Returns true if the current row matches the condition.
    *
    * @param includeUnknown mapping for Druid native two state logic system into SQL three-state logic system. If set
-   *                       to true, this method should also return true if the result is 'unknown' to be a match, such
-   *                       as from the input being null valued. Used primarily to allow
-   *                       {@link org.apache.druid.segment.filter.NotFilter} to invert a match in a SQL compliant
-   *                       manner
+   *                       to true, this method should also return true if the matching result is 'unknown', such
+   *                       as from the input being null valued. See {@link NullHandling#useThreeValueLogic()}.
+   *
    * @return true if the current row matches the condition, or is unknown and {@code includeUnknown} is set to true
    */
   @CalledFromHotLoop

--- a/processing/src/main/java/org/apache/druid/query/filter/vector/VectorValueMatcher.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/vector/VectorValueMatcher.java
@@ -48,10 +48,10 @@ public interface VectorValueMatcher extends VectorSizeInspector
    *
    * @param mask           must not be null; use {@link VectorMatch#allTrue} if you don't need a mask.
    * @param includeUnknown mapping for Druid native two state logic system into SQL three-state logic system. If set
-   *                       to true, this method should also return true if the result is 'unknown' to be a match, such
-   *                       as from the input being null valued. Used primarily to allow
-   *                       {@link org.apache.druid.segment.filter.NotFilter} to invert a match in an SQL compliant
-   *                       manner
+   *                       to true, match vectors returned by this method should include true values wherever the
+   *                       matching result is 'unknown', such as from the input being null valued.
+   *                       See {@link NullHandling#useThreeValueLogic()}.
+   *
    * @return the subset of "mask" that this value matcher accepts. May be the same instance as {@param mask} if
    * every row in the mask matches the filter.
    */

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
@@ -76,7 +76,7 @@ public abstract class LookupExtractor
    * Otherwise unused. Implementations that override {@link #unapplyAll(Set)} may throw
    * {@link UnsupportedOperationException} from this method.
    *
-   * @param value the value to apply the reverse lookup. {@link NullHandling#nullToEmptyIfNeeded(String)} will have
+   * @param value the value to apply the reverse lookup. {@link NullHandling#emptyToNullIfNeeded(String)} will have
    *              been applied to the value.
    *
    * @return the list of keys that maps to the provided value.
@@ -86,7 +86,7 @@ public abstract class LookupExtractor
   /**
    * Reverse lookup from a given set of values.
    *
-   * @param values set of values to reverse lookup. {@link NullHandling#nullToEmptyIfNeeded(String)} will have
+   * @param values set of values to reverse lookup. {@link NullHandling#emptyToNullIfNeeded(String)} will have
    *               been applied to each value.
    *
    * @return iterator of keys that map to to the provided set of values. May contain duplicate keys. Returns null if

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractor.java
@@ -22,11 +22,14 @@ package org.apache.druid.query.lookup;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Iterators;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.extraction.MapLookupExtractor;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +45,8 @@ public abstract class LookupExtractor
    *
    * @param key The value to apply the lookup to.
    *
-   * @return The lookup, or null when key is `null` or cannot have the lookup applied to it and should be treated as missing.
+   * @return The value for this key, or null when key is `null` in {@link NullHandling#sqlCompatible()} mode, or when
+   * key cannot have the lookup applied to it and should be treated as missing.
    */
   @Nullable
   public abstract String apply(@Nullable String key);
@@ -68,37 +72,30 @@ public abstract class LookupExtractor
   }
 
   /**
-   * Provide the reverse mapping from a given value to a list of keys
+   * Reverse lookup from a given value. Used by the default implementation of {@link #unapplyAll(Set)}.
+   * Otherwise unused. Implementations that override {@link #unapplyAll(Set)} may throw
+   * {@link UnsupportedOperationException} from this method.
    *
-   * @param value the value to apply the reverse lookup
+   * @param value the value to apply the reverse lookup. {@link NullHandling#nullToEmptyIfNeeded(String)} will have
+   *              been applied to the value.
    *
-   * @return the list of keys that maps to value or empty list.
-   * Note that for the case of a none existing value in the lookup we have to cases either return an empty list OR list with null element.
-   * returning an empty list implies that user want to ignore such a lookup value.
-   * In the other hand returning a list with the null element implies user want to map the none existing value to the key null.
-   * Null value maps to empty list.
+   * @return the list of keys that maps to the provided value.
    */
-
-  public abstract List<String> unapply(@Nullable String value);
+  protected abstract List<String> unapply(@Nullable String value);
 
   /**
-   * @param values Iterable of values for which will perform reverse lookup
+   * Reverse lookup from a given set of values.
    *
-   * @return Returns {@link Map} whose keys are the contents of {@code values} and whose values are computed on demand using the reverse lookup function {@link #unapply(String)}
-   * or empty map if {@code values} is `null`
-   * User can override this method if there is a better way to perform bulk reverse lookup
+   * @param values set of values to reverse lookup. {@link NullHandling#nullToEmptyIfNeeded(String)} will have
+   *               been applied to each value.
+   *
+   * @return iterator of keys that map to to the provided set of values. May contain duplicate keys. Returns null if
+   * this lookup instance does not support reverse lookups.
    */
-
-  public Map<String, List<String>> unapplyAll(Iterable<String> values)
+  @Nullable
+  public Iterator<String> unapplyAll(Set<String> values)
   {
-    if (values == null) {
-      return Collections.emptyMap();
-    }
-    Map<String, List<String>> map = new HashMap<>();
-    for (String value : values) {
-      map.put(value, unapply(value));
-    }
-    return map;
+    return Iterators.concat(Iterators.transform(values.iterator(), value -> unapply(value).iterator()));
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/Filters.java
@@ -64,19 +64,11 @@ public class Filters
   private static final ColumnSelectorFactory ALL_NULL_COLUMN_SELECTOR_FACTORY = new AllNullColumnSelectorFactory();
 
   /**
-   * Convert a list of DimFilters to a list of Filters.
+   * Convert a {@link DimFilter} to an optimized {@link Filter} for use at the top level of a query.
    *
-   * @param dimFilters list of DimFilters, should all be non-null
-   *
-   * @return list of Filters
-   */
-  public static List<Filter> toFilters(List<DimFilter> dimFilters)
-  {
-    return dimFilters.stream().map(Filters::toFilter).collect(Collectors.toList());
-  }
-
-  /**
-   * Convert a DimFilter to a Filter.
+   * Must not be used by {@link DimFilter} to convert their children, because the three-valued logic parameter
+   * "includeUnknown" will not be correctly propagated. For {@link DimFilter} that convert their children, use
+   * {@link DimFilter#toOptimizedFilter(boolean)} instead.
    *
    * @param dimFilter dimFilter
    *
@@ -85,9 +77,8 @@ public class Filters
   @Nullable
   public static Filter toFilter(@Nullable DimFilter dimFilter)
   {
-    return dimFilter == null ? null : dimFilter.toOptimizedFilter();
+    return dimFilter == null ? null : dimFilter.toOptimizedFilter(false);
   }
-
 
   /**
    * Create a ValueMatcher that applies a predicate to row values.

--- a/processing/src/main/java/org/apache/druid/segment/index/BitmapColumnIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/index/BitmapColumnIndex.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.index;
 
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.segment.column.ColumnIndexCapabilities;
 
@@ -36,10 +37,10 @@ public interface BitmapColumnIndex
    * @param bitmapResultFactory helper to format the {@link org.apache.druid.collections.bitmap.ImmutableBitmap} in a
    *                            form ready for consumption by callers
    * @param includeUnknown      mapping for Druid native two state logic system into SQL three-state logic system. If set
-   *                            to true, this method should also return true if the result is 'unknown' to be a match,
-   *                            such  as from the input being null valued. Used primarily to allow
-   *                            {@link org.apache.druid.segment.filter.NotFilter} to invert a match in an SQL compliant
-   *                            manner
+   *                            to true, bitmaps returned by this method should include true bits for any rows where
+   *                            the matching result is 'unknown', such as from the input being null valued.
+   *                            See {@link NullHandling#useThreeValueLogic()}.
+   *
    * @return bitmap result representing rows matched by this index
    */
   <T> T computeBitmapResult(BitmapResultFactory<T> bitmapResultFactory, boolean includeUnknown);

--- a/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/lookup/LookupJoinable.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -165,7 +166,12 @@ public class LookupJoinable implements Joinable
       } else {
         // Lookup extractor unapply only provides a list of strings, so we can't respect
         // maxCorrelationSetSize easily. This should be handled eventually.
-        correlatedValues = InDimFilter.ValuesSet.copyOf(extractor.unapply(searchColumnValue));
+        final Iterator<String> unapplied = extractor.unapplyAll(Collections.singleton(searchColumnValue));
+        if (unapplied != null) {
+          correlatedValues = InDimFilter.ValuesSet.copyOf(unapplied);
+        } else {
+          return Optional.empty();
+        }
       }
     }
     return Optional.of(correlatedValues);

--- a/processing/src/main/java/org/apache/druid/segment/join/table/BroadcastSegmentIndexedTable.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/table/BroadcastSegmentIndexedTable.java
@@ -43,7 +43,6 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.data.ReadableOffset;
-import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.chrono.ISOChronology;
 
@@ -116,7 +115,7 @@ public class BroadcastSegmentIndexedTable implements IndexedTable
 
     // sort of like the dump segment tool, but build key column indexes when reading the segment
     final Sequence<Cursor> cursors = adapter.makeCursors(
-        Filters.toFilter(null),
+        null,
         queryableIndex.getDataInterval().withChronology(ISOChronology.getInstanceUTC()),
         VirtualColumns.EMPTY,
         Granularities.ALL,

--- a/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/extraction/MapLookupExtractorTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.extraction;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.druid.common.config.NullHandling;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -31,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 
@@ -49,23 +51,23 @@ public class MapLookupExtractorTest
   @Test
   public void testUnApply()
   {
-    Assert.assertEquals(Collections.singletonList("foo"), fn.unapply("bar"));
-    Assert.assertEquals(Sets.newHashSet("null", "empty String"), Sets.newHashSet(fn.unapply("")));
+    Assert.assertEquals(Collections.singletonList("foo"), unapply("bar"));
+    Assert.assertEquals(Sets.newHashSet("null", "empty String"), Sets.newHashSet(unapply("")));
     if (NullHandling.sqlCompatible()) {
       Assert.assertEquals(
           "Null value should be equal to empty list",
           new HashSet<>(),
-          Sets.newHashSet(fn.unapply((String) null))
+          Sets.newHashSet(unapply((String) null))
       );
     } else {
       Assert.assertEquals(
           "Null value should be equal to empty string",
           Sets.newHashSet("null", "empty String"),
-          Sets.newHashSet(fn.unapply((String) null))
+          Sets.newHashSet(unapply((String) null))
       );
     }
-    Assert.assertEquals(Sets.newHashSet(""), Sets.newHashSet(fn.unapply("empty_string")));
-    Assert.assertEquals("not existing value returns empty list", Collections.emptyList(), fn.unapply("not There"));
+    Assert.assertEquals(Sets.newHashSet(""), Sets.newHashSet(unapply("empty_string")));
+    Assert.assertEquals("not existing value returns empty list", Collections.emptyList(), unapply("not There"));
   }
 
   @Test
@@ -159,5 +161,10 @@ public class MapLookupExtractorTest
     Assert.assertNotEquals(fn.hashCode(), fn3.hashCode());
     final MapLookupExtractor fn4 = new MapLookupExtractor(ImmutableMap.of("foo", "bar2"), false);
     Assert.assertNotEquals(fn.hashCode(), fn4.hashCode());
+  }
+
+  private List<String> unapply(final String s)
+  {
+    return Lists.newArrayList(fn.unapplyAll(Collections.singleton(s)));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/FalseDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/FalseDimFilterTest.java
@@ -44,7 +44,7 @@ public class FalseDimFilterTest
   {
     EqualsVerifier.forClass(FalseDimFilter.class)
                   .usingGetClass()
-                  .withIgnoredFields("cachedOptimizedFilter")
+                  .withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown")
                   .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -237,7 +237,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(
         "reverse lookup baz",
-        Sets.newHashSet(),
+        Collections.emptySet(),
         InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
     );
 
@@ -501,13 +501,13 @@ public class InDimFilterTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(
         "reverse lookup baz",
-        Sets.newHashSet(),
+        Collections.emptySet(),
         InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
     );
 
     Assert.assertEquals(
         "reverse lookup baz (includeUnknown)",
-        Sets.newHashSet(),
+        Collections.emptySet(),
         InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
     );
 

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -28,7 +28,9 @@ import com.google.common.collect.Sets;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.MapBasedRow;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.extraction.RegexDimExtractionFn;
+import org.apache.druid.query.lookup.LookupExtractionFn;
 import org.apache.druid.segment.RowAdapters;
 import org.apache.druid.segment.RowBasedColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
@@ -209,7 +211,382 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   public void testOptimizeSingleValueInToSelector()
   {
     final InDimFilter filter = new InDimFilter("dim", Collections.singleton("v1"), null);
-    Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize());
+    Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(false));
+    Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(true));
+  }
+
+  @Test
+  public void testOptimizeLookup_simple()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup bar",
+        Sets.newHashSet("foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup bar (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz",
+        Sets.newHashSet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup baz (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup [def, bar, baz]",
+        Sets.newHashSet("abc", "foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : null,
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup empty string (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_replaceMissingValueWith()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "baz", null, true);
+
+    Assert.assertEquals(
+        "reverse lookup bar",
+        Sets.newHashSet("foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup bar (includeUnknown)",
+        Sets.newHashSet("foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup baz",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup baz (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz]",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null (includeUnknown)",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string (includeUnknown)",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_replaceMissingValue_containsNullValues()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("nv", null);
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "bar", null, true);
+
+    Assert.assertNull(
+        "reverse lookup bar",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup bar (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup baz (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz]",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null",
+        Collections.singleton("nv"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null (includeUnknown)",
+        Collections.singleton("nv"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : Collections.singleton("nv"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string (includeUnknown)",
+        NullHandling.sqlCompatible() ? null : Collections.singleton("nv"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_retainMissingValue()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, true, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup bar",
+        Sets.newHashSet("bar", "foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup bar (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz",
+        Collections.singleton("baz"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup baz (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup [def, bar, baz]",
+        Sets.newHashSet("abc", "bar", "baz", "def", "foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null",
+        Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null (includeUnknown)",
+        Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        NullHandling.sqlCompatible() ? Collections.singleton("") : Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string (includeUnknown)",
+        NullHandling.sqlCompatible() ? null : Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_injective()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, true);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup bar",
+        Sets.newHashSet("foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup bar (includeUnknown)",
+        Sets.newHashSet("foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz",
+        Sets.newHashSet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz (includeUnknown)",
+        Sets.newHashSet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup [def, bar, baz]",
+        Sets.newHashSet("abc", "foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        Sets.newHashSet("abc", "foo"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null",
+        NullHandling.sqlCompatible() ? Collections.singleton(null) : Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null (includeUnknown)",
+        NullHandling.sqlCompatible() ? Collections.singleton(null) : Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string (includeUnknown)",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_containingNull()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put(null, "nv");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup nv",
+        Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup nv (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : null,
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup empty string (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -346,7 +346,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testOptimizeLookup_replaceMissingValue_containsNullValues()
+  public void testOptimizeLookup_replaceMissingValue_containingNull()
   {
     final Map<String, String> lookupMap = new HashMap<>();
     lookupMap.put("nv", null);
@@ -408,6 +408,133 @@ public class InDimFilterTest extends InitializedNullHandlingTest
         "reverse lookup empty string (includeUnknown)",
         NullHandling.sqlCompatible() ? null : Collections.singleton("nv"),
         InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_replaceMissingValue_containingEmptyString()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("emptystring", "");
+    lookupMap.put("abc", "def");
+    lookupMap.put("foo", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "bar", null, true);
+
+    Assert.assertNull(
+        "reverse lookup bar",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup bar (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz",
+        Collections.emptySet(),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup baz (includeUnknown)",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : null,
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz]",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup [def, bar, baz] (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : Collections.singleton("emptystring"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup null (includeUnknown)",
+        NullHandling.sqlCompatible() ? Collections.emptySet() : Collections.singleton("emptystring"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        Collections.singleton("emptystring"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertEquals(
+        "reverse lookup empty string (includeUnknown)",
+        Collections.singleton("emptystring"),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_containingEmptyString()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("emptystring", "");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup empty string",
+        NullHandling.sqlCompatible() ? Collections.singleton("emptystring") : null,
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup empty string (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    );
+  }
+
+  @Test
+  public void testOptimizeLookup_emptyStringKey()
+  {
+    final Map<String, String> lookupMap = new HashMap<>();
+    lookupMap.put("", "bar");
+    final MapLookupExtractor lookup = new MapLookupExtractor(lookupMap, false);
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
+
+    Assert.assertEquals(
+        "reverse lookup bar",
+        NullHandling.sqlCompatible() ? Collections.singleton("") : Collections.singleton(null),
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup bar (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    );
+
+    Assert.assertNull(
+        "reverse lookup null (includeUnknown)",
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
     );
   }
 
@@ -549,7 +676,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testOptimizeLookup_containingNull()
+  public void testOptimizeLookup_nullKey()
   {
     final Map<String, String> lookupMap = new HashMap<>();
     lookupMap.put(null, "nv");
@@ -558,7 +685,8 @@ public class InDimFilterTest extends InitializedNullHandlingTest
 
     Assert.assertEquals(
         "reverse lookup nv",
-        Collections.singleton(null),
+        // null keys are always mapped to null in SQL-compatible mode
+        NullHandling.sqlCompatible() ? Collections.emptySet() : Collections.singleton(null),
         InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), false)
     );
 

--- a/processing/src/test/java/org/apache/druid/query/filter/IsBooleanDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/IsBooleanDimFilterTest.java
@@ -86,12 +86,12 @@ public class IsBooleanDimFilterTest extends InitializedNullHandlingTest
   {
     EqualsVerifier.forClass(IsTrueDimFilter.class).usingGetClass()
                   .withNonnullFields("field")
-                  .withIgnoredFields("cachedOptimizedFilter")
+                  .withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown")
                   .verify();
 
     EqualsVerifier.forClass(IsFalseDimFilter.class).usingGetClass()
                   .withNonnullFields("field")
-                  .withIgnoredFields("cachedOptimizedFilter")
+                  .withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown")
                   .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/SelectorDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/SelectorDimFilterTest.java
@@ -75,7 +75,8 @@ public class SelectorDimFilterTest
             )
         )
     );
-    Assert.assertEquals(selectorDimFilter, filter.optimize());
+    Assert.assertEquals(selectorDimFilter, filter.optimize(false));
+    Assert.assertEquals(selectorDimFilter, filter.optimize(true));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/filter/TrueDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/TrueDimFilterTest.java
@@ -44,7 +44,7 @@ public class TrueDimFilterTest
   {
     EqualsVerifier.forClass(TrueDimFilter.class)
                   .usingGetClass()
-                  .withIgnoredFields("cachedOptimizedFilter")
+                  .withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown")
                   .verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/ArrayContainsElementFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/ArrayContainsElementFilterTests.java
@@ -655,9 +655,24 @@ public class ArrayContainsElementFilterTests
       Assert.assertFalse(Arrays.equals(f1.getCacheKey(), f2.getCacheKey()));
       Assert.assertArrayEquals(f1.getCacheKey(), f3.getCacheKey());
 
-      f1 = new ArrayContainsElementFilter("x", ColumnType.DOUBLE_ARRAY, new Object[]{1.001, null, 20.0002, 300.0003}, null);
-      f1_2 = new ArrayContainsElementFilter("x", ColumnType.DOUBLE_ARRAY, Arrays.asList(1.001, null, 20.0002, 300.0003), null);
-      f2 = new ArrayContainsElementFilter("x", ColumnType.DOUBLE_ARRAY, new Object[]{1.001, 20.0002, 300.0003, null}, null);
+      f1 = new ArrayContainsElementFilter(
+          "x",
+          ColumnType.DOUBLE_ARRAY,
+          new Object[]{1.001, null, 20.0002, 300.0003},
+          null
+      );
+      f1_2 = new ArrayContainsElementFilter(
+          "x",
+          ColumnType.DOUBLE_ARRAY,
+          Arrays.asList(1.001, null, 20.0002, 300.0003),
+          null
+      );
+      f2 = new ArrayContainsElementFilter(
+          "x",
+          ColumnType.DOUBLE_ARRAY,
+          new Object[]{1.001, 20.0002, 300.0003, null},
+          null
+      );
       f3 = new ArrayContainsElementFilter(
           "x",
           ColumnType.DOUBLE_ARRAY,
@@ -669,7 +684,12 @@ public class ArrayContainsElementFilterTests
       Assert.assertArrayEquals(f1.getCacheKey(), f3.getCacheKey());
 
       NestedDataModule.registerHandlersAndSerde();
-      f1 = new ArrayContainsElementFilter("x", ColumnType.NESTED_DATA, ImmutableMap.of("x", ImmutableList.of(1, 2, 3)), null);
+      f1 = new ArrayContainsElementFilter(
+          "x",
+          ColumnType.NESTED_DATA,
+          ImmutableMap.of("x", ImmutableList.of(1, 2, 3)),
+          null
+      );
       f1_2 = new ArrayContainsElementFilter(
           "x",
           ColumnType.NESTED_DATA,
@@ -722,10 +742,16 @@ public class ArrayContainsElementFilterTests
                         "elementMatchValueEval",
                         "elementMatchValue",
                         "predicateFactory",
-                        "cachedOptimizedFilter"
+                        "optimizedFilterIncludeUnknown",
+                        "optimizedFilterNoIncludeUnknown"
                     )
                     .withPrefabValues(ColumnType.class, ColumnType.STRING, ColumnType.DOUBLE)
-                    .withIgnoredFields("predicateFactory", "cachedOptimizedFilter", "elementMatchValue")
+                    .withIgnoredFields(
+                        "predicateFactory",
+                        "optimizedFilterIncludeUnknown",
+                        "optimizedFilterNoIncludeUnknown",
+                        "elementMatchValue"
+                    )
                     .verify();
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -668,7 +668,7 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
       return null;
     }
 
-    final DimFilter maybeOptimized = optimize ? dimFilter.optimize() : dimFilter;
+    final DimFilter maybeOptimized = optimize ? dimFilter.optimize(false) : dimFilter;
     final Filter filter = maybeOptimized.toFilter();
     try {
       return cnf ? Filters.toCnf(filter) : filter;
@@ -683,7 +683,7 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
     if (dimFilter == null) {
       return null;
     }
-    return optimize ? dimFilter.optimize() : dimFilter;
+    return optimize ? dimFilter.optimize(false) : dimFilter;
   }
 
   private Sequence<Cursor> makeCursorSequence(final Filter filter)

--- a/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
@@ -414,13 +414,22 @@ public class EqualityFilterTests
         // auto ingests arrays instead of strings
         if (NullHandling.sqlCompatible()) {
           assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "", null), ImmutableList.of());
-          assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of(""), null), ImmutableList.of("2"));
+          assertFilterMatches(
+              new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of(""), null),
+              ImmutableList.of("2")
+          );
         }
         assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "a", null), ImmutableList.of());
-        assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of("a"), null), ImmutableList.of("3"));
+        assertFilterMatches(
+            new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of("a"), null),
+            ImmutableList.of("3")
+        );
         assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "b", null), ImmutableList.of());
         assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "c", null), ImmutableList.of());
-        assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of("c"), null), ImmutableList.of("4"));
+        assertFilterMatches(
+            new EqualityFilter("dim2", ColumnType.STRING_ARRAY, ImmutableList.of("c"), null),
+            ImmutableList.of("4")
+        );
         assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "d", null), ImmutableList.of());
 
         // array matchers can match the whole array
@@ -469,7 +478,9 @@ public class EqualityFilterTests
         assertFilterMatches(new EqualityFilter("dim2", ColumnType.STRING, "d", null), ImmutableList.of());
         assertFilterMatches(
             NotDimFilter.of(new EqualityFilter("dim2", ColumnType.STRING, "d", null)),
-            NullHandling.replaceWithDefault() ? ImmutableList.of("0", "1", "2", "3", "4", "5") : ImmutableList.of("0", "2", "3", "4")
+            NullHandling.replaceWithDefault()
+            ? ImmutableList.of("0", "1", "2", "3", "4", "5")
+            : ImmutableList.of("0", "2", "3", "4")
         );
       }
     }
@@ -1276,11 +1287,17 @@ public class EqualityFilterTests
                         "matchValueEval",
                         "matchValue",
                         "predicateFactory",
-                        "cachedOptimizedFilter"
+                        "optimizedFilterIncludeUnknown",
+                        "optimizedFilterNoIncludeUnknown"
                     )
                     .withPrefabValues(ColumnType.class, ColumnType.STRING, ColumnType.DOUBLE)
                     .withPrefabValues(ExprEval.class, ExprEval.of("hello"), ExprEval.of(1.0))
-                    .withIgnoredFields("predicateFactory", "cachedOptimizedFilter", "matchValue")
+                    .withIgnoredFields(
+                        "predicateFactory",
+                        "optimizedFilterIncludeUnknown",
+                        "optimizedFilterNoIncludeUnknown",
+                        "matchValue"
+                    )
                     .verify();
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
@@ -521,8 +521,14 @@ public class InFilterTest extends BaseFilterTest
     Filter rewrittenFilter = filter.rewriteRequiredColumns(ImmutableMap.of("dim0", "dim1"));
     Assert.assertEquals(filter2, rewrittenFilter);
 
-    Throwable t = Assert.assertThrows(IAE.class, () -> filter.rewriteRequiredColumns(ImmutableMap.of("invalidName", "dim1")));
-    Assert.assertEquals("Received a non-applicable rewrite: {invalidName=dim1}, filter's dimension: dim0", t.getMessage());
+    Throwable t = Assert.assertThrows(
+        IAE.class,
+        () -> filter.rewriteRequiredColumns(ImmutableMap.of("invalidName", "dim1"))
+    );
+    Assert.assertEquals(
+        "Received a non-applicable rewrite: {invalidName=dim1}, filter's dimension: dim0",
+        t.getMessage()
+    );
   }
 
   @Test
@@ -531,7 +537,13 @@ public class InFilterTest extends BaseFilterTest
     EqualsVerifier.forClass(InDimFilter.class)
                   .usingGetClass()
                   .withNonnullFields("dimension", "values")
-                  .withIgnoredFields("cacheKeySupplier", "predicateFactory", "cachedOptimizedFilter", "valuesUtf8")
+                  .withIgnoredFields(
+                      "cacheKeySupplier",
+                      "predicateFactory",
+                      "optimizedFilterIncludeUnknown",
+                      "optimizedFilterNoIncludeUnknown",
+                      "valuesUtf8"
+                  )
                   .verify();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTest.java
@@ -405,7 +405,13 @@ public class InFilterTest extends BaseFilterTest
     assertFilterMatches(toInFilterWithFn("dim1", lookupFn, "HELLO"), ImmutableList.of("b", "e"));
     assertFilterMatches(toInFilterWithFn("dim1", lookupFn, "N/A"), ImmutableList.of());
 
-    assertFilterMatchesSkipArrays(toInFilterWithFn("dim2", lookupFn, "a"), ImmutableList.of());
+    if (optimize) {
+      // Arrays don't cause errors when the extractionFn is optimized, because the "IN" filter vanishes completely.
+      assertFilterMatches(toInFilterWithFn("dim2", lookupFn, "a"), ImmutableList.of());
+    } else {
+      assertFilterMatchesSkipArrays(toInFilterWithFn("dim2", lookupFn, "a"), ImmutableList.of());
+    }
+
     assertFilterMatchesSkipArrays(toInFilterWithFn("dim2", lookupFn, "HELLO"), ImmutableList.of("a", "d"));
     assertFilterMatchesSkipArrays(
         toInFilterWithFn("dim2", lookupFn, "HELLO", "BYE", "UNKNOWN"),

--- a/processing/src/test/java/org/apache/druid/segment/filter/NullFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/NullFilterTests.java
@@ -352,7 +352,7 @@ public class NullFilterTests
     {
       EqualsVerifier.forClass(NullFilter.class).usingGetClass()
                     .withNonnullFields("column")
-                    .withIgnoredFields("cachedOptimizedFilter")
+                    .withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown")
                     .verify();
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
@@ -259,7 +259,7 @@ public class OrFilterTest extends BaseFilterTest
   @Test
   public void testEquals()
   {
-    EqualsVerifier.forClass(OrDimFilter.class).usingGetClass().withIgnoredFields("cachedOptimizedFilter").verify();
+    EqualsVerifier.forClass(OrDimFilter.class).usingGetClass().withIgnoredFields("optimizedFilterIncludeUnknown", "optimizedFilterNoIncludeUnknown").verify();
     EqualsVerifier.forClass(OrFilter.class).usingGetClass().withNonnullFields("filters").verify();
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/filter/RangeFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/RangeFilterTests.java
@@ -1924,7 +1924,8 @@ public class RangeFilterTests
                     .withIgnoredFields(
                         "lower",
                         "upper",
-                        "cachedOptimizedFilter",
+                        "optimizedFilterIncludeUnknown",
+                        "optimizedFilterNoIncludeUnknown",
                         "stringPredicateSupplier",
                         "longPredicateSupplier",
                         "floatPredicateSupplier",

--- a/processing/src/test/java/org/apache/druid/segment/filter/SelectorFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SelectorFilterTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.extraction.TimeDimExtractionFn;
 import org.apache.druid.query.filter.ExtractionDimFilter;
+import org.apache.druid.query.filter.FalseDimFilter;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.lookup.LookupExtractionFn;
@@ -340,12 +341,12 @@ public class SelectorFilterTest extends BaseFilterTest
     SelectorDimFilter optFilter4Optimized = new SelectorDimFilter("dim0", "5", null);
     SelectorDimFilter optFilter6Optimized = new SelectorDimFilter("dim0", "5", null);
 
-    Assert.assertTrue(optFilter1.equals(optFilter1.optimize()));
-    Assert.assertTrue(optFilter2Optimized.equals(optFilter2.optimize()));
-    Assert.assertTrue(optFilter3.equals(optFilter3.optimize()));
-    Assert.assertTrue(optFilter4Optimized.equals(optFilter4.optimize()));
-    Assert.assertTrue(optFilter5.equals(optFilter5.optimize()));
-    Assert.assertTrue(optFilter6Optimized.equals(optFilter6.optimize()));
+    Assert.assertEquals(optFilter1, optFilter1.optimize(false));
+    Assert.assertEquals(optFilter2Optimized, optFilter2.optimize(false));
+    Assert.assertEquals(optFilter3, optFilter3.optimize(false));
+    Assert.assertEquals(optFilter4Optimized, optFilter4.optimize(false));
+    Assert.assertEquals(FalseDimFilter.instance(), optFilter5.optimize(false));
+    Assert.assertEquals(optFilter6Optimized, optFilter6.optimize(false));
 
     assertFilterMatches(optFilter1, ImmutableList.of("0", "1", "2", "5"));
     assertFilterMatches(optFilter2, ImmutableList.of("2", "5"));

--- a/processing/src/test/java/org/apache/druid/segment/join/lookup/LookupJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/lookup/LookupJoinableTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.join.lookup;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.lookup.LookupExtractor;
@@ -38,7 +39,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -315,7 +315,7 @@ public class LookupJoinableTest extends InitializedNullHandlingTest
     );
 
     Assert.assertEquals(
-        InDimFilter.ValuesSet.copyOf(Arrays.asList("foo", "bar", "", null)),
+        Sets.newHashSet("foo", "bar", "", null),
         values.getColumnValues()
     );
   }

--- a/processing/src/test/java/org/apache/druid/segment/join/lookup/LookupJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/lookup/LookupJoinableTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.join.lookup;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.lookup.LookupExtractor;
@@ -68,8 +69,10 @@ public class LookupJoinableTest extends InitializedNullHandlingTest
     keyValues.add(null);
 
     Mockito.doReturn(SEARCH_VALUE_VALUE).when(extractor).apply(SEARCH_KEY_VALUE);
-    Mockito.doReturn(ImmutableList.of(SEARCH_KEY_VALUE)).when(extractor).unapply(SEARCH_VALUE_VALUE);
-    Mockito.doReturn(ImmutableList.of()).when(extractor).unapply(SEARCH_VALUE_UNKNOWN);
+    Mockito.when(extractor.unapplyAll(Collections.singleton(SEARCH_VALUE_VALUE)))
+           .thenAnswer(invocation -> Iterators.singletonIterator(SEARCH_KEY_VALUE));
+    Mockito.when(extractor.unapplyAll(Collections.singleton(SEARCH_VALUE_UNKNOWN)))
+           .thenAnswer(invocation -> Collections.emptyIterator());
     Mockito.doReturn(true).when(extractor).canGetKeySet();
     Mockito.doReturn(keyValues).when(extractor).keySet();
     target = LookupJoinable.wrap(extractor);

--- a/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/RegisteredLookupExtractionFnTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.extraction.MapLookupExtractor;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -36,7 +37,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
-public class RegisteredLookupExtractionFnTest
+public class RegisteredLookupExtractionFnTest extends InitializedNullHandlingTest
 {
   private static Map<String, String> MAP = ImmutableMap.of(
       "foo", "bar",
@@ -64,8 +65,13 @@ public class RegisteredLookupExtractionFnTest
     );
     EasyMock.verify(manager);
 
+    Assert.assertSame(LOOKUP_EXTRACTOR, fn.getDelegate().getLookup());
+
     Assert.assertEquals(false, fn.isInjective());
+    Assert.assertFalse(fn.getDelegate().isInjective());
+
     Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getExtractionType());
+    Assert.assertEquals(ExtractionFn.ExtractionType.MANY_TO_ONE, fn.getDelegate().getExtractionType());
 
     for (String orig : Arrays.asList(null, "foo", "bat")) {
       Assert.assertEquals(LOOKUP_EXTRACTOR.apply(orig), fn.apply(orig));

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.error.DruidExceptionMatcher;
@@ -170,7 +169,7 @@ public class MetadataResourceTest
         AvailableSegmentMetadata.builder(
             segments[0],
             0L,
-            Sets.newHashSet(),
+            Collections.emptySet(),
             null,
             20L
         ).build()
@@ -180,7 +179,7 @@ public class MetadataResourceTest
         AvailableSegmentMetadata.builder(
             segments[1],
             0L,
-            Sets.newHashSet(),
+            Collections.emptySet(),
             null,
             30L
         ).build()
@@ -190,7 +189,7 @@ public class MetadataResourceTest
         AvailableSegmentMetadata.builder(
             segments[1],
             0L,
-            Sets.newHashSet(),
+            Collections.emptySet(),
             null,
             30L
         ).build()
@@ -200,7 +199,7 @@ public class MetadataResourceTest
         AvailableSegmentMetadata.builder(
             realTimeSegments[0],
             1L,
-            Sets.newHashSet(),
+            Collections.emptySet(),
             null,
             10L
         ).build()
@@ -210,7 +209,7 @@ public class MetadataResourceTest
         AvailableSegmentMetadata.builder(
             realTimeSegments[1],
             1L,
-            Sets.newHashSet(),
+            Collections.emptySet(),
             null,
             40L
         ).build()

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -19,11 +19,11 @@
 
 package org.apache.druid.server.http;
 
-import com.google.api.client.util.Sets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.error.DruidExceptionMatcher;
@@ -56,7 +56,6 @@ import org.mockito.stubbing.Answer;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
Enhancements to the reverse-lookup optimization that is part of InDimFilter. As a follow-up to this, I'd like to add the optimization to the SQL planner. But it helps to improve the code before doing that. It has various problems that I think haven't been obvious because the optimization only applies to the `lookup` extractionFn (in core, this is only used for lookups inline with the query), not `registeredLookup` (used for lookups defined with the Coordinator API).

1) Add a "mayIncludeUnknown" parameter to DimFilter#optimize. This is important
   because otherwise the reverse-lookup optimization is done improperly when
   the "in" filter appears under a "not", and the lookup extractionFn may return
   null for some possible values of the filtered column. The "includeUnknown" test
   cases in InDimFilterTest illustrate the difference in behavior.

2) Enhance InDimFilter#optimizeLookup to handle "mayIncludeUnknown", and to be able
   to do a reverse lookup in a wider variety of cases.

3) Make "unapply" protected in LookupExtractor, and move callers to "unapplyAll".
   The main reason is that MapLookupExtractor, a common implementation, lacks a
   reverse mapping and therefore does a scan of the map for each call to "unapply".
   For performance sake these calls need to be batched.