### PR TITLE
add style for table formatting to docs contribution

### DIFF
--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -173,7 +173,7 @@ HUMAN_READABLE_BINARY_BYTE_FORMAT(value, \[precision])
 
 When editing or adding tables, do not include extra characters to "prettify" the table format within the Markdown source.
 Some code editors may format tables by default.
-For an example of how to disable it, see the [IntelliJ formatting file for Druid](https://github.com/apache/druid/blob/master/dev/druid_intellij_formatting.xml#L78).
+See the developer [style guide](https://github.com/apache/druid/blob/master/dev/style-conventions.md) for more information.
 
 :::tip
 

--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -187,7 +187,7 @@ See the developer [style guide](https://github.com/apache/druid/blob/master/dev/
 
 **Incorrect**
 
-```
+```markdown
 | Column 1 | Column 2 | Column 3            |
 | -------- | -------- | ------------------- |
 | value 1  | val 2    | a-very-long-value 3 |

--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -179,7 +179,7 @@ See the developer [style guide](https://github.com/apache/druid/blob/master/dev/
 
 **Correct**
 
-```
+```markdown
 | Column 1 | Column 2 | Column 3 |
 | --- | --- | --- |
 | value 1 | val 2 | a-very-long-value 3 |

--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -171,7 +171,7 @@ HUMAN_READABLE_BINARY_BYTE_FORMAT(value, \[precision])
 
 #### Markdown table format
 
-When editing or adding tables, do not include extra characters to "prettify" the table format within the markdown source.
+When editing or adding tables, do not include extra characters to "prettify" the table format within the Markdown source.
 Some code editors may format tables by default.
 For an example of how to disable it, see the [IntelliJ formatting file for Druid](https://github.com/apache/druid/blob/master/dev/druid_intellij_formatting.xml#L78).
 

--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -175,6 +175,8 @@ When editing or adding tables, do not include extra characters to "prettify" the
 Some code editors may format tables by default.
 For an example of how to disable it, see the [IntelliJ formatting file for Druid](https://github.com/apache/druid/blob/master/dev/druid_intellij_formatting.xml#L78).
 
+:::tip
+
 **Correct**
 
 ```
@@ -190,6 +192,8 @@ For an example of how to disable it, see the [IntelliJ formatting file for Druid
 | -------- | -------- | ------------------- |
 | value 1  | val 2    | a-very-long-value 3 |
 ```
+
+:::
 
 ### Style checklist
 

--- a/docs/development/docs-contribute.md
+++ b/docs/development/docs-contribute.md
@@ -169,6 +169,28 @@ HUMAN_READABLE_BINARY_BYTE_FORMAT(value[, precision])
 HUMAN_READABLE_BINARY_BYTE_FORMAT(value, \[precision])
 :::
 
+#### Markdown table format
+
+When editing or adding tables, do not include extra characters to "prettify" the table format within the markdown source.
+Some code editors may format tables by default.
+For an example of how to disable it, see the [IntelliJ formatting file for Druid](https://github.com/apache/druid/blob/master/dev/druid_intellij_formatting.xml#L78).
+
+**Correct**
+
+```
+| Column 1 | Column 2 | Column 3 |
+| --- | --- | --- |
+| value 1 | val 2 | a-very-long-value 3 |
+```
+
+**Incorrect**
+
+```
+| Column 1 | Column 2 | Column 3            |
+| -------- | -------- | ------------------- |
+| value 1  | val 2    | a-very-long-value 3 |
+```
+
 ### Style checklist
 
 Before publishing new content or updating an existing topic, you can audit your documentation using the following checklist to make sure your contributions align with existing documentation:

--- a/website/.spelling
+++ b/website/.spelling
@@ -131,6 +131,7 @@ InputFormat
 InputSource
 InputSources
 Integer.MAX_VALUE
+IntelliJ
 ioConfig
 Istio
 JBOD


### PR DESCRIPTION
### Description

Clarifies the style for markdown tables in Apache Druid.

- [x] been self-reviewed.