### PR TITLE
Cache value selectors in RowBasedColumnSelectorFactory.

### DIFF
--- a/processing/src/main/java/org/apache/druid/common/config/NullHandling.java
+++ b/processing/src/main/java/org/apache/druid/common/config/NullHandling.java
@@ -182,10 +182,11 @@ public class NullHandling
    * May be null or non-null based on the current SQL-compatible null handling mode.
    */
   @Nullable
-  @SuppressWarnings("unchecked")
   public static Object defaultValueForType(ValueType type)
   {
-    if (type == ValueType.FLOAT) {
+    if (sqlCompatible()) {
+      return null;
+    } else if (type == ValueType.FLOAT) {
       return defaultFloatValue();
     } else if (type == ValueType.DOUBLE) {
       return defaultDoubleValue();

--- a/processing/src/main/java/org/apache/druid/data/input/Rows.java
+++ b/processing/src/main/java/org/apache/druid/data/input/Rows.java
@@ -130,7 +130,7 @@ public final class Rows
           v = Longs.tryParse(metricValueString);
         }
 
-        if (outputType != ValueType.LONG) {
+        if (v == null && outputType != ValueType.LONG) {
           v = Double.valueOf(metricValueString);
         }
 

--- a/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/RowBasedColumnSelectorFactory.java
@@ -447,7 +447,8 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
     } else {
       final Function<T, Object> columnFunction = adapter.columnFunction(columnName);
       final ColumnCapabilities capabilities = columnInspector.getColumnCapabilities(columnName);
-      final ValueType expectedType = capabilities == null ? null : capabilities.getType();
+      final ValueType numberType =
+          capabilities != null && capabilities.getType().isNumeric() ? capabilities.getType() : null;
 
       return new ColumnValueSelector<Object>()
       {
@@ -534,7 +535,7 @@ public class RowBasedColumnSelectorFactory<T> implements ColumnSelectorFactory
             try {
               final Object valueToUse =
                   currentValue instanceof StructuredData ? ((StructuredData) currentValue).getValue() : currentValue;
-              currentValueAsNumber = Rows.objectToNumber(columnName, valueToUse, expectedType, throwParseExceptions);
+              currentValueAsNumber = Rows.objectToNumber(columnName, valueToUse, numberType, throwParseExceptions);
             }
             catch (Throwable e) {
               currentValueAsNumberId = RowIdSupplier.INIT;


### PR DESCRIPTION
There was already caching for dimension selectors. This patch adds caching for value (object and number) selectors. It's helpful when the same field is read multiple times during processing of a single row (for example, by being an input to both MIN and MAX aggregations).

This patch also updates `Rows#objectToNumber` to take an `expectedType` parameter, which is used to avoid parsing numbers twice (when the expected type is unknown, we try both long and double).