### PR TITLE
Rework ExprMacro base classes to simplify implementations.

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
@@ -27,7 +27,6 @@ import org.apache.druid.query.aggregation.datasketches.hll.HllSketchHolder;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class HllPostAggExprMacros
 {
@@ -40,7 +39,7 @@ public class HllPostAggExprMacros
     public Expr apply(List<Expr> args)
     {
       validationHelperCheckAnyOfArgumentCount(args, 1, 2);
-      return new HllSketchEstimateExpr(args);
+      return new HllSketchEstimateExpr(this, args);
     }
 
     @Override
@@ -55,9 +54,9 @@ public class HllPostAggExprMacros
     private Expr estimateExpr;
     private Expr isRound;
 
-    public HllSketchEstimateExpr(List<Expr> args)
+    public HllSketchEstimateExpr(HLLSketchEstimateExprMacro macro, List<Expr> args)
     {
-      super(HLL_SKETCH_ESTIMATE, args);
+      super(macro, args);
       this.estimateExpr = args.get(0);
       if (args.size() == 2) {
         isRound = args.get(1);
@@ -87,13 +86,6 @@ public class HllPostAggExprMacros
       HllSketchHolder h = HllSketchHolder.fromObj(valObj);
       double estimate = h.getEstimate();
       return round ? ExprEval.of(Math.round(estimate)) : ExprEval.of(estimate);
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-      return shuttle.visit(new HllSketchEstimateExpr(newArgs));
     }
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.datasketches.theta.sql;
 
+import com.google.common.collect.Iterables;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -39,7 +40,7 @@ public class ThetaPostAggMacros
     public Expr apply(List<Expr> args)
     {
       validationHelperCheckArgumentCount(args, 1);
-      return new ThetaSketchEstimateExpr(args.get(0));
+      return new ThetaSketchEstimateExpr(this, args);
     }
 
     @Override
@@ -49,14 +50,14 @@ public class ThetaPostAggMacros
     }
   }
 
-  public static class ThetaSketchEstimateExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+  public static class ThetaSketchEstimateExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
   {
     private Expr estimateExpr;
 
-    public ThetaSketchEstimateExpr(Expr arg)
+    public ThetaSketchEstimateExpr(ThetaSketchEstimateExprMacro macro, List<Expr> args)
     {
-      super(THETA_SKETCH_ESTIMATE, arg);
-      this.estimateExpr = arg;
+      super(macro, args);
+      this.estimateExpr = Iterables.getOnlyElement(args);
     }
 
     @Override
@@ -74,12 +75,6 @@ public class ThetaPostAggMacros
       } else {
         throw new IllegalArgumentException("requires a ThetaSketch as the argument");
       }
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new ThetaSketchEstimateExpr(arg));
     }
 
     @Nullable

--- a/extensions-core/testing-tools/src/main/java/org/apache/druid/query/expressions/SleepExprMacro.java
+++ b/extensions-core/testing-tools/src/main/java/org/apache/druid/query/expressions/SleepExprMacro.java
@@ -21,7 +21,7 @@ package org.apache.druid.query.expressions;
 
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
-import org.apache.druid.math.expr.ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprMacroTable.ExprMacro;
 import org.apache.druid.math.expr.ExpressionType;
 
@@ -52,11 +52,11 @@ public class SleepExprMacro implements ExprMacro
 
     Expr arg = args.get(0);
 
-    class SleepExpr extends BaseScalarUnivariateMacroFunctionExpr
+    class SleepExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      public SleepExpr(Expr arg)
+      public SleepExpr(List<Expr> args)
       {
-        super(NAME, arg);
+        super(SleepExprMacro.this, args);
       }
 
       @Override
@@ -78,12 +78,6 @@ public class SleepExprMacro implements ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       /**
        * Explicitly override this method to not vectorize the sleep expression.
        * If we ever want to vectorize this expression, {@link #getOutputType} should be considered to return something
@@ -101,6 +95,6 @@ public class SleepExprMacro implements ExprMacro
         return null;
       }
     }
-    return new SleepExpr(arg);
+    return new SleepExpr(args);
   }
 }

--- a/integration-tests-ex/tools/src/main/java/org/apache/druid/testing/tools/SleepExprMacro.java
+++ b/integration-tests-ex/tools/src/main/java/org/apache/druid/testing/tools/SleepExprMacro.java
@@ -21,7 +21,7 @@ package org.apache.druid.testing.tools;
 
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
-import org.apache.druid.math.expr.ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr;
+import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprMacroTable.ExprMacro;
 import org.apache.druid.math.expr.ExpressionType;
 
@@ -52,11 +52,11 @@ public class SleepExprMacro implements ExprMacro
 
     Expr arg = args.get(0);
 
-    class SleepExpr extends BaseScalarUnivariateMacroFunctionExpr
+    class SleepExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      public SleepExpr(Expr arg)
+      public SleepExpr(List<Expr> args)
       {
-        super(NAME, arg);
+        super(SleepExprMacro.this, args);
       }
 
       @Override
@@ -78,12 +78,6 @@ public class SleepExprMacro implements ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       /**
        * Explicitly override this method to not vectorize the sleep expression.
        * If we ever want to vectorize this expression, {@link #getOutputType} should be considered to return something
@@ -101,6 +95,6 @@ public class SleepExprMacro implements ExprMacro
         return null;
       }
     }
-    return new SleepExpr(arg);
+    return new SleepExpr(args);
   }
 }

--- a/processing/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
@@ -19,13 +19,12 @@
 
 package org.apache.druid.math.expr;
 
+import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.TypeStrategy;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class BuiltInExprMacros
 {
@@ -58,7 +57,7 @@ public class BuiltInExprMacros
 
       public ComplexDecodeBase64Expression(List<Expr> args)
       {
-        super(name(), args);
+        super(ComplexDecodeBase64ExprMacro.this, args);
         validationHelperCheckArgumentCount(args, 2);
         final Expr arg0 = args.get(0);
 
@@ -117,13 +116,6 @@ public class BuiltInExprMacros
         return ExprEval.ofComplex(complexType, typeStrategy.fromBytes(base64));
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        return shuttle.visit(new ComplexDecodeBase64Expression(newArgs));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -160,7 +152,7 @@ public class BuiltInExprMacros
     public Expr apply(List<Expr> args)
     {
       validationHelperCheckArgumentCount(args, 1);
-      return new StringDecodeBase64UTFExpression(args.get(0));
+      return new StringDecodeBase64UTFExpression(args);
     }
 
     /**
@@ -174,11 +166,14 @@ public class BuiltInExprMacros
       return NAME;
     }
 
-    final class StringDecodeBase64UTFExpression extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    final class StringDecodeBase64UTFExpression extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      public StringDecodeBase64UTFExpression(Expr arg)
+      private final Expr arg;
+
+      public StringDecodeBase64UTFExpression(List<Expr> args)
       {
-        super(name(), arg);
+        super(StringDecodeBase64UTFExprMacro.this, args);
+        this.arg = Iterables.getOnlyElement(args);
       }
 
       @Override
@@ -189,12 +184,6 @@ public class BuiltInExprMacros
           return ExprEval.of(null);
         }
         return new StringExpr(StringUtils.fromUtf8(StringUtils.decodeBase64String(toDecode.asString()))).eval(bindings);
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(Collections.singletonList(arg))));
       }
 
       @Nullable

--- a/processing/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/BuiltInExprMacros.java
@@ -152,7 +152,7 @@ public class BuiltInExprMacros
     public Expr apply(List<Expr> args)
     {
       validationHelperCheckArgumentCount(args, 1);
-      return new StringDecodeBase64UTFExpression(args);
+      return new StringDecodeBase64UTFExpression(this, args);
     }
 
     /**
@@ -166,13 +166,13 @@ public class BuiltInExprMacros
       return NAME;
     }
 
-    final class StringDecodeBase64UTFExpression extends ExprMacroTable.BaseScalarMacroFunctionExpr
+    static final class StringDecodeBase64UTFExpression extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
       private final Expr arg;
 
-      public StringDecodeBase64UTFExpression(List<Expr> args)
+      public StringDecodeBase64UTFExpression(StringDecodeBase64UTFExprMacro macro, List<Expr> args)
       {
-        super(StringDecodeBase64UTFExprMacro.this, args);
+        super(macro, args);
         this.arg = Iterables.getOnlyElement(args);
       }
 

--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -684,7 +684,7 @@ public interface Expr extends Cacheable
      * Add set of arguments as {@link BindingAnalysis#arrayVariables} that are *directly* {@link IdentifierExpr},
      * else they are ignored.
      */
-    BindingAnalysis withArrayArguments(Set<Expr> arrayArguments)
+    public BindingAnalysis withArrayArguments(Set<Expr> arrayArguments)
     {
       Set<IdentifierExpr> arrayIdentifiers = new HashSet<>();
       for (Expr expr : arrayArguments) {
@@ -705,7 +705,7 @@ public interface Expr extends Cacheable
     /**
      * Copy, setting if an expression has array inputs
      */
-    BindingAnalysis withArrayInputs(boolean hasArrays)
+    public BindingAnalysis withArrayInputs(boolean hasArrays)
     {
       return new BindingAnalysis(
           freeVariables,
@@ -719,7 +719,7 @@ public interface Expr extends Cacheable
     /**
      * Copy, setting if an expression produces an array output
      */
-    BindingAnalysis withArrayOutput(boolean isOutputArray)
+    public BindingAnalysis withArrayOutput(boolean isOutputArray)
     {
       return new BindingAnalysis(
           freeVariables,

--- a/processing/src/main/java/org/apache/druid/math/expr/Exprs.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Exprs.java
@@ -54,6 +54,18 @@ public class Exprs
   }
 
   /**
+   * Return a {@link Expr.BindingAnalysis} that represents an analysis of all provided args.
+   */
+  public static Expr.BindingAnalysis analyzeBindings(final List<Expr> args)
+  {
+    Expr.BindingAnalysis accumulator = new Expr.BindingAnalysis();
+    for (final Expr arg : args) {
+      accumulator = accumulator.with(arg);
+    }
+    return accumulator;
+  }
+
+  /**
    * Decomposes any expr into a list of exprs that, if ANDed together, are equivalent to the input expr.
    *
    * @param expr any expr

--- a/processing/src/main/java/org/apache/druid/query/expression/ArrayQuantileExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ArrayQuantileExprMacro.java
@@ -21,7 +21,6 @@ package org.apache.druid.query.expression;
 
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import it.unimi.dsi.fastutil.doubles.DoubleList;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -70,11 +69,11 @@ public class ArrayQuantileExprMacro implements ExprMacroTable.ExprMacro
 
     final double rank = ((Number) rankArg.getLiteralValue()).doubleValue();
 
-    class ArrayQuantileExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class ArrayQuantileExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private ArrayQuantileExpr(Expr arg)
+      private ArrayQuantileExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(ArrayQuantileExprMacro.this, args);
       }
 
       @Nonnull
@@ -92,27 +91,15 @@ public class ArrayQuantileExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.ofDouble(quantileFromSortedArray(doubles, rank));
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.DOUBLE;
       }
-
-      @Override
-      public String stringify()
-      {
-        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), rankArg.stringify());
-      }
     }
 
-    return new ArrayQuantileExpr(arg);
+    return new ArrayQuantileExpr(args);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
@@ -35,7 +35,7 @@ import java.util.List;
  * - {@code contains_string("foobar", "car") - 0 }
  * - {@code contains_string("foobar", "Bar") - 1 }
  * <p>
- * See {@link ContainsExprMacro} for the case-sensitive version.
+ * @see ContainsExprMacro for the case-sensitive version.
  */
 
 public class CaseInsensitiveContainsExprMacro implements ExprMacroTable.ExprMacro

--- a/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/CaseInsensitiveContainsExprMacro.java
@@ -55,6 +55,6 @@ public class CaseInsensitiveContainsExprMacro implements ExprMacroTable.ExprMacr
 
     final Expr arg = args.get(0);
     final Expr searchStr = args.get(1);
-    return new ContainsExpr(FN_NAME, arg, searchStr, false, shuttle -> apply(shuttle.visitAll(args)));
+    return new ContainsExpr(this, arg, searchStr, false);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
@@ -35,7 +35,7 @@ import java.util.List;
  * - {@code contains_string("foobar", "car") - 0 }
  * - {@code contains_string("foobar", "Bar") - 0 }
  * <p>
- * See {@link CaseInsensitiveContainsExprMacro} for the case-insensitive version.
+ * @see CaseInsensitiveContainsExprMacro for the case-insensitive version.
  */
 public class ContainsExprMacro implements ExprMacroTable.ExprMacro
 {

--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExprMacro.java
@@ -54,6 +54,6 @@ public class ContainsExprMacro implements ExprMacroTable.ExprMacro
 
     final Expr arg = args.get(0);
     final Expr searchStr = args.get(1);
-    return new ContainsExpr(FN_NAME, arg, searchStr, true, shuttle -> shuttle.visit(apply(shuttle.visitAll(args))));
+    return new ContainsExpr(this, arg, searchStr, true);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/HyperUniqueExpressions.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/HyperUniqueExpressions.java
@@ -141,7 +141,7 @@ public class HyperUniqueExpressions
       {
         public HllExpr(List<Expr> args)
         {
-          super(NAME, args);
+          super(HllAddExprMacro.this, args);
         }
 
         @Override
@@ -177,7 +177,8 @@ public class HyperUniqueExpressions
               break;
             case DOUBLE:
               if (NullHandling.replaceWithDefault() || !input.isNumericNull()) {
-                collector.add(CardinalityAggregator.HASH_FUNCTION.hashLong(Double.doubleToLongBits(input.asDouble())).asBytes());
+                collector.add(CardinalityAggregator.HASH_FUNCTION.hashLong(Double.doubleToLongBits(input.asDouble()))
+                                                                 .asBytes());
               }
               break;
             case LONG:
@@ -186,7 +187,8 @@ public class HyperUniqueExpressions
               }
               break;
             case COMPLEX:
-              if (TYPE.equals(input.type()) || hllType.is(ExprType.COMPLEX) && hllCollector.value() instanceof HyperLogLogCollector) {
+              if (TYPE.equals(input.type())
+                  || hllType.is(ExprType.COMPLEX) && hllCollector.value() instanceof HyperLogLogCollector) {
                 collector.fold((HyperLogLogCollector) input.value());
                 break;
               }
@@ -198,12 +200,6 @@ public class HyperUniqueExpressions
           }
 
           return ExprEval.ofComplex(TYPE, collector);
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          return shuttle.visit(apply(shuttle.visitAll(args)));
         }
 
         @Nullable
@@ -232,11 +228,11 @@ public class HyperUniqueExpressions
     {
       validationHelperCheckArgumentCount(args, 1);
 
-      class HllExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+      class HllExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
       {
-        public HllExpr(Expr arg)
+        public HllExpr(List<Expr> args)
         {
-          super(NAME, arg);
+          super(HllEstimateExprMacro.this, args);
         }
 
         @Override
@@ -258,12 +254,6 @@ public class HyperUniqueExpressions
           return ExprEval.ofDouble(collector.estimateCardinality());
         }
 
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          return shuttle.visit(apply(shuttle.visitAll(args)));
-        }
-
         @Nullable
         @Override
         public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -271,7 +261,7 @@ public class HyperUniqueExpressions
           return ExpressionType.DOUBLE;
         }
       }
-      return new HllExpr(args.get(0));
+      return new HllExpr(args);
     }
   }
 
@@ -290,11 +280,11 @@ public class HyperUniqueExpressions
     {
       validationHelperCheckArgumentCount(args, 1);
 
-      class HllExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+      class HllExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
       {
-        public HllExpr(Expr arg)
+        public HllExpr(List<Expr> args)
         {
-          super(NAME, arg);
+          super(HllRoundEstimateExprMacro.this, args);
         }
 
         @Override
@@ -312,12 +302,6 @@ public class HyperUniqueExpressions
           return ExprEval.ofLong(collector.estimateCardinalityRound());
         }
 
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          return shuttle.visit(apply(shuttle.visitAll(args)));
-        }
-
         @Nullable
         @Override
         public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -325,7 +309,7 @@ public class HyperUniqueExpressions
           return ExpressionType.LONG;
         }
       }
-      return new HllExpr(args.get(0));
+      return new HllExpr(args);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -77,11 +77,11 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
       final IPAddressString blockString = getSubnetInfo(args);
       final IPAddress block = blockString.toAddress().toPrefixBlock();
 
-      class IPv4AddressMatchExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+      class IPv4AddressMatchExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
       {
-        private IPv4AddressMatchExpr(Expr arg)
+        private IPv4AddressMatchExpr(List<Expr> args)
         {
-          super(FN_NAME, arg);
+          super(IPv4AddressMatchExprMacro.this, args);
         }
 
         @Nonnull
@@ -115,27 +115,15 @@ public class IPv4AddressMatchExprMacro implements ExprMacroTable.ExprMacro
           return address != null && block.contains(address);
         }
 
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          return shuttle.visit(apply(shuttle.visitAll(args)));
-        }
-
         @Nullable
         @Override
         public ExpressionType getOutputType(InputBindingInspector inspector)
         {
           return ExpressionType.LONG;
         }
-
-        @Override
-        public String stringify()
-        {
-          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(ARG_SUBNET).stringify());
-        }
       }
 
-      return new IPv4AddressMatchExpr(arg);
+      return new IPv4AddressMatchExpr(args);
     }
 
     catch (AddressStringException e) {

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacro.java
@@ -23,7 +23,6 @@ import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import inet.ipaddr.ipv4.IPv4Address;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressParseExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressParseExprMacro.java
@@ -63,11 +63,11 @@ public class IPv4AddressParseExprMacro implements ExprMacroTable.ExprMacro
 
     Expr arg = args.get(0);
 
-    class IPv4AddressParseExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class IPv4AddressParseExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private IPv4AddressParseExpr(Expr arg)
+      private IPv4AddressParseExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(IPv4AddressParseExprMacro.this, args);
       }
 
       @Nonnull
@@ -85,12 +85,6 @@ public class IPv4AddressParseExprMacro implements ExprMacroTable.ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -99,7 +93,7 @@ public class IPv4AddressParseExprMacro implements ExprMacroTable.ExprMacro
       }
     }
 
-    return new IPv4AddressParseExpr(arg);
+    return new IPv4AddressParseExpr(args);
   }
 
   private static ExprEval evalAsString(ExprEval eval)

--- a/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacro.java
@@ -62,11 +62,11 @@ public class IPv4AddressStringifyExprMacro implements ExprMacroTable.ExprMacro
 
     Expr arg = args.get(0);
 
-    class IPv4AddressStringifyExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class IPv4AddressStringifyExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private IPv4AddressStringifyExpr(Expr arg)
+      private IPv4AddressStringifyExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(IPv4AddressStringifyExprMacro.this, args);
       }
 
       @Nonnull
@@ -84,12 +84,6 @@ public class IPv4AddressStringifyExprMacro implements ExprMacroTable.ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -98,7 +92,7 @@ public class IPv4AddressStringifyExprMacro implements ExprMacroTable.ExprMacro
       }
     }
 
-    return new IPv4AddressStringifyExpr(arg);
+    return new IPv4AddressStringifyExpr(args);
   }
 
   private static ExprEval evalAsString(ExprEval eval)

--- a/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
@@ -20,7 +20,6 @@
 package org.apache.druid.query.expression;
 
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -70,11 +69,11 @@ public class LikeExprMacro implements ExprMacroTable.ExprMacro
         escapeChar
     );
 
-    class LikeExtractExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class LikeExtractExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private LikeExtractExpr(Expr arg)
+      private LikeExtractExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(LikeExprMacro.this, args);
       }
 
       @Nonnull
@@ -88,35 +87,14 @@ public class LikeExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.ofLongBoolean(match.matches(false));
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.LONG;
       }
-
-      @Override
-      public String stringify()
-      {
-        if (escapeExpr != null) {
-          return StringUtils.format(
-              "%s(%s, %s, %s)",
-              FN_NAME,
-              arg.stringify(),
-              patternExpr.stringify(),
-              escapeExpr.stringify()
-          );
-        }
-        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), patternExpr.stringify());
-      }
     }
-    return new LikeExtractExpr(arg);
+    return new LikeExtractExpr(args);
   }
 }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/LikeExprMacro.java
@@ -97,4 +97,3 @@ public class LikeExprMacro implements ExprMacroTable.ExprMacro
     return new LikeExtractExpr(args);
   }
 }
-

--- a/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
@@ -68,7 +68,7 @@ public class NestedDataExpressions
       {
         public StructExpr(List<Expr> args)
         {
-          super(NAME, args);
+          super(JsonObjectExprMacro.this, args);
         }
 
         @Override
@@ -86,13 +86,6 @@ public class NestedDataExpressions
           }
 
           return ExprEval.ofComplex(ExpressionType.NESTED_DATA, theMap);
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new StructExpr(newArgs));
         }
 
         @Nullable
@@ -133,7 +126,7 @@ public class NestedDataExpressions
       {
         public ToJsonStringExpr(List<Expr> args)
         {
-          super(name(), args);
+          super(ToJsonStringExprMacro.this, args);
         }
 
         @Override
@@ -155,13 +148,6 @@ public class NestedDataExpressions
                 input.value()
             );
           }
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new ToJsonStringExpr(newArgs));
         }
 
         @Nullable
@@ -202,7 +188,7 @@ public class NestedDataExpressions
       {
         public ParseJsonExpr(List<Expr> args)
         {
-          super(name(), args);
+          super(ParseJsonExprMacro.this, args);
         }
 
         @Override
@@ -228,13 +214,6 @@ public class NestedDataExpressions
               ExpressionType.STRING,
               arg.type()
           );
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new ParseJsonExpr(newArgs));
         }
 
         @Nullable
@@ -275,7 +254,7 @@ public class NestedDataExpressions
       {
         public ParseJsonExpr(List<Expr> args)
         {
-          super(name(), args);
+          super(TryParseJsonExprMacro.this, args);
         }
 
         @Override
@@ -300,13 +279,6 @@ public class NestedDataExpressions
               ExpressionType.NESTED_DATA,
               null
           );
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new ParseJsonExpr(newArgs));
         }
 
         @Nullable
@@ -350,7 +322,7 @@ public class NestedDataExpressions
 
       public JsonValueExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonValueExprMacro.this, args);
         this.parts = getJsonPathPartsFromLiteral(JsonValueExprMacro.this, args.get(1));
       }
 
@@ -365,17 +337,6 @@ public class NestedDataExpressions
           return valAtPath;
         }
         return ExprEval.of(null);
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonValueExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonValueDynamicExpr(newArgs));
-        }
       }
 
       @Nullable
@@ -394,7 +355,7 @@ public class NestedDataExpressions
 
       public JsonValueCastExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonValueExprMacro.this, args);
         this.parts = getJsonPathPartsFromLiteral(JsonValueExprMacro.this, args.get(1));
         this.castTo = ExpressionType.fromString((String) args.get(2).getLiteralValue());
         if (castTo == null) {
@@ -418,17 +379,6 @@ public class NestedDataExpressions
         return ExprEval.ofType(castTo, null);
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonValueCastExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonValueDynamicExpr(newArgs));
-        }
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -441,7 +391,7 @@ public class NestedDataExpressions
     {
       public JsonValueDynamicExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonValueExprMacro.this, args);
       }
 
       @Override
@@ -467,21 +417,6 @@ public class NestedDataExpressions
           return castTo == null ? valAtPath : valAtPath.castTo(castTo);
         }
         return castTo == null ? ExprEval.of(null) : ExprEval.ofType(castTo, null);
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          if (newArgs.size() == 3 && newArgs.get(2).isLiteral()) {
-            return shuttle.visit(new JsonValueCastExpr(newArgs));
-          } else {
-            return shuttle.visit(new JsonValueExpr(newArgs));
-          }
-        } else {
-          return shuttle.visit(new JsonValueDynamicExpr(newArgs));
-        }
       }
 
       @Nullable
@@ -520,7 +455,7 @@ public class NestedDataExpressions
 
       public JsonQueryExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonQueryExprMacro.this, args);
         this.parts = getJsonPathPartsFromLiteral(JsonQueryExprMacro.this, args.get(1));
       }
 
@@ -532,17 +467,6 @@ public class NestedDataExpressions
             ExpressionType.NESTED_DATA,
             NestedPathFinder.find(unwrap(input), parts)
         );
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonQueryExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonQueryDynamicExpr(newArgs));
-        }
       }
 
       @Nullable
@@ -558,7 +482,7 @@ public class NestedDataExpressions
     {
       public JsonQueryDynamicExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonQueryExprMacro.this, args);
       }
 
       @Override
@@ -571,17 +495,6 @@ public class NestedDataExpressions
             ExpressionType.NESTED_DATA,
             NestedPathFinder.find(unwrap(input), parts)
         );
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonQueryExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonQueryDynamicExpr(newArgs));
-        }
       }
 
       @Nullable
@@ -620,7 +533,7 @@ public class NestedDataExpressions
 
       public JsonQueryArrayExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonQueryArrayExprMacro.this, args);
         this.parts = getJsonPathPartsFromLiteral(JsonQueryArrayExprMacro.this, args.get(1));
       }
 
@@ -641,17 +554,6 @@ public class NestedDataExpressions
         );
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonQueryArrayExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonQueryArrayDynamicExpr(newArgs));
-        }
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
@@ -665,7 +567,7 @@ public class NestedDataExpressions
     {
       public JsonQueryArrayDynamicExpr(List<Expr> args)
       {
-        super(name(), args);
+        super(JsonQueryArrayExprMacro.this, args);
       }
 
       @Override
@@ -685,17 +587,6 @@ public class NestedDataExpressions
             JSON_ARRAY,
             ExprEval.bestEffortOf(value).asArray()
         );
-      }
-
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-        if (newArgs.get(1).isLiteral()) {
-          return shuttle.visit(new JsonQueryArrayExpr(newArgs));
-        } else {
-          return shuttle.visit(new JsonQueryArrayDynamicExpr(newArgs));
-        }
       }
 
       @Nullable
@@ -750,7 +641,7 @@ public class NestedDataExpressions
       {
         public JsonPathsExpr(List<Expr> args)
         {
-          super(name(), args);
+          super(JsonPathsExprMacro.this, args);
         }
 
         @Override
@@ -767,13 +658,6 @@ public class NestedDataExpressions
               ExpressionType.STRING_ARRAY,
               transformed
           );
-        }
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new JsonPathsExpr(newArgs));
         }
 
         @Nullable
@@ -805,7 +689,7 @@ public class NestedDataExpressions
       {
         public JsonKeysExpr(List<Expr> args)
         {
-          super(name(), args);
+          super(JsonKeysExprMacro.this, args);
         }
 
         @Override
@@ -816,14 +700,6 @@ public class NestedDataExpressions
               ExpressionType.STRING_ARRAY,
               NestedPathFinder.findKeys(unwrap(input), parts)
           );
-        }
-
-
-        @Override
-        public Expr visit(Shuttle shuttle)
-        {
-          List<Expr> newArgs = args.stream().map(x -> x.visit(shuttle)).collect(Collectors.toList());
-          return shuttle.visit(new JsonKeysExpr(newArgs));
         }
 
         @Nullable

--- a/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
@@ -702,7 +702,6 @@ public class NestedDataExpressions
           );
         }
 
-        @Nullable
         @Override
         public ExpressionType getOutputType(InputBindingInspector inspector)
         {

--- a/processing/src/main/java/org/apache/druid/query/expression/RegexpExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/RegexpExtractExprMacro.java
@@ -66,11 +66,11 @@ public class RegexpExtractExprMacro implements ExprMacroTable.ExprMacro
 
     final int index = indexExpr == null ? 0 : ((Number) indexExpr.getLiteralValue()).intValue();
 
-    class RegexpExtractExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class RegexpExtractExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private RegexpExtractExpr(Expr arg)
+      private RegexpExtractExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(RegexpExtractExprMacro.this, args);
       }
 
       @Nonnull
@@ -89,34 +89,13 @@ public class RegexpExtractExprMacro implements ExprMacroTable.ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.STRING;
       }
-
-      @Override
-      public String stringify()
-      {
-        if (indexExpr != null) {
-          return StringUtils.format(
-              "%s(%s, %s, %s)",
-              FN_NAME,
-              arg.stringify(),
-              patternExpr.stringify(),
-              indexExpr.stringify()
-          );
-        }
-        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), patternExpr.stringify());
-      }
     }
-    return new RegexpExtractExpr(arg);
+    return new RegexpExtractExpr(args);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/RegexpLikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/RegexpLikeExprMacro.java
@@ -59,11 +59,11 @@ public class RegexpLikeExprMacro implements ExprMacroTable.ExprMacro
         StringUtils.nullToEmptyNonDruidDataString((String) patternExpr.getLiteralValue())
     );
 
-    class RegexpLikeExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class RegexpLikeExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private RegexpLikeExpr(Expr arg)
+      private RegexpLikeExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(RegexpLikeExprMacro.this, args);
       }
 
       @Nonnull
@@ -81,25 +81,14 @@ public class RegexpLikeExprMacro implements ExprMacroTable.ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.LONG;
       }
-
-      @Override
-      public String stringify()
-      {
-        return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), patternExpr.stringify());
-      }
     }
-    return new RegexpLikeExpr(arg);
+
+    return new RegexpLikeExpr(args);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/RegexpReplaceExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/RegexpReplaceExprMacro.java
@@ -57,7 +57,7 @@ public class RegexpReplaceExprMacro implements ExprMacroTable.ExprMacro
   {
     public BaseRegexpReplaceExpr(final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(RegexpReplaceExprMacro.this, args);
     }
 
     @Nullable
@@ -65,12 +65,6 @@ public class RegexpReplaceExprMacro implements ExprMacroTable.ExprMacro
     public ExpressionType getOutputType(InputBindingInspector inspector)
     {
       return ExpressionType.STRING;
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(apply(shuttle.visitAll(args)));
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
@@ -49,9 +49,9 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
     validationHelperCheckArgumentRange(args, 2, 4);
 
     if (args.stream().skip(1).allMatch(Expr::isLiteral)) {
-      return new TimestampCeilExpr(args);
+      return new TimestampCeilExpr(this, args);
     } else {
-      return new TimestampCeilDynamicExpr(args);
+      return new TimestampCeilDynamicExpr(this, args);
     }
   }
 
@@ -60,9 +60,9 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
   {
     private final Granularity granularity;
 
-    TimestampCeilExpr(final List<Expr> args)
+    TimestampCeilExpr(final TimestampCeilExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
       this.granularity = getGranularity(args, InputBindings.nilBindings());
     }
 
@@ -81,12 +81,6 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.of(bucketStartTime);
       }
       return ExprEval.of(granularity.increment(bucketStartTime));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampCeilExpr(shuttle.visitAll(args)));
     }
 
     @Nullable
@@ -132,9 +126,9 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
   @VisibleForTesting
   static class TimestampCeilDynamicExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
   {
-    TimestampCeilDynamicExpr(final List<Expr> args)
+    TimestampCeilDynamicExpr(final TimestampCeilExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
     }
 
     @Nonnull
@@ -148,12 +142,6 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.of(bucketStartTime);
       }
       return ExprEval.of(granularity.increment(bucketStartTime));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampCeilDynamicExpr(shuttle.visitAll(args)));
     }
 
     @Nullable

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampExtractExprMacro.java
@@ -124,20 +124,6 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
     }
   }
 
-  private static String stringifyExpr(final List<Expr> args)
-  {
-    if (args.size() > 2) {
-      return StringUtils.format(
-          "%s(%s, %s, %s)",
-          FN_NAME,
-          args.get(0).stringify(),
-          args.get(1).stringify(),
-          args.get(2).stringify()
-      );
-    }
-    return StringUtils.format("%s(%s, %s)", FN_NAME, args.get(0).stringify(), args.get(1).stringify());
-  }
-
   private static ISOChronology computeChronology(final List<Expr> args, final Expr.ObjectBinding bindings)
   {
     String timeZoneVal = (String) args.get(2).eval(bindings).value();
@@ -176,7 +162,7 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
 
     private TimestampExtractExpr(final List<Expr> args, final Unit unit, final ISOChronology chronology)
     {
-      super(FN_NAME, args);
+      super(TimestampExtractExprMacro.this, args);
       this.unit = unit;
       this.chronology = chronology;
     }
@@ -194,23 +180,11 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
       return getExprEval(dateTime, unit);
     }
 
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(apply(shuttle.visitAll(args)));
-    }
-
     @Nullable
     @Override
     public ExpressionType getOutputType(InputBindingInspector inspector)
     {
       return getOutputExpressionType(unit);
-    }
-
-    @Override
-    public String stringify()
-    {
-      return stringifyExpr(args);
     }
   }
 
@@ -220,7 +194,7 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
 
     private TimestampExtractDynamicExpr(final List<Expr> args, final Unit unit)
     {
-      super(FN_NAME, args);
+      super(TimestampExtractExprMacro.this, args);
       this.unit = unit;
     }
 
@@ -238,23 +212,11 @@ public class TimestampExtractExprMacro implements ExprMacroTable.ExprMacro
       return getExprEval(dateTime, unit);
     }
 
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(apply(shuttle.visitAll(args)));
-    }
-
     @Nullable
     @Override
     public ExpressionType getOutputType(InputBindingInspector inspector)
     {
       return getOutputExpressionType(unit);
-    }
-
-    @Override
-    public String stringify()
-    {
-      return stringifyExpr(args);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
@@ -50,9 +50,9 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
     validationHelperCheckArgumentRange(args, 2, 4);
 
     if (args.stream().skip(1).allMatch(Expr::isLiteral)) {
-      return new TimestampFloorExpr(args);
+      return new TimestampFloorExpr(this, args);
     } else {
-      return new TimestampFloorDynamicExpr(args);
+      return new TimestampFloorDynamicExpr(this, args);
     }
   }
 
@@ -70,9 +70,9 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
   {
     private final PeriodGranularity granularity;
 
-    TimestampFloorExpr(final List<Expr> args)
+    TimestampFloorExpr(final TimestampFloorExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
       this.granularity = computeGranularity(args, InputBindings.nilBindings());
     }
 
@@ -102,12 +102,6 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.of(null);
       }
       return ExprEval.of(granularity.bucketStart(eval.asLong()));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampFloorExpr(shuttle.visitAll(args)));
     }
 
     @Nullable
@@ -167,9 +161,9 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
 
   public static class TimestampFloorDynamicExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
   {
-    TimestampFloorDynamicExpr(final List<Expr> args)
+    TimestampFloorDynamicExpr(final TimestampFloorExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
     }
 
     @Nonnull
@@ -178,12 +172,6 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
     {
       final PeriodGranularity granularity = computeGranularity(args, bindings);
       return ExprEval.of(granularity.bucketStart(args.get(0).eval(bindings).asLong()));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampFloorDynamicExpr(shuttle.visitAll(args)));
     }
 
     @Nullable

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFormatExprMacro.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query.expression;
 
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -69,11 +68,11 @@ public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
                                         ? ISODateTimeFormat.dateTime().withZone(timeZone)
                                         : DateTimeFormat.forPattern(formatString).withZone(timeZone);
 
-    class TimestampFormatExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class TimestampFormatExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private TimestampFormatExpr(Expr arg)
+      private TimestampFormatExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(TimestampFormatExprMacro.this, args);
       }
 
       @Nonnull
@@ -88,38 +87,14 @@ public class TimestampFormatExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.of(formatter.print(arg.eval(bindings).asLong()));
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.STRING;
       }
-
-      @Override
-      public String stringify()
-      {
-        if (args.size() > 2) {
-          return StringUtils.format(
-              "%s(%s, %s, %s)",
-              FN_NAME,
-              arg.stringify(),
-              args.get(1).stringify(),
-              args.get(2).stringify()
-          );
-        }
-        if (args.size() > 1) {
-          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(1).stringify());
-        }
-        return super.stringify();
-      }
     }
 
-    return new TimestampFormatExpr(arg);
+    return new TimestampFormatExpr(args);
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampParseExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampParseExprMacro.java
@@ -20,7 +20,6 @@
 package org.apache.druid.query.expression;
 
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -66,11 +65,11 @@ public class TimestampParseExprMacro implements ExprMacroTable.ExprMacro
         ? createDefaultParser(timeZone)
         : DateTimes.wrapFormatter(DateTimeFormat.forPattern(formatString).withZone(timeZone));
 
-    class TimestampParseExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
+    class TimestampParseExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
     {
-      private TimestampParseExpr(Expr arg)
+      private TimestampParseExpr(List<Expr> args)
       {
-        super(FN_NAME, arg);
+        super(TimestampParseExprMacro.this, args);
       }
 
       @Nonnull
@@ -92,39 +91,15 @@ public class TimestampParseExprMacro implements ExprMacroTable.ExprMacro
         }
       }
 
-      @Override
-      public Expr visit(Shuttle shuttle)
-      {
-        return shuttle.visit(apply(shuttle.visitAll(args)));
-      }
-
       @Nullable
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
         return ExpressionType.LONG;
       }
-
-      @Override
-      public String stringify()
-      {
-        if (args.size() > 2) {
-          return StringUtils.format(
-              "%s(%s, %s, %s)",
-              FN_NAME,
-              arg.stringify(),
-              args.get(1).stringify(),
-              args.get(2).stringify()
-          );
-        }
-        if (args.size() > 1) {
-          return StringUtils.format("%s(%s, %s)", FN_NAME, arg.stringify(), args.get(1).stringify());
-        }
-        return super.stringify();
-      }
     }
 
-    return new TimestampParseExpr(arg);
+    return new TimestampParseExpr(args);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampShiftExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampShiftExprMacro.java
@@ -52,11 +52,11 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
     validationHelperCheckArgumentRange(args, 3, 4);
 
     if (args.stream().skip(1).allMatch(Expr::isLiteral)) {
-      return new TimestampShiftExpr(args);
+      return new TimestampShiftExpr(this, args);
     } else {
       // Use dynamic impl if any args are non-literal. Don't bother optimizing for the case where period is
       // literal but step isn't.
-      return new TimestampShiftDynamicExpr(args);
+      return new TimestampShiftDynamicExpr(this, args);
     }
   }
 
@@ -87,9 +87,9 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
     private final Period period;
     private final int step;
 
-    TimestampShiftExpr(final List<Expr> args)
+    TimestampShiftExpr(final TimestampShiftExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
       period = getPeriod(args, InputBindings.nilBindings());
       chronology = getTimeZone(args, InputBindings.nilBindings());
       step = getStep(args, InputBindings.nilBindings());
@@ -104,12 +104,6 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
         return ExprEval.of(null);
       }
       return ExprEval.of(chronology.add(period, timestamp.asLong(), step));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampShiftExpr(shuttle.visitAll(args)));
     }
 
     @Override
@@ -147,9 +141,9 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
 
   private static class TimestampShiftDynamicExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
   {
-    TimestampShiftDynamicExpr(final List<Expr> args)
+    TimestampShiftDynamicExpr(final TimestampShiftExprMacro macro, final List<Expr> args)
     {
-      super(FN_NAME, args);
+      super(macro, args);
     }
 
     @Nonnull
@@ -164,12 +158,6 @@ public class TimestampShiftExprMacro implements ExprMacroTable.ExprMacro
       final Chronology chronology = getTimeZone(args, bindings);
       final int step = getStep(args, bindings);
       return ExprEval.of(chronology.add(period, timestamp.asLong(), step));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return shuttle.visit(new TimestampShiftDynamicExpr(shuttle.visitAll(args)));
     }
 
     @Nullable

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionValidationException;
 import org.apache.druid.math.expr.InputBindings;
+import org.apache.druid.math.expr.Parser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
   private static final Expr IPV6_MAPPED = ExprEval.of("::ffff:192.168.0.1").toExpr();
   private static final Expr SUBNET_192_168 = ExprEval.of("192.168.0.0/16").toExpr();
   private static final Expr SUBNET_10 = ExprEval.of("10.0.0.0/8").toExpr();
-  private static final Expr NOT_LITERAL = new NotLiteralExpr(null);
+  private static final Expr NOT_LITERAL = Parser.parse("\"notliteral\"", ExprMacroTable.nil());
 
   public IPv4AddressMatchExprMacroTest()
   {
@@ -209,27 +210,5 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
     Expr expr = apply(Arrays.asList(args));
     ExprEval eval = expr.eval(InputBindings.nilBindings());
     return eval.asBoolean();
-  }
-
-  /* Helper for tests */
-  @SuppressWarnings({"ReturnOfNull", "NullableProblems"})  // suppressed since this is a test helper class
-  private static class NotLiteralExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
-  {
-    NotLiteralExpr(Expr arg)
-    {
-      super("not", arg);
-    }
-
-    @Override
-    public ExprEval eval(ObjectBinding bindings)
-    {
-      return null;
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return null;
-    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/TimestampShiftMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/TimestampShiftMacroTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
+import org.apache.druid.math.expr.Parser;
 import org.joda.time.DateTime;
 import org.joda.time.Days;
 import org.joda.time.Minutes;
@@ -199,7 +200,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
         ImmutableList.of(
             ExprEval.of(timestamp.getMillis()).toExpr(),
             ExprEval.of("P1Y").toExpr(),
-            new NotLiteralExpr("step"),
+            Parser.parse("\"step\"", ExprMacroTable.nil()), // "step" is not a literal
             ExprEval.of("America/Los_Angeles").toExpr()
         ));
 
@@ -244,26 +245,6 @@ public class TimestampShiftMacroTest extends MacroTestBase
       Assert.assertEquals(2678400000L, expr.eval(InputBindings.nilBindings()).value());
     } else {
       Assert.assertNull(expr.eval(InputBindings.nilBindings()).value());
-    }
-  }
-
-  private static class NotLiteralExpr extends ExprMacroTable.BaseScalarUnivariateMacroFunctionExpr
-  {
-    NotLiteralExpr(String name)
-    {
-      super(name, ExprEval.of(name).toExpr());
-    }
-
-    @Override
-    public ExprEval eval(ObjectBinding bindings)
-    {
-      return ExprEval.ofType(bindings.getType(name), bindings.get(name));
-    }
-
-    @Override
-    public Expr visit(Shuttle shuttle)
-    {
-      return null;
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/TrimExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/TrimExprMacroTest.java
@@ -28,7 +28,7 @@ public class TrimExprMacroTest
   public void testEqualsContractForTrimStaticCharsExpr()
   {
     EqualsVerifier.forClass(TrimExprMacro.TrimStaticCharsExpr.class)
-                  .withIgnoredFields("analyzeInputsSupplier", "visitFn")
+                  .withIgnoredFields("analyzeInputsSupplier", "mode", "stringExpr", "chars")
                   .usingGetClass()
                   .verify();
   }
@@ -37,7 +37,7 @@ public class TrimExprMacroTest
   public void testEqualsContractForTrimDynamicCharsExpr()
   {
     EqualsVerifier.forClass(TrimExprMacro.TrimDynamicCharsExpr.class)
-                  .withIgnoredFields("visitFn")
+                  .withIgnoredFields("analyzeInputsSupplier", "mode", "stringExpr", "charsExpr")
                   .usingGetClass()
                   .verify();
   }


### PR DESCRIPTION
This patch removes BaseScalarUnivariateMacroFunctionExpr, adds BaseMacroFunctionExpr at the top of the hierarchy (a suitable base class for ExprMacros that take either arrays or scalars), and adds an implementation for "visit" to BaseMacroFunctionExpr.

The effect on implementations is generally cleaner code:

- Exprs no longer need to implement "visit".
- Exprs no longer need to implement "stringify", even if they don't use all of their args at runtime, because BaseMacroFunctionExpr has access to even unused args.
- Exprs that accept arrays can extend BaseMacroFunctionExpr and inherit a bunch of useful methods. The only one they need to implement themselves that scalar exprs don't is "supplyAnalyzeInputs".