### PR TITLE
Follow-ups to SEARCH and IN from #15609.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/SearchOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/SearchOperatorConversion.java
@@ -128,7 +128,6 @@ public class SearchOperatorConversion implements SqlOperatorConversion
 
     // Compute points that occur in the complement of the range set. These are "NOT IN" points.
     final List<Comparable> notInPoints;
-    final List<RexNode> notInRexNodes;
     final RexNode notInRexNode;
 
     if (sarg.isPoints()) {


### PR DESCRIPTION
- Rename ExprType to BaseType in CollectComparisons, since ExprType is a thing that exists elsewhere.
- Remove unused "notInRexNodes" from SearchOperatorConversion.