### PR TITLE
Fix redundant expansion in SearchOperatorConversion.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/SearchOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/SearchOperatorConversion.java
@@ -169,7 +169,7 @@ public class SearchOperatorConversion implements SqlOperatorConversion
     }
 
     // Use RexUtil.sargRef to expand the rest of the sarg, if any.
-    if (!sarg.isPoints() || !sarg.isComplementedPoints()) {
+    if (!sarg.isPoints() && !sarg.isComplementedPoints()) {
       // Remaining ranges, after separating out the "IN" and "NOT IN" points.
       // The "IN" points are excluded, and the "NOT IN" points are added back in.
       final RangeSet<Comparable> remainderRanges = TreeRangeSet.create();


### PR DESCRIPTION
This logic error from #15609 causes sarg expansion to happen twice for IN or NOT IN points. It doesn't affect the final generated native query, because the redundant expansions gets combined. But it slows down planning, especially for large NOT IN.