### PR TITLE
Web console: Fix spec conversion, expose failOnEmptyInsert

### DIFF
--- a/web-console/src/druid-models/query-context/query-context.tsx
+++ b/web-console/src/druid-models/query-context/query-context.tsx
@@ -146,6 +146,22 @@ export function changeTaskAssigment(
     : deepDelete(context, 'taskAssignment');
 }
 
+// failOnEmptyInsert
+
+export function getFailOnEmptyInsert(context: QueryContext): boolean | undefined {
+  const { failOnEmptyInsert } = context;
+  return typeof failOnEmptyInsert === 'boolean' ? failOnEmptyInsert : undefined;
+}
+
+export function changeFailOnEmptyInsert(
+  context: QueryContext,
+  failOnEmptyInsert: boolean | undefined,
+): QueryContext {
+  return typeof failOnEmptyInsert === 'boolean'
+    ? deepSet(context, 'failOnEmptyInsert', failOnEmptyInsert)
+    : deepDelete(context, 'failOnEmptyInsert');
+}
+
 // finalizeAggregations
 
 export function getFinalizeAggregations(context: QueryContext): boolean | undefined {

--- a/web-console/src/helpers/__snapshots__/spec-conversion.spec.ts.snap
+++ b/web-console/src/helpers/__snapshots__/spec-conversion.spec.ts.snap
@@ -58,6 +58,7 @@ SELECT
   COUNT(*) AS "count",
   SUM("added") AS "sum_added",
   SUM("commentLength") AS "sum_commentLength",
+  MAX("commentLength") AS "max_commentLength",
   SUM("delta") AS "sum_delta",
   SUM("deltaBucket") AS "sum_deltaBucket",
   SUM("deleted") AS "sum_deleted",

--- a/web-console/src/helpers/spec-conversion.spec.ts
+++ b/web-console/src/helpers/spec-conversion.spec.ts
@@ -193,6 +193,11 @@ describe('spec conversion', () => {
               fieldName: 'commentLength',
             },
             {
+              name: 'max_commentLength',
+              type: 'longMax',
+              fieldName: 'commentLength',
+            },
+            {
               name: 'sum_delta',
               type: 'longSum',
               fieldName: 'delta',

--- a/web-console/src/helpers/spec-conversion.ts
+++ b/web-console/src/helpers/spec-conversion.ts
@@ -18,6 +18,7 @@
 
 import {
   C,
+  dedupe,
   L,
   RefName,
   SqlColumnDeclaration,
@@ -119,6 +120,8 @@ export function convertSpecToSql(spec: any): QueryWithContext {
       ),
     );
   }
+
+  columnDeclarations = dedupe(columnDeclarations, d => d.getColumnName());
 
   const transforms: Transform[] = deepGet(spec, 'spec.dataSchema.transformSpec.transforms') || [];
   if (!Array.isArray(transforms)) {
@@ -346,14 +349,14 @@ export function convertSpecToSql(spec: any): QueryWithContext {
 
 function convertQueryGranularity(
   timeExpression: string,
-  queryGranularity: { type: string } | string | undefined,
+  queryGranularity: { type: unknown } | string | undefined,
 ) {
   if (!queryGranularity) return timeExpression;
 
   const effectiveQueryGranularity =
     typeof queryGranularity === 'string'
       ? queryGranularity
-      : typeof queryGranularity.type === 'string'
+      : typeof queryGranularity?.type === 'string'
       ? queryGranularity.type
       : undefined;
 

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -38,6 +38,7 @@ import { IndexSpecDialog } from '../../../dialogs/index-spec-dialog/index-spec-d
 import type { DruidEngine, IndexSpec, QueryContext, WorkbenchQuery } from '../../../druid-models';
 import {
   changeDurableShuffleStorage,
+  changeFailOnEmptyInsert,
   changeFinalizeAggregations,
   changeGroupByEnableMultiValueUnnesting,
   changeMaxParseExceptions,
@@ -47,6 +48,7 @@ import {
   changeUseCache,
   changeWaitUntilSegmentsLoad,
   getDurableShuffleStorage,
+  getFailOnEmptyInsert,
   getFinalizeAggregations,
   getGroupByEnableMultiValueUnnesting,
   getMaxParseExceptions,
@@ -111,6 +113,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
   const queryParameters = query.queryParameters;
 
   const maxParseExceptions = getMaxParseExceptions(queryContext);
+  const failOnEmptyInsert = getFailOnEmptyInsert(queryContext);
   const finalizeAggregations = getFinalizeAggregations(queryContext);
   const waitUntilSegmentsLoad = getWaitUntilSegmentsLoad(queryContext);
   const groupByEnableMultiValueUnnesting = getGroupByEnableMultiValueUnnesting(queryContext);
@@ -305,6 +308,15 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         />
                       ))}
                     </MenuItem>
+                    <MenuTristate
+                      icon={IconNames.DISABLE}
+                      text="Fail on empty insert"
+                      value={failOnEmptyInsert}
+                      undefinedEffectiveValue={false}
+                      onValueChange={v =>
+                        changeQueryContext(changeFailOnEmptyInsert(queryContext, v))
+                      }
+                    />
                     <MenuTristate
                       icon={IconNames.TRANSLATE}
                       text="Finalize aggregations"


### PR DESCRIPTION
Fix an issue where source columns were not deduped in the spec converter, expose the new `failOnEmptyInsert` toggle in the UI