### PR TITLE
docs: add note about finalizeaggregations for sql-based ingestion

### DIFF
--- a/docs/multi-stage-query/examples.md
+++ b/docs/multi-stage-query/examples.md
@@ -32,7 +32,7 @@ sidebar_label: Examples
 These example queries show you some of the things you can do when modifying queries for your use case. Copy the example queries into the **Query** view of the web console and run them to see what they do.
 
 :::tip
-When you insert or replace data with SQL-based ingestion, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For more information, see [Rollup](./concepts.md#rollup)
+When you insert or replace data with SQL-based ingestion, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For more information, see [Rollup](./concepts.md#rollup).
 :::
 
 ## INSERT with no rollup

--- a/docs/multi-stage-query/examples.md
+++ b/docs/multi-stage-query/examples.md
@@ -31,6 +31,10 @@ sidebar_label: Examples
 
 These example queries show you some of the things you can do when modifying queries for your use case. Copy the example queries into the **Query** view of the web console and run them to see what they do.
 
+:::tip
+When you do an insert or replace, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For more information, see [Rollup](./concepts.md#rollup)
+:::
+
 ## INSERT with no rollup
 
 This example inserts data into a table named `w000` without performing any data rollup:

--- a/docs/multi-stage-query/examples.md
+++ b/docs/multi-stage-query/examples.md
@@ -32,7 +32,7 @@ sidebar_label: Examples
 These example queries show you some of the things you can do when modifying queries for your use case. Copy the example queries into the **Query** view of the web console and run them to see what they do.
 
 :::tip
-When you do an insert or replace, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For more information, see [Rollup](./concepts.md#rollup)
+When you insert or replace data with SQL-based ingestion, set the context parameter `finalizeAggregations` to `false`. This context parameter is automatically set for you if you use the Druid console. If you use the API, you must explicitly set it. For more information, see [Rollup](./concepts.md#rollup)
 :::
 
 ## INSERT with no rollup


### PR DESCRIPTION
### Description

Adds a note about needing to set `finalizeAggregations` to `false` manually for the API
Rendered output:

![image](https://github.com/apache/druid/assets/53799971/926e9cda-c8d7-41ae-ac16-264e2e0e13b8)

Based on this Slack convo: https://apachedruidworkspace.slack.com/archives/C0309C9L90D/p1675826252549959

This PR has:

- [x] been self-reviewed.
