### PR TITLE
fix issue with nested virtual column index supplier for partial paths when processing from raw

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
@@ -1170,10 +1170,15 @@ public class NestedFieldVirtualColumn implements VirtualColumn
     if (theColumn instanceof CompressedNestedDataComplexColumn) {
       final CompressedNestedDataComplexColumn<?> nestedColumn = (CompressedNestedDataComplexColumn<?>) theColumn;
       final ColumnIndexSupplier nestedColumnPathIndexSupplier = nestedColumn.getColumnIndexSupplier(parts);
+      if (nestedColumnPathIndexSupplier == null && processFromRaw) {
+        // if processing from raw, a non-exstent path from parts doesn't mean the path doesn't really exist
+        // so fall back to no indexes
+        return NoIndexesColumnIndexSupplier.getInstance();
+      }
       if (expectedType != null) {
         final Set<ColumnType> types = nestedColumn.getColumnTypes(parts);
         // if the expected output type is numeric but not all of the input types are numeric, we might have additional
-        // null values than what the null value bitmap is tracking, wrap it
+        // null values than what the null value bitmap is tracking, fall back to not using indexes
         if (expectedType.isNumeric() && (types == null || types.stream().anyMatch(t -> !t.isNumeric()))) {
           return NoIndexesColumnIndexSupplier.getInstance();
         }


### PR DESCRIPTION
### Description
Fixes an issue when filtering `NestedFieldVirtualColumn` using 'processFromRaw' (e.g. `JSON_QUERY` instead of `JSON_VALUE`) when using partial paths. `NestedFieldVirtualColumn` was incorrectly returning `null` from `getIndexSupplier` in this case instead of `NoIndexesColumnIndexSupplier.getInstance()` to instruct the processing to fall back to using value matchers. Added test case for this, as well as another similar case which was working correctly where it should also fall back to using no-indexes when referring to an array element, to ensure no future regressions.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
