### PR TITLE
fix issue with json paths not correctly handling negative index for Object[] like it has for List

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedPathArrayElement.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedPathArrayElement.java
@@ -46,15 +46,21 @@ public class NestedPathArrayElement implements NestedPathPart
       List<?> currentList = (List<?>) input;
       final int currentSize = currentList.size();
       if (index < 0) {
-        if (currentSize + index >= 0) {
-          return currentList.get(currentSize + index);
+        final int adjusted = currentSize + index;
+        if (adjusted >= 0) {
+          return currentList.get(adjusted);
         }
       } else if (currentList.size() > index) {
         return currentList.get(index);
       }
     } else if (input instanceof Object[]) {
       Object[] currentList = (Object[]) input;
-      if (currentList.length > index) {
+      if (index < 0) {
+        final int adjusted = currentList.length + index;
+        if (adjusted >= 0) {
+          return currentList[adjusted];
+        }
+      } else if (currentList.length > index) {
         return currentList[index];
       }
     }

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedPathFinderTest.java
@@ -36,7 +36,8 @@ public class NestedPathFinderTest
       "y", ImmutableMap.of("a", "hello", "b", "world"),
       "z", "foo",
       "[sneaky]", "bar",
-      "[also_sneaky]", ImmutableList.of(ImmutableMap.of("a", "x"), ImmutableMap.of("b", "y", "c", "z"))
+      "[also_sneaky]", ImmutableList.of(ImmutableMap.of("a", "x"), ImmutableMap.of("b", "y", "c", "z")),
+      "objarray", new Object[]{"a", "b", "c"}
   );
 
   @Test
@@ -434,6 +435,19 @@ public class NestedPathFinderTest
     Assert.assertEquals("b", NestedPathFinder.find(NESTER, pathParts));
 
     pathParts = NestedPathFinder.parseJqPath(".x[-4]");
+    Assert.assertNull(NestedPathFinder.find(NESTER, pathParts));
+
+    // object array
+    pathParts = NestedPathFinder.parseJqPath(".objarray[1]");
+    Assert.assertEquals("b", NestedPathFinder.find(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".objarray[-1]");
+    Assert.assertEquals("c", NestedPathFinder.find(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".objarray[-2]");
+    Assert.assertEquals("b", NestedPathFinder.find(NESTER, pathParts));
+
+    pathParts = NestedPathFinder.parseJqPath(".objarray[-4]");
     Assert.assertNull(NestedPathFinder.find(NESTER, pathParts));
 
     // nonexistent


### PR DESCRIPTION
### Description
Fixes a bug with `NestedPathArrayElement` which was missing negative index handling for `Object[]` like it had for `List`. This meant that while a query like `json_query(c1, '$.a_array[-2].a_str')` would work correctly because it would get a `List` from the raw data, something like `json_query(json_query_array(c1, '$.a_array'), '$[-2].a_str')` would fail with an array out of bounds exception because `json_query_array` spits out `Object[]`. This PR fixes the problem so that both are consistent.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
