### PR TITLE
Audit API DELETE datasource (markAllSegmentsAsUnused)

### DIFF
--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -605,7 +605,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUnusedAllSegmentsInDataSource()
+  public void testMarkAsUnusedAllSegmentsInDataSourceBadRequest()
   {
     OverlordClient overlordClient = EasyMock.createStrictMock(OverlordClient.class);
     EasyMock.replay(overlordClient, server);
@@ -624,6 +624,19 @@ public class DataSourcesResourceTest
     }
 
     EasyMock.verify(overlordClient, server);
+  }
+
+  @Test
+  public void testMarkAsUnusedAllSegmentsInDataSource()
+  {
+    prepareRequestForAudit();
+
+    DataSourcesResource dataSourcesResource = createResource();
+    Response response = dataSourcesResource
+        .markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", null, null, request);
+    Assert.assertEquals(200, response.getStatus());
+
+    EasyMock.verify(request);
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -631,7 +631,10 @@ public class DataSourcesResourceTest
   {
     prepareRequestForAudit();
 
-    DataSourcesResource dataSourcesResource = createResource();
+    OverlordClient overlordClient = EasyMock.createStrictMock(OverlordClient.class);
+    EasyMock.replay(overlordClient, server);
+    DataSourcesResource dataSourcesResource =
+        new DataSourcesResource(inventoryView, segmentsMetadataManager, null, overlordClient, null, null, auditManager);
     Response response = dataSourcesResource
         .markAsUnusedAllSegmentsOrKillUnusedSegmentsInInterval("datasource", null, null, request);
     Assert.assertEquals(200, response.getStatus());


### PR DESCRIPTION
### Changes
- Add audit for `DELETE /druid/coordinator/v1/datasources/{datasourceName}`
- Minor renaming

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
