### PR TITLE
Fix incorrect test case in the string first/last serde's null handling

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/aggregation/BackwardCompatibleSerializablePairLongStringSimpleStagedSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/BackwardCompatibleSerializablePairLongStringSimpleStagedSerdeTest.java
@@ -59,7 +59,7 @@ public class BackwardCompatibleSerializablePairLongStringSimpleStagedSerdeTest
     SerializablePairLongString value = new SerializablePairLongString(Long.MAX_VALUE, null);
     // Write using the older serde, read using the newer serde
     Assert.assertEquals(
-        new SerializablePairLongString(Long.MAX_VALUE, ""),
+        new SerializablePairLongString(Long.MAX_VALUE, null),
         readUsingSerde(writeUsingSerde(value, OLDER_SERDE), SERDE)
     );
     // Write using the newer serde, read using the older serde
@@ -77,7 +77,7 @@ public class BackwardCompatibleSerializablePairLongStringSimpleStagedSerdeTest
     SerializablePairLongString value = new SerializablePairLongString(Long.MAX_VALUE, "");
     // Write using the older serde, read using the newer serde
     Assert.assertEquals(
-        new SerializablePairLongString(Long.MAX_VALUE, ""),
+        new SerializablePairLongString(Long.MAX_VALUE, null),
         readUsingSerde(writeUsingSerde(value, OLDER_SERDE), SERDE)
     );
     // Write using the newer serde, read using the older serde


### PR DESCRIPTION
### Description
Fixes a couple of incorrect test cases, that got merged accidentally. 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
