### PR TITLE
Fix summary iterator

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
@@ -790,7 +790,10 @@ public class GroupingEngine
     List<AggregatorFactory> aggSpec = q.getAggregatorSpecs();
     ResultRow resultRow = ResultRow.create(q.getResultRowSizeWithPostAggregators());
     for (int i = 0; i < aggSpec.size(); i++) {
-      resultRow.set(i, aggSpec.get(i).factorize(new AllNullColumnSelectorFactory()).get());
+      resultRow.set(
+          q.getResultRowAggregatorStart() + i,
+          aggSpec.get(i).factorize(new AllNullColumnSelectorFactory()).get()
+      );
     }
     Map<String, Object> map = resultRow.toMap(q);
     for (int i = 0; i < q.getPostAggregatorSpecs().size(); i++) {


### PR DESCRIPTION
### Description

This PR fixes the summary iterator to add aggregators in the correct position. The summary iterator is used when dims are not present, therefore the new change is identical to the old one, but seems more correct while reading. 

<hr>

##### Key changed/added classes in this PR

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
