### PR TITLE
Fix StandardDeviationPostAggregator to account for null return values from the NoopAggregator

### DIFF
--- a/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/StandardDeviationPostAggregator.java
+++ b/extensions-core/stats/src/main/java/org/apache/druid/query/aggregation/variance/StandardDeviationPostAggregator.java
@@ -79,7 +79,11 @@ public class StandardDeviationPostAggregator implements PostAggregator
   @Nullable
   public Double compute(Map<String, Object> combinedAggregators)
   {
-    Double variance = ((VarianceAggregatorCollector) combinedAggregators.get(fieldName)).getVariance(isVariancePop);
+    Object varianceAggregatorCollector = combinedAggregators.get(fieldName);
+    if (!(varianceAggregatorCollector instanceof VarianceAggregatorCollector)) {
+      return NullHandling.defaultDoubleValue();
+    }
+    Double variance = ((VarianceAggregatorCollector) varianceAggregatorCollector).getVariance(isVariancePop);
     return variance == null ? NullHandling.defaultDoubleValue() : (Double) Math.sqrt(variance);
   }
 


### PR DESCRIPTION
### Description
Fixes NPE which can arise if the `StandardDeviationPostAggregator` is passed in `null`. This adds a check to make sure that the object is the desired type before casting.

The following query fails before the patch, however, please post it.

```json
{
  "queryType": "groupBy",
  "dataSource": {
    "type": "table",
    "name": "wikipedia"
  },
  "intervals": {
    "type": "intervals",
    "intervals": [
      "1998-01-09T23:55:00.000Z/1999-01-10T00:55:00.000Z"
    ]
  },
  "granularity": {
    "type": "all"
  },
  "dimensions": [],
  "aggregations": [
    {
      "type": "variance",
      "name": "preAggregationValue",
      "fieldName": "commentLength",
      "estimator": null,
      "inputType": "float"
    }
  ],
  "postAggregations": [
    {
      "type": "stddev",
      "name": "value",
      "fieldName": "preAggregationValue",
      "estimator": null
    }
  ],
  "limitSpec": {
    "type": "NoopLimitSpec"
  },
  "context": {
    "enableTimeBoundaryPlanning": "true",
    "useCache": true,
    "debug":true
  }
}
```




<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
