### PR TITLE
tidy up group by engines after removal of v1

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
@@ -463,7 +463,9 @@ public class GroupingEngine
       throw new IAE("Should only have one interval, got[%s]", intervals);
     }
 
-    try (final ResourceHolder<ByteBuffer> bufferHolder = bufferPool.take()) {
+    final ResourceHolder<ByteBuffer> bufferHolder = bufferPool.take();
+
+    try {
       final String fudgeTimestampString = NullHandling.emptyToNullIfNeeded(
           query.context().getString(GroupingEngine.CTX_KEY_FUDGE_TIMESTAMP)
       );
@@ -508,6 +510,10 @@ public class GroupingEngine
       }
 
       return result.withBaggage(bufferHolder);
+    }
+    catch (Throwable e) {
+      bufferHolder.close();
+      throw e;
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
@@ -25,14 +25,20 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import org.apache.druid.collections.BlockingPool;
 import org.apache.druid.collections.NonBlockingPool;
 import org.apache.druid.collections.ReferenceCountingResourceHolder;
+import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.annotations.Global;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Merging;
 import org.apache.druid.guice.annotations.Smile;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.collect.Utils;
@@ -57,18 +63,29 @@ import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
-import org.apache.druid.query.groupby.epinephelinae.GroupByBinaryFnV2;
-import org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunnerV2;
-import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2;
+import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.groupby.epinephelinae.BufferArrayGrouper;
+import org.apache.druid.query.groupby.epinephelinae.GroupByMergingQueryRunner;
+import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngine;
+import org.apache.druid.query.groupby.epinephelinae.GroupByResultMergeFn;
 import org.apache.druid.query.groupby.epinephelinae.GroupByRowProcessor;
+import org.apache.druid.query.groupby.epinephelinae.vector.VectorGroupByEngine;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
 import org.apache.druid.query.groupby.orderby.LimitSpec;
 import org.apache.druid.query.groupby.orderby.NoopLimitSpec;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
+import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumns;
+import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.Types;
+import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.join.filter.AllNullColumnSelectorFactory;
 import org.apache.druid.utils.CloseableUtils;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -84,6 +101,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 
+/**
+ * Common code for processing {@link GroupByQuery}.
+ */
 public class GroupingEngine
 {
   public static final String CTX_KEY_FUDGE_TIMESTAMP = "fudgeTimestamp";
@@ -174,7 +194,7 @@ public class GroupingEngine
    */
   public BinaryOperator<ResultRow> createMergeFn(Query<ResultRow> queryParam)
   {
-    return new GroupByBinaryFnV2((GroupByQuery) queryParam);
+    return new GroupByResultMergeFn((GroupByQuery) queryParam);
   }
 
   public GroupByQuery prepareGroupByQuery(GroupByQuery query)
@@ -398,7 +418,7 @@ public class GroupingEngine
       final Iterable<QueryRunner<ResultRow>> queryRunners
   )
   {
-    return new GroupByMergingQueryRunnerV2(
+    return new GroupByMergingQueryRunner(
         configSupplier.get(),
         processingConfig,
         queryProcessingPool,
@@ -430,14 +450,65 @@ public class GroupingEngine
       @Nullable GroupByQueryMetrics groupByQueryMetrics
   )
   {
-    return GroupByQueryEngineV2.process(
-        query,
-        storageAdapter,
-        bufferPool,
-        configSupplier.get().withOverrides(query),
-        processingConfig,
-        groupByQueryMetrics
-    );
+    final GroupByQueryConfig querySpecificConfig = configSupplier.get().withOverrides(query);
+
+    if (storageAdapter == null) {
+      throw new ISE(
+          "Null storage adapter found. Probably trying to issue a query against a segment being memory unmapped."
+      );
+    }
+
+    final List<Interval> intervals = query.getQuerySegmentSpec().getIntervals();
+    if (intervals.size() != 1) {
+      throw new IAE("Should only have one interval, got[%s]", intervals);
+    }
+
+    try (final ResourceHolder<ByteBuffer> bufferHolder = bufferPool.take()) {
+      final String fudgeTimestampString = NullHandling.emptyToNullIfNeeded(
+          query.context().getString(GroupingEngine.CTX_KEY_FUDGE_TIMESTAMP)
+      );
+
+      final DateTime fudgeTimestamp = fudgeTimestampString == null
+                                      ? null
+                                      : DateTimes.utc(Long.parseLong(fudgeTimestampString));
+
+      final Filter filter = Filters.convertToCNFFromQueryContext(query, Filters.toFilter(query.getFilter()));
+      final Interval interval = Iterables.getOnlyElement(query.getIntervals());
+
+      final boolean doVectorize = query.context().getVectorize().shouldVectorize(
+          VectorGroupByEngine.canVectorize(query, storageAdapter, filter)
+      );
+
+      final Sequence<ResultRow> result;
+
+      if (doVectorize) {
+        result = VectorGroupByEngine.process(
+            query,
+            storageAdapter,
+            bufferHolder.get(),
+            fudgeTimestamp,
+            filter,
+            interval,
+            querySpecificConfig,
+            processingConfig,
+            groupByQueryMetrics
+        );
+      } else {
+        result = GroupByQueryEngine.process(
+            query,
+            storageAdapter,
+            bufferHolder.get(),
+            fudgeTimestamp,
+            querySpecificConfig,
+            processingConfig,
+            filter,
+            interval,
+            groupByQueryMetrics
+        );
+      }
+
+      return result.withBaggage(bufferHolder);
+    }
   }
 
   /**
@@ -741,6 +812,89 @@ public class GroupingEngine
     }
 
     return aggsAndPostAggs;
+  }
+
+
+  /**
+   * Returns the cardinality of array needed to do array-based aggregation, or -1 if array-based aggregation
+   * is impossible.
+   */
+  public static int getCardinalityForArrayAggregation(
+      GroupByQueryConfig querySpecificConfig,
+      GroupByQuery query,
+      StorageAdapter storageAdapter,
+      ByteBuffer buffer
+  )
+  {
+    if (querySpecificConfig.isForceHashAggregation()) {
+      return -1;
+    }
+
+    final List<DimensionSpec> dimensions = query.getDimensions();
+    final ColumnCapabilities columnCapabilities;
+    final int cardinality;
+
+    // Find cardinality
+    if (dimensions.isEmpty()) {
+      columnCapabilities = null;
+      cardinality = 1;
+    } else if (dimensions.size() == 1) {
+      // Only real columns can use array-based aggregation, since virtual columns cannot currently report their
+      // cardinality. We need to check if a virtual column exists with the same name, since virtual columns can shadow
+      // real columns, and we might miss that since we're going directly to the StorageAdapter (which only knows about
+      // real columns).
+      if (query.getVirtualColumns().exists(Iterables.getOnlyElement(dimensions).getDimension())) {
+        return -1;
+      }
+      // We cannot support array-based aggregation on array based grouping as we we donot have all the indexes up front
+      // to allocate appropriate values
+      if (dimensions.get(0).getOutputType().isArray()) {
+        return -1;
+      }
+
+      final String columnName = Iterables.getOnlyElement(dimensions).getDimension();
+      columnCapabilities = storageAdapter.getColumnCapabilities(columnName);
+      cardinality = storageAdapter.getDimensionCardinality(columnName);
+    } else {
+      // Cannot use array-based aggregation with more than one dimension.
+      return -1;
+    }
+
+    // Choose array-based aggregation if the grouping key is a single string dimension of a known cardinality
+    if (Types.is(columnCapabilities, ValueType.STRING) && cardinality > 0) {
+      final AggregatorFactory[] aggregatorFactories = query.getAggregatorSpecs().toArray(new AggregatorFactory[0]);
+      final long requiredBufferCapacity = BufferArrayGrouper.requiredBufferCapacity(
+          cardinality,
+          aggregatorFactories
+      );
+
+      // Check that all keys and aggregated values can be contained in the buffer
+      if (requiredBufferCapacity < 0 || requiredBufferCapacity > buffer.capacity()) {
+        return -1;
+      } else {
+        return cardinality;
+      }
+    } else {
+      return -1;
+    }
+  }
+
+  public static void convertRowTypesToOutputTypes(
+      final List<DimensionSpec> dimensionSpecs,
+      final ResultRow resultRow,
+      final int resultRowDimensionStart
+  )
+  {
+    for (int i = 0; i < dimensionSpecs.size(); i++) {
+      DimensionSpec dimSpec = dimensionSpecs.get(i);
+      final int resultRowIndex = resultRowDimensionStart + i;
+      final ColumnType outputType = dimSpec.getOutputType();
+
+      resultRow.set(
+          resultRowIndex,
+          DimensionHandlerUtils.convertObjectToType(resultRow.get(resultRowIndex), outputType)
+      );
+    }
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/BufferArrayGrouper.java
@@ -77,7 +77,7 @@ public class BufferArrayGrouper implements VectorGrouper, IntGrouper
    * Returns -1 if cardinality + 1 (for null) > Integer.MAX_VALUE. Returns computed required buffer capacity
    * otherwise.
    */
-  static long requiredBufferCapacity(int cardinality, AggregatorFactory[] aggregatorFactories)
+  public static long requiredBufferCapacity(int cardinality, AggregatorFactory[] aggregatorFactories)
   {
     final long cardinalityWithMissingValue = computeCardinalityWithMissingValue(cardinality);
     // Cardinality should be in the integer range. See DimensionDictionarySelector.

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByMergingQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByMergingQueryRunner.java
@@ -73,7 +73,7 @@ import java.util.concurrent.TimeoutException;
  * using a buffer provided by {@code mergeBufferPool} and a parallel executor provided by {@code exec}. Outputs a
  * fully aggregated stream of {@link ResultRow} objects. Does not apply post-aggregators.
  *
- * The input {@code queryables} are expected to come from a {@link GroupByQueryEngineV2}. This code runs on data
+ * The input {@code queryables} are expected to come from a {@link GroupByQueryEngine}. This code runs on data
  * servers, like Historicals.
  *
  * This class has some resemblance to {@link GroupByRowProcessor}. See the javadoc of that class for a discussion of
@@ -82,9 +82,9 @@ import java.util.concurrent.TimeoutException;
  * Used by
  * {@link org.apache.druid.query.groupby.GroupingEngine#mergeRunners(QueryProcessingPool, Iterable)}
  */
-public class GroupByMergingQueryRunnerV2 implements QueryRunner<ResultRow>
+public class GroupByMergingQueryRunner implements QueryRunner<ResultRow>
 {
-  private static final Logger log = new Logger(GroupByMergingQueryRunnerV2.class);
+  private static final Logger log = new Logger(GroupByMergingQueryRunner.class);
   private static final String CTX_KEY_MERGE_RUNNERS_USING_CHAINED_EXECUTION = "mergeRunnersUsingChainedExecution";
 
   private final GroupByQueryConfig config;
@@ -98,7 +98,7 @@ public class GroupByMergingQueryRunnerV2 implements QueryRunner<ResultRow>
   private final String processingTmpDir;
   private final int mergeBufferSize;
 
-  public GroupByMergingQueryRunnerV2(
+  public GroupByMergingQueryRunner(
       GroupByQueryConfig config,
       DruidProcessingConfig processingConfig,
       QueryProcessingPool queryProcessingPool,

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByResultMergeFn.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByResultMergeFn.java
@@ -36,11 +36,11 @@ import java.util.function.BinaryOperator;
  * Used by
  * {@link org.apache.druid.query.groupby.GroupingEngine#mergeResults}.
  */
-public class GroupByBinaryFnV2 implements BinaryOperator<ResultRow>
+public class GroupByResultMergeFn implements BinaryOperator<ResultRow>
 {
   private final GroupByQuery query;
 
-  public GroupByBinaryFnV2(GroupByQuery query)
+  public GroupByResultMergeFn(GroupByQuery query)
   {
     this.query = query;
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByRowProcessor.java
@@ -53,7 +53,7 @@ import java.util.UUID;
  *
  * This class has two primary uses: processing nested groupBys, and processing subtotals.
  *
- * This class has some similarity to {@link GroupByMergingQueryRunnerV2}, but is different enough that it deserved to
+ * This class has some similarity to {@link GroupByMergingQueryRunner}, but is different enough that it deserved to
  * be its own class. Some common code between the two classes is in {@link RowBasedGrouperHelper}.
  */
 public class GroupByRowProcessor

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -98,7 +98,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * This class contains shared code between {@link GroupByMergingQueryRunnerV2} and {@link GroupByRowProcessor}.
+ * This class contains shared code between {@link GroupByMergingQueryRunner} and {@link GroupByRowProcessor}.
  */
 public class RowBasedGrouperHelper
 {

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -58,9 +58,9 @@ import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerFactory;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
+import org.apache.druid.query.groupby.GroupingEngine;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.groupby.TestGroupByBuffers;
-import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2;
 import org.apache.druid.query.scan.ScanQueryConfig;
 import org.apache.druid.query.scan.ScanQueryEngine;
 import org.apache.druid.query.scan.ScanQueryQueryToolChest;
@@ -774,7 +774,7 @@ public class AggregationTestHelper implements Closeable
                 resultRows.stream()
                           .peek(row -> {
                             GroupByQuery query = (GroupByQuery) queryPlus.getQuery();
-                            GroupByQueryEngineV2.convertRowTypesToOutputTypes(
+                            GroupingEngine.convertRowTypesToOutputTypes(
                                 query.getDimensions(),
                                 row,
                                 query.getResultRowDimensionStart()

--- a/processing/src/test/java/org/apache/druid/query/groupby/NestedGroupByArrayQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/NestedGroupByArrayQueryTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
-import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -485,7 +484,7 @@ public class NestedGroupByArrayQueryTest
     List<ResultRow> serdeAndBack =
         results.stream()
                .peek(
-                   row -> GroupByQueryEngineV2.convertRowTypesToOutputTypes(
+                   row -> GroupingEngine.convertRowTypesToOutputTypes(
                        query.getDimensions(),
                        row,
                        query.getResultRowDimensionStart()

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngineTest.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class GroupByQueryEngineV2Test
+public class GroupByQueryEngineTest
 {
   private static final String DIM = "d0";
   ColumnSelectorFactory factory;
@@ -51,7 +51,7 @@ public class GroupByQueryEngineV2Test
                                                                   .setDictionaryValuesUnique(true);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).once();
     EasyMock.replay(factory);
-    Assert.assertTrue(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertTrue(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 
@@ -66,7 +66,7 @@ public class GroupByQueryEngineV2Test
                                                                   .setDictionaryValuesUnique(true);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).once();
     EasyMock.replay(factory);
-    Assert.assertFalse(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertFalse(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 
@@ -81,7 +81,7 @@ public class GroupByQueryEngineV2Test
                                                                   .setDictionaryValuesUnique(false);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).once();
     EasyMock.replay(factory);
-    Assert.assertFalse(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertFalse(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 
@@ -96,7 +96,7 @@ public class GroupByQueryEngineV2Test
                                                                   .setDictionaryValuesUnique(false);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).once();
     EasyMock.replay(factory);
-    Assert.assertFalse(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertFalse(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 
@@ -111,11 +111,11 @@ public class GroupByQueryEngineV2Test
                                                                       .setDictionaryValuesUnique(false);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).anyTimes();
     EasyMock.replay(factory);
-    Assert.assertTrue(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertTrue(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     capabilities.setType(ColumnType.DOUBLE);
-    Assert.assertTrue(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertTrue(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     capabilities.setType(ColumnType.FLOAT);
-    Assert.assertTrue(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertTrue(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 
@@ -130,7 +130,7 @@ public class GroupByQueryEngineV2Test
                                                                       .setDictionaryValuesUnique(false);
     EasyMock.expect(factory.getColumnCapabilities(DIM)).andReturn(capabilities).once();
     EasyMock.replay(factory);
-    Assert.assertTrue(GroupByQueryEngineV2.canPushDownLimit(factory, DIM));
+    Assert.assertTrue(GroupByQueryEngine.canPushDownLimit(factory, DIM));
     EasyMock.verify(factory);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/epinephelinae/LimitedBufferHashGrouperTest.java
@@ -434,7 +434,7 @@ public class LimitedBufferHashGrouperTest extends InitializedNullHandlingTest
   }
 
   /**
-   * key serde for more realistic ordering tests, similar to the {@link GroupByQueryEngineV2.GroupByEngineKeySerde} or
+   * key serde for more realistic ordering tests, similar to the {@link GroupByQueryEngine.GroupByEngineKeySerde} or
    * {@link RowBasedGrouperHelper.RowBasedKeySerde} which are likely to be used in practice by the group-by engine,
    * which also both use {@link GrouperBufferComparatorUtils} to make comparators
    */

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -138,24 +138,26 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         );
         ResourceHolder<ByteBuffer> processingBuffer = pool.take()
     ) {
-
+      final GroupByQuery query = GroupByQuery.builder()
+                                             .setDataSource("test")
+                                             .setGranularity(Granularities.ALL)
+                                             .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
+                                             .addDimension("billy")
+                                             .addDimension("sally")
+                                             .addAggregator(new LongSumAggregatorFactory("cnt", "cnt"))
+                                             .addOrderByColumn("billy")
+                                             .build();
+      final Filter filter = Filters.convertToCNFFromQueryContext(query, Filters.toFilter(query.getFilter()));
+      final Interval interval = Iterables.getOnlyElement(query.getIntervals());
       final Sequence<ResultRow> rows = GroupByQueryEngine.process(
-          GroupByQuery.builder()
-                      .setDataSource("test")
-                      .setGranularity(Granularities.ALL)
-                      .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
-                      .addDimension("billy")
-                      .addDimension("sally")
-                      .addAggregator(new LongSumAggregatorFactory("cnt", "cnt"))
-                      .addOrderByColumn("billy")
-                      .build(),
+          query,
           new IncrementalIndexStorageAdapter(index),
           processingBuffer.get(),
           null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
-          null,
-          Intervals.ETERNITY,
+          filter,
+          interval,
           null
       );
 
@@ -200,36 +202,38 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         );
         ResourceHolder<ByteBuffer> processingBuffer = pool.take();
     ) {
-
+      final GroupByQuery query = GroupByQuery.builder()
+                                             .setDataSource("test")
+                                             .setGranularity(Granularities.ALL)
+                                             .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
+                                             .addDimension("billy")
+                                             .addDimension("sally")
+                                             .addAggregator(
+                                                 new LongSumAggregatorFactory("cnt", "cnt")
+                                             )
+                                             .addAggregator(
+                                                 new JavaScriptAggregatorFactory(
+                                                     "fieldLength",
+                                                     Arrays.asList("sally", "billy"),
+                                                     "function(current, s, b) { return current + (s == null ? 0 : s.length) + (b == null ? 0 : b.length); }",
+                                                     "function() { return 0; }",
+                                                     "function(a,b) { return a + b; }",
+                                                     JavaScriptConfig.getEnabledInstance()
+                                                 )
+                                             )
+                                             .addOrderByColumn("billy")
+                                             .build();
+      final Filter filter = Filters.convertToCNFFromQueryContext(query, Filters.toFilter(query.getFilter()));
+      final Interval interval = Iterables.getOnlyElement(query.getIntervals());
       final Sequence<ResultRow> rows = GroupByQueryEngine.process(
-          GroupByQuery.builder()
-                      .setDataSource("test")
-                      .setGranularity(Granularities.ALL)
-                      .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
-                      .addDimension("billy")
-                      .addDimension("sally")
-                      .addAggregator(
-                          new LongSumAggregatorFactory("cnt", "cnt")
-                      )
-                      .addAggregator(
-                          new JavaScriptAggregatorFactory(
-                              "fieldLength",
-                              Arrays.asList("sally", "billy"),
-                              "function(current, s, b) { return current + (s == null ? 0 : s.length) + (b == null ? 0 : b.length); }",
-                              "function() { return 0; }",
-                              "function(a,b) { return a + b; }",
-                              JavaScriptConfig.getEnabledInstance()
-                          )
-                      )
-                      .addOrderByColumn("billy")
-                      .build(),
+          query,
           new IncrementalIndexStorageAdapter(index),
           processingBuffer.get(),
           null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
-          null,
-          Intervals.ETERNITY,
+          filter,
+          interval,
           null
       );
 
@@ -378,23 +382,27 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         ResourceHolder<ByteBuffer> processingBuffer = pool.take();
     ) {
 
+      final GroupByQuery query = GroupByQuery.builder()
+                                             .setDataSource("test")
+                                             .setGranularity(Granularities.ALL)
+                                             .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
+                                             .addDimension("billy")
+                                             .addDimension("sally")
+                                             .addAggregator(new LongSumAggregatorFactory("cnt", "cnt"))
+                                             .setDimFilter(DimFilters.dimEquals("sally", (String) null))
+                                             .build();
+      final Filter filter = Filters.convertToCNFFromQueryContext(query, Filters.toFilter(query.getFilter()));
+      final Interval interval = Iterables.getOnlyElement(query.getIntervals());
+
       final Sequence<ResultRow> rows = GroupByQueryEngine.process(
-          GroupByQuery.builder()
-                      .setDataSource("test")
-                      .setGranularity(Granularities.ALL)
-                      .setInterval(new Interval(DateTimes.EPOCH, DateTimes.nowUtc()))
-                      .addDimension("billy")
-                      .addDimension("sally")
-                      .addAggregator(new LongSumAggregatorFactory("cnt", "cnt"))
-                      .setDimFilter(DimFilters.dimEquals("sally", (String) null))
-                      .build(),
+          query,
           new IncrementalIndexStorageAdapter(index),
           processingBuffer.get(),
           null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
-          null,
-          Intervals.ETERNITY,
+          filter,
+          interval,
           null
       );
 

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexStorageAdapterTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.druid.collections.CloseableStupidPool;
+import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.guice.NestedDataModule;
@@ -50,7 +51,7 @@ import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.ResultRow;
-import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngineV2;
+import org.apache.druid.query.groupby.epinephelinae.GroupByQueryEngine;
 import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.query.topn.TopNQueryEngine;
 import org.apache.druid.query.topn.TopNResultValue;
@@ -134,10 +135,11 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         CloseableStupidPool<ByteBuffer> pool = new CloseableStupidPool<>(
             "GroupByQueryEngine-bufferPool",
             () -> ByteBuffer.allocate(50000)
-        )
+        );
+        ResourceHolder<ByteBuffer> processingBuffer = pool.take()
     ) {
 
-      final Sequence<ResultRow> rows = GroupByQueryEngineV2.process(
+      final Sequence<ResultRow> rows = GroupByQueryEngine.process(
           GroupByQuery.builder()
                       .setDataSource("test")
                       .setGranularity(Granularities.ALL)
@@ -148,9 +150,12 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
                       .addOrderByColumn("billy")
                       .build(),
           new IncrementalIndexStorageAdapter(index),
-          pool,
+          processingBuffer.get(),
+          null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
+          null,
+          Intervals.ETERNITY,
           null
       );
 
@@ -192,10 +197,11 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         CloseableStupidPool<ByteBuffer> pool = new CloseableStupidPool<>(
             "GroupByQueryEngine-bufferPool",
             () -> ByteBuffer.allocate(50000)
-        )
+        );
+        ResourceHolder<ByteBuffer> processingBuffer = pool.take();
     ) {
 
-      final Sequence<ResultRow> rows = GroupByQueryEngineV2.process(
+      final Sequence<ResultRow> rows = GroupByQueryEngine.process(
           GroupByQuery.builder()
                       .setDataSource("test")
                       .setGranularity(Granularities.ALL)
@@ -218,9 +224,12 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
                       .addOrderByColumn("billy")
                       .build(),
           new IncrementalIndexStorageAdapter(index),
-          pool,
+          processingBuffer.get(),
+          null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
+          null,
+          Intervals.ETERNITY,
           null
       );
 
@@ -365,10 +374,11 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
         CloseableStupidPool<ByteBuffer> pool = new CloseableStupidPool<>(
             "GroupByQueryEngine-bufferPool",
             () -> ByteBuffer.allocate(50000)
-        )
+        );
+        ResourceHolder<ByteBuffer> processingBuffer = pool.take();
     ) {
 
-      final Sequence<ResultRow> rows = GroupByQueryEngineV2.process(
+      final Sequence<ResultRow> rows = GroupByQueryEngine.process(
           GroupByQuery.builder()
                       .setDataSource("test")
                       .setGranularity(Granularities.ALL)
@@ -379,9 +389,12 @@ public class IncrementalIndexStorageAdapterTest extends InitializedNullHandlingT
                       .setDimFilter(DimFilters.dimEquals("sally", (String) null))
                       .build(),
           new IncrementalIndexStorageAdapter(index),
-          pool,
+          processingBuffer.get(),
+          null,
           new GroupByQueryConfig(),
           new DruidProcessingConfig(),
+          null,
+          Intervals.ETERNITY,
           null
       );
 


### PR DESCRIPTION
### Description
This PR cleans up some stuff after the removal of group by v1 in #14866 so that stuff is a bit easier to follow. The biggest material change is that all common code of `GroupByQueryEngineV2` that is used by both non-vectorized and vectorized engines has been moved into `GroupingEngine`, including the `process` method which chooses which of non-vectorized and vectorized processing to use, and has been inlined into the `process` method of `GroupingEngine`.  

Other changes:
* `GroupByQueryEngineV2` has been renamed to `GroupByQueryEngine`, and now is totally focused on non-vectorized processing (since shared stuff has been moved into `GroupingEngine`
* `GroupByMergingQueryRunnerV2` has been renamed to `GroupByMergingQueryRunner`
* `GroupByBinaryFnV2` has been renamed to `GroupByResultMergeFn`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] been tested in a test Druid cluster.
