### PR TITLE
docs: update kafka emitter docs for hiddenProperties

### DIFF
--- a/docs/development/extensions-contrib/kafka-emitter.md
+++ b/docs/development/extensions-contrib/kafka-emitter.md
@@ -46,6 +46,9 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 | `druid.emitter.kafka.segmentMetadata.topic`        | Kafka topic name for emitter's target to emit segment metadata. If `event.types` contains `segment_metadata`, this field cannot be empty. | no        | none                  |
 | `druid.emitter.kafka.producer.config`              | JSON configuration to set additional properties to Kafka producer.                                                                        | no        | none                  |
 | `druid.emitter.kafka.clusterName`                  | Optional value to specify the name of your Druid cluster. It can help make groups in your monitoring environment.                         | no        | none                  |
+| `druid.emitter.kafka.producer.hiddenProperties`                  | Optional value to specify sensitive values, such as username and passwords, you need to provide but want to mask in the logs. You'll need to use `druid.emitter.kafka.producer.config` to specify related properties, such as the authentication mechanism if you supply a username and password through this config.                       | no        | none                  |
+
+
 
 ### Example
 
@@ -57,5 +60,7 @@ druid.emitter.kafka.alert.topic=druid-alert
 druid.emitter.kafka.request.topic=druid-request-logs
 druid.emitter.kafka.segmentMetadata.topic=druid-segment-metadata 
 druid.emitter.kafka.producer.config={"max.block.ms":10000}
+druid.emitter.kafka.producer.config={"sasl.mechanism": "PLAIN", "security.protocol": "SASL_SSL"}
+druid.emitter.kafka.producer.hiddenProperties={"config":{"sasl.jaas.config": "org.apache.kafka.common.security.plain.PlainLoginModule required username=\\"KV...NI\\" password=\\"gA3...n6a/\\";"}}
 ```
 


### PR DESCRIPTION
### Description

Adds the new hiddenProperties config from https://github.com/apache/druid/pull/15485

<hr>

This PR has:

- [x] been self-reviewed.
