### PR TITLE
Skip compaction for intervals without data

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -339,6 +339,10 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     while (compactibleSegmentIterator.hasNext()) {
       List<DataSegment> segments = compactibleSegmentIterator.next();
 
+      if (segments.stream().noneMatch(DataSegment::hasData)) {
+        continue;
+      }
+
       final SegmentsToCompact candidates = SegmentsToCompact.from(segments);
       final Interval interval = candidates.getUmbrellaInterval();
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/compact/NewestSegmentFirstIterator.java
@@ -339,7 +339,9 @@ public class NewestSegmentFirstIterator implements CompactionSegmentIterator
     while (compactibleSegmentIterator.hasNext()) {
       List<DataSegment> segments = compactibleSegmentIterator.next();
 
-      if (segments.stream().noneMatch(DataSegment::hasData)) {
+      // Do not compact an interval which comprises of a single tombstone
+      // If there are multiple tombstones in the interval, we may still want to compact them
+      if (segments.size() == 1 && segments.get(0).isTombstone()) {
         continue;
       }
 


### PR DESCRIPTION
Compaction may get stuck on an interval with a tombstone as the compaction will succeed without setting the compaction state due to lack of data.

To prevent this, the segment iterator has been modified to not return any intervals having only a single Tombstone.
However, an interval with a segment with data appended on a Tombstone will be returned.
An interval with multiple tombstones will also be returned to allow condensing them.

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
