### PR TITLE
Fix some naming related to AggregatePullUpLookupRule.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -90,14 +90,14 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
                     false,
                     replaceMissingValueWith,
                     null,
-                    // If SplitLookupRule is disabled, then enable optimization at the extractionFn level, since a
+                    // If LOOKUP pull-up is disabled, then enable optimization at the extractionFn level, since a
                     // similar optimization may be done by the native query toolchests. We'd like to ensure that if
                     // people upgrade to a version where this rule was added, and then disable the rule due to some
                     // problem with it, they still get any optimization that the native layer was able to do.
                     //
                     // Note that we don't check plannerContext.isReverseLookup(), because the native layer doesn't
                     // optimize filters on RegisteredLookupExtractionFn anyway.
-                    !plannerContext.isSplitLookup()
+                    !plannerContext.isPullUpLookup()
                 )
             );
           } else {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -333,7 +333,7 @@ public class CalciteRulesManager
       builder.addRuleInstance(new FilterDecomposeConcatRule());
 
       // Include rule to split injective LOOKUP across a GROUP BY.
-      if (plannerContext.isSplitLookup()) {
+      if (plannerContext.isPullUpLookup()) {
         builder.addRuleInstance(new AggregatePullUpLookupRule(plannerContext));
       }
 


### PR DESCRIPTION
It was called "split" rather than "pull up" in some places. This patch standardizes on "pull up".