### PR TITLE
Lazy, memoized key set in ObjectFlatteners.

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/parsers/ObjectFlatteners.java
@@ -90,7 +90,7 @@ public class ObjectFlatteners
         final Set<String> keys;
 
         if (flattenSpec.isUseFieldDiscovery()) {
-          class KeySet extends ForwardingSet<String>
+          class DiscoveredKeySet extends ForwardingSet<String>
           {
             /**
              * Lazy supplier, because the key set may be requested but then not have any methods called on it.
@@ -118,7 +118,7 @@ public class ObjectFlatteners
             }
           }
 
-          keys = new KeySet();
+          keys = new DiscoveredKeySet();
         } else {
           keys = extractors.keySet();
         }


### PR DESCRIPTION
Useful for two reasons. First, we don't need to recompute the key set on every call to `keySet()`, `size()`, etc. Second, because when dimension discovery is *not* enabled, the parser requests the key set but does not call any methods on it. When the key set is lazy, we can avoid computing it entirely.

Benchmarks:

```
Benchmark                         Mode  Cnt     Score    Error  Units
JsonLineReaderBenchmark.baseline  avgt    5  2055.294 ± 28.688  us/op [before]
JsonLineReaderBenchmark.baseline  avgt   25  1755.839 ±  4.062  us/op [after]
JsonLineReaderBenchmark.baseline  avgt    5  1505.401 ± 19.889  us/op [this patch + #15681]
```