### PR TITLE
Add new context parameter for using concurrent locks

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -380,6 +380,10 @@ public class MultiStageQueryContext
    */
   public static TaskLockType validateAndGetTaskLockType(QueryContext queryContext, boolean isReplaceQuery)
   {
+    final boolean useConcurrentLocks = queryContext.getBoolean(Tasks.USE_CONCURRENT_LOCKS, false);
+    if (useConcurrentLocks) {
+      return isReplaceQuery ? TaskLockType.REPLACE : TaskLockType.APPEND;
+    }
     final TaskLockType taskLockType = QueryContexts.getAsEnum(
         Tasks.TASK_LOCK_TYPE,
         queryContext.getString(Tasks.TASK_LOCK_TYPE, null),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -380,7 +380,10 @@ public class MultiStageQueryContext
    */
   public static TaskLockType validateAndGetTaskLockType(QueryContext queryContext, boolean isReplaceQuery)
   {
-    final boolean useConcurrentLocks = queryContext.getBoolean(Tasks.USE_CONCURRENT_LOCKS, false);
+    final boolean useConcurrentLocks = queryContext.getBoolean(
+        Tasks.USE_CONCURRENT_LOCKS,
+        Tasks.DEFAULT_USE_CONCURRENT_LOCKS
+    );
     if (useConcurrentLocks) {
       return isReplaceQuery ? TaskLockType.REPLACE : TaskLockType.APPEND;
     }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.msq.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.indexing.common.TaskLockType;
+import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.msq.indexing.destination.MSQSelectDestination;
 import org.apache.druid.msq.kernel.WorkerAssignmentStrategy;
 import org.apache.druid.query.BadQueryContextException;
@@ -291,6 +293,22 @@ public class MultiStageQueryContextTest
         e,
         ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
             "Expected key [indexSpec] to be an indexSpec, but got [{]"))
+    );
+  }
+
+  @Test
+  public void testUseConcurrentLocks()
+  {
+    final QueryContext context = QueryContext.of(ImmutableMap.of(Tasks.USE_CONCURRENT_LOCKS, true));
+
+    Assert.assertEquals(
+        TaskLockType.REPLACE,
+        MultiStageQueryContext.validateAndGetTaskLockType(context, true)
+    );
+
+    Assert.assertEquals(
+        TaskLockType.APPEND,
+        MultiStageQueryContext.validateAndGetTaskLockType(context, false)
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
@@ -151,6 +151,10 @@ public class TaskLocks
       Map<String, Object> taskContext
   )
   {
+    final boolean useConcurrentLocks = (boolean) taskContext.getOrDefault(Tasks.USE_CONCURRENT_LOCKS, false);
+    if (useConcurrentLocks) {
+      return TaskLockType.APPEND;
+    }
     final Object lockType = taskContext.get(Tasks.TASK_LOCK_TYPE);
     if (lockType == null) {
       final boolean useSharedLock = (boolean) taskContext.getOrDefault(Tasks.USE_SHARED_LOCK, false);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
@@ -151,7 +151,10 @@ public class TaskLocks
       Map<String, Object> taskContext
   )
   {
-    final boolean useConcurrentLocks = (boolean) taskContext.getOrDefault(Tasks.USE_CONCURRENT_LOCKS, false);
+    final boolean useConcurrentLocks = (boolean) taskContext.getOrDefault(
+        Tasks.USE_CONCURRENT_LOCKS,
+        Tasks.DEFAULT_USE_CONCURRENT_LOCKS
+    );
     if (useConcurrentLocks) {
       return TaskLockType.APPEND;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -484,6 +484,16 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
       return TaskLockType.EXCLUSIVE;
     }
 
+    final boolean useConcurrentLocks = QueryContexts.getAsBoolean(
+        Tasks.USE_CONCURRENT_LOCKS,
+        getContextValue(Tasks.USE_CONCURRENT_LOCKS),
+        false
+    );
+    final IngestionMode ingestionMode = getIngestionMode();
+    if (useConcurrentLocks) {
+      return ingestionMode == IngestionMode.APPEND ? TaskLockType.APPEND : TaskLockType.REPLACE;
+    }
+
     final TaskLockType contextTaskLockType = QueryContexts.getAsEnum(
         Tasks.TASK_LOCK_TYPE,
         getContextValue(Tasks.TASK_LOCK_TYPE),
@@ -498,7 +508,6 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
       lockType = contextTaskLockType;
     }
 
-    final IngestionMode ingestionMode = getIngestionMode();
     if ((lockType == TaskLockType.SHARED || lockType == TaskLockType.APPEND)
         && ingestionMode != IngestionMode.APPEND) {
       // Lock types SHARED and APPEND are allowed only in APPEND ingestion mode

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -487,7 +487,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
     final boolean useConcurrentLocks = QueryContexts.getAsBoolean(
         Tasks.USE_CONCURRENT_LOCKS,
         getContextValue(Tasks.USE_CONCURRENT_LOCKS),
-        false
+        Tasks.DEFAULT_USE_CONCURRENT_LOCKS
     );
     final IngestionMode ingestionMode = getIngestionMode();
     if (useConcurrentLocks) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -49,6 +49,7 @@ public class Tasks
   public static final boolean DEFAULT_STORE_COMPACTION_STATE = false;
   public static final boolean DEFAULT_USE_MAX_MEMORY_ESTIMATES = false;
   public static final TaskLockType DEFAULT_TASK_LOCK_TYPE = TaskLockType.EXCLUSIVE;
+  public static final boolean DEFAULT_USE_CONCURRENT_LOCKS = false;
 
   public static final String PRIORITY_KEY = "priority";
   public static final String LOCK_TIMEOUT_KEY = "taskLockTimeout";

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -56,6 +56,7 @@ public class Tasks
   public static final String STORE_EMPTY_COLUMNS_KEY = "storeEmptyColumns";
   public static final String USE_SHARED_LOCK = "useSharedLock";
   public static final String TASK_LOCK_TYPE = "taskLockType";
+  public static final String USE_CONCURRENT_LOCKS = "useConcurrentLocks";
 
   /**
    * Context flag denoting if maximum possible values should be used to estimate

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
@@ -338,6 +338,17 @@ public class TaskLocksTest
   }
 
   @Test
+  public void testLockTypeForAppendUsingConcurrentLocks()
+  {
+    Assert.assertEquals(
+        TaskLockType.APPEND,
+        TaskLocks.determineLockTypeForAppend(
+            ImmutableMap.of(Tasks.USE_CONCURRENT_LOCKS, true)
+        )
+    );
+  }
+
+  @Test
   public void testLockTypeForAppendWithLockTypeInContext()
   {
     Assert.assertEquals(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -1313,14 +1313,14 @@ public class TaskLockboxTest
         Intervals.of("2017/2018")
     );
 
-    LockFilterPolicy requestForExclusiveLowerPriorityLock = new LockFilterPolicy(
+    LockFilterPolicy requestForReplaceLowerPriorityLock = new LockFilterPolicy(
         task.getDataSource(),
         25,
         ImmutableMap.of(Tasks.TASK_LOCK_TYPE, TaskLockType.REPLACE.name())
     );
 
     Map<String, List<Interval>> conflictingIntervals =
-        lockbox.getLockedIntervals(ImmutableList.of(requestForExclusiveLowerPriorityLock));
+        lockbox.getLockedIntervals(ImmutableList.of(requestForReplaceLowerPriorityLock));
     Assert.assertTrue(conflictingIntervals.isEmpty());
   }
 


### PR DESCRIPTION
This PR introduces a new task context flag `useConcurrentLocks`. 
This can be set for an individual task or at a cluster level using `druid.indexer.task.default.context`.

When set to true any appending task would use an APPEND lock and any other ingestion task would use a REPLACE lock when using time chunk locking. 
If not, we fall back on the context flag `taskLockType` and then `useSharedLock`.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
