### PR TITLE
Better error message when partition space is exhausted

### DIFF
--- a/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -403,9 +403,9 @@ class OvershadowableManager<T extends Overshadowable<T>>
       TreeMap<RootPartitionRange, Short2ObjectSortedMap<AtomicUpdateGroup<T>>> stateMap
   )
   {
-    final RootPartitionRange lowFench = new RootPartitionRange((short) 0, (short) 0);
+    final RootPartitionRange lowFence = new RootPartitionRange((short) 0, (short) 0);
     final RootPartitionRange highFence = new RootPartitionRange(partitionId, partitionId);
-    return stateMap.subMap(lowFench, false, highFence, false).descendingMap().entrySet().iterator();
+    return stateMap.subMap(lowFence, false, highFence, false).descendingMap().entrySet().iterator();
   }
 
   /**
@@ -418,9 +418,12 @@ class OvershadowableManager<T extends Overshadowable<T>>
       TreeMap<RootPartitionRange, Short2ObjectSortedMap<AtomicUpdateGroup<T>>> stateMap
   )
   {
-    final RootPartitionRange lowFench = new RootPartitionRange(partitionId, partitionId);
+    final RootPartitionRange lowFence = new RootPartitionRange(partitionId, partitionId);
     final RootPartitionRange highFence = new RootPartitionRange(Short.MAX_VALUE, Short.MAX_VALUE);
-    return stateMap.subMap(lowFench, false, highFence, false).entrySet().iterator();
+    if (lowFence.compareTo(highFence) > 0) {
+      throw new ISE("PartitionId[%d] must be in the range [0, 32767].", Short.toUnsignedInt(partitionId));
+    }
+    return stateMap.subMap(lowFence, false, highFence, false).entrySet().iterator();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/OvershadowableManager.java
@@ -421,9 +421,11 @@ class OvershadowableManager<T extends Overshadowable<T>>
     final RootPartitionRange lowFence = new RootPartitionRange(partitionId, partitionId);
     final RootPartitionRange highFence = new RootPartitionRange(Short.MAX_VALUE, Short.MAX_VALUE);
     if (lowFence.compareTo(highFence) > 0) {
-      throw new ISE("PartitionId[%d] must be in the range [0, 32767].", Short.toUnsignedInt(partitionId));
+      throw new ISE("PartitionId[%d] must be in the range [0, 32767]. "
+                    + "Try compacting the interval to reduce the segment count.", Short.toUnsignedInt(partitionId));
+    } else {
+      return stateMap.subMap(lowFence, false, highFence, false).entrySet().iterator();
     }
-    return stateMap.subMap(lowFence, false, highFence, false).entrySet().iterator();
   }
 
   /**


### PR DESCRIPTION
Segment locking introduced a limitation where the partition id of a segment must lie within [0, 32767]. When the partitionId falls outside this range, a cryptic error `fromKey  > toKey` can be thrown.
This PR is an attempt to improve the error message when the partition space is exhausted.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
