### PR TITLE
update version check for profiling to >= 17

### DIFF
--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -25,9 +25,16 @@ if [ "$#" -ne 5 ]; then
     echo "usage: $0 <jdk_version> <run_id> <run_number> <run_attempt> <module>"
 fi
 
-if [[ "$1" == "17" ]];
+if [[ "$1" -ge "17" ]];
 then
   curl https://static.imply.io/cp/$JAR_INPUT_FILE -s -o $JAR_OUTPUT_FILE
+
+  # Run 'java -version' and capture the output
+  output=$(java -version 2>&1)
+
+  # Extract the version number using grep and awk
+  jvm_version=$(echo "$output" | grep "version" | awk -F '"' '{print $2}')
+
 
   echo $ENV_VAR=-javaagent:"$PWD"/$JAR_OUTPUT_FILE \
   -Djfr.profiler.http.username=druid-ci \
@@ -36,7 +43,8 @@ then
   -Djfr.profiler.tags.run_id=$2 \
   -Djfr.profiler.tags.run_number=$3 \
   -Djfr.profiler.tags.run_attempt=$4 \
-  -Djfr.profiler.tags.module=$5
+  -Djfr.profiler.tags.module=$5 \
+  -Djfr.profiler.tags.jvm_version=$jvm_version
 else
   echo $ENV_VAR=\"\"
 fi


### PR DESCRIPTION
This changes the JFR profiling version from == 17 to >= 17 

#### Renamed the class ...
#### Added a forbidden-apis entry ...


#### Release note
none

<hr>

##### Key changed/added classes in this PR
<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
