### PR TITLE
Implement task payload management with azure storage

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureTaskLogs.java
@@ -100,6 +100,20 @@ public class AzureTaskLogs implements TaskLogs
   }
 
   @Override
+  public void pushTaskPayload(String taskid, File taskPayloadFile)
+  {
+    final String taskKey = getTaskPayloadKey(taskid);
+    log.info("Pushing task payload [%s] to location [%s]", taskPayloadFile, taskKey);
+    pushTaskFile(taskPayloadFile, taskKey);
+  }
+
+  @Override
+  public Optional<InputStream> streamTaskPayload(String taskid) throws IOException
+  {
+    return streamTaskFile(taskid, 0, getTaskPayloadKey(taskid));
+  }
+
+  @Override
   public Optional<InputStream> streamTaskLog(final String taskid, final long offset) throws IOException
   {
     return streamTaskFile(taskid, offset, getTaskLogKey(taskid));
@@ -164,6 +178,11 @@ public class AzureTaskLogs implements TaskLogs
   private String getTaskStatusKey(String taskid)
   {
     return StringUtils.format("%s/%s/status.json", config.getPrefix(), taskid);
+  }
+
+  private String getTaskPayloadKey(String taskid)
+  {
+    return StringUtils.format("%s/%s/task.json", config.getPrefix(), taskid);
   }
 
   @Override


### PR DESCRIPTION
### Description
Implement pushTaskPayload/streamTaskPayload for azure blob storage so mmless ingestion can run with larger ingestion payloads when using azure as the deep storage location.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

Currently, if you try running mmless ingestion with azure blob storage as the deep storage provider and use a task payload that is too large, the task logs will throw a NotImplementedException because the relevant functions are not implemented.


#### Release note
Support ingestion payloads larger than ~1MB for mmless ingestion on azure.

##### Key changed/added classes in this PR
 * `AzureTaskLogs`
 * `AzureTaskLogsTest`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
