### PR TITLE
Fix comparator and remove deprecated methods from spectatorHistogram extension

### DIFF
--- a/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramAggregatorFactory.java
+++ b/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramAggregatorFactory.java
@@ -33,7 +33,6 @@ import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.column.ColumnType;
-import org.apache.druid.segment.column.ValueType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramAggregatorFactory.java
+++ b/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramAggregatorFactory.java
@@ -32,6 +32,7 @@ import org.apache.druid.query.aggregation.ObjectAggregateCombiner;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 
 import javax.annotation.Nonnull;
@@ -54,6 +55,7 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
   private final byte cacheTypeId;
 
   public static final String TYPE_NAME = "spectatorHistogram";
+  public static final ColumnType TYPE = ColumnType.ofComplex(TYPE_NAME);
 
   @JsonCreator
   public SpectatorHistogramAggregatorFactory(
@@ -148,17 +150,6 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public List<AggregatorFactory> getRequiredColumns()
-  {
-    return Collections.singletonList(
-        new SpectatorHistogramAggregatorFactory(
-            fieldName,
-            fieldName
-        )
-    );
-  }
-
-  @Override
   public Object deserialize(Object serializedHistogram)
   {
     return SpectatorHistogram.deserialize(serializedHistogram);
@@ -191,21 +182,15 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  public String getComplexTypeName()
+  public ColumnType getIntermediateType()
   {
-    return TYPE_NAME;
+    return TYPE;
   }
 
   @Override
-  public ValueType getType()
+  public ColumnType getResultType()
   {
-    return ValueType.COMPLEX;
-  }
-
-  @Override
-  public ValueType getFinalizedType()
-  {
-    return ValueType.COMPLEX;
+    return TYPE;
   }
 
   @Override
@@ -290,6 +275,7 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
   public static class Timer extends SpectatorHistogramAggregatorFactory
   {
     public static final String TYPE_NAME = "spectatorHistogramTimer";
+    public static final ColumnType TYPE = ColumnType.ofComplex(TYPE_NAME);
 
     public Timer(
         @JsonProperty("name") final String name,
@@ -305,9 +291,15 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
     }
 
     @Override
-    public String getComplexTypeName()
+    public ColumnType getIntermediateType()
     {
-      return TYPE_NAME;
+      return TYPE;
+    }
+
+    @Override
+    public ColumnType getResultType()
+    {
+      return TYPE;
     }
 
     @Override
@@ -315,23 +307,13 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
     {
       return new SpectatorHistogramAggregatorFactory.Timer(getName(), getName());
     }
-
-    @Override
-    public List<AggregatorFactory> getRequiredColumns()
-    {
-      return Collections.singletonList(
-          new SpectatorHistogramAggregatorFactory.Timer(
-              getFieldName(),
-              getFieldName()
-          )
-      );
-    }
   }
 
   @JsonTypeName(SpectatorHistogramAggregatorFactory.Distribution.TYPE_NAME)
   public static class Distribution extends SpectatorHistogramAggregatorFactory
   {
     public static final String TYPE_NAME = "spectatorHistogramDistribution";
+    public static final ColumnType TYPE = ColumnType.ofComplex(TYPE_NAME);
 
     public Distribution(
         @JsonProperty("name") final String name,
@@ -347,26 +329,21 @@ public class SpectatorHistogramAggregatorFactory extends AggregatorFactory
     }
 
     @Override
-    public String getComplexTypeName()
+    public ColumnType getIntermediateType()
     {
-      return TYPE_NAME;
+      return TYPE;
+    }
+
+    @Override
+    public ColumnType getResultType()
+    {
+      return TYPE;
     }
 
     @Override
     public AggregatorFactory getCombiningFactory()
     {
       return new SpectatorHistogramAggregatorFactory.Distribution(getName(), getName());
-    }
-
-    @Override
-    public List<AggregatorFactory> getRequiredColumns()
-    {
-      return Collections.singletonList(
-          new SpectatorHistogramAggregatorFactory.Distribution(
-              getFieldName(),
-              getFieldName()
-          )
-      );
     }
   }
 }

--- a/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramPercentilesPostAggregator.java
+++ b/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramPercentilesPostAggregator.java
@@ -22,7 +22,6 @@ package org.apache.druid.spectator.histogram;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Doubles;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.PostAggregatorIds;

--- a/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramPercentilesPostAggregator.java
+++ b/extensions-contrib/spectator-histogram/src/main/java/org/apache/druid/spectator/histogram/SpectatorHistogramPercentilesPostAggregator.java
@@ -91,9 +91,9 @@ public class SpectatorHistogramPercentilesPostAggregator implements PostAggregat
   }
 
   @Override
-  public Comparator<Double> getComparator()
+  public Comparator<Object> getComparator()
   {
-    return Doubles::compare;
+    return ColumnType.DOUBLE_ARRAY.getStrategy();
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/PassthroughAggregatorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/PassthroughAggregatorFactory.java
@@ -73,13 +73,6 @@ public class PassthroughAggregatorFactory extends AggregatorFactory
   }
 
   @Override
-  @JsonProperty
-  public String getComplexTypeName()
-  {
-    return complexTypeName;
-  }
-
-  @Override
   public byte[] getCacheKey()
   {
     throw new UnsupportedOperationException();


### PR DESCRIPTION
Fix comparator and remove deprecated methods from spectatorHistogram extension

### Description
This is a followup to https://github.com/apache/druid/pull/15340#pullrequestreview-1819254598
and include the following fixes:
- Fix correct Comparator for double array type in SpectatorHistogramPercentilesPostAggregator
- Remove deprecated methods from SpectatorHistogramAggregatorFactory

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
