### PR TITLE
Fix incorrect scale when reading decimal from parquet

### DIFF
--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
@@ -426,8 +426,12 @@ public class ParquetGroupConverter
             int scale = pt.asPrimitiveType().getDecimalMetadata().getScale();
             switch (pt.getPrimitiveTypeName()) {
               case INT32:
+                // The primitive returned from Group is an unscaledValue.
+                // We need to do unscaledValue * 10^(-scale) to convert back to decimal
                 return new BigDecimal(g.getInteger(fieldIndex, index)).movePointLeft(scale);
               case INT64:
+                // The primitive returned from Group is an unscaledValue.
+                // We need to do unscaledValue * 10^(-scale) to convert back to decimal
                 return new BigDecimal(g.getLong(fieldIndex, index)).movePointLeft(scale);
               case FIXED_LEN_BYTE_ARRAY:
               case BINARY:

--- a/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
+++ b/extensions-core/parquet-extensions/src/main/java/org/apache/druid/data/input/parquet/simple/ParquetGroupConverter.java
@@ -426,9 +426,9 @@ public class ParquetGroupConverter
             int scale = pt.asPrimitiveType().getDecimalMetadata().getScale();
             switch (pt.getPrimitiveTypeName()) {
               case INT32:
-                return new BigDecimal(g.getInteger(fieldIndex, index));
+                return new BigDecimal(g.getInteger(fieldIndex, index)).movePointLeft(scale);
               case INT64:
-                return new BigDecimal(g.getLong(fieldIndex, index));
+                return new BigDecimal(g.getLong(fieldIndex, index)).movePointLeft(scale);
               case FIXED_LEN_BYTE_ARRAY:
               case BINARY:
                 Binary value = g.getBinary(fieldIndex, index);

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
@@ -62,6 +62,35 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
         parserType,
         true
     );
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(fixed_len_dec) ############
+    name: fixed_len_dec
+    path: fixed_len_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: FIXED_LEN_BYTE_ARRAY
+    logical_type: Decimal(precision=10, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0.0
+    1.0
+    2.0
+    3.0
+    4.0
+    5.0
+    6.0
+    7.0
+    8.0
+    9.0
+    0.0
+    1.0
+    2.0
+    3.0
+    4.0
+    5.0
+     */
     List<InputRow> rows = getAllRows(parserType, config);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
     Assert.assertEquals("1.0", rows.get(0).getDimension("fixed_len_dec").get(0));
@@ -80,10 +109,39 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
         parserType,
         true
     );
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(i32_dec) ############
+    name: i32_dec
+    path: i32_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: INT32
+    logical_type: Decimal(precision=5, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+    6.00
+    7.00
+    8.00
+    9.00
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+     */
     List<InputRow> rows = getAllRows(parserType, config);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("100", rows.get(0).getDimension("i32_dec").get(0));
-    Assert.assertEquals(new BigDecimal(100), rows.get(0).getMetric("metric1"));
+    Assert.assertEquals("1.00", rows.get(0).getDimension("i32_dec").get(0));
+    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(0).getMetric("metric1"));
   }
 
   @Test
@@ -98,9 +156,38 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
         parserType,
         true
     );
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(i64_dec) ############
+    name: i64_dec
+    path: i64_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: INT64
+    logical_type: Decimal(precision=10, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+    6.00
+    7.00
+    8.00
+    9.00
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+     */
     List<InputRow> rows = getAllRows(parserType, config);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("100", rows.get(0).getDimension("i64_dec").get(0));
-    Assert.assertEquals(new BigDecimal(100), rows.get(0).getMetric("metric1"));
+    Assert.assertEquals("1.00", rows.get(0).getDimension("i64_dec").get(0));
+    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(0).getMetric("metric1"));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetReaderTest.java
@@ -63,6 +63,36 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
 
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(fixed_len_dec) ############
+    name: fixed_len_dec
+    path: fixed_len_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: FIXED_LEN_BYTE_ARRAY
+    logical_type: Decimal(precision=10, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0.0
+    1.0
+    2.0
+    3.0
+    4.0
+    5.0
+    6.0
+    7.0
+    8.0
+    9.0
+    0.0
+    1.0
+    2.0
+    3.0
+    4.0
+    5.0
+     */
+
     List<InputRow> rows = readAllRows(reader);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
     Assert.assertEquals("1.0", rows.get(1).getDimension("fixed_len_dec").get(0));
@@ -100,10 +130,40 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
 
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(i32_dec) ############
+    name: i32_dec
+    path: i32_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: INT32
+    logical_type: Decimal(precision=5, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+    6.00
+    7.00
+    8.00
+    9.00
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+     */
+
     List<InputRow> rows = readAllRows(reader);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("100", rows.get(1).getDimension("i32_dec").get(0));
-    Assert.assertEquals(new BigDecimal(100), rows.get(1).getMetric("metric1"));
+    Assert.assertEquals("1.00", rows.get(1).getDimension("i32_dec").get(0));
+    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
 
     reader = createReader(
         file,
@@ -112,7 +172,7 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     final String expectedJson = "{\n"
-                                + "  \"i32_dec\" : 100\n"
+                                + "  \"i32_dec\" : 1.00\n"
                                 + "}";
     Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
   }
@@ -137,10 +197,40 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
 
+    /*
+    The raw data in the parquet file has the following columns:
+    ############ Column(i64_dec) ############
+    name: i64_dec
+    path: i64_dec
+    max_definition_level: 1
+    max_repetition_level: 0
+    physical_type: INT64
+    logical_type: Decimal(precision=10, scale=2)
+    converted_type (legacy): DECIMAL
+
+    The raw data in the parquet file has the following rows:
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+    6.00
+    7.00
+    8.00
+    9.00
+    0
+    1.00
+    2.00
+    3.00
+    4.00
+    5.00
+     */
+
     List<InputRow> rows = readAllRows(reader);
     Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("100", rows.get(1).getDimension("i64_dec").get(0));
-    Assert.assertEquals(new BigDecimal(100), rows.get(1).getMetric("metric1"));
+    Assert.assertEquals("1.00", rows.get(1).getDimension("i64_dec").get(0));
+    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
 
     reader = createReader(
         file,
@@ -149,7 +239,7 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     final String expectedJson = "{\n"
-                                + "  \"i64_dec\" : 100\n"
+                                + "  \"i64_dec\" : 1.00\n"
                                 + "}";
     Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
   }


### PR DESCRIPTION
Fix incorrect scale when reading decimal from parquet

### Description
Getting the Primitive from Group gives us back unscaledValue. We need to do unscaledValue * 10^(-scale) as explained in https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal. The solution used here is similar to https://github.com/apache/parquet-mr/pull/530 (which is using the movePointLeft method of BigDecimal to adjust based on the scale value)

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
