### PR TITLE
Web console: allow segment table to sort on start and end when grouped

### DIFF
--- a/web-console/src/react-table/react-table-extra.scss
+++ b/web-console/src/react-table/react-table-extra.scss
@@ -26,6 +26,10 @@
     .rt-td.padded,
     .rt-expandable {
       padding: $table-cell-v-padding $table-cell-h-padding;
+
+      .default-aggregated {
+        padding: 0;
+      }
     }
   }
 

--- a/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
+++ b/web-console/src/views/segments-view/__snapshots__/segments-view.spec.tsx.snap
@@ -218,6 +218,7 @@ exports[`SegmentsView matches snapshot 1`] = `
             "width": 100,
           },
           Object {
+            "Aggregated": [Function],
             "Cell": [Function],
             "Header": "Shard spec",
             "accessor": "shard_spec",


### PR DESCRIPTION
Propagate the `start` and `end` sort on to the grouped interval table allowing sort on start and end to work when grouping by interval.