### PR TITLE
Remove documentation for unused segments retrieval API

### DIFF
--- a/docs/api-reference/legacy-metadata-api.md
+++ b/docs/api-reference/legacy-metadata-api.md
@@ -248,16 +248,6 @@ Returns full segment metadata for a specific segment in the cluster.
 
 Return the tiers that a datasource exists in.
 
-`GET /druid/coordinator/v1/datasources/{dataSourceName}/unusedSegments?interval={interval}&limit={limit}&lastSegmentId={lastSegmentId}&sortOrder={sortOrder}`
-
-Returns a list of unused segments for a datasource in the cluster contained within an optionally specified interval.
-Optional parameters for limit and lastSegmentId can be given as well, to limit results and enable paginated results.
-The results may be sorted in either ASC, or DESC order concerning their id, start, and end time, depending on
-specifying the sortOrder parameter. The default behavior in the absence of all optional parameters is to return all
-unused segments for the given datasource in no guaranteed order.
-
-Example usage: `GET /druid/coordinator/v1/datasources/inline_data/unusedSegments?interval=2023-12-01_2023-12-10&limit=10&lastSegmentId=inline_data_2023-12-03T00%3A00%3A00.000Z_2023-12-04T00%3A00%3A00.000Z_2023-12-09T14%3A16%3A53.738Z&sortOrder=ASC}`
-
 ## Intervals
 
 Note that all _interval_ URL parameters are ISO 8601 strings delimited by a `_` instead of a `/` as in `2016-06-27_2016-06-28`.

--- a/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
+import io.netty.util.internal.UnstableApi;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.error.InvalidInput;
@@ -337,6 +338,11 @@ public class MetadataResource
     return builder.entity(Collections2.transform(segments, DataSegment::getId)).build();
   }
 
+  /**
+   * Do not use this API. It will be removed and eventually replaced by a SQL systems table.
+   */
+  @Deprecated
+  @UnstableApi
   @GET
   @Path("/datasources/{dataSourceName}/unusedSegments")
   @Produces(MediaType.APPLICATION_JSON)

--- a/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
-import io.netty.util.internal.UnstableApi;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
 import org.apache.druid.error.InvalidInput;
@@ -338,11 +337,6 @@ public class MetadataResource
     return builder.entity(Collections2.transform(segments, DataSegment::getId)).build();
   }
 
-  /**
-   * Do not use this API. It will be removed and eventually replaced by a SQL systems table.
-   */
-  @Deprecated
-  @UnstableApi
   @GET
   @Path("/datasources/{dataSourceName}/unusedSegments")
   @Produces(MediaType.APPLICATION_JSON)

--- a/website/.spelling
+++ b/website/.spelling
@@ -374,7 +374,6 @@ kubernetes
 kubexit
 k8s
 laning
-lastSegmentId
 lifecycle
 localhost
 log4j
@@ -504,7 +503,6 @@ Smoosh
 smoosh
 smooshed
 snapshotting
-sortOrder
 splittable
 ssl
 sslmode


### PR DESCRIPTION
Remove documentation for `/unusedSegments` coordinator API added in https://github.com/apache/druid/pull/15415/.

We'll wire up changes to a systems SQL table in a follow-up patch instead.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
