### PR TITLE
Close open segments contained by interval of higher version open segments

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriver.java
@@ -43,12 +43,14 @@ import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.realtime.FireDepartmentMetrics;
 import org.apache.druid.segment.realtime.appenderator.SegmentWithState.SegmentState;
 import org.apache.druid.timeline.DataSegment;
+import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -207,7 +209,7 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
 
       for (final SegmentIdWithShardSpec identifier : identifiers) {
         log.info("Moving segment[%s] out of active list.", identifier);
-        final long key = identifier.getInterval().getStartMillis();
+        final Interval key = identifier.getInterval();
         final SegmentsOfInterval segmentsOfInterval = activeSegmentsForSequence.get(key);
         if (segmentsOfInterval == null ||
             segmentsOfInterval.getAppendingSegment() == null ||
@@ -457,11 +459,11 @@ public class StreamAppenderatorDriver extends BaseAppenderatorDriver
 
     SegmentsForSequence build()
     {
-      final NavigableMap<Long, SegmentsOfInterval> map = new TreeMap<>();
+      final Map<Interval, SegmentsOfInterval> map = new HashMap<>();
       for (Entry<SegmentIdWithShardSpec, Pair<SegmentWithState, List<SegmentWithState>>> entry :
           intervalToSegments.entrySet()) {
         map.put(
-            entry.getKey().getInterval().getStartMillis(),
+            entry.getKey().getInterval(),
             new SegmentsOfInterval(entry.getKey().getInterval(), entry.getValue().lhs, entry.getValue().rhs)
         );
       }


### PR DESCRIPTION
With concurrent append and replace, a streaming task may have several hour granular segments, and coarser day granular segments may be allocated when a concurrent replace with day granularity occurs.

Streaming ingestion may fail due to the presence of overlapping intervals of open segments with an error like:
Encountered exception while running task.
`java.lang.IllegalStateException: Current appendingSegment[SegmentWithState{segmentIdentifier=quickstart-events_1980-04-01T00:00:00.000Z_1980-04-02T00:00:00.000Z_1970-01-01T00:00:00.000Z_5, state=APPENDING}] is not null. Its state must be changed before setting a new appendingSegment[SegmentWithState{segmentIdentifier=quickstart-events_1980-04-01T00:00:00.000Z_1980-05-01T00:00:00.000Z_2024-01-11T03:30:41.627Z_13, state=APPENDING}]
`

This PR attempts to use an interval instead of the start time in SegmentsForSequence as the key, and close any segments of lower versions when a higher version segment with an interval that contains the existing segments' is added.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
