### PR TITLE
Fix AzureStorage.batchDeleteFiles

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -175,7 +175,7 @@ public class AzureStorage
   {
 
     BlobBatchClient blobBatchClient = new BlobBatchClientBuilder(getOrCreateBlobContainerClient(containerName, maxAttempts)).buildClient();
-    blobBatchClient.deleteBlobs(Lists.newArrayList(paths), DeleteSnapshotsOptionType.ONLY);
+    blobBatchClient.deleteBlobs(Lists.newArrayList(paths), DeleteSnapshotsOptionType.INCLUDE);
   }
 
   public List<String> listDir(final String containerName, final String virtualDirPath, final Integer maxAttempts)


### PR DESCRIPTION
Fixes a utility function in Azure Storage.

### Description

Currently the batchDeleteFiles method in AzureStorage calls BlobBatchClient.deleteBlobs with DeleteSnapshotsOptionType.ONLY. This will only delete the snapshots and not the actual blob (https://stackoverflow.com/questions/70880598/azure-blob-deletion-using-azure-storage-blob-and-nodejs)

Currently this utility method is used in one place, by the azure MSQE storage connector to cleanup intermediate files. Without this fix, those files will hang around until the task log cleaner cleans them up.

I tested this in a test druid + azure setup. I don't think a unit test is going to be very useful but i can look into a integration test.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

Fixed a bug with MSQE intermediate file cleanup.

#### Release note
- Azure + MSQE durable storage cleanup bugfix.


<hr>

##### Key changed/added classes in this PR
 * `AzureStorage`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
