### PR TITLE
Fix flaky jsonassert

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <parquet.version>1.13.1</parquet.version>
+    <cs.skyscreamer.version>1.5.0</cs.skyscreamer.version>
   </properties>
   <dependencies>
     <dependency>
@@ -178,6 +179,12 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>${cs.skyscreamer.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <profiles>

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -31,8 +31,10 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
@@ -305,7 +307,12 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -30,8 +30,10 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 import java.util.List;
@@ -93,7 +95,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -126,7 +133,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -167,7 +179,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -205,8 +222,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
 
@@ -243,7 +264,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -276,7 +302,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -319,7 +350,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test
@@ -360,7 +396,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    try {
+      JSONAssert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()), true);
+    } 
+    catch (JSONException e) {
+      e.printStackTrace();
+    }
   }
 
   @Test


### PR DESCRIPTION

# What is the purpose of this PR
This PR fixes the flaky tests of  FlattenSpecParquetReaderTest classes resulting from the JSON string comparison. 

# Why the tests fail
All the tests of class FlattenSpecParquetReaderTest fail due to the comparison of a predefined JSON string and string found from Jackson ObjectWriter. The expected order is not guaranteed always from ObjectWriter by default.

# Reproduce the test failure
Run any of the tests with the NonDex maven plugin. For instance ,The commands to recreate the flaky test failures are:
sudo  mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1FlattenSelectListItem 


# Expected results
The tests should run successfully when run with NonDex.

# Actual Result
We get the following failure for the test org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest#testNested1FlattenSelectListItem #persistVirtualMachineStatsTestPersistsSuccessfully :
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] org.apache.druid.data.input.parquet.FlattenSpecParquetReaderTest.testNested1FlattenSelectListItem
[ERROR]   Run 1: FlattenSpecParquetReaderTest.testNested1FlattenSelectListItem:363 expected:<{
  "[nestedData" : {
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim3" : 1,
    "dim2" : "d2v1",
    "metric2" : 2
  },
  "dim1" : "d1v1",
  "metric1" : 1,
  "timestamp" : 1537229880023]
}> but was:<{
  "[metric1" : 1,
  "nestedData" : {
    "metric2" : 2,
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim2" : "d2v1",
    "dim3" : 1
  },
  "timestamp" : 1537229880023,
  "dim1" : "d1v1"]
}>
[ERROR]   Run 2: FlattenSpecParquetReaderTest.testNested1FlattenSelectListItem:363 expected:<{
  "[nestedData" : {
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim3" : 1,
    "dim2" : "d2v1",
    "metric2" : 2
  },
  "dim1" : "d1v1",
  "metric1" : 1],
  "timestamp" : 15...> but was:<{
  "[dim1" : "d1v1",
  "metric1" : 1,
  "nestedData" : {
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim3" : 1,
    "metric2" : 2,
    "dim2" : "d2v1"
  }],
  "timestamp" : 15...>
[ERROR]   Run 3: FlattenSpecParquetReaderTest.testNested1FlattenSelectListItem:363 expected:<...estedData" : {
    "[listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim3" : 1,
    "dim2" : "d2v1",
    "metric2" : 2
  },
  "dim1" : "d1v1",
  "metric1" : 1,
  "timestamp" : 1537229880023]
}> but was:<...estedData" : {
    "[dim2" : "d2v1",
    "metric2" : 2,
    "dim3" : 1,
    "listDim" : [ "listDim1v1", "listDim1v2" ]
  },
  "timestamp" : 1537229880023,
  "dim1" : "d1v1",
  "metric1" : 1]
}>
[ERROR]   Run 4: FlattenSpecParquetReaderTest.testNested1FlattenSelectListItem:363 expected:<{
  "[nestedData" : {
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "dim3" : 1,
    "dim2" : "d2v1",
    "metric2" : 2
  },
  "dim1" : "d1v1",
  "metric1" : 1,
  "timestamp" : 1537229880023]
}> but was:<{
  "[metric1" : 1,
  "timestamp" : 1537229880023,
  "nestedData" : {
    "dim2" : "d2v1",
    "dim3" : 1,
    "listDim" : [ "listDim1v1", "listDim1v2" ],
    "metric2" : 2
  },
  "dim1" : "d1v1"]
}>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

# Fix
For all the tests of the class FlattenSpecParquetReaderTest: Used the JSONAssert library that confirms test passing irrespective of JSON key order in JSON string.