### PR TITLE
pac4j: fix incompatible dependencies + authorization regression

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -38,8 +38,8 @@
 
     <!-- Following must be updated along with any updates to pac4j version -->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
-    <nimbus.jose.jwt.version>7.9</nimbus.jose.jwt.version>
-    <oauth2.oidc.sdk.version>6.5</oauth2.oidc.sdk.version>
+    <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
+    <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>
   </properties>
 
   <dependencies>

--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -145,11 +145,11 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pac4j.version>4.5.7</pac4j.version>
 
-    <!-- Following must be updated along with any updates to pac4j version -->
+    <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
     <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
     <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>

--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -145,6 +145,11 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.mockito</groupId>
+          <artifactId>mockito-core</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -48,7 +48,8 @@ public class Pac4jFilter implements Filter
 {
   private static final Logger LOGGER = new Logger(Pac4jFilter.class);
 
-  private static final HttpActionAdapter<Object, JEEContext> HTTP_ACTION_ADAPTER = new JEEHttpActionAdapter();
+  // JEE_HTTP_ACTION_ADAPTER updates the response in the context according to the HTTPAction.
+  private static final HttpActionAdapter<Object, JEEContext> JEE_HTTP_ACTION_ADAPTER = new JEEHttpActionAdapter();
 
   private final Config pac4jConfig;
   private final SecurityLogic<Object, JEEContext> securityLogic;
@@ -95,7 +96,7 @@ public class Pac4jFilter implements Filter
       callbackLogic.perform(
           context,
           pac4jConfig,
-          HTTP_ACTION_ADAPTER,
+          JEE_HTTP_ACTION_ADAPTER,
           "/",
           true, false, false, null);
     } else {
@@ -110,7 +111,7 @@ public class Pac4jFilter implements Filter
               return profiles.iterator().next().getId();
             }
           },
-          HTTP_ACTION_ADAPTER,
+          JEE_HTTP_ACTION_ADAPTER,
           null, "none", null, null);
 
       if (uid != null) {

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.pac4j;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.exception.http.ForbiddenAction;
+import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.exception.http.WithLocationAction;
+import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(MockitoJUnitRunner.class)
+public class Pac4jFilterTest
+{
+
+  private static final JEEHttpActionAdapter JEE_HTTP_ACTION_ADAPTER = new JEEHttpActionAdapter();
+  @Mock
+  private HttpServletRequest request;
+  @Mock
+  private HttpServletResponse response;
+  private JEEContext context;
+
+  @Before
+  public void setUp()
+  {
+    context = new JEEContext(request, response);
+  }
+
+  @Test
+  public void testActionAdapterForRedirection()
+  {
+    HttpAction httpAction = new FoundAction("testUrl");
+    Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
+    Mockito.doReturn(((WithLocationAction) httpAction).getLocation()).when(response).getHeader(any());
+    JEE_HTTP_ACTION_ADAPTER.adapt(httpAction, context);
+    Assert.assertEquals(response.getStatus(), 302);
+    Assert.assertEquals(response.getHeader("Location"), "testUrl");
+  }
+
+  @Test
+  public void testActionAdapterForForbidden()
+  {
+    HttpAction httpAction = ForbiddenAction.INSTANCE;
+    Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
+    JEE_HTTP_ACTION_ADAPTER.adapt(httpAction, context);
+    Assert.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
+  }
+
+}

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -42,7 +42,6 @@ import static org.mockito.ArgumentMatchers.any;
 public class Pac4jFilterTest
 {
 
-  private static final JEEHttpActionAdapter JEE_HTTP_ACTION_ADAPTER = new JEEHttpActionAdapter();
   @Mock
   private HttpServletRequest request;
   @Mock
@@ -61,7 +60,7 @@ public class Pac4jFilterTest
     HttpAction httpAction = new FoundAction("testUrl");
     Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
     Mockito.doReturn(((WithLocationAction) httpAction).getLocation()).when(response).getHeader(any());
-    JEE_HTTP_ACTION_ADAPTER.adapt(httpAction, context);
+    JEEHttpActionAdapter.INSTANCE.adapt(httpAction, context);
     Assert.assertEquals(response.getStatus(), 302);
     Assert.assertEquals(response.getHeader("Location"), "testUrl");
   }
@@ -71,7 +70,7 @@ public class Pac4jFilterTest
   {
     HttpAction httpAction = ForbiddenAction.INSTANCE;
     Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
-    JEE_HTTP_ACTION_ADAPTER.adapt(httpAction, context);
+    JEEHttpActionAdapter.INSTANCE.adapt(httpAction, context);
     Assert.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
   }
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -815,6 +815,16 @@ libraries:
 
 ---
 
+name: com.nimbusds content-type
+license_category: binary
+module: extensions/druid-pac4j
+license_name: Apache License version 2.0
+version: 2.1
+libraries:
+  - com.nimbusds: content-type
+
+---
+
 name: com.nimbusds oauth2-oidc-sdk
 license_category: binary
 module: extensions/druid-pac4j

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -809,7 +809,7 @@ name: com.nimbusds nimbus-jose-jwt
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 7.9
+version: 8.22.1
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 
@@ -819,7 +819,7 @@ name: com.nimbusds oauth2-oidc-sdk
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 6.5
+version: 8.22
 libraries:
   - com.nimbusds: oauth2-oidc-sdk
 


### PR DESCRIPTION
### Description

- After upgrading the pac4j version here: https://github.com/apache/druid/pull/15522. We were not able to access the druid ui. 
- Upgraded the Nimbus libraries version to a compatible version to pac4j.
-  In the older pac4j version, when we return RedirectAction there we also update the webcontext Response status code and add the authentication URL to the header. But in the newer pac4j version, we just simply return the RedirectAction. So that's why it was not getting redirected to the generated authentication URL.
- To fix the above, I have updated the NOOP_HTTP_ACTION_ADAPTER to JEE_HTTP_ACTION_ADAPTER and it updates the HTTP Response in context as per the HTTP Action.
 

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
