### PR TITLE
Return a 503 status code instead of 400 during transient errors

### DIFF
--- a/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
@@ -113,7 +113,11 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
       handleEnabledRequest(response);
       return;
     } else {
-      handleBadRequest(response, StringUtils.format("Unsupported proxy destination [%s]", request.getRequestURI()));
+      handleBadRequest(
+          response,
+          StringUtils.format("Unsupported proxy destination[%s]", request.getRequestURI()),
+          HttpServletResponse.SC_BAD_GATEWAY
+      );
       return;
     }
 
@@ -121,8 +125,10 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
       handleBadRequest(
           response,
           StringUtils.format(
-              "Unable to determine destination for [%s]; is your coordinator/overlord running?", request.getRequestURI()
-          )
+              "Unable to determine destination[%s]; is your coordinator/overlord running?",
+              request.getRequestURI()
+          ),
+          HttpServletResponse.SC_SERVICE_UNAVAILABLE
       );
       return;
     }
@@ -185,11 +191,11 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
     super.onServerResponseHeaders(clientRequest, proxyResponse, serverResponse);
   }
 
-  private void handleBadRequest(HttpServletResponse response, String errorMessage) throws IOException
+  private void handleBadRequest(HttpServletResponse response, String errorMessage, int statusCode) throws IOException
   {
     if (!response.isCommitted()) {
       response.resetBuffer();
-      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.setStatus(statusCode);
       jsonMapper.writeValue(response.getOutputStream(), ImmutableMap.of("error", errorMessage));
     }
     response.flushBuffer();

--- a/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
@@ -113,7 +113,7 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
       handleEnabledRequest(response);
       return;
     } else {
-      handleBadRequest(
+      handleInvalidRequest(
           response,
           StringUtils.format("Unsupported proxy destination[%s]", request.getRequestURI()),
           HttpServletResponse.SC_BAD_REQUEST
@@ -122,7 +122,7 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
     }
 
     if (currentLeader == null) {
-      handleBadRequest(
+      handleInvalidRequest(
           response,
           StringUtils.format(
               "Unable to determine destination[%s]; is your coordinator/overlord running?",
@@ -191,7 +191,7 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
     super.onServerResponseHeaders(clientRequest, proxyResponse, serverResponse);
   }
 
-  private void handleBadRequest(HttpServletResponse response, String errorMessage, int statusCode) throws IOException
+  private void handleInvalidRequest(HttpServletResponse response, String errorMessage, int statusCode) throws IOException
   {
     if (!response.isCommitted()) {
       response.resetBuffer();

--- a/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
+++ b/server/src/main/java/org/apache/druid/server/AsyncManagementForwardingServlet.java
@@ -116,7 +116,7 @@ public class AsyncManagementForwardingServlet extends AsyncProxyServlet
       handleBadRequest(
           response,
           StringUtils.format("Unsupported proxy destination[%s]", request.getRequestURI()),
-          HttpServletResponse.SC_BAD_GATEWAY
+          HttpServletResponse.SC_BAD_REQUEST
       );
       return;
     }

--- a/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
+++ b/server/src/test/java/org/apache/druid/server/AsyncManagementForwardingServletTest.java
@@ -71,6 +71,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
   private static int coordinatorPort;
   private static int overlordPort;
+  private static boolean isValidLeader;
 
   private Server coordinator;
   private Server overlord;
@@ -109,6 +110,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     coordinator.start();
     overlord.start();
+    isValidLeader = true;
   }
 
   @After
@@ -119,6 +121,7 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
 
     COORDINATOR_EXPECTED_REQUEST.reset();
     OVERLORD_EXPECTED_REQUEST.reset();
+    isValidLeader = true;
   }
 
   @Override
@@ -345,6 +348,45 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
   }
 
   @Test
+  public void testCoordinatorLeaderUnknown() throws Exception
+  {
+    isValidLeader = false;
+    HttpURLConnection connection = ((HttpURLConnection)
+        new URL(StringUtils.format("http://localhost:%d/druid/coordinator", port)).openConnection());
+    connection.setRequestMethod("GET");
+
+    Assert.assertEquals(503, connection.getResponseCode());
+    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
+    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+  }
+
+  @Test
+  public void testOverlordLeaderUnknown() throws Exception
+  {
+    isValidLeader = false;
+    HttpURLConnection connection = ((HttpURLConnection)
+        new URL(StringUtils.format("http://localhost:%d/druid/indexer", port)).openConnection());
+    connection.setRequestMethod("GET");
+
+    Assert.assertEquals(503, connection.getResponseCode());
+    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
+    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+    isValidLeader = true;
+  }
+
+  @Test
+  public void testUnsupportedProxyDestination() throws Exception
+  {
+    HttpURLConnection connection = ((HttpURLConnection)
+        new URL(StringUtils.format("http://localhost:%d/proxy/other/status2", port)).openConnection());
+    connection.setRequestMethod("GET");
+
+    Assert.assertEquals(400, connection.getResponseCode());
+    Assert.assertFalse("coordinator called", COORDINATOR_EXPECTED_REQUEST.called);
+    Assert.assertFalse("overlord called", OVERLORD_EXPECTED_REQUEST.called);
+  }
+
+  @Test
   public void testLocalRequest() throws Exception
   {
     HttpURLConnection connection = ((HttpURLConnection)
@@ -422,7 +464,11 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         @Override
         public String getCurrentLeader()
         {
-          return StringUtils.format("http://localhost:%d", coordinatorPort);
+          if (isValidLeader) {
+            return StringUtils.format("http://localhost:%d", coordinatorPort);
+          } else {
+            return null;
+          }
         }
       };
 
@@ -431,7 +477,11 @@ public class AsyncManagementForwardingServletTest extends BaseJettyTest
         @Override
         public String getCurrentLeader()
         {
-          return StringUtils.format("http://localhost:%d", overlordPort);
+          if (isValidLeader) {
+            return StringUtils.format("http://localhost:%d", overlordPort);
+          } else {
+            return null;
+          }
         }
       };
 


### PR DESCRIPTION
Fix an issue where if a coordinator is unavailable, for example, during a rolling upgrade, the server would return a 400 HTTP status code instead of a 503. We now return a 503 because it's a transient error and a client should retry in this case.  Also, while at it, include interpolations in the error response messages.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
