### PR TITLE
docs: clean up some rolling updates stuff

### DIFF
--- a/docs/operations/rolling-updates.md
+++ b/docs/operations/rolling-updates.md
@@ -27,15 +27,13 @@ For rolling Apache Druid cluster updates with no downtime, we recommend updating
 following order:
 
 1. Historical
-2. \*Overlord (if any)
-3. \*Middle Manager/Indexers (if any)
-4. Standalone Real-time (if any)
-5. Broker
+2. Middle Manager and Indexers (if any)
+3. Broker
+4. Routers
+5. Overlord (Note that you can upgrade the Overlord before any MiddleManager processes if you use [autoscaling-based replacement](#autoscaling-based-replacement).)
 6. Coordinator ( or merged Coordinator+Overlord )
 
 For information about the latest release, see [Druid releases](https://github.com/apache/druid/releases).
-
-\* In 0.12.0, there are protocol changes between the Kafka supervisor and Kafka Indexing task and also some changes to the metadata formats persisted on disk. Therefore, to support rolling upgrade, all the Middle Managers will need to be upgraded first before the Overlord. Note that this ordering is different from the standard order of upgrade, also note that this ordering is only necessary when using the Kafka Indexing Service. If one is not using Kafka Indexing Service or can handle down time for Kafka Supervisor then one can upgrade in any order.
 
 ## Historical
 

--- a/docs/operations/rolling-updates.md
+++ b/docs/operations/rolling-updates.md
@@ -27,13 +27,13 @@ For rolling Apache Druid cluster updates with no downtime, we recommend updating
 following order:
 
 1. Historical
-2. Middle Manager and Indexers (if any)
+2. Middle Manager and Indexer (if any)
 3. Broker
-4. Routers
+4. Router
 5. Overlord (Note that you can upgrade the Overlord before any MiddleManager processes if you use [autoscaling-based replacement](#autoscaling-based-replacement).)
 6. Coordinator ( or merged Coordinator+Overlord )
 
-If you need to do a rolling downgrade, reverse the order and start with the Coordinator.
+If you need to do a rolling downgrade, reverse the order and start with the Coordinator processes.
 
 For information about the latest release, see [Druid releases](https://github.com/apache/druid/releases).
 

--- a/docs/operations/rolling-updates.md
+++ b/docs/operations/rolling-updates.md
@@ -33,6 +33,8 @@ following order:
 5. Overlord (Note that you can upgrade the Overlord before any MiddleManager processes if you use [autoscaling-based replacement](#autoscaling-based-replacement).)
 6. Coordinator ( or merged Coordinator+Overlord )
 
+If you need to do a rolling downgrade, reverse the order and start with the Coordinator.
+
 For information about the latest release, see [Druid releases](https://github.com/apache/druid/releases).
 
 ## Historical


### PR DESCRIPTION
Cleans up some old stuff in the rolling updates doc as well as clarifies the upgrade order a little.

This PR has:

- [x] been self-reviewed.
