### PR TITLE
Temporarily bump up delay in security auth IT from 5s to 10s

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -82,11 +82,12 @@ public class ITBasicAuthConfigurationTest extends AbstractAuthConfigurationTest
   {
     super.setupHttpClientsAndUsers();
 
-    // Add a delay to allow propagation of credentials to all services
+    // Add a large enough delay to allow propagation of credentials to all services. It'd be ideal
+    // to have a "readiness" endpoint exposed by different services that'd return the version of auth creds cached.
     try {
-      Thread.sleep(5000);
+      Thread.sleep(10000);
     }
-    catch (Throwable t) {
+    catch (InterruptedException e) {
       // Ignore exception
     }
   }


### PR DESCRIPTION
A follow up to https://github.com/apache/druid/pull/15679: temporarily bump up the delay from 5s to 10s as the security IT  been flaking relatively frequently. I think a more comprehensive fix would be to have status checks/"readiness" endpoints exposed by the different services, but that'll require more code changes. So in the interim, to unblock CI, temporarily bump up the delay. 

A few runs where this failure was observed:
- https://github.com/apache/druid/actions/runs/7658891775/job/20875216030
- https://github.com/apache/druid/actions/runs/7653925377/job/20859026794
- https://github.com/apache/druid/actions/runs/7653624284/job/20858040511

The stacktrace of the failing test:

```
Error:  test_avaticaQueryWithContext_datasourceAndContextParamsUser_succeed(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.15 s  <<< FAILURE!
java.lang.RuntimeException: org.apache.calcite.avatica.AvaticaSqlException: Error 2 (00002) : Error while executing SQL "SELECT * FROM INFORMATION_SCHEMA.COLUMNS": Remote driver error: Unauthorized
Caused by: org.apache.calcite.avatica.AvaticaSqlException: Error 2 (00002) : Error while executing SQL "SELECT * FROM INFORMATION_SCHEMA.COLUMNS": Remote driver error: Unauthorized

Error:  test_avaticaQueryWithContext_datasourceOnlyUser_fail(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.063 s
Error:  test_avaticaQuery_broker(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 2.713 s
Error:  test_avaticaQuery_router(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.269 s
Error:  test_groupMappings_invalidAuthName_fails(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.032 s
Error:  test_internalSystemUser_hasNodeAccess(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.02 s
Error:  test_sqlQueryWithContext_datasourceAndContextParamsUser_succeed(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.532 s
Error:  test_sqlQueryWithContext_datasourceOnlyUser_fail(org.apache.druid.tests.security.ITBasicAuthConfigurationTest)  Time elapsed: 0.048 s
```

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader..
