### PR TITLE
Identify not range filters without negating subexpressions

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBoundsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/filtration/CombineAndSimplifyBoundsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.filtration;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.query.filter.BoundDimFilter;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.RangeFilter;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.sql.calcite.BaseCalciteQueryTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class CombineAndSimplifyBoundsTest extends BaseCalciteQueryTest
+{
+
+  enum RangeFilterType
+  {
+    BOUND {
+      @Override
+      public DimFilter range(String lit1, boolean gte, String name, boolean lte, String lit2)
+      {
+        return new BoundDimFilter(
+            name,
+            lit1,
+            lit2,
+            !gte,
+            !lte,
+            true,
+            null,
+            null
+        );
+      }
+    },
+    RANGE {
+      @Override
+      public DimFilter range(String lit1, boolean gte, String name, boolean lte, String lit2)
+      {
+        return new RangeFilter(
+            name,
+            ColumnType.STRING,
+            lit1,
+            lit2,
+            !gte,
+            !lte,
+            null
+        );
+      }
+    };
+
+    public final DimFilter lt(String name, String literal)
+    {
+      return range(null, false, name, false, literal);
+    }
+
+    public final DimFilter le(String name, String literal)
+    {
+      return range(null, false, name, true, literal);
+    }
+
+    public final DimFilter gt(String name, String literal)
+    {
+      return range(literal, false, name, false, null);
+    }
+
+    public final DimFilter ge(String name, String literal)
+    {
+      return range(literal, true, name, false, null);
+    }
+
+    public final DimFilter eq(String name, String literal)
+    {
+      return range(literal, true, name, true, literal);
+    }
+
+    public abstract DimFilter range(String lit1, boolean gte, String name, boolean lte, String lit2);
+  }
+
+  @Parameters
+  public static List<Object[]> getParameters()
+  {
+    return ImmutableList.of(
+        new Object[] {RangeFilterType.BOUND},
+        new Object[] {RangeFilterType.RANGE}
+    );
+  }
+
+  final RangeFilterType rangeFilter;
+
+  public CombineAndSimplifyBoundsTest(RangeFilterType rangeFilter)
+  {
+    this.rangeFilter = rangeFilter;
+  }
+
+  @Test
+  public void testNotAZ()
+  {
+    String dim1 = "dim1";
+    DimFilter inputFilter = or(
+        rangeFilter.lt(dim1, "a"),
+        rangeFilter.gt(dim1, "z")
+    );
+    DimFilter expected = not(rangeFilter.range("a", true, dim1, true, "z"));
+
+    check(inputFilter, expected);
+  }
+
+  @Test
+  public void testAZ()
+  {
+    String dim1 = "dim1";
+    DimFilter inputFilter = and(
+        rangeFilter.gt(dim1, "a"),
+        rangeFilter.lt(dim1, "z")
+    );
+    DimFilter expected = rangeFilter.range("a", false, dim1, false, "z");
+
+    check(inputFilter, expected);
+  }
+
+  @Test
+  public void testNot2()
+  {
+    String dim1 = "dim1";
+    DimFilter inputFilter = or(
+        rangeFilter.le(dim1, "a"),
+        rangeFilter.range("f", true, dim1, false, "j"),
+        rangeFilter.gt(dim1, "z")
+    );
+    DimFilter expected = not(
+        or(
+            rangeFilter.range("a", false, dim1, false, "f"),
+            rangeFilter.range("j", true, dim1, true, "z")
+        )
+    );
+
+    check(inputFilter, expected);
+  }
+
+  private void check(DimFilter inputFilter, DimFilter expected)
+  {
+    Filtration filt = Filtration.create(inputFilter, null);
+    Filtration ret = CombineAndSimplifyBounds.instance().apply(filt);
+    assertEquals(expected, ret.getDimFilter());
+  }
+}


### PR DESCRIPTION
Earlier betweenish (range/bounds) filters were identified thru a process of negating the subexpressions which may have not performed that well. (it could have dominated the runtime in some cases) This patch makes that unnecessary as its able to create the negate expression directly.

This behaviour was observed by @gargvishesh in [PR-15688](https://github.com/apache/druid/pull/15688#issuecomment-1903316530)

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `CombineAndSimplifyBounds`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
