### PR TITLE
docs: add mermaid diagram support

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,6 +41,9 @@ module.exports={
   },
   "onBrokenLinks": "log",
   "onBrokenMarkdownLinks": "throw",
+  markdown: {
+    mermaid: true,
+  },
   "presets": [
     [
       "@docusaurus/preset-classic",
@@ -73,7 +76,8 @@ module.exports={
         "redirects": Redirects
       }
     ],
-    "docusaurus-lunr-search"
+    "docusaurus-lunr-search",
+    "@docusaurus/theme-mermaid"
   ],
   "themeConfig": {
     colorMode: {

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "@docusaurus/core": "^2.4.1",
     "@docusaurus/plugin-client-redirects": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",
+    "@docusaurus/theme-mermaid": "^2.4.1",
     "clsx": "^1.1.1",
     "docusaurus-lunr-search": "^3.3.1",
     "fast-glob": "^3.2.2",


### PR DESCRIPTION

### Description
Adds support for mermaid diagrams to the OSS website. Will also need to open an identical one in the `druid-website-src` repo.

![image](https://github.com/apache/druid/assets/53799971/91b4f4b8-0614-4a55-8e12-0efef27a9bb3)


This PR has:

- [x] been self-reviewed.
 