### PR TITLE
Allow null values for account when injecting AzureAccountConfig

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
@@ -22,7 +22,6 @@ package org.apache.druid.storage.azure;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 
 /**
  * Stores the configuration for an Azure account.
@@ -37,7 +36,6 @@ public class AzureAccountConfig
   private int maxTries = 3;
 
   @JsonProperty
-  @NotNull
   private String account;
 
   @JsonProperty

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorageDruidModule.java
@@ -114,6 +114,11 @@ public class AzureStorageDruidModule implements DruidModule
   @LazySingleton
   public AzureClientFactory getAzureClientFactory(final AzureAccountConfig config)
   {
+    if (StringUtils.isEmpty(config.getAccount())) {
+      throw new ISE("Set 'account' to the storage account that needs to be configured in the azure config."
+          + " Please refer to azure documentation.");
+    }
+
     if (StringUtils.isEmpty(config.getKey()) && StringUtils.isEmpty(config.getSharedAccessStorageToken()) && BooleanUtils.isNotTrue(config.getUseAzureCredentialsChain())) {
       throw new ISE("Either set 'key' or 'sharedAccessStorageToken' or 'useAzureCredentialsChain' in the azure config."
           + " Please refer to azure documentation.");

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageDruidModuleTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageDruidModuleTest.java
@@ -267,6 +267,20 @@ public class AzureStorageDruidModuleTest extends EasyMockSupport
   }
 
   @Test
+  public void testAccountUnset()
+  {
+    Properties properties = initializePropertes();
+    properties.remove("druid.azure.account");
+    expectedException.expect(ProvisionException.class);
+    expectedException.expectMessage("Set 'account' to the storage account that needs to be configured in the azure config. Please refer to azure documentation.");
+    makeInjectorWithProperties(properties).getInstance(
+        Key.get(new TypeLiteral<AzureClientFactory>()
+        {
+        })
+    );
+  }
+
+  @Test
   public void testGetBlobStorageEndpointWithDefaultProperties()
   {
     Properties properties = initializePropertes();


### PR DESCRIPTION
Fixes a issue with ingesting using the azureStorage input source when not running on azure itself.
https://github.com/apache/druid/commit/3e512249e37407c0ece2b241d4b16e448eb18f0a

### Description
AzureStorageAccountInputSource injects AzureAccountConfig because it builds a AzureIngestClientFactory to handle pulling azure blobs for ingestion. AzureIngestClientFactory uses AzureAccountConfig for retry configs when hitting blob storage and for default credentials if credentials are not specified in AzureStorageAccountInputSource.properties.

The problem with this is AzureAccountConfig cannot be injected if druid.azure.account is not set, which it won't be if someone is e.g. trying to ingest azure blobs from a cluster deployed in aws. The config's value itself is ignored since the actual storage account is specified in AzureStorageAccountInputSource, so the currrent workaround is to just it to a dummy value.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

I think it would be ideal to remove AzureAccountConfig from being injected in AzureStorageAccountInputSource entirely (since its more a config for specifying azure as deep storage rather than a ingestion source), but I don't think this is possible without e.g. removing the convenient feature where you use a cluster's regular azure authentication (for deep storage) if no additional credentials are specified in the ingestion spec.

For now I just made druid.azure.account nullable in AzureAccountConfig and added a check in AzureStorageDruidModule to make sure the value is not null when the cluster is using azure as deep storage (rather than just as a ingestion source)

#### Release note
- Bugfix for reading azure blobs with the azureStorage input type
- 
##### Key changed/added classes in this PR
 * `AzureAccountConfig`
 * `AzureStorageDruidModule`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
