### PR TITLE
Support Preceding with negative indices in window function

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
@@ -75,7 +75,7 @@ public class DefaultFramedOnHeapAggregatable implements FramedOnHeapAggregatable
         int lowerOffset = frame.getLowerOffset();
         int upperOffset = frame.getUpperOffset();
 
-        if (numRows <  upperOffset -lowerOffset + 1) {
+        if (numRows < upperOffset - lowerOffset + 1) {
           // In this case, there are not enough rows to completely build up the full window aperture before it needs to
           // also start contracting the aperture because of the upper offset. So we use a method that specifically
           // handles checks for both expanding and reducing the aperture on every iteration.
@@ -629,10 +629,10 @@ public class DefaultFramedOnHeapAggregatable implements FramedOnHeapAggregatable
       nextIndex = 1;
       upperLimit = upperOffset - lowerOffset;
     } else if (lowerOffset < 0 && upperOffset < 0) {
-      nextIndex = upperOffset-lowerOffset+1;
+      nextIndex = upperOffset - lowerOffset + 1;
       upperLimit = 0;
     } else {
-      nextIndex = 1-lowerOffset;
+      nextIndex = 1 - lowerOffset;
       upperLimit = upperOffset;
     }
 
@@ -648,7 +648,7 @@ public class DefaultFramedOnHeapAggregatable implements FramedOnHeapAggregatable
     // The first few rows will slowly build out the window to consume the upper-offset.  The window will not
     // be full until we have walked upperOffset number of rows, so phase 1 runs until we have consumed
     // upperOffset number of rows.
-    for (int upperIndex = 0; upperIndex < upperLimit ; ++upperIndex) {
+    for (int upperIndex = 0; upperIndex < upperLimit; ++upperIndex) {
       for (Aggregator[] aggregator : aggregators) {
         for (int j = 0; j < nextIndex; ++j) {
           aggregator[j].aggregate();

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
@@ -187,7 +187,7 @@ public class DefaultFramedOnHeapAggregatable implements FramedOnHeapAggregatable
                   groupToRowIndex(relativeGroupId(1))
               ),
               Interval.of(
-                  groupToRowIndex(relativeGroupId(-lowerOffset)),
+                  groupToRowIndex(relativeGroupId(lowerOffset < 0 ? lowerOffset : -lowerOffset)),
                   groupToRowIndex(relativeGroupId(upperOffset))
               )
           );

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/semantic/DefaultFramedOnHeapAggregatable.java
@@ -771,7 +771,7 @@ public class DefaultFramedOnHeapAggregatable implements FramedOnHeapAggregatable
 
     // This is the index to stop at for the current window aperture
     // The first row is used by all of the results for the lowerOffset num results, plus 1 for the "current row"
-    int stopIndex = Math.min(lowerOffset + 1, windowSize);
+    int stopIndex = Math.min(Math.abs(lowerOffset) + 1, windowSize);
 
     int startIndex = 0;
     int rowId = rowIdProvider.get();

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/FramedOnHeapAggregatableTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/FramedOnHeapAggregatableTest.java
@@ -91,7 +91,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 1, false, 2, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -1, false, 2, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),
@@ -143,7 +143,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 2, false, 0, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -2, false, 0, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),
@@ -169,7 +169,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 5, false, 7, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -5, false, 7, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),
@@ -197,7 +197,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 5, false, 1, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -5, false, 1, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),
@@ -225,7 +225,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 5, false, 0, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -5, false, 0, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),
@@ -337,7 +337,7 @@ public class FramedOnHeapAggregatableTest extends SemanticTestBase
     FramedOnHeapAggregatable agger = FramedOnHeapAggregatable.fromRAC(rac);
 
     final RowsAndColumns results = agger.aggregateAll(
-        new WindowFrame(WindowFrame.PeerType.ROWS, false, 5, false, 0, null),
+        new WindowFrame(WindowFrame.PeerType.ROWS, false, -5, false, 0, null),
         new AggregatorFactory[]{
             new LongSumAggregatorFactory("sumFromLong", "intCol"),
             new DoubleMaxAggregatorFactory("maxFromInt", "intCol"),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -368,7 +368,27 @@ public class Windowing
         upperOffset = -upperOffset;
       }
       if (lowerOffset >= upperOffset) {
-        throw InvalidInput.exception("The first value of range should be lesser than the second value");
+        final String first, second;
+        int val;
+        if (group.lowerBound.isPreceding()) {
+          val = Math.abs(lowerOffset);
+          first = val + " PRECEDING";
+        } else {
+          val = Math.abs(upperOffset);
+          first = val + " FOLLOWING";
+        }
+        if (group.upperBound.isPreceding()) {
+          val = Math.abs(upperOffset);
+          second = val + " PRECEDING";
+        } else {
+          val = Math.abs(upperOffset);
+          second = val + " FOLLOWING";
+        }
+        throw InvalidInput.exception(
+            "The first value of range in the window [%s] should be lesser than the second value [%s]",
+            first,
+            second
+        );
       }
       return new WindowFrame(
           group.isRows ? WindowFrame.PeerType.ROWS : WindowFrame.PeerType.RANGE,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -367,7 +367,7 @@ public class Windowing
       if (group.upperBound.isPreceding()) {
         upperOffset = -upperOffset;
       }
-      if (lowerOffset >= upperOffset) {
+      if (lowerOffset > upperOffset) {
         final String first, second;
         int val;
         if (group.lowerBound.isPreceding()) {

--- a/sql/src/test/resources/calcite/tests/window/wikipediaAggregationsMultipleOrdering.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/wikipediaAggregationsMultipleOrdering.sqlTest
@@ -18,7 +18,7 @@ expectedOperators:
       frame:
         peerType: "RANGE"
         lowUnbounded: false
-        lowOffset: 3
+        lowOffset: -3
         uppUnbounded: false
         uppOffset: 2
         orderBy:

--- a/sql/src/test/resources/calcite/tests/window/wikipediaFramedAggregations.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/wikipediaFramedAggregations.sqlTest
@@ -17,7 +17,7 @@ expectedOperators:
       frame:
           peerType: "RANGE"
           lowUnbounded: false
-          lowOffset: 3
+          lowOffset: -3
           uppUnbounded: false
           uppOffset: 2
           orderBy: [ {column: "d1", direction: ASC} ]

--- a/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
@@ -3,24 +3,14 @@ type: "operatorValidation"
 sql: |
   WITH virtual_table as (select m2 ,sum(m1) as summ1
   from foo group by 1 order by summ1 DESC)
-  select m2,summ1,sum(summ1) OVER (order by m2 rows between 1 PRECEDING and 2 PRECEDING) as sumfinal
+  select m2,summ1,sum(summ1) OVER (order by m2 rows between 1 PRECEDING and 2 FOLLOWING) as sumfinal
   from virtual_table order by 1
 
-expectedOperators:
-  - type: "naivePartition"
-    partitionColumns: []
-  - type: "window"
-    processor:
-      type: "framedAgg"
-      frame: { peerType: "ROWS", lowUnbounded: true, lowOffset: 0, uppUnbounded: true, uppOffset: 0 }
-      aggregations:
-        - type: "doubleSum"
-          name: "w0"
-          fieldName: "m1"
+
 expectedResults:
-  - [1.0,21.0]
-  - [2.0,21.0]
-  - [3.0,21.0]
-  - [4.0,21.0]
-  - [5.0,21.0]
-  - [6.0,21.0]
+  - [1.0,1.0,6.0]
+  - [2.0,2.0,10.0]
+  - [3.0,3.0,14.0]
+  - [4.0,4.0,18.0]
+  - [5.0,5.0,15.0]
+  - [6.0,6.0,11.0]

--- a/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
@@ -1,0 +1,26 @@
+type: "operatorValidation"
+
+sql: |
+  WITH virtual_table as (select m2 ,sum(m1) as summ1
+  from foo group by 1 order by summ1 DESC)
+  select m2,summ1,sum(summ1) OVER (order by m2 rows between 2 PRECEDING and 1 PRECEDING) as sumfinal
+  from virtual_table order by 1
+
+expectedOperators:
+  - type: "naivePartition"
+    partitionColumns: []
+  - type: "window"
+    processor:
+      type: "framedAgg"
+      frame: { peerType: "ROWS", lowUnbounded: true, lowOffset: 0, uppUnbounded: true, uppOffset: 0 }
+      aggregations:
+        - type: "doubleSum"
+          name: "w0"
+          fieldName: "m1"
+expectedResults:
+  - [1.0,21.0]
+  - [2.0,21.0]
+  - [3.0,21.0]
+  - [4.0,21.0]
+  - [5.0,21.0]
+  - [6.0,21.0]

--- a/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/window_range_1.sqlTest
@@ -3,7 +3,7 @@ type: "operatorValidation"
 sql: |
   WITH virtual_table as (select m2 ,sum(m1) as summ1
   from foo group by 1 order by summ1 DESC)
-  select m2,summ1,sum(summ1) OVER (order by m2 rows between 2 PRECEDING and 1 PRECEDING) as sumfinal
+  select m2,summ1,sum(summ1) OVER (order by m2 rows between 1 PRECEDING and 2 PRECEDING) as sumfinal
   from virtual_table order by 1
 
 expectedOperators:


### PR DESCRIPTION
This aims to solve https://github.com/apache/druid/issues/15739 by introducing a change in the native query plan for Windowing query where a query like 
```
WITH virtual_table as (select m2 ,sum(m1) as summ1
from foo group by 1 order by summ1 DESC)
select m2,summ1,sum(summ1) OVER (order by m2 rows between 1 PRECEDING and 2 FOLLOWING) as sumfinal
from virtual_table order by 1
```
will be planned in the `between 1 PRECEDING and 2 FOLLOWING` part as 
```
"processor": {
            "type": "framedAgg",
            "frame": {
              "peerType": "ROWS",
              "lowUnbounded": false,
              "lowOffset": -1,
              "uppUnbounded": false,
              "uppOffset": 2,
              "orderBy": null
            },
            "aggregations": [
              {
                "type": "doubleSum",
                "name": "w0",
                "fieldName": "a0"
              }
            ]
          }
```

This would allow us to support all the cases which postgres supports such as 
```
between 1 PRECEDING and 2 FOLLOWING
between 2 PRECEDING and 1 PRECEDING
between 1 FOLLOWING and 2 FOLLOWING
```

This will also handle cases with a meaningful error where the upper offset is of a lesser value than the lower offset such as 
```
between 1 PRECEDING and 2 PRECEDING
between 2 FOLLOWING and 1 FOLLOWING
```
This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
