### PR TITLE
Add azure integration tests for 'azureStorage' input type

### DIFF
--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractCloudInputSourceParallelIndexTest.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/AbstractCloudInputSourceParallelIndexTest.java
@@ -48,9 +48,11 @@ public abstract class AbstractCloudInputSourceParallelIndexTest extends Abstract
   private static final String WIKIPEDIA_DATA_3 = "wikipedia_index_data3.json";
   private static final String GOOGLE = "google";
   private static final String AZURE = "azure";
+  private static final String AZURE_V2 = "azureStorage";
   private static final String GOOGLE_PREFIX = "googlePrefix";
   private static final String GOOGLE_BUCKET = "googleBucket";
   private static final String AZURE_CONTAINER = "azureContainer";
+  private static final String AZURE_STORAGE_ACCOUNT = "azureAccount";
   private static final Logger LOG = new Logger(AbstractCloudInputSourceParallelIndexTest.class);
 
   String indexDatasource = "wikipedia_cloud_index_test_";
@@ -106,6 +108,8 @@ public abstract class AbstractCloudInputSourceParallelIndexTest extends Abstract
   {
     if (GOOGLE.equals(inputSourceType)) {
       return config.getProperty(GOOGLE_PREFIX);
+    } else if (AZURE_V2.equals(inputSourceType)) {
+      return config.getProperty(AZURE_CONTAINER) + "/" + config.getCloudPath();
     } else {
       return config.getCloudPath();
     }
@@ -117,6 +121,8 @@ public abstract class AbstractCloudInputSourceParallelIndexTest extends Abstract
       return config.getProperty(GOOGLE_BUCKET);
     } else if (AZURE.equals(inputSourceType)) {
       return config.getProperty(AZURE_CONTAINER);
+    } else if (AZURE_V2.equals(inputSourceType)) {
+      return config.getProperty(AZURE_STORAGE_ACCOUNT);
     } else {
       return config.getCloudBucket();
     }

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/ITAzureV2ParallelIndexTest.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/indexer/ITAzureV2ParallelIndexTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testsEx.indexer;
+
+import junitparams.Parameters;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.testsEx.categories.AzureDeepStorage;
+import org.apache.druid.testsEx.config.DruidTestRunner;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+/**
+ * IMPORTANT:
+ * To run this test, you must set the following env variables in the build environment -
+ * DRUID_CLOUD_PATH - path inside the container where the test data files will be uploaded
+ * <p>
+ * The AZURE account, key and container should be set in AZURE_ACCOUNT, AZURE_KEY and AZURE_CONTAINER respectively.
+ * <p>
+ * <a href="https://druid.apache.org/docs/latest/development/extensions-core/azure.html">Azure Deep Storage setup in druid</a>
+ */
+
+@RunWith(DruidTestRunner.class)
+@Category(AzureDeepStorage.class)
+public class ITAzureV2ParallelIndexTest extends AbstractAzureInputSourceParallelIndexTest
+{
+  @Test
+  @Parameters(method = "resources")
+  public void testAzureIndexData(Pair<String, List<?>> azureInputSource) throws Exception
+  {
+    doTest(azureInputSource, new Pair<>(false, false), "azureStorage");
+  }
+}

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITAzureV2SQLBasedIngestionTest.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITAzureV2SQLBasedIngestionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testsEx.msq;
+
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.testsEx.categories.AzureDeepStorage;
+import org.apache.druid.testsEx.config.DruidTestRunner;
+import org.apache.druid.testsEx.indexer.AbstractAzureInputSourceParallelIndexTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+/**
+ * IMPORTANT:
+ * To run this test, you must set the following env variables in the build environment -
+ * <p>
+ * The AZURE account, key and container should be set in AZURE_ACCOUNT, AZURE_KEY and AZURE_CONTAINER respectively.
+ * <p>
+ * <a href="https://druid.apache.org/docs/latest/development/extensions-core/azure.html">Azure Deep Storage setup in druid</a>
+ */
+
+@RunWith(DruidTestRunner.class)
+@Category(AzureDeepStorage.class)
+public class ITAzureV2SQLBasedIngestionTest extends AbstractAzureInputSourceParallelIndexTest
+{
+  private static final String CLOUD_INGEST_SQL = "/multi-stage-query/wikipedia_cloud_index_msq.sql";
+  private static final String INDEX_QUERIES_FILE = "/multi-stage-query/wikipedia_index_queries.json";
+
+  @Test
+  @Parameters(method = "resources")
+  @TestCaseName("Test_{index} ({0})")
+  public void testSQLBasedBatchIngestion(Pair<String, List<?>> azureStorageInputSource)
+  {
+    doMSQTest(azureStorageInputSource, CLOUD_INGEST_SQL, INDEX_QUERIES_FILE, "azureStorage");
+  }
+}


### PR DESCRIPTION
Adding ingest/query tests for data ingested with the azureStorage ingest spec.

### Description
This is a followup to https://github.com/apache/druid/commit/3e512249e37407c0ece2b241d4b16e448eb18f0a.

Since there is a new input type i added a couple integ tests for it.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

It might be nice to test the read from a different storage account functionality as well (these tests still read from a single storage account), but I think that should be a separate change.

I tested these cases locally and they all succeeded as expected.

<hr>

##### Key changed/added classes in this PR
 * `AbstractCloudInputSourceParallelIndexTest `
 * `ITAzureV2ParallelIndexTest `
 * `ITAzureV2SQLBasedIngestionTest `

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [X] added integration tests.
- [X] been tested in a test Druid cluster.
