### PR TITLE
Fix GHA logs dir and make tar and upload conditional on web console test failures

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: Tar druid logs
         if: ${{ failure() }}
-        run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ logs
+        run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
 
       - name: Upload druid logs to GitHub
         if: ${{ failure() }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -178,6 +178,8 @@ jobs:
           { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
 
       - name: web console end-to-end test
+        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
+        id: web-console-test
         run: |
           ./.github/scripts/setup_generate_license.sh
           web-console/script/druid build
@@ -186,7 +188,7 @@ jobs:
           web-console/script/druid stop
 
       - name: Tar druid logs
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
         run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
 
       - name: Upload druid logs to GitHub

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -187,11 +187,11 @@ jobs:
           web-console/script/druid stop
 
       - name: Tar druid logs
-        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
+        if: ${{ steps.web-console-test.conclusion == 'failure' }}
         run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
 
       - name: Upload druid logs to GitHub
-        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
+        if: ${{ steps.web-console-test.conclusion == 'failure' }}
         uses: actions/upload-artifact@master
         with:
           name: Druid logs web-checks

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -178,8 +178,6 @@ jobs:
           { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
 
       - name: web console end-to-end test
-        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
-        id: web-console-test
         run: |
           ./.github/scripts/setup_generate_license.sh
           web-console/script/druid build
@@ -192,7 +190,7 @@ jobs:
         run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
 
       - name: Upload druid logs to GitHub
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
         uses: actions/upload-artifact@master
         with:
           name: Druid logs web-checks

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -178,6 +178,7 @@ jobs:
           { for i in 1 2 3; do npm run codecov && break || sleep 15; done }
 
       - name: web console end-to-end test
+        id: web-console-test
         run: |
           ./.github/scripts/setup_generate_license.sh
           web-console/script/druid build


### PR DESCRIPTION
The PR makes 2 change:
* Correct the current logs directory tarred in GHA static checks to `log` 
* Make the steps of logs tar-ing and uploading conditional on web console test failures, which currently happens on any step failure in static checks workflow

Sample logs before this change for failed static checks: https://github.com/apache/druid/actions/runs/7719743853/job/21043502498