### PR TITLE
Concurrent Streaming and Replace improvements

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AppenderatorDriverRealtimeIndexTask.java
@@ -351,20 +351,21 @@ public class AppenderatorDriverRealtimeIndexTask extends AbstractTask implements
       int sequenceNumber = 0;
       String sequenceName = makeSequenceName(getId(), sequenceNumber);
 
-      final TransactionalSegmentPublisher publisher = (mustBeNullOrEmptyOverwriteSegments, segments, commitMetadata) -> {
-        if (mustBeNullOrEmptyOverwriteSegments != null && !mustBeNullOrEmptyOverwriteSegments.isEmpty()) {
-          throw new ISE(
-              "Stream ingestion task unexpectedly attempted to overwrite segments: %s",
-              SegmentUtils.commaSeparatedIdentifiers(mustBeNullOrEmptyOverwriteSegments)
-          );
-        }
-        final SegmentTransactionalInsertAction action = SegmentTransactionalInsertAction.appendAction(
-            segments,
-            null,
-            null
-        );
-        return toolbox.getTaskActionClient().submit(action);
-      };
+      final TransactionalSegmentPublisher publisher =
+          (mustBeNullOrEmptyOverwriteSegments, segments, commitMetadata, segmentIdToUpgradedVersions) -> {
+            if (mustBeNullOrEmptyOverwriteSegments != null && !mustBeNullOrEmptyOverwriteSegments.isEmpty()) {
+              throw new ISE(
+                  "Stream ingestion task unexpectedly attempted to overwrite segments: %s",
+                  SegmentUtils.commaSeparatedIdentifiers(mustBeNullOrEmptyOverwriteSegments)
+              );
+            }
+            final SegmentTransactionalInsertAction action = SegmentTransactionalInsertAction.appendAction(
+                segments,
+                null,
+                null
+            );
+            return toolbox.getTaskActionClient().submit(action);
+          };
 
       // Skip connecting firehose if we've been stopped before we got started.
       synchronized (this) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -918,7 +918,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
 
     final TaskLockType taskLockType = getTaskLockHelper().getLockTypeToUse();
     final TransactionalSegmentPublisher publisher =
-        (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) -> toolbox.getTaskActionClient().submit(
+        (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions)
+            -> toolbox.getTaskActionClient().submit(
             buildPublishAction(segmentsToBeOverwritten, segmentsToPublish, taskLockType)
         );
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1170,13 +1170,14 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     final TaskLockType taskLockType = getTaskLockHelper().getLockTypeToUse();
     final TransactionalSegmentPublisher publisher =
-        (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) -> toolbox.getTaskActionClient().submit(
+        (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions)
+            -> toolbox.getTaskActionClient().submit(
             buildPublishAction(segmentsToBeOverwritten, segmentsToPublish, taskLockType)
         );
 
     final boolean published =
         newSegments.isEmpty()
-        || publisher.publishSegments(oldSegments, newSegments, annotateFunction, null).isSuccess();
+        || publisher.publishSegments(oldSegments, newSegments, annotateFunction, null, null).isSuccess();
 
     if (published) {
       LOG.info("Published [%d] segments", newSegments.size());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SequenceMetadata.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SequenceMetadata.java
@@ -37,6 +37,7 @@ import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.SegmentUtils;
+import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import org.apache.druid.timeline.DataSegment;
 
@@ -351,7 +352,8 @@ public class SequenceMetadata<PartitionIdType, SequenceOffsetType>
     public SegmentPublishResult publishAnnotatedSegments(
         @Nullable Set<DataSegment> mustBeNullOrEmptyOverwriteSegments,
         Set<DataSegment> segmentsToPush,
-        @Nullable Object commitMetadata
+        @Nullable Object commitMetadata,
+        @Nullable Map<String, Set<SegmentIdWithShardSpec>> segmentIdToUpgradeVersions
     ) throws IOException
     {
       if (mustBeNullOrEmptyOverwriteSegments != null && !mustBeNullOrEmptyOverwriteSegments.isEmpty()) {
@@ -417,7 +419,7 @@ public class SequenceMetadata<PartitionIdType, SequenceOffsetType>
         );
         final DataSourceMetadata endMetadata = runner.createDataSourceMetadata(finalPartitions);
         action = taskLockType == TaskLockType.APPEND
-                 ? SegmentTransactionalAppendAction.forSegmentsAndMetadata(segmentsToPush, startMetadata, endMetadata)
+                 ? SegmentTransactionalAppendAction.forSegmentsAndMetadata(segmentsToPush, startMetadata, endMetadata, segmentIdToUpgradeVersions)
                  : SegmentTransactionalInsertAction.appendAction(segmentsToPush, startMetadata, endMetadata);
       } else {
         action = taskLockType == TaskLockType.APPEND

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
@@ -80,7 +80,7 @@ public class SequenceMetadataTest
 
     ISE exception = Assert.assertThrows(
         ISE.class,
-        () -> transactionalSegmentPublisher.publishAnnotatedSegments(notNullNotEmptySegment, ImmutableSet.of(), null)
+        () -> transactionalSegmentPublisher.publishAnnotatedSegments(notNullNotEmptySegment, ImmutableSet.of(), null, null)
     );
     Assert.assertEquals(
         "Stream ingestion task unexpectedly attempted to overwrite segments: "
@@ -115,6 +115,6 @@ public class SequenceMetadataTest
     );
     TransactionalSegmentPublisher transactionalSegmentPublisher = sequenceMetadata.createPublisher(mockSeekableStreamIndexTaskRunner, mockTaskToolbox, false);
 
-    transactionalSegmentPublisher.publishAnnotatedSegments(null, notNullNotEmptySegment, ImmutableMap.of());
+    transactionalSegmentPublisher.publishAnnotatedSegments(null, notNullNotEmptySegment, ImmutableMap.of(), null);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -174,7 +174,8 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
       DataSourceMetadata startMetadata,
-      DataSourceMetadata endMetadata
+      DataSourceMetadata endMetadata,
+      Map<String, Set<SegmentIdWithShardSpec>> segmentIdToUpgradedVersions
   )
   {
     return SegmentPublishResult.ok(commitSegments(appendSegments));

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -312,7 +312,8 @@ public interface IndexerMetadataStorageCoordinator
       Set<DataSegment> appendSegments,
       Map<DataSegment, ReplaceTaskLock> appendSegmentToReplaceLock,
       DataSourceMetadata startMetadata,
-      DataSourceMetadata endMetadata
+      DataSourceMetadata endMetadata,
+      Map<String, Set<SegmentIdWithShardSpec>> segmentToUpgradeVersions
   );
 
   /**

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BaseAppenderatorDriver.java
@@ -614,6 +614,13 @@ public abstract class BaseAppenderatorDriver implements Closeable
     final Object callerMetadata = metadata == null
                                   ? null
                                   : ((AppenderatorDriverMetadata) metadata).getCallerMetadata();
+    final Map<String, Set<SegmentIdWithShardSpec>> segmentIdToUpgradedVersions;
+    if (appenderator instanceof StreamAppenderator) {
+      segmentIdToUpgradedVersions = ((StreamAppenderator) appenderator).getBaseSegmentToUpgradedVersions();
+    } else {
+      segmentIdToUpgradedVersions = null;
+    }
+
     return executor.submit(
       () -> {
         try {
@@ -625,7 +632,8 @@ public abstract class BaseAppenderatorDriver implements Closeable
                     segmentsToBeOverwritten,
                     ourSegments,
                     outputSegmentsAnnotateFunction,
-                    callerMetadata
+                    callerMetadata,
+                    segmentIdToUpgradedVersions
                 );
 
                 if (publishResult.isSuccess()) {

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentsAndCommitMetadata.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/SegmentsAndCommitMetadata.java
@@ -30,24 +30,44 @@ import java.util.Objects;
 
 public class SegmentsAndCommitMetadata
 {
-  private static final SegmentsAndCommitMetadata NIL = new SegmentsAndCommitMetadata(Collections.emptyList(), null);
+  private static final SegmentsAndCommitMetadata NIL = new SegmentsAndCommitMetadata(Collections.emptyList(), null, null);
 
   private final Object commitMetadata;
   private final ImmutableList<DataSegment> segments;
+  private final ImmutableList<DataSegment> upgradedSegments;
+
+  public SegmentsAndCommitMetadata(
+      List<DataSegment> segments,
+      @Nullable Object commitMetadata,
+      @Nullable List<DataSegment> upgradedSegments
+  )
+  {
+    this.segments = ImmutableList.copyOf(segments);
+    if (upgradedSegments == null) {
+      this.upgradedSegments = ImmutableList.of();
+    } else {
+      this.upgradedSegments = ImmutableList.copyOf(upgradedSegments);
+    }
+    this.commitMetadata = commitMetadata;
+  }
 
   public SegmentsAndCommitMetadata(
       List<DataSegment> segments,
       @Nullable Object commitMetadata
   )
   {
-    this.segments = ImmutableList.copyOf(segments);
-    this.commitMetadata = commitMetadata;
+    this(segments, commitMetadata, null);
   }
 
   @Nullable
   public Object getCommitMetadata()
   {
     return commitMetadata;
+  }
+
+  public List<DataSegment> getUpgradedSegments()
+  {
+    return upgradedSegments;
   }
 
   public List<DataSegment> getSegments()
@@ -66,13 +86,14 @@ public class SegmentsAndCommitMetadata
     }
     SegmentsAndCommitMetadata that = (SegmentsAndCommitMetadata) o;
     return Objects.equals(commitMetadata, that.commitMetadata) &&
-           Objects.equals(segments, that.segments);
+           Objects.equals(segments, that.segments) &&
+           Objects.equals(upgradedSegments, that.upgradedSegments);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(commitMetadata, segments);
+    return Objects.hash(commitMetadata, segments, upgradedSegments);
   }
 
   @Override
@@ -81,6 +102,7 @@ public class SegmentsAndCommitMetadata
     return getClass().getSimpleName() + "{" +
            "commitMetadata=" + commitMetadata +
            ", segments=" + SegmentUtils.commaSeparatedIdentifiers(segments) +
+           ", upgradedSegments=" + SegmentUtils.commaSeparatedIdentifiers(upgradedSegments) +
            '}';
   }
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisher.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/TransactionalSegmentPublisher.java
@@ -24,6 +24,7 @@ import org.apache.druid.timeline.DataSegment;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -42,14 +43,16 @@ public interface TransactionalSegmentPublisher
   SegmentPublishResult publishAnnotatedSegments(
       @Nullable Set<DataSegment> segmentsToBeOverwritten,
       Set<DataSegment> segmentsToPublish,
-      @Nullable Object commitMetadata
+      @Nullable Object commitMetadata,
+      @Nullable Map<String, Set<SegmentIdWithShardSpec>> segmentIdToUpgradeVersions
   ) throws IOException;
 
   default SegmentPublishResult publishSegments(
       @Nullable Set<DataSegment> segmentsToBeOverwritten,
       Set<DataSegment> segmentsToPublish,
       Function<Set<DataSegment>, Set<DataSegment>> outputSegmentsAnnotateFunction,
-      @Nullable Object commitMetadata
+      @Nullable Object commitMetadata,
+      @Nullable Map<String, Set<SegmentIdWithShardSpec>> segmentIdToUpgradeVersions
   ) throws IOException
   {
     final Function<Set<DataSegment>, Set<DataSegment>> annotateFunction = outputSegmentsAnnotateFunction
@@ -57,7 +60,8 @@ public interface TransactionalSegmentPublisher
     return publishAnnotatedSegments(
         segmentsToBeOverwritten,
         annotateFunction.apply(segmentsToPublish),
-        commitMetadata
+        commitMetadata,
+        segmentIdToUpgradeVersions
     );
   }
 

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/ClosedSegmentsSinksBatchAppenderatorDriverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/ClosedSegmentsSinksBatchAppenderatorDriverTest.java
@@ -204,7 +204,8 @@ public class ClosedSegmentsSinksBatchAppenderatorDriverTest extends EasyMockSupp
 
   static TransactionalSegmentPublisher makeOkPublisher()
   {
-    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) -> SegmentPublishResult.ok(ImmutableSet.of());
+    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions)
+        -> SegmentPublishResult.ok(ImmutableSet.of());
   }
 
   static class TestSegmentAllocator implements SegmentAllocator

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/OpenAndClosedSegmentsBatchAppenderatorDriverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/OpenAndClosedSegmentsBatchAppenderatorDriverTest.java
@@ -200,6 +200,7 @@ public class OpenAndClosedSegmentsBatchAppenderatorDriverTest extends EasyMockSu
 
   static TransactionalSegmentPublisher makeOkPublisher()
   {
-    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) -> SegmentPublishResult.ok(ImmutableSet.of());
+    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions)
+        -> SegmentPublishResult.ok(ImmutableSet.of());
   }
 }

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorDriverTest.java
@@ -375,13 +375,13 @@ public class StreamAppenderatorDriverTest extends EasyMockSupport
 
   static TransactionalSegmentPublisher makeOkPublisher()
   {
-    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) ->
+    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions) ->
         SegmentPublishResult.ok(Collections.emptySet());
   }
 
   static TransactionalSegmentPublisher makeFailingPublisher(boolean failWithException)
   {
-    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata) -> {
+    return (segmentsToBeOverwritten, segmentsToPublish, commitMetadata, segmentIdToUpgradedVersions) -> {
       final RuntimeException exception = new RuntimeException("test");
       if (failWithException) {
         throw exception;


### PR DESCRIPTION
This PR fixes 2 issues with Streaming ingestion with concurrent replace.

1) Temporary duplicate results in queries
Suppose a streaming ingestion task has open segments V0-1 with a used segment V0-0, and a replace occurs concurrently with version V1. The replace job would convert the used segment to V1-0, and the open pending segment to V1-1.
However, when the appending job commits segments using the transactional append action, the pending segment is committed as V1-2. This means that there could be a period where V1-1 has not been unannounced, and V1-2 has been loaded, during which both results are visible.
This PR aims to remove that redundancy by committing V1-1 directly.

2) Temporary data loss in queries
Currently, handoff for streaming ingestion looks only at the original set of segments to the append action. This PR enhances the notifier to look at the upgraded segments as well. Without this change, an append that happens after a replace may miss data that relies on the handoff.


- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
