### PR TITLE
Resolve CVE issues

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -191,7 +191,7 @@ name: AWS SDK for Java
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.12.497
+version: 1.12.638
 libraries:
   - com.amazonaws: aws-java-sdk-core
   - com.amazonaws: aws-java-sdk-ec2
@@ -4632,7 +4632,7 @@ libraries:
 
 name: com.amazonaws aws-java-sdk-bundle
 license_category: binary
-version: 1.12.497
+version: 1.12.638
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -643,4 +643,25 @@
       <cve>CVE-2019-0210</cve>
       <cve>CVE-2020-13949</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+        FP per issue #6100 - CVE-2023-36052 since it is related to Azure-cli not to the azure-core libraries
+        ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.azure/azure*@*.*$</packageUrl>
+    <cve>CVE-2023-36052</cve>
+  </suppress>
+  <suppress>
+    <!-- CVE is for a totally unrelated Sketch mac app -->
+    <notes><![CDATA[
+     file name: sketches-java-0.8.2.jar
+     ]]></notes>
+    <cve>CVE-2021-40531</cve>
+  </suppress>
+  <suppress>
+    <!-- CVE reports versions until 1.10.2 affected. The current version 1.11.1 is already greater and the latest. -->
+    <notes><![CDATA[
+      file name: azure-identity-1.11.1.jar
+    ]]></notes>
+    <cve>CVE-2023-36415</cve>
+  </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
              however it is required in some cases when running against mockito 4.x (mockito 4.x is required for Java <11.
              We use the following property to pick the proper artifact based on Java version (see pre-java-11 profile) -->
         <mockito.inline.artifact>core</mockito.inline.artifact>
-        <aws.sdk.version>1.12.497</aws.sdk.version>
+        <aws.sdk.version>1.12.638</aws.sdk.version>
         <caffeine.version>2.8.0</caffeine.version>
         <jacoco.version>0.8.7</jacoco.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>


### PR DESCRIPTION
As part of CVE resolution, this PR:

* Changes AWS SDK version from `1.12.497` to `1.12.638` -- the first version not using the problematic `ion-java-1.0.2.jar` binary
* Supresses the CVE for azure libraries as it's is related to azure-cli which is not used
* Supresses the CVE for `sketches-java-0.8.2.jar` since the CVE is unrelated to the library