### PR TITLE
Support Window operators in decoupled planning

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -248,10 +248,22 @@ public class CalciteRulesManager
         ),
         Programs.sequence(
             druidPreProgram,
+            buildBaseRuleSetProgram(plannerContext),
+            new LoggingProgram("After baseRuleSet program", isDebug),
             Programs.ofRules(logicalConventionRuleSet(plannerContext)),
             new LoggingProgram("After logical volcano planner program", isDebug)
         )
     );
+  }
+
+  private Program buildBaseRuleSetProgram(PlannerContext plannerContext)
+  {
+    final HepProgramBuilder builder = HepProgram.builder();
+    builder.addMatchLimit(CalciteRulesManager.HEP_DEFAULT_MATCH_LIMIT);
+    builder.addGroupBegin();
+    builder.addRuleCollection(baseRuleSet(plannerContext));
+    builder.addGroupEnd();
+    return Programs.of(builder.build(), true, DefaultRelMetadataProvider.INSTANCE);
   }
 
   /**
@@ -405,7 +417,7 @@ public class CalciteRulesManager
   {
     final ImmutableList.Builder<RelOptRule> retVal = ImmutableList
         .<RelOptRule>builder()
-        .addAll(baseRuleSet(plannerContext))
+        .add(CoreRules.SORT_REMOVE)
         .add(new DruidLogicalRules(plannerContext).rules().toArray(new RelOptRule[0]));
     return retVal.build();
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidQueryGenerator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidQueryGenerator.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalCorrelate;
 import org.apache.calcite.rel.logical.LogicalExchange;
@@ -43,6 +44,7 @@ import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.rel.PartialDruidQuery;
@@ -308,9 +310,25 @@ public class DruidQueryGenerator extends RelShuttleImpl
       return visitFilter((Filter) other);
     } else if (other instanceof LogicalValues) {
       return visit((LogicalValues) other);
+    } else if (other instanceof Window) {
+      return visitWindow((Window) other);
     }
 
-    return super.visit(other);
+    throw new UOE("Found unsupported RelNode [%s]", other.getClass().getSimpleName());
+  }
+
+  private RelNode visitWindow(Window other)
+  {
+    RelNode result = super.visit(other);
+    if (!PartialDruidQuery.Stage.WINDOW.canFollow(currentStage)) {
+      queryList.add(partialDruidQuery);
+      queryTables.add(currentTable);
+      partialDruidQuery = PartialDruidQuery.createOuterQuery(partialDruidQuery);
+    }
+    partialDruidQuery = partialDruidQuery.withWindow((Window) result);
+    currentStage = PartialDruidQuery.Stage.WINDOW;
+
+    return result;
   }
 
   public PartialDruidQuery getPartialDruidQuery()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -50,7 +50,6 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.FilteredDataSource;
-import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.JoinDataSource;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryDataSource;
@@ -1454,7 +1453,7 @@ public class DruidQuery
     if (dataSource.isConcrete()) {
       return null;
     }
-    if (!(dataSource instanceof InlineDataSource || dataSource instanceof QueryDataSource)) {
+    if (dataSource instanceof TableDataSource) {
       // We need a scan query to pull the results up for us before applying the window
       // Returning null here to ensure that the planner generates that alternative
       return null;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite.rel;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -65,6 +66,7 @@ import org.apache.druid.sql.calcite.rule.GroupByRules;
 import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -132,8 +134,9 @@ public class Windowing
     List<String> priorPartitionColumns = null;
     LinkedHashSet<ColumnWithDirection> priorSortColumns = new LinkedHashSet<>();
 
-    final RelCollation priorCollation = partialQuery.getScan().getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
-    if (priorCollation != null) {
+    RelTrait trait = partialQuery.getScan().getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+    if (trait != null && trait instanceof RelCollation) {
+      final RelCollation priorCollation = (RelCollation) trait;
       // Populate initial priorSortColumns using collation of the input to the window operation. Allows us to skip
       // the initial sort operator if the rows were already in the desired order.
       priorSortColumns = computeSortColumnsFromRelCollation(priorCollation, sourceRowSignature);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -22,7 +22,6 @@ package org.apache.druid.sql.calcite.rel;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -66,7 +65,6 @@ import org.apache.druid.sql.calcite.rule.GroupByRules;
 import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import javax.annotation.Nonnull;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -134,9 +132,8 @@ public class Windowing
     List<String> priorPartitionColumns = null;
     LinkedHashSet<ColumnWithDirection> priorSortColumns = new LinkedHashSet<>();
 
-    RelTrait trait = partialQuery.getScan().getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
-    if (trait != null && trait instanceof RelCollation) {
-      final RelCollation priorCollation = (RelCollation) trait;
+    final RelCollation priorCollation = partialQuery.getScan().getTraitSet().getTrait(RelCollationTraitDef.INSTANCE);
+    if (priorCollation != null) {
       // Populate initial priorSortColumns using collation of the input to the window operation. Allows us to skip
       // the initial sort operator if the rows were already in the desired order.
       priorSortColumns = computeSortColumnsFromRelCollation(priorCollation, sourceRowSignature);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/logical/DruidWindow.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/logical/DruidWindow.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rel.logical;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.List;
+
+/**
+ * {@link DruidLogicalNode} convention node for {@link Filter} plan node.
+ */
+public class DruidWindow extends Window implements DruidLogicalNode
+{
+  public DruidWindow(RelOptCluster cluster, RelTraitSet traitSet, List<RelHint> hints, RelNode input,
+      List<RexLiteral> constants, RelDataType rowType, List<Group> groups)
+  {
+    super(cluster, traitSet, hints, input, constants, rowType, groups);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs)
+  {
+    return new DruidWindow(getCluster(), traitSet, hints, inputs.get(0), constants, rowType, groups);
+  }
+
+  @Override
+  public RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq)
+  {
+    return planner.getCostFactory().makeCost(mq.getRowCount(this), 0, 0);
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/logical/DruidLogicalRules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/logical/DruidLogicalRules.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite.rule.logical;
 import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalProject;
@@ -83,6 +84,12 @@ public class DruidLogicalRules
                 Convention.NONE,
                 DruidLogicalConvention.instance(),
                 DruidValuesRule.class.getSimpleName()
+            ),
+            new DruidWindowRule(
+                Window.class,
+                Convention.NONE,
+                DruidLogicalConvention.instance(),
+                DruidWindowRule.class.getSimpleName()
             )
         )
     );

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/logical/DruidWindowRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/logical/DruidWindowRule.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule.logical;
+
+import org.apache.calcite.plan.RelTrait;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Window;
+import org.apache.druid.sql.calcite.rel.logical.DruidLogicalConvention;
+import org.apache.druid.sql.calcite.rel.logical.DruidWindow;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class DruidWindowRule extends ConverterRule
+{
+
+  public DruidWindowRule(Class<? extends RelNode> clazz, RelTrait in, RelTrait out, String descriptionPrefix)
+  {
+    super(
+        Config.INSTANCE
+            .withConversion(clazz, in, out, descriptionPrefix)
+    );
+  }
+
+  @Override
+  public @Nullable RelNode convert(RelNode rel)
+  {
+    Window w = (Window) rel;
+    RelTraitSet newTrait = w.getTraitSet().replace(DruidLogicalConvention.instance());
+    return new DruidWindow(
+        w.getCluster(),
+        newTrait,
+        w.getHints(),
+        convert(
+            w.getInput(),
+            w.getInput().getTraitSet().replace(DruidLogicalConvention.instance())
+        ),
+        w.getConstants(),
+        w.getRowType(),
+        w.groups
+    );
+
+  }
+
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -111,6 +111,7 @@ import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.JoinType;
+import org.apache.druid.sql.calcite.DecoupledTestConfig.NativeQueryIgnore;
 import org.apache.druid.sql.calcite.NotYetSupported.Modes;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.filtration.Filtration;
@@ -7619,7 +7620,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  @NotYetSupported(Modes.PLAN_MISMATCH)
   @Test
   public void testExactCountDistinctUsingSubqueryWithWherePushDown()
   {
@@ -8173,6 +8173,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.AGG_COL_EXCHANGE)
   @Test
   public void testGroupBySortPushDown()
   {
@@ -8268,6 +8269,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.IMPROVED_PLAN)
   @Test
   public void testGroupByLimitPushdownExtraction()
   {
@@ -8722,6 +8724,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.SLIGHTLY_WORSE_PLAN)
   @SqlTestFrameworkConfig(numMergeBuffers = 3)
   @Test
   public void testQueryWithSelectProjectAndIdentityProjectDoesNotRename()
@@ -10180,7 +10183,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         )
     );
   }
-
 
   @Test
   public void testGroupByExtractYear()
@@ -12631,6 +12633,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.EXPR_POSTAGG)
   @Test
   public void testGroupByWithLiteralInSubqueryGrouping()
   {
@@ -12819,6 +12822,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.EXPR_POSTAGG)
   @Test
   public void testRepeatedIdenticalVirtualExpressionGrouping()
   {
@@ -14272,7 +14276,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
-  @NotYetSupported(Modes.PLAN_MISMATCH)
   @Test
   public void testPlanWithInFilterLessThanInSubQueryThreshold()
   {
@@ -14423,6 +14426,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
     );
   }
 
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.AGGREGATE_REMOVE_NOT_FIRED)
   @Test
   public void testSubqueryTypeMismatchWithLiterals()
   {
@@ -15068,7 +15072,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         .run();
   }
 
-  @NotYetSupported(Modes.CANNOT_TRANSLATE)
+  @DecoupledTestConfig(nativeQueryIgnore = NativeQueryIgnore.SLIGHTLY_WORSE_PLAN)
   @Test
   public void testWindowingWithScanAndSort()
   {
@@ -15168,7 +15172,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         .run();
   }
 
-  @NotYetSupported(Modes.CANNOT_TRANSLATE)
   @Test
   public void testWindowingWithOrderBy()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteQueryTest.java
@@ -35,22 +35,33 @@ public class DecoupledPlanningCalciteQueryTest extends CalciteQueryTest
 
   private static final ImmutableMap<String, Object> CONTEXT_OVERRIDES = ImmutableMap.of(
       PlannerConfig.CTX_NATIVE_QUERY_SQL_PLANNING_MODE, PlannerConfig.NATIVE_QUERY_SQL_PLANNING_MODE_DECOUPLED,
-      QueryContexts.ENABLE_DEBUG, true);
+      QueryContexts.ENABLE_DEBUG, true
+  );
 
   @Override
   protected QueryTestBuilder testBuilder()
   {
-    return new QueryTestBuilder(
-        new CalciteTestConfig(CONTEXT_OVERRIDES)
-        {
-          @Override
-          public SqlTestFramework.PlannerFixture plannerFixture(PlannerConfig plannerConfig, AuthConfig authConfig)
-          {
-            plannerConfig = plannerConfig.withOverrides(CONTEXT_OVERRIDES);
-            return queryFramework().plannerFixture(DecoupledPlanningCalciteQueryTest.this, plannerConfig, authConfig);
-          }
-        })
+
+    CalciteTestConfig testConfig = new CalciteTestConfig(CONTEXT_OVERRIDES)
+    {
+      @Override
+      public SqlTestFramework.PlannerFixture plannerFixture(PlannerConfig plannerConfig, AuthConfig authConfig)
+      {
+        plannerConfig = plannerConfig.withOverrides(CONTEXT_OVERRIDES);
+        return queryFramework().plannerFixture(DecoupledPlanningCalciteQueryTest.this, plannerConfig, authConfig);
+      }
+    };
+
+    QueryTestBuilder builder = new QueryTestBuilder(testConfig)
         .cannotVectorize(cannotVectorize)
         .skipVectorize(skipVectorize);
+
+    DecoupledTestConfig decTestConfig = queryFrameworkRule.getDescription().getAnnotation(DecoupledTestConfig.class);
+
+    if (decTestConfig != null && decTestConfig.nativeQueryIgnore().isPresent()) {
+      builder.verifyNativeQueries(x -> false);
+    }
+
+    return builder;
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledTestConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledTestConfig.java
@@ -19,31 +19,54 @@
 
 package org.apache.druid.sql.calcite;
 
+import org.apache.calcite.rel.rules.CoreRules;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Specifies test case level matching customizations for decoupled mode.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 public @interface DecoupledTestConfig
 {
+  /**
+   * Enables the framework to ignore native query differences.
+   *
+   * The value of this field should describe the root cause of the difference.
+   */
   NativeQueryIgnore nativeQueryIgnore() default NativeQueryIgnore.NONE;
 
   enum NativeQueryIgnore
   {
     NONE,
-    // decoupled has moved virtualcolumn to postagg (improved plan)
-    // CoreRules.AGGREGATE_ANY_PULL_UP_CONSTANTS
+    /**
+     * Decoupled has moved virtualcolumn to postagg (improved plan)
+     * caused by: {@link CoreRules#AGGREGATE_ANY_PULL_UP_CONSTANTS}
+     */
     EXPR_POSTAGG,
-    // dim1/dim2 exchange
+    /**
+     * Aggregate column order changes.
+     *
+     * dim1/dim2 exchange
+     */
     AGG_COL_EXCHANGE,
-    // this happens when AGGREGATE_REMOVE gets supressed by
-    // AGGREGATE_CASE_REWRITE
+    /**
+     * This happens when {@link CoreRules#AGGREGATE_REMOVE} gets supressed by {@link CoreRules#AGGREGATE_CASE_TO_FILTER}
+     */
     AGGREGATE_REMOVE_NOT_FIRED,
-    // improved plan - AGGREGATE_ANY_PULL_UP_CONSTANTS ; enable for default?
+    /**
+     * Improved plan
+     *
+     * Seen that it was induced by {@link CoreRules#AGGREGATE_ANY_PULL_UP_CONSTANTS}
+     */
     IMPROVED_PLAN,
-    // worse plan; may loose vectorization; but no extra queries
+    /**
+     * Worse plan; may loose vectorization; but no extra queries
+     */
     SLIGHTLY_WORSE_PLAN;
 
     public boolean isPresent()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledTestConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledTestConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface DecoupledTestConfig
+{
+  NativeQueryIgnore nativeQueryIgnore() default NativeQueryIgnore.NONE;
+
+  enum NativeQueryIgnore
+  {
+    NONE,
+    // decoupled has moved virtualcolumn to postagg (improved plan)
+    // CoreRules.AGGREGATE_ANY_PULL_UP_CONSTANTS
+    EXPR_POSTAGG,
+    // dim1/dim2 exchange
+    AGG_COL_EXCHANGE,
+    // this happens when AGGREGATE_REMOVE gets supressed by
+    // AGGREGATE_CASE_REWRITE
+    AGGREGATE_REMOVE_NOT_FIRED,
+    // improved plan - AGGREGATE_ANY_PULL_UP_CONSTANTS ; enable for default?
+    IMPROVED_PLAN,
+    // worse plan; may loose vectorization; but no extra queries
+    SLIGHTLY_WORSE_PLAN;
+
+    public boolean isPresent()
+    {
+      return this != NONE;
+    }
+  };
+
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
@@ -81,6 +81,7 @@ public @interface SqlTestFrameworkConfig
     private SqlTestFrameworkConfig config;
     private ClassRule classRule;
     private QueryComponentSupplier testHost;
+    private Description description;
 
     public MethodRule(ClassRule classRule, QueryComponentSupplier testHost)
     {
@@ -105,6 +106,7 @@ public @interface SqlTestFrameworkConfig
     @Override
     public Statement apply(Statement base, Description description)
     {
+      this.description = description;
       config = description.getAnnotation(SqlTestFrameworkConfig.class);
       if (config == null) {
         config = defaultConfig();
@@ -115,6 +117,11 @@ public @interface SqlTestFrameworkConfig
     public SqlTestFramework get()
     {
       return getConfigurationInstance().framework;
+    }
+
+    public Description getDescription()
+    {
+      return description;
     }
 
     private ConfigurationInstance getConfigurationInstance()


### PR DESCRIPTION
### Description

* move baseruleset into a separate program
  * it doesn't interfere with the conversion rules
  * there will be less states in the planner during the conversion
* enable scan&sort style queries to accept column reordings
* add Window related conversion/etc to enable it in decoupled mode
* added `DecoupledTestConfig` to specify per-testcase customization
  * currently its being used to describe why the native query is not checked

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
