### PR TITLE
fix: handle BOOKMARK events in kubernetes pod discovery

### DIFF
--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -131,7 +131,7 @@ public class DefaultK8sApiClient implements K8sApiClient
           try {
             while (watch.hasNext()) {
               Watch.Response<V1Pod> item = watch.next();
-              if (item != null && item.type != null) {
+              if (item != null && item.type != null && !item.type.equals(WatchResult.BOOKMARK)) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
                 if (item.object != null) {
                   result = new DiscoveryDruidNodeAndResourceVersion(
@@ -149,6 +149,11 @@ public class DefaultK8sApiClient implements K8sApiClient
                     item.type,
                     result
                 );
+                return true;
+              } else if (item != null && item.type != null && item.type.equals(WatchResult.BOOKMARK)) {
+                // Events with type BOOKMARK will only contain resourceVersion and no metadata. See
+                // Kubernetes API documentation for details.
+                LOGGER.debug("BOOKMARK event fired, no nothing, only update resourceVersion");
                 return true;
               } else {
                 LOGGER.error("WTH! item or item.type is NULL");

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
@@ -27,6 +27,7 @@ public interface WatchResult
 {
   String ADDED = "ADDED";
   String DELETED = "DELETED";
+  String BOOKMARK = "BOOKMARK";
 
   boolean hasNext() throws SocketTimeoutException;
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

In the ZKless `kubernetes-extensions` we are listening for pod updates and handling them accordingly. As part of that code we are also subscribing for the special `BOOKMARK` event on the watcher, it is to prevent clients for overfetching from the Kubernetes API server, however, we are not handling this event properly. Specifically it does not include any metadata and is only meant to update the resourceVersion for the next call. This PR handles that.

Currently monitoring in our staging cluster.

#### Fixed the bug ...

The following would appear in logs for BOOKMARK events. However, since ADDED and REMOVED events are handled correctly the system would operate more-or-less correctly, only that resourceVersion was never updated because of the exception thrown, so less efficiently.

```
org.apache.druid.k8s.discovery.K8sDruidNodeDiscoveryProvider$NodeRoleWatcher - Error while watching node type [INDEXER]
java.lang.NullPointerException: Cannot invoke "java.util.Map.get(Object)" because the return value of "io.kubernetes.client.openapi.models.V1ObjectMeta.getAnnotations()" is null
        at org.apache.druid.k8s.discovery.DefaultK8sApiClient.getDiscoveryDruidNodeFromPodDef(DefaultK8sApiClient.java:100) ~[?:?]
        at org.apache.druid.k8s.discovery.DefaultK8sApiClient.access$000(DefaultK8sApiClient.java:48) ~[?:?]
        at org.apache.druid.k8s.discovery.DefaultK8sApiClient$2.hasNext(DefaultK8sApiClient.java:139) ~[?:?]
        at org.apache.druid.k8s.discovery.K8sDruidNodeDiscoveryProvider$NodeRoleWatcher.keepWatching(K8sDruidNodeDiscoveryProvider.java:268) ~[?:?]
        at org.apache.druid.k8s.discovery.K8sDruidNodeDiscoveryProvider$NodeRoleWatcher.watch(K8sDruidNodeDiscoveryProvider.java:237) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
