### PR TITLE
use latest datasketches-java-5.0.1

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollector.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollector.java
@@ -150,7 +150,7 @@ public class QuantilesSketchKeyCollector implements KeyCollector<QuantilesSketch
 
     final int numPartitions = Ints.checkedCast(LongMath.divide(sketch.getN(), targetWeight, RoundingMode.CEILING));
 
-    final byte[][] quantiles = (sketch.getPartitionBoundaries(numPartitions, QuantileSearchCriteria.EXCLUSIVE)).boundaries;
+    final byte[][] quantiles = (sketch.getPartitionBoundaries(numPartitions, QuantileSearchCriteria.EXCLUSIVE)).getBoundaries();
     final List<ClusterByPartition> partitions = new ArrayList<>();
 
     for (int i = 0; i < numPartitions; i++) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketch.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketch.java
@@ -129,7 +129,7 @@ public class StringSketch implements StringDistribution
     if (delegate.isEmpty()) {
       return new PartitionBoundaries(new StringTuple[0]);
     }
-    return new PartitionBoundaries((delegate.getPartitionBoundaries(evenPartitionCount, QuantileSearchCriteria.EXCLUSIVE)).boundaries);
+    return new PartitionBoundaries((delegate.getPartitionBoundaries(evenPartitionCount, QuantileSearchCriteria.EXCLUSIVE)).getBoundaries());
   }
 
   @Override

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3079,7 +3079,7 @@ name: DataSketches
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.2.0
+version: 5.0.1
 libraries:
   - org.apache.datasketches: datasketches-java
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
           -->
         <calcite.version>1.35.0</calcite.version>
         <confluent.version>6.2.12</confluent.version>
-        <datasketches.version>4.2.0</datasketches.version>
+        <datasketches.version>5.0.1</datasketches.version>
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>


### PR DESCRIPTION
This is to update the dependency on datasketches-java from 4.2.0 to the latest 5.0.1

one of the changes since 4.2.0 must be relevant to Druid (from 5.0.0 release notes):
"Fixed an integer overflow bug caught by Karan Kumar (via Druid), where very large partitioning datasets using the classic quantiles DoublesSketch::getPartitionBoundaries() would fail"

Other release notes see here:
https://github.com/apache/datasketches-java/releases