### PR TITLE
Update input-sources.md for fixing the warehouse path example under S3

### DIFF
--- a/docs/ingestion/input-sources.md
+++ b/docs/ingestion/input-sources.md
@@ -997,7 +997,7 @@ The following is a sample spec for a S3 warehouse source:
             "namespace": "iceberg_namespace",
             "icebergCatalog": {
               "type": "hive",
-              "warehousePath": "hdfs://warehouse/path",
+              "warehousePath": "s3://warehouse/path",
               "catalogUri": "thrift://hive-metastore.x.com:8970",
               "catalogProperties": {
                 "hive.metastore.connect.retries": "1",


### PR DESCRIPTION
Fixes a typo in the Iceberg warehouse path for s3 in `input-sources.md`.
