### PR TITLE
Handling cast boolean to integer

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidConformance.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidConformance.java
@@ -46,6 +46,13 @@ public class DruidConformance extends SqlAbstractConformance
   }
 
   @Override
+  public boolean allowLenientCoercion()
+  {
+    // for CAST boolean to INTEGER
+    return true;
+  }
+
+  @Override
   public boolean isSortByOrdinal()
   {
     // For ORDER BY 1
@@ -78,4 +85,5 @@ public class DruidConformance extends SqlAbstractConformance
   {
     return true;
   }
+
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -15264,4 +15264,34 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         )
         .run();
   }
+
+  @Test
+  public void testCastBooleanToInteger()
+  {
+    cannotVectorize();
+    testQuery(
+        "SELECT CAST(TRUE as INTEGER)",
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(
+                      InlineDataSource.fromIterable(
+                          ImmutableList.of(
+                              new Object[]{1L}
+                          ),
+                          RowSignature.builder().add("EXPR$0", ColumnType.LONG).build()
+                      )
+                  )
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .legacy(false)
+                  .columns(ImmutableList.of(
+                      "EXPR$0"
+                  ))
+                  .build()
+        ),
+        ImmutableList.of(
+            new Object[]{1}
+        )
+    );
+  }
 }


### PR DESCRIPTION
Previously queries like `SELECT CAST(TRUE as INTEGER)` would throw errors. This PR aims to support it by allowing lenient conformance 

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
