### PR TITLE
Fix serialization bug in PassthroughAggregatorFactory 

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/PassthroughAggregatorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/PassthroughAggregatorFactory.java
@@ -66,10 +66,21 @@ public class PassthroughAggregatorFactory extends AggregatorFactory
     this.complexTypeName = complexTypeName;
   }
 
-  @JsonProperty
+  @JsonProperty("columnName")
   public String getColumnName()
   {
     return columnName;
+  }
+
+  /**
+   * The getter for this variable is named differently because the 'getComplexTypeName' is a deprecated method present
+   * in the super class {@link AggregatorFactory}, and can be removed discriminately here, leading to incorrect serde of
+   * the aggregator factory over the wire
+   */
+  @JsonProperty("complexTypeName")
+  public String getComplexName()
+  {
+    return complexTypeName;
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/PassthroughAggregatorFactoryTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/PassthroughAggregatorFactoryTest.java
@@ -19,8 +19,11 @@
 
 package org.apache.druid.msq.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorFactoryNotMergeableException;
 import org.junit.Assert;
@@ -28,6 +31,21 @@ import org.junit.Test;
 
 public class PassthroughAggregatorFactoryTest
 {
+
+  @Test
+  public void testSerde() throws JsonProcessingException
+  {
+    ObjectMapper objectMapper = new DefaultObjectMapper();
+    objectMapper.registerSubtypes(PassthroughAggregatorFactory.class);
+    AggregatorFactory aggregatorFactory = new PassthroughAggregatorFactory("x", "y");
+    String serializedvalue = objectMapper.writeValueAsString(aggregatorFactory);
+    Assert.assertEquals(
+        "{\"type\":\"passthrough\",\"columnName\":\"x\",\"complexTypeName\":\"y\"}",
+        serializedvalue
+    );
+    Assert.assertEquals(aggregatorFactory, objectMapper.readValue(serializedvalue, AggregatorFactory.class));
+  }
+
   @Test
   public void testRequiredFields()
   {


### PR DESCRIPTION
### Description

PassthroughAggregatorFactory overrides a deprecated method in the AggregatorFactory, on which it relies on for serializing one of its fields `complexTypeName`. This was accidentally removed, leading to a bug in the factory, where the type name doesn't get serialized properly, and places `null` in the type name. This PR revives that method with a different name and adds tests for the same. 

<hr>

##### Key changed/added classes in this PR
 * `PassthroughAggregatorFactory`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
