### PR TITLE
Simplify concurrent streaming ingestion with replace

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceAction.java
@@ -118,18 +118,6 @@ public class SegmentTransactionalReplaceAction implements TaskAction<SegmentPubl
 
     IndexTaskUtils.emitSegmentPublishMetrics(publishResult, task, toolbox);
 
-    // Upgrade any overlapping pending segments
-    // Do not perform upgrade in the same transaction as replace commit so that
-    // failure to upgrade pending segments does not affect success of the commit
-    if (publishResult.isSuccess() && toolbox.getSupervisorManager() != null) {
-      try {
-        tryUpgradeOverlappingPendingSegments(task, toolbox);
-      }
-      catch (Exception e) {
-        log.error(e, "Error while upgrading pending segments for task[%s]", task.getId());
-      }
-    }
-
     return publishResult;
   }
 

--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -119,6 +119,13 @@ public class ServerSelector implements Overshadowable<ServerSelector>
     }
   }
 
+  public boolean hasRealtime()
+  {
+    synchronized (this) {
+      return !realtimeServers.isEmpty();
+    }
+  }
+
   public List<DruidServerMetadata> getCandidates(final int numCandidates)
   {
     List<DruidServerMetadata> candidates;

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1586,13 +1586,13 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
       // Update the set so that subsequent segment IDs use a higher partition number
       allAllocatedIds.add(newId);
-      newSegmentIds.add(
-          DataSegment.builder(segment)
-                     .interval(newId.getInterval())
-                     .version(newId.getVersion())
-                     .shardSpec(newId.getShardSpec())
-                     .build()
-      );
+      final DataSegment upgradedSegment = DataSegment.builder(segment)
+                                                     .interval(newId.getInterval())
+                                                     .version(newId.getVersion())
+                                                     .shardSpec(newId.getShardSpec())
+                                                     .build();
+      upgradedSegment.setPrevSegmentDescriptor(segment.toDescriptor());
+      newSegmentIds.add(upgradedSegment);
     }
 
     return newSegmentIds;
@@ -2093,13 +2093,13 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
 
       // Create upgraded segment with the correct interval, version and shard spec
       String lockVersion = upgradeSegmentToLockVersion.get(oldSegment.getId().toString());
-      upgradedSegments.add(
-          DataSegment.builder(oldSegment)
-                     .interval(newInterval)
-                     .version(lockVersion)
-                     .shardSpec(shardSpec)
-                     .build()
-      );
+      final DataSegment upgradedSegment = DataSegment.builder(oldSegment)
+                                                     .interval(newInterval)
+                                                     .version(lockVersion)
+                                                     .shardSpec(shardSpec)
+                                                     .build();
+      upgradedSegment.setPrevSegmentDescriptor(oldSegment.toDescriptor());
+      upgradedSegments.add(upgradedSegment);
     }
 
     return upgradedSegments;


### PR DESCRIPTION
This PR aims to simplify the working of a concurrent streaming ingestion job with a replacing commit.

The original approach required us to update the pending segments and send the mapping to the peon, and this can be error-prone with uncertainties.

This approach is as follows:
When a segment is upgraded to another segment of a higher version, we store the original id as a descriptor in the newly created segment.
The CachingClusteredClient on the Broker then includes all overshadowed realtime segments (if any), except the higher versions of them which already exist on historicals. The filtered set of realtime segments are then included along with the segments returned by the lookup of the complete timeline in the set of segments to be processed.


TODO:
- Evaluate performance impact on queries
- Clean up the pending segment and task communication methods used in the original approach

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
