### PR TITLE
use NullFilter for SQL rewrite of MV_CONTAINS and MV_OVERLAP for null array elements

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayContainsOperatorConversion.java
@@ -34,6 +34,7 @@ import org.apache.druid.query.filter.AndDimFilter;
 import org.apache.druid.query.filter.ArrayContainsElementFilter;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.EqualityFilter;
+import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
@@ -129,14 +130,18 @@ public class ArrayContainsOperatorConversion extends BaseExpressionDimFilterOper
                                         leftExpr,
                                         leftExpr.getDruidType()
                                     );
-              filters.add(
-                  new EqualityFilter(
-                      column,
-                      ExpressionType.toColumnType(ExpressionType.elementType(exprEval.type())),
-                      val,
-                      null
-                  )
-              );
+              if (val == null) {
+                filters.add(NullFilter.forColumn(column));
+              } else {
+                filters.add(
+                    new EqualityFilter(
+                        column,
+                        ExpressionType.toColumnType(ExpressionType.elementType(exprEval.type())),
+                        val,
+                        null
+                    )
+                );
+              }
             }
           }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ArrayOverlapOperatorConversion.java
@@ -34,6 +34,7 @@ import org.apache.druid.query.filter.ArrayContainsElementFilter;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.EqualityFilter;
 import org.apache.druid.query.filter.InDimFilter;
+import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.query.filter.OrDimFilter;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -135,10 +136,14 @@ public class ArrayOverlapOperatorConversion extends BaseExpressionDimFilterOpera
                                     simpleExtractionExpr,
                                     simpleExtractionExpr.getDruidType()
                                 );
+          final Object elementValue = arrayElements[0];
+          if (elementValue == null) {
+            return NullFilter.forColumn(column);
+          }
           return new EqualityFilter(
               column,
               ExpressionType.toColumnType(exprEval.type()),
-              arrayElements[0],
+              elementValue,
               null
           );
         }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -304,9 +304,15 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                 .context(QUERY_CONTEXT_DEFAULT)
                 .build()
         ),
-        ImmutableList.of(
+        NullHandling.sqlCompatible()
+        ? ImmutableList.of(
             new Object[]{null},
             new Object[]{null}
+        )
+        : ImmutableList.of(
+            new Object[]{""},
+            new Object[]{""},
+            new Object[]{""}
         )
     );
   }
@@ -376,9 +382,15 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                 .context(QUERY_CONTEXT_DEFAULT)
                 .build()
         ),
-        ImmutableList.of(
+        NullHandling.sqlCompatible()
+        ? ImmutableList.of(
             new Object[]{null},
             new Object[]{null}
+        )
+        : ImmutableList.of(
+            new Object[]{""},
+            new Object[]{""},
+            new Object[]{""}
         )
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.extraction.SubstringDimExtractionFn;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.LikeDimFilter;
+import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
@@ -286,6 +287,31 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testMultiValueStringOverlapFilterNull()
+  {
+    testQuery(
+        "SELECT dim3 FROM druid.numfoo WHERE MV_OVERLAP(dim3, ARRAY[NULL]) LIMIT 5",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .eternityInterval()
+                .filters(
+                    NullHandling.sqlCompatible() ? NullFilter.forColumn("dim3") : selector("dim3", null)
+                )
+                .columns("dim3")
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(5)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{null},
+            new Object[]{null}
+        )
+    );
+  }
+
+  @Test
   public void testMultiValueStringOverlapFilterNonLiteral()
   {
     testQuery(
@@ -328,6 +354,31 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
         ),
         ImmutableList.of(
             new Object[]{"[\"a\",\"b\"]"}
+        )
+    );
+  }
+
+  @Test
+  public void testMultiValueStringContainsFilterNull()
+  {
+    testQuery(
+        "SELECT dim3 FROM druid.numfoo WHERE MV_CONTAINS(dim3, ARRAY[NULL]) LIMIT 5",
+        ImmutableList.of(
+            newScanQueryBuilder()
+                .dataSource(CalciteTests.DATASOURCE3)
+                .eternityInterval()
+                .filters(
+                    NullHandling.sqlCompatible() ? NullFilter.forColumn("dim3") : selector("dim3", null)
+                )
+                .columns("dim3")
+                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                .limit(5)
+                .context(QUERY_CONTEXT_DEFAULT)
+                .build()
+        ),
+        ImmutableList.of(
+            new Object[]{null},
+            new Object[]{null}
         )
     );
   }


### PR DESCRIPTION
### Description
Fixes an oversight after #14542 that happens in the SQL planner rewrite of `MV_CONTAINS` and `MV_OVERLAP` when faced with array elements that are `NULL`, where we were incorrectly using `EqualityFilter` instead of `NullFilter` for null elements (`EqualityFilter` does not accept null elements).

Without the changes of this PR, the added tests would fail with errors like:
 ```
org.apache.druid.error.DruidException: Invalid equality filter on column [dim3], matchValue cannot be null
```

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
