### PR TITLE
Improve rolling Supervisor restarts at taskDuration

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
@@ -79,6 +79,8 @@ public class KafkaSupervisorIOConfigTest
     Assert.assertNull(config.getTopicPattern());
     Assert.assertEquals(1, (int) config.getReplicas());
     Assert.assertEquals(1, (int) config.getTaskCount());
+    Assert.assertNull(config.getStopTaskCount());
+    Assert.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
     Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
     Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
     Assert.assertEquals(100, config.getPollTimeout());

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
@@ -62,6 +62,8 @@ public class KinesisSupervisorIOConfigTest
     Assert.assertEquals(KinesisRegion.US_EAST_1.getEndpoint(), config.getEndpoint());
     Assert.assertEquals(1, (int) config.getReplicas());
     Assert.assertEquals(1, (int) config.getTaskCount());
+    Assert.assertNull(config.getStopTaskCount());
+    Assert.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
     Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
     Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
     Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -49,8 +49,7 @@ public abstract class SeekableStreamSupervisorIOConfig
   private final Optional<DateTime> lateMessageRejectionStartDateTime;
   @Nullable private final AutoScalerConfig autoScalerConfig;
   @Nullable private final IdleConfig idleConfig;
-
-  private final int stopTaskCount;
+  @Nullable private final Integer stopTaskCount;
 
   public SeekableStreamSupervisorIOConfig(
       String stream,
@@ -81,8 +80,9 @@ public abstract class SeekableStreamSupervisorIOConfig
     } else {
       this.taskCount = taskCount != null ? taskCount : 1;
     }
-    this.stopTaskCount = stopTaskCount == null ? this.taskCount : stopTaskCount;
-    Preconditions.checkArgument(this.stopTaskCount > 0, "stopTaskCount must be greater than 0");
+    Preconditions.checkArgument(stopTaskCount == null || stopTaskCount > 0,
+                                "stopTaskCount must be greater than 0");
+    this.stopTaskCount = stopTaskCount;
     this.taskDuration = defaultDuration(taskDuration, "PT1H");
     this.startDelay = defaultDuration(startDelay, "PT5S");
     this.period = defaultDuration(period, "PT30S");
@@ -205,9 +205,15 @@ public abstract class SeekableStreamSupervisorIOConfig
     return idleConfig;
   }
 
+  @Nullable
   @JsonProperty
-  public int getStopTaskCount()
+  public Integer getStopTaskCount()
   {
     return stopTaskCount;
+  }
+
+  public int getMaxAllowedStops()
+  {
+    return stopTaskCount == null ? taskCount : stopTaskCount;
   }
 }


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

This PR builds on the foundation set by https://github.com/apache/druid/pull/14396 which introduced rolling supervisor restarts as a strategy to potentially reduce the number of task slots required for task handover in Druid. The primary goal of this PR is to refine the behavior and utilization of this feature by addressing two specific areas:

1. **Dynamic Adjustment of stopTaskCount:** Previously, `stopTaskCount` defaulted to the value of `taskCount` if not explicitly specified in the Supervisor spec. This implicit behavior led to inconsistency when `taskCount` was manually increased, as `stopTaskCount` did not automatically adjust to reflect the new taskCount. This PR eliminates this implicit defaulting. Now, if `stopTaskCount` is not set, it remains null and is preserved as such, requiring explicit configuration to activate rolling restarts.
2. **Optimized Task Cycling:** When `stopTaskCount` is configured to a low value (e.g., 1), it could lead to prolonged cycling and stopping of active tasks, especially for tasks that started earlier. To address this, the PR introduces logic to sort active running tasks by their start date, prioritizing the stopping of older tasks first. This approach aims to prevent early-started tasks from running excessively long, improving the overall efficiency of task cycling.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `SeekableStreamSupervisor` updated to sort task groups by start time to prioritize early termination of earlier groups 
 * `SeekableStreamSupervisorIOConfig` removed the automatic defaulting of `stopTaskCount` to `taskCount`, ensuring that `stopTaskCount` must be explicitly defined to influence the rolling restart behavior.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
