### PR TITLE
Add default implementation for `writeHeaderFromRowSignature`

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
@@ -133,7 +133,7 @@ public enum ResultFormat
 
     void writeHeader(RelDataType rowType, boolean includeTypes, boolean includeSqlTypes) throws IOException;
 
-    void writeHeaderFromRowSignature(RowSignature rowSignature, boolean includeTypes) throws IOException;
+    default void writeHeaderFromRowSignature(RowSignature rowSignature, boolean includeTypes) throws IOException {}
 
     /**
      * Start of each result row.

--- a/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/ResultFormat.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.RowSignature;
 
@@ -133,7 +134,10 @@ public enum ResultFormat
 
     void writeHeader(RelDataType rowType, boolean includeTypes, boolean includeSqlTypes) throws IOException;
 
-    default void writeHeaderFromRowSignature(RowSignature rowSignature, boolean includeTypes) throws IOException {}
+    default void writeHeaderFromRowSignature(RowSignature rowSignature, boolean includeTypes) throws IOException
+    {
+      throw DruidException.defensive("Writing header from RowSignature is not supported.");
+    }
 
     /**
      * Start of each result row.


### PR DESCRIPTION
In https://github.com/apache/druid/commit/514b3b4d0195984a3f347b4a8dbf8a41a9032e8f a new function was added to ResultFormat, which might break some implementations.

This adds a default implementation to avoid breaking any old implementations of this class.