### PR TITLE
Update k8sTaskRunner log message

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -221,7 +221,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
         synchronized (tasks) {
           workItem = tasks.get(taskId);
           if (workItem == null) {
-            log.error("Task [%s] disappeared", taskId);
+            log.warn("Task [%s] disappeared. This could happen if the task was canceled or if it crashed.", taskId);
             return;
           }
         }


### PR DESCRIPTION
### Description
Downgrade a log message about tasks disappearing to WARN. A task can disappear from the task runner for normal operations - like a user cancelling the task or a task crashing. WARN seems appropriate since it could indicate a crashing peon.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] been tested in a test Druid cluster.