### PR TITLE
Add explicit failure() check in tar and upload logs steps in static-checks.yml

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -187,11 +187,11 @@ jobs:
           web-console/script/druid stop
 
       - name: Tar druid logs
-        if: ${{ steps.web-console-test.conclusion == 'failure' }}
+        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
         run: tar cvzf ./druid-logs.tgz -C ./distribution/target/apache-druid-*-SNAPSHOT/ log
 
       - name: Upload druid logs to GitHub
-        if: ${{ steps.web-console-test.conclusion == 'failure' }}
+        if: ${{ failure() && steps.web-console-test.conclusion == 'failure' }}
         uses: actions/upload-artifact@master
         with:
           name: Druid logs web-checks


### PR DESCRIPTION
On adding an if clause in a Github actions step, there is an implicit addition of a [success pre-condition](https://docs.github.com/en/actions/learn-github-actions/expressions#failure-with-conditions) on all previous steps for the next step to execute. In order to override this in the if clause to have it evaluated on failures as well, an explicit failure check needs to be added prior to the actual condition being tested. This PR adds this fix to tar and upload logs steps in static-checks.yml