### PR TITLE
[Backport] fix: handle BOOKMARK events in kubernetes pod discovery (#15819)

### DIFF
--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DefaultK8sApiClient.java
@@ -131,7 +131,7 @@ public class DefaultK8sApiClient implements K8sApiClient
           try {
             while (watch.hasNext()) {
               Watch.Response<V1Pod> item = watch.next();
-              if (item != null && item.type != null) {
+              if (item != null && item.type != null && !item.type.equals(WatchResult.BOOKMARK)) {
                 DiscoveryDruidNodeAndResourceVersion result = null;
                 if (item.object != null) {
                   result = new DiscoveryDruidNodeAndResourceVersion(
@@ -149,6 +149,11 @@ public class DefaultK8sApiClient implements K8sApiClient
                     item.type,
                     result
                 );
+                return true;
+              } else if (item != null && item.type != null && item.type.equals(WatchResult.BOOKMARK)) {
+                // Events with type BOOKMARK will only contain resourceVersion and no metadata. See
+                // Kubernetes API documentation for details.
+                LOGGER.debug("BOOKMARK event fired, no nothing, only update resourceVersion");
                 return true;
               } else {
                 LOGGER.error("WTH! item or item.type is NULL");

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/WatchResult.java
@@ -27,6 +27,7 @@ public interface WatchResult
 {
   String ADDED = "ADDED";
   String DELETED = "DELETED";
+  String BOOKMARK = "BOOKMARK";
 
   boolean hasNext() throws SocketTimeoutException;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `29.0.0`:
 - [fix: handle BOOKMARK events in kubernetes pod discovery (#15819)](https://github.com/apache/druid/pull/15819)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)