### PR TITLE
Remove aws-sdk-bundle from druid-ranger-security extension

### DIFF
--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -41,6 +41,13 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>6.4.0</version>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-bundle</artifactId>
+                <!-- Deliberately not using the aws.sdk.version because the latter versions are very large.
+                  This is a temporary hack to reduce the size of the distribution -->
+                <version>1.12.497</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -41,11 +41,6 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>6.4.0</version>
             </dependency>
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-bundle</artifactId>
-                <version>${aws.sdk.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4642,7 +4642,7 @@ libraries:
 
 name: com.amazonaws aws-java-sdk-bundle
 license_category: binary
-version: 1.12.638
+version: 1.12.497
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -664,4 +664,12 @@
     ]]></notes>
     <cve>CVE-2023-36415</cve>
   </suppress>
+  <suppress>
+    <!-- CVE is in Amazon Ion, which is primarily used by Amazon QLDB. Ranger security uses aws-java-sdk-bundle, that's why the CVE is popping up, it primarily uses Amazon Cloudwatch and in all likeliness not using the Amazon Ion Library -->
+    <notes><![CDATA[
+      file name: aws-java-sdk-bundle-1.12.497.jar
+    ]]></notes>
+    <cve>CVE-2024-21634</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
`aws-sdk-bundle` bloats up the `druid-ranger-security` extension. This PR removes the dependency from the extension's pom. I am not sure if any aws library is required. 