### PR TITLE
allow compaction config slots to drop to 0

### DIFF
--- a/web-console/src/dialogs/compaction-dynamic-config-dialog/compaction-dynamic-config-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dynamic-config-dialog/compaction-dynamic-config-dialog.tsx
@@ -46,7 +46,7 @@ const COMPACTION_DYNAMIC_CONFIG_FIELDS: Field<CompactionDynamicConfig>[] = [
     type: 'number',
     defaultValue: DEFAULT_MAX,
     info: <>The maximum number of task slots for compaction tasks</>,
-    min: 1,
+    min: 0,
   },
 ];
 


### PR DESCRIPTION
`maxCompactionTaskSlots` can be zero (indication a pause to compaction)