### PR TITLE
Clean up kafka emitter tests, add more validations and code coverage.

### DIFF
--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -121,6 +121,11 @@
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -116,6 +116,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -116,12 +116,24 @@ public class KafkaEmitterConfigTest
   }
 
   @Test
-  public void testSerDeNotRequiredKafkaProducerConfigOrKafkaSecretProducer()
+  public void testSerDeNotRequiredKafkaProducerConfigOrKafkaSecretProducer() throws JsonProcessingException
   {
-    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig("localhost:9092", null, "metricTest",
-                                                                   "alertTest", null, "metadataTest",
-                                                                   "clusterNameTest", null, null, null
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "localhost:9092",
+        null,
+        "metricTest",
+        "alertTest",
+        null,
+        "metadataTest",
+        null,
+        ImmutableMap.of("env", "preProd"),
+        null,
+        null
     );
+    String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
+    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
     try {
       @SuppressWarnings("unused")
       KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, MAPPER);

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -163,7 +163,6 @@ public class KafkaEmitterConfigTest
     Assert.assertTrue(new KafkaEmitterModule().getJacksonModules().isEmpty());
   }
 
-
   @Test
   public void testNullBootstrapServers()
   {

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -19,95 +19,254 @@
 
 package org.apache.druid.emitter.kafka;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
+import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
 import org.apache.druid.java.util.emitter.service.SegmentMetadataEvent;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.server.QueryStats;
 import org.apache.druid.server.RequestLogLine;
 import org.apache.druid.server.log.DefaultRequestLogEventBuilderFactory;
-import org.apache.druid.server.log.RequestLogEvent;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
 public class KafkaEmitterTest
 {
-  @Parameterized.Parameter(0)
-  public Set<KafkaEmitterConfig.EventType> eventsType;
+  private KafkaProducer<String, String> producer;
 
-  @Parameterized.Parameter(1)
-  public String requestTopic;
-
-  @Parameterized.Parameters(name = "{index}: eventTypes - {0}, requestTopic - {1}")
-  public static Object[] data()
+  @Before
+  public void setup()
   {
-    return new Object[][] {
-        {new HashSet<>(Arrays.asList(KafkaEmitterConfig.EventType.METRICS, KafkaEmitterConfig.EventType.REQUESTS, KafkaEmitterConfig.EventType.ALERTS, KafkaEmitterConfig.EventType.SEGMENT_METADATA)), "requests"},
-        {new HashSet<>(Arrays.asList(KafkaEmitterConfig.EventType.METRICS, KafkaEmitterConfig.EventType.ALERTS, KafkaEmitterConfig.EventType.SEGMENT_METADATA)), null}
-    };
+    producer = mock(KafkaProducer.class);
   }
 
-  // there is 1 seconds wait in kafka emitter before it starts sending events to broker, set a timeout for 10 seconds
-  @Test(timeout = 10_000)
-  public void testKafkaEmitter() throws InterruptedException
+  @After
+  public void tearDown()
   {
-    final List<ServiceMetricEvent> serviceMetricEvents = ImmutableList.of(
-        ServiceMetricEvent.builder().setMetric("m1", 1).build("service", "host")
+    producer.close();
+  }
+
+  private static final ObjectMapper MAPPER = new DefaultObjectMapper();
+
+  private static final List<Event> SERVICE_METRIC_EVENTS = ImmutableList.of(
+      ServiceMetricEvent.builder().setMetric("m1", 1).build("service", "host")
+  );
+
+  private static final List<Event> ALERT_EVENTS = ImmutableList.of(
+      new AlertEvent("service", "host", "description")
+  );
+
+  private static final List<Event> REQUEST_LOG_EVENTS = ImmutableList.of(
+      DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder(
+          "requests",
+          RequestLogLine.forSql(
+              "", null, DateTimes.nowUtc(), null, new QueryStats(ImmutableMap.of())
+          )
+      ).build("service", "host")
+  );
+
+  private static final List<Event> SEGMENT_METADATA_EVENTS = ImmutableList.of(
+      new SegmentMetadataEvent(
+          "dummy_datasource",
+          DateTimes.of("2001-01-01T00:00:00.000Z"),
+          DateTimes.of("2001-01-02T00:00:00.000Z"),
+          DateTimes.of("2001-01-03T00:00:00.000Z"),
+          "dummy_version",
+          true
+      )
+  );
+
+  @Test(timeout = 10_000)
+  public void testKafkaEmitterServiceMetricEvents() throws JsonProcessingException, InterruptedException
+  {
+    final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "",
+        new HashSet<>(Collections.singletonList(KafkaEmitterConfig.EventType.METRICS)),
+        "metrics",
+        "alerts",
+        "requests",
+        "segment_metadata",
+        "clusterName",
+        ImmutableMap.of("clusterId", "cluster-101"),
+        null,
+        null
     );
 
-    final List<AlertEvent> alertEvents = ImmutableList.of(
-        new AlertEvent("service", "host", "description")
+    final KafkaEmitter kafkaEmitter = initKafkaEmitter(kafkaEmitterConfig);
+
+    final List<Event> inputEvents = flattenEvents(SERVICE_METRIC_EVENTS);
+    final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
+
+    final Map<String, List<String>> topicToExpectedEvents = trackExpectedEvents(SERVICE_METRIC_EVENTS, kafkaEmitterConfig);
+    final Map<String, List<String>> topicToActualEvents = trackActualEventsInCallback(eventLatch);
+
+    emitEvents(kafkaEmitter, SERVICE_METRIC_EVENTS, eventLatch);
+
+    validateEvents(topicToExpectedEvents, topicToActualEvents);
+
+    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+
+    validateEvents(topicToExpectedEvents, topicToActualEvents);
+  }
+
+  @Test(timeout = 10_000)
+  public void testKafkaEmitterAllEvents() throws JsonProcessingException, InterruptedException
+  {
+    final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "",
+        new HashSet<>(Arrays.asList(KafkaEmitterConfig.EventType.values())),
+        "metrics",
+        "alerts",
+        "requests",
+        "segment_metadata",
+        null,
+        ImmutableMap.of("clusterId", "cluster-101", "env", "staging"),
+        null,
+        null
     );
 
-    final List<RequestLogEvent> requestLogEvents = ImmutableList.of(
-        DefaultRequestLogEventBuilderFactory.instance().createRequestLogEventBuilder("requests",
-            RequestLogLine.forSql("", null, DateTimes.nowUtc(), null, new QueryStats(ImmutableMap.of()))
-        ).build("service", "host")
+    final KafkaEmitter kafkaEmitter = initKafkaEmitter(kafkaEmitterConfig);
+
+    final List<Event> inputEvents = flattenEvents(
+        SERVICE_METRIC_EVENTS,
+        ALERT_EVENTS,
+        REQUEST_LOG_EVENTS,
+        SEGMENT_METADATA_EVENTS
+    );
+    final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
+
+    final Map<String, List<String>> topicToExpectedEvents = trackExpectedEvents(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> topicToActualEvents = trackActualEventsInCallback(eventLatch);
+
+    emitEvents(kafkaEmitter, inputEvents, eventLatch);
+
+    validateEvents(topicToExpectedEvents, topicToActualEvents);
+
+    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+
+  }
+
+  @Test(timeout = 10_000)
+  public void testKafkaEmitterDefaultEvents() throws JsonProcessingException, InterruptedException
+  {
+    final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "",
+        KafkaEmitterConfig.DEFAULT_EVENT_TYPES,
+        "metrics",
+        "alerts",
+        "requests",
+        "segment_metadata",
+        "clusterName",
+        null,
+        null,
+        null
     );
 
-    final List<SegmentMetadataEvent> segmentMetadataEvents = ImmutableList.of(
-        new SegmentMetadataEvent(
-            "dummy_datasource",
-            DateTimes.of("2001-01-01T00:00:00.000Z"),
-            DateTimes.of("2001-01-02T00:00:00.000Z"),
-            DateTimes.of("2001-01-03T00:00:00.000Z"),
-            "dummy_version",
-            true
-        )
+    final KafkaEmitter kafkaEmitter = initKafkaEmitter(kafkaEmitterConfig);
+
+    final List<Event> inputEvents = flattenEvents(
+        SERVICE_METRIC_EVENTS,
+        ALERT_EVENTS
+    );
+    final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
+
+    final Map<String, List<String>> topicToExpectedEvents = trackExpectedEvents(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> topicToActualEvents = trackActualEventsInCallback(eventLatch);
+
+    emitEvents(kafkaEmitter, inputEvents, eventLatch);
+
+    validateEvents(topicToExpectedEvents, topicToActualEvents);
+
+    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+  }
+
+  @Test(timeout = 10_000)
+  public void testKafkaEmitterDefaultEventsMissing() throws JsonProcessingException, InterruptedException
+  {
+    final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "",
+        new HashSet<>(Collections.singletonList(KafkaEmitterConfig.EventType.ALERTS)),
+        "metrics",
+        "alerts",
+        "requests",
+        "segment_metadata",
+        "clusterName",
+        null,
+        null,
+        null
     );
 
-    int totalEvents = serviceMetricEvents.size() + alertEvents.size() + requestLogEvents.size() + segmentMetadataEvents.size();
-    int totalEventsExcludingRequestLogEvents = totalEvents - requestLogEvents.size();
+    final KafkaEmitter kafkaEmitter = initKafkaEmitter(kafkaEmitterConfig);
 
-    final CountDownLatch countDownSentEvents = new CountDownLatch(
-        requestTopic == null ? totalEventsExcludingRequestLogEvents : totalEvents);
+    // Includes everything, but we've only subscribed to alerts type.
+    final List<Event> inputEvents = flattenEvents(
+        SERVICE_METRIC_EVENTS,
+        ALERT_EVENTS,
+        SEGMENT_METADATA_EVENTS,
+        REQUEST_LOG_EVENTS
+    );
 
-    final KafkaProducer<String, String> producer = mock(KafkaProducer.class);
-    ObjectMapper mapper = new ObjectMapper();
-    mapper.registerModule(new JodaModule());
+    final CountDownLatch eventLatch = new CountDownLatch(ALERT_EVENTS.size());
+
+    final Map<String, List<String>> topicToExpectedEvents = trackExpectedEvents(ALERT_EVENTS, kafkaEmitterConfig);
+    final Map<String, List<String>> topicToActualEvents = trackActualEventsInCallback(eventLatch);
+
+    emitEvents(kafkaEmitter, inputEvents, eventLatch);
+
+    validateEvents(topicToExpectedEvents, topicToActualEvents);
+
+    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+
+    // Others would be dropped
+    Assert.assertEquals(SERVICE_METRIC_EVENTS.size(), kafkaEmitter.getMetricLostCount());
+    Assert.assertEquals(SEGMENT_METADATA_EVENTS.size(), kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertEquals(REQUEST_LOG_EVENTS.size(), kafkaEmitter.getRequestLostCount());
+  }
+
+  private KafkaEmitter initKafkaEmitter(
+      final KafkaEmitterConfig kafkaEmitterConfig
+  )
+  {
     final KafkaEmitter kafkaEmitter = new KafkaEmitter(
-        new KafkaEmitterConfig("", eventsType, "metrics", "alerts", requestTopic, "metadata", "test-cluster", ImmutableMap.of("clusterId", "cluster-101"), null, null),
-        mapper
+        kafkaEmitterConfig,
+        new DefaultObjectMapper()
     )
     {
       @Override
@@ -118,34 +277,84 @@ public class KafkaEmitterTest
         return producer;
       }
     };
+    return kafkaEmitter;
+  }
 
-    when(producer.send(any(), any())).then((invocation) -> {
-      countDownSentEvents.countDown();
-      return null;
-    });
-
+  private void emitEvents(
+      final KafkaEmitter kafkaEmitter,
+      final List<Event> emitEvents,
+      final CountDownLatch eventLatch
+  ) throws InterruptedException
+  {
     kafkaEmitter.start();
 
-    for (Event event : serviceMetricEvents) {
+    for (final Event event : emitEvents) {
       kafkaEmitter.emit(event);
     }
-    for (Event event : alertEvents) {
-      kafkaEmitter.emit(event);
-    }
-    for (Event event : requestLogEvents) {
-      kafkaEmitter.emit(event);
-    }
-    for (Event event : segmentMetadataEvents) {
-      kafkaEmitter.emit(event);
-    }
-    countDownSentEvents.await();
 
+    eventLatch.await();
     kafkaEmitter.close();
+  }
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(requestTopic == null ? requestLogEvents.size() : 0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+  private List<Event> flattenEvents(List<Event>... eventLists)
+  {
+    final List<Event> flattenedList = new ArrayList<>();
+    for (List<Event> events : eventLists) {
+      flattenedList.addAll(events);
+    }
+    return flattenedList;
+  }
+
+  private Map<String, List<String>> trackActualEventsInCallback(
+      final CountDownLatch eventLatch
+  )
+  {
+    final Map<String, List<String>> topicToActualEvents = new HashMap<>();
+    when(producer.send(any(), any())).then((invocation) -> {
+      final ProducerRecord<?, ?> producerRecord = invocation.getArgument(0);
+      final Object value = producerRecord.value();
+
+      topicToActualEvents.computeIfAbsent(
+          producerRecord.topic(), k -> new ArrayList<>()
+      ).add(String.valueOf(value));
+
+      eventLatch.countDown();
+      return null;
+    });
+    return topicToActualEvents;
+  }
+
+  private Map<String, List<String>> trackExpectedEvents(
+      final List<Event> events,
+      final KafkaEmitterConfig kafkaEmitterConfig
+  ) throws JsonProcessingException
+  {
+    final Map<String, List<String>> topicToExpectedEvents = new HashMap<>();
+    for (final Event event : events) {
+      final EventMap eventMap = event.toMap();
+      if (kafkaEmitterConfig.getExtraDimensions() != null) {
+        eventMap.putAll(kafkaEmitterConfig.getExtraDimensions());
+      }
+      eventMap.computeIfAbsent("clusterName", k -> kafkaEmitterConfig.getClusterName());
+      topicToExpectedEvents.computeIfAbsent(
+          event.getFeed(), k -> new ArrayList<>()).add(MAPPER.writeValueAsString(eventMap)
+      );
+    }
+    return topicToExpectedEvents;
+  }
+
+  private void validateEvents(
+      final Map<String, List<String>> topicToExpectedEvents,
+      final Map<String, List<String>> topicToActualEvents
+  )
+  {
+    Assert.assertEquals(topicToExpectedEvents.size(), topicToActualEvents.size());
+
+    for (final Map.Entry<String, List<String>> actualEntry : topicToActualEvents.entrySet()) {
+      final String topic = actualEntry.getKey();
+      final List<String> actualEvents = actualEntry.getValue();
+      final List<String> expectedEvents = topicToExpectedEvents.get(topic);
+      Assert.assertEquals(expectedEvents, actualEvents);
+    }
   }
 }

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -130,10 +130,10 @@ public class KafkaEmitterTest
     final List<Event> inputEvents = flattenEvents(SERVICE_METRIC_EVENTS);
     final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
 
-    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEvents(SERVICE_METRIC_EVENTS, kafkaEmitterConfig);
-    final Map<String, List<String>> feedToActualEvents = trackActualEventsInCallback(eventLatch);
+    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEventsPerFeed(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> feedToActualEvents = trackActualEventsPerFeed(eventLatch);
 
-    emitEvents(kafkaEmitter, SERVICE_METRIC_EVENTS, eventLatch);
+    emitEvents(kafkaEmitter, inputEvents, eventLatch);
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
@@ -172,8 +172,8 @@ public class KafkaEmitterTest
     );
     final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
 
-    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEvents(inputEvents, kafkaEmitterConfig);
-    final Map<String, List<String>> feedToActualEvents = trackActualEventsInCallback(eventLatch);
+    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEventsPerFeed(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> feedToActualEvents = trackActualEventsPerFeed(eventLatch);
 
     emitEvents(kafkaEmitter, inputEvents, eventLatch);
 
@@ -211,8 +211,8 @@ public class KafkaEmitterTest
     );
     final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
 
-    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEvents(inputEvents, kafkaEmitterConfig);
-    final Map<String, List<String>> feedToActualEvents = trackActualEventsInCallback(eventLatch);
+    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEventsPerFeed(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> feedToActualEvents = trackActualEventsPerFeed(eventLatch);
 
     emitEvents(kafkaEmitter, inputEvents, eventLatch);
 
@@ -243,7 +243,7 @@ public class KafkaEmitterTest
 
     final KafkaEmitter kafkaEmitter = initKafkaEmitter(kafkaEmitterConfig);
 
-    // Emit everything, but we've only subscribed to alert events.
+    // Emit everything. Since we only subscribe to alert feeds, everything else should be dropped.
     final List<Event> inputEvents = flattenEvents(
         SERVICE_METRIC_EVENTS,
         ALERT_EVENTS,
@@ -253,8 +253,8 @@ public class KafkaEmitterTest
 
     final CountDownLatch eventLatch = new CountDownLatch(ALERT_EVENTS.size());
 
-    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEvents(ALERT_EVENTS, kafkaEmitterConfig);
-    final Map<String, List<String>> feedToActualEvents = trackActualEventsInCallback(eventLatch);
+    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEventsPerFeed(ALERT_EVENTS, kafkaEmitterConfig);
+    final Map<String, List<String>> feedToActualEvents = trackActualEventsPerFeed(eventLatch);
 
     emitEvents(kafkaEmitter, inputEvents, eventLatch);
 
@@ -296,8 +296,8 @@ public class KafkaEmitterTest
 
     final CountDownLatch eventLatch = new CountDownLatch(inputEvents.size());
 
-    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEvents(inputEvents, kafkaEmitterConfig);
-    final Map<String, List<String>> feedToActualEvents = trackActualEventsInCallback(eventLatch);
+    final Map<String, List<String>> feedToExpectedEvents = trackExpectedEventsPerFeed(inputEvents, kafkaEmitterConfig);
+    final Map<String, List<String>> feedToActualEvents = trackActualEventsPerFeed(eventLatch);
 
     emitEvents(kafkaEmitter, inputEvents, eventLatch);
 
@@ -314,7 +314,7 @@ public class KafkaEmitterTest
       final KafkaEmitterConfig kafkaEmitterConfig
   )
   {
-    final KafkaEmitter kafkaEmitter = new KafkaEmitter(
+    return new KafkaEmitter(
         kafkaEmitterConfig,
         new DefaultObjectMapper()
     )
@@ -327,7 +327,6 @@ public class KafkaEmitterTest
         return producer;
       }
     };
-    return kafkaEmitter;
   }
 
   private void emitEvents(
@@ -355,7 +354,7 @@ public class KafkaEmitterTest
     return flattenedList;
   }
 
-  private Map<String, List<String>> trackActualEventsInCallback(
+  private Map<String, List<String>> trackActualEventsPerFeed(
       final CountDownLatch eventLatch
   )
   {
@@ -374,7 +373,7 @@ public class KafkaEmitterTest
     return feedToActualEvents;
   }
 
-  private Map<String, List<String>> trackExpectedEvents(
+  private Map<String, List<String>> trackExpectedEventsPerFeed(
       final List<Event> events,
       final KafkaEmitterConfig kafkaEmitterConfig
   ) throws JsonProcessingException


### PR DESCRIPTION
The `KafkaEmitterTest` wasn't validating the net events emitted but only the dropped counters, which aren't particularly useful. This patch adds the missing event validation in `KafkaEmitterTest` and also cleans up the code to write unit tests easily.

Further, this module in general has insufficient code coverage overall. As a result, developers making changes in this extension often run into code coverage issues. This change should address that as well.

Additionally, the precondition config checks have been migrated to `DruidException`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

