### PR TITLE
Double Precision in Spatial Filters

### DIFF
--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/Bound.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/Bound.java
@@ -42,7 +42,7 @@ public interface Bound
 
   boolean overlaps(ImmutableNode node);
 
-  boolean contains(float[] coords);
+  boolean contains(double[] coords);
 
   Iterable<ImmutablePoint> filter(Iterable<ImmutablePoint> points);
 

--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/GutmanSearchStrategy.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/GutmanSearchStrategy.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Iterables;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.spatial.ImmutableNode;
 import org.apache.druid.collections.spatial.ImmutablePoint;
+import org.apache.druid.java.util.common.Numbers;
 
 /**
  */
@@ -116,7 +117,7 @@ public class GutmanSearchStrategy implements SearchStrategy
             @Override
             public boolean apply(ImmutableNode immutableNode)
             {
-              return bound.contains(immutableNode.getMinCoordinates());
+              return bound.contains(Numbers.floatArrayToDouble(immutableNode.getMinCoordinates()));
             }
           }
       );
@@ -155,7 +156,7 @@ public class GutmanSearchStrategy implements SearchStrategy
                       @Override
                       public boolean apply(ImmutableNode immutableNode)
                       {
-                        return bound.contains(immutableNode.getMinCoordinates());
+                        return bound.contains(Numbers.floatArrayToDouble(immutableNode.getMinCoordinates()));
                       }
                     }
                 );

--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/RadiusBound.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/RadiusBound.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.apache.druid.collections.spatial.ImmutablePoint;
+import org.apache.druid.java.util.common.Numbers;
 
 import java.nio.ByteBuffer;
 
@@ -32,12 +33,12 @@ import java.nio.ByteBuffer;
 public class RadiusBound extends RectangularBound
 {
   private static final byte CACHE_TYPE_ID = 0x01;
-  private final float[] coords;
+  private final double[] coords;
   private final float radius;
 
   @JsonCreator
   public RadiusBound(
-      @JsonProperty("coords") float[] coords,
+      @JsonProperty("coords") double[] coords,
       @JsonProperty("radius") float radius,
       @JsonProperty("limit") int limit
   )
@@ -49,25 +50,25 @@ public class RadiusBound extends RectangularBound
   }
 
   public RadiusBound(
-      float[] coords,
+      double[] coords,
       float radius
   )
   {
     this(coords, radius, 0);
   }
 
-  private static float[] getMinCoords(float[] coords, float radius)
+  private static double[] getMinCoords(double[] coords, double radius)
   {
-    float[] retVal = new float[coords.length];
+    double[] retVal = new double[coords.length];
     for (int i = 0; i < coords.length; i++) {
       retVal[i] = coords[i] - radius;
     }
     return retVal;
   }
 
-  private static float[] getMaxCoords(float[] coords, float radius)
+  private static double[] getMaxCoords(double[] coords, float radius)
   {
-    float[] retVal = new float[coords.length];
+    double[] retVal = new double[coords.length];
     for (int i = 0; i < coords.length; i++) {
       retVal[i] = coords[i] + radius;
     }
@@ -75,7 +76,7 @@ public class RadiusBound extends RectangularBound
   }
 
   @JsonProperty
-  public float[] getCoords()
+  public double[] getCoords()
   {
     return coords;
   }
@@ -87,7 +88,7 @@ public class RadiusBound extends RectangularBound
   }
 
   @Override
-  public boolean contains(float[] otherCoords)
+  public boolean contains(double[] otherCoords)
   {
     double total = 0.0;
     for (int i = 0; i < coords.length; i++) {
@@ -107,7 +108,7 @@ public class RadiusBound extends RectangularBound
           @Override
           public boolean apply(ImmutablePoint point)
           {
-            return contains(point.getCoords());
+            return contains(Numbers.floatArrayToDouble(point.getCoords()));
           }
         }
     );
@@ -116,11 +117,11 @@ public class RadiusBound extends RectangularBound
   @Override
   public byte[] getCacheKey()
   {
-    final ByteBuffer minCoordsBuffer = ByteBuffer.allocate(coords.length * Float.BYTES);
-    minCoordsBuffer.asFloatBuffer().put(coords);
+    final ByteBuffer minCoordsBuffer = ByteBuffer.allocate(coords.length * Double.BYTES);
+    minCoordsBuffer.asDoubleBuffer().put(coords);
     final byte[] minCoordsCacheKey = minCoordsBuffer.array();
     final ByteBuffer cacheKey = ByteBuffer
-        .allocate(1 + minCoordsCacheKey.length + Integer.BYTES + Float.BYTES)
+        .allocate(1 + minCoordsCacheKey.length + Integer.BYTES + Double.BYTES)
         .put(minCoordsCacheKey)
         .putFloat(radius)
         .putInt(getLimit())

--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/RectangularBound.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/RectangularBound.java
@@ -26,6 +26,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.apache.druid.collections.spatial.ImmutableNode;
 import org.apache.druid.collections.spatial.ImmutablePoint;
+import org.apache.druid.java.util.common.Numbers;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -37,15 +38,15 @@ public class RectangularBound implements Bound
 {
   private static final byte CACHE_TYPE_ID = 0x0;
 
-  private final float[] minCoords;
-  private final float[] maxCoords;
+  private final double[] minCoords;
+  private final double[] maxCoords;
   private final int limit;
   private final int numDims;
 
   @JsonCreator
   public RectangularBound(
-      @JsonProperty("minCoords") float[] minCoords,
-      @JsonProperty("maxCoords") float[] maxCoords,
+      @JsonProperty("minCoords") double[] minCoords,
+      @JsonProperty("maxCoords") double[] maxCoords,
       @JsonProperty("limit") int limit
   )
   {
@@ -59,21 +60,21 @@ public class RectangularBound implements Bound
   }
 
   public RectangularBound(
-      float[] minCoords,
-      float[] maxCoords
+      double[] minCoords,
+      double[] maxCoords
   )
   {
     this(minCoords, maxCoords, 0);
   }
 
   @JsonProperty
-  public float[] getMinCoords()
+  public double[] getMinCoords()
   {
     return minCoords;
   }
 
   @JsonProperty
-  public float[] getMaxCoords()
+  public double[] getMaxCoords()
   {
     return maxCoords;
   }
@@ -107,7 +108,7 @@ public class RectangularBound implements Bound
   }
 
   @Override
-  public boolean contains(float[] coords)
+  public boolean contains(double[] coords)
   {
     for (int i = 0; i < numDims; i++) {
       if (coords[i] < minCoords[i] || coords[i] > maxCoords[i]) {
@@ -128,7 +129,7 @@ public class RectangularBound implements Bound
           @Override
           public boolean apply(ImmutablePoint immutablePoint)
           {
-            return contains(immutablePoint.getCoords());
+            return contains(Numbers.floatArrayToDouble(immutablePoint.getCoords()));
           }
         }
     );
@@ -137,12 +138,12 @@ public class RectangularBound implements Bound
   @Override
   public byte[] getCacheKey()
   {
-    ByteBuffer minCoordsBuffer = ByteBuffer.allocate(minCoords.length * Float.BYTES);
-    minCoordsBuffer.asFloatBuffer().put(minCoords);
+    ByteBuffer minCoordsBuffer = ByteBuffer.allocate(minCoords.length * Double.BYTES);
+    minCoordsBuffer.asDoubleBuffer().put(minCoords);
     final byte[] minCoordsCacheKey = minCoordsBuffer.array();
 
-    ByteBuffer maxCoordsBuffer = ByteBuffer.allocate(maxCoords.length * Float.BYTES);
-    maxCoordsBuffer.asFloatBuffer().put(maxCoords);
+    ByteBuffer maxCoordsBuffer = ByteBuffer.allocate(maxCoords.length * Double.BYTES);
+    maxCoordsBuffer.asDoubleBuffer().put(maxCoords);
     final byte[] maxCoordsCacheKey = maxCoordsBuffer.array();
 
     final ByteBuffer cacheKey = ByteBuffer

--- a/processing/src/main/java/org/apache/druid/java/util/common/Numbers.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Numbers.java
@@ -207,6 +207,15 @@ public final class Numbers
     throw new NumberFormatException("Cannot parse string to long");
   }
 
+  public static double[] floatArrayToDouble(float[] arr) {
+    if(arr == null) return null;
+    double[] doubles = new double[arr.length];
+    for (int i = 0; i < arr.length; i++) {
+      doubles[i] = arr[i];
+    }
+    return doubles;
+  }
+
   private Numbers()
   {
   }

--- a/processing/src/main/java/org/apache/druid/segment/filter/SpatialFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/SpatialFilter.java
@@ -154,7 +154,7 @@ public class SpatialFilter implements Filter
         if (input == null) {
           return DruidPredicateMatch.UNKNOWN;
         }
-        final float[] coordinate = SpatialDimensionRowTransformer.decode(input);
+        final double[] coordinate = SpatialDimensionRowTransformer.decode(input);
         return DruidPredicateMatch.of(bound.contains(coordinate));
       };
     }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
@@ -189,7 +189,7 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
       return false;
     }
     for (String dimVal : dimVals) {
-      if (tryParseFloat(dimVal) == null) {
+      if (tryParseDouble(dimVal) == null) {
         return false;
       }
     }
@@ -203,7 +203,7 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
     }
     Iterable<String> dimVals = SPLITTER.split(dimVal);
     for (String val : dimVals) {
-      if (tryParseFloat(val) == null) {
+      if (tryParseDouble(val) == null) {
         return false;
       }
     }
@@ -211,7 +211,7 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
   }
 
   @Nullable
-  private static Double tryParseFloat(String val)
+  private static Double tryParseDouble(String val)
   {
     try {
       return Double.parseDouble(val);
@@ -239,11 +239,11 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
     final double[] coordinate = new double[parts.size()];
 
     for (int i = 0; i < coordinate.length; i++) {
-      final Double floatPart = tryParseFloat(parts.get(i));
-      if (floatPart == null) {
+      final Double doublePart = tryParseDouble(parts.get(i));
+      if (doublePart == null) {
         return null;
       } else {
-        coordinate[i] = floatPart;
+        coordinate[i] = doublePart;
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
@@ -211,10 +211,10 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
   }
 
   @Nullable
-  private static Float tryParseFloat(String val)
+  private static Double tryParseFloat(String val)
   {
     try {
-      return Float.parseFloat(val);
+      return Double.parseDouble(val);
     }
     catch (NullPointerException | NumberFormatException e) {
       return null;
@@ -229,17 +229,17 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
    * @return decoded coordinate, or null if it could not be decoded
    */
   @Nullable
-  public static float[] decode(final String encodedCoordinate)
+  public static double[] decode(final String encodedCoordinate)
   {
     if (encodedCoordinate == null) {
       return null;
     }
 
     final ImmutableList<String> parts = ImmutableList.copyOf(SPLITTER.split(encodedCoordinate));
-    final float[] coordinate = new float[parts.size()];
+    final double[] coordinate = new double[parts.size()];
 
     for (int i = 0; i < coordinate.length; i++) {
-      final Float floatPart = tryParseFloat(parts.get(i));
+      final Double floatPart = tryParseFloat(parts.get(i));
       if (floatPart == null) {
         return null;
       } else {

--- a/processing/src/test/java/org/apache/druid/collections/spatial/ImmutableRTreeTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/spatial/ImmutableRTreeTest.java
@@ -66,7 +66,7 @@ public class ImmutableRTreeTest
     ImmutableRTree firstTree = ImmutableRTree.newImmutableFromMutable(tree);
     ByteBuffer buffer = ByteBuffer.wrap(firstTree.toBytes());
     ImmutableRTree secondTree = new ImmutableRTree(buffer, bf);
-    Iterable<ImmutableBitmap> points = secondTree.search(new RadiusBound(new float[]{0, 0}, 10));
+    Iterable<ImmutableBitmap> points = secondTree.search(new RadiusBound(new double[]{0, 0}, 10));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
     Set<Integer> expected = Sets.newHashSet(1, 2, 3, 4, 5);
@@ -91,7 +91,7 @@ public class ImmutableRTreeTest
     ImmutableRTree firstTree = ImmutableRTree.newImmutableFromMutable(tree);
     ByteBuffer buffer = ByteBuffer.wrap(firstTree.toBytes());
     ImmutableRTree secondTree = new ImmutableRTree(buffer, bf);
-    Iterable<ImmutableBitmap> points = secondTree.search(new RadiusBound(new float[]{0, 0}, 10));
+    Iterable<ImmutableBitmap> points = secondTree.search(new RadiusBound(new double[]{0, 0}, 10));
     ImmutableBitmap finalSet = bf.union(points);
 
     Assert.assertTrue(finalSet.size() >= 5);
@@ -122,7 +122,7 @@ public class ImmutableRTreeTest
     Assert.assertEquals(tree.getRoot().getChildren().size(), 10);
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -152,7 +152,7 @@ public class ImmutableRTreeTest
     Assert.assertEquals(tree.getRoot().getChildren().size(), 10);
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -183,7 +183,7 @@ public class ImmutableRTreeTest
     }
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -214,7 +214,7 @@ public class ImmutableRTreeTest
     }
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -248,8 +248,8 @@ public class ImmutableRTreeTest
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
         new RectangularBound(
-            new float[]{0, 0},
-            new float[]{9, 9}
+            new double[]{0, 0},
+            new double[]{9, 9}
         )
     );
     ImmutableBitmap finalSet = bf.union(points);
@@ -284,8 +284,8 @@ public class ImmutableRTreeTest
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
         new RectangularBound(
-            new float[]{0, 0},
-            new float[]{9, 9}
+            new double[]{0, 0},
+            new double[]{9, 9}
         )
     );
     ImmutableBitmap finalSet = bf.union(points);
@@ -319,7 +319,7 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
-        new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+        new RadiusBound(new double[]{0.0f, 0.0f}, 5)
     );
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 3);
@@ -352,7 +352,7 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
-        new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+        new RadiusBound(new double[]{0.0f, 0.0f}, 5)
     );
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 3);
@@ -394,8 +394,8 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(PolygonBound.from(
-        new float[]{1.0f, 1.0f, 2.0f, 2.0f, 4.0f, 4.0f},
-        new float[]{1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f}
+        new double[]{1.0f, 1.0f, 2.0f, 2.0f, 4.0f, 4.0f},
+        new double[]{1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f}
     ));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() == 500);
@@ -440,8 +440,8 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(PolygonBound.from(
-        new float[]{1.0f, 1.0f, 2.0f, 2.0f, 4.0f, 4.0f},
-        new float[]{1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f}
+        new double[]{1.0f, 1.0f, 2.0f, 2.0f, 4.0f, 4.0f},
+        new double[]{1.0f, 2.0f, 2.0f, 3.0f, 3.0f, 1.0f}
     ));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() == 500);
@@ -465,7 +465,7 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
-        new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+        new RadiusBound(new double[]{0.0f, 0.0f}, 5)
     );
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertEquals(finalSet.size(), 0);
@@ -480,7 +480,7 @@ public class ImmutableRTreeTest
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
     Iterable<ImmutableBitmap> points = searchTree.search(
-        new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+        new RadiusBound(new double[]{0.0f, 0.0f}, 5)
     );
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertEquals(finalSet.size(), 0);
@@ -507,7 +507,7 @@ public class ImmutableRTreeTest
     }
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5, 2));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5, 2));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -539,7 +539,7 @@ public class ImmutableRTreeTest
     }
 
     ImmutableRTree searchTree = ImmutableRTree.newImmutableFromMutable(tree);
-    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{0, 0}, 5, 2));
+    Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{0, 0}, 5, 2));
     ImmutableBitmap finalSet = bf.union(points);
     Assert.assertTrue(finalSet.size() >= 5);
 
@@ -579,7 +579,7 @@ public class ImmutableRTreeTest
 
         stopwatch.reset().start();
 
-        Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new float[]{50, 50}, radius));
+        Iterable<ImmutableBitmap> points = searchTree.search(new RadiusBound(new double[]{50, 50}, radius));
 
         Iterables.size(points);
         stop = stopwatch.elapsed(TimeUnit.MILLISECONDS);
@@ -631,8 +631,8 @@ public class ImmutableRTreeTest
 
         Iterable<ImmutableBitmap> points = searchTree.search(
             new RectangularBound(
-                new float[]{40, 40},
-                new float[]{60, 60},
+                new double[]{40, 40},
+                new double[]{60, 60},
                 100
             )
         );

--- a/processing/src/test/java/org/apache/druid/collections/spatial/search/PolygonBoundTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/spatial/search/PolygonBoundTest.java
@@ -31,52 +31,52 @@ public class PolygonBoundTest
   public void testCacheKey()
   {
     Assert.assertArrayEquals(
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 1).getCacheKey(),
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 1).getCacheKey()
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 1).getCacheKey(),
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 1).getCacheKey()
     );
     Assert.assertFalse(Arrays.equals(
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 1).getCacheKey(),
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 1F}, 1).getCacheKey()
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 1).getCacheKey(),
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 1F}, 1).getCacheKey()
     ));
     Assert.assertFalse(Arrays.equals(
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 1).getCacheKey(),
-        PolygonBound.from(new float[]{1F, 2F, 2F}, new float[]{0F, 2F, 0F}, 1).getCacheKey()
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 1).getCacheKey(),
+        PolygonBound.from(new double[]{1F, 2F, 2F}, new double[]{0F, 2F, 0F}, 1).getCacheKey()
     ));
     Assert.assertFalse(Arrays.equals(
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 1).getCacheKey(),
-        PolygonBound.from(new float[]{1F, 2F, 3F}, new float[]{0F, 2F, 0F}, 2).getCacheKey()
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 1).getCacheKey(),
+        PolygonBound.from(new double[]{1F, 2F, 3F}, new double[]{0F, 2F, 0F}, 2).getCacheKey()
     ));
   }
 
   @Test
   public void testContains()
   {
-    final PolygonBound triangle = PolygonBound.from(new float[]{1f, 4f, 7f}, new float[]{1f, 4f, 1f});
+    final PolygonBound triangle = PolygonBound.from(new double[]{1f, 4f, 7f}, new double[]{1f, 4f, 1f});
     final float delta = 1e-5f;
 
-    Assert.assertTrue(triangle.contains(new float[]{1f, 1f}));
-    Assert.assertFalse(triangle.contains(new float[]{1f, 1f - delta}));
-    Assert.assertFalse(triangle.contains(new float[]{1f, 1f + delta}));
-    Assert.assertTrue(triangle.contains(new float[]{1f + delta, 1f}));
-    Assert.assertFalse(triangle.contains(new float[]{1f - delta, 1f}));
-    Assert.assertTrue(triangle.contains(new float[]{1f + delta, 1f}));
-    Assert.assertFalse(triangle.contains(new float[]{1f - delta, 1f}));
-    Assert.assertTrue(triangle.contains(new float[]{5f, 1f}));
-    Assert.assertFalse(triangle.contains(new float[]{1f, 5f}));
-    Assert.assertTrue(triangle.contains(new float[]{3f, 2f}));
+    Assert.assertTrue(triangle.contains(new double[]{1f, 1f}));
+    Assert.assertFalse(triangle.contains(new double[]{1f, 1f - delta}));
+    Assert.assertFalse(triangle.contains(new double[]{1f, 1f + delta}));
+    Assert.assertTrue(triangle.contains(new double[]{1f + delta, 1f}));
+    Assert.assertFalse(triangle.contains(new double[]{1f - delta, 1f}));
+    Assert.assertTrue(triangle.contains(new double[]{1f + delta, 1f}));
+    Assert.assertFalse(triangle.contains(new double[]{1f - delta, 1f}));
+    Assert.assertTrue(triangle.contains(new double[]{5f, 1f}));
+    Assert.assertFalse(triangle.contains(new double[]{1f, 5f}));
+    Assert.assertTrue(triangle.contains(new double[]{3f, 2f}));
 
-    final PolygonBound rightTriangle = PolygonBound.from(new float[]{1f, 1f, 5f}, new float[]{1f, 5f, 1f});
+    final PolygonBound rightTriangle = PolygonBound.from(new double[]{1f, 1f, 5f}, new double[]{1f, 5f, 1f});
 
-    Assert.assertTrue(rightTriangle.contains(new float[]{1f, 5f}));
-    Assert.assertTrue(rightTriangle.contains(new float[]{2f, 4f}));
-    Assert.assertTrue(rightTriangle.contains(new float[]{2f - delta, 4f}));
-    Assert.assertFalse(rightTriangle.contains(new float[]{2f + delta, 4f}));
-    Assert.assertTrue(rightTriangle.contains(new float[]{2f, 4f - delta}));
-    Assert.assertFalse(rightTriangle.contains(new float[]{2f, 4f + delta}));
-    Assert.assertTrue(rightTriangle.contains(new float[]{3f - delta, 3f}));
-    Assert.assertFalse(rightTriangle.contains(new float[]{3f + delta, 3f}));
-    Assert.assertTrue(rightTriangle.contains(new float[]{3f, 3f - delta}));
-    Assert.assertFalse(rightTriangle.contains(new float[]{3f, 3f + delta}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{1f, 5f}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{2f, 4f}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{2f - delta, 4f}));
+    Assert.assertFalse(rightTriangle.contains(new double[]{2f + delta, 4f}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{2f, 4f - delta}));
+    Assert.assertFalse(rightTriangle.contains(new double[]{2f, 4f + delta}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{3f - delta, 3f}));
+    Assert.assertFalse(rightTriangle.contains(new double[]{3f + delta, 3f}));
+    Assert.assertTrue(rightTriangle.contains(new double[]{3f, 3f - delta}));
+    Assert.assertFalse(rightTriangle.contains(new double[]{3f, 3f + delta}));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/collections/spatial/search/RadiusBoundTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/spatial/search/RadiusBoundTest.java
@@ -29,8 +29,8 @@ public class RadiusBoundTest
   @Test
   public void testCacheKey()
   {
-    final float[] coords0 = new float[]{1.0F, 2.0F};
-    final float[] coords1 = new float[]{1.1F, 2.1F};
+    final double[] coords0 = new double[]{1.0F, 2.0F};
+    final double[] coords1 = new double[]{1.1F, 2.1F};
     Assert.assertArrayEquals(
         new RadiusBound(coords0, 3.0F, 10).getCacheKey(),
         new RadiusBound(coords0, 3.0F, 10).getCacheKey()

--- a/processing/src/test/java/org/apache/druid/collections/spatial/search/RectangularBoundTest.java
+++ b/processing/src/test/java/org/apache/druid/collections/spatial/search/RectangularBoundTest.java
@@ -31,20 +31,20 @@ public class RectangularBoundTest
   public void testCacheKey()
   {
     Assert.assertArrayEquals(
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 1).getCacheKey(),
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 1).getCacheKey()
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 1).getCacheKey(),
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 1).getCacheKey()
     );
     Assert.assertFalse(Arrays.equals(
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 1).getCacheKey(),
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 3F}, 1).getCacheKey()
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 1).getCacheKey(),
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 3F}, 1).getCacheKey()
     ));
     Assert.assertFalse(Arrays.equals(
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 1).getCacheKey(),
-        new RectangularBound(new float[]{1F, 0F}, new float[]{2F, 2F}, 1).getCacheKey()
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 1).getCacheKey(),
+        new RectangularBound(new double[]{1F, 0F}, new double[]{2F, 2F}, 1).getCacheKey()
     ));
     Assert.assertFalse(Arrays.equals(
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 1).getCacheKey(),
-        new RectangularBound(new float[]{1F, 1F}, new float[]{2F, 2F}, 2).getCacheKey()
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 1).getCacheKey(),
+        new RectangularBound(new double[]{1F, 1F}, new double[]{2F, 2F}, 2).getCacheKey()
     ));
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -542,7 +542,7 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+                                          new RadiusBound(new double[]{0.0f, 0.0f}, 5)
                                       )
                                   )
                                   .aggregators(
@@ -594,7 +594,7 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
                                   .filters(
                                       new SpatialDimFilter(
                                           "spatialIsRad",
-                                          new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+                                          new RadiusBound(new double[]{0.0f, 0.0f}, 5)
                                       )
                                   )
                                   .aggregators(
@@ -645,7 +645,7 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RectangularBound(new float[]{0.0f, 0.0f}, new float[]{9.0f, 9.0f})
+                                          new RectangularBound(new double[]{0.0f, 0.0f}, new double[]{9.0f, 9.0f})
                                       )
                                   )
                                   .aggregators(

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
@@ -478,7 +478,7 @@ public class SpatialFilterBonusTest
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+                                          new RadiusBound(new double[]{0.0f, 0.0f}, 5)
                                       )
                                   )
                                   .aggregators(
@@ -528,7 +528,7 @@ public class SpatialFilterBonusTest
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RectangularBound(new float[]{0.0f, 0.0f}, new float[]{9.0f, 9.0f})
+                                          new RectangularBound(new double[]{0.0f, 0.0f}, new double[]{9.0f, 9.0f})
                                       )
                                   )
                                   .aggregators(
@@ -618,7 +618,7 @@ public class SpatialFilterBonusTest
                                               new LongSumAggregatorFactory("valFiltered", "val"),
                                               new SpatialDimFilter(
                                                   "dim.geo",
-                                                  new RectangularBound(new float[]{0.0f, 0.0f}, new float[]{9.0f, 9.0f})
+                                                  new RectangularBound(new double[]{0.0f, 0.0f}, new double[]{9.0f, 9.0f})
                                               )
                                           ),
                                           new LongSumAggregatorFactory("val", "val")

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
@@ -551,7 +551,7 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+                                          new RadiusBound(new double[]{0.0f, 0.0f}, 5)
                                       )
                                   )
                                   .aggregators(
@@ -603,7 +603,7 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
                                   .filters(
                                       new SpatialDimFilter(
                                           "spatialIsRad",
-                                          new RadiusBound(new float[]{0.0f, 0.0f}, 5)
+                                          new RadiusBound(new double[]{0.0f, 0.0f}, 5)
                                       )
                                   )
                                   .aggregators(
@@ -654,7 +654,7 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
                                   .filters(
                                       new SpatialDimFilter(
                                           "dim.geo",
-                                          new RectangularBound(new float[]{0.0f, 0.0f}, new float[]{9.0f, 9.0f})
+                                          new RectangularBound(new double[]{0.0f, 0.0f}, new double[]{9.0f, 9.0f})
                                       )
                                   )
                                   .aggregators(


### PR DESCRIPTION
**Background:** 
Geo spatial column in druid at present stores coordinate as CSV string in string column and does RTree based indexing while ingestion. RTree based index are created based on the Float values of coordinates and not double, this conversion basically looses the accuracy of up 111 meters in geo distance. 

For querying, druid support geo filters like Rectangle, Radius and Polygon with float precision, thus if user enters double precision coordinate then it looses the actual precision by at max 111 meters. 


**What are the remediation steps?** 
We can not change the RTree indexing data type from float to double, it will not be backward compatible change. But we can very much prevent the precious loss at the Spatial filter level and at least compare with accurate coordinates with underline float RTree indexing. This will improve the accuracy but wont fix it 100 %. 

We are working on one more Improvement Proposal for implementing Geo Complex column double precision and this PR is mandatory for that change anyways.


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
