### PR TITLE
Modify Dockerfile to build sql module correctly

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -36,8 +36,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 COPY . /src
 WORKDIR /src
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -B -ff -q dependency:go-offline \
-      install \
+      mvn -B -ff -q install \
+      dependency:go-offline \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \
       -Dmaven.javadoc.skip=true \


### PR DESCRIPTION
The Freemarker plugin used to build is the Freemarker version 2.3.33-SNAPSHOT, which does not get resolved when doing `mvn dependency:go:offline`, however does get resolved when doing `mvn install`. This PR changes the order of the commands used so that the docker build succeeds. 