### PR TITLE
add check to build docker image

### DIFF
--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -14,7 +14,15 @@
 # limitations under the License.
 
 name: "Distribution Checks"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+' # release branches
+      - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
+    paths:
+      - 'distribution/**'
+  pull_request:
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -14,8 +14,7 @@
 # limitations under the License.
 
 name: "Distribution Checks"
-on:
-  [push, pull_request]:
+on: [push, pull_request]
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -22,6 +22,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
     paths:
       - 'distribution/**'
+      - '**/pom.xml'
   pull_request:
     branches:
       - master
@@ -29,6 +30,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
     paths:
       - 'distribution/**'
+      - '**/pom.xml'
 
 jobs:
   docker-build:

--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Distribution Checks"
+on:
+  [push, pull_request]:
+    branches:
+      - master
+      - '[0-9]+.[0-9]+.[0-9]+' # release branches
+      - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
+    paths:
+      - 'distribution/**'
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: DOCKER_BUILDKIT=1 docker build -t apache/druid:tag -f distribution/docker/Dockerfile .

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY . /src
 WORKDIR /src
+
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
       mvn -B -ff -q dependency:go-offline \
       install \

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -35,9 +35,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 COPY . /src
 WORKDIR /src
-
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -B -ff -q dependency:go-offline \
+      mvn -B -ff -q \
       install \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \


### PR DESCRIPTION
* added workflow to build the image
* checked to see if the issues like #15892 can be detected
* removed `go-offline` target
* restricted to only run if there are changes matching `distribution/**`  or `**/pom.xml`
<details>
<summary>on average it seems like there will be ~10 commits matching that every month; I think that might be enough</summary>

```
$ git log  '**/pom.xml' 'distribution/**'|grep '^Date'|head -n30
Date:   Tue Feb 13 11:03:37 2024 +0100
Date:   Tue Feb 13 10:49:34 2024 +0100
Date:   Wed Feb 7 23:54:06 2024 -0800
Date:   Tue Feb 6 07:55:17 2024 -0800
Date:   Thu Feb 1 23:32:30 2024 -0800
Date:   Thu Feb 1 23:05:23 2024 +0530
Date:   Tue Jan 30 21:53:50 2024 -0800
Date:   Wed Jan 24 10:47:33 2024 +0100
Date:   Tue Jan 23 07:47:07 2024 -0700
Date:   Tue Jan 23 15:55:54 2024 +0530
Date:   Thu Jan 18 03:18:46 2024 -0800
Date:   Sun Jan 14 09:52:30 2024 -0800
Date:   Sat Jan 13 13:14:01 2024 -0800
Date:   Fri Jan 12 00:06:31 2024 -0800
Date:   Mon Jan 8 13:46:08 2024 -0600
Date:   Wed Jan 3 18:36:05 2024 -0500
Date:   Fri Dec 15 13:33:14 2023 -0500
Date:   Thu Dec 14 07:34:49 2023 +0530
Date:   Wed Dec 13 17:22:54 2023 -0800
Date:   Thu Dec 14 00:14:05 2023 +0530
Date:   Tue Dec 12 17:27:57 2023 -0500
Date:   Tue Dec 5 14:50:32 2023 -0500
Date:   Tue Dec 5 11:24:37 2023 -0500
Date:   Tue Dec 5 18:57:56 2023 +0530
Date:   Mon Dec 4 16:20:40 2023 -0500
Date:   Sun Dec 3 10:26:40 2023 -0500
Date:   Wed Nov 29 00:35:22 2023 -0500
Date:   Tue Nov 28 02:11:19 2023 -0800
Date:   Wed Nov 22 02:17:18 2023 -0800
Date:   Fri Nov 17 12:32:28 2023 +0530
```
</details>