### PR TITLE
Handling recursive NVLs with convertlet

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DruidNVLOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DruidNVLOperatorConversion.java
@@ -19,32 +19,14 @@
 
 package org.apache.druid.sql.calcite.expression.builtin;
 
-import com.google.common.collect.ImmutableList;
-import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
-import org.apache.calcite.sql2rel.SqlRexContext;
-import org.apache.calcite.sql2rel.SqlRexConvertlet;
-import org.apache.druid.query.filter.DimFilter;
-import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
-import org.apache.druid.sql.calcite.planner.convertlet.DruidConvertletFactory;
-import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
 
 public class DruidNVLOperatorConversion extends CoalesceOperatorConversion
-    implements DruidConvertletFactory, SqlRexConvertlet
 {
   private static final SqlFunction OPERATOR = new SqlNVLFunction();
 
@@ -70,44 +52,6 @@ public class DruidNVLOperatorConversion extends CoalesceOperatorConversion
   public DruidNVLOperatorConversion()
   {
     super(OPERATOR);
-  }
-
-  @Override
-  public SqlRexConvertlet createConvertlet(PlannerContext plannerContext)
-  {
-    return this;
-  }
-
-  @Override
-  public RexNode convertCall(final SqlRexContext cx, final SqlCall call)
-  {
-
-    final RexBuilder rexBuilder = cx.getRexBuilder();
-    final List<RexNode> newArgs = new ArrayList<RexNode>();
-    for (SqlNode node : call.getOperandList()) {
-      newArgs.add(cx.convertExpression(node));
-    }
-    return rexBuilder.makeCall(OPERATOR, newArgs);
-  }
-
-  @Override
-  public List<SqlOperator> operators()
-  {
-    return ImmutableList.of(calciteOperator());
-  }
-
-  @Nullable
-  @Override
-  public DimFilter toDruidFilter(
-      PlannerContext plannerContext,
-      RowSignature rowSignature,
-      @Nullable VirtualColumnRegistry virtualColumnRegistry,
-      RexNode rexNode)
-  {
-    if (true) {
-      throw new RuntimeException();
-    }
-    return null;
   }
 
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DruidNVLOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/DruidNVLOperatorConversion.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.expression.builtin;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeTransforms;
+import org.apache.calcite.sql2rel.SqlRexContext;
+import org.apache.calcite.sql2rel.SqlRexConvertlet;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.planner.convertlet.DruidConvertletFactory;
+import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DruidNVLOperatorConversion extends CoalesceOperatorConversion
+    implements DruidConvertletFactory, SqlRexConvertlet
+{
+  private static final SqlFunction OPERATOR = new SqlNVLFunction();
+
+  public static class SqlNVLFunction extends SqlFunction
+  {
+
+    public SqlNVLFunction()
+    {
+      super(
+          "NVL",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.LEAST_RESTRICTIVE
+              .andThen(SqlTypeTransforms.TO_NULLABLE_ALL),
+          null,
+          OperandTypes.SAME_SAME,
+          SqlFunctionCategory.SYSTEM
+      );
+    }
+  }
+
+  public static final DruidNVLOperatorConversion INSTANCE = new DruidNVLOperatorConversion();
+
+  public DruidNVLOperatorConversion()
+  {
+    super(OPERATOR);
+  }
+
+  @Override
+  public SqlRexConvertlet createConvertlet(PlannerContext plannerContext)
+  {
+    return this;
+  }
+
+  @Override
+  public RexNode convertCall(final SqlRexContext cx, final SqlCall call)
+  {
+
+    final RexBuilder rexBuilder = cx.getRexBuilder();
+    final List<RexNode> newArgs = new ArrayList<RexNode>();
+    for (SqlNode node : call.getOperandList()) {
+      newArgs.add(cx.convertExpression(node));
+    }
+    return rexBuilder.makeCall(OPERATOR, newArgs);
+  }
+
+  @Override
+  public List<SqlOperator> operators()
+  {
+    return ImmutableList.of(calciteOperator());
+  }
+
+  @Nullable
+  @Override
+  public DimFilter toDruidFilter(
+      PlannerContext plannerContext,
+      RowSignature rowSignature,
+      @Nullable VirtualColumnRegistry virtualColumnRegistry,
+      RexNode rexNode)
+  {
+    if (true) {
+      throw new RuntimeException();
+    }
+    return null;
+  }
+
+}
+

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -81,6 +81,7 @@ import org.apache.druid.sql.calcite.expression.builtin.ConcatOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ContainsOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.DateTruncOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.DecodeBase64UTFOperatorConversion;
+import org.apache.druid.sql.calcite.expression.builtin.DruidNVLOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.ExtractOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.FloorOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.GreatestOperatorConversion;
@@ -396,7 +397,8 @@ public class DruidOperatorTable implements SqlOperatorTable
                    .add(new DirectOperatorConversion(SqlStdOperatorTable.IS_NOT_FALSE, "notfalse"))
                    .add(new DirectOperatorConversion(SqlStdOperatorTable.IS_NOT_TRUE, "nottrue"))
                    .add(new CoalesceOperatorConversion(SqlStdOperatorTable.COALESCE))
-                   .add(new CoalesceOperatorConversion(SqlLibraryOperators.NVL))
+                   //.add(new CoalesceOperatorConversion(SqlLibraryOperators.NVL))
+                   .add(new DruidNVLOperatorConversion())
                    .add(new CoalesceOperatorConversion(SqlLibraryOperators.IFNULL))
                    .add(new BinaryOperatorConversion(SqlStdOperatorTable.MULTIPLY, "*"))
                    .add(new BinaryOperatorConversion(SqlStdOperatorTable.MOD, "%"))

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidConvertletTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidConvertletTable.java
@@ -27,7 +27,6 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql2rel.SqlRexConvertlet;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
-import org.apache.druid.sql.calcite.expression.builtin.DruidNVLOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.NestedDataOperatorConversions;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
@@ -46,7 +45,7 @@ public class DruidConvertletTable implements SqlRexConvertletTable
                    .add(CurrentTimestampAndFriendsConvertletFactory.INSTANCE)
                    .add(TimeInIntervalConvertletFactory.INSTANCE)
                    .add(NestedDataOperatorConversions.DRUID_JSON_VALUE_CONVERTLET_FACTORY_INSTANCE)
-                   .add(DruidNVLOperatorConversion.INSTANCE)
+                   .add(DruidNVLConvertletFactory.INSTANCE)
                    .build();
 
   // Operators we don't have standard conversions for, but which can be converted into ones that do by

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidConvertletTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidConvertletTable.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql2rel.SqlRexConvertlet;
 import org.apache.calcite.sql2rel.SqlRexConvertletTable;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
+import org.apache.druid.sql.calcite.expression.builtin.DruidNVLOperatorConversion;
 import org.apache.druid.sql.calcite.expression.builtin.NestedDataOperatorConversions;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 
@@ -45,6 +46,7 @@ public class DruidConvertletTable implements SqlRexConvertletTable
                    .add(CurrentTimestampAndFriendsConvertletFactory.INSTANCE)
                    .add(TimeInIntervalConvertletFactory.INSTANCE)
                    .add(NestedDataOperatorConversions.DRUID_JSON_VALUE_CONVERTLET_FACTORY_INSTANCE)
+                   .add(DruidNVLOperatorConversion.INSTANCE)
                    .build();
 
   // Operators we don't have standard conversions for, but which can be converted into ones that do by

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidNVLConvertletFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/convertlet/DruidNVLConvertletFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.planner.convertlet;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql2rel.SqlRexContext;
+import org.apache.calcite.sql2rel.SqlRexConvertlet;
+import org.apache.druid.sql.calcite.expression.builtin.DruidNVLOperatorConversion;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DruidNVLConvertletFactory implements DruidConvertletFactory, SqlRexConvertlet
+{
+  public static final DruidNVLConvertletFactory INSTANCE = new DruidNVLConvertletFactory();
+  private static final SqlFunction OPERATOR = new DruidNVLOperatorConversion.SqlNVLFunction();
+
+  @Override
+  public RexNode convertCall(SqlRexContext cx, SqlCall call)
+  {
+    final RexBuilder rexBuilder = cx.getRexBuilder();
+    final List<RexNode> newArgs = new ArrayList<RexNode>();
+    for (SqlNode node : call.getOperandList()) {
+      newArgs.add(cx.convertExpression(node));
+    }
+    return rexBuilder.makeCall(OPERATOR, newArgs);
+  }
+
+  @Override
+  public SqlRexConvertlet createConvertlet(PlannerContext plannerContext)
+  {
+    return this;
+  }
+
+  @Override
+  public List<SqlOperator> operators()
+  {
+    return ImmutableList.of(OPERATOR);
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -2115,8 +2115,10 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                         queryFramework().macroTable()
                     )
                 )
-                .filters(expressionFilter(
-                    "array_overlap(nvl(mv_to_array(\"dim3\"),array('other')),array('a','b','other'))"))
+                .filters(or(
+                    expressionFilter("array_overlap(nvl(mv_to_array(\"dim3\"),array('other')),array('a','b','other'))"),
+                    expressionFilter("array_overlap(nvl(mv_to_array(\"dim3\"),array('other')),array('a','b','other'))")
+                ))
                 .columns("v0")
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                 .limit(5)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -15308,7 +15308,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testNVLColumns()
+  public void testNVLColumnsWithConvertlet()
   {
     // Doesn't conform to the SQL standard, but it's how we do it.
     // This example is used in the sql.md doc.
@@ -15352,7 +15352,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testNVLColumnsRecursive()
+  public void testNVLColumnsRecursiveWithConvertlet()
   {
     // Doesn't conform to the SQL standard, but it's how we do it.
     // This example is used in the sql.md doc.


### PR DESCRIPTION
Currently in Calcite NVL is converted to a case statement. Internally NVL(a,b) translates into CASE when a is not null then a else b. 1 occ of a gets replaced by 2. So recursive uses of NVL will be exponential. 

One solution to this is to not allow the NVL to be evaluated as case statements. The calcite rewrite of NVL to CASE isn't useful for Druid, since with https://github.com/apache/druid/pull/15609 we rewrite the CASE back to COALESCE right after validation, before the cost-based planner runs

I discussed this with @kgyrtkirk and this is an initial solution for recursive NVLs.



This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
