### PR TITLE
fix return type inference of parse_long, which can also be null if string is not parseable into a long

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectQueryMSQTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectQueryMSQTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.DruidInjectorBuilder;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.msq.exec.WorkerMemoryParameters;
@@ -214,5 +215,19 @@ public class CalciteSelectQueryMSQTest extends CalciteQueryTest
                 + "order by 2 desc limit 1001"
         )
         .run();
+  }
+
+  @Override
+  public void testFilterParseLongNullable()
+  {
+    // this isn't really correct in default value mode, the result should be ImmutableList.of(new Object[]{0L})
+    // but MSQ is missing default aggregator values in empty group results. this override can be removed when this
+    // is fixed
+    testBuilder().queryContext(QUERY_CONTEXT_DEFAULT)
+                 .sql("select count(*) from druid.foo where parse_long(dim1, 10) is null")
+                 .expectedResults(
+                     NullHandling.sqlCompatible() ? ImmutableList.of(new Object[]{4L}) : ImmutableList.of()
+                 )
+                 .run();
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/ParseLongOperatorConversion.java
@@ -38,7 +38,7 @@ public class ParseLongOperatorConversion implements SqlOperatorConversion
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder(NAME)
       .operandTypes(SqlTypeFamily.CHARACTER, SqlTypeFamily.INTEGER)
-      .returnTypeCascadeNullable(SqlTypeName.BIGINT)
+      .returnTypeNullable(SqlTypeName.BIGINT)
       .functionCategory(SqlFunctionCategory.STRING)
       .requiredOperandCount(1)
       .build();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -15292,4 +15292,29 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         )
         .run();
   }
+
+  @Test
+  public void testFilterParseLongNullable()
+  {
+    testQuery(
+        "select count(*) from druid.foo where parse_long(dim1, 10) is null",
+        ImmutableList.of(
+            Druids.newTimeseriesQueryBuilder()
+                  .dataSource(CalciteTests.DATASOURCE1)
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .virtualColumns(
+                      expressionVirtualColumn(
+                          "v0",
+                          "parse_long(\"dim1\",10)",
+                          ColumnType.LONG)
+                  )
+                  .filters(isNull("v0"))
+                  .granularity(Granularities.ALL)
+                  .aggregators(new CountAggregatorFactory("a0"))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+        ),
+        ImmutableList.of(new Object[]{NullHandling.sqlCompatible() ? 4L : 0L})
+    );
+  }
 }


### PR DESCRIPTION
### Description
Fixes an issue of the SQL return type inference of `PARSE_LONG`, which was incorrectly using cascade nullable when instead it is always nullable (such as a non-null input string not being able to be parsed into a number). This becomes problematic when used in a filter involving nulls as the planner would incorrectly optimize it to always true/false depending on is null/ not null.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
