### PR TITLE
Fix pod template reading logic

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -20,10 +20,6 @@
 package org.apache.druid.k8s.overlord.taskadapter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.cfg.MapperConfig;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -60,10 +56,12 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * A PodTemplate {@link TaskAdapter} to transform tasks to kubernetes jobs and kubernetes pods to tasks
@@ -84,7 +82,9 @@ public class PodTemplateTaskAdapter implements TaskAdapter
   public static final String TYPE = "customTemplateAdapter";
 
   private static final Logger log = new Logger(PodTemplateTaskAdapter.class);
-  private static final String TASK_PROPERTY = IndexingServiceModuleHelper.INDEXER_RUNNER_PROPERTY_PREFIX + ".k8s.podTemplate.%s";
+
+
+  private static final String TASK_PROPERTY = IndexingServiceModuleHelper.INDEXER_RUNNER_PROPERTY_PREFIX + ".k8s.podTemplate.";
 
   private final KubernetesTaskRunnerConfig taskRunnerConfig;
   private final TaskConfig taskConfig;
@@ -212,27 +212,36 @@ public class PodTemplateTaskAdapter implements TaskAdapter
 
   private HashMap<String, PodTemplate> initializePodTemplates(Properties properties)
   {
-    HashMap<String, PodTemplate> podTemplateMap = new HashMap<>();
-    Optional<PodTemplate> basePodTemplate = loadPodTemplate("base", properties);
-    if (!basePodTemplate.isPresent()) {
+    Set<String> taskAdapterTemplateKeys = getTaskAdapterTemplates(properties);
+    if (!taskAdapterTemplateKeys.contains("base")) {
       throw new IAE("Pod template task adapter requires a base pod template to be specified");
     }
-    podTemplateMap.put("base", basePodTemplate.get());
 
-    MapperConfig config = mapper.getDeserializationConfig();
-    AnnotatedClass cls = AnnotatedClassResolver.resolveWithoutSuperTypes(config, Task.class);
-    Collection<NamedType> taskSubtypes = mapper.getSubtypeResolver().collectAndResolveSubtypesByClass(config, cls);
-    for (NamedType namedType : taskSubtypes) {
-      String taskType = namedType.getName();
-      Optional<PodTemplate> template = loadPodTemplate(taskType, properties);
-      template.ifPresent(podTemplate -> podTemplateMap.put(taskType, podTemplate));
+    HashMap<String, PodTemplate> podTemplateMap = new HashMap<>();
+    for (String taskAdapterTemplateKey : taskAdapterTemplateKeys) {
+      Optional<PodTemplate> template = loadPodTemplate(taskAdapterTemplateKey, properties);
+      template.ifPresent(podTemplate -> podTemplateMap.put(taskAdapterTemplateKey, podTemplate));
     }
     return podTemplateMap;
   }
 
+  private static Set<String> getTaskAdapterTemplates(Properties properties)
+  {
+    Set<String> taskAdapterTemplates = new HashSet<>();
+
+    for (String runtimeProperty : properties.stringPropertyNames()) {
+      if (runtimeProperty.startsWith(TASK_PROPERTY)) {
+        String[] taskAdapterPropertyPaths = runtimeProperty.split("\\.");
+        taskAdapterTemplates.add(taskAdapterPropertyPaths[taskAdapterPropertyPaths.length - 1]);
+      }
+    }
+
+    return taskAdapterTemplates;
+  }
+
   private Optional<PodTemplate> loadPodTemplate(String key, Properties properties)
   {
-    String property = StringUtils.format(TASK_PROPERTY, key);
+    String property = TASK_PROPERTY + key;
     String podTemplateFile = properties.getProperty(property);
     if (podTemplateFile == null) {
       log.debug("Pod template file not specified for [%s]", key);


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/15886
### Description
The previous call `Collection<NamedType> taskSubtypes = mapper.getSubtypeResolver().collectAndResolveSubtypesByClass(config, cls);` to get the list of subtask names for loading per-taskType pod templates was not including task types included via extensions like index_kinesis and index_kafka. Because of this, if you define druid.indexer.runner.k8s.podTemplate.index_kafka, the KubernetesTaskRunner will still use druid.indexer.runner.k8s.podTemplate.base as the base template for tasks.

In order to fix this bug, rather than try to come up with a fixed list of all possible task types, I updated the logic to look for task templates for all properties defined under druid.indexer.runner.k8s.podTemplate.*. I think this does a better job of future-proofing any additional task types we may want to support.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `PodTemplateTaskAdapter`
 * `PodTemplateTaskAdapterTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
