### PR TITLE
fix NestedCommonFormatColumnHandler to use nullable comparator when castToType is set

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnSchema.java
+++ b/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnSchema.java
@@ -76,7 +76,14 @@ public class AutoTypeColumnSchema extends DimensionSchema
   )
   {
     super(name, null, true);
-    this.castToType = castToType;
+    // auto doesn't currently do FLOAT since expressions only support DOUBLE
+    if (ColumnType.FLOAT.equals(castToType)) {
+      this.castToType = ColumnType.DOUBLE;
+    } else if (ColumnType.FLOAT_ARRAY.equals(castToType)) {
+      this.castToType = ColumnType.DOUBLE_ARRAY;
+    } else {
+      this.castToType = castToType;
+    }
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
@@ -100,7 +100,7 @@ public class NestedCommonFormatColumnHandler implements DimensionHandler<Structu
   {
     if (castTo != null) {
       return (s1, s2) ->
-          castTo.getStrategy().compare(
+          castTo.getNullableStrategy().compare(
               StructuredData.unwrap(s1.getObject()),
               StructuredData.unwrap(s2.getObject())
           );


### PR DESCRIPTION
### Description
Fixes a bug when the undocumented `castToType` parameter is set on `'auto'` column schema, which should have been using the 'nullable' comparator to allow null values to be present when merging columns, but wasn't which would lead to null pointer exceptions. Also fixes an issue I noticed while adding tests that if 'FLOAT' type was specified for the `castToType` parameter it would be an exception because that type is not expected to be present, since 'auto' uses the native expressions to determine the input types and expressions don't have direct support for floats, only doubles.

In the future I should probably split this functionality out of the 'auto' schema (maybe even have a simpler version of the auto indexer dedicated to handling non-nested data) but still have the same results of writing out the newer 'nested common format' columns used by 'auto', but I haven't taken that on in this PR.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
