### PR TITLE
Web console: Make array ingest mode ux better

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -296,7 +296,10 @@ export function getSchemaMode(spec: Partial<IngestionSpec>): SchemaMode {
   return Array.isArray(dimensions) && dimensions.length === 0 ? 'string-only-discovery' : 'fixed';
 }
 
-export function getArrayMode(spec: Partial<IngestionSpec>): ArrayMode {
+export function getArrayMode(
+  spec: Partial<IngestionSpec>,
+  whenUnclear: ArrayMode = 'arrays',
+): ArrayMode {
   const schemaMode = getSchemaMode(spec);
   switch (schemaMode) {
     case 'type-aware-discovery':
@@ -331,7 +334,7 @@ export function getArrayMode(spec: Partial<IngestionSpec>): ArrayMode {
         return 'multi-values';
       }
 
-      return 'arrays';
+      return whenUnclear;
     }
   }
 }

--- a/web-console/src/druid-models/query-context/query-context.tsx
+++ b/web-console/src/druid-models/query-context/query-context.tsx
@@ -18,6 +18,8 @@
 
 import { deepDelete, deepSet } from '../../utils';
 
+export type ArrayIngestMode = 'array' | 'mvd';
+
 export interface QueryContext {
   useCache?: boolean;
   populateCache?: boolean;
@@ -32,7 +34,7 @@ export interface QueryContext {
   durableShuffleStorage?: boolean;
   maxParseExceptions?: number;
   groupByEnableMultiValueUnnesting?: boolean;
-  arrayIngestMode?: 'array' | 'mvd';
+  arrayIngestMode?: ArrayIngestMode;
 
   [key: string]: any;
 }
@@ -246,5 +248,22 @@ export function changeMaxParseExceptions(
     return deepSet(context, 'maxParseExceptions', maxParseExceptions);
   } else {
     return deepDelete(context, 'maxParseExceptions');
+  }
+}
+
+// arrayIngestMode
+
+export function getArrayIngestMode(context: QueryContext): ArrayIngestMode | undefined {
+  return context.arrayIngestMode;
+}
+
+export function changeArrayIngestMode(
+  context: QueryContext,
+  arrayIngestMode: ArrayIngestMode | undefined,
+): QueryContext {
+  if (arrayIngestMode) {
+    return deepSet(context, 'arrayIngestMode', arrayIngestMode);
+  } else {
+    return deepDelete(context, 'arrayIngestMode');
   }
 }

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -94,6 +94,8 @@ export class WorkbenchQuery {
     partitionedByHint: string | undefined,
     arrayMode: ArrayMode,
   ): WorkbenchQuery {
+    const queryContext: QueryContext = {};
+    if (arrayMode === 'arrays') queryContext.arrayIngestMode = 'array';
     return new WorkbenchQuery({
       queryString: ingestQueryPatternToQuery(
         externalConfigToIngestQueryPattern(
@@ -103,9 +105,7 @@ export class WorkbenchQuery {
           arrayMode,
         ),
       ).toString(),
-      queryContext: {
-        arrayIngestMode: 'array',
-      },
+      queryContext,
     });
   }
 

--- a/web-console/src/helpers/spec-conversion.spec.ts
+++ b/web-console/src/helpers/spec-conversion.spec.ts
@@ -123,10 +123,7 @@ describe('spec conversion', () => {
     expect(converted.queryString).toMatchSnapshot();
 
     expect(converted.queryContext).toEqual({
-      arrayIngestMode: 'array',
-      groupByEnableMultiValueUnnesting: false,
       maxParseExceptions: 3,
-      finalizeAggregations: false,
       maxNumTasks: 5,
       indexSpec: {
         dimensionCompression: 'lzf',
@@ -232,11 +229,7 @@ describe('spec conversion', () => {
 
     expect(converted.queryString).toMatchSnapshot();
 
-    expect(converted.queryContext).toEqual({
-      arrayIngestMode: 'array',
-      groupByEnableMultiValueUnnesting: false,
-      finalizeAggregations: false,
-    });
+    expect(converted.queryContext).toEqual({});
   });
 
   it('converts index_hadoop spec (with rollup)', () => {
@@ -357,11 +350,7 @@ describe('spec conversion', () => {
 
     expect(converted.queryString).toMatchSnapshot();
 
-    expect(converted.queryContext).toEqual({
-      arrayIngestMode: 'array',
-      groupByEnableMultiValueUnnesting: false,
-      finalizeAggregations: false,
-    });
+    expect(converted.queryContext).toEqual({});
   });
 
   it('converts with issue when there is a __time transform', () => {
@@ -663,5 +652,9 @@ describe('spec conversion', () => {
     });
 
     expect(converted.queryString).toMatchSnapshot();
+
+    expect(converted.queryContext).toEqual({
+      arrayIngestMode: 'array',
+    });
   });
 });

--- a/web-console/src/helpers/spec-conversion.ts
+++ b/web-console/src/helpers/spec-conversion.ts
@@ -32,11 +32,18 @@ import type {
   DimensionSpec,
   IngestionSpec,
   MetricSpec,
+  QueryContext,
   QueryWithContext,
   TimestampSpec,
   Transform,
 } from '../druid-models';
-import { inflateDimensionSpec, NO_SUCH_COLUMN, TIME_COLUMN, upgradeSpec } from '../druid-models';
+import {
+  getArrayMode,
+  inflateDimensionSpec,
+  NO_SUCH_COLUMN,
+  TIME_COLUMN,
+  upgradeSpec,
+} from '../druid-models';
 import { deepGet, filterMap, nonEmptyArray, oneOf } from '../utils';
 
 export function getSpecDatasourceName(spec: Partial<IngestionSpec>): string {
@@ -73,11 +80,11 @@ export function convertSpecToSql(spec: any): QueryWithContext {
   }
   spec = upgradeSpec(spec, true);
 
-  const context: Record<string, any> = {
-    finalizeAggregations: false,
-    groupByEnableMultiValueUnnesting: false,
-    arrayIngestMode: 'array',
-  };
+  const context: QueryContext = {};
+
+  if (getArrayMode(spec, 'multi-values') === 'arrays') {
+    context.arrayIngestMode = 'array';
+  }
 
   const indexSpec = deepGet(spec, 'spec.tuningConfig.indexSpec');
   if (indexSpec) {

--- a/web-console/src/views/sql-data-loader-view/sql-data-loader-view.tsx
+++ b/web-console/src/views/sql-data-loader-view/sql-data-loader-view.tsx
@@ -48,7 +48,6 @@ import './sql-data-loader-view.scss';
 const INITIAL_QUERY_CONTEXT: QueryContext = {
   finalizeAggregations: false,
   groupByEnableMultiValueUnnesting: false,
-  arrayIngestMode: 'array',
 };
 
 interface LoaderContent extends QueryWithContext {
@@ -190,6 +189,8 @@ export const SqlDataLoaderView = React.memo(function SqlDataLoaderView(
             initInputFormat={inputFormat}
             doneButton={false}
             onSet={({ inputSource, inputFormat, signature, timeExpression, arrayMode }) => {
+              const queryContext: QueryContext = { ...INITIAL_QUERY_CONTEXT };
+              if (arrayMode === 'arrays') queryContext.arrayIngestMode = 'array';
               setContent({
                 queryString: ingestQueryPatternToQuery(
                   externalConfigToIngestQueryPattern(
@@ -199,7 +200,7 @@ export const SqlDataLoaderView = React.memo(function SqlDataLoaderView(
                     arrayMode,
                   ),
                 ).toString(),
-                queryContext: INITIAL_QUERY_CONTEXT,
+                queryContext,
               });
             }}
             altText="Skip the wizard and continue with custom SQL"

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -25,6 +25,7 @@ import {
   MenuDivider,
   MenuItem,
   Position,
+  Tag,
   useHotkeys,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -95,6 +96,20 @@ const NAMED_TIMEZONES: string[] = [
   'Pacific/Guam', // +10.0
   'Australia/Sydney', // +11.0
 ];
+
+const ARRAY_INGEST_MODE_DESCRIPTION: Record<ArrayIngestMode, JSX.Element> = {
+  array: (
+    <>
+      array: Load SQL <Tag minimal>VARCHAR ARRAY</Tag> as Druid{' '}
+      <Tag minimal>ARRAY&lt;string&gt;</Tag>
+    </>
+  ),
+  mvd: (
+    <>
+      mvd: Load SQL <Tag minimal>VARCHAR ARRAY</Tag> as Druid <Tag minimal>multi-value STRING</Tag>
+    </>
+  ),
+};
 
 export interface RunPanelProps {
   query: WorkbenchQuery;
@@ -491,7 +506,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                     <MenuItem
                       key={i}
                       icon={tickIcon(m === arrayIngestMode)}
-                      text={m ?? '(server default)'}
+                      text={m ? ARRAY_INGEST_MODE_DESCRIPTION[m] : '(server default)'}
                       onClick={() => changeQueryContext(changeArrayIngestMode(queryContext, m))}
                     />
                   ))}
@@ -499,9 +514,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                   <MenuItem
                     icon={IconNames.HELP}
                     text="Documentation"
-                    href={`${getLink(
-                      'DOCS',
-                    )}/querying/arrays#differences-between-arrays-and-multi-value-dimensions`}
+                    href={`${getLink('DOCS')}/querying/arrays#arrayingestmode`}
                     target="_blank"
                   />
                 </Menu>

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -35,8 +35,15 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { MenuCheckbox, MenuTristate } from '../../../components';
 import { EditContextDialog, StringInputDialog } from '../../../dialogs';
 import { IndexSpecDialog } from '../../../dialogs/index-spec-dialog/index-spec-dialog';
-import type { DruidEngine, IndexSpec, QueryContext, WorkbenchQuery } from '../../../druid-models';
+import type {
+  ArrayIngestMode,
+  DruidEngine,
+  IndexSpec,
+  QueryContext,
+  WorkbenchQuery,
+} from '../../../druid-models';
 import {
+  changeArrayIngestMode,
   changeDurableShuffleStorage,
   changeFailOnEmptyInsert,
   changeFinalizeAggregations,
@@ -47,6 +54,7 @@ import {
   changeUseApproximateTopN,
   changeUseCache,
   changeWaitUntilSegmentsLoad,
+  getArrayIngestMode,
   getDurableShuffleStorage,
   getFailOnEmptyInsert,
   getFinalizeAggregations,
@@ -59,6 +67,7 @@ import {
   getWaitUntilSegmentsLoad,
   summarizeIndexSpec,
 } from '../../../druid-models';
+import { getLink } from '../../../links';
 import { deepGet, deepSet, pluralIfNeeded, tickIcon } from '../../../utils';
 import { MaxTasksButton } from '../max-tasks-button/max-tasks-button';
 import { QueryParametersDialog } from '../query-parameters-dialog/query-parameters-dialog';
@@ -112,6 +121,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
   const numContextKeys = Object.keys(queryContext).length;
   const queryParameters = query.queryParameters;
 
+  const arrayIngestMode = getArrayIngestMode(queryContext);
   const maxParseExceptions = getMaxParseExceptions(queryContext);
   const failOnEmptyInsert = getFailOnEmptyInsert(queryContext);
   const finalizeAggregations = getFinalizeAggregations(queryContext);
@@ -471,6 +481,37 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
               queryContext={queryContext}
               changeQueryContext={changeQueryContext}
             />
+          )}
+          {ingestMode && (
+            <Popover2
+              position={Position.BOTTOM_LEFT}
+              content={
+                <Menu>
+                  {([undefined, 'array', 'mvd'] as (ArrayIngestMode | undefined)[]).map((m, i) => (
+                    <MenuItem
+                      key={i}
+                      icon={tickIcon(m === arrayIngestMode)}
+                      text={m ?? '(server default)'}
+                      onClick={() => changeQueryContext(changeArrayIngestMode(queryContext, m))}
+                    />
+                  ))}
+                  <MenuDivider />
+                  <MenuItem
+                    icon={IconNames.HELP}
+                    text="Documentation"
+                    href={`${getLink(
+                      'DOCS',
+                    )}/querying/arrays#differences-between-arrays-and-multi-value-dimensions`}
+                    target="_blank"
+                  />
+                </Menu>
+              }
+            >
+              <Button
+                text={`Array ingest mode: ${arrayIngestMode ?? '(server default)'}`}
+                rightIcon={IconNames.CARET_DOWN}
+              />
+            </Popover2>
           )}
         </ButtonGroup>
       )}

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -101,12 +101,12 @@ const ARRAY_INGEST_MODE_DESCRIPTION: Record<ArrayIngestMode, JSX.Element> = {
   array: (
     <>
       array: Load SQL <Tag minimal>VARCHAR ARRAY</Tag> as Druid{' '}
-      <Tag minimal>ARRAY&lt;string&gt;</Tag>
+      <Tag minimal>ARRAY&lt;STRING&gt;</Tag>
     </>
   ),
   mvd: (
     <>
-      mvd: Load SQL <Tag minimal>VARCHAR ARRAY</Tag> as Druid <Tag minimal>multi-value STRING</Tag>
+      mvd: Load SQL <Tag minimal>VARCHAR ARRAY</Tag> as Druid multi-value <Tag minimal>STRING</Tag>
     </>
   ),
 };

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -320,18 +320,13 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
 
     return (
       <ConnectExternalDataDialog
-        onSetExternalConfig={(
-          externalConfig,
-          timeExpression,
-          partitionedByHint,
-          forceMultiValue,
-        ) => {
+        onSetExternalConfig={(externalConfig, timeExpression, partitionedByHint, arrayMode) => {
           this.handleNewTab(
             WorkbenchQuery.fromInitExternalConfig(
               externalConfig,
               timeExpression,
               partitionedByHint,
-              forceMultiValue,
+              arrayMode,
             ),
             'Ext ' + guessDataSourceNameFromInputSource(externalConfig.inputSource),
           );


### PR DESCRIPTION
This PR tries to address an issue of "web console tab context poisoning" that is when a web console user re-uses a tab by deleting the SQL query in the tab and writing/pasting a new one. The user might forget that deleting all the SQL does not clear the context parameters which will be attached to subsequent queries issued.

Specifically here is a scenario that is of concern:
- User plays with the "Connect external data" flow which creates a new tab for them with `arrayIngestMode: array` set (as was added in https://github.com/apache/druid/pull/15588)
- After sometime, the user comes back and re-uses that tab by selecting the entire SQL query and pasting over some REPLACE/INSERT query into their production datasource that contains MVDs to do some fix up. They do not realize that while they cleared the SQL query, `arrayIngestMode: array` is still set in the query context in that tab.
- The MVD columns become mixed with ARRAYs and some queries against these columns start working in unexpected ways.

This PR makes two changes (in two respective commits):

1) Change it so that the `arrayIngestMode: array` context parameter is only set when the user has opted in to arrays (via the toggle that is off by default). Currently `arrayIngestMode: array` is always being set by all UI flows and the toggle only affects the SQL that is generated.
  This change affects:
  - The "Connect external data" wizard flow
  - The "SQL data loader"
  - The spec to SQL converter (in this case `arrayIngestMode: array` is only set if the ingestion spec is detected as using arrays by having dimensions specs of type "auto" + "castToType: ARRAY<...>")

2) Make the `arrayIngestMode` selection more prominent in the UI so that it is shown on the "Run panel" and is not hidden inside of a menu.

![image](https://github.com/apache/druid/assets/177816/7d542adb-8aaa-495c-b4d7-2c3ad405b7df)
