### PR TITLE
[Docs] Fix redirects for streaming ingestion docs

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -120,12 +120,19 @@ const Redirects=[
       "/docs/latest/development/community-extensions/rabbitmq.html",
       "/docs/latest/development/kafka-simple-consumer-firehose.html",
       "/docs/latest/development/extensions-core/kafka-supervisor-operations.html",
-      "/docs/latest/development/extensions-core/kafka-supervisor-reference.html"
+      "/docs/latest/development/extensions-core/kafka-supervisor-reference.html",
+      "/docs/latest/development/extensions-core/kafka-ingestion.html",
+      "/docs/latest/development/extensions-core/kafka-supervisor-operations",
+      "/docs/latest/development/extensions-core/kafka-supervisor-reference",
+      "/docs/latest/development/extensions-core/kafka-ingestion"
     ],
     "to": "/docs/latest/ingestion/kafka-ingestion"
   },
   {
-    "from": "/docs/latest/development/extensions-core/kinesis-ingestion.html",
+    "from": [
+      "/docs/latest/development/extensions-core/kinesis-ingestion.html",
+      "/docs/latest/development/extensions-core/kinesis-ingestion"
+    ],
     "to": "/docs/latest/ingestion/kinesis-ingestion"
   },
   {


### PR DESCRIPTION
This PR addresses the missing redirect for development/extensions-core/kafka-ingestion.html and introduces new redirects without the .html extension.

This PR has:

- [x] been self-reviewed.
