### PR TITLE
Web console: make flattenSpec location adaptive

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -50,6 +50,7 @@ import {
   getDimensionSpecName,
   getDimensionSpecs,
 } from '../dimension-spec/dimension-spec';
+import type { FlattenSpec } from '../flatten-spec/flatten-spec';
 import type { IndexSpec } from '../index-spec/index-spec';
 import { summarizeIndexSpec } from '../index-spec/index-spec';
 import type { InputFormat } from '../input-format/input-format';
@@ -379,6 +380,27 @@ export function getPossibleSystemFieldsForSpec(spec: Partial<IngestionSpec>): st
   const inputSource = deepGet(spec, 'spec.ioConfig.inputSource');
   if (!inputSource) return [];
   return getPossibleSystemFieldsForInputSource(inputSource);
+}
+
+export function getFlattenSpec(spec: Partial<IngestionSpec>): FlattenSpec | undefined {
+  const inputFormat: InputFormat | undefined = deepGet(spec, 'spec.ioConfig.inputFormat');
+  if (!inputFormat) return;
+  return (
+    (inputFormat.type === 'kafka'
+      ? inputFormat.valueFormat?.flattenSpec
+      : inputFormat.flattenSpec) || undefined
+  );
+}
+
+export function changeFlattenSpec(
+  spec: Partial<IngestionSpec>,
+  flattenSpec: FlattenSpec | undefined,
+): Partial<IngestionSpec> {
+  if (deepGet(spec, 'spec.ioConfig.inputFormat.type') === 'kafka') {
+    return deepSet(spec, 'spec.ioConfig.inputFormat.valueFormat.flattenSpec', flattenSpec);
+  } else {
+    return deepSet(spec, 'spec.ioConfig.inputFormat.flattenSpec', flattenSpec);
+  }
 }
 
 export function getPossibleSystemFieldsForInputSource(inputSource: InputSource): string[] {

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -36,6 +36,7 @@ import {
   DETECTION_TIMESTAMP_SPEC,
   getDimensionNamesFromTransforms,
   getDimensionSpecName,
+  getFlattenSpec,
   getSpecType,
   getTimestampSchema,
   isDruidSource,
@@ -157,7 +158,7 @@ export function applyCache(sampleSpec: SampleSpec, cacheRows: CacheRows) {
     data: cacheRows.map(r => JSONBig.stringify(r)).join('\n'),
   });
 
-  const flattenSpec = deepGet(sampleSpec, 'spec.ioConfig.inputFormat.flattenSpec');
+  const flattenSpec = getFlattenSpec(sampleSpec);
   let inputFormat: InputFormat = { type: 'json', keepNullColumns: true };
   if (flattenSpec) {
     inputFormat = deepSet(inputFormat, 'flattenSpec', flattenSpec);


### PR DESCRIPTION
When using the `kafka` inputFormat the flattenSpen needs to live at of `spec.ioConfig.inputFormat.valueFormat.flattenSpec` vs `spec.ioConfig.inputFormat.flattenSpec`. Right now the streaming ingestion flow generates an incorrect spec (with the flattenSpec set incorrectly) if using kafka input format. This results in the flattenSpec being ignored.