### PR TITLE
Upgrade GHA dependencies

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -89,3 +89,8 @@
   - changed-files:
     - any-glob-to-any-file:
       - 'extensions-contrib/kubernetes-overlord-extensions/**'
+
+'GHA':
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
         java-version: '8'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup java
         uses: actions/setup-java@v3
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup java
         uses: actions/setup-java@v3

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Cache Maven m2 repository
         id: maven
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -36,6 +36,6 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the Docker image
         run: DOCKER_BUILDKIT=1 docker build -t apache/druid:tag -f distribution/docker/Dockerfile .

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -85,21 +85,21 @@ jobs:
 
       - name: Restore Maven repository
         id: maven-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-${{ github.sha }}
 
       - name: Restore targets
         id: targets-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ./**/target
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-targets-${{ github.sha }}
 
       - name: Retrieve cached docker image
         id: docker-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           key: druid-container-jdk${{ inputs.build_jdk }}.tar.gz-${{ github.sha }}
           path: |

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.build_jdk }}
           distribution: 'zulu'

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup java
         uses: actions/setup-java@v3

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.runtime_jdk }}
           distribution: 'zulu'

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup java
         uses: actions/setup-java@v3

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Restore Maven repository
         id: maven-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.build_jdk }}-${{ github.sha }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
       # we include github.sha in the cache key to make it specific to that build/jdk
       - name: Restore Maven repository
         id: maven-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ inputs.jdk }}-${{ github.sha }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
       coverage_failure: ${{ steps.set_outputs.outputs.coverage_failure }}
     steps:
       - name: checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       # skip the "cache: maven" step from setup-java. We explicitly use a
       # different cache key since we cannot reuse it across commits.
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ inputs.jdk }}

--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -33,7 +33,7 @@ jobs:
       # the common extension in revised ITs is different from the one in standard ITs
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -32,7 +32,7 @@ jobs:
       core: ${{ steps.filter.outputs.core || github.event_name != 'pull_request'}}
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -160,7 +160,7 @@ jobs:
       # we include github.sha in the cache key to make it specific to that build/jdk
       - name: Restore Maven repository
         id: maven-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-8-${{ github.sha }}

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
           distribution: 'zulu'

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -148,7 +148,7 @@ jobs:
       BUILD_DRUID_CLUSTER: true
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup java
         uses: actions/setup-java@v3

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -47,7 +47,7 @@ jobs:
       - name: checkout branch
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
@@ -120,7 +120,7 @@ jobs:
       - name: checkout branch
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '8'
@@ -152,7 +152,7 @@ jobs:
       - name: checkout branch
         uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:
@@ -150,7 +150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -64,7 +64,7 @@ jobs:
 
       # skip the "cache: maven" step from setup-java. We explicitly use a
       # different cache key since we cannot reuse it across commits.
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.jdk }}

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # skip the "cache: maven" step from setup-java. We explicitly use a
       # different cache key since we cannot reuse it across commits.

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -17,6 +17,7 @@ name: "Unit & Integration tests CI"
 on:
   push:
     paths-ignore:
+      - '.github/**'
       - '**/*.md'
       - 'dev/**'
       - 'docs/**'
@@ -30,6 +31,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
   pull_request:
     paths-ignore:
+      - '.github/**'
       - '**/*.md'
       - 'dev/**'
       - 'docs/**'

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -17,7 +17,6 @@ name: "Unit & Integration tests CI"
 on:
   push:
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
       - 'dev/**'
       - 'docs/**'
@@ -31,7 +30,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
   pull_request:
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
       - 'dev/**'
       - 'docs/**'

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -73,7 +73,7 @@ jobs:
       # we include github.sha in the cache key to make it specific to that build/jdk
       - name: Cache Maven m2 repository
         id: maven
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ matrix.jdk }}-${{ github.sha }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cache targets
         id: target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ./**/target
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cache image
         id: docker_container
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: druid-container-jdk${{ matrix.jdk }}.tar.gz-${{ github.sha }}
           path: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,7 +54,7 @@ jobs:
       # run everything if not a PR
       core: ${{ steps.filter.outputs.core  || github.event_name != 'pull_request'}}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:


### PR DESCRIPTION
### Description

Upgrade the following GitHub actions:
- `actions/checkout` from v3 to [v4](https://github.com/actions/checkout/releases/tag/v4.1.1)
- `actions/setup-java` from v3 to [v4](https://github.com/actions/setup-java/releases/tag/v4.0.0)
- `actions/cache/restore` from v3 to [v4](https://github.com/actions/cache?tab=readme-ov-file#v4)
- `actions/stale` from v8 to [v9](https://github.com/actions/stale/releases/tag/v9.0.0)
- `dorny/paths-filter` from v2 to [v3](https://github.com/dorny/paths-filter/releases/tag/v3.0.1)


All of them now run on node 20 by default, instead of of node 16, which is now EOL.

Also, add a "GHA" auto-labeler config. Tested the changes with this patch in my fork: https://github.com/abhishekrb19/incubator-druid/pull/44

This PR has:

- [x] been self-reviewed.

