### PR TITLE
fix REGEXP_LIKE, CONTAINS_STRING, ICONTAINS_STRING for correct 3vl behavior

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ContainsExpr.java
@@ -71,7 +71,7 @@ class ContainsExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
 
     if (s == null) {
       // same behavior as regexp_like.
-      return ExprEval.ofLongBoolean(false);
+      return ExprEval.ofLong(null);
     } else {
       final boolean doesContain = searchFunction.apply(s);
       return ExprEval.ofLongBoolean(doesContain);

--- a/processing/src/main/java/org/apache/druid/query/expression/RegexpLikeExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/RegexpLikeExprMacro.java
@@ -74,7 +74,7 @@ public class RegexpLikeExprMacro implements ExprMacroTable.ExprMacro
 
         if (s == null) {
           // True nulls do not match anything. Note: this branch only executes in SQL-compatible null handling mode.
-          return ExprEval.ofLongBoolean(false);
+          return ExprEval.ofLong(null);
         } else {
           final Matcher matcher = pattern.matcher(s);
           return ExprEval.ofLongBoolean(matcher.find());

--- a/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
@@ -166,11 +166,11 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   @Test
   public void testEmptyStringSearchOnNull()
   {
-    final ExprEval<?> result = eval("icontains_string(a, '')", InputBindings.nilBindings());
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(!NullHandling.sqlCompatible()).value(),
-        result.value()
-    );
+    ExprEval<?> result = eval("icontains_string(a, '')", InputBindings.nilBindings());
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertNull(result.value());
+    } else {
+      Assert.assertEquals(ExprEval.ofLongBoolean(true).value(), result.value());
+    }
   }
-
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
@@ -151,9 +151,10 @@ public class ContainsExprMacroTest extends MacroTestBase
   public void testEmptyStringSearchOnNull()
   {
     final ExprEval<?> result = eval("contains_string(a, '')", InputBindings.nilBindings());
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(!NullHandling.sqlCompatible()).value(),
-        result.value()
-    );
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertNull(result.value());
+    } else {
+      Assert.assertEquals(ExprEval.ofLongBoolean(true).value(), result.value());
+    }
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
@@ -151,9 +151,10 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   public void testEmptyStringPatternOnNull()
   {
     final ExprEval<?> result = eval("regexp_like(a, '')", InputBindings.nilBindings());
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(NullHandling.replaceWithDefault()).value(),
-        result.value()
-    );
+    if (NullHandling.sqlCompatible()) {
+      Assert.assertNull(result.value());
+    } else {
+      Assert.assertEquals(ExprEval.ofLongBoolean(true).value(), result.value());
+    }
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -581,7 +581,7 @@ public class ExpressionsTest extends CalciteTestBase
             testHelper.makeLiteral("(.)")
         ),
         makeExpression("regexp_like(null,'(.)')"),
-        0L
+        NullHandling.sqlCompatible() ? null : 0L
     );
 
     testHelper.testExpressionString(
@@ -593,7 +593,7 @@ public class ExpressionsTest extends CalciteTestBase
         makeExpression("regexp_like(null,'')"),
 
         // In SQL-compatible mode, nulls don't match anything. Otherwise, they match like empty strings.
-        NullHandling.sqlCompatible() ? 0L : 1L
+        NullHandling.sqlCompatible() ? null : 1L
     );
 
     testHelper.testExpressionString(
@@ -603,7 +603,7 @@ public class ExpressionsTest extends CalciteTestBase
             testHelper.makeLiteral("null")
         ),
         makeExpression("regexp_like(null,'null')"),
-        0L
+        NullHandling.sqlCompatible() ? null : 0L
     );
   }
 


### PR DESCRIPTION
### Description
Fixes `regexp_like`, `contains_string`, and `icontains_string` to return `null` instead of `false` in SQL compatible null handling mode to have correct three-value logic behavior. I did not put this behavior behind a flag, though if we are worried about the bug fix changing behavior I suppose we could associate it with `NullHandling.useThreeValueLogic()`, though kind of weird since that is currently tied to use for native filters, or `ExpressionProcessing.useStrictBooleans()` which traditionally controls the other expression related 3vl stuff.

#### Release note
`REGEXP_LIKE`, `CONTAINS_STRING`, and `ICONTAINS_STRING` correctly return null for null value inputs in SQL compatible null handling mode (the default configuration).

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
