### PR TITLE
update the doc for dump-segment tool when using jdk11+

### DIFF
--- a/docs/operations/dump-segment.md
+++ b/docs/operations/dump-segment.md
@@ -36,6 +36,20 @@ java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList="[]" org.apache.dr
   --out /home/druid/output.txt
 ```
 
+If you use JDK11 and above, you need to add the following additional parameters
++ --add-opens java.base/java.lang=ALL-UNNAMED
++ --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+  The following is a example
+
+```
+java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
+  -classpath "/my/druid/lib/*" \
+  -Ddruid.extensions.loadList="[]" org.apache.druid.cli.Main \
+  tools dump-segment \
+  --directory /home/druid/path/to/segment/ \
+  --out /home/druid/output.txt
+```
+
 ### Output format
 
 #### Data dumps

--- a/docs/operations/dump-segment.md
+++ b/docs/operations/dump-segment.md
@@ -37,9 +37,11 @@ java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList="[]" org.apache.dr
 ```
 
 If you use JDK11 and above, you need to add the following additional parameters
-+ --add-opens java.base/java.lang=ALL-UNNAMED
-+ --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-  The following is a example
+```
+--add-opens java.base/java.lang=ALL-UNNAMED
+--add-opens java.base/sun.nio.ch=ALL-UNNAMED
+```
+The following is an example
 
 ```
 java --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED \

--- a/docs/operations/dump-segment.md
+++ b/docs/operations/dump-segment.md
@@ -36,7 +36,7 @@ java -classpath "/my/druid/lib/*" -Ddruid.extensions.loadList="[]" org.apache.dr
   --out /home/druid/output.txt
 ```
 
-If you use JDK11 and above, you need to add the following additional parameters
+If you use JDK 11 and above, you need to add the following additional parameters
 ```
 --add-opens java.base/java.lang=ALL-UNNAMED
 --add-opens java.base/sun.nio.ch=ALL-UNNAMED


### PR DESCRIPTION
Fixes #13645.
### Description
update the dump-segment tool document, when use java11 +, add two more parameter for the command line

#### Update the document for dump-segment tool ...


#### Release note
update the doc for dump-segment tool when using jdk11+

<hr>

##### Key changed/added classes in this PR
 * `dump-segment.md`


<hr>

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
