### PR TITLE
Fix compaction tasks reports getting overwritten

### DIFF
--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -93,8 +93,7 @@ An example output is shown below:
 }
 ```
 
-For compaction tasks alone, there could be multiple `index`, `index_parallel` tasks run based on the split of input
-interval, and they all have a seperate reports. So, the key field for the report also includes the index of the split.
+Compaction tasks can generate multiple sets of segment output reports based on how the input interval is split. So the overall report contains mappings from each split to each report.
 Example report could be:
 
 ```json

--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -93,6 +93,59 @@ An example output is shown below:
 }
 ```
 
+For compaction tasks alone, there could be multiple `index`, `index_parallel` tasks run based on the split of input
+interval, and they all have a seperate reports. So, the key field for the report also includes the index of the split.
+Example report could be:
+
+```json
+{
+  "ingestionStatsAndErrors_0": {
+    "taskId": "compact_twitter_2018-09-24T18:24:23.920Z",
+    "payload": {
+      "ingestionState": "COMPLETED",
+      "unparseableEvents": {},
+      "rowStats": {
+        "buildSegments": {
+          "processed": 5390324,
+          "processedBytes": 5109573212,
+          "processedWithError": 0,
+          "thrownAway": 0,
+          "unparseable": 0
+        }
+      },
+      "segmentAvailabilityConfirmed": false,
+      "segmentAvailabilityWaitTimeMs": 0,
+      "recordsProcessed": null,
+      "errorMsg": null
+    },
+    "type": "ingestionStatsAndErrors"
+  },
+  "ingestionStatsAndErrors_1": {
+   "taskId": "compact_twitter_2018-09-25T18:24:23.920Z",
+   "payload": {
+    "ingestionState": "COMPLETED",
+    "unparseableEvents": {},
+    "rowStats": {
+     "buildSegments": {
+      "processed": 12345,
+      "processedBytes": 132456789,
+      "processedWithError": 0,
+      "thrownAway": 0,
+      "unparseable": 0
+     }
+    },
+    "segmentAvailabilityConfirmed": false,
+    "segmentAvailabilityWaitTimeMs": 0,
+    "recordsProcessed": null,
+    "errorMsg": null
+   },
+   "type": "ingestionStatsAndErrors"
+  }
+}
+```
+
+
+
 #### Segment Availability Fields
 
 For some task types, the indexing task can wait for the newly ingested segments to become available for queries after ingestion completes. The below fields inform the end user regarding the duration and result of the availability wait. For batch ingestion task types, refer to `tuningConfig` docs to see if the task supports an availability waiting period.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -521,7 +521,7 @@ public class CompactionTask extends AbstractBatchIndexTask
             Optional.ofNullable(eachSpec.getCompletionReports())
                     .ifPresent(reports -> completionReports.putAll(CollectionUtils.mapKeys(
                         reports,
-                        key -> String.format(
+                        key -> StringUtils.format(
                             "%s-%s",
                             eachSpec.getBaseSubtaskSpecName(),
                             key
@@ -677,7 +677,8 @@ public class CompactionTask extends AbstractBatchIndexTask
                     segmentCacheManagerFactory,
                     ioConfig
                 ),
-                compactionTuningConfig
+                compactionTuningConfig,
+                true
             )
         );
       }
@@ -718,7 +719,8 @@ public class CompactionTask extends AbstractBatchIndexTask
                   segmentCacheManagerFactory,
                   ioConfig
               ),
-              compactionTuningConfig
+              compactionTuningConfig,
+              true
           )
       );
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -519,14 +519,8 @@ public class CompactionTask extends AbstractBatchIndexTask
               log.warn("Failed to run indexSpec: [%s].\nTrying the next indexSpec.", json);
             }
             Optional.ofNullable(eachSpec.getCompletionReports())
-                    .ifPresent(reports -> completionReports.putAll(CollectionUtils.mapKeys(
-                        reports,
-                        key -> StringUtils.format(
-                            "%s-%s",
-                            eachSpec.getBaseSubtaskSpecName(),
-                            key
-                        )
-                    )));
+                    .ifPresent(reports -> completionReports.putAll(
+                        CollectionUtils.mapKeys(reports, key -> getReportkey(eachSpec.getBaseSubtaskSpecName(), key))));
           } else {
             failCnt++;
             log.warn("indexSpec is not ready: [%s].\nTrying the next indexSpec.", json);
@@ -575,6 +569,11 @@ public class CompactionTask extends AbstractBatchIndexTask
   private String createIndexTaskSpecId(int i)
   {
     return StringUtils.format("%s_%d", getId(), i);
+  }
+
+  private String getReportkey(String baseSequenceName, String currentKey)
+  {
+    return StringUtils.format("%s_%s", currentKey, baseSequenceName.substring(baseSequenceName.lastIndexOf('_') + 1));
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -551,7 +551,8 @@ public class CompactionTask extends AbstractBatchIndexTask
         getTaskResource(),
         ingestionSpec,
         baseSequenceName,
-        createContextForSubtask()
+        createContextForSubtask(),
+        true
     );
   }
 
@@ -676,8 +677,7 @@ public class CompactionTask extends AbstractBatchIndexTask
                     segmentCacheManagerFactory,
                     ioConfig
                 ),
-                compactionTuningConfig,
-                true
+                compactionTuningConfig
             )
         );
       }
@@ -718,8 +718,7 @@ public class CompactionTask extends AbstractBatchIndexTask
                   segmentCacheManagerFactory,
                   ioConfig
               ),
-              compactionTuningConfig,
-              true
+              compactionTuningConfig
           )
       );
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
@@ -28,21 +28,17 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.IngestionSpec;
 
-import javax.annotation.Nullable;
-
 public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOConfig, ParallelIndexTuningConfig>
 {
   private final DataSchema dataSchema;
   private final ParallelIndexIOConfig ioConfig;
   private final ParallelIndexTuningConfig tuningConfig;
-  private final boolean skipPublishingReports;
 
   @JsonCreator
   public ParallelIndexIngestionSpec(
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("ioConfig") ParallelIndexIOConfig ioConfig,
-      @JsonProperty("tuningConfig") ParallelIndexTuningConfig tuningConfig,
-      @JsonProperty("skipPublishingReports") Boolean skipPublishingReports
+      @JsonProperty("tuningConfig") ParallelIndexTuningConfig tuningConfig
   )
   {
     super(dataSchema, ioConfig, tuningConfig);
@@ -62,21 +58,11 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
     this.dataSchema = dataSchema;
     this.ioConfig = ioConfig;
     this.tuningConfig = tuningConfig == null ? ParallelIndexTuningConfig.defaultConfig() : tuningConfig;
-    this.skipPublishingReports = skipPublishingReports == null ? false : skipPublishingReports;
-  }
-
-  public ParallelIndexIngestionSpec(
-      DataSchema dataSchema,
-      ParallelIndexIOConfig ioConfig,
-      ParallelIndexTuningConfig tuningConfig
-  )
-  {
-    this(dataSchema, ioConfig, tuningConfig, false);
   }
 
   public ParallelIndexIngestionSpec withDataSchema(DataSchema dataSchema)
   {
-    return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig, true);
+    return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig);
   }
 
   @Override
@@ -98,12 +84,5 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
   public ParallelIndexTuningConfig getTuningConfig()
   {
     return tuningConfig;
-  }
-
-  @JsonProperty("skipPublishingReports")
-  @Nullable
-  public Boolean isSkipPublishingReports()
-  {
-    return skipPublishingReports;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
@@ -33,12 +33,14 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
   private final DataSchema dataSchema;
   private final ParallelIndexIOConfig ioConfig;
   private final ParallelIndexTuningConfig tuningConfig;
+  private final boolean skipPublishingReports;
 
   @JsonCreator
   public ParallelIndexIngestionSpec(
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("ioConfig") ParallelIndexIOConfig ioConfig,
-      @JsonProperty("tuningConfig") ParallelIndexTuningConfig tuningConfig
+      @JsonProperty("tuningConfig") ParallelIndexTuningConfig tuningConfig,
+      @JsonProperty("skipPublishingReports") boolean skipPublishingReports
   )
   {
     super(dataSchema, ioConfig, tuningConfig);
@@ -58,11 +60,21 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
     this.dataSchema = dataSchema;
     this.ioConfig = ioConfig;
     this.tuningConfig = tuningConfig == null ? ParallelIndexTuningConfig.defaultConfig() : tuningConfig;
+    this.skipPublishingReports = skipPublishingReports;
+  }
+
+  public ParallelIndexIngestionSpec(
+      DataSchema dataSchema,
+      ParallelIndexIOConfig ioConfig,
+      ParallelIndexTuningConfig tuningConfig
+  )
+  {
+    this(dataSchema, ioConfig, tuningConfig, false);
   }
 
   public ParallelIndexIngestionSpec withDataSchema(DataSchema dataSchema)
   {
-    return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig);
+    return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig, true);
   }
 
   @Override
@@ -84,5 +96,11 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
   public ParallelIndexTuningConfig getTuningConfig()
   {
     return tuningConfig;
+  }
+
+  @JsonProperty("skipPublishingReports")
+  public boolean isSkipPublishingReports()
+  {
+    return skipPublishingReports;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
@@ -40,7 +40,7 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
       @JsonProperty("dataSchema") DataSchema dataSchema,
       @JsonProperty("ioConfig") ParallelIndexIOConfig ioConfig,
       @JsonProperty("tuningConfig") ParallelIndexTuningConfig tuningConfig,
-      @JsonProperty("skipPublishingReports") boolean skipPublishingReports
+      @JsonProperty("skipPublishingReports") Boolean skipPublishingReports
   )
   {
     super(dataSchema, ioConfig, tuningConfig);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexIngestionSpec.java
@@ -28,6 +28,8 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.IngestionSpec;
 
+import javax.annotation.Nullable;
+
 public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOConfig, ParallelIndexTuningConfig>
 {
   private final DataSchema dataSchema;
@@ -60,7 +62,7 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
     this.dataSchema = dataSchema;
     this.ioConfig = ioConfig;
     this.tuningConfig = tuningConfig == null ? ParallelIndexTuningConfig.defaultConfig() : tuningConfig;
-    this.skipPublishingReports = skipPublishingReports;
+    this.skipPublishingReports = skipPublishingReports == null ? false : skipPublishingReports;
   }
 
   public ParallelIndexIngestionSpec(
@@ -99,7 +101,8 @@ public class ParallelIndexIngestionSpec extends IngestionSpec<ParallelIndexIOCon
   }
 
   @JsonProperty("skipPublishingReports")
-  public boolean isSkipPublishingReports()
+  @Nullable
+  public Boolean isSkipPublishingReports()
   {
     return skipPublishingReports;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -670,9 +670,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!isCompactionTask) {
-      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
-    }
+    writeCompletionReports(toolbox);
     return taskStatus;
   }
 
@@ -840,9 +838,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!isCompactionTask) {
-      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
-    }
+    writeCompletionReports(toolbox);
     return taskStatus;
   }
 
@@ -940,9 +936,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!isCompactionTask) {
-      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
-    }
+    writeCompletionReports(toolbox);
     return taskStatus;
   }
 
@@ -1265,6 +1259,13 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
             )
         )
     );
+  }
+
+  private void writeCompletionReports(TaskToolbox toolbox)
+  {
+    if (!isCompactionTask) {
+      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
+    }
   }
 
   private static IndexTuningConfig convertToIndexTuningConfig(ParallelIndexTuningConfig tuningConfig)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -202,6 +202,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   private volatile Pair<Map<String, Object>, Map<String, Object>> indexGenerateRowStats;
 
   private IngestionState ingestionState;
+  private Map<String, TaskReport> completionReports;
 
 
   @JsonCreator
@@ -290,6 +291,20 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
                                .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
+  }
+
+  @Nullable
+  @JsonIgnore
+  public Map<String, TaskReport> getCompletionReports()
+  {
+    return completionReports;
+  }
+
+  @Nullable
+  @JsonIgnore
+  public String getBaseSubtaskSpecName()
+  {
+    return baseSubtaskSpecName;
   }
 
   @JsonProperty("spec")
@@ -651,10 +666,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       }
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
-    toolbox.getTaskReportFileWriter().write(
-        getId(),
-        getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted)
-    );
+    completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
     return taskStatus;
   }
 
@@ -821,10 +833,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    toolbox.getTaskReportFileWriter().write(
-        getId(),
-        getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted)
-    );
+    completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
     return taskStatus;
   }
 
@@ -921,10 +930,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    toolbox.getTaskReportFileWriter().write(
-        getId(),
-        getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted)
-    );
+    completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
     return taskStatus;
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -203,6 +203,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
   private IngestionState ingestionState;
   private Map<String, TaskReport> completionReports;
+  private final Boolean skipPublishingReports;
 
 
   @JsonCreator
@@ -214,7 +215,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       @JsonProperty("context") Map<String, Object> context
   )
   {
-    this(id, groupId, taskResource, ingestionSchema, null, context);
+    this(id, groupId, taskResource, ingestionSchema, null, context, false);
   }
 
   public ParallelIndexSupervisorTask(
@@ -223,7 +224,8 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       TaskResource taskResource,
       ParallelIndexIngestionSpec ingestionSchema,
       @Nullable String baseSubtaskSpecName,
-      Map<String, Object> context
+      Map<String, Object> context,
+      Boolean skipPublishingReports
   )
   {
     super(
@@ -260,6 +262,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     awaitSegmentAvailabilityTimeoutMillis = ingestionSchema.getTuningConfig().getAwaitSegmentAvailabilityTimeoutMillis();
     this.ingestionState = IngestionState.NOT_STARTED;
+    this.skipPublishingReports = skipPublishingReports;
   }
 
   private static void checkPartitionsSpecForForceGuaranteedRollup(PartitionsSpec partitionsSpec)
@@ -667,7 +670,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!ingestionSchema.isSkipPublishingReports()) {
+    if (!skipPublishingReports) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;
@@ -837,7 +840,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!ingestionSchema.isSkipPublishingReports()) {
+    if (!skipPublishingReports) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;
@@ -937,7 +940,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!ingestionSchema.isSkipPublishingReports()) {
+    if (!skipPublishingReports) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -203,7 +203,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
   private IngestionState ingestionState;
   private Map<String, TaskReport> completionReports;
-  private final Boolean skipPublishingReports;
+  private final Boolean isCompactionTask;
 
 
   @JsonCreator
@@ -225,7 +225,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       ParallelIndexIngestionSpec ingestionSchema,
       @Nullable String baseSubtaskSpecName,
       Map<String, Object> context,
-      Boolean skipPublishingReports
+      Boolean isCompactionTask
   )
   {
     super(
@@ -262,7 +262,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     awaitSegmentAvailabilityTimeoutMillis = ingestionSchema.getTuningConfig().getAwaitSegmentAvailabilityTimeoutMillis();
     this.ingestionState = IngestionState.NOT_STARTED;
-    this.skipPublishingReports = skipPublishingReports;
+    this.isCompactionTask = isCompactionTask;
   }
 
   private static void checkPartitionsSpecForForceGuaranteedRollup(PartitionsSpec partitionsSpec)
@@ -670,7 +670,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!skipPublishingReports) {
+    if (!isCompactionTask) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;
@@ -840,7 +840,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!skipPublishingReports) {
+    if (!isCompactionTask) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;
@@ -940,7 +940,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
-    if (!skipPublishingReports) {
+    if (!isCompactionTask) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
     return taskStatus;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1229,7 +1229,9 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
     if (currentSubTaskHolder.setTask(sequentialIndexTask)
         && sequentialIndexTask.isReady(toolbox.getTaskActionClient())) {
-      return sequentialIndexTask.run(toolbox);
+      TaskStatus status = sequentialIndexTask.run(toolbox);
+      completionReports = sequentialIndexTask.getCompletionReports();
+      return status;
     } else {
       String msg = "Task was asked to stop. Finish as failed";
       LOG.info(msg);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -667,6 +667,9 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
+    if (!ingestionSchema.isSkipPublishingReports()) {
+      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
+    }
     return taskStatus;
   }
 
@@ -834,6 +837,9 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
+    if (!ingestionSchema.isSkipPublishingReports()) {
+      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
+    }
     return taskStatus;
   }
 
@@ -931,6 +937,9 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
 
     completionReports = getTaskCompletionReports(taskStatus, segmentAvailabilityConfirmationCompleted);
+    if (!ingestionSchema.isSkipPublishingReports()) {
+      toolbox.getTaskReportFileWriter().write(getId(), completionReports);
+    }
     return taskStatus;
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
@@ -39,6 +39,7 @@ import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReportData;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
@@ -246,6 +247,9 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
       );
       Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
     }
+
+    List<IngestionStatsAndErrorsTaskReportData> reports = getIngestionReports();
+    Assert.assertEquals(reports.size(), 3); // since three index tasks are run by single compaction task
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
@@ -49,9 +50,13 @@ import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReport;
+import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReportData;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.indexing.common.RetryPolicyFactory;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
+import org.apache.druid.indexing.common.SingleFileTaskReportFileWriter;
+import org.apache.druid.indexing.common.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
@@ -232,6 +237,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   private CoordinatorClient coordinatorClient;
   // An executor that executes API calls using a different thread from the caller thread as if they were remote calls.
   private ExecutorService remoteApiExecutor;
+  private File reportsFile;
 
   protected AbstractParallelIndexSupervisorTaskTest(
       double transientTaskFailureRate,
@@ -257,6 +263,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     remoteApiExecutor = Execs.singleThreaded("coordinator-api-executor");
     coordinatorClient = new LocalCoordinatorClient(remoteApiExecutor);
     prepareObjectMapper(objectMapper, getIndexIO());
+    reportsFile = temporaryFolder.newFile();
   }
 
   @After
@@ -702,6 +709,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .indexMergerV9(getIndexMergerV9Factory().create(task.getContextValue(Tasks.STORE_EMPTY_COLUMNS_KEY, true)))
         .taskReportFileWriter(new NoopTestTaskReportFileWriter())
         .intermediaryDataManager(intermediaryDataManager)
+        .taskReportFileWriter(new SingleFileTaskReportFileWriter(reportsFile))
         .authorizerMapper(AuthTestUtils.TEST_AUTHORIZER_MAPPER)
         .chatHandlerProvider(new NoopChatHandlerProvider())
         .rowIngestionMetersFactory(new TestUtils().getRowIngestionMetersFactory())
@@ -1063,5 +1071,21 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       }
       throw new ISE("Can't find segment for id[%s]", segmentId);
     }
+  }
+
+  public Map<String, TaskReport> getReports() throws IOException
+  {
+    return objectMapper.readValue(reportsFile, new TypeReference<Map<String, TaskReport>>()
+    {
+    });
+  }
+
+  public List<IngestionStatsAndErrorsTaskReportData> getIngestionReports() throws IOException
+  {
+    return getReports().entrySet()
+                       .stream()
+                       .filter(entry -> entry.getKey().contains(IngestionStatsAndErrorsTaskReport.REPORT_KEY))
+                       .map(entry -> (IngestionStatsAndErrorsTaskReportData) entry.getValue().getPayload())
+                       .collect(Collectors.toList());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -314,7 +314,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
         int succedsBeforeFailing
     )
     {
-      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context);
+      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context, false);
       this.succeedsBeforeFailing = succedsBeforeFailing;
     }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -243,7 +243,7 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
         int succedsBeforeFailing
     )
     {
-      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context);
+      super(id, groupId, taskResource, ingestionSchema, baseSubtaskSpecName, context, false);
       this.failInPhase = succedsBeforeFailing;
     }
 

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
@@ -32,7 +32,7 @@ import org.apache.druid.testing.utils.ITRetryUtil;
 import org.apache.druid.tests.TestNGGroup;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITCompactionTaskTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.tests.indexer;
 
 import com.google.inject.Inject;
 import org.apache.commons.io.IOUtils;
+import org.apache.druid.indexing.common.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.GranularityType;
@@ -31,6 +32,7 @@ import org.apache.druid.testing.utils.ITRetryUtil;
 import org.apache.druid.tests.TestNGGroup;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
+import org.junit.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
@@ -198,7 +200,7 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
       );
 
       queryHelper.testQueriesFromString(queryResponseTemplate);
-      compactData(compactionResource, newSegmentGranularity, null);
+      String taskId = compactData(compactionResource, newSegmentGranularity, null);
 
       // The original 4 segments should be compacted into 2 new segments
       checkNumberOfSegments(2);
@@ -215,10 +217,17 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
         expectedIntervalAfterCompaction = newIntervals;
       }
       checkCompactionIntervals(expectedIntervalAfterCompaction);
+
+      Map<String, IngestionStatsAndErrorsTaskReport> reports = indexer.getTaskReport(taskId);
+      Assert.assertTrue(reports != null && reports.size() > 0);
     }
   }
 
-  private void compactData(String compactionResource, GranularityType newSegmentGranularity, GranularityType newQueryGranularity) throws Exception
+  private String compactData(
+      String compactionResource,
+      GranularityType newSegmentGranularity,
+      GranularityType newQueryGranularity
+  ) throws Exception
   {
     String template = getResourceAsString(compactionResource);
     template = StringUtils.replace(template, "%%DATASOURCE%%", fullDatasourceName);
@@ -251,6 +260,8 @@ public class ITCompactionTaskTest extends AbstractIndexerTest
         () -> coordinator.areSegmentsLoaded(fullDatasourceName),
         "Segment Compaction"
     );
+
+    return taskID;
   }
 
   private void checkQueryGranularity(String queryResource, String expectedQueryGranularity, int segmentCount) throws Exception


### PR DESCRIPTION
### Description

A single compaction task could be splitted the into multiple index tasks based on the interval given in spec. In such cases, all the index tasks are run with same id and the task completion report is getting over written. This PR skips writing the report for each parallel index task and instead writes on the compaction task completion.

With this change instead of overwriting the reports file, we make multiple entries and it looks something like:
```
{
  "ingestionStatsAndErrors_2": {
    "type": "ingestionStatsAndErrors",
    "taskId": "compact_test_klkggepm_2024-02-28T17:27:17.327Z",
    "payload": {
      "ingestionState": "COMPLETED",
      "unparseableEvents": {
        "buildSegments": []
      },
      "rowStats": {
        "totals": {
          "buildSegments": {
            "processed": 3,
            "processedBytes": 1500,
            "processedWithError": 0,
            "thrownAway": 0,
            "unparseable": 0
          }
        }
      },
      "errorMsg": null,
      "segmentAvailabilityConfirmed": false,
      "segmentAvailabilityWaitTimeMs": 0,
      "recordsProcessed": {}
    }
  },
  "ingestionStatsAndErrors_1": {
    "type": "ingestionStatsAndErrors",
    "taskId": "compact_test_klkggepm_2024-02-28T17:27:17.327Z",
    "payload": {
      "ingestionState": "COMPLETED",
      "unparseableEvents": {
        "buildSegments": []
      },
      "rowStats": {
        "totals": {
          "buildSegments": {
            "processed": 3,
            "processedBytes": 1500,
            "processedWithError": 0,
            "thrownAway": 0,
            "unparseable": 0
          }
        }
      },
      "errorMsg": null,
      "segmentAvailabilityConfirmed": false,
      "segmentAvailabilityWaitTimeMs": 0,
      "recordsProcessed": {}
    }
  },
  "ingestionStatsAndErrors_0": {
    "type": "ingestionStatsAndErrors",
    "taskId": "compact_test_klkggepm_2024-02-28T17:27:17.327Z",
    "payload": {
      "ingestionState": "COMPLETED",
      "unparseableEvents": {
        "buildSegments": []
      },
      "rowStats": {
        "totals": {
          "buildSegments": {
            "processed": 3,
            "processedBytes": 1500,
            "processedWithError": 0,
            "thrownAway": 0,
            "unparseable": 0
          }
        }
      },
      "errorMsg": null,
      "segmentAvailabilityConfirmed": false,
      "segmentAvailabilityWaitTimeMs": 0,
      "recordsProcessed": {}
    }
  }
}
```

<hr>

##### Key changed/added classes in this PR
 * `CompactionTask`
 * `ParallelIndexSupervisorTask`

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
