### PR TITLE
Web console: fix crash when parsing data in data loader that can not be parsed

### DIFF
--- a/web-console/src/utils/object-change.spec.ts
+++ b/web-console/src/utils/object-change.spec.ts
@@ -18,7 +18,15 @@
 
 import * as JSONBig from 'json-bigint-native';
 
-import { deepDelete, deepExtend, deepGet, deepSet, makePath, parsePath } from './object-change';
+import {
+  allowKeys,
+  deepDelete,
+  deepExtend,
+  deepGet,
+  deepSet,
+  makePath,
+  parsePath,
+} from './object-change';
 
 describe('object-change', () => {
   describe('parsePath', () => {
@@ -33,6 +41,17 @@ describe('object-change', () => {
     it('works', () => {
       expect(makePath(['hello', 'wow', '0'])).toEqual('hello.wow.0');
       expect(makePath(['hello', 'wow.moon', '0'])).toEqual('hello.{wow.moon}.0');
+    });
+  });
+
+  describe('allowKeys', () => {
+    it('works with bad objects', () => {
+      expect(allowKeys(null, ['a', 'b', 'c'] as any)).toEqual(null);
+      expect(allowKeys(undefined as any, ['a', 'b', 'c'] as any)).toEqual(undefined);
+    });
+
+    it('works in a normal case', () => {
+      expect(allowKeys({ a: 1, z: 4 }, ['a', 'b', 'c'] as any)).toEqual({ a: 1 });
     });
   });
 

--- a/web-console/src/utils/object-change.ts
+++ b/web-console/src/utils/object-change.ts
@@ -160,9 +160,10 @@ export function deepExtend<T extends Record<string, any>>(target: T, diff: Recor
 }
 
 export function allowKeys<T>(obj: T, keys: (keyof T)[]): T {
-  const newObj: T = {} as any;
+  if (!obj || typeof obj !== 'object') return obj;
+  const newObj = {} as T;
   for (const key of keys) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       newObj[key] = obj[key];
     }
   }

--- a/web-console/src/utils/sampler.ts
+++ b/web-console/src/utils/sampler.ts
@@ -134,7 +134,7 @@ export interface SampleEntry {
 export function getCacheRowsFromSampleResponse(sampleResponse: SampleResponse): CacheRows {
   return filterMap(sampleResponse.data, d => ({
     ...d.input,
-    ...allowKeys<any>(d.parsed, ALL_POSSIBLE_SYSTEM_FIELDS),
+    ...allowKeys<any>(d.parsed || {}, ALL_POSSIBLE_SYSTEM_FIELDS),
   })).slice(0, 20);
 }
 


### PR DESCRIPTION
Due to a fragility in `allowKeys` and the change introduced in https://github.com/apache/druid/pull/15858 the data loader now crashes if the incoming sample can not be parsed. (`undefined` value going into `allowKeys` causes crash).

For repro try loading

```
{"__time":"2016-06-27T00:00:11.080Z","isRobot":"true","channel":"#sv.wikipedia","flags":"NB","isUnpatrolled":"false","page":"Salo Toraut","diffUrl":"https://sv.wikipedia.org/w/index.php?oldid=36099284&rcid=89369918","added":31,"comment":"Botskapande Indonesien omdirigering","commentLength":35,"isNew":"true","isMinor":"false","delta":31,"isAnonymous":"false","user":"Lsjbot","deltaBucket":0,"deleted":0,"namespace":"Main","cityName":null,"countryName":null,"regionIsoCode":null,"metroCode":null,"countryIsoCode":null,"regionName":null}
```

which will not parse due to the __time column