### PR TITLE
Add query templates to catalog 

### DIFF
--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sql/LiveCatalogResolver.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sql/LiveCatalogResolver.java
@@ -22,6 +22,8 @@ package org.apache.druid.catalog.sql;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.catalog.model.ColumnSpec;
 import org.apache.druid.catalog.model.Columns;
+import org.apache.druid.catalog.model.IngestionTemplate;
+import org.apache.druid.catalog.model.IngestionTemplateInfo;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.TableId;
 import org.apache.druid.catalog.model.facade.DatasourceFacade;
@@ -42,6 +44,7 @@ import javax.inject.Inject;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -212,5 +215,12 @@ public class LiveCatalogResolver implements CatalogResolver
         .addAll(datasourceNames)
         .addAll(catalogTableNames)
         .build();
+  }
+
+  @Override
+  public String generateQueryFromTemplate(IngestionTemplateInfo templateInfo)
+  {
+    List<IngestionTemplate> templates = catalog.getTemplates(templateInfo.getRequiredTemplateNames());
+    return templateInfo.generateQueryFromTemplates(templates);
   }
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/CatalogStorage.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/CatalogStorage.java
@@ -21,6 +21,7 @@ package org.apache.druid.catalog.storage;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.catalog.CatalogException.NotFoundException;
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.SchemaRegistry;
 import org.apache.druid.catalog.model.SchemaRegistry.SchemaSpec;
@@ -127,5 +128,16 @@ public class CatalogStorage implements CatalogUpdateProvider, CatalogSource
   {
     TableMetadata table = table(id);
     return table == null ? null : tableRegistry.resolve(table.spec());
+  }
+
+  @Override
+  public IngestionTemplate getTemplate(String templateName)
+  {
+    try {
+      return catalogMgr.getTemplate(templateName);
+    }
+    catch (NotFoundException e) {
+      return null;
+    }
   }
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/CatalogManager.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/storage/sql/CatalogManager.java
@@ -22,6 +22,7 @@ package org.apache.druid.catalog.storage.sql;
 import org.apache.druid.catalog.CatalogException;
 import org.apache.druid.catalog.CatalogException.DuplicateKeyException;
 import org.apache.druid.catalog.CatalogException.NotFoundException;
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.TableId;
 import org.apache.druid.catalog.model.TableMetadata;
 import org.apache.druid.catalog.model.TableSpec;
@@ -176,4 +177,14 @@ public interface CatalogManager
    * schema.
    */
   List<TableMetadata> tablesInSchema(String dbSchema);
+
+  long createTemplate(String name, IngestionTemplate template) throws DuplicateKeyException;
+
+  long replaceTemplate(String name, IngestionTemplate template) throws NotFoundException;
+
+  void deleteTemplate(String name) throws NotFoundException;
+
+  List<String> getTemplateNames();
+
+  IngestionTemplate getTemplate(String name) throws NotFoundException;
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CachedMetadataCatalog.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CachedMetadataCatalog.java
@@ -20,6 +20,7 @@
 package org.apache.druid.catalog.sync;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.SchemaRegistry;
 import org.apache.druid.catalog.model.SchemaRegistry.SchemaSpec;
@@ -353,6 +354,17 @@ public class CachedMetadataCatalog implements MetadataCatalog, CatalogUpdateList
   {
     SchemaEntry schemaEntry = entryFor(schemaName);
     return schemaEntry == null ? Collections.emptySet() : schemaEntry.tableNames();
+  }
+
+  @Override
+  public List<IngestionTemplate> getTemplates(List<String> templateNames)
+  {
+    List<IngestionTemplate> templates = new ArrayList<>();
+    for (String templateName : templateNames) {
+      IngestionTemplate template = base.getTemplate(templateName);
+      templates.add(template);
+    }
+    return templates;
   }
 
   /**

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogClient.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/CatalogClient.java
@@ -22,6 +22,7 @@ package org.apache.druid.catalog.sync;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.catalog.http.CatalogResource;
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.TableDefnRegistry;
 import org.apache.druid.catalog.model.TableId;
@@ -59,11 +60,15 @@ public class CatalogClient implements CatalogSource
 {
   public static final String SCHEMA_SYNC_PATH = CatalogResource.ROOT_PATH + CatalogResource.SCHEMA_SYNC;
   public static final String TABLE_SYNC_PATH = CatalogResource.ROOT_PATH + CatalogResource.TABLE_SYNC;
+  public static final String TEMPLATE_GET_PATH = CatalogResource.ROOT_PATH + CatalogResource.TEMPLATES_PATH;
   private static final TypeReference<List<TableMetadata>> LIST_OF_TABLE_METADATA_TYPE = new TypeReference<List<TableMetadata>>()
   {
   };
   // Not strictly needed as a TypeReference, but doing so makes the code simpler.
   private static final TypeReference<TableMetadata> TABLE_METADATA_TYPE = new TypeReference<TableMetadata>()
+  {
+  };
+  private static final TypeReference<IngestionTemplate> TEMPLATE_TYPE = new TypeReference<IngestionTemplate>()
   {
   };
 
@@ -106,6 +111,13 @@ public class CatalogClient implements CatalogSource
   {
     TableMetadata table = table(id);
     return table == null ? null : tableRegistry.resolve(table.spec());
+  }
+
+  @Override
+  public IngestionTemplate getTemplate(String templateName)
+  {
+    String url = StringUtils.replace(TEMPLATE_GET_PATH, "{name}", templateName);
+    return send(url, TEMPLATE_TYPE);
   }
 
   /**

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/LocalMetadataCatalog.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/LocalMetadataCatalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.catalog.sync;
 
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.SchemaRegistry;
 import org.apache.druid.catalog.model.SchemaRegistry.SchemaSpec;
@@ -27,6 +28,7 @@ import org.apache.druid.catalog.model.TableMetadata;
 
 import javax.inject.Inject;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -87,5 +89,16 @@ public class LocalMetadataCatalog implements MetadataCatalog
       tables.add(table.id().name());
     }
     return tables;
+  }
+
+  @Override
+  public List<IngestionTemplate> getTemplates(List<String> templateNames)
+  {
+    List<IngestionTemplate> templates = new ArrayList<>();
+    for (String templateName : templateNames) {
+      IngestionTemplate template = catalog.getTemplate(templateName);
+      templates.add(template);
+    }
+    return templates;
   }
 }

--- a/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/MetadataCatalog.java
+++ b/extensions-core/druid-catalog/src/main/java/org/apache/druid/catalog/sync/MetadataCatalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.catalog.sync;
 
+import org.apache.druid.catalog.model.IngestionTemplate;
 import org.apache.druid.catalog.model.ResolvedTable;
 import org.apache.druid.catalog.model.TableId;
 import org.apache.druid.catalog.model.TableMetadata;
@@ -44,6 +45,7 @@ public interface MetadataCatalog
     List<TableMetadata> tablesForSchema(String dbSchema);
     TableMetadata table(TableId id);
     ResolvedTable resolveTable(TableId id);
+    IngestionTemplate getTemplate(String templateName);
   }
 
   interface CatalogUpdateProvider
@@ -73,4 +75,6 @@ public interface MetadataCatalog
   List<TableMetadata> tables(String schemaName);
 
   Set<String> tableNames(String schemaName);
+
+  List<IngestionTemplate> getTemplates(List<String> templateNames);
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcher.java
@@ -238,7 +238,7 @@ public class SegmentLoadStatusFetcher implements AutoCloseable
   {
     Request request = brokerClient.makeRequest(HttpMethod.POST, "/druid/v2/sql/");
     SqlQuery sqlQuery = new SqlQuery(StringUtils.format(LOAD_QUERY, datasource, versionsConditionString),
-                                     ResultFormat.OBJECTLINES,
+                                     null, ResultFormat.OBJECTLINES,
                                      false, false, false, null, null
     );
     request.setContent(MediaType.APPLICATION_JSON, objectMapper.writeValueAsBytes(sqlQuery));

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -691,7 +691,7 @@ public class SqlStatementResource
                                                       .build();
     return new SqlQuery(
         sqlQuery.getQuery(),
-        sqlQuery.getResultFormat(),
+        null, sqlQuery.getResultFormat(),
         sqlQuery.includeHeader(),
         sqlQuery.includeTypesHeader(),
         sqlQuery.includeSqlTypesHeader(),

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -98,7 +98,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
 
     Response response = resource.doPost(new SqlQuery(
         "select cnt,dim1 from foo",
-        null,
+        null, null,
         false,
         false,
         false,
@@ -151,7 +151,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResourceTest.assertExceptionMessage(
         resource.doPost(new SqlQuery(
             "select * from foo",
-            null,
+            null, null,
             false,
             false,
             false,
@@ -166,7 +166,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResourceTest.assertExceptionMessage(
         resource.doPost(new SqlQuery(
             "select * from foo",
-            null,
+            null, null,
             false,
             false,
             false,
@@ -184,6 +184,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
   {
     Response response = resource.doPost(new SqlQuery(
         "insert into foo1 select  __time, dim1 , count(*) as cnt from foo where dim1 is not null and __time < TIMESTAMP '1971-01-01 00:00:00' group by 1, 2 PARTITIONED by day clustered by dim1",
+        null,
         null,
         false,
         false,
@@ -215,6 +216,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     Response response = resource.doPost(new SqlQuery(
         "replace into foo1 overwrite all select  __time, dim1 , count(*) as cnt from foo where dim1 is not null and __time < TIMESTAMP '1971-01-01 00:00:00' group by 1, 2 PARTITIONED by day clustered by dim1",
         null,
+        null,
         false,
         false,
         false,
@@ -244,6 +246,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
   {
     Response response = resource.doPost(new SqlQuery(
         "insert into foo1 select  __time, dim1 , count(*) as cnt from foo where dim1 is not null and __time < TIMESTAMP '1971-01-01 00:00:00' group by 1, 2 PARTITIONED by day clustered by dim1",
+        null,
         null,
         false,
         false,
@@ -292,7 +295,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     context.put("sqlQueryId", "queryId");
     Response response = resource.doPost(new SqlQuery(
         "explain plan for select * from foo",
-        null,
+        null, null,
         false,
         false,
         false,
@@ -321,7 +324,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), resource.doPost(
         new SqlQuery(
             StringUtils.format("select * from %s", CalciteTests.FORBIDDEN_DATASOURCE),
-            null,
+            null, null,
             false,
             false,
             false,
@@ -353,7 +356,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResourceTest.assertExceptionMessage(resourceWithDurableStorage.doPost(
                                                         new SqlQuery(
                                                             "select * from foo",
-                                                            null,
+                                                            null, null,
                                                             false,
                                                             false,
                                                             false,
@@ -376,7 +379,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResult sqlStatementResult = (SqlStatementResult) resource.doPost(
         new SqlQuery(
             "select cnt,dim1 from foo",
-            null,
+            null, null,
             false,
             false,
             false,
@@ -461,7 +464,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             + "    '[{\"name\": \"timestamp\", \"type\": \"string\"}, {\"name\": \"page\", \"type\": \"string\"}, {\"name\": \"user\", \"type\": \"string\"}]'\n"
             + "  )\n"
             + ") where user like '%ot%'",
-            null,
+            null, null,
             false,
             false,
             false,
@@ -544,7 +547,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResult sqlStatementResult = (SqlStatementResult) resource.doPost(
         new SqlQuery(
             "select cnt,dim1 from foo",
-            null,
+            null, null,
             false,
             false,
             false,
@@ -604,7 +607,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     SqlStatementResult sqlStatementResult = (SqlStatementResult) resource.doPost(
         new SqlQuery(
             "select cnt,dim1 from foo",
-            ResultFormat.OBJECTLINES,
+            null, ResultFormat.OBJECTLINES,
             false,
             false,
             false,
@@ -676,6 +679,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     Response response = resource.doPost(new SqlQuery(
         "insert into foo1 select  __time, dim1 , count(*) as cnt from foo where dim1 is not null group by 1, 2 PARTITIONED by day clustered by dim1",
         null,
+        null,
         false,
         false,
         false,
@@ -718,6 +722,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
   {
     Response response = resource.doPost(new SqlQuery(
         "replace into foo1 overwrite all select  __time, dim1 , count(*) as cnt from foo where dim1 is not null group by 1, 2 PARTITIONED by day clustered by dim1",
+        null,
         null,
         false,
         false,

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITKeyStatisticsSketchMergeMode.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/msq/ITKeyStatisticsSketchMergeMode.java
@@ -105,7 +105,7 @@ public class ITKeyStatisticsSketchMergeMode
     );
 
     // Submit the task and wait for the datasource to get loaded
-    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, false, false, false, context, null);
+    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, null, false, false, false, context, null);
     SqlTaskStatus sqlTaskStatus = msqHelper.submitMsqTask(sqlQuery);
 
     if (sqlTaskStatus.getState().isFailure()) {
@@ -175,7 +175,7 @@ public class ITKeyStatisticsSketchMergeMode
     );
 
     // Submit the task and wait for the datasource to get loaded
-    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, false, false, false, context, null);
+    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, null, false, false, false, context, null);
     SqlTaskStatus sqlTaskStatus = msqHelper.submitMsqTask(sqlQuery);
 
     if (sqlTaskStatus.getState().isFailure()) {
@@ -250,7 +250,7 @@ public class ITKeyStatisticsSketchMergeMode
     );
 
     // Submit the task and wait for the datasource to get loaded
-    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, false, false, false, context, null);
+    SqlQuery sqlQuery = new SqlQuery(queryLocal, null, null, false, false, false, context, null);
     SqlTaskStatus sqlTaskStatus = msqHelper.submitMsqTask(sqlQuery);
 
     if (sqlTaskStatus.getState().isFailure()) {

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
@@ -103,7 +103,7 @@ public class MsqTestQueryHelper extends AbstractTestQueryHelper<MsqQueryWithResu
    */
   public SqlTaskStatus submitMsqTask(String sqlQueryString, Map<String, Object> context) throws ExecutionException, InterruptedException
   {
-    return submitMsqTask(new SqlQuery(sqlQueryString, null, false, false, false, context, null));
+    return submitMsqTask(new SqlQuery(sqlQueryString, null, null, false, false, false, context, null));
   }
 
   // Run the task, wait for it to complete, fetch the reports, verify the results,

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlTestQueryHelper.java
@@ -51,7 +51,7 @@ public class SqlTestQueryHelper extends AbstractTestQueryHelper<SqlQueryWithResu
   {
     final SqlQuery query = new SqlQuery(
         "SELECT 1 FROM \"" + datasource + "\" LIMIT 1",
-        null,
+        null, null,
         false,
         false,
         false,

--- a/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITNilColumnTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/indexer/ITNilColumnTest.java
@@ -165,7 +165,7 @@ public class ITNilColumnTest extends AbstractKafkaIndexingServiceTest
                     NIL_DIM1,
                     NIL_DIM2
                 ),
-                null,
+                null, null,
                 false,
                 false,
                 false,
@@ -190,7 +190,7 @@ public class ITNilColumnTest extends AbstractKafkaIndexingServiceTest
                     NIL_DIM1,
                     NIL_DIM2
                 ),
-                null,
+                null, null,
                 false,
                 false,
                 false,

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlCancelTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlCancelTest.java
@@ -85,7 +85,9 @@ public class ITSqlCancelTest
       queryResponseFutures.add(
           sqlClient.queryAsync(
               sqlHelper.getQueryURL(config.getRouterUrl()),
-              new SqlQuery(QUERY, null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, queryId), null)
+              new SqlQuery(QUERY,
+                           null,
+                           null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, queryId), null)
           )
       );
     }
@@ -122,7 +124,9 @@ public class ITSqlCancelTest
     final Future<StatusResponseHolder> queryResponseFuture = sqlClient
         .queryAsync(
             sqlHelper.getQueryURL(config.getRouterUrl()),
-            new SqlQuery(QUERY, null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, "validId"), null)
+            new SqlQuery(QUERY,
+                         null,
+                         null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, "validId"), null)
         );
 
     // Wait until the sqlLifecycle is authorized and registered

--- a/server/src/main/java/org/apache/druid/catalog/model/ConcatIngestionTemplate.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/ConcatIngestionTemplate.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+
+@JsonTypeName("concat")
+public class ConcatIngestionTemplate implements IngestionTemplate
+{
+  @JsonProperty
+  private final String body;
+
+  @JsonCreator
+  public ConcatIngestionTemplate(
+      @JsonProperty("body") String body
+  )
+  {
+    Preconditions.checkNotNull(body);
+    this.body = body;
+  }
+
+  public String getBody()
+  {
+    return body;
+  }
+
+  @Override
+  public String getType()
+  {
+    return "concat";
+  }
+}

--- a/server/src/main/java/org/apache/druid/catalog/model/ConcatIngestionTemplateInfo.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/ConcatIngestionTemplateInfo.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.java.util.common.IAE;
+
+import java.util.List;
+
+@JsonTypeName("concat")
+public class ConcatIngestionTemplateInfo implements IngestionTemplateInfo
+{
+  @JsonProperty
+  private final String templateName;
+
+  @JsonProperty
+  private final String prepend;
+
+  @JsonCreator
+  public ConcatIngestionTemplateInfo(
+      @JsonProperty("templateName") String templateName,
+      @JsonProperty("prepend") String prepend
+  )
+  {
+    Preconditions.checkNotNull(templateName);
+    Preconditions.checkNotNull(prepend);
+    this.templateName = templateName;
+    this.prepend = prepend;
+  }
+
+  @Override
+  public String getType()
+  {
+    return "concat";
+  }
+
+  @Override
+  public List<String> getRequiredTemplateNames()
+  {
+    return ImmutableList.of(templateName);
+  }
+
+  @Override
+  public String generateQueryFromTemplates(List<IngestionTemplate> templates)
+  {
+    if (templates.size() != 1) {
+      throw new IAE("Only 1 referenced template can be used with concat templates.");
+    }
+    if (!(templates.get(0) instanceof ConcatIngestionTemplate)) {
+      throw new IAE("Referenced template [%s] is not a concat template.", templates.get(0));
+    }
+
+    ConcatIngestionTemplate concatTemplate = (ConcatIngestionTemplate) templates.get(0);
+    return prepend + concatTemplate.getBody();
+  }
+
+  @JsonProperty("templateName")
+  public String getTemplateName()
+  {
+    return templateName;
+  }
+
+  @JsonProperty("prepend")
+  public String getPrepend()
+  {
+    return prepend;
+  }
+}

--- a/server/src/main/java/org/apache/druid/catalog/model/IngestionTemplate.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/IngestionTemplate.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "concat", value = ConcatIngestionTemplate.class)
+})
+public interface IngestionTemplate
+{
+  String getType();
+}

--- a/server/src/main/java/org/apache/druid/catalog/model/IngestionTemplateInfo.java
+++ b/server/src/main/java/org/apache/druid/catalog/model/IngestionTemplateInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.catalog.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.List;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(value = {
+    @JsonSubTypes.Type(name = "concat", value = ConcatIngestionTemplateInfo.class)
+})
+public interface IngestionTemplateInfo
+{
+  String getType();
+
+  List<String> getRequiredTemplateNames();
+
+  String generateQueryFromTemplates(List<IngestionTemplate> templates);
+}
+

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -225,7 +225,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   {
     final SqlQuery query = new SqlQuery(
         "SELECT * FROM foo",
-        ResultFormat.ARRAY,
+        null, ResultFormat.ARRAY,
         false,
         false,
         false,
@@ -550,7 +550,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
   {
     final SqlQuery query = new SqlQuery(
         "SELECT * FROM foo",
-        ResultFormat.ARRAY,
+        null, ResultFormat.ARRAY,
         false,
         false,
         false,

--- a/services/src/test/java/org/apache/druid/server/router/ManualTieredBrokerSelectorStrategyTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/ManualTieredBrokerSelectorStrategyTest.java
@@ -245,7 +245,7 @@ public class ManualTieredBrokerSelectorStrategyTest
   {
     return new SqlQuery(
         "SELECT * FROM test",
-        null,
+        null, null,
         false,
         false,
         false,

--- a/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -389,7 +389,7 @@ public class TieredBrokerHostSelectorTest
   {
     return new SqlQuery(
         "SELECT * FROM test",
-        null,
+        null, null,
         false,
         false,
         false,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CatalogResolver.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CatalogResolver.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.sql.calcite.planner;
 
+import org.apache.druid.catalog.model.IngestionTemplateInfo;
 import org.apache.druid.sql.calcite.table.DatasourceTable;
 import org.apache.druid.sql.calcite.table.DruidTable;
 
@@ -57,6 +58,12 @@ public interface CatalogResolver
     {
       return datasourceNames;
     }
+
+    @Override
+    public String generateQueryFromTemplate(IngestionTemplateInfo templateInfo)
+    {
+      return null;
+    }
   }
 
   /**
@@ -71,4 +78,6 @@ public interface CatalogResolver
   );
 
   Set<String> getTableNames(Set<String> datasourceNames);
+
+  String generateQueryFromTemplate(IngestionTemplateInfo templateInfo);
 }

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.calcite.avatica.remote.TypedValue;
+import org.apache.druid.catalog.model.IngestionTemplateInfo;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.QueryContext;
 
@@ -51,12 +52,14 @@ public class SqlQuery
   private final boolean header;
   private final boolean typesHeader;
   private final boolean sqlTypesHeader;
+  private final IngestionTemplateInfo templateInfo;
   private final Map<String, Object> context;
   private final List<SqlParameter> parameters;
 
   @JsonCreator
   public SqlQuery(
       @JsonProperty("query") final String query,
+      @JsonProperty("templateInfo") final IngestionTemplateInfo templateInfo,
       @JsonProperty("resultFormat") final ResultFormat resultFormat,
       @JsonProperty("header") final boolean header,
       @JsonProperty("typesHeader") final boolean typesHeader,
@@ -70,6 +73,7 @@ public class SqlQuery
     this.header = header;
     this.typesHeader = typesHeader;
     this.sqlTypesHeader = sqlTypesHeader;
+    this.templateInfo = templateInfo;
     this.context = context == null ? ImmutableMap.of() : context;
     this.parameters = parameters == null ? ImmutableList.of() : parameters;
 
@@ -86,6 +90,7 @@ public class SqlQuery
   {
     return new SqlQuery(
         getQuery(),
+        getTemplateInfo(),
         getResultFormat(),
         includeHeader(),
         includeTypesHeader(),
@@ -128,6 +133,12 @@ public class SqlQuery
     return sqlTypesHeader;
   }
 
+  @JsonProperty("templateInfo")
+  public IngestionTemplateInfo getTemplateInfo()
+  {
+    return templateInfo;
+  }
+
   @JsonProperty
   public Map<String, Object> getContext()
   {
@@ -165,6 +176,7 @@ public class SqlQuery
            sqlTypesHeader == sqlQuery.sqlTypesHeader &&
            Objects.equals(query, sqlQuery.query) &&
            resultFormat == sqlQuery.resultFormat &&
+           Objects.equals(templateInfo, sqlQuery.templateInfo) &&
            Objects.equals(context, sqlQuery.context) &&
            Objects.equals(parameters, sqlQuery.parameters);
   }
@@ -172,7 +184,7 @@ public class SqlQuery
   @Override
   public int hashCode()
   {
-    return Objects.hash(query, resultFormat, header, typesHeader, sqlTypesHeader, context, parameters);
+    return Objects.hash(query, resultFormat, header, typesHeader, sqlTypesHeader, templateInfo, context, parameters);
   }
 
   @Override
@@ -184,6 +196,7 @@ public class SqlQuery
            ", header=" + header +
            ", typesHeader=" + typesHeader +
            ", sqlTypesHeader=" + sqlTypesHeader +
+           ", templateInfo=" + templateInfo +
            ", context=" + context +
            ", parameters=" + parameters +
            '}';

--- a/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
@@ -345,7 +345,7 @@ public class SqlStatementTest
   {
     return new SqlQuery(
         sql,
-        null,
+        null, null,
         false,
         false,
         false,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/http/SqlQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/http/SqlQueryTest.java
@@ -40,7 +40,7 @@ public class SqlQueryTest extends CalciteTestBase
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
     final SqlQuery query = new SqlQuery(
         "SELECT ?",
-        ResultFormat.ARRAY,
+        null, ResultFormat.ARRAY,
         true,
         true,
         true,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/TrivialTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/TrivialTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.sql.calcite.planner;
 
+import org.apache.druid.catalog.model.IngestionTemplateInfo;
 import org.apache.druid.sql.calcite.table.DatasourceTable.PhysicalDatasourceMetadata;
 import org.apache.druid.sql.calcite.table.DruidTable;
 
@@ -53,6 +54,12 @@ public class TrivialTest
     public Set<String> getTableNames(Set<String> datasourceNames)
     {
       return Collections.emptySet();
+    }
+
+    @Override
+    public String generateQueryFromTemplate(IngestionTemplateInfo templateInfo)
+    {
+      return null;
     }
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -330,6 +330,7 @@ public class SqlResourceTest extends CalciteTestBase
         CalciteTests.TEST_AUTHORIZER_MAPPER,
         sqlStatementFactory,
         lifecycleManager,
+        CatalogResolver.NULL_RESOLVER,
         new ServerConfig(),
         TEST_RESPONSE_CONTEXT_CONFIG,
         DUMMY_DRUID_NODE
@@ -390,7 +391,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final SqlQuery sqlQuery = new SqlQuery(
         "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
-        null,
+        null, null,
         false,
         false,
         false,
@@ -478,7 +479,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT __time, CAST(__time AS DATE) AS t2 FROM druid.foo LIMIT 1",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -501,7 +502,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT __time, CAST(__time AS DATE) AS t2 FROM druid.foo LIMIT ?",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -524,7 +525,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT __time, CAST(__time AS DATE) AS t2 FROM druid.foo LIMIT 1",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -547,7 +548,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT MAX(__time) as t1, MAX(__time) FILTER(WHERE dim1 = 'non_existing') as t2 FROM druid.foo",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -578,7 +579,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT dim2 \"x\", dim2 \"y\" FROM druid.foo LIMIT 1",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -601,7 +602,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "SELECT dim2 \"x\", dim2 \"y\" FROM druid.foo GROUP BY dim2",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -660,7 +661,7 @@ public class SqlResourceTest extends CalciteTestBase
             )
         ),
         doPost(
-            new SqlQuery(query, ResultFormat.ARRAY, false, false, false, null, null),
+            new SqlQuery(query, null, ResultFormat.ARRAY, false, false, false, null, null),
             new TypeReference<List<List<Object>>>()
             {
             }
@@ -675,7 +676,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     final String query = "SELECT cnt FROM foo";
     final Pair<ErrorResponse, String> response =
-        doPostRaw(new SqlQuery(query, ResultFormat.ARRAY, false, false, false, null, null), req);
+        doPostRaw(new SqlQuery(query, null, ResultFormat.ARRAY, false, false, false, null, null), req);
 
     // Truncated response: missing final ]
     Assert.assertNull(response.lhs);
@@ -689,7 +690,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     final String query = "SELECT cnt FROM foo";
     final Pair<ErrorResponse, String> response =
-        doPostRaw(new SqlQuery(query, ResultFormat.OBJECT, false, false, false, null, null), req);
+        doPostRaw(new SqlQuery(query, null, ResultFormat.OBJECT, false, false, false, null, null), req);
 
     // Truncated response: missing final ]
     Assert.assertNull(response.lhs);
@@ -703,7 +704,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     final String query = "SELECT cnt FROM foo";
     final Pair<ErrorResponse, String> response =
-        doPostRaw(new SqlQuery(query, ResultFormat.ARRAYLINES, false, false, false, null, null), req);
+        doPostRaw(new SqlQuery(query, null, ResultFormat.ARRAYLINES, false, false, false, null, null), req);
 
     // Truncated response: missing final LFLF
     Assert.assertNull(response.lhs);
@@ -717,7 +718,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     final String query = "SELECT cnt FROM foo";
     final Pair<ErrorResponse, String> response =
-        doPostRaw(new SqlQuery(query, ResultFormat.OBJECTLINES, false, false, false, null, null), req);
+        doPostRaw(new SqlQuery(query, null, ResultFormat.OBJECTLINES, false, false, false, null, null), req);
 
     // Truncated response: missing final LFLF
     Assert.assertNull(response.lhs);
@@ -731,7 +732,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     final String query = "SELECT cnt FROM foo";
     final Pair<ErrorResponse, String> response =
-        doPostRaw(new SqlQuery(query, ResultFormat.CSV, false, false, false, null, null), req);
+        doPostRaw(new SqlQuery(query, null, ResultFormat.CSV, false, false, false, null, null), req);
 
     // Truncated response: missing final LFLF
     Assert.assertNull(response.lhs);
@@ -752,7 +753,7 @@ public class SqlResourceTest extends CalciteTestBase
     };
 
     MockHttpServletResponse response = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, true, true, true, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, true, true, true, null, null),
         req.mimic()
     );
 
@@ -769,7 +770,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
 
     MockHttpServletResponse responseNoSqlTypesHeader = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, true, true, false, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, true, true, false, null, null),
         req.mimic()
     );
 
@@ -785,7 +786,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
 
     MockHttpServletResponse responseNoTypesHeader = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, true, false, true, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, true, false, true, null, null),
         req.mimic()
     );
 
@@ -801,7 +802,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
 
     MockHttpServletResponse responseNoTypes = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, true, false, false, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, true, false, false, null, null),
         req.mimic()
     );
 
@@ -816,7 +817,7 @@ public class SqlResourceTest extends CalciteTestBase
     );
 
     MockHttpServletResponse responseNoHeader = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, false, false, false, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, false, false, false, null, null),
         req.mimic()
     );
 
@@ -836,7 +837,7 @@ public class SqlResourceTest extends CalciteTestBase
     final String query = "SELECT (1, 2) FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1";
 
     MockHttpServletResponse response = postForAsyncResponse(
-        new SqlQuery(query, ResultFormat.ARRAY, true, true, true, null, null),
+        new SqlQuery(query, null, ResultFormat.ARRAY, true, true, true, null, null),
         req
     );
 
@@ -864,7 +865,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.ARRAYLINES, false, false, false, null, null)
+        new SqlQuery(query, null, ResultFormat.ARRAYLINES, false, false, false, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -909,7 +910,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.ARRAYLINES, true, true, true, null, null)
+        new SqlQuery(query, null, ResultFormat.ARRAYLINES, true, true, true, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -957,7 +958,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT (1, 2) FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.ARRAYLINES, true, true, true, null, null)
+        new SqlQuery(query, null, ResultFormat.ARRAYLINES, true, true, true, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -1018,7 +1019,7 @@ public class SqlResourceTest extends CalciteTestBase
                 .build()
         ).stream().map(transformer).collect(Collectors.toList()),
         doPost(
-            new SqlQuery(query, ResultFormat.OBJECT, false, false, false, null, null),
+            new SqlQuery(query, null, ResultFormat.OBJECT, false, false, false, null, null),
             new TypeReference<List<Map<String, Object>>>()
             {
             }
@@ -1031,7 +1032,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.OBJECTLINES, false, false, false, null, null)
+        new SqlQuery(query, null, ResultFormat.OBJECTLINES, false, false, false, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -1088,7 +1089,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair =
-        doPostRaw(new SqlQuery(query, ResultFormat.OBJECTLINES, true, false, false, null, null));
+        doPostRaw(new SqlQuery(query, null, ResultFormat.OBJECTLINES, true, false, false, null, null));
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
     final String nullStr = NullHandling.replaceWithDefault() ? "" : null;
@@ -1148,7 +1149,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair =
-        doPostRaw(new SqlQuery(query, ResultFormat.OBJECTLINES, true, true, true, null, null));
+        doPostRaw(new SqlQuery(query, null, ResultFormat.OBJECTLINES, true, true, true, null, null));
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
     final String nullStr = NullHandling.replaceWithDefault() ? "" : null;
@@ -1214,7 +1215,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT (1, 2) FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1";
     final Pair<ErrorResponse, String> pair =
-        doPostRaw(new SqlQuery(query, ResultFormat.OBJECTLINES, true, true, true, null, null));
+        doPostRaw(new SqlQuery(query, null, ResultFormat.OBJECTLINES, true, true, true, null, null));
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
     final List<String> lines = Splitter.on('\n').splitToList(response);
@@ -1243,7 +1244,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.CSV, false, false, false, null, null)
+        new SqlQuery(query, null, ResultFormat.CSV, false, false, false, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -1265,7 +1266,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT *, CASE dim2 WHEN '' THEN dim2 END FROM foo LIMIT 2";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.CSV, true, true, true, null, null)
+        new SqlQuery(query, null, ResultFormat.CSV, true, true, true, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -1290,7 +1291,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     final String query = "SELECT (1, 2) FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1";
     final Pair<ErrorResponse, String> pair = doPostRaw(
-        new SqlQuery(query, ResultFormat.CSV, true, true, true, null, null)
+        new SqlQuery(query, null, ResultFormat.CSV, true, true, true, null, null)
     );
     Assert.assertNull(pair.lhs);
     final String response = pair.rhs;
@@ -1318,7 +1319,7 @@ public class SqlResourceTest extends CalciteTestBase
     final List<Map<String, Object>> rows = doPost(
         new SqlQuery(
             "EXPLAIN PLAN FOR SELECT COUNT(*) AS cnt FROM druid.foo",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1425,7 +1426,7 @@ public class SqlResourceTest extends CalciteTestBase
     final ErrorResponse errorResponse = doPost(
         new SqlQuery(
             "SELECT DISTINCT dim1 FROM foo",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1458,7 +1459,7 @@ public class SqlResourceTest extends CalciteTestBase
     ErrorResponse exception = postSyncForException(
         new SqlQuery(
             "SELECT ANSWER TO LIFE",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1486,7 +1487,7 @@ public class SqlResourceTest extends CalciteTestBase
     final Response response = postForSyncResponse(
         new SqlQuery(
             "SELECT ANSWER TO LIFE",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1511,7 +1512,7 @@ public class SqlResourceTest extends CalciteTestBase
     final Response response = postForSyncResponse(
         new SqlQuery(
             "SELECT ANSWER TO LIFE",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1534,6 +1535,7 @@ public class SqlResourceTest extends CalciteTestBase
         CalciteTests.TEST_AUTHORIZER_MAPPER,
         sqlStatementFactory,
         lifecycleManager,
+        CatalogResolver.NULL_RESOLVER,
         new ServerConfig()
         {
           @Override
@@ -1557,7 +1559,7 @@ public class SqlResourceTest extends CalciteTestBase
     ErrorResponse exception = postSyncForException(
         new SqlQuery(
             "SELECT ANSWER TO LIFE",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1593,7 +1595,7 @@ public class SqlResourceTest extends CalciteTestBase
     ErrorResponse exception = postSyncForException(
         new SqlQuery(
             "SELECT assertion_error() FROM foo LIMIT 2",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1639,7 +1641,7 @@ public class SqlResourceTest extends CalciteTestBase
           return postForAsyncResponse(
               new SqlQuery(
                   "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
-                  null,
+                  null, null,
                   false,
                   false,
                   false,
@@ -1662,7 +1664,7 @@ public class SqlResourceTest extends CalciteTestBase
         final Response retVal = postForSyncResponse(
             new SqlQuery(
                 "SELECT COUNT(*) AS cnt, 'foo' AS TheFoo FROM druid.foo",
-                null,
+                null, null,
                 false,
                 false,
                 false,
@@ -1722,6 +1724,7 @@ public class SqlResourceTest extends CalciteTestBase
     ErrorResponse exception = postSyncForException(
         new SqlQuery(
             "SELECT CAST(__time AS DATE), dim1, dim2, dim3 FROM druid.foo GROUP by __time, dim1, dim2, dim3 ORDER BY dim2 DESC",
+            null,
             ResultFormat.OBJECT,
             false,
             false,
@@ -1867,7 +1870,7 @@ public class SqlResourceTest extends CalciteTestBase
     final ErrorResponse errorResponse = doPost(
         new SqlQuery(
             "SELECT 1337",
-            ResultFormat.OBJECT,
+            null, ResultFormat.OBJECT,
             false,
             false,
             false,
@@ -1891,7 +1894,7 @@ public class SqlResourceTest extends CalciteTestBase
   {
     Map<String, Object> queryContext = ImmutableMap.of(DruidSqlInsert.SQL_INSERT_SEGMENT_GRANULARITY, "all");
     ErrorResponse exception = postSyncForException(
-        new SqlQuery("SELECT 1337", ResultFormat.OBJECT, false, false, false, queryContext, null),
+        new SqlQuery("SELECT 1337", null, ResultFormat.OBJECT, false, false, false, queryContext, null),
         Status.BAD_REQUEST.getStatusCode()
     );
 
@@ -1923,7 +1926,7 @@ public class SqlResourceTest extends CalciteTestBase
 
   private static SqlQuery createSimpleQueryWithId(String sqlQueryId, String sql)
   {
-    return new SqlQuery(sql, null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, sqlQueryId), null);
+    return new SqlQuery(sql, null, null, false, false, false, ImmutableMap.of(BaseQuery.SQL_QUERY_ID, sqlQueryId), null);
   }
 
   private Pair<ErrorResponse, List<Map<String, Object>>> doPost(final SqlQuery query) throws Exception


### PR DESCRIPTION
This PR adds a feature to the Druid catalog for storing query templates that can be referenced when issuing queries via Druid SQL. 

An initial "concat" template is implemented, which stores a portion of a query that will be appended to a variable query portion submitted at query time.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
