### PR TITLE
feat: add debug log for S3 showing ID when granting full control

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -197,7 +197,9 @@ public class S3Utils
   static AccessControlList grantFullControlToBucketOwner(ServerSideEncryptingAmazonS3 s3Client, String bucket)
   {
     final AccessControlList acl = s3Client.getBucketAcl(bucket);
-    acl.grantAllPermissions(new Grant(new CanonicalGrantee(acl.getOwner().getId()), Permission.FullControl));
+    final String bucketOwnerId = acl.getOwner().getId();
+    log.debug("Granting Full Control to ID: [%s]", bucketOwnerId);
+    acl.grantAllPermissions(new Grant(new CanonicalGrantee(bucketOwnerId), Permission.FullControl));
     return acl;
   }
 


### PR DESCRIPTION
### Adds a debug log message for S3 when granting Full Control ACL
If either `druid.indexer.logs.disableAcl` or `druid.storage.disableAcl` is set to true, and logging is set to debug, this will generate a message every time an object is written to S3 that contains the ID of the Bucket Owner.

The main use of this is to help identify a misconfiguration of the above mentioned configurations. If storage is set to true, and the logs is not (and they use the same bucket), then the MiddleManager will may to write the task log to S3 and even if the task was successful, it will treat it as a failed task, causing it to restart.

By adding this log message, it should show an identifiable difference between the behavior in Peon logs and MiddleManager logs.


- [ ] been self-reviewed.
- [ ] been tested in a test Druid cluster.
