### PR TITLE
Upgrade pending segments transactionally

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceAction.java
@@ -93,8 +93,9 @@ public class SegmentTransactionalReplaceAction implements TaskAction<SegmentPubl
     final Set<ReplaceTaskLock> replaceLocksForTask
         = toolbox.getTaskLockbox().findReplaceLocksForTask(task);
     final SupervisorManager supervisorManager = toolbox.getSupervisorManager();
-    final Optional<String> activeSupervisorIdWithAppendLock =
-        supervisorManager.getActiveSupervisorIdForDatasourceWithAppendLock(task.getDataSource());
+    final Optional<String> activeSupervisorIdWithAppendLock = supervisorManager == null
+        ? Optional.absent()
+        : supervisorManager.getActiveSupervisorIdForDatasourceWithAppendLock(task.getDataSource());
     final Set<String> activeRealtimeSequencePrefixes;
     if (!activeSupervisorIdWithAppendLock.isPresent()) {
       activeRealtimeSequencePrefixes = ImmutableSet.of();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -154,7 +154,8 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   @Override
   public SegmentPublishResult commitReplaceSegments(
       Set<DataSegment> replaceSegments,
-      Set<ReplaceTaskLock> locksHeldByReplaceTask
+      Set<ReplaceTaskLock> locksHeldByReplaceTask,
+      Set<String> activeRealtimeSequencePrefixes
   )
   {
     return SegmentPublishResult.ok(commitSegments(replaceSegments));
@@ -225,15 +226,6 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
         maxVersion,
         partialShardSpec.complete(objectMapper, 0, 0)
     );
-  }
-
-  @Override
-  public Map<SegmentIdWithShardSpec, SegmentIdWithShardSpec> upgradePendingSegmentsOverlappingWith(
-      Set<DataSegment> replaceSegments,
-      Set<String> activeBaseSequenceNames
-  )
-  {
-    return Collections.emptyMap();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -325,32 +325,14 @@ public interface IndexerMetadataStorageCoordinator
    * in {@link #commitAppendSegments}</li>
    * </ul>
    *
-   * @param replaceSegments        All segments created by a REPLACE task that
-   *                               must be committed in a single transaction.
-   * @param locksHeldByReplaceTask All active non-revoked REPLACE locks held by the task
+   * @param replaceSegments                All segments created by a REPLACE task that
+   *                                       must be committed in a single transaction.
+   * @param locksHeldByReplaceTask         All active non-revoked REPLACE locks held by the task
+   * @param activeRealtimeSequencePrefixes Set of sequence prefixes of active and pending completion task group
    */
   SegmentPublishResult commitReplaceSegments(
       Set<DataSegment> replaceSegments,
-      Set<ReplaceTaskLock> locksHeldByReplaceTask
-  );
-
-  /**
-   * Creates and inserts new IDs for the pending segments hat overlap with the given
-   * replace segments being committed. The newly created pending segment IDs:
-   * <ul>
-   * <li>Have the same interval and version as that of an overlapping segment
-   * committed by the REPLACE task.</li>
-   * <li>Cannot be committed but are only used to serve realtime queries against
-   * those versions.</li>
-   * </ul>
-   *
-   * @param replaceSegments Segments being committed by a REPLACE task
-   * @param activeRealtimeSequencePrefixes Set of sequence prefixes of active and pending completion task groups
-   *                                       of the supervisor (if any) for this datasource
-   * @return Map from originally allocated pending segment to its new upgraded ID.
-   */
-  Map<SegmentIdWithShardSpec, SegmentIdWithShardSpec> upgradePendingSegmentsOverlappingWith(
-      Set<DataSegment> replaceSegments,
+      Set<ReplaceTaskLock> locksHeldByReplaceTask,
       Set<String> activeRealtimeSequencePrefixes
   );
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/PendingSegmentUpgradeRecord.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/PendingSegmentUpgradeRecord.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
+
+import java.util.Objects;
+
+public class PendingSegmentUpgradeRecord
+{
+  private final SegmentIdWithShardSpec oldId;
+  private final SegmentIdWithShardSpec newId;
+
+  public PendingSegmentUpgradeRecord(
+      SegmentIdWithShardSpec oldId,
+      SegmentIdWithShardSpec newId
+  )
+  {
+    this.oldId = oldId;
+    this.newId = newId;
+  }
+
+  public SegmentIdWithShardSpec getOldId()
+  {
+    return oldId;
+  }
+
+  public SegmentIdWithShardSpec getNewId()
+  {
+    return newId;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PendingSegmentUpgradeRecord that = (PendingSegmentUpgradeRecord) o;
+    return Objects.equals(oldId, that.oldId) &&
+           Objects.equals(newId, that.newId);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(oldId, newId);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PendingSegmentUpgradeRecord{" +
+           "oldId='" + oldId + '\'' +
+           ", newId='" + newId + '\'' +
+           '}';
+  }
+}

--- a/server/src/main/java/org/apache/druid/indexing/overlord/PendingSegmentUpgradeRecord.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/PendingSegmentUpgradeRecord.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 
 import java.util.Objects;
@@ -28,20 +30,23 @@ public class PendingSegmentUpgradeRecord
   private final SegmentIdWithShardSpec oldId;
   private final SegmentIdWithShardSpec newId;
 
+  @JsonCreator
   public PendingSegmentUpgradeRecord(
-      SegmentIdWithShardSpec oldId,
-      SegmentIdWithShardSpec newId
+      @JsonProperty("oldId") SegmentIdWithShardSpec oldId,
+      @JsonProperty("newId") SegmentIdWithShardSpec newId
   )
   {
     this.oldId = oldId;
     this.newId = newId;
   }
 
+  @JsonProperty
   public SegmentIdWithShardSpec getOldId()
   {
     return oldId;
   }
 
+  @JsonProperty
   public SegmentIdWithShardSpec getNewId()
   {
     return newId;

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -689,7 +689,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest
       replacingSegments.add(segment);
     }
 
-    coordinator.commitReplaceSegments(replacingSegments, ImmutableSet.of(replaceLock));
+    coordinator.commitReplaceSegments(replacingSegments, ImmutableSet.of(replaceLock), ImmutableSet.of());
 
     Assert.assertEquals(
         2L * segmentsAppendedWithReplaceLock.size() + replacingSegments.size(),


### PR DESCRIPTION
The segment transactional replace action facilitates concurrent replace with streaming append by 
1) Upgrading pending segments in the metadata store 
2) Relaying this information to the streaming tasks so that they may update their internal state for queries

Presently both the steps happen outside the transaction in which the replacing segments are committed.
This PR aims to fix potential conflicts by ensuring that the pending segment upgrade happens in the same transaction in which the segments are committed.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
