### PR TITLE
Use cache for password hash while validating LDAP password

### DIFF
--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/LdapUserPrincipal.java
@@ -92,9 +92,9 @@ public class LdapUserPrincipal implements Principal
     return lastVerified.get();
   }
 
-  public boolean hasSameCredentials(char[] password)
+  public boolean hasSameCredentials(char[] password, PasswordHashGenerator hashGenerator)
   {
-    byte[] recalculatedHash = PasswordHashGenerator.computePasswordHash(
+    byte[] recalculatedHash = hashGenerator.getOrComputePasswordHash(
         password,
         this.credentials.getSalt(),
         this.credentials.getIterations()

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/validator/LDAPCredentialsValidator.java
@@ -153,14 +153,13 @@ public class LDAPCredentialsValidator implements CredentialsValidator
       char[] password
   )
   {
-    SearchResult userResult;
-    LdapName userDn;
-    Map<String, Object> contextMap = new HashMap<>();
+    final SearchResult userResult;
+    final LdapName userDn;
+    final Map<String, Object> contextMap = new HashMap<>();
+    final LdapUserPrincipal principal = this.cache.getOrExpire(username);
 
-    LdapUserPrincipal principal = this.cache.getOrExpire(username);
-    if (principal != null && principal.hasSameCredentials(password)) {
+    if (principal != null && principal.hasSameCredentials(password, hashGenerator)) {
       contextMap.put(BasicAuthUtils.SEARCH_RESULT_CONTEXT_KEY, principal.getSearchResult());
-      return new AuthenticationResult(username, authorizerName, authenticatorName, contextMap);
     } else {
       ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
       try {
@@ -208,8 +207,8 @@ public class LDAPCredentialsValidator implements CredentialsValidator
 
       this.cache.put(username, newPrincipal);
       contextMap.put(BasicAuthUtils.SEARCH_RESULT_CONTEXT_KEY, userResult);
-      return new AuthenticationResult(username, authorizerName, authenticatorName, contextMap);
     }
+    return new AuthenticationResult(username, authorizerName, authenticatorName, contextMap);
   }
 
   /**

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authentication/validator/LDAPCredentialsValidatorTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/authentication/validator/LDAPCredentialsValidatorTest.java
@@ -36,7 +36,6 @@ import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.LdapContext;
 import javax.naming.spi.InitialContextFactory;
-
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -93,6 +92,7 @@ public class LDAPCredentialsValidatorTest
         ),
         properties
     );
+    validator.validateCredentials("ldap", "ldap", "validUser", "password".toCharArray());
     validator.validateCredentials("ldap", "ldap", "validUser", "password".toCharArray());
   }
 

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/validator/MetadataStoreCredentialsValidatorTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/validator/MetadataStoreCredentialsValidatorTest.java
@@ -23,10 +23,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Provider;
 import com.google.inject.util.Providers;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.security.basic.BasicSecurityAuthenticationException;
 import org.apache.druid.security.basic.authentication.db.cache.BasicAuthenticatorCacheManager;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentialUpdate;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentials;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorUser;
+import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -135,9 +137,10 @@ public class MetadataStoreCredentialsValidatorTest
     String username = "userA";
     String password = "badpassword";
 
-    Assert.assertThrows(
-        IAE.class,
+    Exception exception = Assert.assertThrows(
+        BasicSecurityAuthenticationException.class,
         () -> VALIDATOR.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray())
     );
+    Assert.assertEquals(Access.DEFAULT_ERROR_MESSAGE, exception.getMessage());
   }
 }

--- a/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/validator/MetadataStoreCredentialsValidatorTest.java
+++ b/extensions-core/druid-basic-security/src/test/java/org/apache/druid/security/basic/authentication/validator/MetadataStoreCredentialsValidatorTest.java
@@ -17,39 +17,30 @@
  * under the License.
  */
 
-package org.apache.druid.security.authentication.validator;
+package org.apache.druid.security.basic.authentication.validator;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Provider;
 import com.google.inject.util.Providers;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.security.basic.BasicSecurityAuthenticationException;
 import org.apache.druid.security.basic.authentication.db.cache.BasicAuthenticatorCacheManager;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentialUpdate;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorCredentials;
 import org.apache.druid.security.basic.authentication.entity.BasicAuthenticatorUser;
-import org.apache.druid.security.basic.authentication.validator.MetadataStoreCredentialsValidator;
-import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.easymock.EasyMock;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
-public class DBCredentialsValidatorTest
+public class MetadataStoreCredentialsValidatorTest
 {
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  private static BasicAuthenticatorCredentials USER_A_CREDENTIALS = new BasicAuthenticatorCredentials(
+  private static final BasicAuthenticatorCredentials USER_A_CREDENTIALS = new BasicAuthenticatorCredentials(
       new BasicAuthenticatorCredentialUpdate("helloworld", 20)
   );
 
-  private static Provider<BasicAuthenticatorCacheManager> CACHE_MANAGER_PROVIDER = Providers.of(
+  private static final Provider<BasicAuthenticatorCacheManager> CACHE_MANAGER_PROVIDER = Providers.of(
       new BasicAuthenticatorCacheManager()
       {
         @Override
@@ -69,9 +60,8 @@ public class DBCredentialsValidatorTest
       }
   );
 
-  private static MetadataStoreCredentialsValidator validator = new MetadataStoreCredentialsValidator(CACHE_MANAGER_PROVIDER);
-
-
+  private static final MetadataStoreCredentialsValidator VALIDATOR
+      = new MetadataStoreCredentialsValidator(CACHE_MANAGER_PROVIDER);
 
   @Test
   public void validateBadAuthenticator()
@@ -87,9 +77,11 @@ public class DBCredentialsValidatorTest
 
     MetadataStoreCredentialsValidator validator = new MetadataStoreCredentialsValidator(Providers.of(cacheManager));
 
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("No userMap is available for authenticator with prefix: [notbasic]");
-    validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
+    IAE exception = Assert.assertThrows(
+        IAE.class,
+        () -> validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray())
+    );
+    Assert.assertEquals("No userMap is available for authenticator with prefix: [notbasic]", exception.getMessage());
 
     EasyMock.verify(cacheManager);
   }
@@ -102,7 +94,7 @@ public class DBCredentialsValidatorTest
     String username = "userB";
     String password = "helloworld";
 
-    AuthenticationResult result = validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
+    AuthenticationResult result = VALIDATOR.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
     Assert.assertNull(result);
   }
 
@@ -114,7 +106,7 @@ public class DBCredentialsValidatorTest
     String username = "userC";
     String password = "helloworld";
 
-    AuthenticationResult result = validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
+    AuthenticationResult result = VALIDATOR.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
     Assert.assertNull(result);
   }
 
@@ -126,7 +118,7 @@ public class DBCredentialsValidatorTest
     String username = "userA";
     String password = "helloworld";
 
-    AuthenticationResult result = validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
+    AuthenticationResult result = VALIDATOR.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
 
     Assert.assertNotNull(result);
     Assert.assertEquals(username, result.getIdentity());
@@ -143,8 +135,9 @@ public class DBCredentialsValidatorTest
     String username = "userA";
     String password = "badpassword";
 
-    expectedException.expect(BasicSecurityAuthenticationException.class);
-    expectedException.expectMessage(Access.DEFAULT_ERROR_MESSAGE);
-    validator.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray());
+    Assert.assertThrows(
+        IAE.class,
+        () -> VALIDATOR.validateCredentials(authenticatorName, authorizerName, username, password.toCharArray())
+    );
   }
 }


### PR DESCRIPTION
Follow up to #15648 

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
