### PR TITLE
Concurrent replace should work with supervisors using concurrent locks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -87,7 +87,7 @@ public class SupervisorManager
       final Supervisor supervisor = entry.getValue().lhs;
       final SupervisorSpec supervisorSpec = entry.getValue().rhs;
 
-      boolean useConcurrentLocks = Tasks.DEFAULT_USE_CONCURRENT_LOCKS;
+      Boolean useConcurrentLocks = Tasks.DEFAULT_USE_CONCURRENT_LOCKS;
       TaskLockType taskLockType = Tasks.DEFAULT_TASK_LOCK_TYPE;
       if (supervisorSpec instanceof SeekableStreamSupervisorSpec) {
         SeekableStreamSupervisorSpec seekableStreamSupervisorSpec = (SeekableStreamSupervisorSpec) supervisorSpec;
@@ -95,15 +95,17 @@ public class SupervisorManager
         if (context != null) {
           useConcurrentLocks = QueryContexts.getAsBoolean(
               Tasks.USE_CONCURRENT_LOCKS,
-              context.get(Tasks.USE_CONCURRENT_LOCKS),
-              Tasks.DEFAULT_USE_CONCURRENT_LOCKS
+              context.get(Tasks.USE_CONCURRENT_LOCKS)
           );
 
-          taskLockType = QueryContexts.getAsEnum(
-              Tasks.TASK_LOCK_TYPE,
-              context.get(Tasks.TASK_LOCK_TYPE),
-              TaskLockType.class
-          );
+          if (useConcurrentLocks == null) {
+            useConcurrentLocks = false;
+            taskLockType = QueryContexts.getAsEnum(
+                Tasks.TASK_LOCK_TYPE,
+                context.get(Tasks.TASK_LOCK_TYPE),
+                TaskLockType.class
+            );
+          }
         }
       }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -468,6 +468,21 @@ public class SupervisorManagerTest extends EasyMockSupport
     EasyMock.replay(activeSpec);
     metadataSupervisorManager.insert(EasyMock.anyString(), EasyMock.anyObject());
 
+    SeekableStreamSupervisorSpec activeSpecWithConcurrentLocks = EasyMock.mock(SeekableStreamSupervisorSpec.class);
+    Supervisor activeSupervisorWithConcurrentLocks = EasyMock.mock(SeekableStreamSupervisor.class);
+    EasyMock.expect(activeSpecWithConcurrentLocks.getId()).andReturn("activeSpecWithConcurrentLocks").anyTimes();
+    EasyMock.expect(activeSpecWithConcurrentLocks.isSuspended()).andReturn(false).anyTimes();
+    EasyMock.expect(activeSpecWithConcurrentLocks.getDataSources())
+            .andReturn(ImmutableList.of("activeConcurrentLocksDS")).anyTimes();
+    EasyMock.expect(activeSpecWithConcurrentLocks.createSupervisor())
+            .andReturn(activeSupervisorWithConcurrentLocks).anyTimes();
+    EasyMock.expect(activeSpecWithConcurrentLocks.createAutoscaler(activeSupervisorWithConcurrentLocks))
+            .andReturn(null).anyTimes();
+    EasyMock.expect(activeSpecWithConcurrentLocks.getContext())
+            .andReturn(ImmutableMap.of(Tasks.USE_CONCURRENT_LOCKS, true)).anyTimes();
+    EasyMock.replay(activeSpecWithConcurrentLocks);
+    metadataSupervisorManager.insert(EasyMock.anyString(), EasyMock.anyObject());
+
     SeekableStreamSupervisorSpec activeAppendSpec = EasyMock.mock(SeekableStreamSupervisorSpec.class);
     Supervisor activeAppendSupervisor = EasyMock.mock(SeekableStreamSupervisor.class);
     EasyMock.expect(activeAppendSpec.getId()).andReturn("activeAppendSpec").anyTimes();
@@ -498,6 +513,9 @@ public class SupervisorManagerTest extends EasyMockSupport
 
     manager.createOrUpdateAndStartSupervisor(activeAppendSpec);
     Assert.assertTrue(manager.getActiveSupervisorIdForDatasourceWithAppendLock("activeAppendDS").isPresent());
+
+    manager.createOrUpdateAndStartSupervisor(activeSpecWithConcurrentLocks);
+    Assert.assertTrue(manager.getActiveSupervisorIdForDatasourceWithAppendLock("activeConcurrentLocksDS").isPresent());
 
     verifyAll();
   }


### PR DESCRIPTION
A concurrent replace should allow the existing pending segments of a peon to be upgraded via the supervisor.
Currently, we check if there is such an active supervisor for streaming ingestion when the context value of `taskLockType`: `APPEND`.
This PR ensures that `useConcurrentLocks`:`true` works as well.

Please note that if `useConcurrentLocks` is set to `false`, it would supersede `taskLockType`:`APPEND`

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
