### PR TITLE
Web console: make double detection better

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.spec.ts
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.spec.ts
@@ -720,6 +720,7 @@ describe('spec utils', () => {
       expect(guessColumnTypeFromInput([null, 1, 2.1, 3], true)).toEqual('double');
       expect(guessColumnTypeFromInput([null, '1', '2.1', '3'], false)).toEqual('string');
       expect(guessColumnTypeFromInput([null, '1', '2.1', '3'], true)).toEqual('double');
+      expect(guessColumnTypeFromInput([null, '1.0', '2.0', '3.0'], true)).toEqual('double');
     });
 
     it('works for ARRAY<string>', () => {

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -2588,7 +2588,9 @@ function isIntegerOrNull(x: any): boolean {
 
 function isIntegerOrNullAcceptString(x: any): boolean {
   return (
-    x == null || ((typeof x === 'number' || typeof x === 'string') && Number.isInteger(Number(x)))
+    x == null ||
+    (typeof x === 'number' && Number.isInteger(x)) ||
+    (typeof x === 'string' && !x.includes('.') && Number.isInteger(Number(x)))
   );
 }
 

--- a/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
+++ b/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
@@ -193,6 +193,9 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
     inputSourceAndFormat.inputSource,
   );
 
+  const needsResample = inputSourceAndFormatToSample !== inputSourceAndFormat;
+  const nextDisabled = !inputSourceFormatAndMore || needsResample;
+
   return (
     <div className="input-format-step">
       <div className="preview">
@@ -246,7 +249,7 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
               onChange={setInputSourceAndFormat as any}
             />
           )}
-          {inputSourceAndFormatToSample !== inputSourceAndFormat && (
+          {needsResample && (
             <FormGroup className="control-buttons">
               <Button
                 text="Preview changes"
@@ -283,7 +286,7 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
                   text={altText}
                   rightIcon={IconNames.ARROW_TOP_RIGHT}
                   minimal
-                  disabled={!inputSourceFormatAndMore}
+                  disabled={nextDisabled}
                   onClick={() => {
                     if (!inputSourceFormatAndMore) return;
                     onAltSet(inputSourceFormatAndMore);
@@ -299,7 +302,7 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
               text={doneButton ? 'Done' : 'Next'}
               rightIcon={doneButton ? IconNames.TICK : IconNames.ARROW_RIGHT}
               intent={Intent.PRIMARY}
-              disabled={!inputSourceFormatAndMore}
+              disabled={nextDisabled}
               onClick={() => {
                 if (!inputSourceFormatAndMore) return;
                 onSet(inputSourceFormatAndMore);


### PR DESCRIPTION
This PR fixes a type detection issue where the `v` column in a CSV like

```
n,v
a,1.0
b,2.0
c,3.0
```

Would be detected as BIGINT instead of DOUBLE because we never considered the string representation of the number.

Also fixing a bug that I stumbled on when testing the above issue. The InputFormat detection step let's a user click next when a resample is needed putting them in a bad state because the signature is only detected on sample. I did that by mistake while testing.