### PR TITLE
restore information about truncated responses to sql api

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -65,7 +65,7 @@ The request body takes the following properties:
 
   * `arrayLines`: Returns newline-delimited JSON arrays with the HTTP response header `Content-Type: text/plain`.  
      Newline separation facilitates parsing the entire response set as a stream if you don't have a streaming JSON parser.
- This format includes a single trailing newline character so you can detect a truncated response.
+     This format includes a single trailing newline character so you can detect a truncated response.
 
   * `csv`: Returns comma-separated values with one row per line. Sent with the HTTP response header `Content-Type: text/csv`.  
      Druid uses double quotes to escape individual field values. For example, a value with a comma returns `"A,B"`.

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -53,11 +53,25 @@ The request body takes the following properties:
 * `query`: SQL query string.
 
 * `resultFormat`: String that indicates the format to return query results. Select one of the following formats:
-  * `object`: Returns a JSON array of JSON objects with the HTTP response header `Content-Type: application/json`.
-  * `array`: Returns a JSON array of JSON arrays with the HTTP response header `Content-Type: application/json`.
-  * `objectLines`: Returns newline-delimited JSON objects with a trailing blank line. Returns the HTTP response header `Content-Type: text/plain`.
-  * `arrayLines`: Returns newline-delimited JSON arrays with a trailing blank line. Returns the HTTP response header `Content-Type: text/plain`.
-  * `csv`: Returns a comma-separated values with one row per line and a trailing blank line. Returns the HTTP response header `Content-Type: text/csv`.
+  * `object`: Returns a JSON array of JSON objects with the HTTP response header `Content-Type: application/json`.  
+     Each object's field names match the columns returned by the SQL query, and are provided in the same order as the SQL query.
+
+  * `array`: Returns a JSON array of JSON arrays with the HTTP response header `Content-Type: application/json`.  
+     Each inner array has elements matching the columns returned by the SQL query, in order.
+
+  * `objectLines`: Returns newline-delimited JSON objects with the HTTP response header `Content-Type: text/plain`.  
+     Newline separation can make it easier to parse the entire response set as a stream if you don't have a streaming JSON parser.
+     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
+
+  * `arrayLines`: Returns newline-delimited JSON arrays with the HTTP response header `Content-Type: text/plain`.  
+     Newline separation can make it easier to parse the entire response set as a stream if you don't have a streaming JSON parser.
+     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
+
+  * `csv`: Returns comma-separated values with one row per line. Sent with the HTTP response header `Content-Type: text/csv`.  
+     Druid uses double quotes to escape individual field values. For example a value with a comma returns `"A,B"`.
+     If the field value contains a double quote character, Druid escapes it with a second double quote character.
+     For example `foo"bar` becomes `foo""bar`.
+     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
 
 * `header`: Boolean value that determines whether to return information on column names. When set to `true`, Druid returns the column names as the first row of the results. To also get information on the column types, set `typesHeader` or `sqlTypesHeader` to `true`. For a comparative overview of data formats and configurations for the header, see the [Query output format](#query-output-format) table.
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -54,24 +54,24 @@ The request body takes the following properties:
 
 * `resultFormat`: String that indicates the format to return query results. Select one of the following formats:
   * `object`: Returns a JSON array of JSON objects with the HTTP response header `Content-Type: application/json`.  
-     Each object's field names match the columns returned by the SQL query, and are provided in the same order as the SQL query.
+     Object field names match the columns returned by the SQL query in the same order as the SQL query.
 
   * `array`: Returns a JSON array of JSON arrays with the HTTP response header `Content-Type: application/json`.  
      Each inner array has elements matching the columns returned by the SQL query, in order.
 
   * `objectLines`: Returns newline-delimited JSON objects with the HTTP response header `Content-Type: text/plain`.  
-     Newline separation can make it easier to parse the entire response set as a stream if you don't have a streaming JSON parser.
-     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
+     Newline separation facilitates parsing the entire response set as a stream if you don't have a streaming JSON parser.
+     This format includes a trailer of one blank newline character so you can detect a truncated response.
 
   * `arrayLines`: Returns newline-delimited JSON arrays with the HTTP response header `Content-Type: text/plain`.  
-     Newline separation can make it easier to parse the entire response set as a stream if you don't have a streaming JSON parser.
-     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
+     Newline separation facilitates parsing the entire response set as a stream if you don't have a streaming JSON parser.
+ This format includes a trailer of one blank newline character so you can detect a truncated response.
 
   * `csv`: Returns comma-separated values with one row per line. Sent with the HTTP response header `Content-Type: text/csv`.  
      Druid uses double quotes to escape individual field values. For example a value with a comma returns `"A,B"`.
      If the field value contains a double quote character, Druid escapes it with a second double quote character.
      For example `foo"bar` becomes `foo""bar`.
-     To make it possible to detect a truncated response, this format includes a trailer of one blank newline character.
+      This format includes a trailer of one blank newline character so you can detect a truncated response.
 
 * `header`: Boolean value that determines whether to return information on column names. When set to `true`, Druid returns the column names as the first row of the results. To also get information on the column types, set `typesHeader` or `sqlTypesHeader` to `true`. For a comparative overview of data formats and configurations for the header, see the [Query output format](#query-output-format) table.
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -61,17 +61,17 @@ The request body takes the following properties:
 
   * `objectLines`: Returns newline-delimited JSON objects with the HTTP response header `Content-Type: text/plain`.  
      Newline separation facilitates parsing the entire response set as a stream if you don't have a streaming JSON parser.
-     This format includes a trailer of one blank newline character so you can detect a truncated response.
+     This format includes a single trailing newline character so you can detect a truncated response.
 
   * `arrayLines`: Returns newline-delimited JSON arrays with the HTTP response header `Content-Type: text/plain`.  
      Newline separation facilitates parsing the entire response set as a stream if you don't have a streaming JSON parser.
- This format includes a trailer of one blank newline character so you can detect a truncated response.
+ This format includes a single trailing newline character so you can detect a truncated response.
 
   * `csv`: Returns comma-separated values with one row per line. Sent with the HTTP response header `Content-Type: text/csv`.  
-     Druid uses double quotes to escape individual field values. For example a value with a comma returns `"A,B"`.
+     Druid uses double quotes to escape individual field values. For example, a value with a comma returns `"A,B"`.
      If the field value contains a double quote character, Druid escapes it with a second double quote character.
-     For example `foo"bar` becomes `foo""bar`.
-      This format includes a trailer of one blank newline character so you can detect a truncated response.
+     For example, `foo"bar` becomes `foo""bar`.
+      This format includes a single trailing newline character so you can detect a truncated response.
 
 * `header`: Boolean value that determines whether to return information on column names. When set to `true`, Druid returns the column names as the first row of the results. To also get information on the column types, set `typesHeader` or `sqlTypesHeader` to `true`. For a comparative overview of data formats and configurations for the header, see the [Query output format](#query-output-format) table.
 
@@ -140,11 +140,11 @@ The request body takes the following properties:
 
 #### Client-side error handling and truncated responses
 
-Druid reports errors that occur before the response body is sent as JSON, with an HTTP 500 status code, using the same format as [native Druid query errors](../querying/querying.md#query-errors).
+Druid reports errors that occur before the response body is sent as JSON with an HTTP 500 status code. The errors are reported using the same format as [native Druid query errors](../querying/querying.md#query-errors).
 If an error occurs while Druid is sending the response body, the server handling the request stops the response midstream and logs an error.
 
 This means that when you call the SQL API, you must properly handle response truncation.
-For  `object` and `array` formats, truncated responses will be invalid JSON.
+For  `object` and `array` formats, truncated responses are invalid JSON.
 For line-oriented formats, Druid includes a newline character as the final character of every complete response. Absence of a final newline character indicates a truncated response.
 
 If you detect a truncated response, treat it as an error.

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -124,6 +124,16 @@ The request body takes the following properties:
 </TabItem>
 </Tabs>
 
+#### Client-side error handling and truncated responses
+
+Druid reports errors that occur before the response body is sent as JSON, with an HTTP 500 status code, using the same format as [native Druid query errors](../querying/querying.md#query-errors).
+If an error occurs while Druid is sending the response body, the server handling the request stops the response midstream and logs an error.
+
+This means that when you call the SQL API, you must properly handle response truncation.
+For  `object` and `array` formats, truncated responses will be invalid JSON.
+For line-oriented formats, Druid includes a newline character as the final character of every complete response. Absence of a final newline character indicates a truncated response.
+
+If you detect a truncated response, treat it as an error.
 
 ---
 


### PR DESCRIPTION
Restores information about truncated responses for SQL HTTP API

The refactor of the SQL API removed some information about error handling and truncated responses:
https://github.com/apache/druid/pull/14711#issuecomment-1970076591

This PR restores that information. 

Open question on whether or not it applies to query from deep storage or not.

cc: @gianm 


This PR has:

- [x ] been self-reviewed.

