### PR TITLE
Revert explain attributes change

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
@@ -241,7 +241,7 @@ public class MSQTaskQueryMaker implements QueryMaker
       );
 
       final DataSourceMSQDestination dataSourceMSQDestination = new DataSourceMSQDestination(
-          targetDataSource.getType(),
+          targetDataSource.getDestinationName(),
           segmentGranularityObject,
           segmentSortOrder,
           replaceTimeChunks

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/ExplainAttributes.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/ExplainAttributes.java
@@ -22,7 +22,6 @@ package org.apache.druid.sql.calcite.planner;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.java.util.common.granularity.Granularity;
-import org.apache.druid.sql.destination.IngestDestination;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -35,7 +34,7 @@ public final class ExplainAttributes
   private final String statementType;
 
   @Nullable
-  private final IngestDestination targetDataSource;
+  private final String targetDataSource;
 
   @Nullable
   private final Granularity partitionedBy;
@@ -48,7 +47,7 @@ public final class ExplainAttributes
 
   public ExplainAttributes(
       @JsonProperty("statementType") final String statementType,
-      @JsonProperty("targetDataSource") @Nullable final IngestDestination targetDataSource,
+      @JsonProperty("targetDataSource") @Nullable final String targetDataSource,
       @JsonProperty("partitionedBy") @Nullable final Granularity partitionedBy,
       @JsonProperty("clusteredBy") @Nullable final List<String> clusteredBy,
       @JsonProperty("replaceTimeChunks") @Nullable final String replaceTimeChunks
@@ -77,7 +76,7 @@ public final class ExplainAttributes
   @Nullable
   @JsonProperty
   @JsonInclude(JsonInclude.Include.NON_NULL)
-  public IngestDestination getTargetDataSource()
+  public String getTargetDataSource()
   {
     return targetDataSource;
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/IngestHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/IngestHandler.java
@@ -308,7 +308,7 @@ public abstract class IngestHandler extends QueryHandler
     {
       return new ExplainAttributes(
           DruidSqlInsert.OPERATOR.getName(),
-          targetDatasource,
+          targetDatasource.getType(),
           ingestionGranularity,
           DruidSqlParserUtils.resolveClusteredByColumnsToOutputColumns(sqlNode.getClusteredBy(), rootQueryRel.fields),
           null
@@ -405,7 +405,7 @@ public abstract class IngestHandler extends QueryHandler
     {
       return new ExplainAttributes(
           DruidSqlReplace.OPERATOR.getName(),
-          targetDatasource,
+          targetDatasource.getType(),
           ingestionGranularity,
           DruidSqlParserUtils.resolveClusteredByColumnsToOutputColumns(sqlNode.getClusteredBy(), rootQueryRel.fields),
           replaceIntervals

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/IngestHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/IngestHandler.java
@@ -308,7 +308,7 @@ public abstract class IngestHandler extends QueryHandler
     {
       return new ExplainAttributes(
           DruidSqlInsert.OPERATOR.getName(),
-          targetDatasource.getType(),
+          targetDatasource.getDestinationName(),
           ingestionGranularity,
           DruidSqlParserUtils.resolveClusteredByColumnsToOutputColumns(sqlNode.getClusteredBy(), rootQueryRel.fields),
           null
@@ -405,7 +405,7 @@ public abstract class IngestHandler extends QueryHandler
     {
       return new ExplainAttributes(
           DruidSqlReplace.OPERATOR.getName(),
-          targetDatasource.getType(),
+          targetDatasource.getDestinationName(),
           ingestionGranularity,
           DruidSqlParserUtils.resolveClusteredByColumnsToOutputColumns(sqlNode.getClusteredBy(), rootQueryRel.fields),
           replaceIntervals

--- a/sql/src/main/java/org/apache/druid/sql/destination/ExportDestination.java
+++ b/sql/src/main/java/org/apache/druid/sql/destination/ExportDestination.java
@@ -46,7 +46,7 @@ public class ExportDestination implements IngestDestination
   }
 
   @Override
-  public String getType()
+  public String getDestinationName()
   {
     return TYPE_KEY;
   }

--- a/sql/src/main/java/org/apache/druid/sql/destination/IngestDestination.java
+++ b/sql/src/main/java/org/apache/druid/sql/destination/IngestDestination.java
@@ -29,5 +29,5 @@ import org.apache.druid.guice.annotations.UnstableApi;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public interface IngestDestination
 {
-  String getType();
+  String getDestinationName();
 }

--- a/sql/src/main/java/org/apache/druid/sql/destination/TableDestination.java
+++ b/sql/src/main/java/org/apache/druid/sql/destination/TableDestination.java
@@ -41,7 +41,7 @@ public class TableDestination implements IngestDestination
   }
 
   @Override
-  public String getType()
+  public String getDestinationName()
   {
     return tableName;
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteInsertDmlTest.java
@@ -663,7 +663,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
     skipVectorize();
 
     final String resources = "[{\"name\":\"dst\",\"type\":\"DATASOURCE\"},{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"floor_m1\",\"dim1\",\"CEIL(\\\"m2\\\")\"]}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"dst\",\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"floor_m1\",\"dim1\",\"CEIL(\\\"m2\\\")\"]}";
 
     final String sql = "EXPLAIN PLAN FOR INSERT INTO druid.dst "
                        + "SELECT __time, FLOOR(m1) as floor_m1, dim1, CEIL(m2) as ceil_m2 FROM foo "
@@ -768,7 +768,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
     skipVectorize();
 
     final String resources = "[{\"name\":\"EXTERNAL\",\"type\":\"EXTERNAL\"},{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},\"partitionedBy\":{\"type\":\"all\"},\"clusteredBy\":[\"namespace\",\"country\"]}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"foo\",\"partitionedBy\":{\"type\":\"all\"},\"clusteredBy\":[\"namespace\",\"country\"]}";
 
     final String sql = "EXPLAIN PLAN FOR\n"
                        + "INSERT INTO \"foo\"\n"
@@ -866,7 +866,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
     skipVectorize();
 
     final String resources = "[{\"name\":\"EXTERNAL\",\"type\":\"EXTERNAL\"},{\"name\":\"my_table\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"my_table\"},\"partitionedBy\":\"HOUR\",\"clusteredBy\":[\"__time\",\"isRobotAlias\",\"countryCapital\",\"regionName\"]}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"my_table\",\"partitionedBy\":\"HOUR\",\"clusteredBy\":[\"__time\",\"isRobotAlias\",\"countryCapital\",\"regionName\"]}";
 
     final String sql = "EXPLAIN PLAN FOR\n"
                        + "INSERT INTO my_table\n"
@@ -1273,7 +1273,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
         + "}]";
 
     final String resources = "[{\"name\":\"EXTERNAL\",\"type\":\"EXTERNAL\"},{\"name\":\"dst\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":{\"type\":\"all\"}}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"dst\",\"partitionedBy\":{\"type\":\"all\"}}";
 
     // Use testQuery for EXPLAIN (not testIngestionQuery).
     testQuery(
@@ -1378,7 +1378,7 @@ public class CalciteInsertDmlTest extends CalciteIngestionDmlTest
         + "}]";
 
     final String resources = "[{\"name\":\"dst\",\"type\":\"DATASOURCE\"},{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"floor_m1\",\"dim1\",\"CEIL(\\\"m2\\\")\"]}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"dst\",\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"floor_m1\",\"dim1\",\"CEIL(\\\"m2\\\")\"]}";
 
     // Use testQuery for EXPLAIN (not testIngestionQuery).
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteReplaceDmlTest.java
@@ -661,7 +661,7 @@ public class CalciteReplaceDmlTest extends CalciteIngestionDmlTest
                 + "\"columnMappings\":[{\"queryColumn\":\"x\",\"outputColumn\":\"x\"},{\"queryColumn\":\"y\",\"outputColumn\":\"y\"},{\"queryColumn\":\"z\",\"outputColumn\":\"z\"}]}]";
 
     final String resources = "[{\"name\":\"EXTERNAL\",\"type\":\"EXTERNAL\"},{\"name\":\"dst\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":{\"type\":\"all\"},\"replaceTimeChunks\":\"all\"}";
+    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":\"dst\",\"partitionedBy\":{\"type\":\"all\"},\"replaceTimeChunks\":\"all\"}";
 
     // Use testQuery for EXPLAIN (not testIngestionQuery).
     testQuery(
@@ -741,7 +741,7 @@ public class CalciteReplaceDmlTest extends CalciteIngestionDmlTest
 
     final String explanation = "[{\"query\":{\"queryType\":\"scan\",\"dataSource\":{\"type\":\"table\",\"name\":\"foo\"},\"intervals\":{\"type\":\"intervals\",\"intervals\":[\"-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z\"]},\"resultFormat\":\"compactedList\",\"orderBy\":[{\"columnName\":\"dim1\",\"order\":\"ascending\"}],\"columns\":[\"__time\",\"cnt\",\"dim1\",\"dim2\",\"dim3\",\"m1\",\"m2\",\"unique_dim1\"],\"legacy\":false,\"context\":{\"sqlInsertSegmentGranularity\":\"\\\"DAY\\\"\",\"sqlQueryId\":\"dummy\",\"sqlReplaceTimeChunks\":\"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z\",\"vectorize\":\"false\",\"vectorizeVirtualColumns\":\"false\"},\"columnTypes\":[\"LONG\",\"LONG\",\"STRING\",\"STRING\",\"STRING\",\"FLOAT\",\"DOUBLE\",\"COMPLEX<hyperUnique>\"],\"granularity\":{\"type\":\"all\"}},\"signature\":[{\"name\":\"__time\",\"type\":\"LONG\"},{\"name\":\"dim1\",\"type\":\"STRING\"},{\"name\":\"dim2\",\"type\":\"STRING\"},{\"name\":\"dim3\",\"type\":\"STRING\"},{\"name\":\"cnt\",\"type\":\"LONG\"},{\"name\":\"m1\",\"type\":\"FLOAT\"},{\"name\":\"m2\",\"type\":\"DOUBLE\"},{\"name\":\"unique_dim1\",\"type\":\"COMPLEX<hyperUnique>\"}],\"columnMappings\":[{\"queryColumn\":\"__time\",\"outputColumn\":\"__time\"},{\"queryColumn\":\"dim1\",\"outputColumn\":\"dim1\"},{\"queryColumn\":\"dim2\",\"outputColumn\":\"dim2\"},{\"queryColumn\":\"dim3\",\"outputColumn\":\"dim3\"},{\"queryColumn\":\"cnt\",\"outputColumn\":\"cnt\"},{\"queryColumn\":\"m1\",\"outputColumn\":\"m1\"},{\"queryColumn\":\"m2\",\"outputColumn\":\"m2\"},{\"queryColumn\":\"unique_dim1\",\"outputColumn\":\"unique_dim1\"}]}]";
     final String resources = "[{\"name\":\"dst\",\"type\":\"DATASOURCE\"},{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"dim1\"],\"replaceTimeChunks\":\"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z\"}";
+    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":\"dst\",\"partitionedBy\":\"DAY\",\"clusteredBy\":[\"dim1\"],\"replaceTimeChunks\":\"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z\"}";
 
     final String sql = "EXPLAIN PLAN FOR"
                        + " REPLACE INTO dst"
@@ -845,7 +845,7 @@ public class CalciteReplaceDmlTest extends CalciteIngestionDmlTest
                                + "{\"queryColumn\":\"dim2\",\"outputColumn\":\"dim2\"},{\"queryColumn\":\"dim3\",\"outputColumn\":\"dim3\"},{\"queryColumn\":\"cnt\",\"outputColumn\":\"cnt\"},"
                                + "{\"queryColumn\":\"m1\",\"outputColumn\":\"m1\"},{\"queryColumn\":\"m2\",\"outputColumn\":\"m2\"},{\"queryColumn\":\"unique_dim1\",\"outputColumn\":\"unique_dim1\"}]}]";
     final String resources = "[{\"name\":\"dst\",\"type\":\"DATASOURCE\"},{\"name\":\"foo\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":\"HOUR\","
+    final String attributes = "{\"statementType\":\"REPLACE\",\"targetDataSource\":\"dst\",\"partitionedBy\":\"HOUR\","
                               + "\"clusteredBy\":[\"__time\",\"dim1\",\"dim3\",\"dim2\"],\"replaceTimeChunks\":\"2000-01-01T00:00:00.000Z/2000-01-02T00:00:00.000Z\"}";
 
     final String sql = "EXPLAIN PLAN FOR"

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestTableFunctionTest.java
@@ -322,7 +322,7 @@ public class IngestTableFunctionTest extends CalciteIngestionDmlTest
         "\"signature\":[{\"name\":\"x\",\"type\":\"STRING\"},{\"name\":\"y\",\"type\":\"STRING\"},{\"name\":\"z\",\"type\":\"LONG\"}]," +
         "\"columnMappings\":[{\"queryColumn\":\"x\",\"outputColumn\":\"x\"},{\"queryColumn\":\"y\",\"outputColumn\":\"y\"},{\"queryColumn\":\"z\",\"outputColumn\":\"z\"}]}]";
     final String resources = "[{\"name\":\"EXTERNAL\",\"type\":\"EXTERNAL\"},{\"name\":\"dst\",\"type\":\"DATASOURCE\"}]";
-    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"dst\"},\"partitionedBy\":{\"type\":\"all\"}}";
+    final String attributes = "{\"statementType\":\"INSERT\",\"targetDataSource\":\"dst\",\"partitionedBy\":{\"type\":\"all\"}}";
 
     testQuery(
         PLANNER_CONFIG_NATIVE_QUERY_EXPLAIN,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/TestInsertQueryMaker.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/TestInsertQueryMaker.java
@@ -55,7 +55,7 @@ public class TestInsertQueryMaker implements QueryMaker
 
     // 2) Return the dataSource and signature of the insert operation, so tests can confirm they are correct.
     return QueryResponse.withEmptyContext(
-        Sequences.simple(ImmutableList.of(new Object[]{destination.getType(), signature}))
+        Sequences.simple(ImmutableList.of(new Object[]{destination.getDestinationName(), signature}))
     );
   }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/ExplainAttributesTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/ExplainAttributesTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.sql.destination.TableDestination;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -65,14 +64,14 @@ public class ExplainAttributesTest
   {
     ExplainAttributes insertAttributes = new ExplainAttributes(
         "INSERT",
-        new TableDestination("foo"),
+        "foo",
         Granularities.DAY,
         null,
         null
     );
     final String expectedAttributes = "{"
                                       + "\"statementType\":\"INSERT\","
-                                      + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
+                                      + "\"targetDataSource\":\"foo\","
                                       + "\"partitionedBy\":\"DAY\""
                                       + "}";
     Assert.assertEquals(expectedAttributes, DEFAULT_OBJECT_MAPPER.writeValueAsString(insertAttributes));
@@ -83,14 +82,14 @@ public class ExplainAttributesTest
   {
     ExplainAttributes insertAttributes = new ExplainAttributes(
         "INSERT",
-        new TableDestination("foo"),
+        "foo",
         Granularities.ALL,
         null,
         null
     );
     final String expectedAttributes = "{"
                                       + "\"statementType\":\"INSERT\","
-                                      + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
+                                      + "\"targetDataSource\":\"foo\","
                                       + "\"partitionedBy\":{\"type\":\"all\"}"
                                       + "}";
     Assert.assertEquals(expectedAttributes, DEFAULT_OBJECT_MAPPER.writeValueAsString(insertAttributes));
@@ -101,33 +100,33 @@ public class ExplainAttributesTest
   {
     ExplainAttributes replaceAttributes1 = new ExplainAttributes(
         "REPLACE",
-        new TableDestination("foo"),
+        "foo",
         Granularities.HOUR,
         null,
         "ALL"
     );
     final String expectedAttributes1 = "{"
-        + "\"statementType\":\"REPLACE\","
-        + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
-        + "\"partitionedBy\":\"HOUR\","
-        + "\"replaceTimeChunks\":\"ALL\""
-        + "}";
+                                       + "\"statementType\":\"REPLACE\","
+                                       + "\"targetDataSource\":\"foo\","
+                                       + "\"partitionedBy\":\"HOUR\","
+                                       + "\"replaceTimeChunks\":\"ALL\""
+                                       + "}";
     Assert.assertEquals(expectedAttributes1, DEFAULT_OBJECT_MAPPER.writeValueAsString(replaceAttributes1));
 
 
     ExplainAttributes replaceAttributes2 = new ExplainAttributes(
         "REPLACE",
-        new TableDestination("foo"),
+        "foo",
         Granularities.HOUR,
         null,
         "2019-08-25T02:00:00.000Z/2019-08-25T03:00:00.000Z"
     );
     final String expectedAttributes2 = "{"
-                                      + "\"statementType\":\"REPLACE\","
-                                      + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
-                                      + "\"partitionedBy\":\"HOUR\","
-                                      + "\"replaceTimeChunks\":\"2019-08-25T02:00:00.000Z/2019-08-25T03:00:00.000Z\""
-                                      + "}";
+                                       + "\"statementType\":\"REPLACE\","
+                                       + "\"targetDataSource\":\"foo\","
+                                       + "\"partitionedBy\":\"HOUR\","
+                                       + "\"replaceTimeChunks\":\"2019-08-25T02:00:00.000Z/2019-08-25T03:00:00.000Z\""
+                                       + "}";
     Assert.assertEquals(expectedAttributes2, DEFAULT_OBJECT_MAPPER.writeValueAsString(replaceAttributes2));
   }
 
@@ -136,14 +135,14 @@ public class ExplainAttributesTest
   {
     ExplainAttributes replaceAttributes1 = new ExplainAttributes(
         "REPLACE",
-        new TableDestination("foo"),
+        "foo",
         Granularities.HOUR,
         Arrays.asList("foo", "CEIL(`f2`)"),
         "ALL"
     );
     final String expectedAttributes1 = "{"
                                        + "\"statementType\":\"REPLACE\","
-                                       + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
+                                       + "\"targetDataSource\":\"foo\","
                                        + "\"partitionedBy\":\"HOUR\","
                                        + "\"clusteredBy\":[\"foo\",\"CEIL(`f2`)\"],"
                                        + "\"replaceTimeChunks\":\"ALL\""
@@ -153,14 +152,14 @@ public class ExplainAttributesTest
 
     ExplainAttributes replaceAttributes2 = new ExplainAttributes(
         "REPLACE",
-        new TableDestination("foo"),
+        "foo",
         Granularities.HOUR,
         Arrays.asList("foo", "boo"),
         "2019-08-25T02:00:00.000Z/2019-08-25T03:00:00.000Z"
     );
     final String expectedAttributes2 = "{"
                                        + "\"statementType\":\"REPLACE\","
-                                       + "\"targetDataSource\":{\"type\":\"table\",\"tableName\":\"foo\"},"
+                                       + "\"targetDataSource\":\"foo\","
                                        + "\"partitionedBy\":\"HOUR\","
                                        + "\"clusteredBy\":[\"foo\",\"boo\"],"
                                        + "\"replaceTimeChunks\":\"2019-08-25T02:00:00.000Z/2019-08-25T03:00:00.000Z\""


### PR DESCRIPTION
Reverts a change made to explain attributes made by https://github.com/apache/druid/pull/15689. This will maintain backward compatibility. 
The `targetDataSource` attribute is changed to return a string containing the datasources name, or "extern" if the query is an export.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
