### PR TITLE
Update docs to document breaking change in explain attributes

### DIFF
--- a/docs/querying/sql-translation.md
+++ b/docs/querying/sql-translation.md
@@ -71,7 +71,7 @@ EXPLAIN PLAN statements return:
 - a `RESOURCES` column that describes the resources used in the query
 - an `ATTRIBUTES` column that describes the attributes of the query, including:
   - `statementType`: the SQL statement type
-  - `targetDataSource`: the target datasource in an INSERT or REPLACE statement
+  - `targetDataSource`: a JSON object representing the target datasource in an INSERT or REPLACE statement.
   - `partitionedBy`: the time-based partitioning granularity in an INSERT or REPLACE statement
   - `clusteredBy`: the clustering columns in an INSERT or REPLACE statement
   - `replaceTimeChunks`: the time chunks in a REPLACE statement

--- a/docs/querying/sql-translation.md
+++ b/docs/querying/sql-translation.md
@@ -71,7 +71,7 @@ EXPLAIN PLAN statements return:
 - a `RESOURCES` column that describes the resources used in the query
 - an `ATTRIBUTES` column that describes the attributes of the query, including:
   - `statementType`: the SQL statement type
-  - `targetDataSource`: a JSON object representing the target datasource in an INSERT or REPLACE statement.
+  - `targetDataSource`: a JSON object representing the target datasource in an INSERT or REPLACE statement
   - `partitionedBy`: the time-based partitioning granularity in an INSERT or REPLACE statement
   - `clusteredBy`: the clustering columns in an INSERT or REPLACE statement
   - `replaceTimeChunks`: the time chunks in a REPLACE statement
@@ -444,7 +444,10 @@ The above EXPLAIN PLAN returns the following result:
   ],
   {
     "statementType": "INSERT",
-    "targetDataSource": "wikipedia",
+    "targetDataSource": {
+      "type":"table",
+      "tableName":"wikipedia"
+    },
     "partitionedBy": {
       "type": "all"
     }
@@ -665,7 +668,10 @@ The above EXPLAIN PLAN query returns the following result:
   ],
   {
     "statementType": "REPLACE",
-    "targetDataSource": "wikipedia",
+    "targetDataSource": {
+      "type":"table",
+      "tableName":"wikipedia"
+    },
     "partitionedBy": "DAY",
     "clusteredBy": ["cityName","countryName"],
     "replaceTimeChunks": "all"

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -57,6 +57,12 @@ For tips about how to write a good release note, see [Release notes](https://git
 
 This section contains important information about new and existing features.
 
+### Breaking change
+
+Druid 29 has a breaking change for EXPLAIN queries.
+In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object.
+This change is only present in Druid 29 and is not present in earlier or later versions.
+
 ### MSQ export statements (experimental)
 
 Druid 29.0.0 adds experimental support for export statements to the MSQ task engine. This allows query tasks to write data to an external destination through the [`EXTERN` function](https://druid.apache.org/docs/latest/multi-stage-query/reference#extern-function).

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -59,9 +59,32 @@ This section contains important information about new and existing features.
 
 ### Breaking change
 
-Druid 29 has a breaking change for EXPLAIN queries.
+Druid 29 has a breaking change for EXPLAIN for INSERT/REPLACE MSQ queries.
 In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object.
 This change is only present in Druid 29 and is not present in earlier or later versions.
+
+The JSON object returned plan will have the structure if the target is a datasource:
+```json
+    ...,
+    "targetDataSource": {
+      "type":"table",
+      "tableName":"wikipedia"
+    },
+    ...
+```
+
+The JSON object returned plan will have the structure if the target is an external export location using :
+```json
+    ...,
+    "targetDataSource": {
+      "type":"external",
+      "storageConnectorProvider": {
+        "type":"<export-type>",
+        "exportPath":"<export-path>"
+      }
+    },
+    ...
+```
 
 ### MSQ export statements (experimental)
 

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -57,35 +57,6 @@ For tips about how to write a good release note, see [Release notes](https://git
 
 This section contains important information about new and existing features.
 
-### Breaking change
-
-Druid 29 has a breaking change for EXPLAIN for INSERT/REPLACE MSQ queries.
-In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object.
-This change is only present in Druid 29 and is not present in earlier or later versions.
-
-The JSON object returned plan will have the structure if the target is a datasource:
-```json
-    ...,
-    "targetDataSource": {
-      "type":"table",
-      "tableName":"wikipedia"
-    },
-    ...
-```
-
-The JSON object returned plan will have the structure if the target is an external export location using :
-```json
-    ...,
-    "targetDataSource": {
-      "type":"external",
-      "storageConnectorProvider": {
-        "type":"<export-type>",
-        "exportPath":"<export-path>"
-      }
-    },
-    ...
-```
-
 ### MSQ export statements (experimental)
 
 Druid 29.0.0 adds experimental support for export statements to the MSQ task engine. This allows query tasks to write data to an external destination through the [`EXTERN` function](https://druid.apache.org/docs/latest/multi-stage-query/reference#extern-function).
@@ -583,6 +554,35 @@ Improved the Iceberg extension as follows:
 ## Upgrade notes and incompatible changes
 
 ### Upgrade notes
+
+#### Changes in `targetDataSource` payload present in the explain plan for MSQ queries
+
+Druid 29 has a breaking change for EXPLAIN for INSERT/REPLACE MSQ queries.
+In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object.
+This change is only present in Druid 29 and is not present in earlier or later versions.
+
+The JSON object returned plan will have the structure if the target is a datasource:
+```json
+{
+  "targetDataSource": {
+    "type": "table",
+    "tableName": "wikipedia"
+  }
+}
+```
+
+The JSON object returned plan will have the structure if the target is an external export location using :
+```json
+{
+  "targetDataSource": {
+    "type": "external",
+    "storageConnectorProvider": {
+      "type": "<export-type>",
+      "exportPath": "<export-path>"
+    }
+  }
+}
+```
 
 #### Changed `equals` filter for native queries
 

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -30,9 +30,9 @@ For the full release notes for a specific version, see the [releases page](https
 
 ### Upgrade notes
 
-### Breaking change
+#### Changes in `targetDataSource` payload present in the explain plan for MSQ queries
 
-- Druid 29 has a breaking change for EXPLAIN queries. In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object. This change is only present in Druid 29 and is not present in earlier or later versions.
+In the attribute field returned as part of the result for an EXPLAIN MSQ query, the value of the key `targetDataSource` from a string to a JSON object. This change is only present in Druid 29 and is not present in earlier or later versions.
 
 #### Changed `equals` filter for native queries
 

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -30,6 +30,10 @@ For the full release notes for a specific version, see the [releases page](https
 
 ### Upgrade notes
 
+### Breaking change
+
+- Druid 29 has a breaking change for EXPLAIN queries. In the attribute field returned as part of the result for an explain query, the value of the key `targetDataSource` from a string to a JSON object. This change is only present in Druid 29 and is not present in earlier or later versions.
+
 #### Changed `equals` filter for native queries
 
 The [equality filter](https://druid.apache.org/docs/latest/querying/filters#equality-filter) on mixed type `auto` columns that contain arrays must now be filtered as their presenting type. This means that if any rows are arrays (for example, the segment metadata and `information_schema` reports the type as some array type), then the native queries must also filter as if they are some array type.


### PR DESCRIPTION
Updates the docs to include a breaking change made regarding the attributes returned by an explain query. The return type of the field `targetDataSource` was changed to an object instead of a string containing the data source name.


This change is only present in Druid 29, and not in future versions, so it has been documented here. The change has been reverted in future versions here: https://github.com/apache/druid/pull/16004
