### PR TITLE
Pull up literals in InputAccessor

### DIFF
--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -1330,6 +1330,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
                 + " group by 1,2"
         )
         .expectedResults(
+            ResultMatchMode.RELAX_NULLS,
             ImmutableList.of(
                 new Object[] {null, "a", 1L},
                 new Object[] {"1.0", "a", 1L},

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -32,7 +32,6 @@ import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.Druids;
-import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryDataSource;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -1325,11 +1324,17 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
   {
     // this query was not planable: https://github.com/apache/druid/issues/15353
     testBuilder()
-        .queryContext(ImmutableMap.of(QueryContexts.ENABLE_DEBUG, true))
         .sql(
             "SELECT d1,dim2,APPROX_COUNT_DISTINCT_DS_HLL(dim2, 18) as val"
                 + " FROM (select d1,dim1,dim2 from druid.foo group by d1,dim1,dim2 order by dim1 limit 3) t "
                 + " group by 1,2"
+        )
+        .expectedResults(
+            ImmutableList.of(
+                new Object[] {null, "a", 1L},
+                new Object[] {"1.0", "a", 1L},
+                new Object[] {"1.7", null, 0L}
+            )
         )
         .run();
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -591,10 +591,9 @@ public class DruidQuery
           virtualColumnRegistry,
           rexBuilder,
           InputAccessor.buildFor(
-              rexBuilder,
-              rowSignature,
+              aggregate,
               partialQuery.getSelectProject(),
-              null),
+              rowSignature),
           aggregations,
           aggName,
           aggCall,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/InputAccessor.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/InputAccessor.java
@@ -20,12 +20,17 @@
 package org.apache.druid.sql.calcite.rel;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.Window;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.sql.calcite.expression.Expressions;
+import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -38,43 +43,67 @@ import java.util.stream.Collectors;
  */
 public class InputAccessor
 {
-  private final Project project;
-  private final ImmutableList<RexLiteral> constants;
-  private final RexBuilder rexBuilder;
+  private final RelNode relNode;
+  @Nullable
+  private final Project flattenedProject;
   private final RowSignature inputRowSignature;
+  @Nullable
+  private final ImmutableList<RexLiteral> constants;
+  private final RelNode inputRelNode;
+  private final RelDataType inputRelRowType;
+  private final RelOptPredicateList predicates;
   private final int inputFieldCount;
+  private final RelDataType inputDruidRowType;
 
   public static InputAccessor buildFor(
-      RexBuilder rexBuilder,
-      RowSignature inputRowSignature,
-      @Nullable Project project,
-      @Nullable ImmutableList<RexLiteral> constants)
+      RelNode relNode,
+      @Nullable Project flattenedProject,
+      RowSignature rowSignature)
   {
-    return new InputAccessor(rexBuilder, inputRowSignature, project, constants);
+    return new InputAccessor(
+        relNode,
+        flattenedProject,
+        rowSignature
+    );
   }
 
   private InputAccessor(
-      RexBuilder rexBuilder,
-      RowSignature inputRowSignature,
-      Project project,
-      ImmutableList<RexLiteral> constants)
+      RelNode relNode,
+      Project flattenedProject,
+      RowSignature rowSignature)
   {
-    this.rexBuilder = rexBuilder;
-    this.inputRowSignature = inputRowSignature;
-    this.project = project;
-    this.constants = constants;
-    this.inputFieldCount = project != null ? project.getRowType().getFieldCount() : inputRowSignature.size();
+    this.relNode = relNode;
+    this.constants = getConstants(relNode);
+    this.inputRelNode = relNode.getInput(0).stripped();
+    this.flattenedProject = flattenedProject;
+    this.inputRowSignature = rowSignature;
+    this.inputRelRowType = inputRelNode.getRowType();
+    this.predicates = relNode.getCluster().getMetadataQuery().getPulledUpPredicates(inputRelNode);
+    this.inputFieldCount = inputRelRowType.getFieldCount();
+    this.inputDruidRowType = RowSignatures.toRelDataType(inputRowSignature, getRexBuilder().getTypeFactory());
+  }
+
+  private ImmutableList<RexLiteral> getConstants(RelNode relNode)
+  {
+    if (relNode instanceof Window) {
+      return ((Window) relNode).constants;
+    }
+    return null;
   }
 
   public RexNode getField(int argIndex)
   {
-
     if (argIndex < inputFieldCount) {
-      return Expressions.fromFieldAccess(
-          rexBuilder.getTypeFactory(),
-          inputRowSignature,
-          project,
-          argIndex);
+      RexInputRef inputRef = RexInputRef.of(argIndex, inputRelRowType);
+      RexNode constant = predicates.constantMap.get(inputRef);
+      if (constant != null) {
+        return constant;
+      }
+      if (flattenedProject != null) {
+        return flattenedProject.getProjects().get(argIndex);
+      } else {
+        return RexInputRef.of(argIndex, inputDruidRowType);
+      }
     } else {
       return constants.get(argIndex - inputFieldCount);
     }
@@ -90,18 +119,17 @@ public class InputAccessor
 
   public @Nullable Project getProject()
   {
-    return project;
+    return flattenedProject;
   }
-
 
   public RexBuilder getRexBuilder()
   {
-    return rexBuilder;
+    return relNode.getCluster().getRexBuilder();
   }
-
 
   public RowSignature getInputRowSignature()
   {
     return inputRowSignature;
   }
+
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Windowing.java
@@ -180,10 +180,9 @@ public class Windowing
               virtualColumnRegistry,
               rexBuilder,
               InputAccessor.buildFor(
-                  rexBuilder,
-                  sourceRowSignature,
+                  window,
                   partialQuery.getSelectProject(),
-                  window.constants),
+                  sourceRowSignature),
               Collections.emptyList(),
               aggName,
               aggregateCall,


### PR DESCRIPTION
* pull up literals in `InputAccessor`
* remove the need to pass `constants` of `Window`  operator

Fixes #15353


This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
