### PR TITLE
Make servedSegments nullable to maintain compatibility

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/SegmentsInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/SegmentsInputSlice.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.druid.msq.input.InputSlice;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 
@@ -50,7 +51,7 @@ public class SegmentsInputSlice implements InputSlice
   public SegmentsInputSlice(
       @JsonProperty("dataSource") String dataSource,
       @JsonProperty("segments") List<RichSegmentDescriptor> descriptors,
-      @JsonProperty("servedSegments") List<DataServerRequestDescriptor> servedSegments
+      @JsonProperty("servedSegments") @Nullable List<DataServerRequestDescriptor> servedSegments
   )
   {
     this.dataSource = dataSource;
@@ -71,6 +72,7 @@ public class SegmentsInputSlice implements InputSlice
   }
 
   @JsonProperty("servedSegments")
+  @Nullable
   public List<DataServerRequestDescriptor> getServedSegments()
   {
     return servedSegments;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/SegmentsInputSlice.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/table/SegmentsInputSlice.java
@@ -20,6 +20,7 @@
 package org.apache.druid.msq.input.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.druid.msq.input.InputSlice;
@@ -71,8 +72,9 @@ public class SegmentsInputSlice implements InputSlice
     return descriptors;
   }
 
-  @JsonProperty("servedSegments")
   @Nullable
+  @JsonProperty("servedSegments")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   public List<DataServerRequestDescriptor> getServedSegments()
   {
     return servedSegments;

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
@@ -84,7 +84,19 @@ public class SegmentsInputSliceTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    final SegmentsInputSlice slice = new SegmentsInputSlice(
+    final String sliceString = "{\n"
+                               + "    \"type\": \"segments\","
+                               + "    \"dataSource\": \"myds\",\n"
+                               + "    \"segments\": [\n"
+                               + "        {\n"
+                               + "            \"itvl\": \"2000-01-01T00:00:00.000Z/2000-02-01T00:00:00.000Z\",\n"
+                               + "            \"ver\": \"1\",\n"
+                               + "            \"part\": 0\n"
+                               + "        }\n"
+                               + "    ]\n"
+                               + "}";
+
+    final SegmentsInputSlice expectedSlice = new SegmentsInputSlice(
         "myds",
         ImmutableList.of(
             new RichSegmentDescriptor(
@@ -98,8 +110,8 @@ public class SegmentsInputSliceTest
     );
 
     Assert.assertEquals(
-        slice,
-        mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
+        expectedSlice,
+        mapper.readValue(sliceString, InputSlice.class)
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/table/SegmentsInputSliceTest.java
@@ -79,6 +79,31 @@ public class SegmentsInputSliceTest
   }
 
   @Test
+  public void testSerde2() throws Exception
+  {
+    final ObjectMapper mapper = TestHelper.makeJsonMapper()
+                                          .registerModules(new MSQIndexingModule().getJacksonModules());
+
+    final SegmentsInputSlice slice = new SegmentsInputSlice(
+        "myds",
+        ImmutableList.of(
+            new RichSegmentDescriptor(
+                Intervals.of("2000/P1M"),
+                Intervals.of("2000/P1M"),
+                "1",
+                0
+            )
+        ),
+        null
+    );
+
+    Assert.assertEquals(
+        slice,
+        mapper.readValue(mapper.writeValueAsString(slice), InputSlice.class)
+    );
+  }
+
+  @Test
   public void testEquals()
   {
     EqualsVerifier.forClass(SegmentsInputSlice.class).usingGetClass().verify();


### PR DESCRIPTION
This marks `servedSegments` as `Nullable` to make it backward compatible with older workers and controllers in the case of a rolling upgrade. Null checks are also added to where these values are used in the code.