### PR TITLE
Fix bug with cancelling pending tasks when running kubernetes ingestion.

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -263,11 +263,14 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
       return;
     }
 
+    workItem.shutdown();
+    if (!workItem.getResult().isDone()) {
+      return;
+    }
     synchronized (tasks) {
       tasks.remove(taskid);
     }
-
-    workItem.shutdown();
+    
   }
 
   @Override

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
@@ -61,7 +61,7 @@ public class KubernetesPeonClient
     this.emitter = emitter;
   }
 
-  public Pod launchPeonJobAndWaitForStart(Job job, Task task, long howLong, TimeUnit timeUnit)
+  public Pod launchPeonJobAndWaitForStart(Job job, Task task, long howLong, TimeUnit timeUnit) throws IllegalStateException
   {
     long start = System.currentTimeMillis();
     // launch job
@@ -74,12 +74,15 @@ public class KubernetesPeonClient
       Pod result = client.pods().inNamespace(namespace).withName(mainPod.getMetadata().getName())
                          .waitUntilCondition(pod -> {
                            if (pod == null) {
-                             return false;
+                             return true;
                            }
                            return pod.getStatus() != null && pod.getStatus().getPodIP() != null;
                          }, howLong, timeUnit);
+      
+      if (result == null) {
+        throw new IllegalStateException("K8s pod for the task [%s] appeared and disappeared. It can happen if the task was canceled");
+      }
       long duration = System.currentTimeMillis() - start;
-      log.info("Took task %s %d ms for pod to startup", jobName, duration);
       emitK8sPodMetrics(task, "k8s/peon/startup/time", duration);
       return result;
     });

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -94,7 +93,7 @@ public class KubernetesPeonClientTest
   }
 
   @Test
-  void test_launchPeonJobAndWaitForStart_withDisappearingPod_throwsKubernetesClientTimeoutException()
+  void test_launchPeonJobAndWaitForStart_withDisappearingPod_throwIllegalStateExceptionn()
   {
     Job job = new JobBuilder()
         .withNewMetadata()
@@ -115,7 +114,7 @@ public class KubernetesPeonClientTest
         ).once();
 
     Assertions.assertThrows(
-        KubernetesClientTimeoutException.class,
+        IllegalStateException.class,
         () -> instance.launchPeonJobAndWaitForStart(job, NoopTask.create(), 1, TimeUnit.SECONDS)
     );
   }


### PR DESCRIPTION
Fixes a bug that can occur when running kubernetes ingestion if a task is cancelled when the job has been created but the pod is still pending.

### Description
Currently, the KubernetesPeonClient.launchPeonJobAndWaitForStart method will treat a job as pending if the corresponding pod has dissapeared and wait until its pod startup timeout before exiting with a timeout.

This behavior is incorrect because right before the wait condition, we run getPeonPodWithRetries(jobName), which only returns when the pod has been created. the wait logic is supposed to wait until the pod has been assigned an IP, but if the pod has disappeared when we have already seen it appear, we should not keep waiting since that indicates something has happened to the pod.

A manifestation of this bad behavior is the error described above, where a task is cancelled but the task runner thread waits in launchPeonJobAndWaitForStart and only exits once its timeout has completed. 

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

The fix to the immediate bug is pretty straightforward, to have the wait for pod IP logic actually exit with a exception when the pod has disappeared instead of looping waiting for a pod that will never appear.

I think there is another deeper problem with this logic though, which is that it is generally possible for the kubernetes task runner threads/underlying Kubernetes jobs to hang around waiting while the TaskQueue (which is ultimately responsible for the source of truth of tasks) is unaware of them.

(background)
- TaskQueue calls KubernetesTaskRunner.getKnownTasks to get the list of tasks that the runner knows are running, then compares this list with its internal state (normally in the metadata DB) and tries to keep the two synced up by issuing run/shutdown calls to the task runner until the states match. in KubernetesTaskRunner, the getKnownTasks checks the tasks map.
- When TaskQueue calls KubernetesTaskRunner.run, the runner adds the task to the tasks map, then submits a task to ListeningExecutorService which will eventually assign a thread to submit the task to kubernetes as a Job, wait for the job to complete, and then report success.
- When TaskQueue calls KubernetesTaskRunner.shutdown, the runner shuts down the Kubernetes job and then removes the task from the tasks map, but expects the ListeningExecutorService thread to exit itself when it sees that the kubernetes job has been deleted.

(the problem)
the problem here is that as soon as shutdown is called, the task is removed from the map and no longer returned in getKnownTasks. As far as the taskQueue is concerned, the task is completed and it doesn't need to think about it anymore.

this assumption is fine when tasks run to completion, because the ListeningExecutorService thread completing the task run future is the thing that actually tells TaskQueue that the task is completed and it can call shutdown on the task. in this case everything happens in the order we want it to (ListeningExecutorService thread exits -> taskQueue sees task is complete -> task runner cleans up task)

this assumption doesn't always work when tasks are cancelled, because the TaskQueue itself initiates the shutdown, the KubernetesTaskRunner reports the task as shutdown, then expects the ListeningExecutorService thread to exit. However, there is nothing actually making sure that the thread will exit properly here. This bug (where the thread waits on the disappeared pod), is a example of undefined behavior by the thread. 

There are other race conditions possible where the thread is running the code to spin up the job, but before the job is created, the task is cancelled and reported as shutdown by the KubernetesTaskRunner, and then the thread subsequently creates the job and starts running in the background even though druid thinks the task has completed.

To work around this, I think KubernetesTaskRunner should not remove the task from the tasks map (aka inform TaskQueue that the task is shutdown), until the underlying executor thread has actually completed the task run future.

In the normal task run case, this doesn't change anything since the normal behavior is executor thread finishes task run future -> task queue notices -> shutdown KubernetesTaskRunner (the future would obviously already be completed at this point since it kicks off the whole process).

In the task cancellation case, the first shutdown call would delete the k8s job but not remove the task from the tasks map. the next time the task queue runs its internal management loop, it would see the task still being reported in getKnownTasks and issue another shutdown call. at this point the future should have completed and the task should be removed from the tasks map.

in the case of the wait for disappeared bug, this wouldn't actually have helped, since the future would have been still running forever and taskQueue would have periodically issued shutdown calls that did nothing (that bug still needs to be fixed directly).

in the case of a race condition, the job would actually get shutdown by TaskQueue since it would see the future still running, so we wouldn't have a errant job running. in general i think this behavior (don't report a task as done until the task runner is sure its done) makes more sense too

#### Release note
Fix scheduling bugs with Kubernetes ingestion.

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
