### PR TITLE
fix bug with like filter on missing columns not correctly considering extractionFn

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/filter/LikeFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/LikeFilterTest.java
@@ -33,10 +33,12 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.query.extraction.MapLookupExtractor;
 import org.apache.druid.query.extraction.SubstringDimExtractionFn;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.LikeDimFilter;
 import org.apache.druid.query.filter.NotDimFilter;
+import org.apache.druid.query.lookup.LookupExtractionFn;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.column.ColumnType;
@@ -258,6 +260,27 @@ public class LikeFilterTest extends BaseFilterTest
           ImmutableList.of()
       );
     }
+  }
+
+  @Test
+  public void testNonNullableExtractionFnMissingColumn()
+  {
+    final LookupExtractionFn extractionFn = new LookupExtractionFn(
+        new MapLookupExtractor(ImmutableMap.of("foo", "bar"), false),
+        false,
+        "replaced",
+        false,
+        false
+    );
+    final LikeDimFilter filter = new LikeDimFilter("fake", "__DOESNT_EXIST__%", null, extractionFn);
+    assertFilterMatches(
+        filter,
+        ImmutableList.of()
+    );
+    assertFilterMatches(
+        NotDimFilter.of(filter),
+        ImmutableList.of("0", "1", "2", "3", "4", "5", "6")
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixes a bug with `LikeFilter` that can occur when using an `extractionFn` that replaces null values with non-null values, such as a lookup with replace missing values set, and then querying a segment with a missing column. In this case, the query would incorrectly check if the like-matcher matched `null` instead of applying the `extractionFn` which might change `null` to not, and choose the incorrect index for the case.

The added test models this case, and fails without the changes to `LikeFilter`.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
