### PR TITLE
Docs: Fix spelling of 5 GB.

### DIFF
--- a/docs/operations/segment-optimization.md
+++ b/docs/operations/segment-optimization.md
@@ -51,7 +51,7 @@ You may need to consider the followings to optimize your segments.
   doesn't match with the "number of rows per segment", please consider optimizing
   number of rows per segment rather than this value. Note that certain deep storage
   implementations also impose an upper limit on segment size. For example, S3 deep
-  storage imposes an upper limit of 5GB.
+  storage imposes an upper limit of 5 GB.
 
 :::info
  The above recommendation works in general, but the optimal setting can


### PR DESCRIPTION
The spellchecker does not consider "5GB" to be spelled correctly.

This error was introduced in #15938, which I merged even though a check was failing, because the check looked to me like some unrelated issue with npm plugins.