### PR TITLE
fixup!: #15981 Missing completion reports on index_parallel tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -503,7 +503,8 @@ public class CompactionTask extends AbstractBatchIndexTask
 
       int failCnt = 0;
       Map<String, TaskReport> completionReports = new HashMap<>();
-      for (ParallelIndexSupervisorTask eachSpec : indexTaskSpecs) {
+      for (int i = 0; i < indexTaskSpecs.size(); i++) {
+        ParallelIndexSupervisorTask eachSpec = indexTaskSpecs.get(i);
         final String json = toolbox.getJsonMapper().writerWithDefaultPrettyPrinter().writeValueAsString(eachSpec);
         if (!currentSubTaskHolder.setTask(eachSpec)) {
           String errMsg = "Task was asked to stop. Finish as failed.";
@@ -518,9 +519,11 @@ public class CompactionTask extends AbstractBatchIndexTask
               failCnt++;
               log.warn("Failed to run indexSpec: [%s].\nTrying the next indexSpec.", json);
             }
+
+            String reportKeyPrefix = "_" + i;
             Optional.ofNullable(eachSpec.getCompletionReports())
                     .ifPresent(reports -> completionReports.putAll(
-                        CollectionUtils.mapKeys(reports, key -> getReportkey(eachSpec.getBaseSubtaskSpecName(), key))));
+                        CollectionUtils.mapKeys(reports, key -> key + reportKeyPrefix)));
           } else {
             failCnt++;
             log.warn("indexSpec is not ready: [%s].\nTrying the next indexSpec.", json);
@@ -570,11 +573,6 @@ public class CompactionTask extends AbstractBatchIndexTask
   private String createIndexTaskSpecId(int i)
   {
     return StringUtils.format("%s_%d", getId(), i);
-  }
-
-  private String getReportkey(String baseSequenceName, String currentKey)
-  {
-    return StringUtils.format("%s_%s", currentKey, baseSequenceName.substring(baseSequenceName.lastIndexOf('_') + 1));
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -520,10 +520,10 @@ public class CompactionTask extends AbstractBatchIndexTask
               log.warn("Failed to run indexSpec: [%s].\nTrying the next indexSpec.", json);
             }
 
-            String reportKeyPrefix = "_" + i;
+            String reportKeySuffix = "_" + i;
             Optional.ofNullable(eachSpec.getCompletionReports())
                     .ifPresent(reports -> completionReports.putAll(
-                        CollectionUtils.mapKeys(reports, key -> key + reportKeyPrefix)));
+                        CollectionUtils.mapKeys(reports, key -> key + reportKeySuffix)));
           } else {
             failCnt++;
             log.warn("indexSpec is not ready: [%s].\nTrying the next indexSpec.", json);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -170,6 +170,11 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
   private IngestionState ingestionState;
 
   private boolean shouldCleanup;
+
+  // There are cases where index task is not run as a standalone task and the
+  // generated completion reports are written by parent. In such cases, this
+  // flag would be helpful to specify that the child index task should not
+  // publish reports.
   private boolean shouldSendReports;
 
   @MonotonicNonNull

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -174,8 +174,8 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
   // There are cases where index task is not run as a standalone task and the
   // generated completion reports are written by parent. In such cases, this
   // flag would be helpful to specify that the child index task should not
-  // publish reports.
-  private boolean shouldSendReports;
+  // write reports.
+  private boolean shouldWriteReports;
 
   @MonotonicNonNull
   private ParseExceptionHandler determinePartitionsParseExceptionHandler;
@@ -232,7 +232,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
       Map<String, Object> context,
       int maxAllowedLockCount,
       boolean shouldCleanup,
-      boolean shouldSendReports
+      boolean shouldWriteReports
   )
   {
     super(
@@ -248,7 +248,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
     this.ingestionSchema = ingestionSchema;
     this.ingestionState = IngestionState.NOT_STARTED;
     this.shouldCleanup = shouldCleanup;
-    this.shouldSendReports = shouldSendReports;
+    this.shouldWriteReports = shouldWriteReports;
   }
 
   @Override
@@ -590,7 +590,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
   private void updateAndWriteCompletionReports(TaskToolbox toolbox)
   {
     completionReports = getTaskCompletionReports();
-    if (shouldSendReports) {
+    if (shouldWriteReports) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -219,7 +219,6 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler
    * @param isStandAloneTask used to specify if indextask.run() is run as a part of another task
    *                         skips writing reports and cleanup if not a standalone task
    */
-
   public IndexTask(
       String id,
       String groupId,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1208,14 +1208,14 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
         getContext(),
         getIngestionSchema().getTuningConfig().getMaxAllowedLockCount(),
         // Don't run cleanup in the IndexTask since we are wrapping it in the ParallelIndexSupervisorTask
-        false,
-        !isCompactionTask
+        false
     );
 
     if (currentSubTaskHolder.setTask(sequentialIndexTask)
         && sequentialIndexTask.isReady(toolbox.getTaskActionClient())) {
       TaskStatus status = sequentialIndexTask.run(toolbox);
       completionReports = sequentialIndexTask.getCompletionReports();
+      writeCompletionReports();
       return status;
     } else {
       String msg = "Task was asked to stop. Finish as failed";
@@ -1258,6 +1258,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
   )
   {
     completionReports = getTaskCompletionReports(status, segmentAvailabilityConfirmationCompleted);
+    writeCompletionReports();
+  }
+
+  private void writeCompletionReports()
+  {
     if (!isCompactionTask) {
       toolbox.getTaskReportFileWriter().write(getId(), completionReports);
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -225,7 +225,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       ParallelIndexIngestionSpec ingestionSchema,
       @Nullable String baseSubtaskSpecName,
       Map<String, Object> context,
-      Boolean isCompactionTask
+      boolean isCompactionTask
   )
   {
     super(
@@ -662,7 +662,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       }
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
-    updateAndWriteCompletionReports(toolbox, taskStatus, segmentAvailabilityConfirmationCompleted);
+    updateAndWriteCompletionReports(toolbox, taskStatus);
     return taskStatus;
   }
 
@@ -829,7 +829,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    updateAndWriteCompletionReports(toolbox, taskStatus, segmentAvailabilityConfirmationCompleted);
+    updateAndWriteCompletionReports(toolbox, taskStatus);
     return taskStatus;
   }
 
@@ -926,7 +926,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    updateAndWriteCompletionReports(toolbox, taskStatus, segmentAvailabilityConfirmationCompleted);
+    updateAndWriteCompletionReports(toolbox, taskStatus);
     return taskStatus;
   }
 
@@ -1254,8 +1254,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
 
   private void updateAndWriteCompletionReports(
       TaskToolbox toolbox,
-      TaskStatus status,
-      boolean segmentAvailabilityConfirmationCompleted
+      TaskStatus status
   )
   {
     completionReports = getTaskCompletionReports(status, segmentAvailabilityConfirmationCompleted);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1838,6 +1838,12 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     }
   }
 
+  @VisibleForTesting
+  public void setToolbox(TaskToolbox toolbox)
+  {
+    this.toolbox = toolbox;
+  }
+
   /**
    * Represents a partition uniquely identified by an Interval and a bucketId.
    *

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -527,12 +527,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     try {
 
       initializeSubTaskCleaner();
+      this.toolbox = toolbox;
 
       if (isParallelMode()) {
         // emit metric for parallel batch ingestion mode:
         emitMetric(toolbox.getEmitter(), "ingest/count", 1);
-
-        this.toolbox = toolbox;
 
         if (isGuaranteedRollup(
             getIngestionMode(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -662,7 +662,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       }
       taskStatus = TaskStatus.failure(getId(), errorMessage);
     }
-    updateAndWriteCompletionReports(toolbox, taskStatus);
+    updateAndWriteCompletionReports(taskStatus);
     return taskStatus;
   }
 
@@ -829,7 +829,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    updateAndWriteCompletionReports(toolbox, taskStatus);
+    updateAndWriteCompletionReports(taskStatus);
     return taskStatus;
   }
 
@@ -926,7 +926,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
       taskStatus = TaskStatus.failure(getId(), errMsg);
     }
 
-    updateAndWriteCompletionReports(toolbox, taskStatus);
+    updateAndWriteCompletionReports(taskStatus);
     return taskStatus;
   }
 
@@ -1252,10 +1252,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask implemen
     );
   }
 
-  private void updateAndWriteCompletionReports(
-      TaskToolbox toolbox,
-      TaskStatus status
-  )
+  private void updateAndWriteCompletionReports(TaskStatus status)
   {
     completionReports = getTaskCompletionReports(status, segmentAvailabilityConfirmationCompleted);
     writeCompletionReports();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -2714,7 +2714,8 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null,
         0,
-        false
+        false,
+        true
     ).cleanUp(null, null);
   }
 
@@ -2750,6 +2751,7 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null,
         0,
+        true,
         true
     ).cleanUp(toolbox, null);
     EasyMock.verify(toolbox, taskConfig);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -2714,8 +2714,7 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null,
         0,
-        false,
-        true
+        false
     ).cleanUp(null, null);
   }
 
@@ -2751,7 +2750,6 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null,
         0,
-        true,
         true
     ).cleanUp(toolbox, null);
     EasyMock.verify(toolbox, taskConfig);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskReportSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskReportSerdeTest.java
@@ -95,6 +95,52 @@ public class TaskReportSerdeTest
   }
 
   @Test
+  public void testSerializationOnMissingPartitionStats() throws Exception
+  {
+    String json = "{\n"
+                  + "  \"type\": \"ingestionStatsAndErrors\",\n"
+                  + "  \"taskId\": \"ingestionStatsAndErrors\",\n"
+                  + "  \"payload\": {\n"
+                  + "    \"ingestionState\": \"COMPLETED\",\n"
+                  + "    \"unparseableEvents\": {\n"
+                  + "      \"hello\": \"world\"\n"
+                  + "    },\n"
+                  + "    \"rowStats\": {\n"
+                  + "      \"number\": 1234\n"
+                  + "    },\n"
+                  + "    \"errorMsg\": \"an error message\",\n"
+                  + "    \"segmentAvailabilityConfirmed\": true,\n"
+                  + "    \"segmentAvailabilityWaitTimeMs\": 1000\n"
+                  + "  }\n"
+                  + "}";
+
+    IngestionStatsAndErrorsTaskReport expected = new IngestionStatsAndErrorsTaskReport(
+        IngestionStatsAndErrorsTaskReport.REPORT_KEY,
+        new IngestionStatsAndErrorsTaskReportData(
+            IngestionState.COMPLETED,
+            ImmutableMap.of(
+                "hello", "world"
+            ),
+            ImmutableMap.of(
+                "number", 1234
+            ),
+            "an error message",
+            true,
+            1000L,
+            null
+        )
+    );
+
+
+    Assert.assertEquals(expected, jsonMapper.readValue(
+        json,
+        new TypeReference<TaskReport>()
+        {
+        }
+    ));
+  }
+
+  @Test
   public void testExceptionWhileWritingReport() throws Exception
   {
     final File reportFile = temporaryFolder.newFile();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -202,7 +202,7 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     Assert.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
-
+    task.setToolbox(toolbox);
     TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
 
     Assert.assertTrue(taskStatus.isFailure());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -211,7 +211,7 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     Assert.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
-
+    task.setToolbox(toolbox);
     TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
 
     Assert.assertTrue(taskStatus.isFailure());


### PR DESCRIPTION
### Description

Fixed the bug where completion task reports are not being generated on `index_parallel` tasks.

The fix made in #15981 misses to call the `writeCompletionReports` inside `ParallelIndexSupervisorTask#runSequential`.

Also, this PR tries to address the comments made on #15981 and #15930 after merged.

<hr>

##### Key changed/added classes in this PR
 * `CompactionTask`
 * `IndexTask`
 * `ParallelIndexSupervisorTask`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
