### PR TITLE
Update Kubernetes doc for Helm Chart

### DIFF
--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -25,10 +25,20 @@ title: "kubernetes"
 
 Apache Druid distribution is also available as [Docker](https://www.docker.com/) image from [Docker Hub](https://hub.docker.com/r/apache/druid) . For example, you can obtain latest release using the command below.
 
-```
+```bash
 $ docker pull apache/druid
 ```
 
-[druid-operator](https://github.com/datainfrahq/druid-operator) can be used to manage a Druid cluster on [Kubernetes](https://kubernetes.io/) .
+[Apache Druid Helm Chart](https://github.com/asdf2014/druid-helm) can be used to deploy a Druid cluster on Kubernetes with following commands:
+
+```bash
+# Add repository
+$ helm repo add druid-helm https://asdf2014.github.io/druid-helm/
+
+# Install chart
+$ helm install my-druid druid-helm/druid --version 29.0.4
+```
+
+[druid-operator](https://github.com/datainfrahq/druid-operator) also can be used to manage a Druid cluster on [Kubernetes](https://kubernetes.io/) .
 
 Druid clusters deployed on Kubernetes can function without Zookeeper using [druid–kubernetes-extensions](../development/extensions-core/kubernetes.md) .


### PR DESCRIPTION
### Description

This patch enhances the Kubernetes doc for Druid Helm Chart with related commands.

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
