### PR TITLE
Remove exception on failure response from GCS delete API

### DIFF
--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.google;
 
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Predicates;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.ISE;
@@ -69,12 +70,12 @@ public class GoogleDataSegmentKiller implements DataSegmentKiller
       // anymore, but we still delete them if exists.
       deleteIfPresent(bucket, descriptorPath);
     }
-    catch (IOException e) {
+    catch (StorageException e) {
       throw new SegmentLoadingException(e, "Couldn't kill segment[%s]: [%s]", segment.getId(), e.getMessage());
     }
   }
 
-  private void deleteIfPresent(String bucket, String path) throws IOException
+  private void deleteIfPresent(String bucket, String path)
   {
     try {
       RetryUtils.retry(

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
@@ -86,7 +86,7 @@ public class GoogleDataSegmentKiller implements DataSegmentKiller
       throw e;
     }
     catch (Exception e) {
-      throw new RE(e, "Failed to delete google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new RE(e, "Failed to delete google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
   }
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.storage.google;
 
-import com.google.api.client.http.HttpResponseException;
 import com.google.common.base.Predicates;
 import com.google.inject.Inject;
 import org.apache.druid.java.util.common.ISE;
@@ -87,15 +86,6 @@ public class GoogleDataSegmentKiller implements DataSegmentKiller
           1,
           5
       );
-    }
-    catch (HttpResponseException e) {
-      if (e.getStatusCode() != 404) {
-        throw e;
-      }
-      LOG.debug("Already deleted: [%s] [%s]", bucket, path);
-    }
-    catch (IOException ioe) {
-      throw ioe;
     }
     catch (Exception e) {
       throw new RE(e, "Failed to delete [%s] [%s]", bucket, path);

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleDataSegmentKiller.java
@@ -88,6 +88,9 @@ public class GoogleDataSegmentKiller implements DataSegmentKiller
           5
       );
     }
+    catch (StorageException e) {
+      throw e;
+    }
     catch (Exception e) {
       throw new RE(e, "Failed to delete [%s] [%s]", bucket, path);
     }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -61,6 +61,8 @@ public class GoogleStorage
 
   private final HumanReadableBytes DEFAULT_WRITE_CHUNK_SIZE = new HumanReadableBytes("4MiB");
 
+  private final String FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH = "Failed to fetch google cloud storage object from bucket [%s] and path [%s].";
+
   public GoogleStorage(final Supplier<Storage> storage)
   {
     this.storage = storage;
@@ -136,7 +138,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.values()));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
     }
     return new GoogleStorageObjectMetadata(
         blob.getBucket(),
@@ -150,11 +152,11 @@ public class GoogleStorage
   public void delete(final String bucket, final String path)
   {
     // Though currently not documented for the GCS delete api, a false response is indicative of file not found.
-    // All other errors appear as StorageException which is a runtime exceptions. Ref:
+    // All other errors appear as a StorageException Ref:
     // https://github.com/googleapis/java-storage/blob/0b5f11af941032e6a55b12d243acf128a6464400/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java#L685
     if (!storage.get().delete(bucket, path)) {
       log.debug(StringUtils.nonStrictFormat(
-          "Google cloud storage object to be deleted not found in bucket[%s] and path[%s].",
+          "Google cloud storage object to be deleted not found in bucket [%s] and path [%s].",
           bucket,
           path
       ));
@@ -182,7 +184,7 @@ public class GoogleStorage
           }
           cursor++;
         }
-        log.debug("Google cloud storage object(s) in bucket %s to be deleted not found. Paths: " + failedPaths, bucket);
+        log.debug("Google cloud storage object(s) to be deleted not found in bucket [%s] and path(s) " + failedPaths, bucket);
       }
     }
   }
@@ -197,7 +199,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.SIZE));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
     }
     return blob.getSize();
   }
@@ -206,7 +208,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
     }
     return blob.getGeneratedId();
   }
@@ -243,7 +245,7 @@ public class GoogleStorage
     Page<Blob> blobPage = storage.get().list(bucket, options.toArray(new Storage.BlobListOption[0]));
 
     if (blobPage == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, prefix);
+      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, prefix);
     }
 
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -170,18 +170,20 @@ public class GoogleStorage
   public void batchDelete(final String bucket, final Iterable<String> paths)
   {
     final List<Boolean> statuses = storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
-    final List<String> failedPaths = new ArrayList<>();
-    final Iterator<String> pathIterator = paths.iterator();
-    int cursor = 0;
-    while (pathIterator.hasNext()) {
-      String failedPath = pathIterator.next();
-      if (!statuses.get(cursor)) {
-        failedPaths.add(failedPath);
-      }
-      cursor++;
-    }
     if (statuses.contains(false)) {
-      log.debug("Google cloud storage object(s) in bucket %s to be deleted not found. Paths: " + failedPaths, bucket);
+      if (log.isDebugEnabled()) {
+        final List<String> failedPaths = new ArrayList<>();
+        final Iterator<String> pathIterator = paths.iterator();
+        int cursor = 0;
+        while (pathIterator.hasNext()) {
+          String failedPath = pathIterator.next();
+          if (!statuses.get(cursor)) {
+            failedPaths.add(failedPath);
+          }
+          cursor++;
+        }
+        log.debug("Google cloud storage object(s) in bucket %s to be deleted not found. Paths: " + failedPaths, bucket);
+      }
     }
   }
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -31,7 +31,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.annotation.Nullable;
@@ -60,8 +59,6 @@ public class GoogleStorage
   private final Supplier<Storage> storage;
 
   private final HumanReadableBytes DEFAULT_WRITE_CHUNK_SIZE = new HumanReadableBytes("4MiB");
-
-  private final String FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH = "Failed to fetch google cloud storage object from bucket [%s] and path [%s].";
 
   public GoogleStorage(final Supplier<Storage> storage)
   {
@@ -138,7 +135,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.values()));
     if (blob == null) {
-      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return new GoogleStorageObjectMetadata(
         blob.getBucket(),
@@ -149,22 +146,29 @@ public class GoogleStorage
     );
   }
 
+
+  /**
+   * Deletes an object in a bucket on the specified path
+
+   * A false response from GCS delete API is indicative of file not found. Any other error is raised as a StorageException
+   * and should be explicitly handled.
+   Ref: <a href="https://github.com/googleapis/java-storage/blob/v2.29.1/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java">HttpStorageRpc.java</a>
+   *
+   * @param bucket GCS bucket
+   * @param path  Object path
+   */
   public void delete(final String bucket, final String path)
   {
-    // Though currently not documented for the GCS delete api, a false response is indicative of file not found.
-    // All other errors appear as a StorageException Ref:
-    // https://github.com/googleapis/java-storage/blob/0b5f11af941032e6a55b12d243acf128a6464400/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java#L685
     if (!storage.get().delete(bucket, path)) {
-      log.debug(StringUtils.nonStrictFormat(
-          "Google cloud storage object to be deleted not found in bucket [%s] and path [%s].",
-          bucket,
-          path
-      ));
+      log.debug("Google cloud storage object to be deleted not found in bucket[%s] and path[%s].", bucket, path);
     }
   }
 
   /**
    * Deletes a list of objects in a bucket
+   * A false response from GCS delete API is indicative of file not found. Any other error is raised as a StorageException
+   * and should be explicitly handled.
+   * Ref: <a href="https://github.com/googleapis/java-storage/blob/v2.29.1/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java">HttpStorageRpc.java</a>
    *
    * @param bucket GCS bucket
    * @param paths  Iterable for absolute paths of objects to be deleted inside the bucket
@@ -184,7 +188,11 @@ public class GoogleStorage
           }
           cursor++;
         }
-        log.debug("Google cloud storage object(s) to be deleted not found in bucket [%s] and path(s) " + failedPaths, bucket);
+        log.debug(
+            "Google cloud storage object(s) to be deleted not found in bucket[%s]. Failed paths:%s",
+            bucket,
+            failedPaths
+        );
       }
     }
   }
@@ -199,7 +207,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.SIZE));
     if (blob == null) {
-      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return blob.getSize();
   }
@@ -208,7 +216,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
     if (blob == null) {
-      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return blob.getGeneratedId();
   }
@@ -245,7 +253,7 @@ public class GoogleStorage
     Page<Blob> blobPage = storage.get().list(bucket, options.toArray(new Storage.BlobListOption[0]));
 
     if (blobPage == null) {
-      throw new IOE(FAILED_TO_FETCH_OBJECT_FROM_BUCKET_AND_PATH, bucket, prefix);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and prefix[%s].", bucket, prefix);
     }
 
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -134,7 +134,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.values()));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s].", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return new GoogleStorageObjectMetadata(
         blob.getBucket(),
@@ -154,7 +154,7 @@ public class GoogleStorage
       throw new HttpResponseException.Builder(
           404,
           StringUtils.nonStrictFormat(
-              "Google cloud storage object not found [bucket: %s, path: %s].",
+              "Google cloud storage object not found in bucket[%s] and path[%s].",
               bucket,
               path
           ),

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -20,8 +20,6 @@
 package org.apache.druid.storage.google;
 
 import com.google.api.client.http.AbstractInputStreamContent;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponseException;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.WriteChannel;
@@ -33,7 +31,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
-import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -145,22 +142,12 @@ public class GoogleStorage
     );
   }
 
-  public void delete(final String bucket, final String path) throws IOException
+  public void delete(final String bucket, final String path)
   {
     // Though currently not documented for the GCS delete api, a false response is indicative of file not found.
     // All other errors appear as StorageException which is a runtime exceptions. Refer to
     // https://github.com/googleapis/java-storage/blob/0b5f11af941032e6a55b12d243acf128a6464400/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java#L685
-    if (!storage.get().delete(bucket, path)) {
-      throw new HttpResponseException.Builder(
-          404,
-          StringUtils.nonStrictFormat(
-              "Google cloud storage object not found in bucket[%s] and path[%s].",
-              bucket,
-              path
-          ),
-          new HttpHeaders()
-      ).build();
-    }
+    storage.get().delete(bucket, path);
   }
 
   /**
@@ -169,16 +156,9 @@ public class GoogleStorage
    * @param bucket GCS bucket
    * @param paths  Iterable for absolute paths of objects to be deleted inside the bucket
    */
-  public void batchDelete(final String bucket, final Iterable<String> paths) throws IOException
+  public void batchDelete(final String bucket, final Iterable<String> paths)
   {
-    List<Boolean> statuses = storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
-    if (statuses.contains(false)) {
-      throw new HttpResponseException.Builder(
-          404,
-          "Google cloud storage object(s) not found ",
-          new HttpHeaders()
-      ).build();
-    }
+    storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
   }
 
   public boolean exists(final String bucket, final String path)
@@ -191,7 +171,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.SIZE));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s]", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return blob.getSize();
   }
@@ -200,7 +180,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s]", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
     }
     return blob.getGeneratedId();
   }
@@ -237,7 +217,7 @@ public class GoogleStorage
     Page<Blob> blobPage = storage.get().list(bucket, options.toArray(new Storage.BlobListOption[0]));
 
     if (blobPage == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, prefix: %s]", bucket, prefix);
+      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, prefix);
     }
 
 

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -33,6 +33,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
+import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -152,7 +153,7 @@ public class GoogleStorage
     if (!storage.get().delete(bucket, path)) {
       throw new HttpResponseException.Builder(
           404,
-          String.format(
+          StringUtils.nonStrictFormat(
               "Google cloud storage object not found [bucket: %s, path: %s].",
               bucket,
               path

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -39,7 +39,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -135,7 +134,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.values()));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path[%s].", bucket, path);
     }
     return new GoogleStorageObjectMetadata(
         blob.getBucket(),
@@ -160,7 +159,7 @@ public class GoogleStorage
   public void delete(final String bucket, final String path)
   {
     if (!storage.get().delete(bucket, path)) {
-      log.debug("Google cloud storage object to be deleted not found in bucket[%s] and path[%s].", bucket, path);
+      log.debug("Google cloud storage object to be deleted not found in bucket [%s] and path [%s].", bucket, path);
     }
   }
 
@@ -177,23 +176,10 @@ public class GoogleStorage
   {
     final List<Boolean> statuses = storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
     if (statuses.contains(false)) {
-      if (log.isDebugEnabled()) {
-        final List<String> failedPaths = new ArrayList<>();
-        final Iterator<String> pathIterator = paths.iterator();
-        int cursor = 0;
-        while (pathIterator.hasNext()) {
-          String failedPath = pathIterator.next();
-          if (!statuses.get(cursor)) {
-            failedPaths.add(failedPath);
-          }
-          cursor++;
-        }
-        log.debug(
-            "Google cloud storage object(s) to be deleted not found in bucket[%s]. Failed paths:%s",
-            bucket,
-            failedPaths
-        );
-      }
+      log.debug(
+          "Google cloud storage object(s) to be deleted not found in bucket [%s].",
+          bucket
+      );
     }
   }
 
@@ -207,7 +193,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.SIZE));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
     return blob.getSize();
   }
@@ -216,7 +202,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
     if (blob == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and path[%s].", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
     return blob.getGeneratedId();
   }
@@ -253,7 +239,7 @@ public class GoogleStorage
     Page<Blob> blobPage = storage.get().list(bucket, options.toArray(new Storage.BlobListOption[0]));
 
     if (blobPage == null) {
-      throw new IOE("Failed to fetch google cloud storage object from bucket[%s] and prefix[%s].", bucket, prefix);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and prefix [%s].", bucket, prefix);
     }
 
 
@@ -277,6 +263,5 @@ public class GoogleStorage
   {
     BlobId blobId = BlobId.of(bucket, path);
     return BlobInfo.newBuilder(blobId).build();
-
   }
 }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
@@ -20,6 +20,7 @@
 package org.apache.druid.storage.google;
 
 import com.google.api.client.http.HttpResponseException;
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
@@ -40,6 +41,9 @@ public class GoogleUtils
     if (t instanceof HttpResponseException) {
       final HttpResponseException e = (HttpResponseException) t;
       return e.getStatusCode() == 429 || (e.getStatusCode() / 500 == 1);
+    } else if (t instanceof StorageException) {
+      final StorageException e = (StorageException) t;
+      return e.getCode() == 429 || e.getCode() == 408 || (e.getCode() / 500 == 1);
     }
     return t instanceof IOException;
   }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
@@ -43,7 +43,7 @@ public class GoogleUtils
       return e.getStatusCode() == 429 || (e.getStatusCode() / 500 == 1);
     } else if (t instanceof StorageException) {
       final StorageException e = (StorageException) t;
-      return e.getCode() == 429 || e.getCode() == 408 || (e.getCode() / 500 == 1);
+      return e.isRetryable();
     }
     return t instanceof IOException;
   }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
@@ -111,13 +111,13 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
   }
 
   @Override
-  public void deleteFiles(Iterable<String> paths) throws IOException
+  public void deleteFiles(Iterable<String> paths)
   {
     storage.batchDelete(config.getBucket(), Iterables.transform(paths, this::objectPath));
   }
 
   @Override
-  public void deleteRecursively(String path) throws IOException
+  public void deleteRecursively(String path)
   {
     final String fullPath = objectPath(path);
     Iterator<GoogleStorageObjectMetadata> storageObjects = GoogleUtils.lazyFetchingStorageObjectsIterator(

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
@@ -73,7 +73,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
     catch (IOException e) {
       throw new RE(
           e,
-          StringUtils.format("Cannot create tempDir[%s] for google storage connector", config.getTempDir())
+          StringUtils.format("Cannot create tempDir [%s] for google storage connector", config.getTempDir())
       );
     }
   }
@@ -95,7 +95,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
   {
     try {
       final String fullPath = objectPath(path);
-      log.debug("Deleting file at bucket[%s] and path[%s].", config.getBucket(), fullPath);
+      log.debug("Deleting file at bucket [%s] and path [%s].", config.getBucket(), fullPath);
 
       GoogleUtils.retryGoogleCloudStorageOperation(
           () -> {
@@ -120,7 +120,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
       });
     }
     catch (Exception e) {
-      log.error("Failed to delete object(s) at bucket[%s].", config.getBucket());
+      log.error("Failed to delete object(s) at bucket [%s].", config.getBucket());
       throw new IOException(e);
     }
 
@@ -147,7 +147,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
       });
     }
     catch (Exception e) {
-      log.error("Failed to delete object(s) at bucket[%s] and prefix[%s].", config.getBucket(), fullPath);
+      log.error("Failed to delete object(s) at bucket [%s] and prefix [%s].", config.getBucket(), fullPath);
       throw new IOException(e);
     }
   }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
@@ -105,7 +105,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
       );
     }
     catch (Exception e) {
-      log.error("Failed to delete object at bucket[%s] and path[%s].", config.getBucket(), path);
+      log.error("Failed to delete object at bucket [%s] and path [%s].", config.getBucket(), path);
       throw new IOException(e);
     }
   }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
@@ -73,7 +73,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
     catch (IOException e) {
       throw new RE(
           e,
-          StringUtils.format("Cannot create tempDir : [%s] for google storage connector", config.getTempDir())
+          StringUtils.format("Cannot create tempDir[%s] for google storage connector", config.getTempDir())
       );
     }
   }
@@ -95,7 +95,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
   {
     try {
       final String fullPath = objectPath(path);
-      log.debug("Deleting file at bucket: [%s], path: [%s]", config.getBucket(), fullPath);
+      log.debug("Deleting file at bucket[%s] and path[%s].", config.getBucket(), fullPath);
 
       GoogleUtils.retryGoogleCloudStorageOperation(
           () -> {
@@ -105,19 +105,29 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
       );
     }
     catch (Exception e) {
-      log.error("Error occurred while deleting file at path [%s]. Error: [%s]", path, e.getMessage());
+      log.error("Failed to delete object at bucket[%s] and path[%s].", config.getBucket(), path);
       throw new IOException(e);
     }
   }
 
   @Override
-  public void deleteFiles(Iterable<String> paths)
+  public void deleteFiles(Iterable<String> paths) throws IOException
   {
-    storage.batchDelete(config.getBucket(), Iterables.transform(paths, this::objectPath));
+    try {
+      GoogleUtils.retryGoogleCloudStorageOperation(() -> {
+        storage.batchDelete(config.getBucket(), Iterables.transform(paths, this::objectPath));
+        return null;
+      });
+    }
+    catch (Exception e) {
+      log.error("Failed to delete object(s) at bucket[%s].", config.getBucket());
+      throw new IOException(e);
+    }
+
   }
 
   @Override
-  public void deleteRecursively(String path)
+  public void deleteRecursively(String path) throws IOException
   {
     final String fullPath = objectPath(path);
     Iterator<GoogleStorageObjectMetadata> storageObjects = GoogleUtils.lazyFetchingStorageObjectsIterator(
@@ -127,10 +137,19 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
         inputDataConfig.getMaxListingLength()
     );
 
-    storage.batchDelete(
-        config.getBucket(),
-        () -> Iterators.transform(storageObjects, GoogleStorageObjectMetadata::getName)
-    );
+    try {
+      GoogleUtils.retryGoogleCloudStorageOperation(() -> {
+        storage.batchDelete(
+            config.getBucket(),
+            () -> Iterators.transform(storageObjects, GoogleStorageObjectMetadata::getName)
+        );
+        return null;
+      });
+    }
+    catch (Exception e) {
+      log.error("Failed to delete object(s) at bucket[%s] and prefix[%s].", config.getBucket(), fullPath);
+      throw new IOException(e);
+    }
   }
 
   @Override

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.storage.google;
 
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.RE;
@@ -51,7 +51,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   private static final long TIME_0 = 0L;
   private static final long TIME_1 = 1L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RUNTIME_EXCEPTION = new IAE("Runtime Exception");
+  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
 
 
   private static final DataSegment DATA_SEGMENT = new DataSegment(

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -96,7 +96,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test(expected = RE.class)
-  public void killWithErrorTest() throws SegmentLoadingException, IOException
+  public void killWithErrorTest() throws SegmentLoadingException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION);
@@ -111,7 +111,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test(expected = RE.class)
-  public void killRetryWithErrorTest() throws SegmentLoadingException, IOException
+  public void killRetryWithErrorTest() throws SegmentLoadingException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -19,9 +19,6 @@
 
 package org.apache.druid.storage.google;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting;
-import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.IAE;
@@ -82,7 +79,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test
-  public void killTest() throws SegmentLoadingException, IOException
+  public void killTest() throws SegmentLoadingException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall();
@@ -101,11 +98,6 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   @Test(expected = RE.class)
   public void killWithErrorTest() throws SegmentLoadingException, IOException
   {
-    final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
-        JacksonFactory.getDefaultInstance(),
-        300,
-        "test"
-    );
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION);
 
@@ -121,11 +113,6 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   @Test(expected = RE.class)
   public void killRetryWithErrorTest() throws SegmentLoadingException, IOException
   {
-    final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
-        JacksonFactory.getDefaultInstance(),
-        500,
-        "test"
-    );
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(DESCRIPTOR_PATH));

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -96,7 +96,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test
-  public void killWithErrorTest() throws SegmentLoadingException
+  public void killWithErrorTest()
   {
     Assert.assertThrows(SegmentLoadingException.class, () -> {
       storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
@@ -113,7 +113,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   }
 
   @Test
-  public void killRetryWithErrorTest() throws SegmentLoadingException, IOException
+  public void killRetryWithErrorTest() throws SegmentLoadingException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
     EasyMock.expectLastCall().andThrow(RECOVERABLE_EXCEPTION).once().andVoid().once();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -95,19 +95,21 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(expected = SegmentLoadingException.class)
+  @Test
   public void killWithErrorTest() throws SegmentLoadingException
   {
-    storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
-    EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION);
+    Assert.assertThrows(SegmentLoadingException.class, () -> {
+      storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
+      EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION);
 
-    replayAll();
+      replayAll();
 
-    GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
+      GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
 
-    killer.kill(DATA_SEGMENT);
+      killer.kill(DATA_SEGMENT);
 
-    verifyAll();
+      verifyAll();
+    });
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -21,13 +21,13 @@ package org.apache.druid.storage.google;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.googleapis.testing.json.GoogleJsonResponseExceptionFactoryTesting;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
@@ -54,8 +54,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   private static final long TIME_0 = 0L;
   private static final long TIME_1 = 1L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RECOVERABLE_EXCEPTION = new HttpResponseException.Builder(429, "recoverable", new HttpHeaders()).build();
-  private static final Exception NON_RECOVERABLE_EXCEPTION = new HttpResponseException.Builder(404, "non recoverable", new HttpHeaders()).build();
+  private static final Exception RUNTIME_EXCEPTION = new IAE("Runtime Exception");
 
 
   private static final DataSegment DATA_SEGMENT = new DataSegment(
@@ -99,7 +98,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(expected = SegmentLoadingException.class)
+  @Test(expected = RE.class)
   public void killWithErrorTest() throws SegmentLoadingException, IOException
   {
     final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
@@ -108,7 +107,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
         "test"
     );
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
-    EasyMock.expectLastCall().andThrow(exception);
+    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION);
 
     replayAll();
 
@@ -119,7 +118,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
+  @Test(expected = RE.class)
   public void killRetryWithErrorTest() throws SegmentLoadingException, IOException
   {
     final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
@@ -128,9 +127,9 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
         "test"
     );
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
-    EasyMock.expectLastCall().andThrow(exception).once().andVoid().once();
+    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(DESCRIPTOR_PATH));
-    EasyMock.expectLastCall().andThrow(exception).once().andVoid().once();
+    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();
 
     replayAll();
 
@@ -192,32 +191,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
 
 
   @Test
-  public void test_killAll_recoverableExceptionWhenDeletingObjects_deletesAllTaskLogs() throws IOException
-  {
-    GoogleStorageObjectMetadata object1 = GoogleTestUtils.newStorageObject(BUCKET, KEY_1, TIME_0);
-
-    GoogleTestUtils.expectListObjectsPageRequest(storage, PREFIX_URI, MAX_KEYS, ImmutableList.of(object1));
-
-    GoogleTestUtils.expectDeleteObjects(
-        storage,
-        ImmutableList.of(object1),
-        ImmutableMap.of(object1, RECOVERABLE_EXCEPTION)
-    );
-
-    EasyMock.expect(accountConfig.getBucket()).andReturn(BUCKET).anyTimes();
-    EasyMock.expect(accountConfig.getPrefix()).andReturn(PREFIX).anyTimes();
-    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
-
-    EasyMock.replay(accountConfig, inputDataConfig, storage);
-
-    GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
-    killer.killAll();
-
-    EasyMock.verify(accountConfig, inputDataConfig, storage);
-  }
-
-  @Test
-  public void test_killAll_nonrecoverableExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
+  public void test_killAll_runtimeExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
   {
     boolean ioExceptionThrown = false;
     try {
@@ -228,7 +202,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
       GoogleTestUtils.expectDeleteObjects(
           storage,
           ImmutableList.of(),
-          ImmutableMap.of(object1, NON_RECOVERABLE_EXCEPTION)
+          ImmutableMap.of(object1, RUNTIME_EXCEPTION)
       );
 
       EasyMock.expect(accountConfig.getBucket()).andReturn(BUCKET).anyTimes();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
@@ -51,7 +50,8 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   private static final long TIME_0 = 0L;
   private static final long TIME_1 = 1L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
+  private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "recoverable");
+  private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "non-recoverable");
 
 
   private static final DataSegment DATA_SEGMENT = new DataSegment(
@@ -95,11 +95,11 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(expected = RE.class)
+  @Test(expected = SegmentLoadingException.class)
   public void killWithErrorTest() throws SegmentLoadingException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
-    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION);
+    EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION);
 
     replayAll();
 
@@ -110,13 +110,13 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(expected = RE.class)
-  public void killRetryWithErrorTest() throws SegmentLoadingException
+  @Test
+  public void killRetryWithErrorTest() throws SegmentLoadingException, IOException
   {
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
-    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();
+    EasyMock.expectLastCall().andThrow(RECOVERABLE_EXCEPTION).once().andVoid().once();
     storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(DESCRIPTOR_PATH));
-    EasyMock.expectLastCall().andThrow(RUNTIME_EXCEPTION).once().andVoid().once();
+    EasyMock.expectLastCall().andThrow(RECOVERABLE_EXCEPTION).once().andVoid().once();
 
     replayAll();
 
@@ -178,7 +178,32 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
 
 
   @Test
-  public void test_killAll_runtimeExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
+  public void test_killAll_recoverableExceptionWhenDeletingObjects_deletesAllTaskLogs() throws IOException
+  {
+    GoogleStorageObjectMetadata object1 = GoogleTestUtils.newStorageObject(BUCKET, KEY_1, TIME_0);
+
+    GoogleTestUtils.expectListObjectsPageRequest(storage, PREFIX_URI, MAX_KEYS, ImmutableList.of(object1));
+
+    GoogleTestUtils.expectDeleteObjects(
+        storage,
+        ImmutableList.of(object1),
+        ImmutableMap.of(object1, RECOVERABLE_EXCEPTION)
+    );
+
+    EasyMock.expect(accountConfig.getBucket()).andReturn(BUCKET).anyTimes();
+    EasyMock.expect(accountConfig.getPrefix()).andReturn(PREFIX).anyTimes();
+    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+
+    EasyMock.replay(accountConfig, inputDataConfig, storage);
+
+    GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
+    killer.killAll();
+
+    EasyMock.verify(accountConfig, inputDataConfig, storage);
+  }
+
+  @Test
+  public void test_killAll_nonrecoverableExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
   {
     boolean ioExceptionThrown = false;
     try {
@@ -189,7 +214,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
       GoogleTestUtils.expectDeleteObjects(
           storage,
           ImmutableList.of(),
-          ImmutableMap.of(object1, RUNTIME_EXCEPTION)
+          ImmutableMap.of(object1, NON_RECOVERABLE_EXCEPTION)
       );
 
       EasyMock.expect(accountConfig.getBucket()).andReturn(BUCKET).anyTimes();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -51,7 +51,7 @@ public class GoogleStorageTest
   static final String PATH = "/path";
   static final long SIZE = 100;
   static final OffsetDateTime UPDATE_TIME = OffsetDateTime.MIN;
-  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
+  private static final Exception STORAGE_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
 
 
   @Before
@@ -83,7 +83,7 @@ public class GoogleStorageTest
   @Test
   public void testDeleteFailure()
   {
-    EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(RUNTIME_EXCEPTION);
+    EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
     boolean thrownStorageException = false;
     try {
@@ -143,7 +143,7 @@ public class GoogleStorageTest
   {
     List<String> paths = ImmutableList.of("/path1", "/path2");
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
-            .andThrow(RUNTIME_EXCEPTION);
+            .andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
     boolean thrownStorageException = false;
     try {

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -85,15 +85,15 @@ public class GoogleStorageTest
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(RUNTIME_EXCEPTION);
     EasyMock.replay(mockStorage);
-    boolean thrownRuntimeException = false;
+    boolean thrownStorageException = false;
     try {
       googleStorage.delete(BUCKET, PATH);
 
     }
-    catch (RuntimeException e) {
-      thrownRuntimeException = true;
+    catch (StorageException e) {
+      thrownStorageException = true;
     }
-    assertTrue(thrownRuntimeException);
+    assertTrue(thrownStorageException);
   }
 
   @Test
@@ -145,15 +145,15 @@ public class GoogleStorageTest
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
             .andThrow(RUNTIME_EXCEPTION);
     EasyMock.replay(mockStorage);
-    boolean thrownRuntimeException = false;
+    boolean thrownStorageException = false;
     try {
       googleStorage.batchDelete(BUCKET, paths);
 
     }
-    catch (RuntimeException e) {
-      thrownRuntimeException = true;
+    catch (StorageException e) {
+      thrownStorageException = true;
     }
-    assertTrue(thrownRuntimeException);
+    assertTrue(thrownStorageException);
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -23,8 +23,8 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
-import org.apache.druid.java.util.common.IAE;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -51,7 +51,7 @@ public class GoogleStorageTest
   static final String PATH = "/path";
   static final long SIZE = 100;
   static final OffsetDateTime UPDATE_TIME = OffsetDateTime.MIN;
-  private static final Exception RUNTIME_EXCEPTION = new IAE("Runtime Exception");
+  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
 
 
   @Before
@@ -68,6 +68,14 @@ public class GoogleStorageTest
   public void testDeleteSuccess()
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andReturn(true);
+    EasyMock.replay(mockStorage);
+    googleStorage.delete(BUCKET, PATH);
+  }
+
+  @Test
+  public void testDeleteFileNotFound()
+  {
+    EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andReturn(false);
     EasyMock.replay(mockStorage);
     googleStorage.delete(BUCKET, PATH);
   }
@@ -106,6 +114,28 @@ public class GoogleStorageTest
     assertTrue(paths.size() == recordedPaths.size() && paths.containsAll(recordedPaths) && recordedPaths.containsAll(
         paths));
     assertEquals(BUCKET, recordedBlobIds.get(0).getBucket());
+
+  }
+
+  @Test
+  public void testBatchDeleteFileNotFound()
+  {
+    List<String> paths = ImmutableList.of("/path1", "/path2");
+    final Capture<Iterable<BlobId>> pathIterable = Capture.newInstance();
+    EasyMock.expect(mockStorage.delete(EasyMock.capture(pathIterable))).andReturn(ImmutableList.of(true, false));
+    EasyMock.replay(mockStorage);
+
+    googleStorage.batchDelete(BUCKET, paths);
+
+    List<BlobId> recordedBlobIds = new ArrayList<>();
+    pathIterable.getValue().iterator().forEachRemaining(recordedBlobIds::add);
+
+    List<String> recordedPaths = recordedBlobIds.stream().map(BlobId::getName).collect(Collectors.toList());
+
+    assertTrue(paths.size() == recordedPaths.size() && paths.containsAll(recordedPaths) && recordedPaths.containsAll(
+        paths));
+    assertEquals(BUCKET, recordedBlobIds.get(0).getBucket());
+
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.google;
 
+import com.google.api.client.http.HttpResponseException;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -74,15 +75,17 @@ public class GoogleStorageTest
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andReturn(false);
     EasyMock.replay(mockStorage);
-    boolean thrownIOException = false;
+    boolean thrownHTTPNotFoundException = false;
     try {
       googleStorage.delete(BUCKET, PATH);
 
     }
     catch (IOException e) {
-      thrownIOException = true;
+      if (e instanceof HttpResponseException && ((HttpResponseException) e).getStatusCode() == 404) {
+        thrownHTTPNotFoundException = true;
+      }
     }
-    assertTrue(thrownIOException);
+    assertTrue(thrownHTTPNotFoundException);
   }
 
   @Test
@@ -112,15 +115,17 @@ public class GoogleStorageTest
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
             .andReturn(ImmutableList.of(false, true));
     EasyMock.replay(mockStorage);
-    boolean thrownIOException = false;
+    boolean thrownHTTPNotFoundException = false;
     try {
       googleStorage.batchDelete(BUCKET, paths);
 
     }
     catch (IOException e) {
-      thrownIOException = true;
+      if (e instanceof HttpResponseException && ((HttpResponseException) e).getStatusCode() == 404) {
+        thrownHTTPNotFoundException = true;
+      }
     }
-    assertTrue(thrownIOException);
+    assertTrue(thrownHTTPNotFoundException);
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -85,15 +86,7 @@ public class GoogleStorageTest
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
-    boolean thrownStorageException = false;
-    try {
-      googleStorage.delete(BUCKET, PATH);
-
-    }
-    catch (StorageException e) {
-      thrownStorageException = true;
-    }
-    assertTrue(thrownStorageException);
+    Assert.assertThrows(StorageException.class, () -> googleStorage.delete(BUCKET, PATH));
   }
 
   @Test
@@ -132,8 +125,9 @@ public class GoogleStorageTest
 
     List<String> recordedPaths = recordedBlobIds.stream().map(BlobId::getName).collect(Collectors.toList());
 
-    assertTrue(paths.size() == recordedPaths.size() && paths.containsAll(recordedPaths) && recordedPaths.containsAll(
-        paths));
+    assertTrue(paths.size() == recordedPaths.size());
+    assertTrue(paths.containsAll(recordedPaths));
+    assertTrue(recordedPaths.containsAll(paths));
     assertEquals(BUCKET, recordedBlobIds.get(0).getBucket());
 
   }
@@ -145,15 +139,7 @@ public class GoogleStorageTest
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
             .andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
-    boolean thrownStorageException = false;
-    try {
-      googleStorage.batchDelete(BUCKET, paths);
-
-    }
-    catch (StorageException e) {
-      thrownStorageException = true;
-    }
-    assertTrue(thrownStorageException);
+    Assert.assertThrows(StorageException.class, () -> googleStorage.batchDelete(BUCKET, paths));
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -57,7 +57,8 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private static final long TIME_NOW = 2L;
   private static final long TIME_FUTURE = 3L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
+  private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "non-recoverable");
+  private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "recoverable");
 
 
   private GoogleStorage storage;
@@ -247,8 +248,33 @@ public class GoogleTaskLogsTest extends EasyMockSupport
     EasyMock.verify(inputDataConfig, storage, timeSupplier);
   }
 
+
   @Test
-  public void test_killAll_runtimeExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
+  public void test_killAll_recoverableExceptionWhenDeletingObjects_deletesAllTaskLogs() throws IOException
+  {
+    GoogleStorageObjectMetadata object1 = GoogleTestUtils.newStorageObject(BUCKET, KEY_1, TIME_0);
+
+    EasyMock.expect(timeSupplier.getAsLong()).andReturn(TIME_NOW);
+
+    GoogleTestUtils.expectListObjectsPageRequest(storage, PREFIX_URI, MAX_KEYS, ImmutableList.of(object1));
+
+    GoogleTestUtils.expectDeleteObjects(
+        storage,
+        ImmutableList.of(object1),
+        ImmutableMap.of(object1, RECOVERABLE_EXCEPTION)
+    );
+
+    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+
+    EasyMock.replay(inputDataConfig, storage, timeSupplier);
+
+    googleTaskLogs.killAll();
+
+    EasyMock.verify(inputDataConfig, storage, timeSupplier);
+  }
+
+  @Test
+  public void test_killAll_nonrecoverableExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
   {
     boolean ioExceptionThrown = false;
     try {
@@ -261,7 +287,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
       GoogleTestUtils.expectDeleteObjects(
           storage,
           ImmutableList.of(),
-          ImmutableMap.of(object1, RUNTIME_EXCEPTION)
+          ImmutableMap.of(object1, NON_RECOVERABLE_EXCEPTION)
       );
 
       EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
@@ -301,7 +327,29 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   }
 
   @Test
-  public void test_killOlderThan_runtimeExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
+  public void test_killOlderThan_recoverableExceptionWhenListingObjects_deletesAllTaskLogs() throws IOException
+  {
+    GoogleStorageObjectMetadata object1 = GoogleTestUtils.newStorageObject(BUCKET, KEY_1, TIME_0);
+
+    GoogleTestUtils.expectListObjectsPageRequest(storage, PREFIX_URI, MAX_KEYS, ImmutableList.of(object1));
+
+    GoogleTestUtils.expectDeleteObjects(
+        storage,
+        ImmutableList.of(object1),
+        ImmutableMap.of(object1, RECOVERABLE_EXCEPTION)
+    );
+
+    EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);
+
+    EasyMock.replay(inputDataConfig, storage);
+
+    googleTaskLogs.killOlderThan(TIME_NOW);
+
+    EasyMock.verify(inputDataConfig, storage);
+  }
+
+  @Test
+  public void test_killOlderThan_nonrecoverableExceptionWhenListingObjects_doesntDeleteAnyTaskLogs()
   {
     boolean ioExceptionThrown = false;
     try {
@@ -312,7 +360,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
       GoogleTestUtils.expectDeleteObjects(
           storage,
           ImmutableList.of(),
-          ImmutableMap.of(object1, RUNTIME_EXCEPTION)
+          ImmutableMap.of(object1, NON_RECOVERABLE_EXCEPTION)
       );
 
       EasyMock.expect(inputDataConfig.getMaxListingLength()).andReturn(MAX_KEYS);

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -20,13 +20,13 @@
 package org.apache.druid.storage.google;
 
 import com.google.api.client.http.InputStreamContent;
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
@@ -57,7 +57,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private static final long TIME_NOW = 2L;
   private static final long TIME_FUTURE = 3L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RUNTIME_EXCEPTION = new IAE("Runtime Exception");
+  private static final Exception RUNTIME_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
 
 
   private GoogleStorage storage;

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -57,8 +57,8 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private static final long TIME_NOW = 2L;
   private static final long TIME_FUTURE = 3L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "non-recoverable");
-  private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "recoverable");
+  private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "recoverable");
+  private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "non-recoverable");
 
   private GoogleStorage storage;
   private GoogleTaskLogs googleTaskLogs;

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -60,7 +60,6 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "non-recoverable");
   private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "recoverable");
 
-
   private GoogleStorage storage;
   private GoogleTaskLogs googleTaskLogs;
   private GoogleTaskLogsConfig config;

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTestUtils.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTestUtils.java
@@ -71,7 +71,7 @@ public class GoogleTestUtils extends EasyMockSupport
       GoogleStorage storage,
       List<GoogleStorageObjectMetadata> deleteObjectExpected,
       Map<GoogleStorageObjectMetadata, Exception> deleteObjectToException
-  ) throws IOException
+  )
   {
     Map<GoogleStorageObjectMetadata, IExpectationSetters<GoogleStorageObjectMetadata>> requestToResultExpectationSetter = new HashMap<>();
     for (Map.Entry<GoogleStorageObjectMetadata, Exception> deleteObjectAndException : deleteObjectToException.entrySet()) {

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.storage.google;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import com.google.cloud.storage.StorageException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -76,6 +77,26 @@ public class GoogleUtilsTest
     Assert.assertTrue(
         GoogleUtils.isRetryable(
             new IOException("generic io exception")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(429, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(500, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(503, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(599, "ignored")
         )
     );
   }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
@@ -79,6 +79,11 @@ public class GoogleUtilsTest
             new IOException("generic io exception")
         )
     );
+    Assert.assertFalse(
+        GoogleUtils.isRetryable(
+            new StorageException(404, "ignored")
+        )
+    );
     Assert.assertTrue(
         GoogleUtils.isRetryable(
             new StorageException(429, "ignored")
@@ -94,7 +99,7 @@ public class GoogleUtilsTest
             new StorageException(503, "ignored")
         )
     );
-    Assert.assertTrue(
+    Assert.assertFalse(
         GoogleUtils.isRetryable(
             new StorageException(599, "ignored")
         )

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -107,7 +107,7 @@ public class GoogleStorageConnectorTest
   }
 
   @Test
-  public void testDeleteFiles()
+  public void testDeleteFiles() throws IOException
   {
     Capture<String> containerCapture = EasyMock.newCapture();
     Capture<Iterable<String>> pathsCapture = EasyMock.newCapture();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -107,7 +107,7 @@ public class GoogleStorageConnectorTest
   }
 
   @Test
-  public void testDeleteFiles() throws IOException
+  public void testDeleteFiles()
   {
     Capture<String> containerCapture = EasyMock.newCapture();
     Capture<Iterable<String>> pathsCapture = EasyMock.newCapture();

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/utils/GcsTestUtil.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/utils/GcsTestUtil.java
@@ -99,7 +99,7 @@ public class GcsTestUtil
     );
   }
 
-  public void deleteFileFromGcs(String gcsObjectName) throws IOException
+  public void deleteFileFromGcs(String gcsObjectName)
   {
     LOG.info("Deleting object %s at path %s in bucket %s", gcsObjectName, GOOGLE_PREFIX, GOOGLE_BUCKET);
     googleStorageClient.delete(GOOGLE_BUCKET, GOOGLE_PREFIX + "/" + gcsObjectName);


### PR DESCRIPTION
The previously used `Google API Client` library for Google Cloud Storage returned a 404 HTTPResponseException for `delete` when the object to be deleted was not found, and was propagated as-is by the Druid GCS extension. The currently used `Google Cloud Client` library just returns a `false` response in that scenario, which was being converted to a generic `IOException` in the extension -- breaking flows where file missing is an acceptable behaviour. 

This PR removes the exception altogether since all current delete scenarios don't care if the file-to-be-deleted is missing