### PR TITLE
updated description of rowsPerPage in export operations

### DIFF
--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -106,8 +106,8 @@ Keep the following in mind when using EXTERN to export rows:
 - You can export to Amazon S3 or local storage.
 - The destination provided should contain no other files or directories.
 
-When you export data, use the `rowsPerPage` context parameter to control the maximum size of exported files. The default is 100,000.
-If the result has more rows than this parameter, Druid will split the output into more files.
+When you export data, use the `rowsPerPage` context parameter to restrict the size of exported files.
+When the number of rows in the result set exceeds the value of the parameter, Druid splits the output into multiple files.
 
 ```sql
 INSERT INTO

--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -106,7 +106,8 @@ Keep the following in mind when using EXTERN to export rows:
 - You can export to Amazon S3 or local storage.
 - The destination provided should contain no other files or directories.
 
-When you export data, use the `rowsPerPage` context parameter to control how many rows get exported. The default is 100,000.
+When you export data, use the `rowsPerPage` context parameter to control the maximum size of exported files. The default is 100,000.
+If the result has more rows than this parameter, Druid will split the output into more files.
 
 ```sql
 INSERT INTO


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->



<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Fixes docs on export and how to use `rowsPerPage` context parameter.


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ x ] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ x ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
