### PR TITLE
[Backport] fix bug with expression virtual column indexes on missing columns for expressions that turn null values into not null values

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -207,6 +207,11 @@ public interface Expr extends Cacheable
 
       final ColumnIndexSupplier delegateIndexSupplier = columnIndexSelector.getIndexSupplier(column);
       if (delegateIndexSupplier == null) {
+        // if the column doesn't exist, check to see if the expression evaluates to a non-null result... if so, we might
+        // need to make a value matcher anyway
+        if (eval(InputBindings.nilBindings()).valueOrDefault() != null) {
+          return NoIndexesColumnIndexSupplier.getInstance();
+        }
         return null;
       }
       final DictionaryEncodedValueIndex<?> delegateRawIndex = delegateIndexSupplier.as(

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -152,6 +152,7 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
           new ExpressionVirtualColumn("vdim3-concat", "dim3 + dim3", ColumnType.LONG, TestExprMacroTable.INSTANCE),
           new ExpressionVirtualColumn("vdim2-offset", "array_offset(dim2, 1)", ColumnType.STRING, TestExprMacroTable.INSTANCE),
           new ExpressionVirtualColumn("nestedArrayLong", "array(arrayLong)", ColumnType.ofArray(ColumnType.LONG_ARRAY), TestExprMacroTable.INSTANCE),
+          new ExpressionVirtualColumn("fake-nvl", "nvl(fake, 'hello')", ColumnType.STRING, TestExprMacroTable.INSTANCE),
           new ListFilteredVirtualColumn("allow-dim0", DefaultDimensionSpec.of("dim0"), ImmutableSet.of("3", "4"), true),
           new ListFilteredVirtualColumn("deny-dim0", DefaultDimensionSpec.of("dim0"), ImmutableSet.of("3", "4"), false),
           new ListFilteredVirtualColumn("allow-dim2", DefaultDimensionSpec.of("dim2"), ImmutableSet.of("a"), true),

--- a/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
@@ -124,6 +124,7 @@ public class EqualityFilterTests
       assertFilterMatches(new EqualityFilter("vdim0", ColumnType.LONG, 1L, null), ImmutableList.of("1"));
     }
 
+
     @Test
     public void testListFilteredVirtualColumn()
     {
@@ -405,6 +406,20 @@ public class EqualityFilterTests
             ImmutableList.of("0", "1", "2", "3", "4", "5")
         );
       }
+    }
+
+
+    @Test
+    public void testSingleValueVirtualStringColumnMissingColumnCoalesce()
+    {
+      assertFilterMatches(
+          new EqualityFilter("fake-nvl", ColumnType.STRING, "0", null),
+          ImmutableList.of()
+      );
+      assertFilterMatches(
+          new EqualityFilter("fake-nvl", ColumnType.STRING, "hello", null),
+          ImmutableList.of("0", "1", "2", "3", "4", "5")
+      );
     }
 
     @Test


### PR DESCRIPTION
Backport of #15959 to 29.0.1.