### PR TITLE
Add deep storage segment metric

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -332,7 +332,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`segment/unneededEternityTombstone/count`|Number of non-overshadowed eternity tombstones marked as unused.| |Varies|
 |`segment/unavailable/count`|Number of unique segments left to load until all used segments are available for queries.|`dataSource`|0|
 |`segment/underReplicated/count`|Number of segments, including replicas, left to load until all used segments are available for queries.|`tier`, `dataSource`|0|
-|`segment/deepStorageOnly/count`|Number of unique segments that are only available for querying directly from deep storage.|`dataSource`|Varies|
+|`segment/availableDeepStorageOnly/count`|Number of unique segments that are only available for querying directly from deep storage.|`dataSource`|Varies|
 |`tier/historical/count`|Number of available historical nodes in each tier.|`tier`|Varies|
 |`tier/replication/factor`|Configured maximum replication factor in each tier.|`tier`|Varies|
 |`tier/required/capacity`|Total capacity in bytes required in each tier.|`tier`|Varies|

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -332,6 +332,7 @@ These metrics are for the Druid Coordinator and are reset each time the Coordina
 |`segment/unneededEternityTombstone/count`|Number of non-overshadowed eternity tombstones marked as unused.| |Varies|
 |`segment/unavailable/count`|Number of unique segments left to load until all used segments are available for queries.|`dataSource`|0|
 |`segment/underReplicated/count`|Number of segments, including replicas, left to load until all used segments are available for queries.|`tier`, `dataSource`|0|
+|`segment/deepStorageOnly/count`|Number of unique segments that are only available for querying directly from deep storage.|`dataSource`|Varies|
 |`tier/historical/count`|Number of available historical nodes in each tier.|`tier`|Varies|
 |`tier/replication/factor`|Configured maximum replication factor in each tier.|`tier`|Varies|
 |`tier/required/capacity`|Total capacity in bytes required in each tier.|`tier`|Varies|

--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinator.java
@@ -252,6 +252,25 @@ public class DruidCoordinator
     return datasourceToUnavailableSegments;
   }
 
+  public Object2IntMap<String> getDatasourceToDeepStorageQueryOnlySegmentCount()
+  {
+    if (segmentReplicationStatus == null) {
+      return Object2IntMaps.emptyMap();
+    }
+
+    final Object2IntOpenHashMap<String> datasourceToDeepStorageOnlySegments = new Object2IntOpenHashMap<>();
+
+    final Iterable<DataSegment> dataSegments = metadataManager.segments().iterateAllUsedSegments();
+    for (DataSegment segment : dataSegments) {
+      SegmentReplicaCount replicaCount = segmentReplicationStatus.getReplicaCountsInCluster(segment.getId());
+      if (replicaCount != null && replicaCount.totalLoaded() == 0 && replicaCount.required() == 0) {
+        datasourceToDeepStorageOnlySegments.addTo(segment.getDataSource(), 1);
+      }
+    }
+
+    return datasourceToDeepStorageOnlySegments;
+  }
+
   public Map<String, Double> getDatasourceToLoadStatus()
   {
     final Map<String, Double> loadStatus = new HashMap<>();
@@ -760,6 +779,13 @@ public class DruidCoordinator
           (tier, countsPerDatasource) -> countsPerDatasource.forEach(
               (dataSource, underReplicatedCount) ->
                   stats.addToSegmentStat(Stats.Segments.UNDER_REPLICATED, tier, dataSource, underReplicatedCount)
+          )
+      );
+      getDatasourceToDeepStorageQueryOnlySegmentCount().forEach(
+          (dataSource, numDeepStorageOnly) -> stats.add(
+              Stats.Segments.DEEP_STORAGE_ONLY,
+              RowKey.of(Dimension.DATASOURCE, dataSource),
+              numDeepStorageOnly
           )
       );
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -54,7 +54,7 @@ public class Stats
     public static final CoordinatorStat UNAVAILABLE
         = CoordinatorStat.toDebugAndEmit("unavailable", "segment/unavailable/count");
     public static final CoordinatorStat DEEP_STORAGE_ONLY
-            = CoordinatorStat.toDebugAndEmit("deepStorageOnly", "segment/deepStorageOnly/count");
+            = CoordinatorStat.toDebugAndEmit("deepStorageOnly", "segment/availableDeepStorageOnly/count");
     public static final CoordinatorStat UNNEEDED
         = CoordinatorStat.toDebugAndEmit("unneeded", "segment/unneeded/count");
     public static final CoordinatorStat OVERSHADOWED

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -53,6 +53,8 @@ public class Stats
         = CoordinatorStat.toDebugAndEmit("underreplicated", "segment/underReplicated/count");
     public static final CoordinatorStat UNAVAILABLE
         = CoordinatorStat.toDebugAndEmit("unavailable", "segment/unavailable/count");
+    public static final CoordinatorStat DEEP_STORAGE_ONLY
+            = CoordinatorStat.toDebugAndEmit("deepStorageOnly", "segment/deepStorageOnly/count");
     public static final CoordinatorStat UNNEEDED
         = CoordinatorStat.toDebugAndEmit("unneeded", "segment/unneeded/count");
     public static final CoordinatorStat OVERSHADOWED

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -895,6 +895,11 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertNotNull(underRepliicationCountsPerDataSourceColdTier);
     Assert.assertEquals(0, underRepliicationCountsPerDataSourceColdTier.getLong(dataSource));
 
+    Object2IntMap<String> numsDeepStorageOnlySegmentsPerDataSource =
+            coordinator.getDatasourceToDeepStorageQueryOnlySegmentCount();
+
+    Assert.assertEquals(1, numsDeepStorageOnlySegmentsPerDataSource.getInt(dataSource));
+
     coordinator.stop();
     leaderUnannouncerLatch.await();
 


### PR DESCRIPTION
Addressing some followup comments from the change in the metric made in https://github.com/apache/druid/pull/16020

### Description
If a datasource has a replicaCount=0 rule that applies to some segments that are not covered by a replicaCount>0 rule, those segments will not be reported as unavailable in segment/unavailable/count. Since they are not queryable by native queries (only using the query from deep storage feature), we want a separate metric that lets us check how many segments fit these criteria.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
Add metric segment/deepStorage/count that counts the number of segments that are only queryable through the query from deep storage metric.

#### Release note
New metric to support query from deep storage feature.

##### Key changed/added classes in this PR
 * `DruidCoordinator`
 * `Stats`

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
