### PR TITLE
MSQ: Plan without implicit sorting.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskSqlEngine.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskSqlEngine.java
@@ -118,6 +118,7 @@ public class MSQTaskSqlEngine implements SqlEngine
       case GROUPING_SETS:
       case WINDOW_FUNCTIONS:
       case ALLOW_TOP_LEVEL_UNION_ALL:
+      case GROUPBY_IMPLICITLY_SORTS:
         return false;
       case UNNEST:
       case CAN_SELECT:

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskSqlEngine.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskSqlEngine.java
@@ -107,7 +107,7 @@ public class MSQTaskSqlEngine implements SqlEngine
   }
 
   @Override
-  public boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext)
+  public boolean featureAvailable(EngineFeature feature)
   {
     switch (feature) {
       case ALLOW_BINDABLE_PLAN:

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -676,7 +676,7 @@ public class MSQReplaceTest extends MSQTestBase
                              + "PARTITIONED BY MONTH")
                      .setQueryContext(context)
                      .setExpectedValidationErrorMatcher(invalidSqlContains(
-                             "INSERT and REPLACE queries cannot have a LIMIT unless PARTITIONED BY is \"ALL\""
+                         "INSERT and REPLACE queries cannot have a LIMIT unless PARTITIONED BY is \"ALL\""
                      ))
                      .verifyPlanningErrors();
   }
@@ -692,7 +692,7 @@ public class MSQReplaceTest extends MSQTestBase
                              + "OFFSET 10"
                              + "PARTITIONED BY ALL TIME")
                      .setExpectedValidationErrorMatcher(invalidSqlContains(
-                             "INSERT and REPLACE queries cannot have an OFFSET"
+                         "INSERT and REPLACE queries cannot have an OFFSET"
                      ))
                      .setQueryContext(context)
                      .verifyPlanningErrors();
@@ -876,6 +876,44 @@ public class MSQReplaceTest extends MSQTestBase
   }
 
   @Test
+  public void testReplaceOnFoo1RangeClusteredBySubset()
+  {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("__time", ColumnType.LONG)
+                                            .add("dim1", ColumnType.STRING)
+                                            .add("m1", ColumnType.FLOAT)
+                                            .add("cnt", ColumnType.LONG)
+                                            .build();
+
+    testIngestQuery().setSql(
+                         "REPLACE INTO foo1\n"
+                         + "OVERWRITE ALL\n"
+                         + "SELECT dim1, m1, COUNT(*) AS cnt\n"
+                         + "FROM foo\n"
+                         + "GROUP BY dim1, m1\n"
+                         + "PARTITIONED BY ALL\n"
+                         + "CLUSTERED BY dim1"
+                     )
+                     .setExpectedDataSource("foo1")
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
+                     .setExpectedShardSpec(DimensionRangeShardSpec.class)
+                     .setExpectedRowSignature(rowSignature)
+                     .setQueryContext(context)
+                     .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
+                     .setExpectedResultRows(
+                         ImmutableList.of(
+                             new Object[]{0L, "", 1.0f, 1L},
+                             new Object[]{0L, "1", 4.0f, 1L},
+                             new Object[]{0L, "10.1", 2.0f, 1L},
+                             new Object[]{0L, "2", 3.0f, 1L},
+                             new Object[]{0L, "abc", 6.0f, 1L},
+                             new Object[]{0L, "def", 5.0f, 1L}
+                         )
+                     )
+                     .verifyResults();
+  }
+
+  @Test
   public void testReplaceSegmentsInsertIntoNewTable()
   {
     RowSignature rowSignature = RowSignature.builder()
@@ -916,7 +954,7 @@ public class MSQReplaceTest extends MSQTestBase
                              + "FROM foo "
                              + "PARTITIONED BY ALL TIME "
                              + "CLUSTERED BY m2, m1 DESC"
-                             )
+                     )
                      .setExpectedValidationErrorMatcher(
                          invalidSqlIs("Invalid CLUSTERED BY clause [`m1` DESC]: cannot sort in descending order.")
                      )

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQReplaceTest.java
@@ -902,7 +902,7 @@ public class MSQReplaceTest extends MSQTestBase
                      .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
                      .setExpectedResultRows(
                          ImmutableList.of(
-                             new Object[]{0L, "", 1.0f, 1L},
+                             new Object[]{0L, NullHandling.sqlCompatible() ? "" : null, 1.0f, 1L},
                              new Object[]{0L, "1", 4.0f, 1L},
                              new Object[]{0L, "10.1", 2.0f, 1L},
                              new Object[]{0L, "2", 3.0f, 1L},

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectJoinQueryMSQTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteSelectJoinQueryMSQTest.java
@@ -122,10 +122,9 @@ public abstract class CalciteSelectJoinQueryMSQTest
       return new MSQTaskSqlEngine(indexingServiceClient, queryJsonMapper)
       {
         @Override
-        public boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext)
+        public boolean featureAvailable(EngineFeature feature)
         {
-          plannerContext.queryContextMap().put(PlannerContext.CTX_SQL_JOIN_ALGORITHM, joinAlgorithm.toString());
-          return super.featureAvailable(feature, plannerContext);
+          return super.featureAvailable(feature);
         }
 
         @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -574,9 +574,8 @@ public class PlannerContext
   /**
    * Checks if the current {@link SqlEngine} supports a particular feature.
    *
-   * When executing a specific query, use this method instead of
-   * {@link SqlEngine#featureAvailable(EngineFeature, PlannerContext)}, because it also verifies feature flags such as
-   * {@link #CTX_ENABLE_WINDOW_FNS}.
+   * When executing a specific query, use this method instead of {@link SqlEngine#featureAvailable(EngineFeature)},
+   * because it also verifies feature flags such as {@link #CTX_ENABLE_WINDOW_FNS}.
    */
   public boolean featureAvailable(final EngineFeature feature)
   {
@@ -585,7 +584,11 @@ public class PlannerContext
       // Short-circuit: feature requires context flag.
       return false;
     }
-    return engine.featureAvailable(feature, this);
+    if (feature == EngineFeature.TIME_BOUNDARY_QUERY && !queryContext().isTimeBoundaryPlanningEnabled()) {
+      // Short-circuit: feature requires context flag.
+      return false;
+    }
+    return engine.featureAvailable(feature);
   }
 
   public QueryMaker getQueryMaker()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/querygen/DruidQueryGenerator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/querygen/DruidQueryGenerator.java
@@ -92,7 +92,7 @@ public class DruidQueryGenerator
         return newVertex.get();
       }
       inputVertex = vertexFactory.createVertex(
-          PartialDruidQuery.createOuterQuery(((PDQVertex) inputVertex).partialDruidQuery),
+          PartialDruidQuery.createOuterQuery(((PDQVertex) inputVertex).partialDruidQuery, vertexFactory.plannerContext),
           ImmutableList.of(inputVertex)
       );
       newVertex = inputVertex.extendWith(stack);

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidCorrelateUnnestRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidCorrelateUnnestRel.java
@@ -137,7 +137,7 @@ public class DruidCorrelateUnnestRel extends DruidRel<DruidCorrelateUnnestRel>
   {
     return new DruidCorrelateUnnestRel(
         getCluster(),
-        newQueryBuilder.getTraitSet(getConvention()),
+        newQueryBuilder.getTraitSet(getConvention(), getPlannerContext()),
         correlateRel,
         newQueryBuilder,
         getPlannerContext()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidJoinQueryRel.java
@@ -136,7 +136,7 @@ public class DruidJoinQueryRel extends DruidRel<DruidJoinQueryRel>
   {
     return new DruidJoinQueryRel(
         getCluster(),
-        newQueryBuilder.getTraitSet(getConvention()),
+        newQueryBuilder.getTraitSet(getConvention(), getPlannerContext()),
         joinRel,
         leftFilter,
         newQueryBuilder,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidOuterQueryRel.java
@@ -83,7 +83,7 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
   {
     return new DruidOuterQueryRel(
         sourceRel.getCluster(),
-        partialQuery.getTraitSet(sourceRel.getConvention()),
+        partialQuery.getTraitSet(sourceRel.getConvention(), sourceRel.getPlannerContext()),
         sourceRel,
         partialQuery,
         sourceRel.getPlannerContext()
@@ -101,7 +101,7 @@ public class DruidOuterQueryRel extends DruidRel<DruidOuterQueryRel>
   {
     return new DruidOuterQueryRel(
         getCluster(),
-        newQueryBuilder.getTraitSet(getConvention()),
+        newQueryBuilder.getTraitSet(getConvention(), getPlannerContext()),
         sourceRel,
         newQueryBuilder,
         getPlannerContext()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQueryRel.java
@@ -171,7 +171,7 @@ public class DruidQueryRel extends DruidRel<DruidQueryRel>
   {
     return new DruidQueryRel(
         getCluster(),
-        newQueryBuilder.getTraitSet(getConvention()),
+        newQueryBuilder.getTraitSet(getConvention(), getPlannerContext()),
         table,
         druidTable,
         getPlannerContext(),

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionDataSourceRel.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidUnionDataSourceRel.java
@@ -106,7 +106,7 @@ public class DruidUnionDataSourceRel extends DruidRel<DruidUnionDataSourceRel>
   {
     return new DruidUnionDataSourceRel(
         getCluster(),
-        newQueryBuilder.getTraitSet(getConvention()),
+        newQueryBuilder.getTraitSet(getConvention(), getPlannerContext()),
         unionRel,
         unionColumnNames,
         newQueryBuilder,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRules.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidRules.java
@@ -200,7 +200,7 @@ public class DruidRules
 
         final DruidOuterQueryRel outerQueryRel = DruidOuterQueryRel.create(
             druidRel,
-            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery())
+            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery(), druidRel.getPlannerContext())
                              .withAggregate(aggregate)
         );
         if (outerQueryRel.isValidDruidQuery()) {
@@ -223,7 +223,7 @@ public class DruidRules
 
         final DruidOuterQueryRel outerQueryRel = DruidOuterQueryRel.create(
             druidRel,
-            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery())
+            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery(), druidRel.getPlannerContext())
                              .withWhereFilter(filter)
         );
         if (outerQueryRel.isValidDruidQuery()) {
@@ -246,7 +246,7 @@ public class DruidRules
 
         final DruidOuterQueryRel outerQueryRel = DruidOuterQueryRel.create(
             druidRel,
-            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery())
+            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery(), druidRel.getPlannerContext())
                              .withSelectProject(filter)
         );
         if (outerQueryRel.isValidDruidQuery()) {
@@ -269,7 +269,7 @@ public class DruidRules
 
         final DruidOuterQueryRel outerQueryRel = DruidOuterQueryRel.create(
             druidRel,
-            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery())
+            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery(), druidRel.getPlannerContext())
                              .withSort(sort)
         );
         if (outerQueryRel.isValidDruidQuery()) {
@@ -292,7 +292,7 @@ public class DruidRules
 
         final DruidOuterQueryRel outerQueryRel = DruidOuterQueryRel.create(
             druidRel,
-            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery())
+            PartialDruidQuery.createOuterQuery(druidRel.getPartialDruidQuery(), druidRel.getPlannerContext())
                              .withWindow(window)
         );
         if (outerQueryRel.isValidDruidQuery()) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/EngineFeature.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/EngineFeature.java
@@ -125,5 +125,16 @@ public enum EngineFeature
   /**
    * Queries can write to an external datasource using {@link org.apache.druid.sql.destination.ExportDestination}
    */
-  WRITE_EXTERNAL_DATA;
+  WRITE_EXTERNAL_DATA,
+
+  /**
+   * Whether GROUP BY implies an ORDER BY on the same fields.
+   * There are two reasons we need this:
+   * (1) We may want MSQ to hash-partition for GROUP BY instead of using a global sort, which would mean MSQ would not
+   * implicitly ORDER BY when there is a GROUP BY.
+   * (2) When doing REPLACE with MSQ, CLUSTERED BY is transformed to ORDER BY. We need to retain that ORDER BY, as it
+   * may be a subset of the GROUP BY, and it is important to remember which fields the user wanted to include in
+   * {@link org.apache.druid.timeline.partition.DimensionRangeShardSpec}.
+   */
+  GROUPBY_IMPLICITLY_SORTS
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/EngineFeature.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/EngineFeature.java
@@ -20,10 +20,9 @@
 package org.apache.druid.sql.calcite.run;
 
 import org.apache.druid.sql.calcite.external.ExternalDataSource;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 /**
- * Arguments to {@link SqlEngine#featureAvailable(EngineFeature, PlannerContext)}.
+ * Arguments to {@link SqlEngine#featureAvailable(EngineFeature)}.
  */
 public enum EngineFeature
 {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
@@ -107,6 +107,7 @@ public class NativeSqlEngine implements SqlEngine
       case UNNEST:
       case ALLOW_BROADCAST_RIGHTY_JOIN:
       case ALLOW_TOP_LEVEL_UNION_ALL:
+      case GROUPBY_IMPLICITLY_SORTS:
         return true;
       case TIME_BOUNDARY_QUERY:
         return plannerContext.queryContext().isTimeBoundaryPlanningEnabled();

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
@@ -95,7 +95,7 @@ public class NativeSqlEngine implements SqlEngine
   }
 
   @Override
-  public boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext)
+  public boolean featureAvailable(EngineFeature feature)
   {
     switch (feature) {
       case CAN_SELECT:
@@ -107,10 +107,9 @@ public class NativeSqlEngine implements SqlEngine
       case UNNEST:
       case ALLOW_BROADCAST_RIGHTY_JOIN:
       case ALLOW_TOP_LEVEL_UNION_ALL:
+      case TIME_BOUNDARY_QUERY:
       case GROUPBY_IMPLICITLY_SORTS:
         return true;
-      case TIME_BOUNDARY_QUERY:
-        return plannerContext.queryContext().isTimeBoundaryPlanningEnabled();
       case CAN_INSERT:
       case CAN_REPLACE:
       case READ_EXTERNAL_DATA:

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlEngine.java
@@ -39,9 +39,11 @@ public interface SqlEngine
   String name();
 
   /**
-   * Whether a feature applies to this engine or not.
+   * Whether a feature applies to this engine or not. Most callers should use
+   * {@link PlannerContext#featureAvailable(EngineFeature)} instead, which also checks feature flags in context
+   * parameters.
    */
-  boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext);
+  boolean featureAvailable(EngineFeature feature);
 
   /**
    * Validates a provided query context. Returns quietly if the context is OK; throws {@link ValidationException}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/view/ViewSqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/view/ViewSqlEngine.java
@@ -77,6 +77,7 @@ public class ViewSqlEngine implements SqlEngine
       case TIMESERIES_QUERY:
       case TIME_BOUNDARY_QUERY:
       case SCAN_NEEDS_SIGNATURE:
+      case GROUPBY_IMPLICITLY_SORTS:
         return false;
 
       default:

--- a/sql/src/main/java/org/apache/druid/sql/calcite/view/ViewSqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/view/ViewSqlEngine.java
@@ -51,7 +51,7 @@ public class ViewSqlEngine implements SqlEngine
   }
 
   @Override
-  public boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext)
+  public boolean featureAvailable(EngineFeature feature)
   {
     switch (feature) {
       // Use most permissive set of SELECT features, since our goal is to get the row type of the view.

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -94,7 +94,6 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.sql.SqlStatementFactory;
 import org.apache.druid.sql.calcite.QueryTestRunner.QueryResults;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
-import org.apache.druid.sql.calcite.expression.ExpressionTestHelper;
 import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
@@ -128,7 +127,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -755,8 +753,7 @@ public class BaseCalciteQueryTest extends CalciteTestBase
 
   public void assumeFeatureAvailable(EngineFeature feature)
   {
-    boolean featureAvailable = queryFramework().engine()
-        .featureAvailable(feature, ExpressionTestHelper.PLANNER_CONTEXT);
+    boolean featureAvailable = queryFramework().engine().featureAvailable(feature);
     assumeTrue(StringUtils.format("test disabled; feature [%s] is not available!", feature), featureAvailable);
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -93,7 +93,6 @@ import org.apache.druid.query.filter.RegexDimFilter;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
-import org.apache.druid.query.groupby.orderby.NoopLimitSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec.Direction;
 import org.apache.druid.query.operator.ColumnWithDirection;
@@ -2259,7 +2258,18 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setGranularity(Granularities.ALL)
                         .setDimensions(dimensions(new DefaultDimensionSpec("cnt", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        Direction.ASCENDING,
+                                        StringComparators.NUMERIC
+                                    )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
@@ -9283,7 +9293,18 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                    "d0",
+                                    Direction.ASCENDING,
+                                    StringComparators.NUMERIC
+                                )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
@@ -9320,7 +9341,18 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        Direction.ASCENDING,
+                                        StringComparators.NUMERIC
+                                    )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
@@ -10214,7 +10246,18 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        Direction.ASCENDING,
+                                        StringComparators.NUMERIC
+                                    )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
@@ -10252,7 +10295,18 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.STRING)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        Direction.ASCENDING,
+                                        StringComparators.LEXICOGRAPHIC
+                                    )
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(QUERY_CONTEXT_DEFAULT)
                         .build()
         ),
@@ -10486,7 +10540,15 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                             )
                         )
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
-                        .setLimitSpec(NoopLimitSpec.instance())
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec("d0", Direction.ASCENDING, StringComparators.LEXICOGRAPHIC),
+                                    new OrderByColumnSpec("d1", Direction.ASCENDING, StringComparators.NUMERIC)
+                                ),
+                                Integer.MAX_VALUE
+                            )
+                        )
                         .setContext(withTimestampResultContext(QUERY_CONTEXT_DEFAULT, "d1", 1, Granularities.MONTH))
                         .build()
         ),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -93,6 +93,7 @@ import org.apache.druid.query.filter.RegexDimFilter;
 import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
+import org.apache.druid.query.groupby.orderby.NoopLimitSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec.Direction;
 import org.apache.druid.query.operator.ColumnWithDirection;
@@ -2259,7 +2260,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(dimensions(new DefaultDimensionSpec("cnt", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new CountAggregatorFactory("a0")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec(
                                         "d0",
@@ -9294,7 +9297,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec(
                                     "d0",
@@ -9342,7 +9347,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec(
                                         "d0",
@@ -10247,7 +10254,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.LONG)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec(
                                         "d0",
@@ -10296,7 +10305,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         .setDimensions(dimensions(new DefaultDimensionSpec("v0", "d0", ColumnType.STRING)))
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec(
                                         "d0",
@@ -10541,7 +10552,9 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                         )
                         .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
                         .setLimitSpec(
-                            new DefaultLimitSpec(
+                            queryFramework().engine().featureAvailable(EngineFeature.GROUPBY_IMPLICITLY_SORTS)
+                            ? NoopLimitSpec.instance()
+                            : new DefaultLimitSpec(
                                 ImmutableList.of(
                                     new OrderByColumnSpec("d0", Direction.ASCENDING, StringComparators.LEXICOGRAPHIC),
                                     new OrderByColumnSpec("d1", Direction.ASCENDING, StringComparators.NUMERIC)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteScanSignatureTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteScanSignatureTest.java
@@ -138,9 +138,9 @@ public class CalciteScanSignatureTest extends BaseCalciteQueryTest
     }
 
     @Override
-    public boolean featureAvailable(EngineFeature feature, PlannerContext plannerContext)
+    public boolean featureAvailable(EngineFeature feature)
     {
-      return feature == EngineFeature.SCAN_NEEDS_SIGNATURE || parent.featureAvailable(feature, plannerContext);
+      return feature == EngineFeature.SCAN_NEEDS_SIGNATURE || parent.featureAvailable(feature);
     }
 
     @Override

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestionTestSqlEngine.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestionTestSqlEngine.java
@@ -85,6 +85,7 @@ public class IngestionTestSqlEngine implements SqlEngine
       case TIME_BOUNDARY_QUERY:
       case SCAN_NEEDS_SIGNATURE:
       case UNNEST:
+      case GROUPBY_IMPLICITLY_SORTS:
         return false;
       case CAN_INSERT:
       case CAN_REPLACE:

--- a/sql/src/test/java/org/apache/druid/sql/calcite/IngestionTestSqlEngine.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/IngestionTestSqlEngine.java
@@ -75,7 +75,7 @@ public class IngestionTestSqlEngine implements SqlEngine
   }
 
   @Override
-  public boolean featureAvailable(final EngineFeature feature, final PlannerContext plannerContext)
+  public boolean featureAvailable(final EngineFeature feature)
   {
     switch (feature) {
       case CAN_SELECT:


### PR DESCRIPTION
This patch adds an EngineFeature "GROUPBY_IMPLICITLY_SORTS" and sets it true for native, false for MSQ. It's useful for two reasons:

1) In the future we'll likely want MSQ to hash-partition for GROUP BY
   instead of using a global sort, which would mean MSQ would not
   implicitly ORDER BY when there is a GROUP BY.

2) When doing REPLACE with MSQ, CLUSTERED BY is transformed to ORDER BY.
   We should retain that ORDER BY, as it may be a subset of the GROUP BY,
   and it is important to remember which fields the user wanted to include in
   range shard specs.

Due to (2), this patch fixes an issue where sometimes the `CLUSTERED BY` would be "forgotten". The new test case `testReplaceOnFoo1RangeClusteredBySubset` fails without the rest of the patch being applied, because `NumberedShardSpec` is used instead of `DimensionRangeShardSpec`.