### PR TITLE
update jose4j and corresponding license file

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -965,7 +965,7 @@ name: org.bitbucket.b_c jose4j
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: Apache License version 2.0
-version: 0.9.3
+version: 0.9.6
 libraries:
   - org.bitbucket.b_c: jose4j
 

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
-                <version>0.9.3</version>
+                <version>0.9.6</version>
             </dependency>
             <!-- transitive dependency of kafka-clientorg.apache.calcite:calcite-testkit
             and kafka-protobuf-provider


### PR DESCRIPTION
### Description
Update [org.bitbucket.b_c:jose4j](https://bitbucket.org/b_c/jose4j) from 0.9.3 to 0.9.6. to resolve https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-51775

This resolves https://github.com/apache/druid/pull/16075

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
