### PR TITLE
Fix toString for SingleThreadSpecializable ConstantExprs

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/ConstantExpr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ConstantExpr.java
@@ -115,6 +115,11 @@ abstract class ConstantExpr<T> implements Expr, Expr.SingleThreadSpecializable
 
   protected abstract ExprEval<T> realEval();
 
+  @Override
+  public String toString()
+  {
+    return String.valueOf(value);
+  }
 
   @Override
   public Expr toSingleThreaded()
@@ -143,6 +148,18 @@ abstract class ConstantExpr<T> implements Expr, Expr.SingleThreadSpecializable
     protected ExprEval<T> realEval()
     {
       return eval;
+    }
+
+    @Override
+    public String stringify()
+    {
+      return eval.toExpr().stringify();
+    }
+
+    @Override
+    public String toString()
+    {
+      return eval.toExpr().toString();
     }
 
     @Override

--- a/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
@@ -34,13 +34,24 @@ import static org.junit.Assert.assertSame;
 public class ConstantExprTest extends InitializedNullHandlingTest
 {
   @Test
-  public void testArrayExpr()
+  public void testLongArrayExpr()
   {
     checkExpr(
         new ArrayExpr(ExpressionType.LONG_ARRAY, new Long[] {1L, 3L}),
         true,
         "[1, 3]",
         "ARRAY<LONG>[1, 3]"
+    );
+  }
+
+  @Test
+  public void testStringArrayExpr()
+  {
+    checkExpr(
+        new ArrayExpr(ExpressionType.STRING_ARRAY, new String[] {"foo", "bar"}),
+        true,
+        "[foo, bar]",
+        "ARRAY<STRING>['foo', 'bar']"
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.math.expr;
 
+import org.apache.druid.math.expr.Expr.ObjectBinding;
 import org.apache.druid.segment.column.TypeStrategies;
 import org.apache.druid.segment.column.TypeStrategiesTest.NullableLongPair;
 import org.apache.druid.segment.column.TypeStrategiesTest.NullableLongPairTypeStrategy;
@@ -138,27 +139,32 @@ public class ConstantExprTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void test()
+  public void testStringNull()
   {
     checkExpr(
-        new StringExpr("some"),
+        new StringExpr(null),
         true,
-        "some",
-        "'some'"
+        null,
+        "null"
     );
   }
 
-  private void checkExpr(Expr expr, boolean supportsSingleThreaded, String expectedToString,
-      String expectedStringify)
+  private void checkExpr(
+      Expr expr,
+      boolean supportsSingleThreaded,
+      String expectedToString,
+      String expectedStringify
+  )
   {
+    ObjectBinding bindings = InputBindings.nilBindings();
     if (expr.getLiteralValue() != null) {
-      assertNotSame(expr.eval(null), expr.eval(null));
+      assertNotSame(expr.eval(bindings), expr.eval(bindings));
     }
     Expr singleExpr = Expr.singleThreaded(expr);
     if (supportsSingleThreaded) {
-      assertSame(singleExpr.eval(null), singleExpr.eval(null));
+      assertSame(singleExpr.eval(bindings), singleExpr.eval(bindings));
     } else {
-      assertNotSame(singleExpr.eval(null), singleExpr.eval(null));
+      assertNotSame(singleExpr.eval(bindings), singleExpr.eval(bindings));
     }
     assertEquals(expectedToString, expr.toString());
     assertEquals(expectedStringify, expr.stringify());


### PR DESCRIPTION
With #15694 after `ConstantExpr#toSingleThreaded` the `toString` and `stringify` methods have changed.
This change fixes that to align those methods with the original expression.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
