### PR TITLE
Fixup KillUnusedSegmentsTest

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -905,14 +905,14 @@ public class KillUnusedSegmentsTest
     }
   }
 
-  private void updateUsedStatusLastUpdated(DataSegment segment, DateTime newValue)
+  private void updateUsedStatusLastUpdated(DataSegment segment, DateTime lastUpdatedTime)
   {
     derbyConnectorRule.getConnector().retryWithHandle(
         handle -> handle.update(
             StringUtils.format(
                 "UPDATE %1$s SET USED_STATUS_LAST_UPDATED = ? WHERE ID = ?", getSegmentsTable()
             ),
-            newValue.toString(),
+            lastUpdatedTime.toString(),
             segment.getId().toString()
         )
     );

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -48,7 +48,6 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
 {
   private final ConcurrentMap<String, DataSegment> allSegments = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, DataSegment> usedSegments = new ConcurrentHashMap<>();
-  private final ConcurrentMap<String, DataSegmentPlus> unusedSegments = new ConcurrentHashMap<>();
 
   private volatile DataSourcesSnapshot snapshot;
 
@@ -63,13 +62,6 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   {
     allSegments.remove(segment.getId().toString());
     usedSegments.remove(segment.getId().toString());
-    snapshot = null;
-  }
-
-  public void addUnusedSegment(DataSegmentPlus segment)
-  {
-    unusedSegments.put(segment.getDataSegment().getId().toString(), segment);
-    allSegments.put(segment.getDataSegment().getId().toString(), segment.getDataSegment());
     snapshot = null;
   }
 
@@ -141,7 +133,6 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
     for (SegmentId segmentId : segmentIds) {
       if (allSegments.containsKey(segmentId.toString())) {
         DataSegment dataSegment = allSegments.get(segmentId.toString());
-        unusedSegments.put(segmentId.toString(), new DataSegmentPlus(dataSegment, now, now));
         usedSegments.remove(segmentId.toString());
         ++numModifiedSegments;
       }
@@ -238,28 +229,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
       final DateTime maxUsedStatusLastUpdatedTime
   )
   {
-    final List<DataSegmentPlus> sortedUnusedSegmentPluses = new ArrayList<>(unusedSegments.values());
-    sortedUnusedSegmentPluses.sort(
-        Comparator.comparingLong(
-            dataSegmentPlus -> dataSegmentPlus.getDataSegment().getInterval().getStartMillis()
-        )
-    );
-
-    final List<Interval> unusedSegmentIntervals = new ArrayList<>();
-
-    for (final DataSegmentPlus unusedSegmentPlus : sortedUnusedSegmentPluses) {
-      final DataSegment unusedSegment = unusedSegmentPlus.getDataSegment();
-      if (dataSource.equals(unusedSegment.getDataSource())) {
-        final Interval interval = unusedSegment.getInterval();
-
-        if ((minStartTime == null || interval.getStart().isAfter(minStartTime)) &&
-            interval.getEnd().isBefore(maxEndTime) &&
-            unusedSegmentPlus.getUsedStatusLastUpdatedDate().isBefore(maxUsedStatusLastUpdatedTime)) {
-          unusedSegmentIntervals.add(interval);
-        }
-      }
-    }
-    return unusedSegmentIntervals.stream().limit(limit).collect(Collectors.toList());
+    return null;
   }
 
   @Override

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -48,6 +48,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
 {
   private final ConcurrentMap<String, DataSegment> allSegments = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, DataSegment> usedSegments = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, DataSegmentPlus> unusedSegments = new ConcurrentHashMap<>();
 
   private volatile DataSourcesSnapshot snapshot;
 
@@ -62,6 +63,13 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   {
     allSegments.remove(segment.getId().toString());
     usedSegments.remove(segment.getId().toString());
+    snapshot = null;
+  }
+
+  public void addUnusedSegment(DataSegmentPlus segment)
+  {
+    unusedSegments.put(segment.getDataSegment().getId().toString(), segment);
+    allSegments.put(segment.getDataSegment().getId().toString(), segment.getDataSegment());
     snapshot = null;
   }
 
@@ -133,6 +141,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
     for (SegmentId segmentId : segmentIds) {
       if (allSegments.containsKey(segmentId.toString())) {
         DataSegment dataSegment = allSegments.get(segmentId.toString());
+        unusedSegments.put(segmentId.toString(), new DataSegmentPlus(dataSegment, now, now));
         usedSegments.remove(segmentId.toString());
         ++numModifiedSegments;
       }
@@ -229,7 +238,28 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
       final DateTime maxUsedStatusLastUpdatedTime
   )
   {
-    return null;
+    final List<DataSegmentPlus> sortedUnusedSegmentPluses = new ArrayList<>(unusedSegments.values());
+    sortedUnusedSegmentPluses.sort(
+        Comparator.comparingLong(
+            dataSegmentPlus -> dataSegmentPlus.getDataSegment().getInterval().getStartMillis()
+        )
+    );
+
+    final List<Interval> unusedSegmentIntervals = new ArrayList<>();
+
+    for (final DataSegmentPlus unusedSegmentPlus : sortedUnusedSegmentPluses) {
+      final DataSegment unusedSegment = unusedSegmentPlus.getDataSegment();
+      if (dataSource.equals(unusedSegment.getDataSource())) {
+        final Interval interval = unusedSegment.getInterval();
+
+        if ((minStartTime == null || interval.getStart().isAfter(minStartTime)) &&
+            interval.getEnd().isBefore(maxEndTime) &&
+            unusedSegmentPlus.getUsedStatusLastUpdatedDate().isBefore(maxUsedStatusLastUpdatedTime)) {
+          unusedSegmentIntervals.add(interval);
+        }
+      }
+    }
+    return unusedSegmentIntervals.stream().limit(limit).collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
[Issue 15951](https://github.com/apache/druid/issues/15951) is more of a gap in the test implementation `TestSegmentsMetadataManager`, where infinity intervals were not handled. In the actual implementation, there is special handling for this case in `appendConditionForIntervalsAndMatchMode`, so segments with eternity intervals will be cleaned up. I have removed the `@Ignore` test annotations and will close the [issue](https://github.com/apache/druid/issues/15951).

Instead of extending `TestSegmentsMetadataManager` to match the actual implementation in `SqlSegmentsMetadataManager`, I've removed the unused segment functionality in `TestSegmentsMetadataManager` to make it a no-op. This is because it's too cumbersome to keep the test implementation in sync with the actual implementation, especially as we add more filtering capabilities to `SqlSegmentsMetadataManager`, so it'd be best to treat `SqlSegmentsMetadataManager` as the source of truth for most cases. The only drawback to this approach is that the functional tests are somewhat slower, now requiring the setup of Derby, etc. (e.g., 18s instead of 8s locally).


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.