### PR TITLE
[Backport 29.0.1] Remove exception on failure response from GCS delete API

### DIFF
--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -31,6 +31,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -52,6 +53,8 @@ public class GoogleStorage
    * <p>
    * See OmniDataSegmentKiller for how DataSegmentKillers are initialized.
    */
+  private static final Logger log = new Logger(GoogleStorage.class);
+
   private final Supplier<Storage> storage;
 
   private final HumanReadableBytes DEFAULT_WRITE_CHUNK_SIZE = new HumanReadableBytes("4MiB");
@@ -131,7 +134,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.values()));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s]", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path[%s].", bucket, path);
     }
     return new GoogleStorageObjectMetadata(
         blob.getBucket(),
@@ -142,28 +145,41 @@ public class GoogleStorage
     );
   }
 
-  public void delete(final String bucket, final String path) throws IOException
+
+  /**
+   * Deletes an object in a bucket on the specified path
+
+   * A false response from GCS delete API is indicative of file not found. Any other error is raised as a StorageException
+   * and should be explicitly handled.
+   Ref: <a href="https://github.com/googleapis/java-storage/blob/v2.29.1/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java">HttpStorageRpc.java</a>
+   *
+   * @param bucket GCS bucket
+   * @param path  Object path
+   */
+  public void delete(final String bucket, final String path)
   {
     if (!storage.get().delete(bucket, path)) {
-      throw new IOE(
-          "Failed deleting google cloud storage object [bucket: %s path: %s]",
-          bucket,
-          path
-      );
+      log.debug("Google cloud storage object to be deleted not found in bucket [%s] and path [%s].", bucket, path);
     }
   }
 
   /**
    * Deletes a list of objects in a bucket
+   * A false response from GCS delete API is indicative of file not found. Any other error is raised as a StorageException
+   * and should be explicitly handled.
+   * Ref: <a href="https://github.com/googleapis/java-storage/blob/v2.29.1/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java">HttpStorageRpc.java</a>
    *
    * @param bucket GCS bucket
    * @param paths  Iterable for absolute paths of objects to be deleted inside the bucket
    */
-  public void batchDelete(final String bucket, final Iterable<String> paths) throws IOException
+  public void batchDelete(final String bucket, final Iterable<String> paths)
   {
-    List<Boolean> statuses = storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
+    final List<Boolean> statuses = storage.get().delete(Iterables.transform(paths, input -> BlobId.of(bucket, input)));
     if (statuses.contains(false)) {
-      throw new IOE("Failed deleting google cloud storage object(s)");
+      log.debug(
+          "Google cloud storage object(s) to be deleted not found in bucket [%s].",
+          bucket
+      );
     }
   }
 
@@ -177,7 +193,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.SIZE));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s]", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
     return blob.getSize();
   }
@@ -186,7 +202,7 @@ public class GoogleStorage
   {
     Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
     if (blob == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, path: %s]", bucket, path);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
     return blob.getGeneratedId();
   }
@@ -223,7 +239,7 @@ public class GoogleStorage
     Page<Blob> blobPage = storage.get().list(bucket, options.toArray(new Storage.BlobListOption[0]));
 
     if (blobPage == null) {
-      throw new IOE("Failed fetching google cloud storage object [bucket: %s, prefix: %s]", bucket, prefix);
+      throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and prefix [%s].", bucket, prefix);
     }
 
 
@@ -247,6 +263,5 @@ public class GoogleStorage
   {
     BlobId blobId = BlobId.of(bucket, path);
     return BlobInfo.newBuilder(blobId).build();
-
   }
 }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleUtils.java
@@ -20,6 +20,7 @@
 package org.apache.druid.storage.google;
 
 import com.google.api.client.http.HttpResponseException;
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.impl.CloudObjectLocation;
@@ -40,6 +41,9 @@ public class GoogleUtils
     if (t instanceof HttpResponseException) {
       final HttpResponseException e = (HttpResponseException) t;
       return e.getStatusCode() == 429 || (e.getStatusCode() / 500 == 1);
+    } else if (t instanceof StorageException) {
+      final StorageException e = (StorageException) t;
+      return e.isRetryable();
     }
     return t instanceof IOException;
   }

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/output/GoogleStorageConnector.java
@@ -73,7 +73,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
     catch (IOException e) {
       throw new RE(
           e,
-          StringUtils.format("Cannot create tempDir : [%s] for google storage connector", config.getTempDir())
+          StringUtils.format("Cannot create tempDir [%s] for google storage connector", config.getTempDir())
       );
     }
   }
@@ -95,7 +95,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
   {
     try {
       final String fullPath = objectPath(path);
-      log.debug("Deleting file at bucket: [%s], path: [%s]", config.getBucket(), fullPath);
+      log.debug("Deleting file at bucket [%s] and path [%s].", config.getBucket(), fullPath);
 
       GoogleUtils.retryGoogleCloudStorageOperation(
           () -> {
@@ -105,7 +105,7 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
       );
     }
     catch (Exception e) {
-      log.error("Error occurred while deleting file at path [%s]. Error: [%s]", path, e.getMessage());
+      log.error("Failed to delete object at bucket [%s] and path [%s].", config.getBucket(), path);
       throw new IOException(e);
     }
   }
@@ -113,7 +113,17 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
   @Override
   public void deleteFiles(Iterable<String> paths) throws IOException
   {
-    storage.batchDelete(config.getBucket(), Iterables.transform(paths, this::objectPath));
+    try {
+      GoogleUtils.retryGoogleCloudStorageOperation(() -> {
+        storage.batchDelete(config.getBucket(), Iterables.transform(paths, this::objectPath));
+        return null;
+      });
+    }
+    catch (Exception e) {
+      log.error("Failed to delete object(s) at bucket [%s].", config.getBucket());
+      throw new IOException(e);
+    }
+
   }
 
   @Override
@@ -127,10 +137,19 @@ public class GoogleStorageConnector extends ChunkingStorageConnector<GoogleInput
         inputDataConfig.getMaxListingLength()
     );
 
-    storage.batchDelete(
-        config.getBucket(),
-        () -> Iterators.transform(storageObjects, GoogleStorageObjectMetadata::getName)
-    );
+    try {
+      GoogleUtils.retryGoogleCloudStorageOperation(() -> {
+        storage.batchDelete(
+            config.getBucket(),
+            () -> Iterators.transform(storageObjects, GoogleStorageObjectMetadata::getName)
+        );
+        return null;
+      });
+    }
+    catch (Exception e) {
+      log.error("Failed to delete object(s) at bucket [%s] and prefix [%s].", config.getBucket(), fullPath);
+      throw new IOException(e);
+    }
   }
 
   @Override

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -23,9 +23,11 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,6 +52,8 @@ public class GoogleStorageTest
   static final String PATH = "/path";
   static final long SIZE = 100;
   static final OffsetDateTime UPDATE_TIME = OffsetDateTime.MIN;
+  private static final Exception STORAGE_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
+
 
   @Before
   public void setUp()
@@ -62,7 +66,7 @@ public class GoogleStorageTest
   }
 
   @Test
-  public void testDeleteSuccess() throws IOException
+  public void testDeleteSuccess()
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andReturn(true);
     EasyMock.replay(mockStorage);
@@ -70,23 +74,23 @@ public class GoogleStorageTest
   }
 
   @Test
-  public void testDeleteFailure()
+  public void testDeleteFileNotFound()
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andReturn(false);
     EasyMock.replay(mockStorage);
-    boolean thrownIOException = false;
-    try {
-      googleStorage.delete(BUCKET, PATH);
-
-    }
-    catch (IOException e) {
-      thrownIOException = true;
-    }
-    assertTrue(thrownIOException);
+    googleStorage.delete(BUCKET, PATH);
   }
 
   @Test
-  public void testBatchDeleteSuccess() throws IOException
+  public void testDeleteFailure()
+  {
+    EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(STORAGE_EXCEPTION);
+    EasyMock.replay(mockStorage);
+    Assert.assertThrows(StorageException.class, () -> googleStorage.delete(BUCKET, PATH));
+  }
+
+  @Test
+  public void testBatchDeleteSuccess()
   {
     List<String> paths = ImmutableList.of("/path1", "/path2");
     final Capture<Iterable<BlobId>> pathIterable = Capture.newInstance();
@@ -103,6 +107,29 @@ public class GoogleStorageTest
     assertTrue(paths.size() == recordedPaths.size() && paths.containsAll(recordedPaths) && recordedPaths.containsAll(
         paths));
     assertEquals(BUCKET, recordedBlobIds.get(0).getBucket());
+
+  }
+
+  @Test
+  public void testBatchDeleteFileNotFound()
+  {
+    List<String> paths = ImmutableList.of("/path1", "/path2");
+    final Capture<Iterable<BlobId>> pathIterable = Capture.newInstance();
+    EasyMock.expect(mockStorage.delete(EasyMock.capture(pathIterable))).andReturn(ImmutableList.of(true, false));
+    EasyMock.replay(mockStorage);
+
+    googleStorage.batchDelete(BUCKET, paths);
+
+    List<BlobId> recordedBlobIds = new ArrayList<>();
+    pathIterable.getValue().iterator().forEachRemaining(recordedBlobIds::add);
+
+    List<String> recordedPaths = recordedBlobIds.stream().map(BlobId::getName).collect(Collectors.toList());
+
+    assertTrue(paths.size() == recordedPaths.size());
+    assertTrue(paths.containsAll(recordedPaths));
+    assertTrue(recordedPaths.containsAll(paths));
+    assertEquals(BUCKET, recordedBlobIds.get(0).getBucket());
+
   }
 
   @Test
@@ -110,17 +137,9 @@ public class GoogleStorageTest
   {
     List<String> paths = ImmutableList.of("/path1", "/path2");
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
-            .andReturn(ImmutableList.of(false, true));
+            .andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
-    boolean thrownIOException = false;
-    try {
-      googleStorage.batchDelete(BUCKET, paths);
-
-    }
-    catch (IOException e) {
-      thrownIOException = true;
-    }
-    assertTrue(thrownIOException);
+    Assert.assertThrows(StorageException.class, () -> googleStorage.batchDelete(BUCKET, paths));
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.storage.google;
 
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.InputStreamContent;
+import com.google.cloud.storage.StorageException;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -58,8 +57,8 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private static final long TIME_NOW = 2L;
   private static final long TIME_FUTURE = 3L;
   private static final int MAX_KEYS = 1;
-  private static final Exception RECOVERABLE_EXCEPTION = new HttpResponseException.Builder(429, "recoverable", new HttpHeaders()).build();
-  private static final Exception NON_RECOVERABLE_EXCEPTION = new HttpResponseException.Builder(404, "non recoverable", new HttpHeaders()).build();
+  private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "recoverable");
+  private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "non-recoverable");
 
   private GoogleStorage storage;
   private GoogleTaskLogs googleTaskLogs;

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTestUtils.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTestUtils.java
@@ -71,7 +71,7 @@ public class GoogleTestUtils extends EasyMockSupport
       GoogleStorage storage,
       List<GoogleStorageObjectMetadata> deleteObjectExpected,
       Map<GoogleStorageObjectMetadata, Exception> deleteObjectToException
-  ) throws IOException
+  )
   {
     Map<GoogleStorageObjectMetadata, IExpectationSetters<GoogleStorageObjectMetadata>> requestToResultExpectationSetter = new HashMap<>();
     for (Map.Entry<GoogleStorageObjectMetadata, Exception> deleteObjectAndException : deleteObjectToException.entrySet()) {

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.storage.google;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import com.google.cloud.storage.StorageException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -76,6 +77,31 @@ public class GoogleUtilsTest
     Assert.assertTrue(
         GoogleUtils.isRetryable(
             new IOException("generic io exception")
+        )
+    );
+    Assert.assertFalse(
+        GoogleUtils.isRetryable(
+            new StorageException(404, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(429, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(500, "ignored")
+        )
+    );
+    Assert.assertTrue(
+        GoogleUtils.isRetryable(
+            new StorageException(503, "ignored")
+        )
+    );
+    Assert.assertFalse(
+        GoogleUtils.isRetryable(
+            new StorageException(599, "ignored")
         )
     );
   }

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/utils/GcsTestUtil.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/utils/GcsTestUtil.java
@@ -99,7 +99,7 @@ public class GcsTestUtil
     );
   }
 
-  public void deleteFileFromGcs(String gcsObjectName) throws IOException
+  public void deleteFileFromGcs(String gcsObjectName)
   {
     LOG.info("Deleting object %s at path %s in bucket %s", gcsObjectName, GOOGLE_PREFIX, GOOGLE_BUCKET);
     googleStorageClient.delete(GOOGLE_BUCKET, GOOGLE_PREFIX + "/" + gcsObjectName);


### PR DESCRIPTION
PR: https://github.com/apache/druid/pull/16047