### PR TITLE
[Backport] Only use ExprEval in ConstantExpr if its known that it will be safe (#15694)

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/ExpressionSelectorBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/ExpressionSelectorBenchmark.java
@@ -22,11 +22,14 @@ package org.apache.druid.benchmark;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.ExtractionDimensionSpec;
+import org.apache.druid.query.expression.LookupEnabledTestExprMacroTable;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.extraction.StrlenExtractionFn;
 import org.apache.druid.query.extraction.TimeFormatExtractionFn;
@@ -59,21 +62,21 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
 @Fork(value = 1)
-@Warmup(iterations = 15)
-@Measurement(iterations = 30)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 10, time = 3)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class ExpressionSelectorBenchmark
 {
   static {
     NullHandling.initializeForTests();
+    ExpressionProcessing.initializeForTests();
   }
 
   @Param({"1000000"})
@@ -450,6 +453,199 @@ public class ExpressionSelectorBenchmark
 
     blackhole.consume(results);
   }
+
+  @Benchmark
+  public void caseSearched1(Blackhole blackhole)
+  {
+    final Sequence<Cursor> cursors = new QueryableIndexStorageAdapter(index).makeCursors(
+        null,
+        index.getDataInterval(),
+        VirtualColumns.create(
+            ImmutableList.of(
+                new ExpressionVirtualColumn(
+                    "v",
+                    "case_searched(s == 'asd' || isnull(s) || s == 'xxx', 1, s == 'foo' || s == 'bar', 2, 3)",
+                    ColumnType.LONG,
+                    TestExprMacroTable.INSTANCE
+                )
+            )
+        ),
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
+
+    blackhole.consume(results);
+  }
+
+  @Benchmark
+  public void caseSearched2(Blackhole blackhole)
+  {
+    final Sequence<Cursor> cursors = new QueryableIndexStorageAdapter(index).makeCursors(
+        null,
+        index.getDataInterval(),
+        VirtualColumns.create(
+            ImmutableList.of(
+                new ExpressionVirtualColumn(
+                    "v",
+                    "case_searched(s == 'asd' || isnull(s) || n == 1, 1, n == 2, 2, 3)",
+                    ColumnType.LONG,
+                    TestExprMacroTable.INSTANCE
+                )
+            )
+        ),
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
+
+    blackhole.consume(results);
+  }
+
+
+  @Benchmark
+  public void caseSearched100(Blackhole blackhole)
+  {
+
+    StringBuilder caseBranches = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      caseBranches.append(
+          StringUtils.format(
+              "n == %d, %d,",
+              i,
+              i * i
+          )
+      );
+    }
+
+    final Sequence<Cursor> cursors = new QueryableIndexStorageAdapter(index).makeCursors(
+        null,
+        index.getDataInterval(),
+        VirtualColumns.create(
+            ImmutableList.of(
+                new ExpressionVirtualColumn(
+                    "v",
+                    "case_searched(s == 'asd' || isnull(s) || n == 1, 1, " + caseBranches + " 3)",
+                    ColumnType.LONG,
+                    TestExprMacroTable.INSTANCE
+                )
+            )
+        ),
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
+
+    blackhole.consume(results);
+  }
+
+  @Benchmark
+  public void caseSearchedWithLookup(Blackhole blackhole)
+  {
+    final Sequence<Cursor> cursors = new QueryableIndexStorageAdapter(index).makeCursors(
+        null,
+        index.getDataInterval(),
+        VirtualColumns.create(
+            ImmutableList.of(
+                new ExpressionVirtualColumn(
+                    "v",
+                    "case_searched(n == 1001, -1, "
+                        + "lookup(s, 'lookyloo') == 'asd1', 1, "
+                        + "lookup(s, 'lookyloo') == 'asd2', 2, "
+                        + "lookup(s, 'lookyloo') == 'asd3', 3, "
+                        + "lookup(s, 'lookyloo') == 'asd4', 4, "
+                        + "lookup(s, 'lookyloo') == 'asd5', 5, "
+                        + "-2)",
+                    ColumnType.LONG,
+                    LookupEnabledTestExprMacroTable.INSTANCE
+                )
+            )
+        ),
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
+
+    blackhole.consume(results);
+  }
+
+  @Benchmark
+  public void caseSearchedWithLookup2(Blackhole blackhole)
+  {
+    final Sequence<Cursor> cursors = new QueryableIndexStorageAdapter(index).makeCursors(
+        null,
+        index.getDataInterval(),
+        VirtualColumns.create(
+            ImmutableList.of(
+                new ExpressionVirtualColumn(
+                    "ll",
+                    "lookup(s, 'lookyloo')",
+                    ColumnType.STRING,
+                    LookupEnabledTestExprMacroTable.INSTANCE
+                ),
+                new ExpressionVirtualColumn(
+                    "v",
+                    "case_searched(n == 1001, -1, "
+                        + "ll == 'asd1', 1, "
+                        + "ll == 'asd2', 2, "
+                        + "ll == 'asd3', 3, "
+                        + "ll == 'asd4', 4, "
+                        + "ll == 'asd5', 5, "
+                        + "-2)",
+                    ColumnType.LONG,
+                    LookupEnabledTestExprMacroTable.INSTANCE
+                )
+            )
+        ),
+        Granularities.ALL,
+        false,
+        null
+    );
+
+    final List<?> results = cursors
+        .map(cursor -> {
+          final ColumnValueSelector selector = cursor.getColumnSelectorFactory().makeColumnValueSelector("v");
+          consumeLong(cursor, selector, blackhole);
+          return null;
+        })
+        .toList();
+
+    blackhole.consume(results);
+  }
+
+
 
   private void consumeDimension(final Cursor cursor, final DimensionSelector selector, final Blackhole blackhole)
   {

--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -763,4 +763,36 @@ public interface Expr extends Cacheable
       return results;
     }
   }
+
+
+  /**
+   * Returns the single-threaded version of the given expression tree.
+   *
+   * Nested expressions in the subtree are also optimized.
+   * Individual {@link Expr}-s which have a singleThreaded implementation via {@link SingleThreadSpecializable} are substituted.
+   */
+  static Expr singleThreaded(Expr expr)
+  {
+    return expr.visit(
+        node -> {
+          if (node instanceof SingleThreadSpecializable) {
+            SingleThreadSpecializable canBeSingleThreaded = (SingleThreadSpecializable) node;
+            return canBeSingleThreaded.toSingleThreaded();
+          } else {
+            return node;
+          }
+        }
+    );
+  }
+
+  /**
+   * Implementing this interface allows to provide a non-threadsafe {@link Expr} implementation.
+   */
+  interface SingleThreadSpecializable
+  {
+    /**
+     * Non-threadsafe version of this expression.
+     */
+    Expr toSingleThreaded();
+  }
 }

--- a/processing/src/main/java/org/apache/druid/math/expr/ExpressionType.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExpressionType.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.google.errorprone.annotations.Immutable;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.segment.column.BaseTypeSignature;
 import org.apache.druid.segment.column.ColumnType;
@@ -36,6 +37,7 @@ import javax.annotation.Nullable;
  * The type system used to process Druid expressions. This is basically {@link ColumnType}, but without
  * {@link ColumnType#FLOAT} because the expression processing system does not currently directly support them.
  */
+@Immutable
 @JsonSerialize(using = ToStringSerializer.class)
 public class ExpressionType extends BaseTypeSignature<ExprType>
 {

--- a/processing/src/main/java/org/apache/druid/segment/column/BaseTypeSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/BaseTypeSignature.java
@@ -22,10 +22,12 @@ package org.apache.druid.segment.column;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.errorprone.annotations.Immutable;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+@Immutable
 public abstract class BaseTypeSignature<Type extends TypeDescriptor> implements TypeSignature<Type>
 {
   protected final Type type;
@@ -36,7 +38,9 @@ public abstract class BaseTypeSignature<Type extends TypeDescriptor> implements 
   @Nullable
   protected final TypeSignature<Type> elementType;
 
+  @SuppressWarnings("Immutable")
   private final Supplier<TypeStrategy> typeStrategy;
+  @SuppressWarnings("Immutable")
   private final Supplier<NullableTypeStrategy> nullableTypeStrategy;
 
   public BaseTypeSignature(

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnCapabilitiesImpl.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 /**
  *
  */
+@SuppressWarnings("Immutable")
 public class ColumnCapabilitiesImpl implements ColumnCapabilities
 {
   public static final CoercionLogic ALL_FALSE = new CoercionLogic()

--- a/processing/src/main/java/org/apache/druid/segment/column/TypeDescriptor.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/TypeDescriptor.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.column;
 
+import com.google.errorprone.annotations.Immutable;
 
 /**
  * This is a bridge between {@link ValueType} and {@link org.apache.druid.math.expr.ExprType}, so that they can both
@@ -35,6 +36,7 @@ package org.apache.druid.segment.column;
  * {@link org.apache.druid.math.expr.ExprType} to be removed and this interface merged into {@link ValueType} (along
  * with consolidation of several other interfaces, see {@link TypeSignature} javadoc for additional details).
  */
+@Immutable
 public interface TypeDescriptor
 {
   /**

--- a/processing/src/main/java/org/apache/druid/segment/column/TypeSignature.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/TypeSignature.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.column;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.errorprone.annotations.Immutable;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
@@ -68,6 +69,7 @@ import java.util.Objects;
  * can be merged, which will simplify this interface to no longer need be generic, allow {@link ColumnType} to be
  * collapsed into {@link BaseTypeSignature}, and finally unify the type system.
  */
+@Immutable
 public interface TypeSignature<Type extends TypeDescriptor>
 {
   /**

--- a/processing/src/main/java/org/apache/druid/segment/column/ValueType.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ValueType.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.column;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.errorprone.annotations.Immutable;
 import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
@@ -39,6 +40,7 @@ import javax.annotation.Nullable;
  * @see ColumnType
  * @see TypeSignature
  */
+@Immutable
 public enum ValueType implements TypeDescriptor
 {
   /**

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionSelectors.java
@@ -195,7 +195,7 @@ public class ExpressionSelectors
       Expr expression
   )
   {
-    ExpressionPlan plan = ExpressionPlanner.plan(columnSelectorFactory, expression);
+    ExpressionPlan plan = ExpressionPlanner.plan(columnSelectorFactory, Expr.singleThreaded(expression));
     final RowIdSupplier rowIdSupplier = columnSelectorFactory.getRowIdSupplier();
 
     if (plan.is(ExpressionPlan.Trait.SINGLE_INPUT_SCALAR)) {

--- a/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ConstantExprTest.java
@@ -19,36 +19,20 @@
 
 package org.apache.druid.math.expr;
 
-import com.google.errorprone.annotations.Immutable;
-import org.apache.druid.segment.column.TypeDescriptor;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.Test;
 
-/**
- * Base 'value' types of Druid expression language, all {@link Expr} must evaluate to one of these types.
- */
-@Immutable
-public enum ExprType implements TypeDescriptor
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class ConstantExprTest extends InitializedNullHandlingTest
 {
-  DOUBLE,
-  LONG,
-  STRING,
-  ARRAY,
-  COMPLEX;
-
-  @Override
-  public boolean isNumeric()
+  @Test
+  public void testLongSingleThreadedExpr()
   {
-    return LONG.equals(this) || DOUBLE.equals(this);
-  }
-
-  @Override
-  public boolean isPrimitive()
-  {
-    return this != ARRAY && this != COMPLEX;
-  }
-
-  @Override
-  public boolean isArray()
-  {
-    return this == ExprType.ARRAY;
+    LongExpr expr = new LongExpr(11L);
+    assertNotSame(expr.eval(null), expr.eval(null));
+    Expr singleExpr = Expr.singleThreaded(expr);
+    assertSame(singleExpr.eval(null), singleExpr.eval(null));
   }
 }


### PR DESCRIPTION
Only use ExprEval in ConstantExpr if its known that it will be safe (#15694)

*  which creates a singleThreaded version of the actual expression (caching ExprEval is allowed)
*  to make a whole subtree of expressions 'singleThreaded' - uses  to create the new expression tree
*  creates a specialized  which does cache the
* some  annotations were added to make it more likely to notice that there might be something off if a similar change will be made around here for some reason

(cherry picked from commit 27d7c30c38ce3cc2c585f9decc14068a56fd019b)

