### PR TITLE
[Backport-29.0.1] Correct the API used to fetch the version for a GCS object

### DIFF
--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleStorage.java
@@ -198,13 +198,22 @@ public class GoogleStorage
     return blob.getSize();
   }
 
+  /**
+   * Return the etag for an object. This is a value that changes whenever the object's data or metadata changes and is
+   * typically but not always the MD5 hash of the object. Ref:
+   * <a href="https://cloud.google.com/storage/docs/hashes-etags#etags">ETags</a>
+   * @param bucket
+   * @param path
+   * @return
+   * @throws IOException
+   */
   public String version(final String bucket, final String path) throws IOException
   {
-    Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.GENERATION));
+    Blob blob = storage.get().get(bucket, path, Storage.BlobGetOption.fields(Storage.BlobField.ETAG));
     if (blob == null) {
       throw new IOE("Failed to fetch google cloud storage object from bucket [%s] and path [%s].", bucket, path);
     }
-    return blob.getGeneratedId();
+    return blob.getEtag();
   }
 
   /***

--- a/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleTimestampVersionedDataFinder.java
+++ b/extensions-core/google-extensions/src/main/java/org/apache/druid/storage/google/GoogleTimestampVersionedDataFinder.java
@@ -76,7 +76,7 @@ public class GoogleTimestampVersionedDataFinder extends GoogleDataSegmentPuller
       return latest;
     }
     catch (IOException e) {
-      throw new RuntimeException();
+      throw new RuntimeException(e);
     }
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -203,18 +203,18 @@ public class GoogleStorageTest
   @Test
   public void testVersion() throws IOException
   {
-    final String version = "7";
+    final String etag = "abcd";
     EasyMock.expect(mockStorage.get(
         EasyMock.eq(BUCKET),
         EasyMock.eq(PATH),
         EasyMock.anyObject(Storage.BlobGetOption.class)
     )).andReturn(blob);
 
-    EasyMock.expect(blob.getGeneratedId()).andReturn(version);
+    EasyMock.expect(blob.getEtag()).andReturn(etag);
 
     EasyMock.replay(mockStorage, blob);
 
-    assertEquals(version, googleStorage.version(BUCKET, PATH));
+    assertEquals(etag, googleStorage.version(BUCKET, PATH));
   }
 
   @Test


### PR DESCRIPTION
PR: https://github.com/apache/druid/pull/16097