### PR TITLE
Fix `numSegmentsKilled` metric

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTask.java
@@ -273,7 +273,7 @@ public class KillUnusedSegmentsTask extends AbstractFixedIntervalTask
 
       toolbox.getDataSegmentKiller().kill(segmentsToBeKilled);
       numBatchesProcessed++;
-      numSegmentsKilled += unusedSegments.size();
+      numSegmentsKilled += segmentsToBeKilled.size();
 
       LOG.info("Processed [%d] batches for kill task[%s].", numBatchesProcessed, getId());
 


### PR DESCRIPTION
Prior to this patch, the KillTaskReport contained the `numSegmentsKilled` metric, representing the size of unused segments nuked from the metadata store, rather than the actual number of segments killed from deep storage. For instance, there may be cases where an unused segment won't be killed from deep storage if its load spec is in use by another segment. In such cases, only the metadata will be cleaned up. This patch contains a test for this scenario.

Alternatively and at the very least to avoid any confusion, we can capture both the number of nuked segments from the metadata store and the number of segments killed from deep storage as separate metrics in the KillTaskReport.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
