### PR TITLE
Fix data race in getting results from MSQ select tasks.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
@@ -96,7 +96,7 @@ public class MSQResultsReport
       if (selectDestination.shouldTruncateResultsInTaskReport() && rowCount >= Limits.MAX_SELECT_RESULT_ROWS) {
         break;
       }
-      if (rowCount % (Math.min(32, factor) * Limits.MAX_SELECT_RESULT_ROWS) == 0) {
+      if (rowCount % (factor * Limits.MAX_SELECT_RESULT_ROWS) == 0) {
         log.warn(
             "Task report is getting too large with %d rows. Large task reports can cause the controller to go out of memory. "
             + "Consider using the 'limit %d' clause in your query to reduce the number of rows in the result. "
@@ -106,7 +106,7 @@ public class MSQResultsReport
             MultiStageQueryContext.CTX_SELECT_DESTINATION,
             MSQSelectDestination.DURABLESTORAGE.getName()
         );
-        factor = factor * 2;
+        factor = factor < 32 ? factor * 2 : 32;
       }
     }
     return new MSQResultsReport(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/report/MSQResultsReport.java
@@ -83,18 +83,22 @@ public class MSQResultsReport
       MSQSelectDestination selectDestination
   )
   {
-    if (selectDestination.shouldTruncateResultsInTaskReport()) {
-      List<Object[]> results = new ArrayList<>();
-      int rowCount = 0;
-      while (!resultYielder.isDone() && rowCount < Limits.MAX_SELECT_RESULT_ROWS) {
-        results.add(resultYielder.get());
-        resultYielder = resultYielder.next(null);
-        ++rowCount;
+    List<Object[]> results = new ArrayList<>();
+    int rowCount = 0;
+    while (!resultYielder.isDone()) {
+      results.add(resultYielder.get());
+      resultYielder = resultYielder.next(null);
+      ++rowCount;
+      if (selectDestination.shouldTruncateResultsInTaskReport() && rowCount >= Limits.MAX_SELECT_RESULT_ROWS) {
+        break;
       }
-      return new MSQResultsReport(signature, sqlTypeNames, Yielders.each(Sequences.simple(results)), !resultYielder.isDone());
-    } else {
-      return new MSQResultsReport(signature, sqlTypeNames, resultYielder, false);
     }
+    return new MSQResultsReport(
+        signature,
+        sqlTypeNames,
+        Yielders.each(Sequences.simple(results)),
+        !resultYielder.isDone()
+    );
   }
 
   @JsonProperty("signature")


### PR DESCRIPTION
With #15880  going in, it exposed a potential data race where the MSQ controller would post finish to the workers but still fetch the results from them. 
The change pushes the result fetching before we issue a worker finish. 
As a result of this change, now we would materialize all the rows of the select result in the controller memory. This is okay when `selectDestination=durableStorage` but a little problematic when `selectDestination=taskReport` since the former has a limit of 3000 rows but the later can go wild. 

The other way would be to hold of finishing the tasks till we write out the task report. 