### PR TITLE
pacj4: add UserProfile attributes to AuthenticationResult context

### DIFF
--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -19,18 +19,7 @@
 
 package org.apache.druid.security.pac4j;
 
-import java.io.IOException;
-import java.util.Collection;
-
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
@@ -44,7 +33,17 @@ import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
 import org.pac4j.core.profile.UserProfile;
 
-import com.google.common.collect.ImmutableMap;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collection;
 
 public class Pac4jFilter implements Filter
 {

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/Pac4jFilter.java
@@ -113,7 +113,7 @@ public class Pac4jFilter implements Filter
       // Changed the Authorizer from null to "none".
       // In the older version, if it is null, it simply grant access and returns authorized.
       // But in the newer pac4j version, it uses CsrfAuthorizer as default, And because of this, It was returning 403 in API calls.
-      if (profile != null) {
+      if (profile != null && profile.getId() != null) {
         AuthenticationResult authenticationResult = new AuthenticationResult(profile.getId(), authorizerName, name, profile.getAttributes());
         servletRequest.setAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT, authenticationResult);
         filterChain.doFilter(servletRequest, servletResponse);

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.security.pac4j;
 
-import com.google.common.collect.ImmutableMap;
-import org.apache.druid.server.security.AuthenticationResult;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,12 +32,9 @@ import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.WithLocationAction;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
-import org.pac4j.core.profile.BasicUserProfile;
-import org.pac4j.core.profile.UserProfile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -79,18 +74,4 @@ public class Pac4jFilterTest
     Assert.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
   }
 
-  @Test
-  public void testUserProfileInContext()
-  {
-    Map<String, Object> someAttributes = ImmutableMap.<String, Object>builder().put("email", "test@example.com").build();
-    BasicUserProfile userProfile = new BasicUserProfile();
-    userProfile.build("someid", someAttributes);
-
-    Assert.assertEquals(userProfile.getId(), "someid");
-    AuthenticationResult authenticationResult = new AuthenticationResult(userProfile.getId(), "authorizerName", "name", ImmutableMap.of("profile", userProfile));
-
-    UserProfile resultProfile = (UserProfile) authenticationResult.getContext().get("profile");
-    Assert.assertEquals(resultProfile.getAttribute("email"), "test@example.com");
-
-  }
 }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.security.pac4j;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.server.security.AuthenticationResult;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,9 +34,12 @@ import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.WithLocationAction;
 import org.pac4j.core.http.adapter.JEEHttpActionAdapter;
+import org.pac4j.core.profile.BasicUserProfile;
+import org.pac4j.core.profile.UserProfile;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -74,4 +79,18 @@ public class Pac4jFilterTest
     Assert.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
   }
 
+  @Test
+  public void testUserProfileInContext()
+  {
+    Map<String, Object> someAttributes = ImmutableMap.<String, Object>builder().put("email", "test@example.com").build();
+    BasicUserProfile userProfile = new BasicUserProfile();
+    userProfile.build("someid", someAttributes);
+
+    Assert.assertEquals(userProfile.getId(), "someid");
+    AuthenticationResult authenticationResult = new AuthenticationResult(userProfile.getId(), "authorizerName", "name", ImmutableMap.of("profile", userProfile));
+
+    UserProfile resultProfile = (UserProfile) authenticationResult.getContext().get("profile");
+    Assert.assertEquals(resultProfile.getAttribute("email"), "test@example.com");
+
+  }
 }


### PR DESCRIPTION

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

I'm adding OIDC context to the `AuthenticationResult` returned by pac4j extension. I wanted to use this context as input in OpenPolicyAgent authorization. Since `AuthenticationResult` already accepts `context` as a parameter it felt okay to pass the profile attributes there.



#### Release note
pac4j: Add OIDC context to the authentication result

<hr>

##### Key changed/added classes in this PR
 * `org.apache.druid.security.pac4j.Pac4jFilter.doFilter()`
 
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
