### PR TITLE
Web console: fix URI wording for lookups

### DIFF
--- a/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/lookup-edit-dialog/__snapshots__/lookup-edit-dialog.spec.tsx.snap
@@ -127,33 +127,28 @@ exports[`LookupEditDialog matches snapshot 1`] = `
           },
           {
             "defined": [Function],
-            "info": <React.Fragment>
-              <p>
-                URI for the file of interest, specified as a 
-                <Unknown>
-                  file
-                </Unknown>
-                , 
-                <Unknown>
-                  hdfs
-                </Unknown>
-                ,
-                 
-                <Unknown>
-                  s3
-                </Unknown>
-                , or 
-                <Unknown>
-                  gs
-                </Unknown>
-                 path
-              </p>
-              <p>
-                The URI prefix option is strictly better than URI and should be used instead
-              </p>
-            </React.Fragment>,
+            "info": <p>
+              URI for the file of interest, specified as a 
+              <Unknown>
+                file
+              </Unknown>
+              , 
+              <Unknown>
+                hdfs
+              </Unknown>
+              ,
+               
+              <Unknown>
+                s3
+              </Unknown>
+              , or 
+              <Unknown>
+                gs
+              </Unknown>
+               path
+            </p>,
             "issueWithValue": [Function],
-            "label": "URI (deprecated)",
+            "label": "URI",
             "name": "extractionNamespace.uri",
             "placeholder": "s3://bucket/some/key/prefix/lookups-01.gz",
             "required": [Function],

--- a/web-console/src/druid-models/lookup-spec/lookup-spec.tsx
+++ b/web-console/src/druid-models/lookup-spec/lookup-spec.tsx
@@ -169,7 +169,7 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
   {
     name: 'extractionNamespace.uri',
     type: 'string',
-    label: 'URI (deprecated)',
+    label: 'URI',
     placeholder: 's3://bucket/some/key/prefix/lookups-01.gz',
     defined: l =>
       oneOfKnown(deepGet(l, 'extractionNamespace.type'), KNOWN_EXTRACTION_NAMESPACE_TYPES, 'uri') &&
@@ -178,13 +178,10 @@ export const LOOKUP_FIELDS: Field<LookupSpec>[] = [
       !deepGet(l, 'extractionNamespace.uriPrefix') && !deepGet(l, 'extractionNamespace.uri'),
     issueWithValue: issueWithUri,
     info: (
-      <>
-        <p>
-          URI for the file of interest, specified as a <Code>file</Code>, <Code>hdfs</Code>,{' '}
-          <Code>s3</Code>, or <Code>gs</Code> path
-        </p>
-        <p>The URI prefix option is strictly better than URI and should be used instead</p>
-      </>
+      <p>
+        URI for the file of interest, specified as a <Code>file</Code>, <Code>hdfs</Code>,{' '}
+        <Code>s3</Code>, or <Code>gs</Code> path
+      </p>
     ),
   },
   {


### PR DESCRIPTION
Turns out `uriPrefix` is not really strictly better than `uri`