### PR TITLE
Allow non literal rhs in MV_FILTER_ONLY and MV_FILTER_NONE

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/ApplyFunction.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ApplyFunction.java
@@ -442,11 +442,15 @@ public interface ApplyFunction extends NamedFunction
 
       Object[] array = arrayEval.asArray();
       if (array == null) {
-        return ExprEval.of(null);
+        return ExprEval.ofArray(arrayEval.asArrayType(), null);
       }
 
       SettableLambdaBinding lambdaBinding = new SettableLambdaBinding(arrayEval.elementType(), lambdaExpr, bindings);
       Object[] filtered = filter(arrayEval.asArray(), lambdaExpr, lambdaBinding).toArray();
+      // return null array expr if nothing is left in filtered
+      if (filtered.length == 0) {
+        return ExprEval.ofArray(arrayEval.asArrayType(), null);
+      }
       return ExprEval.ofArray(arrayEval.asArrayType(), filtered);
     }
 
@@ -468,44 +472,6 @@ public interface ApplyFunction extends NamedFunction
     {
       // output type is input array type
       return args.get(0).getOutputType(inspector);
-    }
-
-    private <T> Stream<T> filter(T[] array, LambdaExpr expr, SettableLambdaBinding binding)
-    {
-      return Arrays.stream(array).filter(s -> expr.eval(binding.withBinding(expr.getIdentifier(), s)).asBoolean());
-    }
-  }
-
-  /**
-   * Extended version of {@link FilterFunction} to return a null expr if filtered result turns out to be empty
-   */
-  class FilterOnlyFunction extends FilterFunction
-  {
-    static final String NAME = "filter_only";
-
-    @Override
-    public String name()
-    {
-      return NAME;
-    }
-
-    @Override
-    public ExprEval apply(LambdaExpr lambdaExpr, List<Expr> argsExpr, Expr.ObjectBinding bindings)
-    {
-      Expr arrayExpr = argsExpr.get(0);
-      ExprEval arrayEval = arrayExpr.eval(bindings);
-
-      Object[] array = arrayEval.asArray();
-      if (array == null) {
-        return ExprEval.of(null);
-      }
-
-      SettableLambdaBinding lambdaBinding = new SettableLambdaBinding(arrayEval.elementType(), lambdaExpr, bindings);
-      Object[] filtered = filter(arrayEval.asArray(), lambdaExpr, lambdaBinding).toArray();
-      if (filtered.length == 0) {
-        return ExprEval.of(null);
-      }
-      return ExprEval.ofArray(arrayEval.asArrayType(), filtered);
     }
 
     private <T> Stream<T> filter(T[] array, LambdaExpr expr, SettableLambdaBinding binding)

--- a/processing/src/main/java/org/apache/druid/math/expr/Parser.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Parser.java
@@ -556,6 +556,7 @@ public class Parser
       case ApplyFunction.AllMatchFunction.NAME:
       case ApplyFunction.AnyMatchFunction.NAME:
       case ApplyFunction.FilterFunction.NAME:
+      case ApplyFunction.FilterOnlyFunction.NAME:
         // i'm lazy and didn't add 'cartesian_filter', 'cartesian_any', and 'cartesian_and', so instead steal the match
         // expressions lambda and translate it into a 'cartesian_map', and apply that to the match function with a new
         // identity expression lambda since the input is an array of boolean expression results (or should be..)

--- a/processing/src/main/java/org/apache/druid/math/expr/Parser.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Parser.java
@@ -556,7 +556,6 @@ public class Parser
       case ApplyFunction.AllMatchFunction.NAME:
       case ApplyFunction.AnyMatchFunction.NAME:
       case ApplyFunction.FilterFunction.NAME:
-      case ApplyFunction.FilterOnlyFunction.NAME:
         // i'm lazy and didn't add 'cartesian_filter', 'cartesian_any', and 'cartesian_and', so instead steal the match
         // expressions lambda and translate it into a 'cartesian_map', and apply that to the match function with a new
         // identity expression lambda since the input is an array of boolean expression results (or should be..)

--- a/processing/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ApplyFunctionTest.java
@@ -93,6 +93,10 @@ public class ApplyFunctionTest extends InitializedNullHandlingTest
 
     assertExpr("filter((x) -> x > 2, [1, 2, 3, 4, 5])", new Long[] {3L, 4L, 5L});
     assertExpr("filter((x) -> x > 2, b)", new Long[] {3L, 4L, 5L});
+
+    String dummyNull = null;
+    assertExpr("filter((x) -> array_contains([], x), ['a', 'b'])", dummyNull);
+    assertExpr("filter((x) -> array_contains([], x), null)", dummyNull);
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -341,26 +341,12 @@ public class MultiValueStringOperatorConversions
         return null;
       }
 
-      Expr expr = plannerContext.parseExpression(druidExpressions.get(1).getExpression());
-      // the right expression must be a literal array for this to work, since we need the values of the column
-      if (!expr.isLiteral()) {
-        return null;
-      }
-      Object[] lit = expr.eval(InputBindings.nilBindings()).asArray();
-      if (lit == null || lit.length == 0) {
-        return null;
-      }
-      HashSet<String> literals = Sets.newHashSetWithExpectedSize(lit.length);
-      for (Object o : lit) {
-        literals.add(Evals.asString(o));
-      }
-
       final DruidExpression.ExpressionGenerator builder = (args) -> {
         final StringBuilder expressionBuilder;
         if (isAllowList()) {
-          expressionBuilder = new StringBuilder("filter((x) -> array_contains(");
+          expressionBuilder = new StringBuilder("filter_only((x) -> array_contains(");
         } else {
-          expressionBuilder = new StringBuilder("filter((x) -> !array_contains(");
+          expressionBuilder = new StringBuilder("filter_only((x) -> !array_contains(");
         }
 
         expressionBuilder.append(args.get(1).getExpression())
@@ -370,7 +356,17 @@ public class MultiValueStringOperatorConversions
         return expressionBuilder.toString();
       };
 
-      if (druidExpressions.get(0).isSimpleExtraction()) {
+      Expr expr = plannerContext.parseExpression(druidExpressions.get(1).getExpression());
+      if (druidExpressions.get(0).isSimpleExtraction() && expr.isLiteral()) {
+        Object[] lit = expr.eval(InputBindings.nilBindings()).asArray();
+        if (lit == null || lit.length == 0) {
+          return null;
+        }
+        HashSet<String> literals = Sets.newHashSetWithExpectedSize(lit.length);
+        for (Object o : lit) {
+          literals.add(Evals.asString(o));
+        }
+
         DruidExpression druidExpression = DruidExpression.ofVirtualColumn(
             Calcites.getColumnTypeForRelDataType(rexNode.getType()),
             builder,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/MultiValueStringOperatorConversions.java
@@ -344,9 +344,9 @@ public class MultiValueStringOperatorConversions
       final DruidExpression.ExpressionGenerator builder = (args) -> {
         final StringBuilder expressionBuilder;
         if (isAllowList()) {
-          expressionBuilder = new StringBuilder("filter_only((x) -> array_contains(");
+          expressionBuilder = new StringBuilder("filter((x) -> array_contains(");
         } else {
-          expressionBuilder = new StringBuilder("filter_only((x) -> !array_contains(");
+          expressionBuilder = new StringBuilder("filter((x) -> !array_contains(");
         }
 
         expressionBuilder.append(args.get(1).getExpression())

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteMultiValueStringQueryTest.java
@@ -1348,7 +1348,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(
                     new ExpressionVirtualColumn(
                         "v0",
-                        "filter_only((x) -> array_contains(array(\"dim2\"), x), \"dim3\")",
+                        "filter((x) -> array_contains(array(\"dim2\"), x), \"dim3\")",
                         ColumnType.STRING,
                         TestExprMacroTable.INSTANCE
                     )
@@ -1438,7 +1438,7 @@ public class CalciteMultiValueStringQueryTest extends BaseCalciteQueryTest
                 .virtualColumns(
                     new ExpressionVirtualColumn(
                         "v0",
-                        "filter_only((x) -> !array_contains(array(\"dim2\"), x), \"dim3\")",
+                        "filter((x) -> !array_contains(array(\"dim2\"), x), \"dim3\")",
                         ColumnType.STRING,
                         TestExprMacroTable.INSTANCE
                     )


### PR DESCRIPTION
### Description

This PR allows to use the MV_FILTER_ONLY & MV_FILTER_NONE functions with a non literal argument. 
Currently `select mv_filter_only('mvd_dim', 'array_dim') from 'table'` returns a `Unhandled Query Planning Failure`
This is being tackled and also considered for the cases where the `array_dim` having null & empty values


<hr>

##### Key changed/added classes in this PR
 * `MultiValueStringOperatorConversions`
 * `ApplyFunction`
 * `CalciteMultiValueStringQueryTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
