### PR TITLE
reset keySerde when closing groupers to clear out heap dictionaries

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/AbstractBufferHashGrouper.java
@@ -169,6 +169,7 @@ public abstract class AbstractBufferHashGrouper<KeyType> implements Grouper<KeyT
   @Override
   public void close()
   {
+    keySerde.reset();
     aggregators.close();
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1380,6 +1380,14 @@ public class RowBasedGrouperHelper
       if (enableRuntimeDictionaryGeneration) {
         dictionary.clear();
         reverseDictionary.clear();
+        stringArrayDictionary.clear();
+        reverseStringArrayDictionary.clear();
+        doubleArrayDictionary.clear();
+        reverseDoubleArrayDictionary.clear();
+        floatArrayDictionary.clear();
+        reverseFloatArrayDictionary.clear();
+        longArrayDictionary.clear();
+        reverseLongArrayDictionary.clear();
         rankOfDictionaryIds = null;
         currentEstimatedSize = 0;
       }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -215,6 +215,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
   public void close()
   {
     grouper.close();
+    keySerde.reset();
     deleteFiles();
   }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/StreamingMergeSortedGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/StreamingMergeSortedGrouper.java
@@ -348,6 +348,7 @@ public class StreamingMergeSortedGrouper<KeyType> implements Grouper<KeyType>
   @Override
   public void close()
   {
+    keySerde.reset();
     for (BufferAggregator aggregator : aggregators) {
       try {
         aggregator.close();


### PR DESCRIPTION
### Description
`ConcurrentGrouper` [kind of misuses `ThreadLocal` to hold a `SpillingGrouper`](https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/ConcurrentGrouper.java#L71), and never calls `remove()` on it, which can result in large amounts of heap being retained as weak references even after grouping is finished.

Its kind of difficult to rework this such that we use `ThreadLocal` and actually call `remove()`, since the `ConcurrentGrouper` is created on the 'qtp' threads, but the `ThreadLocal` is set from the processing threads, so removing them from the `ThreadLocalMap` of the processing threads is a bit tricksy.

Poking around in the debugger sort of shows the problem, with several 'closed' `SpillingGrouper` present in the `ThreadLocalMap` of processing threads:
<img width="555" alt="Screenshot 2024-03-12 at 9 46 50 PM" src="https://github.com/apache/druid/assets/1577461/a488480a-4d11-4ebf-a3bd-bf68a9d12c5d">


The `ThreadLocalMap` stores these all as `WeakReference`, so they should eventually be reclaimed, but it might take several GC cycles, so OOM can still occur.

Rather than fixing usage of `ThreadLocal` to call remove, a much lower budget way to make this less painful is for `Grouper.close()` to more aggressively free stuff up, since `ConcurrentGrouper` does call close on all of the associated `SpillingGrouper`, including those stored in the `ThreadLocalMap`. The main thing using heap as far as I can tell is the dictionaries built by the `KeySerde`, so calling `keySerde.reset()` on all of the `Grouper.close()` implementations which have a `KeySerde` should free up a bunch of space that is no longer needed.

The `RowBasedKeySerde` implementation of `reset` was missing clearing out the array dictionaries, so I also added that.

I couldn't think of an easy way to write tests for this because its kind of stuffed down pretty deep, but if anyone has any ideas that aren't a ton of work I'm happy to add them.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
