### PR TITLE
Adding more logging for s3 RetryableS3OutputStream

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -269,7 +269,12 @@ public class RetryableS3OutputStream extends OutputStream
     // Closeables are closed in LIFO order
     closer.register(() -> {
       // This should be emitted as a metric
-      LOG.info("Total push time: [%d] ms", pushStopwatch.elapsed(TimeUnit.MILLISECONDS));
+      LOG.info(
+          "Total: %d parts has a push time: %d ms with cumulative size: %d bytes ",
+          numChunksPushed,
+          pushStopwatch.elapsed(TimeUnit.MILLISECONDS),
+          resultsSize
+      );
     });
 
     closer.register(() -> org.apache.commons.io.FileUtils.forceDelete(chunkStorePath));

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -270,10 +270,10 @@ public class RetryableS3OutputStream extends OutputStream
     closer.register(() -> {
       // This should be emitted as a metric
       LOG.info(
-          "Total: %d parts has a push time: %d ms with cumulative size: %d bytes ",
+          "Pushed total [%d] parts containing [%d] bytes in [%d]ms.",
           numChunksPushed,
-          pushStopwatch.elapsed(TimeUnit.MILLISECONDS),
-          resultsSize
+          resultsSize,
+          pushStopwatch.elapsed(TimeUnit.MILLISECONDS)
       );
     });
 


### PR DESCRIPTION
Adding more logging for s3 RetryableS3OutputStream which would help us determine if chunk size needs to be adjusted . 