### PR TITLE
feat: support iterable for druid lookups-cached-single extension

### DIFF
--- a/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/LoadingLookup.java
+++ b/extensions-core/lookups-cached-single/src/main/java/org/apache/druid/server/lookup/LoadingLookup.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -109,25 +110,32 @@ public class LoadingLookup extends LookupExtractor
   @Override
   public boolean canIterate()
   {
-    return false;
+    return true;
   }
 
   @Override
   public boolean canGetKeySet()
   {
-    return false;
+    return true;
   }
 
   @Override
   public Iterable<Map.Entry<String, String>> iterable()
   {
-    throw new UnsupportedOperationException("Cannot iterate");
+    return this.dataFetcher.fetchAll();
   }
 
   @Override
   public Set<String> keySet()
   {
-    throw new UnsupportedOperationException("Cannot get key set");
+    Iterable<Map.Entry<String, String>> data = this.dataFetcher.fetchAll();
+    Set<String> set = new HashSet<>();
+    if (data != null) {
+      data.forEach(each -> {
+        set.add(each.getKey());
+      });
+    }
+    return set;
   }
 
   @Override

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.lookup;
 
+import com.amazonaws.transform.MapEntry;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.NullHandling;
@@ -30,8 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
@@ -132,13 +132,38 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   @Test
   public void testCanGetKeySet()
   {
-    Assert.assertFalse(loadingLookup.canGetKeySet());
+    Assert.assertTrue(loadingLookup.canGetKeySet());
+  }
+
+  @Test
+  public void testCanIterate()
+  {
+    Assert.assertTrue(loadingLookup.canIterate());
   }
 
   @Test
   public void testKeySet()
   {
-    expectedException.expect(UnsupportedOperationException.class);
-    loadingLookup.keySet();
+    Map.Entry<String, String> fetchedData = new AbstractMap.SimpleEntry<>("dummy", "test");
+    EasyMock.expect(dataFetcher.fetchAll()).andReturn(Arrays.asList(fetchedData));
+    EasyMock.replay(dataFetcher);
+    Assert.assertEquals(loadingLookup.keySet().size(), 1);
+    EasyMock.verify(dataFetcher);
+  }
+
+  @Test
+  public void testFetchAll()
+  {
+    Map.Entry<String, String> fetchedData = new AbstractMap.SimpleEntry<>("dummy", "test");
+    EasyMock.expect(dataFetcher.fetchAll()).andReturn(Arrays.asList(fetchedData));
+    EasyMock.replay(dataFetcher);
+    Assert.assertEquals(getIteratorSize(loadingLookup.iterable().iterator()), 1);
+    EasyMock.verify(dataFetcher);
+  }
+
+  public int getIteratorSize(Iterator<Map.Entry<String, String>> it) {
+    int i = 0;
+    for ( ; it.hasNext() ; ++i ) it.next();
+    return i;
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Relates to #15936.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->
This PR aims to change the behavior of the druid `lookups-cached-single` extension. In fact, we aim to introduce the option to iterate over fetched data from the `dataFetcher`. We need this in the case of `loadingLookups`, that's why these changes don't impact the `pollingLookup` feature.
I also added the handling of a use case where the data exists in Druid but not in the actual data fetcher, which is in our use-case JDBC Data fetcher.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `Support iterating over fetched data for the loadinglookups for the druid lookups-cached-single extension`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
