### PR TITLE
fix ColumnType to RelDataType conversion for nested arrays

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -7332,6 +7332,8 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   public void testGroupByNestedArrayInline()
   {
     cannotVectorize();
+    // msq does not support nested arrays currently
+    msqIncompatible();
     testQuery(
         "SELECT c1, ARRAY_PREPEND('1', ARRAY_AGG(ARRAY[1,c2], 100000)) c5 \n"
         + "FROM (VALUES (1,1),(2,2),(3,3)) t(c1,c2)\n"
@@ -7409,6 +7411,8 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   public void testGroupByNestedArrayInlineCount()
   {
     cannotVectorize();
+    // msq does not support nested arrays currently
+    msqIncompatible();
     testQuery(
         "SELECT COUNT(*) c FROM (\n"
         + "SELECT c1, ARRAY_PREPEND('1', ARRAY_AGG(ARRAY[1,c2], 100000)) c5 \n"


### PR DESCRIPTION
### Description
`RowSignatures.toRelDataType` did not correctly handle conversion of nested array types such as `ARRAY<ARRAY<LONG>>` etc, since the `ARRAY` handling case only checked for the primitive column types. I have modified this code to split out the `ColumnType` to `RelDataType` conversion into a new method, `RowSignatures. columnTypeToRelDataType`, and handle arrays by recursively calling this method to convert the element type to a `RelDataType` so that it can handle any type of Druid array.

I kind of think this method maybe should be moved into `Calcites` since a bunch of the other conversion methods that don't involve `RowSignature` live there, but I haven't moved it yet...

Only the second added test would fail, despite just being a count(*) wrapper around the first one. Apparently this query used to run fine, but I believe the changes in #16033 which resulted in `RowSignatures.toRelDataType` started exercising this path a bit more frequently, which is how the problem was noticed.

<hr>


This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
