### PR TITLE
Add versions to `markUsed` and `markUnused` APIs

### DIFF
--- a/docs/api-reference/data-management-api.md
+++ b/docs/api-reference/data-management-api.md
@@ -206,9 +206,8 @@ Marks the state of a group of segments as unused, using an array of segment IDs 
 Pass the array of segment IDs or interval as a JSON object in the request body.
 
 For the interval, specify the start and end times as ISO 8601 strings to identify segments inclusive of the start time and exclusive of the end time.
-Optionally, specify an array of segment versions with interval.
-
-Druid only updates the segments completely contained within the specified interval; partially overlapping segments are not affected.
+Optionally, specify an array of segment versions with interval. Druid updates only the segments completely contained
+within the specified interval that match the optional list of versions; partially overlapping segments are not affected.
 
 #### URL
 
@@ -309,9 +308,8 @@ Marks the state of a group of segments as used, using an array of segment IDs or
 Pass the array of segment IDs or interval as a JSON object in the request body.
 
 For the interval, specify the start and end times as ISO 8601 strings to identify segments inclusive of the start time and exclusive of the end time.
-Optionally, specify an array of segment versions with interval.
-
-Druid only updates the segments completely contained within the specified interval; partially overlapping segments are not affected.
+Optionally, specify an array of segment versions with interval. Druid updates only the segments completely contained
+within the specified interval that match the optional list of versions; partially overlapping segments are not affected.
 
 #### URL
 

--- a/docs/api-reference/data-management-api.md
+++ b/docs/api-reference/data-management-api.md
@@ -217,11 +217,11 @@ within the specified interval that match the optional list of versions; partiall
 
 The group of segments is sent as a JSON request payload that accepts the following properties:
 
-|Property|Description|Example|
-|----------|-------------|---------|
-|`interval`|ISO 8601 segments interval.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
-|`segmentIds`|Array of segment IDs.|`["segmentId1", "segmentId2"]`|
-|`versions`|Array of segment versions. Must be provided with `interval`.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
+|Property|Description|Required|Example|
+|----------|-------------|---------|---------|
+|`interval`|ISO 8601 segments interval.|Yes, if `segmentIds` is not specified.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
+|`segmentIds`|List of segment IDs.|Yes, if `interval` is not specified.|`["segmentId1", "segmentId2"]`|
+|`versions`|List of segment versions. Must be provided with `interval`.|No.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
 
 #### Responses
 
@@ -319,11 +319,11 @@ within the specified interval that match the optional list of versions; partiall
 
 The group of segments is sent as a JSON request payload that accepts the following properties:
 
-|Property|Description|Example|
-|----------|-------------|---------|
-|`interval`| ISO 8601 segments interval.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
-|`segmentIds`|Array of segment IDs.|`["segmentId1", "segmentId2"]`|
-|`versions`|Array of segment versions. Must be provided with an `interval`.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
+|Property|Description|Required|Example|
+|----------|-------------|---------|---------|
+|`interval`|ISO 8601 segments interval.|Yes, if `segmentIds` is not specified.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
+|`segmentIds`|List of segment IDs.|Yes, if `interval` is not specified.|`["segmentId1", "segmentId2"]`|
+|`versions`|List of segment versions. Must be provided with `interval`.|No.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
 
 #### Responses
 

--- a/docs/api-reference/data-management-api.md
+++ b/docs/api-reference/data-management-api.md
@@ -206,6 +206,8 @@ Marks the state of a group of segments as unused, using an array of segment IDs 
 Pass the array of segment IDs or interval as a JSON object in the request body.
 
 For the interval, specify the start and end times as ISO 8601 strings to identify segments inclusive of the start time and exclusive of the end time.
+Optionally, specify an array of segment versions with interval.
+
 Druid only updates the segments completely contained within the specified interval; partially overlapping segments are not affected.
 
 #### URL
@@ -214,12 +216,13 @@ Druid only updates the segments completely contained within the specified interv
 
 #### Request body
 
-The group of segments is sent as a JSON request payload that accepts one of the following properties:
+The group of segments is sent as a JSON request payload that accepts the following properties:
 
 |Property|Description|Example|
 |----------|-------------|---------|
 |`interval`|ISO 8601 segments interval.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
 |`segmentIds`|Array of segment IDs.|`["segmentId1", "segmentId2"]`|
+|`versions`|Array of segment versions. Must be provided with `interval`.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
 
 #### Responses
 
@@ -306,6 +309,8 @@ Marks the state of a group of segments as used, using an array of segment IDs or
 Pass the array of segment IDs or interval as a JSON object in the request body.
 
 For the interval, specify the start and end times as ISO 8601 strings to identify segments inclusive of the start time and exclusive of the end time.
+Optionally, specify an array of segment versions with interval.
+
 Druid only updates the segments completely contained within the specified interval; partially overlapping segments are not affected.
 
 #### URL
@@ -314,12 +319,13 @@ Druid only updates the segments completely contained within the specified interv
 
 #### Request body
 
-The group of segments is sent as a JSON request payload that accepts one of the following properties:
+The group of segments is sent as a JSON request payload that accepts the following properties:
 
 |Property|Description|Example|
 |----------|-------------|---------|
 |`interval`| ISO 8601 segments interval.|`"2015-09-12T03:00:00.000Z/2015-09-12T05:00:00.000Z"`|
 |`segmentIds`|Array of segment IDs.|`["segmentId1", "segmentId2"]`|
+|`versions`|Array of segment versions. Must be provided with an `interval`.|`["2024-03-14T16:00:04.086Z", ""2024-03-12T16:00:04.086Z"]`|
 
 #### Responses
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/MarkSegmentsAsUnusedAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/MarkSegmentsAsUnusedAction.java
@@ -63,9 +63,8 @@ public class MarkSegmentsAsUnusedAction implements TaskAction<Integer>
   @Override
   public Integer perform(Task task, TaskActionToolbox toolbox)
   {
-    int numMarked = toolbox.getIndexerMetadataStorageCoordinator()
-                           .markSegmentsAsUnusedWithinInterval(dataSource, interval);
-    return numMarked;
+    return toolbox.getIndexerMetadataStorageCoordinator()
+                  .markSegmentsAsUnusedWithinInterval(dataSource, interval);
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -387,7 +387,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         segments.size(),
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            Intervals.of("2018-01-01/2020-01-01")
+            Intervals.of("2018-01-01/2020-01-01"),
+            null
         )
     );
 
@@ -434,7 +435,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment1.getInterval()
+            segment1.getInterval(),
+            null
         )
     );
 
@@ -442,7 +444,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment4.getInterval()
+            segment4.getInterval(),
+            null
         )
     );
 
@@ -450,7 +453,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment3.getInterval()
+            segment3.getInterval(),
+            null
         )
     );
 
@@ -508,7 +512,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment1.getInterval()
+            segment1.getInterval(),
+            null
         )
     );
 
@@ -516,7 +521,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment4.getInterval()
+            segment4.getInterval(),
+            null
         )
     );
 
@@ -529,7 +535,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         1,
         getSegmentsMetadataManager().markAsUnusedSegmentsInInterval(
             DATA_SOURCE,
-            segment3.getInterval()
+            segment3.getInterval(),
+            null
         )
     );
 

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -53,7 +53,20 @@ public interface SegmentsMetadataManager
    */
   int markAsUsedAllNonOvershadowedSegmentsInDataSource(String dataSource);
 
-  int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval);
+  /**
+   * Marks non-overshadowed unused segments for the given interval as used.
+   * @return Number of segments updated
+   */
+  default int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval)
+  {
+    return markAsUsedNonOvershadowedSegmentsInInterval(dataSource, interval, null);
+  }
+
+  /**
+   * Marks non-overshadowed unused segments for the given interval and optional list of versions as used.
+   * @return Number of segments updated
+   */
+  int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, List<String> versions);
 
   /**
    * Marks the given segment IDs as "used" only if there are not already overshadowed
@@ -81,7 +94,22 @@ public interface SegmentsMetadataManager
    */
   int markAsUnusedAllSegmentsInDataSource(String dataSource);
 
-  int markAsUnusedSegmentsInInterval(String dataSource, Interval interval);
+  /**
+   * Marks segments as unused that are fully contained in the specified interval. Segments that are already marked as
+   * unused are not updated.
+   * @return Number of segments updated
+   */
+  default int markAsUnusedSegmentsInInterval(String dataSource, Interval interval)
+  {
+    return markAsUnusedSegmentsInInterval(dataSource, interval, null);
+  }
+
+  /**
+   * Marks segments as unused that are fully contained in the specified interval with an optional list of versions.
+   * Segments that are already marked as unused are not updated.
+   * @return The number of segments updated
+   */
+  int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, List<String> versions);
 
   int markSegmentsAsUnused(Set<SegmentId> segmentIds);
 

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -54,10 +54,12 @@ public interface SegmentsMetadataManager
   int markAsUsedAllNonOvershadowedSegmentsInDataSource(String dataSource);
 
   /**
-   * Marks non-overshadowed unused segments for the given interval and optional list of versions as used.
+   * Marks non-overshadowed unused segments for the given interval and optional list of versions
+   * as used. If versions are not specified, all versions of non-overshadowed unused segments in the interval
+   * will be marked as used.
    * @return Number of segments updated
    */
-  int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, List<String> versions);
+  int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, @Nullable List<String> versions);
 
   /**
    * Marks the given segment IDs as "used" only if there are not already overshadowed
@@ -86,11 +88,12 @@ public interface SegmentsMetadataManager
   int markAsUnusedAllSegmentsInDataSource(String dataSource);
 
   /**
-   * Marks segments as unused that are fully contained in the specified interval with an optional list of versions.
+   * Marks segments as unused that are <b>fully contained</b> in the given interval for an optional list of versions.
+   * If versions are not specified, all versions of segments in the interval will be marked as unused.
    * Segments that are already marked as unused are not updated.
    * @return The number of segments updated
    */
-  int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, List<String> versions);
+  int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, @Nullable List<String> versions);
 
   int markSegmentsAsUnused(Set<SegmentId> segmentIds);
 

--- a/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentsMetadataManager.java
@@ -54,15 +54,6 @@ public interface SegmentsMetadataManager
   int markAsUsedAllNonOvershadowedSegmentsInDataSource(String dataSource);
 
   /**
-   * Marks non-overshadowed unused segments for the given interval as used.
-   * @return Number of segments updated
-   */
-  default int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval)
-  {
-    return markAsUsedNonOvershadowedSegmentsInInterval(dataSource, interval, null);
-  }
-
-  /**
    * Marks non-overshadowed unused segments for the given interval and optional list of versions as used.
    * @return Number of segments updated
    */
@@ -93,16 +84,6 @@ public interface SegmentsMetadataManager
    * caller.
    */
   int markAsUnusedAllSegmentsInDataSource(String dataSource);
-
-  /**
-   * Marks segments as unused that are fully contained in the specified interval. Segments that are already marked as
-   * unused are not updated.
-   * @return Number of segments updated
-   */
-  default int markAsUnusedSegmentsInInterval(String dataSource, Interval interval)
-  {
-    return markAsUnusedSegmentsInInterval(dataSource, interval, null);
-  }
 
   /**
    * Marks segments as unused that are fully contained in the specified interval with an optional list of versions.

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -654,21 +654,25 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   @Override
   public int markAsUsedAllNonOvershadowedSegmentsInDataSource(final String dataSource)
   {
-    return doMarkAsUsedNonOvershadowedSegments(dataSource, null);
+    return doMarkAsUsedNonOvershadowedSegments(dataSource, null, null);
   }
 
   @Override
-  public int markAsUsedNonOvershadowedSegmentsInInterval(final String dataSource, final Interval interval)
+  public int markAsUsedNonOvershadowedSegmentsInInterval(
+      final String dataSource,
+      final Interval interval,
+      @Nullable final List<String> versions
+  )
   {
     Preconditions.checkNotNull(interval);
-    return doMarkAsUsedNonOvershadowedSegments(dataSource, interval);
+    return doMarkAsUsedNonOvershadowedSegments(dataSource, interval, versions);
   }
 
-  /**
-   * Implementation for both {@link #markAsUsedAllNonOvershadowedSegmentsInDataSource} (if the given interval is null)
-   * and {@link #markAsUsedNonOvershadowedSegmentsInInterval}.
-   */
-  private int doMarkAsUsedNonOvershadowedSegments(String dataSourceName, @Nullable Interval interval)
+  private int doMarkAsUsedNonOvershadowedSegments(
+      final String dataSourceName,
+      final @Nullable Interval interval,
+      final @Nullable List<String> versions
+  )
   {
     final List<DataSegment> unusedSegments = new ArrayList<>();
     final SegmentTimeline timeline = new SegmentTimeline();
@@ -682,12 +686,12 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
               interval == null ? Intervals.ONLY_ETERNITY : Collections.singletonList(interval);
 
           try (final CloseableIterator<DataSegment> iterator =
-                   queryTool.retrieveUsedSegments(dataSourceName, intervals)) {
+                   queryTool.retrieveUsedSegments(dataSourceName, intervals, versions)) {
             timeline.addSegments(iterator);
           }
 
           try (final CloseableIterator<DataSegment> iterator =
-                   queryTool.retrieveUnusedSegments(dataSourceName, intervals, null, null, null, null, null)) {
+                   queryTool.retrieveUnusedSegments(dataSourceName, intervals, versions, null, null, null, null)) {
             while (iterator.hasNext()) {
               final DataSegment dataSegment = iterator.next();
               timeline.addSegments(Iterators.singletonIterator(dataSegment));
@@ -796,7 +800,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   private int markSegmentsAsUsed(final List<SegmentId> segmentIds)
   {
     if (segmentIds.isEmpty()) {
-      log.info("No segments found to update!");
+      log.info("No segments found to mark as used.");
       return 0;
     }
 
@@ -856,13 +860,18 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public int markAsUnusedSegmentsInInterval(String dataSourceName, Interval interval)
+  public int markAsUnusedSegmentsInInterval(
+      final String dataSource,
+      final Interval interval,
+      @Nullable final List<String> versions
+  )
   {
+    Preconditions.checkNotNull(interval);
     try {
       return connector.getDBI().withHandle(
           handle ->
               SqlSegmentsMetadataQuery.forHandle(handle, connector, dbTables.get(), jsonMapper)
-                                      .markSegmentsUnused(dataSourceName, interval)
+                                      .markSegmentsUnused(dataSource, interval, versions)
       );
     }
     catch (Exception e) {

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -118,9 +118,6 @@ public class DataSourcesResource
   private final DruidCoordinator coordinator;
   private final AuditManager auditManager;
 
-  private static final String INVALID_PAYLOAD_ERROR_MESSAGE = "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
-                                       + " Optionally, include 'versions' only when 'interval' is provided.";
-
   @Inject
   public DataSourcesResource(
       CoordinatorServerView serverInventoryView,
@@ -210,13 +207,13 @@ public class DataSourcesResource
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markAsUsedNonOvershadowedSegments(
       @PathParam("dataSourceName") final String dataSourceName,
-      final MarkDataSourceSegmentsPayload payload
+      final SegmentsToUpdateFilter payload
   )
   {
     if (payload == null || !payload.isValid()) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity(invalidErrMsg)
+          .entity(SegmentsToUpdateFilter.INVALID_PAYLOAD_ERROR_MESSAGE)
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
@@ -256,14 +253,14 @@ public class DataSourcesResource
   @Consumes(MediaType.APPLICATION_JSON)
   public Response markSegmentsAsUnused(
       @PathParam("dataSourceName") final String dataSourceName,
-      final MarkDataSourceSegmentsPayload payload,
+      final SegmentsToUpdateFilter payload,
       @Context final HttpServletRequest req
   )
   {
     if (payload == null || !payload.isValid()) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity(invalidErrMsg)
+          .entity(SegmentsToUpdateFilter.INVALID_PAYLOAD_ERROR_MESSAGE)
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
@@ -998,14 +995,17 @@ public class DataSourcesResource
    * {@code versions} may be optionally specified only when {@code interval} is provided.
    */
   @VisibleForTesting
-  static class MarkDataSourceSegmentsPayload
+  static class SegmentsToUpdateFilter
   {
     private final Interval interval;
     private final Set<String> segmentIds;
     private final List<String> versions;
 
+    private static final String INVALID_PAYLOAD_ERROR_MESSAGE = "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
+                                                                + " Optionally, include 'versions' only when 'interval' is provided.";
+
     @JsonCreator
-    public MarkDataSourceSegmentsPayload(
+    public SegmentsToUpdateFilter(
         @JsonProperty("interval") @Nullable Interval interval,
         @JsonProperty("segmentIds") @Nullable Set<String> segmentIds,
         @JsonProperty("versions") @Nullable List<String> versions

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -260,7 +260,8 @@ public class DataSourcesResource
     if (payload == null || !payload.isValid()) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("Invalid request payload, either interval or segmentIds array must be specified")
+          .entity("Invalid request payload, either 'interval' or 'segmentIds' array must be specified. 'versions' array "
+                  + "may be optionally specified only when 'interval' is provided.")
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
@@ -301,7 +302,7 @@ public class DataSourcesResource
 
   private static Response logAndCreateDataSourceNotFoundResponse(String dataSourceName)
   {
-    log.warn("datasource not found [%s]", dataSourceName);
+    log.warn("datasource[%s] not found", dataSourceName);
     return Response.noContent().build();
   }
 
@@ -318,7 +319,7 @@ public class DataSourcesResource
           .build();
     }
     catch (Exception e) {
-      log.error(e, "Error occurred while updating segments for data source[%s]", dataSourceName);
+      log.error(e, "Error occurred while updating segments for datasource[%s]", dataSourceName);
       return Response
           .serverError()
           .entity(ImmutableMap.of("error", "Exception occurred.", "message", Throwables.getRootCause(e).toString()))
@@ -999,9 +1000,9 @@ public class DataSourcesResource
 
     @JsonCreator
     public MarkDataSourceSegmentsPayload(
-        @JsonProperty("interval") Interval interval,
-        @JsonProperty("segmentIds") Set<String> segmentIds,
-        @JsonProperty("versions") List<String> versions
+        @JsonProperty("interval") @Nullable Interval interval,
+        @JsonProperty("segmentIds") @Nullable Set<String> segmentIds,
+        @JsonProperty("versions") @Nullable List<String> versions
     )
     {
       this.interval = interval;
@@ -1009,18 +1010,21 @@ public class DataSourcesResource
       this.versions = versions;
     }
 
+    @Nullable
     @JsonProperty
     public Interval getInterval()
     {
       return interval;
     }
 
+    @Nullable
     @JsonProperty
     public Set<String> getSegmentIds()
     {
       return segmentIds;
     }
 
+    @Nullable
     @JsonProperty
     public List<String> getVersions()
     {

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -118,7 +118,7 @@ public class DataSourcesResource
   private final DruidCoordinator coordinator;
   private final AuditManager auditManager;
 
-  private final String invalidErrMsg = "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
+  private static final String INVALID_PAYLOAD_ERROR_MESSAGE = "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
                                        + " Optionally, include 'versions' only when 'interval' is provided.";
 
   @Inject

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -118,6 +118,9 @@ public class DataSourcesResource
   private final DruidCoordinator coordinator;
   private final AuditManager auditManager;
 
+  private final String invalidErrMsg = "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
+                                       + " Optionally, include 'versions' only when 'interval' is provided.";
+
   @Inject
   public DataSourcesResource(
       CoordinatorServerView serverInventoryView,
@@ -213,7 +216,7 @@ public class DataSourcesResource
     if (payload == null || !payload.isValid()) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("Invalid request payload, either interval or segmentIds array must be specified")
+          .entity(invalidErrMsg)
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
@@ -260,8 +263,7 @@ public class DataSourcesResource
     if (payload == null || !payload.isValid()) {
       return Response
           .status(Response.Status.BAD_REQUEST)
-          .entity("Invalid request payload, either 'interval' or 'segmentIds' array must be specified. 'versions' array "
-                  + "may be optionally specified only when 'interval' is provided.")
+          .entity(invalidErrMsg)
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
@@ -567,9 +569,9 @@ public class DataSourcesResource
 
   private static class SegmentsLoadStatistics
   {
-    private int numPublishedSegments;
-    private int numUnavailableSegments;
-    private int numLoadedSegments;
+    private final int numPublishedSegments;
+    private final int numUnavailableSegments;
+    private final int numLoadedSegments;
 
     SegmentsLoadStatistics(
         int numPublishedSegments,
@@ -991,6 +993,10 @@ public class DataSourcesResource
     return false;
   }
 
+  /**
+   * Either {@code interval} or {@code segmentIds} array must be specified, but not both.
+   * {@code versions} may be optionally specified only when {@code interval} is provided.
+   */
   @VisibleForTesting
   static class MarkDataSourceSegmentsPayload
   {

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -68,6 +68,7 @@ import org.apache.druid.timeline.TimelineLookup;
 import org.apache.druid.timeline.TimelineObjectHolder;
 import org.apache.druid.timeline.VersionedIntervalTimeline;
 import org.apache.druid.timeline.partition.PartitionChunk;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -205,8 +206,8 @@ public class DataSourcesResource
   @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markAsUsedNonOvershadowedSegments(
-      @PathParam("dataSourceName") String dataSourceName,
-      MarkDataSourceSegmentsPayload payload
+      @PathParam("dataSourceName") final String dataSourceName,
+      final MarkDataSourceSegmentsPayload payload
   )
   {
     if (payload == null || !payload.isValid()) {
@@ -1030,7 +1031,16 @@ public class DataSourcesResource
 
     public boolean isValid()
     {
-      return (interval == null ^ segmentIds == null) && (segmentIds == null || !segmentIds.isEmpty()); // fixme
+      if (interval == null && CollectionUtils.isNullOrEmpty(segmentIds)) {
+        return false;
+      }
+      if (interval != null && segmentIds != null) {
+        return false;
+      }
+      if (!CollectionUtils.isNullOrEmpty(versions) && interval == null) {
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -217,10 +217,14 @@ public class DataSourcesResource
           .build();
     } else {
       SegmentUpdateOperation operation = () -> {
-
         final Interval interval = payload.getInterval();
+        final List<String> versions = payload.getVersions();
         if (interval != null) {
-          return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval);
+          if (versions != null) {
+            return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval, versions);
+          } else {
+            return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval);
+          }
         } else {
           final Set<String> segmentIds = payload.getSegmentIds();
           if (segmentIds == null || segmentIds.isEmpty()) {
@@ -266,9 +270,14 @@ public class DataSourcesResource
     } else {
       SegmentUpdateOperation operation = () -> {
         final Interval interval = payload.getInterval();
+        final List<String> versions = payload.getVersions();
         final int numUpdatedSegments;
         if (interval != null) {
-          numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval);
+          if (versions != null) {
+            numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval, versions);
+          } else {
+            numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval);
+          }
         } else {
           final Set<SegmentId> segmentIds =
               payload.getSegmentIds()
@@ -995,15 +1004,18 @@ public class DataSourcesResource
   {
     private final Interval interval;
     private final Set<String> segmentIds;
+    private final List<String> versions;
 
     @JsonCreator
     public MarkDataSourceSegmentsPayload(
         @JsonProperty("interval") Interval interval,
-        @JsonProperty("segmentIds") Set<String> segmentIds
+        @JsonProperty("segmentIds") Set<String> segmentIds,
+        @JsonProperty("versions") List<String> versions
     )
     {
       this.interval = interval;
       this.segmentIds = segmentIds;
+      this.versions = versions;
     }
 
     @JsonProperty
@@ -1018,9 +1030,15 @@ public class DataSourcesResource
       return segmentIds;
     }
 
+    @JsonProperty
+    public List<String> getVersions()
+    {
+      return versions;
+    }
+
     public boolean isValid()
     {
-      return (interval == null ^ segmentIds == null) && (segmentIds == null || !segmentIds.isEmpty());
+      return (interval == null ^ segmentIds == null) && (segmentIds == null || !segmentIds.isEmpty()); // fixme
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -1029,7 +1029,7 @@ public class DataSourcesResource
       return versions;
     }
 
-    public boolean isValid()
+    private boolean isValid()
     {
       if (interval == null && CollectionUtils.isNullOrEmpty(segmentIds)) {
         return false;
@@ -1037,10 +1037,7 @@ public class DataSourcesResource
       if (interval != null && segmentIds != null) {
         return false;
       }
-      if (!CollectionUtils.isNullOrEmpty(versions) && interval == null) {
-        return false;
-      }
-      return true;
+      return CollectionUtils.isNullOrEmpty(versions) || interval != null;
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -220,11 +220,7 @@ public class DataSourcesResource
         final Interval interval = payload.getInterval();
         final List<String> versions = payload.getVersions();
         if (interval != null) {
-          if (versions != null) {
-            return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval, versions);
-          } else {
-            return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval);
-          }
+          return segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(dataSourceName, interval, versions);
         } else {
           final Set<String> segmentIds = payload.getSegmentIds();
           if (segmentIds == null || segmentIds.isEmpty()) {
@@ -273,11 +269,7 @@ public class DataSourcesResource
         final List<String> versions = payload.getVersions();
         final int numUpdatedSegments;
         if (interval != null) {
-          if (versions != null) {
-            numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval, versions);
-          } else {
-            numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval);
-          }
+          numUpdatedSegments = segmentsMetadataManager.markAsUnusedSegmentsInInterval(dataSourceName, interval, versions);
         } else {
           final Set<SegmentId> segmentIds =
               payload.getSegmentIds()

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -211,7 +211,6 @@ public class DataSourcesResource
   )
   {
     if (payload == null || !payload.isValid()) {
-      log.warn("Invalid request payload: [%s]", payload);
       return Response
           .status(Response.Status.BAD_REQUEST)
           .entity("Invalid request payload, either interval or segmentIds array must be specified")
@@ -259,7 +258,6 @@ public class DataSourcesResource
   )
   {
     if (payload == null || !payload.isValid()) {
-      log.warn("Invalid request payload: [%s]", payload);
       return Response
           .status(Response.Status.BAD_REQUEST)
           .entity("Invalid request payload, either interval or segmentIds array must be specified")
@@ -993,7 +991,7 @@ public class DataSourcesResource
   }
 
   @VisibleForTesting
-  protected static class MarkDataSourceSegmentsPayload
+  static class MarkDataSourceSegmentsPayload
   {
     private final Interval interval;
     private final Set<String> segmentIds;

--- a/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/SqlSegmentsMetadataManagerTest.java
@@ -834,7 +834,7 @@ public class SqlSegmentsMetadataManagerTest
     );
 
     // 2 out of 3 segments match the interval
-    Assert.assertEquals(2, sqlSegmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(DS.KOALA, theInterval));
+    Assert.assertEquals(2, sqlSegmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(DS.KOALA, theInterval, null));
 
     sqlSegmentsMetadataManager.poll();
     Assert.assertEquals(
@@ -882,7 +882,7 @@ public class SqlSegmentsMetadataManagerTest
     );
 
     // 1 out of 3 segments match the interval, other 2 overlap, only the segment fully contained will be marked unused
-    Assert.assertEquals(1, sqlSegmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(DS.KOALA, theInterval));
+    Assert.assertEquals(1, sqlSegmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(DS.KOALA, theInterval, null));
 
     sqlSegmentsMetadataManager.poll();
     Assert.assertEquals(
@@ -938,7 +938,7 @@ public class SqlSegmentsMetadataManagerTest
     final Interval theInterval = Intervals.of("2017-10-15T00:00:00.000/2017-10-18T00:00:00.000");
 
     // 2 out of 3 segments match the interval
-    Assert.assertEquals(2, sqlSegmentsMetadataManager.markAsUnusedSegmentsInInterval(DS.KOALA, theInterval));
+    Assert.assertEquals(2, sqlSegmentsMetadataManager.markAsUnusedSegmentsInInterval(DS.KOALA, theInterval, null));
 
     sqlSegmentsMetadataManager.poll();
     Assert.assertEquals(
@@ -1071,7 +1071,7 @@ public class SqlSegmentsMetadataManagerTest
     final Interval theInterval = Intervals.of("2017-10-16T00:00:00.000/2017-10-20T00:00:00.000");
 
     // 1 out of 3 segments match the interval, other 2 overlap, only the segment fully contained will be marked unused
-    Assert.assertEquals(1, sqlSegmentsMetadataManager.markAsUnusedSegmentsInInterval(DS.KOALA, theInterval));
+    Assert.assertEquals(1, sqlSegmentsMetadataManager.markAsUnusedSegmentsInInterval(DS.KOALA, theInterval, null));
 
     sqlSegmentsMetadataManager.poll();
     Assert.assertEquals(

--- a/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
+++ b/server/src/test/java/org/apache/druid/metadata/TestDerbyConnector.java
@@ -145,7 +145,7 @@ public class TestDerbyConnector extends DerbyConnector
   }
 
   /**
-   * A wrapper class for queries on the segments table.
+   * A wrapper class for updating the segments table.
    */
   public static class SegmentsTable
   {

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -87,7 +87,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval)
+  public int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, List<String> versions)
   {
     return 0;
   }
@@ -116,7 +116,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public int markAsUnusedSegmentsInInterval(String dataSource, Interval interval)
+  public int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, List<String> versions)
   {
     return 0;
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestSegmentsMetadataManager.java
@@ -87,7 +87,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, List<String> versions)
+  public int markAsUsedNonOvershadowedSegmentsInInterval(String dataSource, Interval interval, @Nullable List<String> versions)
   {
     return 0;
   }
@@ -116,7 +116,7 @@ public class TestSegmentsMetadataManager implements SegmentsMetadataManager
   }
 
   @Override
-  public int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, List<String> versions)
+  public int markAsUnusedSegmentsInInterval(String dataSource, Interval interval, @Nullable List<String> versions)
   {
     return 0;
   }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -734,8 +734,9 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsInterval()
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
-    int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull()
+    );
     EasyMock.expect(numUpdatedSegments).andReturn(3).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -749,11 +750,52 @@ public class DataSourcesResourceTest
   }
 
   @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsIntervalWithVersions()
+  {
+    Interval interval = Intervals.of("2010-01-22/P1D");
+
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.eq(ImmutableList.of("v0"))
+    );
+    EasyMock.expect(numUpdatedSegments).andReturn(3).once();
+    EasyMock.replay(segmentsMetadataManager, inventoryView, server);
+
+    DataSourcesResource dataSourcesResource = createResource();
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null, ImmutableList.of("v0"))
+    );
+    Assert.assertEquals(200, response.getStatus());
+    EasyMock.verify(segmentsMetadataManager, inventoryView, server);
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsIntervalWithNonExistentVersion()
+  {
+    Interval interval = Intervals.of("2010-01-22/P1D");
+
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.eq(ImmutableList.of("foo"))
+    );
+    EasyMock.expect(numUpdatedSegments).andReturn(0).once();
+    EasyMock.replay(segmentsMetadataManager, inventoryView, server);
+
+    DataSourcesResource dataSourcesResource = createResource();
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null, ImmutableList.of("foo"))
+    );
+    Assert.assertEquals(200, response.getStatus());
+    EasyMock.verify(segmentsMetadataManager, inventoryView, server);
+  }
+
+  @Test
   public void testMarkAsUsedNonOvershadowedSegmentsIntervalNoneUpdated()
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
-    int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull()
+    );
     EasyMock.expect(numUpdatedSegments).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -771,8 +813,9 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsSet()
   {
     Set<String> segmentIds = ImmutableSet.of(dataSegmentList.get(1).getId().toString());
-    int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegments(EasyMock.eq("datasource1"), EasyMock.eq(segmentIds));
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegments(
+        EasyMock.eq("datasource1"), EasyMock.eq(segmentIds)
+    );
     EasyMock.expect(numUpdatedSegments).andReturn(3).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -790,8 +833,9 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsIntervalException()
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
-    int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull()
+    );
     EasyMock.expect(numUpdatedSegments).andThrow(new RuntimeException("Error!")).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -809,8 +853,9 @@ public class DataSourcesResourceTest
   public void testMarkAsUsedNonOvershadowedSegmentsNoDataSource()
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
-    int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
+    int numUpdatedSegments = segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(
+        EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull()
+    );
     EasyMock.expect(numUpdatedSegments).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -844,7 +889,9 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-22/P1D"), ImmutableSet.of(), null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(
+            Intervals.of("2010-01-22/P1D"), ImmutableSet.of(), null
+        )
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -856,7 +903,9 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2020/2030"), ImmutableSet.of("seg1"), ImmutableList.of("v1", "v2"))
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(
+            Intervals.of("2020/2030"), ImmutableSet.of("seg1"), ImmutableList.of("v1", "v2")
+        )
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -892,7 +941,11 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null, ImmutableList.of("v1", "v2"))
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(
+            null,
+            null,
+            ImmutableList.of("v1", "v2")
+        )
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -1183,11 +1236,50 @@ public class DataSourcesResourceTest
   public void testMarkAsUnusedSegmentsInIntervalNoDataSource()
   {
     final Interval theInterval = Intervals.of("2010-01-01/P1D");
-    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null)).andReturn(0).once();
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null))
+            .andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
         new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, null);
+    DataSourcesResource dataSourcesResource = createResource();
+    prepareRequestForAudit();
+
+    Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
+    EasyMock.verify(segmentsMetadataManager);
+  }
+
+  @Test
+  public void testMarkAsUnusedSegmentsInIntervalWithVersions()
+  {
+    final Interval theInterval = Intervals.of("2010-01-01/P1D");
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, ImmutableList.of("v1")))
+            .andReturn(2).once();
+    EasyMock.replay(segmentsMetadataManager, inventoryView, server);
+
+    final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, ImmutableList.of("v1"));
+    DataSourcesResource dataSourcesResource = createResource();
+    prepareRequestForAudit();
+
+    Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(ImmutableMap.of("numChangedSegments", 2), response.getEntity());
+    EasyMock.verify(segmentsMetadataManager);
+  }
+
+  @Test
+  public void testMarkAsUnusedSegmentsInIntervalWithNonExistentVersion()
+  {
+    final Interval theInterval = Intervals.of("2010-01-01/P1D");
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, ImmutableList.of("foo")))
+            .andReturn(0).once();
+    EasyMock.replay(segmentsMetadataManager, inventoryView, server);
+
+    final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, ImmutableList.of("foo"));
     DataSourcesResource dataSourcesResource = createResource();
     prepareRequestForAudit();
 
@@ -1207,8 +1299,8 @@ public class DataSourcesResourceTest
     Assert.assertEquals(400, response.getStatus());
     Assert.assertNotNull(response.getEntity());
     Assert.assertEquals(
-        "Invalid request payload, either 'interval' or 'segmentIds' array must be specified."
-        + " 'versions' array may be optionally specified only when 'interval' is provided.",
+        "Invalid request payload. Specify either 'interval' or 'segmentIds', but not both."
+        + " Optionally, include 'versions' only when 'interval' is provided.",
         response.getEntity()
     );
   }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -874,7 +874,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsWithNullIntervalAndSegmentIds()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNullIntervalAndSegmentIdsAndVersions()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -901,7 +901,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullIntervalAndNullSegmentIds()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullInterval()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -926,7 +926,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidAllParamsSpecified()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullIntervalAndSegmentIdsAndVersions()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -940,7 +940,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidEmptySegmentIdsArray()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithEmptySegmentIds()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -952,7 +952,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidEmptyVersionsArray()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithEmptyVersions()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -964,19 +964,53 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidVersionsWithoutInterval()
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullVersions()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.SegmentsToUpdateFilter(
-            null,
-            null,
-            ImmutableList.of("v1", "v2")
-        )
+        new DataSourcesResource.SegmentsToUpdateFilter(null, null, ImmutableList.of("v1", "v2"))
     );
     Assert.assertEquals(400, response.getStatus());
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullSegmentIdsAndVersions()
+  {
+    DataSourcesResource dataSourcesResource = createResource();
+
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.SegmentsToUpdateFilter(null, ImmutableSet.of("segment1"), ImmutableList.of("v1", "v2"))
+    );
+    Assert.assertEquals(400, response.getStatus());
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullIntervalAndVersions()
+  {
+    DataSourcesResource dataSourcesResource = createResource();
+
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.SegmentsToUpdateFilter(Intervals.ETERNITY, null, ImmutableList.of("v1", "v2"))
+    );
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsWithNonNullIntervalAndEmptyVersions()
+  {
+    DataSourcesResource dataSourcesResource = createResource();
+
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.SegmentsToUpdateFilter(Intervals.ETERNITY, null, ImmutableList.of())
+    );
+    Assert.assertEquals(200, response.getStatus());
+    Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
   }
 
   @Test
@@ -1193,8 +1227,7 @@ public class DataSourcesResourceTest
             null
         );
 
-    DataSourcesResource dataSourcesResource =
-        createResource();
+    DataSourcesResource dataSourcesResource = createResource();
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
     Assert.assertEquals(500, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1253,8 +1286,7 @@ public class DataSourcesResourceTest
     final DataSourcesResource.SegmentsToUpdateFilter payload =
         new DataSourcesResource.SegmentsToUpdateFilter(theInterval, null, null);
 
-    DataSourcesResource dataSourcesResource =
-        createResource();
+    DataSourcesResource dataSourcesResource = createResource();
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
     Assert.assertEquals(500, response.getStatus());
     Assert.assertNotNull(response.getEntity());
@@ -1349,7 +1381,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkSegmentsAsUnusedWithNullIntervalAndSegmentIds()
+  public void testMarkSegmentsAsUnusedWithNullIntervalAndSegmentIdsAndVersions()
   {
     DataSourcesResource dataSourcesResource = createResource();
 

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -826,7 +826,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadNoArguments()
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidNoArguments()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -838,7 +838,7 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadBothArguments()
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidBothIntervalAndSegmentIds()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -850,7 +850,19 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidPayloadEmptyArray()
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidAllParamsSpecified()
+  {
+    DataSourcesResource dataSourcesResource = createResource();
+
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2020/2030"), ImmutableSet.of("seg1"), ImmutableList.of("v1", "v2"))
+    );
+    Assert.assertEquals(400, response.getStatus());
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidEmptySegmentIdsArray()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
@@ -862,11 +874,26 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsNoPayload()
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidEmptyVersionsArray()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
-    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments("datasource1", null);
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null, ImmutableList.of())
+    );
+    Assert.assertEquals(400, response.getStatus());
+  }
+
+  @Test
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidVersionsNoInterval()
+  {
+    DataSourcesResource dataSourcesResource = createResource();
+
+    Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
+        "datasource1",
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, ImmutableSet.of(), ImmutableList.of("v1", "v2"))
+    );
     Assert.assertEquals(400, response.getStatus());
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -735,7 +735,7 @@ public class DataSourcesResourceTest
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
     int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval));
+        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
     EasyMock.expect(numUpdatedSegments).andReturn(3).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -753,7 +753,7 @@ public class DataSourcesResourceTest
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
     int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval));
+        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
     EasyMock.expect(numUpdatedSegments).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -791,7 +791,7 @@ public class DataSourcesResourceTest
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
     int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval));
+        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
     EasyMock.expect(numUpdatedSegments).andThrow(new RuntimeException("Error!")).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -810,7 +810,7 @@ public class DataSourcesResourceTest
   {
     Interval interval = Intervals.of("2010-01-22/P1D");
     int numUpdatedSegments =
-        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval));
+        segmentsMetadataManager.markAsUsedNonOvershadowedSegmentsInInterval(EasyMock.eq("datasource1"), EasyMock.eq(interval), EasyMock.isNull());
     EasyMock.expect(numUpdatedSegments).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
@@ -1097,7 +1097,7 @@ public class DataSourcesResourceTest
   {
     final Interval theInterval = Intervals.of("2010-01-01/P1D");
 
-    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval)).andReturn(1).once();
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null)).andReturn(1).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
@@ -1117,7 +1117,7 @@ public class DataSourcesResourceTest
   {
     final Interval theInterval = Intervals.of("2010-01-01/P1D");
 
-    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval)).andReturn(0).once();
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null)).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
@@ -1136,7 +1136,7 @@ public class DataSourcesResourceTest
   {
     final Interval theInterval = Intervals.of("2010-01-01/P1D");
 
-    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval))
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null))
             .andThrow(new RuntimeException("Exception occurred"))
             .once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
@@ -1156,7 +1156,7 @@ public class DataSourcesResourceTest
   public void testMarkAsUnusedSegmentsInIntervalNoDataSource()
   {
     final Interval theInterval = Intervals.of("2010-01-01/P1D");
-    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval)).andReturn(0).once();
+    EasyMock.expect(segmentsMetadataManager.markAsUnusedSegmentsInInterval("datasource1", theInterval, null)).andReturn(0).once();
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -886,13 +886,13 @@ public class DataSourcesResourceTest
   }
 
   @Test
-  public void testMarkAsUsedNonOvershadowedSegmentsInvalidVersionsNoInterval()
+  public void testMarkAsUsedNonOvershadowedSegmentsInvalidVersionsWithoutInterval()
   {
     DataSourcesResource dataSourcesResource = createResource();
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, ImmutableSet.of(), ImmutableList.of("v1", "v2"))
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null, ImmutableList.of("v1", "v2"))
     );
     Assert.assertEquals(400, response.getStatus());
   }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -1207,7 +1207,8 @@ public class DataSourcesResourceTest
     Assert.assertEquals(400, response.getStatus());
     Assert.assertNotNull(response.getEntity());
     Assert.assertEquals(
-        "Invalid request payload, either interval or segmentIds array must be specified",
+        "Invalid request payload, either 'interval' or 'segmentIds' array must be specified."
+        + " 'versions' array may be optionally specified only when 'interval' is provided.",
         response.getEntity()
     );
   }

--- a/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/DataSourcesResourceTest.java
@@ -742,7 +742,7 @@ public class DataSourcesResourceTest
     DataSourcesResource dataSourcesResource = createResource();
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null, null)
     );
     Assert.assertEquals(200, response.getStatus());
     EasyMock.verify(segmentsMetadataManager, inventoryView, server);
@@ -761,7 +761,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null, null)
     );
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
     EasyMock.verify(segmentsMetadataManager, inventoryView, server);
@@ -780,7 +780,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, segmentIds)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, segmentIds, null)
     );
     Assert.assertEquals(200, response.getStatus());
     EasyMock.verify(segmentsMetadataManager, inventoryView, server);
@@ -799,7 +799,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(interval, null, null)
     );
     Assert.assertEquals(500, response.getStatus());
     EasyMock.verify(segmentsMetadataManager, inventoryView, server);
@@ -818,7 +818,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-22/P1D"), null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-22/P1D"), null, null)
     );
     Assert.assertEquals(200, response.getStatus());
     Assert.assertEquals(ImmutableMap.of("numChangedSegments", 0), response.getEntity());
@@ -832,7 +832,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null)
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null, null)
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -844,7 +844,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-22/P1D"), ImmutableSet.of())
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-22/P1D"), ImmutableSet.of(), null)
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -856,7 +856,7 @@ public class DataSourcesResourceTest
 
     Response response = dataSourcesResource.markAsUsedNonOvershadowedSegments(
         "datasource1",
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, ImmutableSet.of())
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, ImmutableSet.of(), null)
     );
     Assert.assertEquals(400, response.getStatus());
   }
@@ -1018,7 +1018,8 @@ public class DataSourcesResourceTest
             null,
             segmentIds.stream()
                       .map(SegmentId::toString)
-                      .collect(Collectors.toSet())
+                      .collect(Collectors.toSet()),
+            null
         );
 
     DataSourcesResource dataSourcesResource = createResource();
@@ -1047,7 +1048,8 @@ public class DataSourcesResourceTest
             null,
             segmentIds.stream()
                       .map(SegmentId::toString)
-                      .collect(Collectors.toSet())
+                      .collect(Collectors.toSet()),
+            null
         );
 
     DataSourcesResource dataSourcesResource = createResource();
@@ -1078,7 +1080,8 @@ public class DataSourcesResourceTest
             null,
             segmentIds.stream()
                       .map(SegmentId::toString)
-                      .collect(Collectors.toSet())
+                      .collect(Collectors.toSet()),
+            null
         );
 
     DataSourcesResource dataSourcesResource =
@@ -1098,7 +1101,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, null);
 
     DataSourcesResource dataSourcesResource = createResource();
     prepareRequestForAudit();
@@ -1118,7 +1121,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, null);
 
     DataSourcesResource dataSourcesResource = createResource();
     prepareRequestForAudit();
@@ -1139,7 +1142,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, null);
 
     DataSourcesResource dataSourcesResource =
         createResource();
@@ -1157,7 +1160,7 @@ public class DataSourcesResourceTest
     EasyMock.replay(segmentsMetadataManager, inventoryView, server);
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null);
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(theInterval, null, null);
     DataSourcesResource dataSourcesResource = createResource();
     prepareRequestForAudit();
 
@@ -1189,7 +1192,7 @@ public class DataSourcesResourceTest
         createResource();
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null);
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(null, null, null);
 
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
     Assert.assertEquals(400, response.getStatus());
@@ -1203,7 +1206,7 @@ public class DataSourcesResourceTest
         createResource();
 
     final DataSourcesResource.MarkDataSourceSegmentsPayload payload =
-        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-01/P1D"), ImmutableSet.of());
+        new DataSourcesResource.MarkDataSourceSegmentsPayload(Intervals.of("2010-01-01/P1D"), ImmutableSet.of(), null);
 
     Response response = dataSourcesResource.markSegmentsAsUnused("datasource1", payload, request);
     Assert.assertEquals(400, response.getStatus());


### PR DESCRIPTION
Follow up to https://github.com/apache/druid/pull/15994, this patch adds support for versions to the `markUsed` and `markUnused` APIs. 

Segments can now be marked as used or unused within the specified interval using an optional list of versions, i.e., `(interval, [versions])`. When `versions` is unspecified, _all_ versions of segments in the interval are marked as used or unused, preserving the old behavior before this patch.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Segments can now be marked as used or unused within the specified interval using an optional list of versions, i.e., `(interval, [versions])`. When `versions` is unspecified, _all_ versions of segments in the interval are marked as used or unused, preserving the old behavior.

Sample `markUsed` API with versions:
```bash
curl 'http://localhost:8888/druid/coordinator/v1/datasources/foo/markUsed' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:8888' \
  --data-raw '{"interval":"2020/2030", "versions": ["2024-03-14T13:30:54.460Z"]}' 

{"numChangedSegments":15}
```

Sample `markUnused` API with versions:
```bash
curl 'http://localhost:8888/druid/coordinator/v1/datasources/foo/markUnused' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:8888' \
  --data-raw '{"interval":"2020/2030", "versions": ["2024-03-14T16:00:04.086Z"]}' 

{"numChangedSegments":15}
```
<hr>

##### Key changed/added classes in this PR
 * `SegmentsMetadataManager.java`
 * `SqlSegmentsMetadataManager.java`
 * `SqlSegmentsMetadataQuery.java`
 *  `DatasourcesResource.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x]  a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
