### PR TITLE
Fix basic auth security integration test

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/ITBasicAuthConfigurationTest.java
@@ -85,7 +85,7 @@ public class ITBasicAuthConfigurationTest extends AbstractAuthConfigurationTest
     // Add a large enough delay to allow propagation of credentials to all services. It'd be ideal
     // to have a "readiness" endpoint exposed by different services that'd return the version of auth creds cached.
     try {
-      Thread.sleep(10000);
+      Thread.sleep(20000);
     }
     catch (InterruptedException e) {
       // Ignore exception


### PR DESCRIPTION
Increase the delay used in security IT for propagation of credentials from coordinator to other services from 10s to 20s.

A cleaner fix for this would require versioning of credentials cache and exposing APIs that return the currently served version by a service. That would be overkill to fix this test for now.