### PR TITLE
Improve worst-case performance of LIKE filters by 20x

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
@@ -106,6 +106,32 @@ public class LikeFilterBenchmark
       null
   ).toFilter();
 
+  private static final Filter LIKE_CONTAINS = new LikeDimFilter(
+      "foo",
+      "%50%",
+      null,
+      null
+  ).toFilter();
+
+  private static final Filter REGEX_CONTAINS = new RegexDimFilter(
+      "foo",
+      ".*50.*",
+      null
+  ).toFilter();
+
+  private static final Filter LIKE_KILLER = new LikeDimFilter(
+      "foo",
+      "%%%%x",
+      null,
+      null
+  ).toFilter();
+
+  private static final Filter REGEX_KILLER = new RegexDimFilter(
+      "foo",
+      ".*.*.*.*x",
+      null
+  ).toFilter();
+
   // cardinality, the dictionary will contain evenly spaced integers
   @Param({"1000", "100000", "1000000"})
   int cardinality;
@@ -186,6 +212,42 @@ public class LikeFilterBenchmark
   public void matchRegexPrefix(Blackhole blackhole)
   {
     final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_PREFIX, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchLikeContains(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_CONTAINS, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchRegexContains(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_CONTAINS, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchLikeKiller(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_KILLER, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchRegexKiller(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_KILLER, selector);
     blackhole.consume(bitmapIndex);
   }
 

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
@@ -49,7 +49,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -132,6 +131,19 @@ public class LikeFilterBenchmark
       null
   ).toFilter();
 
+  private static final Filter LIKE_COMPLEX_CONTAINS = new LikeDimFilter(
+      "foo",
+      "%5_0%0_5%",
+      null,
+      null
+  ).toFilter();
+
+  private static final Filter REGEX_COMPLEX_CONTAINS = new RegexDimFilter(
+      "foo",
+      "%5_0%0_5",
+      null
+  ).toFilter();
+
   private static final Filter LIKE_KILLER = new LikeDimFilter(
       "foo",
       "%%%%x",
@@ -186,100 +198,105 @@ public class LikeFilterBenchmark
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchLikeEquals(Blackhole blackhole)
+  public ImmutableBitmap matchLikeEquals()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_EQUALS, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(LIKE_EQUALS, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchSelectorEquals(Blackhole blackhole)
+  public ImmutableBitmap matchSelectorEquals()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(SELECTOR_EQUALS, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(SELECTOR_EQUALS, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchLikePrefix(Blackhole blackhole)
+  public ImmutableBitmap matchLikePrefix()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_PREFIX, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(LIKE_PREFIX, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchBoundPrefix(Blackhole blackhole)
+  public ImmutableBitmap matchBoundPrefix()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(BOUND_PREFIX, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(BOUND_PREFIX, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchRegexPrefix(Blackhole blackhole)
+  public ImmutableBitmap matchRegexPrefix()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_PREFIX, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(REGEX_PREFIX, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchLikeSuffix(Blackhole blackhole)
+  public ImmutableBitmap matchLikeSuffix()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_SUFFIX, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(LIKE_SUFFIX, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchRegexSuffix(Blackhole blackhole)
+  public ImmutableBitmap matchRegexSuffix()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_SUFFIX, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(REGEX_SUFFIX, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchLikeContains(Blackhole blackhole)
+  public ImmutableBitmap matchLikeContains()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_CONTAINS, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(LIKE_CONTAINS, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchRegexContains(Blackhole blackhole)
+  public ImmutableBitmap matchRegexContains()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_CONTAINS, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(REGEX_CONTAINS, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchLikeKiller(Blackhole blackhole)
+  public ImmutableBitmap matchLikeComplexContains()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_KILLER, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(LIKE_COMPLEX_CONTAINS, selector);
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void matchRegexKiller(Blackhole blackhole)
+  public ImmutableBitmap matchRegexComplexContains()
   {
-    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_KILLER, selector);
-    blackhole.consume(bitmapIndex);
+    return Filters.computeDefaultBitmapResults(REGEX_COMPLEX_CONTAINS, selector);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public ImmutableBitmap matchLikeKiller()
+  {
+    return Filters.computeDefaultBitmapResults(LIKE_KILLER, selector);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public ImmutableBitmap matchRegexKiller()
+  {
+    return Filters.computeDefaultBitmapResults(REGEX_KILLER, selector);
   }
 
   private List<Integer> generateInts()

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/LikeFilterBenchmark.java
@@ -106,6 +106,19 @@ public class LikeFilterBenchmark
       null
   ).toFilter();
 
+  private static final Filter REGEX_SUFFIX = new RegexDimFilter(
+      "foo",
+      ".*50$",
+      null
+  ).toFilter();
+
+  private static final Filter LIKE_SUFFIX = new LikeDimFilter(
+      "foo",
+      "%50",
+      null,
+      null
+  ).toFilter();
+
   private static final Filter LIKE_CONTAINS = new LikeDimFilter(
       "foo",
       "%50%",
@@ -212,6 +225,24 @@ public class LikeFilterBenchmark
   public void matchRegexPrefix(Blackhole blackhole)
   {
     final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_PREFIX, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchLikeSuffix(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(LIKE_SUFFIX, selector);
+    blackhole.consume(bitmapIndex);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void matchRegexSuffix(Blackhole blackhole)
+  {
+    final ImmutableBitmap bitmapIndex = Filters.computeDefaultBitmapResults(REGEX_SUFFIX, selector);
     blackhole.consume(bitmapIndex);
   }
 

--- a/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
@@ -421,6 +421,12 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
 
       public int advance(String value, int offset)
       {
+        if (leadingLength > Integer.MAX_VALUE - offset || offset > Integer.MAX_VALUE - leadingLength) {
+          // Even though overflow would be handled by PatternType, CodeQL flags it as needing to be checked here:
+          // https://codeql.github.com/codeql-query-help/java/java-tainted-arithmetic/
+          return -1;
+        }
+
         return patternType.advance(offset + leadingLength, value, clause);
       }
 

--- a/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/LikeDimFilter.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.RangeSet;
+import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Chars;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.StringUtils;
@@ -35,13 +36,18 @@ import org.apache.druid.segment.filter.LikeFilter;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFilter
 {
+  // Regex matching characters that are definitely okay to include unescaped in a regex.
+  // Leads to excessively paranoid escaping, although shouldn't affect runtime beyond compiling the regex.
+  private static final Pattern DEFINITELY_FINE = Pattern.compile("[\\w\\d\\s-]");
+
   private final String dimension;
   private final String pattern;
   @Nullable
@@ -210,8 +216,8 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
     // Prefix that matching strings are known to start with. May be empty.
     private final String prefix;
 
-    // Pattern that describes matching strings.
-    private final List<LikePattern> pattern;
+    // Regex patterns that describes matching strings.
+    private final List<Pattern> pattern;
 
     private final String likePattern;
 
@@ -219,7 +225,7 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
         final String likePattern,
         final SuffixMatch suffixMatch,
         final String prefix,
-        final List<LikePattern> pattern
+        final List<Pattern> pattern
     )
     {
       this.likePattern = likePattern;
@@ -228,17 +234,16 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
       this.pattern = Preconditions.checkNotNull(pattern, "pattern");
     }
 
-    public static LikeMatcher from(final String likePattern, @Nullable final Character escapeChar)
+    public static LikeMatcher from(
+        final String likePattern,
+        @Nullable final Character escapeChar
+    )
     {
       final StringBuilder prefix = new StringBuilder();
-      // The goal is to normalize the pattern so that contiguous sequences of % and/or _ have all the _'s first, then a
-      // single wildcard (if there was at least one), then the next literal, e.g., x_%_%yz = x__%yz
-      // Each pattern clause then consists of zero or more required leading characters (the _'s) and then either a
-      // literal to match immediately (startsWith) or one to search for the next occurence of.
-      final List<LikePattern> pattern = new ArrayList<>();
-      final StringBuilder value = new StringBuilder(); // literals we've seen since the last _ or %
-      LikePattern.PatternType patternType = LikePattern.PatternType.STARTS_WITH; // changes to CONTAINS when we see %
-      int leadingLength = 0; // how many _'s we've seen since the last literal
+      // Splits the input on % to leave only eagerly-matchable sub-patterns. This is to avoid catastrophic backtracking:
+      // https://www.rexegg.com/regex-explosive-quantifiers.html#remote
+      final List<Pattern> pattern = new ArrayList<>();
+      final StringBuilder regex = new StringBuilder("^");
       boolean escaping = false;
       boolean inPrefix = true;
       SuffixMatch suffixMatch = SuffixMatch.MATCH_EMPTY;
@@ -251,38 +256,44 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
           if (suffixMatch == SuffixMatch.MATCH_EMPTY) {
             suffixMatch = SuffixMatch.MATCH_ANY;
           }
-          if (value.length() > 0) {
-            pattern.add(new LikePattern(patternType, value.toString(), leadingLength));
-            value.setLength(0);
-            leadingLength = 0;
+          if (regex.length() > 0) {
+            if (regex.length() > 1 || regex.charAt(0) != '^') {
+              pattern.add(Pattern.compile(regex.toString(), Pattern.DOTALL));
+            }
+            regex.setLength(0);
           }
-          patternType = LikePattern.PatternType.CONTAINS;
         } else if (c == '_' && !escaping) {
           inPrefix = false;
           suffixMatch = SuffixMatch.MATCH_PATTERN;
-          if (value.length() > 0) {
-            pattern.add(new LikePattern(patternType, value.toString(), leadingLength));
-            value.setLength(0);
-            leadingLength = 0;
-            patternType = LikePattern.PatternType.STARTS_WITH;
-          }
-          ++leadingLength;
+          regex.append('.');
         } else {
           if (inPrefix) {
             prefix.append(c);
           } else {
             suffixMatch = SuffixMatch.MATCH_PATTERN;
           }
-          value.append(c);
+          addPatternCharacter(regex, c);
           escaping = false;
         }
       }
 
-      if (value.length() > 0 || leadingLength > 0 || patternType == LikePattern.PatternType.CONTAINS) {
-        pattern.add(new LikePattern(patternType, value.toString(), leadingLength));
+      if (likePattern.isEmpty()) {
+        pattern.add(Pattern.compile("^$"));
+      } else if (regex.length() > 0) {
+        regex.append('$');
+        pattern.add(Pattern.compile(regex.toString(), Pattern.DOTALL));
       }
 
       return new LikeMatcher(likePattern, suffixMatch, prefix.toString(), pattern);
+    }
+
+    private static void addPatternCharacter(final StringBuilder patternBuilder, final char c)
+    {
+      if (DEFINITELY_FINE.matcher(String.valueOf(c)).matches()) {
+        patternBuilder.append(c);
+      } else {
+        patternBuilder.append("\\u").append(BaseEncoding.base16().encode(Chars.toByteArray(c)));
+      }
     }
 
     public DruidPredicateMatch matches(@Nullable final String s)
@@ -290,57 +301,28 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
       return matches(s, pattern);
     }
 
-    private static DruidPredicateMatch matches(@Nullable final String s, List<LikePattern> pattern)
+    private static DruidPredicateMatch matches(@Nullable final String s, List<Pattern> pattern)
     {
       String val = NullHandling.nullToEmptyIfNeeded(s);
       if (val == null) {
         return DruidPredicateMatch.UNKNOWN;
       }
 
-      int suffixOffset = val.length();
-      int suffixIndex = pattern.size();
-
-      // Check for suffixes anchored to the end of the string, e.g., a%b_d_
-      // (We can't eagerly match the b_d_ portion, since that leads to false negatives: abcdexyzbcde)
-      // Note: In the case of a trailing %, the anchored suffix is an empty string.
-      while (suffixIndex > 0) {
-        --suffixIndex;
-
-        LikePattern suffix = pattern.get(suffixIndex);
-
-        if (!val.regionMatches(suffixOffset - suffix.clause.length(), suffix.clause, 0, suffix.clause.length())) {
-          return DruidPredicateMatch.FALSE;
-        }
-
-        suffixOffset = suffixOffset - suffix.clause.length() - suffix.leadingLength;
-
-        if (suffixOffset < 0) {
-          return DruidPredicateMatch.FALSE;
-        }
-
-        if (suffix.patternType == LikePattern.PatternType.CONTAINS) {
-          if (suffixIndex == 0) {
-            // %some_suffix
-            return DruidPredicateMatch.TRUE;
-          }
-          // Encountered a %, so the next pattern part is no longer anchored to the end of string.
-          break;
-        }
-      }
-
-      if (suffixIndex == 0) {
-        // No prefix remains: check we consumed the whole string.
-        return DruidPredicateMatch.of(suffixOffset == 0);
+      if (pattern.size() == 1) {
+        // Most common case is a single pattern: a% => ^a, %z => z$, %m% => m
+        return DruidPredicateMatch.of(pattern.get(0).matcher(val).find());
       }
 
       int offset = 0;
 
-      for (int i = 0; i < suffixIndex; ++i) {
-        offset = pattern.get(i).advance(val, offset);
+      for (Pattern part : pattern) {
+        Matcher matcher = part.matcher(val);
 
-        if (offset == -1 || offset > suffixOffset) {
+        if (!matcher.find(offset)) {
           return DruidPredicateMatch.FALSE;
         }
+
+        offset = matcher.end();
       }
 
       return DruidPredicateMatch.TRUE;
@@ -380,107 +362,16 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
     @VisibleForTesting
     String describeCompilation()
     {
-      StringBuilder description = new StringBuilder();
-
-      description.append(likePattern).append(" => ");
-      description.append(prefix).append(':');
-
-      Iterator<LikePattern> iterator = pattern.iterator();
-      while (iterator.hasNext()) {
-        description.append(iterator.next());
-
-        if (iterator.hasNext()) {
-          description.append('|');
-        }
-      }
-
-      return description.toString();
-    }
-
-    private static class LikePattern
-    {
-      public enum PatternType
-      {
-        STARTS_WITH {
-          @Override
-          int advance(int offset, String haystack, String needle)
-          {
-            return haystack.regionMatches(offset, needle, 0, needle.length()) ? offset + needle.length() : -1;
-          }
-        },
-        CONTAINS {
-          @Override
-          int advance(int offset, String haystack, String needle)
-          {
-            int matchStart = haystack.indexOf(needle, offset);
-
-            return matchStart == -1 ? -1 : matchStart + needle.length();
-          }
-        };
-
-        abstract int advance(int offset, String haystack, String needle);
-      }
-
-      private final PatternType patternType;
-      private final String clause;
-      private final int leadingLength;
-
-      public LikePattern(PatternType patternType, String clause, int leadingLength)
-      {
-        this.patternType = patternType;
-        this.clause = clause;
-        this.leadingLength = leadingLength;
-      }
-
-      public int advance(String value, int offset)
-      {
-        if (leadingLength > Integer.MAX_VALUE - offset || offset > Integer.MAX_VALUE - leadingLength) {
-          // Even though overflow would be handled by PatternType, CodeQL flags it as needing to be checked here:
-          // https://codeql.github.com/codeql-query-help/java/java-tainted-arithmetic/
-          return -1;
-        }
-
-        return patternType.advance(offset + leadingLength, value, clause);
-      }
-
-      @Override
-      public boolean equals(Object o)
-      {
-        if (this == o) {
-          return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-          return false;
-        }
-        LikePattern other = (LikePattern) o;
-        return patternType == other.patternType &&
-               leadingLength == other.leadingLength &&
-               Objects.equals(clause, other.clause);
-      }
-
-      @Override
-      public int hashCode()
-      {
-        return Objects.hash(patternType, leadingLength, clause);
-      }
-
-      @Override
-      public String toString()
-      {
-        String escaped = StringUtils.replace(clause, "\\", "\\\\");
-        escaped = StringUtils.replace(escaped, "%", "\\%");
-        escaped = StringUtils.replace(escaped, "_", "\\_");
-        return StringUtils.repeat("_", leadingLength) + (patternType == PatternType.CONTAINS ? "%" : "") + escaped;
-      }
+      return likePattern + " => " + prefix + ":" + pattern;
     }
 
     @VisibleForTesting
     static class PatternDruidPredicateFactory implements DruidPredicateFactory
     {
       private final ExtractionFn extractionFn;
-      private final List<LikePattern> pattern;
+      private final List<Pattern> pattern;
 
-      PatternDruidPredicateFactory(ExtractionFn extractionFn, List<LikePattern> pattern)
+      PatternDruidPredicateFactory(ExtractionFn extractionFn, List<Pattern> pattern)
       {
         this.extractionFn = extractionFn;
         this.pattern = pattern;
@@ -537,13 +428,13 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
         }
         PatternDruidPredicateFactory that = (PatternDruidPredicateFactory) o;
         return Objects.equals(extractionFn, that.extractionFn) &&
-               Objects.equals(pattern, that.pattern);
+               Objects.equals(pattern.toString(), that.pattern.toString());
       }
 
       @Override
       public int hashCode()
       {
-        return Objects.hash(extractionFn, pattern);
+        return Objects.hash(extractionFn, pattern.toString());
       }
     }
 
@@ -559,13 +450,13 @@ public class LikeDimFilter extends AbstractOptimizableDimFilter implements DimFi
       LikeMatcher that = (LikeMatcher) o;
       return getSuffixMatch() == that.getSuffixMatch() &&
              Objects.equals(getPrefix(), that.getPrefix()) &&
-             Objects.equals(pattern, that.pattern);
+             Objects.equals(pattern.toString(), that.pattern.toString());
     }
 
     @Override
     public int hashCode()
     {
-      return Objects.hash(getSuffixMatch(), getPrefix(), pattern);
+      return Objects.hash(getSuffixMatch(), getPrefix(), pattern.toString());
     }
 
     @Override

--- a/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.extraction.SubstringDimExtractionFn;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
@@ -172,7 +173,7 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   @Test
   public void testPatternEmpty()
   {
-    assertMatch("", null, DruidPredicateMatch.UNKNOWN);
+    assertMatch("", null, NullHandling.replaceWithDefault() ? DruidPredicateMatch.TRUE : DruidPredicateMatch.UNKNOWN);
     assertMatch("", "", DruidPredicateMatch.TRUE);
     assertMatch("", "a", DruidPredicateMatch.FALSE);
     assertMatch("", "This is a test!", DruidPredicateMatch.FALSE);
@@ -199,10 +200,10 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   @Test
   public void testPatternOnlySpecial()
   {
-    assertMatch("%", null, DruidPredicateMatch.UNKNOWN);
+    assertMatch("%", null, NullHandling.replaceWithDefault() ? DruidPredicateMatch.TRUE : DruidPredicateMatch.UNKNOWN);
     assertMatch("%", "", DruidPredicateMatch.TRUE);
     assertMatch("%", "abcxyzxyz", DruidPredicateMatch.TRUE);
-    assertMatch("_", null, DruidPredicateMatch.UNKNOWN);
+    assertMatch("_", null, NullHandling.replaceWithDefault() ? DruidPredicateMatch.FALSE : DruidPredicateMatch.UNKNOWN);
     assertMatch("_", "", DruidPredicateMatch.FALSE);
     assertMatch("_", "a", DruidPredicateMatch.TRUE);
     assertMatch("_", "ab", DruidPredicateMatch.FALSE);

--- a/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
@@ -185,7 +185,9 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     assertMatch("a\nb", "a\nb", DruidPredicateMatch.TRUE);
     assertMatch("a\nb", "a\nc", DruidPredicateMatch.FALSE);
     assertMatch("This is a test", "This is a test", DruidPredicateMatch.TRUE);
+    assertMatch("This is a test", "this is a test", DruidPredicateMatch.FALSE);
     assertMatch("This is a test", "This is a tes", DruidPredicateMatch.FALSE);
+    assertMatch("This is a test", "his is a test", DruidPredicateMatch.FALSE);
     assertMatch("This \\%is a\\_test", "This %is a_test", DruidPredicateMatch.TRUE);
     assertMatch("This \\%is a\\_test", "This \\%is a_test", DruidPredicateMatch.FALSE);
   }
@@ -275,6 +277,34 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     assertMatch("%jkl_", "ijklmn", DruidPredicateMatch.FALSE);
     assertMatch("%jkl_", "hijklm", DruidPredicateMatch.TRUE);
     assertMatch("%jkl_", "hijklmn", DruidPredicateMatch.FALSE);
+  }
+
+  @Test
+  public void testPatternSuffixWithManyParts()
+  {
+    assertMatch("%ba_", "foo bar", DruidPredicateMatch.TRUE);
+    assertMatch("%ba_", "foo bar daz", DruidPredicateMatch.FALSE);
+    assertMatch("%ba_%", "foo bar baz", DruidPredicateMatch.TRUE);
+    assertMatch("a%b_d_", "abcde", DruidPredicateMatch.TRUE);
+    assertMatch("a%b_d_", "abcdexyzbcde", DruidPredicateMatch.TRUE);
+    assertMatch("%b_d_", "abcde", DruidPredicateMatch.TRUE);
+    assertMatch("%b_d_", "abcdexyzbcde", DruidPredicateMatch.TRUE);
+    assertMatch("%b_d_", "abcdexyzbcdef", DruidPredicateMatch.FALSE);
+    assertMatch("%b_d_", "abcdexyzbcd", DruidPredicateMatch.FALSE);
+    assertMatch("%z%_b_d_", "abcdexyzabcde", DruidPredicateMatch.TRUE);
+    assertMatch("%z%_b_d_", "abcdexyzbcde", DruidPredicateMatch.FALSE);
+    assertMatch("%z%_b_d_", "abcdexybcde", DruidPredicateMatch.FALSE);
+    assertMatch("%z%_b_d_", "abcdexbcde", DruidPredicateMatch.FALSE);
+  }
+
+  @Test
+  public void testPatternNoWildcards()
+  {
+    assertMatch("a_c_e_", "abcdef", DruidPredicateMatch.TRUE);
+    assertMatch("a_c_e_", "abcde", DruidPredicateMatch.FALSE);
+    assertMatch("x_c_e_", "abcdef", DruidPredicateMatch.FALSE);
+    assertMatch("xa_c_e_", "abcdef", DruidPredicateMatch.FALSE);
+    assertMatch("a_c_e_x", "abcde", DruidPredicateMatch.FALSE);
   }
 
   private void assertCompilation(String pattern, String expected)


### PR DESCRIPTION
### Description

`LikeDimFilter` was compiling the `LIKE` clause down to a `java.util.regex.Pattern`. Unfortunately, even seemingly simply regexes can lead to [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html). In particular, something as simple as a few `%` wildcards can end up in [exploding the time complexity](https://www.rexegg.com/regex-explosive-quantifiers.html#remote). This MR implements a simple greedy algorithm that avoids the catastrophic backtracking, converting the `LIKE` pattern into a list of `java.util.regex.Pattern` by splitting on the `%` wildcard. The resulting sub-patterns do no backtracking, and a simple greedy loop using `Matcher.find()` to progress through the string is used.

Running an updated version of the `LikeFilterBenchmark` with Java 11 on a `t2.xlarge` instance showed at least a 1.15x speed up for a simple "contains" query (`%50%`), and more than a 20x speed up for a "killer" query with four wildcards but no matches (`%%%%x`). The benchmark uses short strings: cases with longer strings should benefit more.

Note that the `REGEX` operator still suffers from the same potentially-catastrophic runtimes. Using a better library than the built-in `java.util.regex.Pattern` (e.g., [joni](https://github.com/jruby/joni)) would be a good idea to avoid accidental — or intentional — DoSing.

```
Benchmark                                      (cardinality)  Mode  Cnt  Before Score       Error      After Score     Error  Units  Before/After
LikeFilterBenchmark.matchBoundPrefix                    1000  avgt   10         5.410 ±     0.010          5.582 ±     0.004  us/op         0.97x
LikeFilterBenchmark.matchBoundPrefix                  100000  avgt   10       140.920 ±     0.306        141.082 ±     0.391  us/op         1.00x
LikeFilterBenchmark.matchBoundPrefix                 1000000  avgt   10      1082.762 ±     1.070       1171.407 ±     1.628  us/op         0.92x
LikeFilterBenchmark.matchLikeComplexContains            1000  avgt   10       221.572 ±     0.228        183.742 ±     0.210  us/op         1.21x
LikeFilterBenchmark.matchLikeComplexContains          100000  avgt   10     25461.362 ±    21.481      17373.828 ±    42.577  us/op         1.47x
LikeFilterBenchmark.matchLikeComplexContains         1000000  avgt   10    221075.917 ±   919.238     177454.683 ±   506.420  us/op         1.25x
LikeFilterBenchmark.matchLikeContains                   1000  avgt   10       283.015 ±     0.219        218.835 ±     3.126  us/op         1.29x
LikeFilterBenchmark.matchLikeContains                 100000  avgt   10     30202.910 ±    32.697      26713.488 ±    49.525  us/op         1.13x
LikeFilterBenchmark.matchLikeContains                1000000  avgt   10    284661.411 ±   130.324     243381.857 ±   540.143  us/op         1.17x
LikeFilterBenchmark.matchLikeEquals                     1000  avgt   10         0.386 ±     0.001          0.380 ±     0.001  us/op         1.02x
LikeFilterBenchmark.matchLikeEquals                   100000  avgt   10         0.670 ±     0.001          0.705 ±     0.002  us/op         0.95x
LikeFilterBenchmark.matchLikeEquals                  1000000  avgt   10         0.839 ±     0.001          0.796 ±     0.001  us/op         1.05x
LikeFilterBenchmark.matchLikeKiller                     1000  avgt   10      4882.099 ±     7.953        170.142 ±     0.494  us/op        28.69x
LikeFilterBenchmark.matchLikeKiller                   100000  avgt   10    524122.010 ±   390.170      19461.637 ±   117.090  us/op        26.93x
LikeFilterBenchmark.matchLikeKiller                  1000000  avgt   10   5121795.377 ±  4176.052     181162.978 ±   368.443  us/op        28.27x
LikeFilterBenchmark.matchLikePrefix                     1000  avgt   10         5.708 ±     0.005          5.677 ±     0.011  us/op         1.01x
LikeFilterBenchmark.matchLikePrefix                   100000  avgt   10       141.853 ±     0.554        108.313 ±     0.330  us/op         1.31x
LikeFilterBenchmark.matchLikePrefix                  1000000  avgt   10      1199.148 ±     1.298       1153.297 ±     1.575  us/op         1.04x
LikeFilterBenchmark.matchLikeSuffix                     1000  avgt   10       256.020 ±     0.283        196.339 ±     0.564  us/op         1.30x
LikeFilterBenchmark.matchLikeSuffix                   100000  avgt   10     29917.931 ±    28.218      21450.997 ±    20.341  us/op         1.39x
LikeFilterBenchmark.matchLikeSuffix                  1000000  avgt   10    241225.193 ±   465.824     194034.292 ±   362.312  us/op         1.24x
LikeFilterBenchmark.matchRegexComplexContains           1000  avgt   10       119.597 ±     0.635        135.550 ±     0.697  us/op         0.88x
LikeFilterBenchmark.matchRegexComplexContains         100000  avgt   10     13089.670 ±    13.738      13766.712 ±    12.802  us/op         0.95x
LikeFilterBenchmark.matchRegexComplexContains        1000000  avgt   10    130822.830 ±  1624.048     131076.029 ±  1636.811  us/op         1.00x
LikeFilterBenchmark.matchRegexContains                  1000  avgt   10       573.273 ±     0.421        615.399 ±     0.633  us/op         0.93x
LikeFilterBenchmark.matchRegexContains                100000  avgt   10     57259.313 ±   162.747      62900.380 ±    44.746  us/op         0.91x
LikeFilterBenchmark.matchRegexContains               1000000  avgt   10    571335.768 ±  2822.776     542536.982 ±   780.290  us/op         1.05x
LikeFilterBenchmark.matchRegexKiller                    1000  avgt   10     11525.499 ±     8.741      11061.791 ±    21.746  us/op         1.04x
LikeFilterBenchmark.matchRegexKiller                  100000  avgt   10   1170414.723 ±   766.160    1144437.291 ±   886.263  us/op         1.02x
LikeFilterBenchmark.matchRegexKiller                 1000000  avgt   10  11507668.302 ± 11318.176  110381620.014 ± 10707.974  us/op         1.11x
LikeFilterBenchmark.matchRegexPrefix                    1000  avgt   10       156.460 ±     0.097        155.217 ±     0.431  us/op         1.01x
LikeFilterBenchmark.matchRegexPrefix                  100000  avgt   10     15056.491 ±    23.906      15508.965 ±   763.976  us/op         0.97x
LikeFilterBenchmark.matchRegexPrefix                 1000000  avgt   10    154416.563 ±   473.108     153737.912 ±   273.347  us/op         1.00x
LikeFilterBenchmark.matchRegexSuffix                    1000  avgt   10       610.684 ±     0.462        590.352 ±     0.334  us/op         1.03x
LikeFilterBenchmark.matchRegexSuffix                  100000  avgt   10     53196.517 ±    78.155      59460.261 ±    56.934  us/op         0.89x
LikeFilterBenchmark.matchRegexSuffix                 1000000  avgt   10    536100.944 ±   440.353     550098.917 ±   740.464  us/op         0.97x
LikeFilterBenchmark.matchSelectorEquals                 1000  avgt   10         0.390 ±     0.001          0.366 ±     0.001  us/op         1.07x
LikeFilterBenchmark.matchSelectorEquals               100000  avgt   10         0.724 ±     0.001          0.714 ±     0.001  us/op         1.01x
LikeFilterBenchmark.matchSelectorEquals              1000000  avgt   10         0.826 ±     0.001          0.847 ±     0.001  us/op         0.98x
```

#### Release note

Improved: `LIKE` filtering performance with multiple wildcards improved 1.1x (common cases) to 20x (edge cases) by avoiding using `java.util.regex.Pattern` to match `%`.

<hr>

##### Key changed/added classes in this PR
 * `LikeDimFilter.from()` is the most-complicated change: parsing to a list of patterns.
 * `LikeDimFilter.matches()` is updated to loop through the list of patterns.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
