### PR TITLE
Parameterize segment IDs

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -185,11 +185,12 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                                                               .allMatch(Intervals::canCompareEndpointsAsStrings);
     final SqlSegmentsMetadataQuery.IntervalMode intervalMode = SqlSegmentsMetadataQuery.IntervalMode.OVERLAPS;
 
-    SqlSegmentsMetadataQuery.appendConditionForIntervalsAndMatchMode(
-        queryBuilder,
-        compareIntervalEndpointsAsString ? intervals : Collections.emptyList(),
-        intervalMode,
-        connector
+    queryBuilder.append(
+        SqlSegmentsMetadataQuery.getConditionForIntervalsAndMatchMode(
+            compareIntervalEndpointsAsString ? intervals : Collections.emptyList(),
+            intervalMode,
+            connector.getQuoteString()
+        )
     );
 
     final String queryString = StringUtils.format(queryBuilder.toString(), dbTables.getSegmentsTable());

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -201,7 +201,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
               .bind("dataSource", dataSource);
 
           if (compareIntervalEndpointsAsString) {
-            SqlSegmentsMetadataQuery.bindQueryIntervals(query, intervals);
+            SqlSegmentsMetadataQuery.bindIntervalsToQuery(query, intervals);
           }
 
           final List<Pair<DataSegment, String>> segmentsWithCreatedDates = query

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -263,7 +263,7 @@ public class SqlSegmentsMetadataQuery
     final Query<Map<String, Object>> query = handle.createQuery(
         StringUtils.format(
             "SELECT payload, used FROM %s WHERE dataSource = :dataSource %s",
-            dbTables.getSegmentsTable(),  getParameterizedInConditionForColumn(segmentIds, "id")
+            dbTables.getSegmentsTable(), getParameterizedInConditionForColumn(segmentIds, "id")
         )
     );
 
@@ -471,28 +471,28 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
-   * Append the condition for the interval and match mode to the given string builder with a partial query
-   * @param sb - StringBuilder containing the paritial query with SELECT clause and WHERE condition for used, datasource
+   * Get the condition for the interval and match mode.
    * @param intervals - intervals to fetch the segments for
    * @param matchMode - Interval match mode - overlaps or contains
-   * @param connector - SQL connector
+   * @param quoteString - the connector-specific quote string
    */
-  public static void appendConditionForIntervalsAndMatchMode(
-      final StringBuilder sb,
+  public static String getConditionForIntervalsAndMatchMode(
       final Collection<Interval> intervals,
       final IntervalMode matchMode,
-      final SQLMetadataConnector connector
+      final String quoteString
   )
   {
     if (intervals.isEmpty()) {
-      return;
+      return "";
     }
+
+    final StringBuilder sb = new StringBuilder();
 
     sb.append(" AND (");
     for (int i = 0; i < intervals.size(); i++) {
       sb.append(
           matchMode.makeSqlCondition(
-              connector.getQuoteString(),
+              quoteString,
               StringUtils.format(":start%d", i),
               StringUtils.format(":end%d", i)
           )
@@ -525,6 +525,7 @@ public class SqlSegmentsMetadataQuery
       ));
     }
     sb.append(")");
+    return sb.toString();
   }
 
   /**
@@ -730,7 +731,7 @@ public class SqlSegmentsMetadataQuery
     }
 
     if (compareAsString) {
-      appendConditionForIntervalsAndMatchMode(sb, intervals, matchMode, connector);
+      sb.append(getConditionForIntervalsAndMatchMode(intervals, matchMode, connector.getQuoteString()));
     }
 
     final boolean hasVersions = !CollectionUtils.isNullOrEmpty(versions);


### PR DESCRIPTION
#### Issue:
The `markUsed` API accepts either an `interval` or `segmentIds`. When using segment IDs, the underlying query uses an `IN` clause with the user-provided values inlined directly in the query instead of being parameterized.

#### Fix:
This patch fixes that by adding the following utilities specifically for queries that contain an `IN` clause:
- `getParameterizedInConditionForColumn()`
- `bindColumnValuesToQueryWithInCondition()`

#### Other related changes:
Renamed the following functions for consistency and code hygiene:
- `appendConditionForIntervalsAndMatchMode()` to `getConditionForIntervalsAndMatchMode()`. Pass only select arguments to the function.
- `bindQueryIntervals()` to `bindIntervalsToQuery()`

#### Release note:

The `segmentIds` filter in the `markUsed` API payload is parameterized in the DB query.

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] been tested in a test Druid cluster.
