### PR TITLE
Fix mark segment unused when overshadowed by zero replica segment

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -223,6 +223,8 @@ public abstract class CoordinatorSimulationBaseTest implements
     static final String LOAD_QUEUE_COUNT = "segment/loadQueue/count";
     static final String DROP_QUEUE_COUNT = "segment/dropQueue/count";
     static final String CANCELLED_ACTIONS = "segment/loadQueue/cancelled";
+
+    static final String OVERSHADOWED_COUNT = "segment/overshadowed/count";
   }
 
   static class Segments

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/MarkSegmentsAsUnusedTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/MarkSegmentsAsUnusedTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.simulate;
+
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.timeline.DataSegment;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MarkSegmentsAsUnusedTest extends CoordinatorSimulationBaseTest
+{
+  @Override
+  public void setUp()
+  {
+
+  }
+
+  @Test
+  public void testSegmentsOvershadowedByZeroReplicaSegmentsAreMarkedAsUnused()
+  {
+    final long size1TB = 1_000_000;
+    final List<DruidServer> servers = new ArrayList<>();
+    for (int i = 0; i < 2; i++) {
+      servers.add(createHistorical(i, Tier.T1, size1TB));
+    }
+
+    final List<DataSegment> segmentsV0 = Segments.WIKI_10X1D;
+    final CoordinatorDynamicConfig dynamicConfig
+        = CoordinatorDynamicConfig.builder().withMarkSegmentAsUnusedDelayMillis(0).build();
+    final CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withRules(DS.WIKI, Load.on(Tier.T1, 0).forever())
+                             .withServers(servers)
+                             .withSegments(segmentsV0)
+                             .withDynamicConfig(dynamicConfig)
+                             .build();
+    startSimulation(sim);
+
+    // Run 1: No segment is loaded
+    runCoordinatorCycle();
+    verifyNotEmitted(Metric.ASSIGNED_COUNT);
+
+    // Add v1 segments to overshadow v0 segments
+    final List<DataSegment> segmentsV1 = segmentsV0.stream().map(
+        segment -> segment.withVersion(segment.getVersion() + "__new")
+    ).collect(Collectors.toList());
+    addSegments(segmentsV1);
+
+    // Run 2: nothing is loaded, v0 segments are overshadowed and marked as unused
+    runCoordinatorCycle();
+    verifyNotEmitted(Metric.ASSIGNED_COUNT);
+    verifyValue(Metric.OVERSHADOWED_COUNT, 10L);
+  }
+}


### PR DESCRIPTION
### Bug
In the `MarkOvershadowedSegmentsAsUnused` duty, the coordinator marks a segment as unused
if it is overshadowed by a segment currently being served by a historical or broker.
But it is possible to have segments that are eligible for a load rule but require zero replicas to be loaded.
(Such segments can be queried only using the MSQ engine).
If such a zero-replica segment overshadows any other segment, the overshadowed segment will never be
marked as unused and will continue to exist in the metadata store as a dangling segment.

### Changes

- In a coordinator run, keep track of segments that are eligible for a load rule but require zero replicas
- Allow the zero-replicas segments to overshadow old segments and hence mark the latter as unused
- Add simulation test to verify new behaviour. This test fails with the current code.
- Clean up javadocs

### Release note
Fix bug in the `MarkOvershadowedSegmentsAsUnused` coordinator duty to also consider segments that are overshadowed by a segment that requires zero replicas.

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
