### PR TITLE
Redact passwords from tasks fetched from the TaskQueue

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import org.apache.druid.client.indexing.IndexingService;
@@ -94,7 +95,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
       final SupervisorManager supervisorManager,
       final OverlordDutyExecutor overlordDutyExecutor,
       @IndexingService final DruidLeaderSelector overlordLeaderSelector,
-      final SegmentAllocationQueue segmentAllocationQueue
+      final SegmentAllocationQueue segmentAllocationQueue,
+      final ObjectMapper mapper
   )
   {
     this.supervisorManager = supervisorManager;
@@ -125,7 +127,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
               taskRunner,
               taskActionClientFactory,
               taskLockbox,
-              emitter
+              emitter,
+              mapper
           );
 
           // Sensible order to start stuff:

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -157,7 +157,6 @@ public class TaskQueue
   private final AtomicInteger statusUpdatesInQueue = new AtomicInteger();
   private final AtomicInteger handledStatusUpdates = new AtomicInteger();
 
-
   public TaskQueue(
       TaskLockConfig lockConfig,
       TaskQueueConfig config,
@@ -982,7 +981,7 @@ public class TaskQueue
   /**
    * Returns an optional containing the task payload after successfully redacting credentials.
    * Returns an absent optional if there is no task payload corresponding to the taskId in memory.
-   * Throws JsonProcessingException if password could not be redacted due to serialization / deserialization failure
+   * Throws DruidException if password could not be redacted due to serialization / deserialization failure
    */
   public Optional<Task> getActiveTask(String id)
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import org.apache.druid.indexer.TaskInfo;
@@ -107,9 +108,14 @@ public class TaskStorageQueryAdapter
   public Optional<Task> getTask(final String taskid)
   {
     if (taskQueue.isPresent()) {
-      Optional<Task> activeTask = taskQueue.get().getActiveTask(taskid);
-      if (activeTask.isPresent()) {
-        return activeTask;
+      try {
+        Optional<Task> activeTask = taskQueue.get().getActiveTask(taskid);
+        if (activeTask.isPresent()) {
+          return activeTask;
+        }
+      }
+      catch (JsonProcessingException e) {
+        // do nothing
       }
     }
     return storage.getTask(taskid);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.indexing.overlord;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.TaskInfo;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
@@ -114,7 +114,7 @@ public class TaskStorageQueryAdapter
           return activeTask;
         }
       }
-      catch (JsonProcessingException e) {
+      catch (DruidException e) {
         // do nothing
       }
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorageQueryAdapter.java
@@ -21,7 +21,6 @@ package org.apache.druid.indexing.overlord;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
-import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.TaskInfo;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
@@ -108,14 +107,9 @@ public class TaskStorageQueryAdapter
   public Optional<Task> getTask(final String taskid)
   {
     if (taskQueue.isPresent()) {
-      try {
-        Optional<Task> activeTask = taskQueue.get().getActiveTask(taskid);
-        if (activeTask.isPresent()) {
-          return activeTask;
-        }
-      }
-      catch (DruidException e) {
-        // do nothing
+      Optional<Task> activeTask = taskQueue.get().getActiveTask(taskid);
+      if (activeTask.isPresent()) {
+        return activeTask;
       }
     }
     return storage.getTask(taskid);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
@@ -142,7 +142,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
         taskRunner,
         taskActionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     runningTasks.clear();
     taskQueue.start();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -696,7 +696,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
         TaskQueueConfig.class
     );
 
-    return new TaskQueue(lockConfig, tqc, new DefaultTaskConfig(), ts, tr, tac, taskLockbox, emitter);
+    return new TaskQueue(lockConfig, tqc, new DefaultTaskConfig(), ts, tr, tac, taskLockbox, emitter, mapper);
   }
 
   @After

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.indexing.test.TestIndexerMetadataStorageCoordinator;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.easymock.EasyMock;
@@ -120,7 +121,8 @@ public class TaskLockConfigTest
         taskRunner,
         actionClientFactory,
         lockbox,
-        emitter
+        emitter,
+        new DefaultObjectMapper()
     );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
@@ -122,7 +122,8 @@ public class TaskQueueScaleTest
         taskRunner,
         unsupportedTaskActionFactory, // Not used for anything serious
         new TaskLockbox(taskStorage, storageCoordinator),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        jsonMapper
     );
 
     taskQueue.start();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -624,17 +624,15 @@ public class TaskQueueTest extends IngestionTestBase
 
     final Optional<Task> taskInStorage = taskStorage.getTask(taskWithPassword.getId());
     Assert.assertTrue(taskInStorage.isPresent());
-    Assert.assertFalse(mapper.writeValueAsString(taskInStorage.get()).contains(password));
-
+    final String taskInStorageAsString = mapper.writeValueAsString(taskInStorage.get());
+    Assert.assertFalse(taskInStorageAsString.contains(password));
 
     final Optional<Task> taskInQueue = taskQueue.getActiveTask(taskWithPassword.getId());
     Assert.assertTrue(taskInQueue.isPresent());
-    Assert.assertFalse(mapper.writeValueAsString(taskInQueue.get()).contains(password));
+    final String taskInQueueAsString = mapper.writeValueAsString(taskInQueue.get());
+    Assert.assertFalse(taskInQueueAsString.contains(password));
 
-    Assert.assertEquals(
-        mapper.writeValueAsString(taskInStorage.get()),
-        mapper.writeValueAsString(taskInQueue.get())
-    );
+    Assert.assertEquals(taskInStorageAsString, taskInQueueAsString);
   }
 
   private HttpRemoteTaskRunner createHttpRemoteTaskRunner(List<String> runningTasks)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.indexing.overlord;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +29,11 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.druid.common.guava.DSuppliers;
+import org.apache.druid.data.input.impl.DimensionsSpec;
+import org.apache.druid.data.input.impl.HttpInputSource;
+import org.apache.druid.data.input.impl.HttpInputSourceConfig;
+import org.apache.druid.data.input.impl.NoopInputFormat;
+import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.discovery.WorkerNodeService;
 import org.apache.druid.error.DruidException;
@@ -38,10 +46,14 @@ import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
+import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.IngestionTestBase;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexIOConfig;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexIngestionSpec;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTask;
 import org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseParallelIndexTaskRunner;
 import org.apache.druid.indexing.overlord.autoscaling.NoopProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
@@ -53,9 +65,11 @@ import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunner;
 import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerTest;
 import org.apache.druid.indexing.overlord.hrtr.WorkerHolder;
 import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.test.TestIndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
@@ -64,7 +78,12 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.apache.druid.metadata.DefaultPasswordProvider;
+import org.apache.druid.metadata.DerbyMetadataStorageActionHandlerFactory;
+import org.apache.druid.metadata.SQLMetadataConnector;
 import org.apache.druid.segment.TestHelper;
+import org.apache.druid.segment.indexing.DataSchema;
+import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.server.initialization.IndexerZkConfig;
 import org.apache.druid.server.initialization.ZkPathsConfig;
@@ -77,6 +96,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -109,7 +129,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     // task1 emulates a case when there is a task that was issued before task2 and acquired locks conflicting
@@ -154,7 +175,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
 
@@ -194,7 +216,8 @@ public class TaskQueueTest extends IngestionTestBase
             new SimpleTaskRunner(actionClientFactory),
             actionClientFactory,
             getLockbox(),
-            new NoopServiceEmitter()
+            new NoopServiceEmitter(),
+            getObjectMapper()
     );
     taskQueue.setActive(true);
 
@@ -219,7 +242,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"));
@@ -254,7 +278,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"));
@@ -279,7 +304,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask(
@@ -321,7 +347,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"));
@@ -344,7 +371,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask(
@@ -374,7 +402,8 @@ public class TaskQueueTest extends IngestionTestBase
         new SimpleTaskRunner(actionClientFactory),
         actionClientFactory,
         getLockbox(),
-        new NoopServiceEmitter()
+        new NoopServiceEmitter(),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"))
@@ -421,7 +450,8 @@ public class TaskQueueTest extends IngestionTestBase
         taskRunner,
         actionClientFactory,
         getLockbox(),
-        metricsVerifier
+        metricsVerifier,
+        getObjectMapper()
     );
     taskQueue.setActive(true);
     final Task task = new TestTask(
@@ -507,7 +537,8 @@ public class TaskQueueTest extends IngestionTestBase
         taskRunner,
         createActionClientFactory(),
         getLockbox(),
-        new StubServiceEmitter("druid/overlord", "testHost")
+        new StubServiceEmitter("druid/overlord", "testHost"),
+        getObjectMapper()
     );
     taskQueue.setActive(true);
 
@@ -517,6 +548,95 @@ public class TaskQueueTest extends IngestionTestBase
     Assert.assertEquals(TaskStatus.running(runningTask), taskQueue.getTaskStatus(runningTask).get());
     Assert.assertEquals(TaskStatus.success(successfulTask), taskQueue.getTaskStatus(successfulTask).get());
     Assert.assertEquals(TaskStatus.failure(failedTask, failedTask), taskQueue.getTaskStatus(failedTask).get());
+  }
+
+  @Test
+  public void testGetActiveTaskRedactsPassword() throws JsonProcessingException
+  {
+    final String password = "AbCd_1234";
+    final ObjectMapper mapper = getObjectMapper();
+
+    final HttpInputSourceConfig httpInputSourceConfig = new HttpInputSourceConfig(Collections.singleton("http"));
+    mapper.setInjectableValues(new InjectableValues.Std()
+                                   .addValue(HttpInputSourceConfig.class, httpInputSourceConfig)
+                                   .addValue(ObjectMapper.class, new DefaultObjectMapper())
+    );
+
+    final SQLMetadataConnector derbyConnector = derbyConnectorRule.getConnector();
+    final TaskStorage taskStorage = new MetadataTaskStorage(
+        derbyConnector,
+        new TaskStorageConfig(null),
+        new DerbyMetadataStorageActionHandlerFactory(
+            derbyConnector,
+            derbyConnectorRule.metadataTablesConfigSupplier().get(),
+            mapper
+        )
+    );
+
+    final TaskQueue taskQueue = new TaskQueue(
+        new TaskLockConfig(),
+        new TaskQueueConfig(null, null, null, null, null),
+        new DefaultTaskConfig(),
+        taskStorage,
+        EasyMock.createMock(HttpRemoteTaskRunner.class),
+        createActionClientFactory(),
+        new TaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator()),
+        new StubServiceEmitter("druid/overlord", "testHost"),
+        mapper
+    );
+
+    final DataSchema dataSchema = new DataSchema(
+        "DS",
+        new TimestampSpec(null, null, null),
+        new DimensionsSpec(null),
+        null,
+        new UniformGranularitySpec(Granularities.YEAR, Granularities.DAY, null),
+        null
+    );
+    final ParallelIndexIOConfig ioConfig = new ParallelIndexIOConfig(
+        null,
+        new HttpInputSource(Collections.singletonList(URI.create("http://host.org")),
+                            "user",
+                            new DefaultPasswordProvider(password),
+                            null,
+                            httpInputSourceConfig),
+        new NoopInputFormat(),
+        null,
+        null
+    );
+    final ParallelIndexSupervisorTask taskWithPassword = new ParallelIndexSupervisorTask(
+        "taskWithPassword",
+        "taskWithPassword",
+        null,
+        new ParallelIndexIngestionSpec(
+            dataSchema,
+            ioConfig,
+            null
+        ),
+        null,
+        null,
+        false
+    );
+    Assert.assertTrue(mapper.writeValueAsString(taskWithPassword).contains(password));
+
+    taskQueue.start();
+    taskQueue.add(taskWithPassword);
+
+    final Optional<Task> taskFromTaskStorage = taskStorage.getTask(taskWithPassword.getId());
+    Assert.assertTrue(taskFromTaskStorage.isPresent());
+    Assert.assertNotNull(taskFromTaskStorage.get());
+    Assert.assertFalse(mapper.writeValueAsString(taskFromTaskStorage.get()).contains(password));
+
+
+    final Optional<Task> taskFromTaskQueue = taskQueue.getActiveTask(taskWithPassword.getId());
+    Assert.assertTrue(taskFromTaskQueue.isPresent());
+    Assert.assertNotNull(taskFromTaskQueue.get());
+    Assert.assertFalse(mapper.writeValueAsString(taskFromTaskQueue.get()).contains(password));
+
+    Assert.assertEquals(
+        mapper.writeValueAsString(taskFromTaskStorage.get()),
+        mapper.writeValueAsString(taskFromTaskQueue.get())
+    );
   }
 
   private HttpRemoteTaskRunner createHttpRemoteTaskRunner(List<String> runningTasks)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -622,20 +622,18 @@ public class TaskQueueTest extends IngestionTestBase
     taskQueue.start();
     taskQueue.add(taskWithPassword);
 
-    final Optional<Task> taskFromTaskStorage = taskStorage.getTask(taskWithPassword.getId());
-    Assert.assertTrue(taskFromTaskStorage.isPresent());
-    Assert.assertNotNull(taskFromTaskStorage.get());
-    Assert.assertFalse(mapper.writeValueAsString(taskFromTaskStorage.get()).contains(password));
+    final Optional<Task> taskInStorage = taskStorage.getTask(taskWithPassword.getId());
+    Assert.assertTrue(taskInStorage.isPresent());
+    Assert.assertFalse(mapper.writeValueAsString(taskInStorage.get()).contains(password));
 
 
-    final Optional<Task> taskFromTaskQueue = taskQueue.getActiveTask(taskWithPassword.getId());
-    Assert.assertTrue(taskFromTaskQueue.isPresent());
-    Assert.assertNotNull(taskFromTaskQueue.get());
-    Assert.assertFalse(mapper.writeValueAsString(taskFromTaskQueue.get()).contains(password));
+    final Optional<Task> taskInQueue = taskQueue.getActiveTask(taskWithPassword.getId());
+    Assert.assertTrue(taskInQueue.isPresent());
+    Assert.assertFalse(mapper.writeValueAsString(taskInQueue.get()).contains(password));
 
     Assert.assertEquals(
-        mapper.writeValueAsString(taskFromTaskStorage.get()),
-        mapper.writeValueAsString(taskFromTaskQueue.get())
+        mapper.writeValueAsString(taskInStorage.get()),
+        mapper.writeValueAsString(taskInQueue.get())
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -65,6 +65,7 @@ import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
 import org.apache.druid.indexing.overlord.duty.OverlordDutyExecutor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.test.TestIndexerMetadataStorageCoordinator;
+import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -247,7 +248,8 @@ public class OverlordTest
         supervisorManager,
         EasyMock.createNiceMock(OverlordDutyExecutor.class),
         new TestDruidLeaderSelector(),
-        EasyMock.createNiceMock(SegmentAllocationQueue.class)
+        EasyMock.createNiceMock(SegmentAllocationQueue.class),
+        new DefaultObjectMapper()
     );
     EmittingLogger.registerEmitter(serviceEmitter);
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #15882 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Active tasks fetched from TaskQueue's in memory state may reveal sensitive information.

This doesn't happen for payloads fetched from the metadata store, as they are read using a json mapper with an added mixin for redacting credentials.

This PR leans on a similar change in the TaskQueue where a payload is serialized and then deserialized.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `TaskQueue`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
