### PR TITLE
Add errorCode to failure type `InternalServerError`

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
@@ -153,7 +153,8 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     com.google.common.base.Optional<InputStream> taskBody = taskLogs.streamTaskPayload(getTaskId(from).getOriginalTaskId());
     if (!taskBody.isPresent()) {
       throw InternalServerError.exception(
-          "Could not load task payload from deep storage for job [%s]. Check the overlord logs for any errors in uploading task payload to deep storage.",
+          "Could not load task payload from deep storage for job [%s]."
+          + " Check the overlord logs for any errors in uploading task payload to deep storage.",
           from.getMetadata().getName()
       );
     }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -188,7 +188,8 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     com.google.common.base.Optional<InputStream> taskBody = taskLogs.streamTaskPayload(getTaskId(from).getOriginalTaskId());
     if (!taskBody.isPresent()) {
       throw InternalServerError.exception(
-          "Could not load task payload from deep storage for job [%s]. Check the overlord logs for errors uploading task payloads to deep storage.",
+          "Could not load task payload from deep storage for job [%s]."
+          + " Check the overlord logs for errors uploading task payloads to deep storage.",
           from.getMetadata().getName()
       );
     }

--- a/processing/src/main/java/org/apache/druid/error/InternalServerError.java
+++ b/processing/src/main/java/org/apache/druid/error/InternalServerError.java
@@ -21,25 +21,24 @@ package org.apache.druid.error;
 
 public class InternalServerError extends BaseFailure
 {
-  public static DruidException exception(String errorCode, String msg, Object... args)
+  public static DruidException exception(String msg, Object... args)
   {
-    return exception(null, errorCode, msg, args);
+    return exception(null, msg, args);
   }
 
-  public static DruidException exception(Throwable t, String errorCode, String msg, Object... args)
+  public static DruidException exception(Throwable t, String msg, Object... args)
   {
-    return DruidException.fromFailure(new InternalServerError(t, errorCode, msg, args));
+    return DruidException.fromFailure(new InternalServerError(t, msg, args));
   }
 
   private InternalServerError(
       Throwable t,
-      String errorCode,
       String msg,
       Object... args
   )
   {
     super(
-        errorCode,
+        "internalServerError",
         DruidException.Persona.OPERATOR,
         DruidException.Category.RUNTIME_FAILURE,
         t, msg, args

--- a/processing/src/test/java/org/apache/druid/error/InternalServerErrorTest.java
+++ b/processing/src/test/java/org/apache/druid/error/InternalServerErrorTest.java
@@ -31,14 +31,14 @@ public class InternalServerErrorTest
   @Test
   public void testAsErrorResponse()
   {
-    ErrorResponse errorResponse = new ErrorResponse(InternalServerError.exception("runtimeFailure", "Internal Server Error"));
+    ErrorResponse errorResponse = new ErrorResponse(InternalServerError.exception("Internal Server Error"));
     final Map<String, Object> asMap = errorResponse.getAsMap();
 
     MatcherAssert.assertThat(
         asMap,
         DruidMatchers.mapMatcher(
             "error", "druidException",
-            "errorCode", "runtimeFailure",
+            "errorCode", "internalServerError",
             "persona", "OPERATOR",
             "category", "RUNTIME_FAILURE",
             "errorMessage", "Internal Server Error"
@@ -52,7 +52,7 @@ public class InternalServerErrorTest
         new DruidExceptionMatcher(
             DruidException.Persona.OPERATOR,
             DruidException.Category.RUNTIME_FAILURE,
-            "runtimeFailure"
+            "internalServerError"
         ).expectMessageContains("Internal Server Error")
     );
   }


### PR DESCRIPTION
Looking at other failure types such as `InvalidInput`, `InvalidSqlInput`, etc. it makes sense to have the error code be fixed for a certain of failure.

The only two usages of the method `InternalServerError.exception()` were actually passing a whole long message in the error code. This would result in the `errorCode` field being populated with the error message and the `errorMsg` field itself taking the value of the first message argument.

### Changes
- Use error code `internalServerError` for failures of this type
- Remove the error code argument from `InternalServerError.exception()` methods thus fixing the above mentioned bug in the callers.