### PR TITLE
Web console: Better manual capabilities detection indication

### DIFF
--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -267,55 +267,53 @@ exports[`HeaderBar matches snapshot 1`] = `
           <Blueprint4.MenuItem
             active={false}
             disabled={false}
-            icon="cog"
+            icon="high-priority"
             multiline={false}
             popoverProps={{}}
             selected={false}
             shouldDismissPopover={true}
-            text="Console options"
+            text="Force specific console mode"
           >
-            <React.Fragment>
-              <Blueprint4.MenuItem
-                active={false}
-                disabled={false}
-                multiline={false}
-                onClick={[Function]}
-                popoverProps={{}}
-                selected={false}
-                shouldDismissPopover={true}
-                text="Force Coordinator/Overlord mode"
-              />
-              <Blueprint4.MenuItem
-                active={false}
-                disabled={false}
-                multiline={false}
-                onClick={[Function]}
-                popoverProps={{}}
-                selected={false}
-                shouldDismissPopover={true}
-                text="Force Coordinator mode"
-              />
-              <Blueprint4.MenuItem
-                active={false}
-                disabled={false}
-                multiline={false}
-                onClick={[Function]}
-                popoverProps={{}}
-                selected={false}
-                shouldDismissPopover={true}
-                text="Force Overlord mode"
-              />
-              <Blueprint4.MenuItem
-                active={false}
-                disabled={false}
-                multiline={false}
-                onClick={[Function]}
-                popoverProps={{}}
-                selected={false}
-                shouldDismissPopover={true}
-                text="Force no management proxy mode"
-              />
-            </React.Fragment>
+            <Blueprint4.MenuItem
+              active={false}
+              disabled={false}
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={{}}
+              selected={false}
+              shouldDismissPopover={true}
+              text="Force Coordinator/Overlord mode"
+            />
+            <Blueprint4.MenuItem
+              active={false}
+              disabled={false}
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={{}}
+              selected={false}
+              shouldDismissPopover={true}
+              text="Force Coordinator mode"
+            />
+            <Blueprint4.MenuItem
+              active={false}
+              disabled={false}
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={{}}
+              selected={false}
+              shouldDismissPopover={true}
+              text="Force Overlord mode"
+            />
+            <Blueprint4.MenuItem
+              active={false}
+              disabled={false}
+              multiline={false}
+              onClick={[Function]}
+              popoverProps={{}}
+              selected={false}
+              shouldDismissPopover={true}
+              text="Force no management proxy mode"
+            />
           </Blueprint4.MenuItem>
         </Blueprint4.Menu>
       }

--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -272,7 +272,7 @@ exports[`HeaderBar matches snapshot 1`] = `
             popoverProps={{}}
             selected={false}
             shouldDismissPopover={true}
-            text="Force specific console mode"
+            text="Capabilty detection"
           >
             <Blueprint4.MenuItem
               active={false}
@@ -282,7 +282,7 @@ exports[`HeaderBar matches snapshot 1`] = `
               popoverProps={{}}
               selected={false}
               shouldDismissPopover={true}
-              text="Force Coordinator/Overlord mode"
+              text="Manually set Coordinator/Overlord mode"
             />
             <Blueprint4.MenuItem
               active={false}
@@ -292,7 +292,7 @@ exports[`HeaderBar matches snapshot 1`] = `
               popoverProps={{}}
               selected={false}
               shouldDismissPopover={true}
-              text="Force Coordinator mode"
+              text="Manually set Coordinator mode"
             />
             <Blueprint4.MenuItem
               active={false}
@@ -302,7 +302,7 @@ exports[`HeaderBar matches snapshot 1`] = `
               popoverProps={{}}
               selected={false}
               shouldDismissPopover={true}
-              text="Force Overlord mode"
+              text="Manually set Overlord mode"
             />
             <Blueprint4.MenuItem
               active={false}
@@ -312,7 +312,7 @@ exports[`HeaderBar matches snapshot 1`] = `
               popoverProps={{}}
               selected={false}
               shouldDismissPopover={true}
-              text="Force no management proxy mode"
+              text="Manually set Router with no management proxy mode"
             />
           </Blueprint4.MenuItem>
         </Blueprint4.Menu>

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -367,9 +367,8 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
                    than detecting all capabilities for the cluster.
                 </p>
                 <p>
-                  This is an advanced feature used for testing and for working around issues in the
-                  capability detecting logic. If you are not sure why you are in this mode then
-                  clear it.
+                  Forced mode is an advanced feature used for testing and for working around issues with the
+                  capability detecting logic. If you are unsure why the console is in forced mode, clear it.
                 </p>
                 <p>
                   <Button

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -363,8 +363,8 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
             content={
               <PopoverText>
                 <p>
-                  The console is running in a specific forced mode. Instead of detecting the
-                  capabilities of the cluster it is assuming a certain defined set of capabilities.
+                  The console is running in a forced mode that assumes a limited set of capabilities rather
+                   than detecting all capabilities for the cluster.
                 </p>
                 <p>
                   This is an advanced feature used for testing and for working around issues in the

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -385,7 +385,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
                   working around issues with the automatic capability detecting logic.
                 </p>
                 <p>
-                  If you are unsure why the console is in ths mode mode, revert to using automatic
+                  If you are unsure why the console is in this mode, revert to using automatic
                   capability detection.
                 </p>
                 <p>

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -232,7 +232,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
         {capabilitiesOverride && (
           <>
             <MenuItem
-              text="Use manual capabilty detection"
+              text="Use automatic capabilty detection"
               onClick={() => setCapabilitiesOverride(undefined)}
               intent={Intent.PRIMARY}
             />

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -187,7 +187,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
     </Menu>
   );
 
-  function setForcedMode(capabilities: Capabilities | undefined): void {
+  function setCapabilitiesOverride(capabilities: Capabilities | undefined): void {
     if (capabilities) {
       localStorageSetJson(LocalStorageKeys.CAPABILITIES_OVERRIDE, capabilities);
     } else {
@@ -224,35 +224,43 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
         disabled={!capabilities.hasCoordinatorAccess()}
       />
       <MenuDivider />
-      <MenuItem icon={IconNames.HIGH_PRIORITY} text="Force specific console mode">
+      <MenuItem
+        icon={IconNames.HIGH_PRIORITY}
+        text="Capabilty detection"
+        intent={capabilitiesOverride ? Intent.DANGER : undefined}
+      >
         {capabilitiesOverride && (
           <>
-            <MenuItem text="Clear forced mode" onClick={() => setForcedMode(undefined)} />
+            <MenuItem
+              text="Use manual capabilty detection"
+              onClick={() => setCapabilitiesOverride(undefined)}
+              intent={Intent.PRIMARY}
+            />
             <MenuDivider />
           </>
         )}
         {capabilitiesMode !== 'coordinator-overlord' && (
           <MenuItem
-            text="Force Coordinator/Overlord mode"
-            onClick={() => setForcedMode(Capabilities.COORDINATOR_OVERLORD)}
+            text="Manually set Coordinator/Overlord mode"
+            onClick={() => setCapabilitiesOverride(Capabilities.COORDINATOR_OVERLORD)}
           />
         )}
         {capabilitiesMode !== 'coordinator' && (
           <MenuItem
-            text="Force Coordinator mode"
-            onClick={() => setForcedMode(Capabilities.COORDINATOR)}
+            text="Manually set Coordinator mode"
+            onClick={() => setCapabilitiesOverride(Capabilities.COORDINATOR)}
           />
         )}
         {capabilitiesMode !== 'overlord' && (
           <MenuItem
-            text="Force Overlord mode"
-            onClick={() => setForcedMode(Capabilities.OVERLORD)}
+            text="Manually set Overlord mode"
+            onClick={() => setCapabilitiesOverride(Capabilities.OVERLORD)}
           />
         )}
         {capabilitiesMode !== 'no-proxy' && (
           <MenuItem
-            text="Force no management proxy mode"
-            onClick={() => setForcedMode(Capabilities.NO_PROXY)}
+            text="Manually set Router with no management proxy mode"
+            onClick={() => setCapabilitiesOverride(Capabilities.NO_PROXY)}
           />
         )}
       </MenuItem>
@@ -357,23 +365,33 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
         </Popover2>
       </NavbarGroup>
       <NavbarGroup align={Alignment.RIGHT}>
-        <RestrictedMode capabilities={capabilities} onUnrestrict={onUnrestrict} />
+        <RestrictedMode
+          capabilities={capabilities}
+          onUnrestrict={onUnrestrict}
+          onUseAutomaticCapabilityDetection={
+            capabilitiesOverride ? () => setCapabilitiesOverride(undefined) : undefined
+          }
+        />
         {capabilitiesOverride && (
           <Popover2
             content={
               <PopoverText>
                 <p>
-                  The console is running in a forced mode that assumes a limited set of capabilities rather
-                   than detecting all capabilities for the cluster.
+                  The console is running in a manual capability setting mode that assumes a limited
+                  set of capabilities rather than detecting all capabilities for the cluster.
                 </p>
                 <p>
-                  Forced mode is an advanced feature used for testing and for working around issues with the
-                  capability detecting logic. If you are unsure why the console is in forced mode, clear it.
+                  Manual capability setting mode is an advanced feature used for testing and for
+                  working around issues with the automatic capability detecting logic.
+                </p>
+                <p>
+                  If you are unsure why the console is in ths mode mode, revert to using automatic
+                  capability detection.
                 </p>
                 <p>
                   <Button
-                    text="Clear forced mode"
-                    onClick={() => setForcedMode(undefined)}
+                    text="Use automatic capability detection"
+                    onClick={() => setCapabilitiesOverride(undefined)}
                     intent={Intent.PRIMARY}
                   />
                 </p>
@@ -383,7 +401,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
           >
             <Button
               icon={IconNames.HIGH_PRIORITY}
-              text="Forced mode"
+              text="Manual capabilty detection"
               intent={Intent.DANGER}
               minimal
             />

--- a/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
+++ b/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`RestrictedMode matches snapshot 1`] = `
         The console is running in restricted mode.
       </p>
       <p>
-        It appears that you are accessing the console on the Coordinator/Overlord shared service. Due to the lack of access to some APIs on this service the console will operate in a limited mode. The unrestricted version of the console can be accessed on the Router service.
+        You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks  access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
       </p>
       <p>
         For more info check out the

--- a/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
+++ b/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`RestrictedMode matches snapshot 1`] = `
         .
       </p>
       <p>
-        It is possible that there is an issue with the capability detection. You can enable the unrestricted console but certain features might not work if the underlying APIs are not available.
+        It is possible that the console is experiencing an issue with the capability detection. You can enable the unrestricted console, but certain features might not work if the underlying APIs are not available.
       </p>
       <p>
         <Blueprint4.Button

--- a/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
+++ b/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
@@ -10,10 +10,10 @@ exports[`RestrictedMode matches snapshot 1`] = `
         The console is running in restricted mode.
       </p>
       <p>
-        You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks  access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
+        You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
       </p>
       <p>
-        For more info check out the
+        For more info refer to the
          
         <Memo(ExternalLink)
           href="https://druid.apache.org/docs/latest/operations/web-console.html"

--- a/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
+++ b/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RestrictedMode matches snapshot 1`] = `
+exports[`RestrictedMode matches snapshot when in auto capability detection mode 1`] = `
 <Blueprint4.Popover2
   boundary="clippingParents"
   captureDismiss={false}
+  className="restricted-mode"
   content={
     <Memo(PopoverText)>
       <p>
@@ -22,16 +23,89 @@ exports[`RestrictedMode matches snapshot 1`] = `
         </Memo(ExternalLink)>
         .
       </p>
-      <p>
-        It is possible that the console is experiencing an issue with the capability detection. You can enable the unrestricted console, but certain features might not work if the underlying APIs are not available.
-      </p>
+      <React.Fragment>
+        <p>
+          It is possible that the console is experiencing an issue with the capability detection. You can enable the unrestricted console, but certain features might not work if the underlying APIs are not available.
+        </p>
+        <p>
+          <Blueprint4.Button
+            icon="warning-sign"
+            onClick={[Function]}
+            text="Temporarily unrestrict console (with SQL)"
+          />
+        </p>
+      </React.Fragment>
       <p>
         <Blueprint4.Button
           icon="warning-sign"
           onClick={[Function]}
-          text="Temporarily unrestrict console (with SQL)"
+          text="Temporarily unrestrict console (without SQL)"
         />
       </p>
+    </Memo(PopoverText)>
+  }
+  defaultIsOpen={false}
+  disabled={false}
+  fill={false}
+  hasBackdrop={false}
+  hoverCloseDelay={300}
+  hoverOpenDelay={150}
+  inheritDarkTheme={true}
+  interactionKind="click"
+  matchTargetWidth={false}
+  minimal={false}
+  openOnTargetFocus={true}
+  position="bottom-right"
+  positioningStrategy="absolute"
+  shouldReturnFocusOnClose={false}
+  targetTagName="span"
+  transitionDuration={300}
+  usePortal={true}
+>
+  <Blueprint4.Button
+    icon="warning-sign"
+    intent="warning"
+    minimal={true}
+    text="Coordinator/Overlord mode"
+  />
+</Blueprint4.Popover2>
+`;
+
+exports[`RestrictedMode matches snapshot when in manual capability detection mode 1`] = `
+<Blueprint4.Popover2
+  boundary="clippingParents"
+  captureDismiss={false}
+  className="restricted-mode"
+  content={
+    <Memo(PopoverText)>
+      <p>
+        The console is running in restricted mode.
+      </p>
+      <p>
+        You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
+      </p>
+      <p>
+        For more info refer to the
+         
+        <Memo(ExternalLink)
+          href="https://druid.apache.org/docs/latest/operations/web-console.html"
+        >
+          web console documentation
+        </Memo(ExternalLink)>
+        .
+      </p>
+      <React.Fragment>
+        <p>
+          The console did no perform its automatic capability detection because it is running in manual capability detection mode.
+        </p>
+        <p>
+          <Blueprint4.Button
+            intent="primary"
+            onClick={[Function]}
+            text="Use to automatic capability detection"
+          />
+        </p>
+      </React.Fragment>
       <p>
         <Blueprint4.Button
           icon="warning-sign"

--- a/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
+++ b/web-console/src/components/header-bar/restricted-mode/__snapshots__/restricted-mode.spec.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestrictedMode matches snapshot 1`] = `
+<Blueprint4.Popover2
+  boundary="clippingParents"
+  captureDismiss={false}
+  content={
+    <Memo(PopoverText)>
+      <p>
+        The console is running in restricted mode.
+      </p>
+      <p>
+        It appears that you are accessing the console on the Coordinator/Overlord shared service. Due to the lack of access to some APIs on this service the console will operate in a limited mode. The unrestricted version of the console can be accessed on the Router service.
+      </p>
+      <p>
+        For more info check out the
+         
+        <Memo(ExternalLink)
+          href="https://druid.apache.org/docs/latest/operations/web-console.html"
+        >
+          web console documentation
+        </Memo(ExternalLink)>
+        .
+      </p>
+      <p>
+        It is possible that there is an issue with the capability detection. You can enable the unrestricted console but certain features might not work if the underlying APIs are not available.
+      </p>
+      <p>
+        <Blueprint4.Button
+          icon="warning-sign"
+          onClick={[Function]}
+          text="Temporarily unrestrict console (with SQL)"
+        />
+      </p>
+      <p>
+        <Blueprint4.Button
+          icon="warning-sign"
+          onClick={[Function]}
+          text="Temporarily unrestrict console (without SQL)"
+        />
+      </p>
+    </Memo(PopoverText)>
+  }
+  defaultIsOpen={false}
+  disabled={false}
+  fill={false}
+  hasBackdrop={false}
+  hoverCloseDelay={300}
+  hoverOpenDelay={150}
+  inheritDarkTheme={true}
+  interactionKind="click"
+  matchTargetWidth={false}
+  minimal={false}
+  openOnTargetFocus={true}
+  position="bottom-right"
+  positioningStrategy="absolute"
+  shouldReturnFocusOnClose={false}
+  targetTagName="span"
+  transitionDuration={300}
+  usePortal={true}
+>
+  <Blueprint4.Button
+    icon="warning-sign"
+    intent="warning"
+    minimal={true}
+    text="Coordinator/Overlord mode"
+  />
+</Blueprint4.Popover2>
+`;

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.spec.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.spec.tsx
@@ -16,28 +16,18 @@
  * limitations under the License.
  */
 
-import type { CapacityInfo } from '../druid-models';
-import { Api } from '../singletons';
+import React from 'react';
 
-export async function getClusterCapacity(): Promise<CapacityInfo> {
-  const workersResponse = await Api.instance.get('/druid/indexer/v1/totalWorkerCapacity', {
-    timeout: 5000,
+import { Capabilities } from '../../../helpers';
+import { shallow } from '../../../utils/shallow-renderer';
+
+import { RestrictedMode } from './restricted-mode';
+
+describe('RestrictedMode', () => {
+  it('matches snapshot', () => {
+    const headerBar = shallow(
+      <RestrictedMode capabilities={Capabilities.COORDINATOR_OVERLORD} onUnrestrict={() => {}} />,
+    );
+    expect(headerBar).toMatchSnapshot();
   });
-
-  const usedTaskSlots = Number(workersResponse.data.usedClusterCapacity);
-  const totalTaskSlots = Number(workersResponse.data.currentClusterCapacity);
-
-  return {
-    availableTaskSlots: totalTaskSlots - usedTaskSlots,
-    usedTaskSlots,
-    totalTaskSlots,
-  };
-}
-
-export async function maybeGetClusterCapacity(): Promise<CapacityInfo | undefined> {
-  try {
-    return await getClusterCapacity();
-  } catch {
-    return;
-  }
-}
+});

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.spec.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.spec.tsx
@@ -24,9 +24,20 @@ import { shallow } from '../../../utils/shallow-renderer';
 import { RestrictedMode } from './restricted-mode';
 
 describe('RestrictedMode', () => {
-  it('matches snapshot', () => {
+  it('matches snapshot when in auto capability detection mode', () => {
     const headerBar = shallow(
       <RestrictedMode capabilities={Capabilities.COORDINATOR_OVERLORD} onUnrestrict={() => {}} />,
+    );
+    expect(headerBar).toMatchSnapshot();
+  });
+
+  it('matches snapshot when in manual capability detection mode', () => {
+    const headerBar = shallow(
+      <RestrictedMode
+        capabilities={Capabilities.COORDINATOR_OVERLORD}
+        onUnrestrict={() => {}}
+        onUseAutomaticCapabilityDetection={() => {}}
+      />,
     );
     expect(headerBar).toMatchSnapshot();
   });

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -45,10 +45,10 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'No SQL mode';
       message = (
         <p>
-          It appears that the SQL endpoint is disabled. The console will fall back to{' '}
-          <ExternalLink href={getLink('DOCS_API')}>native Druid APIs</ExternalLink> and will be
-          limited in functionality. Look at{' '}
-          <ExternalLink href={getLink('DOCS_SQL')}>the SQL docs</ExternalLink> to enable the SQL
+          The SQL endpoint is disabled. The console will fall back to{' '}
+          <ExternalLink href={getLink('DOCS_API')}>native Druid APIs</ExternalLink> and will operate with
+          limited functionality. Refer to {' '}
+          <ExternalLink href={getLink('DOCS_SQL')}>the SQL docs</ExternalLink> for instructions to enable the SQL
           endpoint.
         </p>
       );

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, Intent, Position } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import { Popover2 } from '@blueprintjs/popover2';
+import React, { type JSX } from 'react';
+
+import { Capabilities } from '../../../helpers';
+import { getLink } from '../../../links';
+import { ExternalLink } from '../../external-link/external-link';
+import { PopoverText } from '../../popover-text/popover-text';
+
+export interface RestrictedModeProps {
+  capabilities: Capabilities;
+  onUnrestrict(capabilities: Capabilities): void;
+}
+
+export const RestrictedMode = React.memo(function RestrictedMode(props: RestrictedModeProps) {
+  const { capabilities, onUnrestrict } = props;
+  const mode = capabilities.getModeExtended();
+
+  let label: string;
+  let message: JSX.Element;
+  switch (mode) {
+    case 'full':
+      return null; // Do not show anything
+
+    case 'no-sql':
+      label = 'No SQL mode';
+      message = (
+        <p>
+          It appears that the SQL endpoint is disabled. The console will fall back to{' '}
+          <ExternalLink href={getLink('DOCS_API')}>native Druid APIs</ExternalLink> and will be
+          limited in functionality. Look at{' '}
+          <ExternalLink href={getLink('DOCS_SQL')}>the SQL docs</ExternalLink> to enable the SQL
+          endpoint.
+        </p>
+      );
+      break;
+
+    case 'no-proxy':
+      label = 'No management proxy mode';
+      message = (
+        <p>
+          It appears that the management proxy is not enabled, the console will operate with limited
+          functionality.
+        </p>
+      );
+      break;
+
+    case 'no-sql-no-proxy':
+      label = 'No SQL mode';
+      message = (
+        <p>
+          It appears that the SQL endpoint and management proxy are disabled. The console can only
+          be used to make queries.
+        </p>
+      );
+      break;
+
+    case 'coordinator-overlord':
+      label = 'Coordinator/Overlord mode';
+      message = (
+        <p>
+          It appears that you are accessing the console on the Coordinator/Overlord shared service.
+          Due to the lack of access to some APIs on this service the console will operate in a
+          limited mode. The unrestricted version of the console can be accessed on the Router
+          service.
+        </p>
+      );
+      break;
+
+    case 'coordinator':
+      label = 'Coordinator mode';
+      message = (
+        <p>
+          It appears that you are accessing the console on the Coordinator service. Due to the lack
+          of access to some APIs on this service the console will operate in a limited mode. The
+          full version of the console can be accessed on the Router service.
+        </p>
+      );
+      break;
+
+    case 'overlord':
+      label = 'Overlord mode';
+      message = (
+        <p>
+          It appears that you are accessing the console on the Overlord service. Due to the lack of
+          access to some APIs on this service the console will operate in a limited mode. The
+          unrestricted version of the console can be accessed on the Router service.
+        </p>
+      );
+      break;
+
+    default:
+      label = 'Restricted mode';
+      message = (
+        <p>
+          Due to the lack of access to some APIs on this service the console will operate in a
+          limited mode. The unrestricted version of the console can be accessed on the Router
+          service.
+        </p>
+      );
+      break;
+  }
+
+  return (
+    <Popover2
+      content={
+        <PopoverText>
+          <p>The console is running in restricted mode.</p>
+          {message}
+          <p>
+            For more info check out the{' '}
+            <ExternalLink href={`${getLink('DOCS')}/operations/web-console.html`}>
+              web console documentation
+            </ExternalLink>
+            .
+          </p>
+          <p>
+            It is possible that there is an issue with the capability detection. You can enable the
+            unrestricted console but certain features might not work if the underlying APIs are not
+            available.
+          </p>
+          <p>
+            <Button
+              icon={IconNames.WARNING_SIGN}
+              text={`Temporarily unrestrict console${capabilities.hasSql() ? '' : ' (with SQL)'}`}
+              onClick={() => onUnrestrict(Capabilities.FULL)}
+            />
+          </p>
+          {!capabilities.hasSql() && (
+            <p>
+              <Button
+                icon={IconNames.WARNING_SIGN}
+                text="Temporarily unrestrict console (without SQL)"
+                onClick={() => onUnrestrict(Capabilities.NO_SQL)}
+              />
+            </p>
+          )}
+        </PopoverText>
+      }
+      position={Position.BOTTOM_RIGHT}
+    >
+      <Button icon={IconNames.WARNING_SIGN} text={label} intent={Intent.WARNING} minimal />
+    </Popover2>
+  );
+});

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -46,10 +46,10 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       message = (
         <p>
           The SQL endpoint is disabled. The console will fall back to{' '}
-          <ExternalLink href={getLink('DOCS_API')}>native Druid APIs</ExternalLink> and will operate with
-          limited functionality. Refer to {' '}
-          <ExternalLink href={getLink('DOCS_SQL')}>the SQL docs</ExternalLink> for instructions to enable the SQL
-          endpoint.
+          <ExternalLink href={getLink('DOCS_API')}>native Druid APIs</ExternalLink> and will operate
+          with limited functionality. Refer to{' '}
+          <ExternalLink href={getLink('DOCS_SQL')}>the SQL docs</ExternalLink> for instructions to
+          enable the SQL endpoint.
         </p>
       );
       break;
@@ -58,8 +58,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'No management proxy mode';
       message = (
         <p>
-         The management proxy is not enabled, the console will operate with limited
-          functionality.
+          The management proxy is disabled, the console will operate with limited functionality.
         </p>
       );
       break;
@@ -68,8 +67,8 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'No SQL mode';
       message = (
         <p>
-          The SQL endpoint and management proxy are disabled.  You can only use the console
-          to make queries.
+          The SQL endpoint and management proxy are disabled. You can only use the console to make
+          JSON-based queries.
         </p>
       );
       break;
@@ -78,7 +77,9 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'Coordinator/Overlord mode';
       message = (
         <p>
-          You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
+          You are accessing the console on the Coordinator/Overlord shared service. Because this
+          service lacks access to some APIs, the console will operate in a limited mode. You can
+          access the unrestricted version of the console on the Router service.
         </p>
       );
       break;
@@ -87,9 +88,9 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'Coordinator mode';
       message = (
         <p>
-          It appears that you are accessing the console on the Coordinator service. Due to the lack
-          of access to some APIs on this service the console will operate in a limited mode. The
-          full version of the console can be accessed on the Router service.
+          You are accessing the console on the Coordinator service. Because this service lacks
+          access to some APIs, the console will operate in a limited mode. You can access the
+          unrestricted version of the console on the Router service.
         </p>
       );
       break;
@@ -98,9 +99,9 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'Overlord mode';
       message = (
         <p>
-          It appears that you are accessing the console on the Overlord service. Due to the lack of
-          access to some APIs on this service the console will operate in a limited mode. The
-          unrestricted version of the console can be accessed on the Router service.
+          You are accessing the console on the Overlord service. Because this service lacks access
+          to some APIs, the console will operate in a limited mode. You can access the unrestricted
+          version of the console on the Router service.
         </p>
       );
       break;
@@ -131,9 +132,9 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
             .
           </p>
           <p>
-            There is an issue with the console capability detection. You can enable the
-            unrestricted console but certain features might not work if the underlying APIs are not
-            available.
+            It is possible that the console is experiencing an issue with the capability detection.
+            You can enable the unrestricted console, but certain features might not work if the
+            underlying APIs are not available.
           </p>
           <p>
             <Button

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -58,7 +58,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'No management proxy mode';
       message = (
         <p>
-          It appears that the management proxy is not enabled, the console will operate with limited
+         The management proxy is not enabled, the console will operate with limited
           functionality.
         </p>
       );

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -134,7 +134,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
             .
           </p>
           <p>
-            It is possible that there is an issue with the capability detection. You can enable the
+            There is an issue with the console capability detection. You can enable the
             unrestricted console but certain features might not work if the underlying APIs are not
             available.
           </p>

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -29,10 +29,11 @@ import { PopoverText } from '../../popover-text/popover-text';
 export interface RestrictedModeProps {
   capabilities: Capabilities;
   onUnrestrict(capabilities: Capabilities): void;
+  onUseAutomaticCapabilityDetection?: () => void;
 }
 
 export const RestrictedMode = React.memo(function RestrictedMode(props: RestrictedModeProps) {
-  const { capabilities, onUnrestrict } = props;
+  const { capabilities, onUnrestrict, onUseAutomaticCapabilityDetection } = props;
   const mode = capabilities.getModeExtended();
 
   let label: string;
@@ -120,6 +121,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
 
   return (
     <Popover2
+      className="restricted-mode"
       content={
         <PopoverText>
           <p>The console is running in restricted mode.</p>
@@ -131,18 +133,38 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
             </ExternalLink>
             .
           </p>
-          <p>
-            It is possible that the console is experiencing an issue with the capability detection.
-            You can enable the unrestricted console, but certain features might not work if the
-            underlying APIs are not available.
-          </p>
-          <p>
-            <Button
-              icon={IconNames.WARNING_SIGN}
-              text={`Temporarily unrestrict console${capabilities.hasSql() ? '' : ' (with SQL)'}`}
-              onClick={() => onUnrestrict(Capabilities.FULL)}
-            />
-          </p>
+          {onUseAutomaticCapabilityDetection ? (
+            <>
+              <p>
+                The console did no perform its automatic capability detection because it is running
+                in manual capability detection mode.
+              </p>
+              <p>
+                <Button
+                  text="Use to automatic capability detection"
+                  onClick={onUseAutomaticCapabilityDetection}
+                  intent={Intent.PRIMARY}
+                />
+              </p>
+            </>
+          ) : (
+            <>
+              <p>
+                It is possible that the console is experiencing an issue with the capability
+                detection. You can enable the unrestricted console, but certain features might not
+                work if the underlying APIs are not available.
+              </p>
+              <p>
+                <Button
+                  icon={IconNames.WARNING_SIGN}
+                  text={`Temporarily unrestrict console${
+                    capabilities.hasSql() ? '' : ' (with SQL)'
+                  }`}
+                  onClick={() => onUnrestrict(Capabilities.FULL)}
+                />
+              </p>
+            </>
+          )}
           {!capabilities.hasSql() && (
             <p>
               <Button

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -68,8 +68,8 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'No SQL mode';
       message = (
         <p>
-          It appears that the SQL endpoint and management proxy are disabled. The console can only
-          be used to make queries.
+          The SQL endpoint and management proxy are disabled.  You can only use the console
+          to make queries.
         </p>
       );
       break;

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -112,8 +112,8 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'Restricted mode';
       message = (
         <p>
-          Due to the lack of access to some APIs on this service the console will operate in a
-          limited mode. The unrestricted version of the console can be accessed on the Router
+          Due to the lack of access to some APIs on this service, the console will operate in a
+          limited mode. You can access the unrestricted version of the console on the Router
           service.
         </p>
       );

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -127,7 +127,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
           <p>The console is running in restricted mode.</p>
           {message}
           <p>
-            For more info check out the{' '}
+            For more info refer to the{' '}
             <ExternalLink href={`${getLink('DOCS')}/operations/web-console.html`}>
               web console documentation
             </ExternalLink>

--- a/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
+++ b/web-console/src/components/header-bar/restricted-mode/restricted-mode.tsx
@@ -78,10 +78,7 @@ export const RestrictedMode = React.memo(function RestrictedMode(props: Restrict
       label = 'Coordinator/Overlord mode';
       message = (
         <p>
-          It appears that you are accessing the console on the Coordinator/Overlord shared service.
-          Due to the lack of access to some APIs on this service the console will operate in a
-          limited mode. The unrestricted version of the console can be accessed on the Router
-          service.
+          You are accessing the console on the Coordinator/Overlord shared service. Because this service lacks access to some APIs, the console will operate in a limited mode. You can access the unrestricted version of the console on the Router service.
         </p>
       );
       break;

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -122,7 +122,8 @@ export class ConsoleApplication extends React.PureComponent<
 
         return await Capabilities.detectCapacity(capabilities);
       },
-      onStateChange: ({ data, loading }) => {
+      onStateChange: ({ data, loading, error }) => {
+        console.error('There was an error retrieving the capabilities', error);
         this.setState({
           capabilities: data || Capabilities.FULL,
           capabilitiesLoading: loading,

--- a/web-console/src/helpers/capabilities.ts
+++ b/web-console/src/helpers/capabilities.ts
@@ -65,8 +65,8 @@ export class Capabilities {
         { timeout: Capabilities.STATUS_TIMEOUT },
       );
     } catch (e) {
-      const { response } = e;
-      if (response.status !== 405 && response.status !== 404) {
+      const status = e.response?.status;
+      if (status !== 405 && status !== 404) {
         return; // other failure
       }
       try {
@@ -87,7 +87,7 @@ export class Capabilities {
           { timeout: Capabilities.STATUS_TIMEOUT },
         );
       } catch (e) {
-        if (response.status !== 405 && response.status !== 404) {
+        if (status !== 405 && status !== 404) {
           return; // other failure
         }
 
@@ -106,9 +106,9 @@ export class Capabilities {
         timeout: Capabilities.STATUS_TIMEOUT,
       });
     } catch (e) {
-      const { response } = e;
+      const status = e.response?.status;
       // If we detect error code 400 the management proxy is enabled but just does not know about the recently added /proxy/enabled route so treat this as a win.
-      return response?.status === 400;
+      return status === 400;
     }
 
     return true;

--- a/web-console/src/helpers/capabilities.ts
+++ b/web-console/src/helpers/capabilities.ts
@@ -108,7 +108,7 @@ export class Capabilities {
     } catch (e) {
       const { response } = e;
       // If we detect error code 400 the management proxy is enabled but just does not know about the recently added /proxy/enabled route so treat this as a win.
-      return response.status === 400;
+      return response?.status === 400;
     }
 
     return true;

--- a/web-console/src/singletons/api.ts
+++ b/web-console/src/singletons/api.ts
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import type { AxiosError, AxiosInstance, CreateAxiosDefaults } from 'axios';
-import axios from 'axios';
+import type { AxiosInstance, CreateAxiosDefaults } from 'axios';
+import axios, { AxiosError } from 'axios';
 import * as JSONBig from 'json-bigint-native';
 
 import { nonEmptyString } from '../utils';
@@ -36,11 +36,15 @@ export class Api {
         const responseData = error.response?.data;
         const message = responseData?.message;
         if (nonEmptyString(message)) {
-          return Promise.reject(new Error(message));
+          return Promise.reject(
+            new AxiosError(message, error.code, error.config, error.request, error.response),
+          );
         }
 
         if (error.config?.method?.toLowerCase() === 'get' && nonEmptyString(responseData)) {
-          return Promise.reject(new Error(responseData));
+          return Promise.reject(
+            new AxiosError(responseData, error.code, error.config, error.request, error.response),
+          );
         }
 
         return Promise.reject(error);


### PR DESCRIPTION
Upgrade the manual capabilities mode UX so that it is clearer that the console is in a manual capabilities mode.

The console has many degraded modes in can operate in this is to account for different (degraded) configurations of the underlying cluster. Here are a few examples:
- The coordinator serves the console but does not let you query SQL
- The router might be running with the management proxy turned off so the console can not reach the coordinator
- The indexer might be dead and unreachable

When the console loads it does a few probing queries to detect what capabilities are available to it. This is called capability detection.

A manual capabilities mode is when the user tells the console to skip the capability detection and just put itself into some specific mode. This is useful for testing (the console) and for getting around flaws in the capability detection. Overall this is a fairly power user feature and should only be used by users that know what (and why) they are doing it.

It has come to my attention that there were some users that has their console in a manual capabilities mode and they did not know it, as a result their console was degraded. I want to update the UI so it would be more clear.

## Current behavior

Setting the manual capabilities mode:

![image](https://github.com/apache/druid/assets/177816/f5d4fcb0-99c9-4095-8abd-96260c90dfef)

Clearing the manual capabilities mode:

![image](https://github.com/apache/druid/assets/177816/e1dd238e-b22d-4ab2-b9d7-67d40a7b1406)

## New behavior

Setting the manual capabilities mode:

![image](https://github.com/apache/druid/assets/177816/ee803f66-b40d-4c0a-a912-d43779c1245f)

Clearing the manual capabilities mode:

![image](https://github.com/apache/druid/assets/177816/09ffb8bd-95ca-4bbf-91c3-771b400f7e79)

![image](https://github.com/apache/druid/assets/177816/7c2695f7-95a6-4213-bee4-e63e7d90a5fb)

Feedback and suggestions welcome.
