### PR TITLE
Visibility into LagBased AutoScaler desired task count

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -258,7 +258,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`dataSource`, `tags`| < 1s |
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
-|`ingest/autoScaler/lagBased/requiredTasks`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `skipReason`|Depends on auto scaler config.|
+|`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -258,8 +258,8 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`dataSource`, `tags`| < 1s |
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
-|`ingest/scale/up/skip`|Count of times LagBasedAutoScaler wanted to scale up but skipped due to `minTriggerScaleActionFrequencyMillis`|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
-|`ingest/scale/up/skip`|Count of times LagBasedAutoScaler wanted to scale down but skipped due to `minTriggerScaleActionFrequencyMillis`|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
+|`ingest/skipScaleUp/count`|Total number of times `lagBased` auto scaler attempted to scale up but was skipped due to `minTriggerScaleActionFrequencyMillis`.|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
+|`ingest/skipScaleDown/count`|Total number of times `lagBased` auto scaler attempted to scale down but skipped due to `minTriggerScaleActionFrequencyMillis`.|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -258,6 +258,8 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`dataSource`, `tags`| < 1s |
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
+|`ingest/scale/up/skip`|Count of times LagBasedAutoScaler wanted to scale up but skipped due to `minTriggerScaleActionFrequencyMillis`|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
+|`ingest/scale/up/skip`|Count of times LagBasedAutoScaler wanted to scale down but skipped due to `minTriggerScaleActionFrequencyMillis`|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -258,8 +258,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/notices/time`|Milliseconds taken to process a notice by the supervisor.|`dataSource`, `tags`| < 1s |
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
-|`ingest/skipScaleUp/count`|Total number of times `lagBased` auto scaler attempted to scale up but was skipped due to `minTriggerScaleActionFrequencyMillis`.|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
-|`ingest/skipScaleDown/count`|Total number of times `lagBased` auto scaler attempted to scale down but skipped due to `minTriggerScaleActionFrequencyMillis`.|`dataSource`, `stream`, `tags`|Depends on auto scaler config.|
+|`ingest/autoScaler/lagBased/requiredTasks`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `skipReason`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -466,9 +466,9 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
             int currentActiveTasks = currentActiveTaskCount();
             if (desriedTaskCount > currentActiveTasks) {
-              emitter.emit(event.setMetric("ingest/scale/up/skip", 1));
+              emitter.emit(event.setMetric("ingest/skipScaleUp/count", 1));
             } else if (desriedTaskCount < currentActiveTasks && desriedTaskCount > 0) {
-              emitter.emit(event.setMetric("ingest/scale/down/skip", 1));
+              emitter.emit(event.setMetric("ingest/skipScaleDown/count", 1));
             }
             return;
           }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpec.java
@@ -167,7 +167,7 @@ public abstract class SeekableStreamSupervisorSpec implements SupervisorSpec
   {
     AutoScalerConfig autoScalerConfig = ingestionSchema.getIOConfig().getAutoScalerConfig();
     if (autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler() && supervisor instanceof SeekableStreamSupervisor) {
-      return autoScalerConfig.createAutoScaler(supervisor, this);
+      return autoScalerConfig.createAutoScaler(supervisor, this, emitter);
     }
     return new NoopTaskAutoScaler();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
@@ -26,6 +26,7 @@ import org.apache.druid.guice.annotations.UnstableApi;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 @UnstableApi
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "autoScalerStrategy", defaultImpl = LagBasedAutoScalerConfig.class)
@@ -38,6 +39,6 @@ public interface AutoScalerConfig
   long getMinTriggerScaleActionFrequencyMillis();
   int getTaskCountMax();
   int getTaskCountMin();
-  SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec);
+  SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter);
 }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
@@ -25,6 +25,7 @@ import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
+import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 import javax.annotation.Nullable;
 
@@ -154,9 +155,9 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   }
 
   @Override
-  public SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec)
+  public SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter)
   {
-    return new LagBasedAutoScaler((SeekableStreamSupervisor) supervisor, spec.getId(), this, spec);
+    return new LagBasedAutoScaler((SeekableStreamSupervisor) supervisor, spec.getId(), this, spec, emitter);
   }
 
   @JsonProperty

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -782,11 +782,13 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(2, taskCountAfterScaleOut);
-    Assert.assertTrue(metricCapture.getValues()
-                                   .stream()
-                                   .map(metric -> metric.build(ImmutableMap.of()))
-                                   .map(ServiceMetricEvent::getMetric)
-                                   .anyMatch("ingest/skipScaleUp/count"::equals));
+    Assert.assertTrue(
+        metricCapture
+            .getValues()
+            .stream()
+            .map(metric -> metric.build(ImmutableMap.of()))
+            .map(ServiceMetricEvent::getMetric)
+            .anyMatch(LagBasedAutoScaler.REQUIRED_TASKS_METRIC::equals));
     EasyMock.verify(dynamicActionEmitter);
     autoScaler.reset();
     autoScaler.stop();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -58,7 +58,6 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
-import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.segment.TestHelper;
@@ -133,8 +132,6 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     monitorSchedulerConfig = EasyMock.mock(DruidMonitorSchedulerConfig.class);
     supervisorStateManagerConfig = EasyMock.mock(SupervisorStateManagerConfig.class);
     supervisor4 = EasyMock.mock(SeekableStreamSupervisor.class);
-
-    EasyMock.expect(spec.getContextValue(DruidMetrics.TAGS)).andReturn(null).anyTimes();
   }
 
   private abstract class BaseTestSeekableStreamSupervisor extends SeekableStreamSupervisor<String, String, ByteEntity>
@@ -624,9 +621,11 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     EasyMock.expect(seekableStreamSupervisorIOConfig.getAutoScalerConfig())
             .andReturn(mapper.convertValue(autoScalerConfig, AutoScalerConfig.class))
             .anyTimes();
+    EasyMock.expect(seekableStreamSupervisorIOConfig.getStream()).andReturn("stream").anyTimes();
     EasyMock.replay(seekableStreamSupervisorIOConfig);
 
     EasyMock.expect(supervisor4.getActiveTaskGroupsCount()).andReturn(0).anyTimes();
+    EasyMock.expect(supervisor4.getIoConfig()).andReturn(seekableStreamSupervisorIOConfig).anyTimes();
     EasyMock.replay(supervisor4);
 
     TestSeekableStreamSupervisorSpec spec = new TestSeekableStreamSupervisorSpec(
@@ -697,8 +696,10 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
                 "1"
             ), AutoScalerConfig.class))
             .anyTimes();
+    EasyMock.expect(seekableStreamSupervisorIOConfig.getStream()).andReturn("stream").anyTimes();
     EasyMock.replay(seekableStreamSupervisorIOConfig);
 
+    EasyMock.expect(supervisor4.getIoConfig()).andReturn(seekableStreamSupervisorIOConfig).anyTimes();
     EasyMock.expect(supervisor4.getActiveTaskGroupsCount()).andReturn(0).anyTimes();
     EasyMock.replay(supervisor4);
 


### PR DESCRIPTION
This PR provides visibility into the actions taken by `LagBasedAutoScaler` and shows us the behaviour of auto scaler. This introduced metric provides insight into what actually is desired task count, how many times did we skip such actions etc. Info obtained from this metric could later be used to tweak the auto scaler config.

#### Release note
- Druid operator could compare between `ingest/autoScaler/lagBased/requiredTasks` and `task/running/count` to know the exact gap between current and desired task counts.
- Druid operator could now track how many times a scale action has been skipped because
    - It occurred too early than `minTriggerScaleActionFrequencyMillis`.
    - Task count is already at max/min and couldn't scale further.


<hr>

##### Key changed/added classes in this PR
 * `DynamicAllocationTasksNotice`
 * `LagBasedAutoScaler`

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
