### PR TITLE
Fix up error handling in unusedSegments API.

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
@@ -44,7 +44,7 @@ public final class Intervals
       return new Interval(interval, ISOChronology.getInstanceUTC());
     }
     catch (IllegalArgumentException e) {
-      throw InvalidInput.exception(e, "Bad Interval[%s]: [%s]", interval, e.getMessage());
+      throw InvalidInput.exception(e, "Bad interval[%s]: [%s]", interval, e.getMessage());
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Intervals.java
@@ -44,7 +44,7 @@ public final class Intervals
       return new Interval(interval, ISOChronology.getInstanceUTC());
     }
     catch (IllegalArgumentException e) {
-      throw InvalidInput.exception(e, "Bad interval[%s]: [%s]", interval, e.getMessage());
+      throw InvalidInput.exception(e, "Invalid interval[%s]: [%s]", interval, e.getMessage());
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -40,7 +40,6 @@ import org.apache.druid.client.ImmutableSegmentLoadInfo;
 import org.apache.druid.client.SegmentLoadInfo;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.DateTimes;
@@ -312,10 +311,7 @@ public class DataSourcesResource
       return Response.ok(ImmutableMap.of("numChangedSegments", numChangedSegments)).build();
     }
     catch (DruidException e) {
-      return Response
-          .status(e.getStatusCode())
-          .entity(new ErrorResponse(e))
-          .build();
+      return ServletResourceUtils.buildErrorResponseFrom(e);
     }
     catch (Exception e) {
       log.error(e, "Error occurred while updating segments for datasource[%s]", dataSourceName);

--- a/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/MetadataResource.java
@@ -20,12 +20,16 @@
 package org.apache.druid.server.http;
 
 import com.google.common.base.Function;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.Segments;
@@ -349,37 +353,52 @@ public class MetadataResource
       @QueryParam("sortOrder") @Nullable final String sortOrder
   )
   {
-    if (dataSource == null || dataSource.isEmpty()) {
-      throw InvalidInput.exception("dataSourceName must be non-empty");
+    try {
+      if (dataSource == null || dataSource.isEmpty()) {
+        throw InvalidInput.exception("dataSourceName must be non-empty.");
+      }
+
+      if (limit != null && limit < 0) {
+        throw InvalidInput.exception("Invalid limit[%s] specified. Limit must be > 0.", limit);
+      }
+
+      if (lastSegmentId != null && SegmentId.tryParse(dataSource, lastSegmentId) == null) {
+        throw InvalidInput.exception("Invalid lastSegmentId[%s] specified.", lastSegmentId);
+      }
+
+      final SortOrder theSortOrder = sortOrder == null ? null : SortOrder.fromValue(sortOrder);
+
+      final Interval theInterval = interval != null ? Intervals.of(interval.replace('_', '/')) : null;
+      final Iterable<DataSegmentPlus> unusedSegments = segmentsMetadataManager.iterateAllUnusedSegmentsForDatasource(
+          dataSource,
+          theInterval,
+          limit,
+          lastSegmentId,
+          theSortOrder
+      );
+
+      final Function<DataSegmentPlus, Iterable<ResourceAction>> raGenerator = segment -> Collections.singletonList(
+          AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(segment.getDataSegment().getDataSource()));
+
+      final Iterable<DataSegmentPlus> authorizedSegments =
+          AuthorizationUtils.filterAuthorizedResources(req, unusedSegments, raGenerator, authorizerMapper);
+
+      final List<DataSegmentPlus> retVal = new ArrayList<>();
+      authorizedSegments.iterator().forEachRemaining(retVal::add);
+      return Response.status(Response.Status.OK).entity(retVal).build();
     }
-    if (limit != null && limit < 0) {
-      throw InvalidInput.exception("Invalid limit[%s] specified. Limit must be > 0", limit);
+    catch (DruidException e) {
+      return Response
+          .status(e.getStatusCode())
+          .entity(new ErrorResponse(e))
+          .build();
     }
-
-    if (lastSegmentId != null && SegmentId.tryParse(dataSource, lastSegmentId) == null) {
-      throw InvalidInput.exception("Invalid lastSegmentId[%s] specified.", lastSegmentId);
+    catch (Exception e) {
+      return Response
+          .serverError()
+          .entity(ImmutableMap.of("error", "Exception occurred.", "message", Throwables.getRootCause(e).toString()))
+          .build();
     }
-
-    SortOrder theSortOrder = sortOrder == null ? null : SortOrder.fromValue(sortOrder);
-
-    final Interval theInterval = interval != null ? Intervals.of(interval.replace('_', '/')) : null;
-    Iterable<DataSegmentPlus> unusedSegments = segmentsMetadataManager.iterateAllUnusedSegmentsForDatasource(
-        dataSource,
-        theInterval,
-        limit,
-        lastSegmentId,
-        theSortOrder
-    );
-
-    final Function<DataSegmentPlus, Iterable<ResourceAction>> raGenerator = segment -> Collections.singletonList(
-        AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(segment.getDataSegment().getDataSource()));
-
-    final Iterable<DataSegmentPlus> authorizedSegments =
-        AuthorizationUtils.filterAuthorizedResources(req, unusedSegments, raGenerator, authorizerMapper);
-
-    final List<DataSegmentPlus> retVal = new ArrayList<>();
-    authorizedSegments.iterator().forEachRemaining(retVal::add);
-    return Response.status(Response.Status.OK).entity(retVal).build();
   }
 
   @GET

--- a/server/src/main/java/org/apache/druid/server/http/security/DatasourceResourceFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/security/DatasourceResourceFilter.java
@@ -20,7 +20,6 @@
 package org.apache.druid.server.http.security;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ContainerRequest;
@@ -33,16 +32,15 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 
 import javax.ws.rs.core.PathSegment;
+import java.util.List;
 
 /**
- * Use this ResourceFilter when the datasource information is present after "datasources" segment in the request Path
- * Here are some example paths where this filter is used -
- * - druid/coordinator/v1/datasources/{dataSourceName}/...
- * - druid/coordinator/v1/metadata/datasources/{dataSourceName}/...
- * - druid/v2/datasources/{dataSourceName}/...
+ * Use this resource filter for API endpoints that contain {@link #DATASOURCES_PATH_SEGMENT} in their request path.
  */
 public class DatasourceResourceFilter extends AbstractResourceFilter
 {
+  private static final String DATASOURCES_PATH_SEGMENT = "datasources";
+
   @Inject
   public DatasourceResourceFilter(
       AuthorizerMapper authorizerMapper
@@ -74,20 +72,11 @@ public class DatasourceResourceFilter extends AbstractResourceFilter
 
   private String getRequestDatasourceName(ContainerRequest request)
   {
-    final String dataSourceName = request.getPathSegments()
-                                         .get(
-                                             Iterables.indexOf(
-                                                 request.getPathSegments(),
-                                                 new Predicate<PathSegment>()
-                                                 {
-                                                   @Override
-                                                   public boolean apply(PathSegment input)
-                                                   {
-                                                     return "datasources".equals(input.getPath());
-                                                   }
-                                                 }
-                                             ) + 1
-                                         ).getPath();
+    final List<PathSegment> pathSegments = request.getPathSegments();
+    final String dataSourceName = pathSegments.get(
+        Iterables.indexOf(pathSegments, input -> DATASOURCES_PATH_SEGMENT.equals(input.getPath())) + 1
+    ).getPath();
+
     Preconditions.checkNotNull(dataSourceName);
     return dataSourceName;
   }

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -25,10 +25,10 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.ImmutableDruidDataSource;
-import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.metadata.SegmentsMetadataManager;
@@ -128,6 +128,15 @@ public class MetadataResourceTest
     Mockito.doReturn(segments[5])
            .when(storageCoordinator)
            .retrieveSegmentForId(segments[5].getId().toString(), true);
+
+    Mockito.doAnswer(mockIterateAllUnusedSegmentsForDatasource())
+           .when(segmentsMetadataManager)
+           .iterateAllUnusedSegmentsForDatasource(
+               ArgumentMatchers.any(),
+               ArgumentMatchers.any(),
+               ArgumentMatchers.any(),
+               ArgumentMatchers.any(),
+               ArgumentMatchers.any());
 
     metadataResource = new MetadataResource(
         segmentsMetadataManager,
@@ -251,101 +260,124 @@ public class MetadataResourceTest
     Assert.assertEquals(new SegmentStatusInCluster(realTimeSegments[1], false, null, 40L, true), resultList.get(5));
   }
 
+
   @Test
-  public void testGetUnusedSegmentsInDataSource()
+  public void testGetUnusedSegmentsInDataSourceWithValidDataSource()
   {
-    Mockito.doAnswer(mockIterateAllUnusedSegmentsForDatasource())
-        .when(segmentsMetadataManager)
-        .iterateAllUnusedSegmentsForDatasource(
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any(),
-            ArgumentMatchers.any());
-
-    // test with null datasource name - fails with expected bad datasource name error
-    DruidExceptionMatcher.invalidInput().expectMessageIs(
-        "dataSourceName must be non-empty"
-    ).assertThrowsAndMatches(
-        () -> metadataResource.getUnusedSegmentsInDataSource(request, null, null, null, null, null)
-    );
-
-    // test with empty datasource name - fails with expected bad datasource name error
-    DruidExceptionMatcher.invalidInput().expectMessageIs(
-        "dataSourceName must be non-empty"
-    ).assertThrowsAndMatches(
-        () -> metadataResource.getUnusedSegmentsInDataSource(request, "", null, null, null, null)
-    );
-
-    // test invalid datasource - returns empty segments
-    Response response = metadataResource.getUnusedSegmentsInDataSource(
-        request,
-        "invalid_datasource",
-        null,
-        null,
-        null,
-        null
-    );
-    List<DataSegmentPlus> resultList = extractResponseList(response);
-    Assert.assertTrue(resultList.isEmpty());
-
-    // test valid datasource with bad limit - fails with expected invalid limit message
-    DruidExceptionMatcher.invalidInput().expectMessageIs(
-        StringUtils.format("Invalid limit[%s] specified. Limit must be > 0", -1)
-    ).assertThrowsAndMatches(
-        () -> metadataResource.getUnusedSegmentsInDataSource(request, DATASOURCE1, null, -1, null, null)
-    );
-
-    // test valid datasource with invalid lastSegmentId - fails with expected invalid lastSegmentId message
-    DruidExceptionMatcher.invalidInput().expectMessageIs(
-        StringUtils.format("Invalid lastSegmentId[%s] specified.", "invalid")
-    ).assertThrowsAndMatches(
-        () -> metadataResource.getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, "invalid", null)
-    );
-
-    // test valid datasource - returns all unused segments for that datasource
-    response = metadataResource.getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, null);
-
-    resultList = extractResponseList(response);
-    Assert.assertEquals(segmentsPlus, resultList);
-
-    // test valid datasource with interval filter - returns all unused segments for that datasource within interval
-    int numDays = 2;
-    String interval = SEGMENT_START_INTERVAL + "_P" + numDays + "D";
-    response = metadataResource.getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, null, null, null);
-
-    resultList = extractResponseList(response);
-    Assert.assertEquals(NUM_PARTITIONS * numDays, resultList.size());
-    Assert.assertEquals(
-        Arrays.asList(segmentsPlus.get(0), segmentsPlus.get(1), segmentsPlus.get(2), segmentsPlus.get(3)),
-        resultList
-    );
-
-    // test valid datasource with interval filter limit and last segment id - returns unused segments for that
-    // datasource within interval upto limit starting at last segment id
-    int limit = 3;
-    response = metadataResource.getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, limit, null, null);
-
-    resultList = extractResponseList(response);
-    Assert.assertEquals(limit, resultList.size());
-    Assert.assertEquals(Arrays.asList(segmentsPlus.get(0), segmentsPlus.get(1), segmentsPlus.get(2)), resultList);
-
-    // test valid datasource with interval filter limit and offset - returns unused segments for that datasource within
-    // interval upto limit starting at offset
-    response = metadataResource.getUnusedSegmentsInDataSource(
-        request,
-        DATASOURCE1,
-        interval,
-        limit,
-        segments[2].getId().toString(),
-        null
-    );
-
-    resultList = extractResponseList(response);
-    Assert.assertEquals(Collections.singletonList(segmentsPlus.get(3)), resultList);
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, null);
+    final List<DataSegmentPlus> observedSegments = extractResponseList(response);
+    Assert.assertEquals(segmentsPlus, observedSegments);
   }
 
-  Answer<Iterable<DataSegmentPlus>> mockIterateAllUnusedSegmentsForDatasource()
+  @Test
+  public void testGetUnusedSegmentsInDataSourceWithIntervalFilter()
+  {
+    final String interval = SEGMENT_START_INTERVAL + "_P2D";
+    final int expectedLimit = NUM_PARTITIONS * 2;
+
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, null, null, null);
+    final List<DataSegmentPlus> observedSegments = extractResponseList(response);
+    Assert.assertEquals(expectedLimit, observedSegments.size());
+    Assert.assertEquals(segmentsPlus.stream().limit(expectedLimit).collect(Collectors.toList()), observedSegments);
+  }
+
+  @Test
+  public void testGetUnusedSegmentsInDataSourceWithLimitFilter()
+  {
+    final int limit = 3;
+    final String interval = SEGMENT_START_INTERVAL + "_P2D";
+
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, limit, null, null);
+    final List<DataSegmentPlus> observedSegments = extractResponseList(response);
+    Assert.assertEquals(limit, observedSegments.size());
+    Assert.assertEquals(segmentsPlus.stream().limit(limit).collect(Collectors.toList()), observedSegments);
+  }
+
+  @Test
+  public void testGetUnusedSegmentsInDataSourceWithLimitAndLastSegmentIdFilter()
+  {
+    final int limit = 3;
+    final String interval = SEGMENT_START_INTERVAL + "_P2D";
+    final String lastSegmentId = segments[limit - 1].getId().toString();
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, interval, limit, lastSegmentId, null);
+    final List<DataSegmentPlus> observedSegments = extractResponseList(response);
+    Assert.assertEquals(Collections.singletonList(segmentsPlus.get(limit)), observedSegments);
+  }
+
+  @Test
+  public void testGetUnusedSegmentsInDataSourceWithNonExistentDataSource()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, "non-existent", null, null, null, null);
+    final List<DataSegmentPlus> observedSegments = extractResponseList(response);
+    Assert.assertTrue(observedSegments.isEmpty());
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithNoDataSource()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, null, null, null, null, null);
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithEmptyDatasourceName()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, "", null, null, null, null);
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals("dataSourceName must be non-empty.", getExceptionMessage(response));
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithInvalidLimit()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, -1, null, null);
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals("Invalid limit[-1] specified. Limit must be > 0.", getExceptionMessage(response));
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithInvalidLastSegmentId()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, "invalid", null);
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals("Invalid lastSegmentId[invalid] specified.", getExceptionMessage(response));
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithInvalidInterval()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, "2015/2014", null, null, null);
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals(
+        "Bad interval[2015/2014]: [The end instant must be greater than the start instant]",
+        getExceptionMessage(response)
+    );
+  }
+
+  @Test
+  public void testGetUnusedSegmentsWithInvalidSortOrder()
+  {
+    final Response response = metadataResource
+        .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, "Ascd");
+    Assert.assertEquals(400, response.getStatus());
+    Assert.assertEquals(
+        "Unexpected value[Ascd] for SortOrder. Possible values are: [ASC, DESC]",
+        getExceptionMessage(response)
+    );
+  }
+
+  private Answer<Iterable<DataSegmentPlus>> mockIterateAllUnusedSegmentsForDatasource()
   {
     return invocationOnMock -> {
       String dataSourceName = invocationOnMock.getArgument(0);
@@ -373,6 +405,15 @@ public class MetadataResourceTest
               : segments.length)
           .collect(Collectors.toList());
     };
+  }
+
+  private static String getExceptionMessage(final Response response)
+  {
+    if (response.getEntity() instanceof DruidException) {
+      return ((DruidException) response.getEntity()).getMessage();
+    } else {
+      return ((ErrorResponse) response.getEntity()).getUnderlyingException().getMessage();
+    }
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -136,8 +136,7 @@ public class MetadataResourceTest
                ArgumentMatchers.any(),
                ArgumentMatchers.any(),
                ArgumentMatchers.any(),
-               ArgumentMatchers.any()
-           );
+               ArgumentMatchers.any());
 
     metadataResource = new MetadataResource(
         segmentsMetadataManager,
@@ -361,7 +360,7 @@ public class MetadataResourceTest
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, "2015/2014", null, null, null);
     Assert.assertEquals(400, response.getStatus());
     Assert.assertEquals(
-        "Bad interval[2015/2014]: [The end instant must be greater than the start instant]",
+        "Invalid interval[2015/2014]: [The end instant must be greater than the start instant]",
         getExceptionMessage(response)
     );
   }

--- a/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/MetadataResourceTest.java
@@ -136,7 +136,8 @@ public class MetadataResourceTest
                ArgumentMatchers.any(),
                ArgumentMatchers.any(),
                ArgumentMatchers.any(),
-               ArgumentMatchers.any());
+               ArgumentMatchers.any()
+           );
 
     metadataResource = new MetadataResource(
         segmentsMetadataManager,
@@ -262,7 +263,7 @@ public class MetadataResourceTest
 
 
   @Test
-  public void testGetUnusedSegmentsInDataSourceWithValidDataSource()
+  public void testGetUnusedSegmentsInDataSource()
   {
     final Response response = metadataResource
         .getUnusedSegmentsInDataSource(request, DATASOURCE1, null, null, null, null);


### PR DESCRIPTION
#### Problem:

Before this patch, the `/datasources/{dataSourceName}/unusedSegments` API throws a 500 with a huge stack trace for any invalid parameters specified in the request. This is because `DruidException`s are thrown without mapping them to a HTTP response. 

<details>
  <summary>Click here to see the stacktrace with a 500 error code</summary>

  ```bash
 curl -X 'GET' -H 'Content-Type:application/json' http://localhost:8081/druid/coordinator/v1/metadata/datasources/foo_it/unusedSegments\?interval=2024-04-01T00%3A00%3A00.000Z/2024-03-01T00%3A00%3A00.000Z
  <html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 org.apache.druid.error.DruidException: Bad Interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]</title>
</head>
<body><h2>HTTP ERROR 500 org.apache.druid.error.DruidException: Bad Interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]</h2>
<table>
<tr><th>URI:</th><td>/druid/coordinator/v1/metadata/datasources/foo_it/unusedSegments</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>org.apache.druid.error.DruidException: Bad Interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]</td></tr>
<tr><th>SERVLET:</th><td>default</td></tr>
<tr><th>CAUSED BY:</th><td>org.apache.druid.error.DruidException: Bad Interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]</td></tr>
<tr><th>CAUSED BY:</th><td>java.lang.IllegalArgumentException: The end instant must be greater than the start instant</td></tr>
</table>
<h3>Caused by:</h3><pre>org.apache.druid.error.DruidException: Bad Interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]
	at org.apache.druid.error.DruidException$DruidExceptionBuilder.build(DruidException.java:460)
	at org.apache.druid.error.BaseFailure.makeException(BaseFailure.java:57)
	at org.apache.druid.error.DruidException.fromFailure(DruidException.java:154)
	at org.apache.druid.error.InvalidInput.exception(InvalidInput.java:35)
	at org.apache.druid.java.util.common.Intervals.of(Intervals.java:47)
	at org.apache.druid.server.http.MetadataResource.getUnusedSegmentsInDataSource(MetadataResource.java:365)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  ```
</details>

#### Changes:

- Handle exceptions in the API and map them to a `Response` object with the appropriate error code.
- Replace `AuthorizationUtils.filterAuthorizedResources()` with `DatasourceResourceFilter`. The endpoint is annotated consistent with other usages.
- Update `DatasourceResourceFilter` to remove the lambda and update javadocs. The usages information is self-evident with an IDE.
- Adjust the invalid interval exception message.
- Break up the large unit test `testGetUnusedSegmentsInDataSource()` into smaller unit tests for each test case. Also, validate the error codes.



With the fix in this patch, a 400 error code is returned without the stacktrace:

```bash
curl -X 'GET' -H 'Content-Type:application/json' http://localhost:8081/druid/coordinator/v1/metadata/datasources/foo_it/unusedSegments\?interval=2024-04-01T00%3A00%3A00.000Z/2024-03-01T00%3A00%3A00.000Z
{"error":"druidException","errorCode":"invalidInput","persona":"USER","category":"INVALID_INPUT","errorMessage":"Invalid interval[2024-04-01T00:00:00.000Z/2024-03-01T00:00:00.000Z]: [The end instant must be greater than the start instant]","context":{}}
```

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
