### PR TITLE
Suggest resetting a supervisor when the topic is updated

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -2429,8 +2429,8 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
     if (!startMetadataMatchesExisting) {
       // Not in the desired start state.
       return new DataStoreMetadataUpdateResult(true, false, StringUtils.format(
-          "Inconsistent metadata state. This can happen if you update input topic in a spec without changing " +
-          "the supervisor name. Stored state: [%s], Target state: [%s].",
+          "Inconsistent metadata state. This can happen when the input topic in the supervisor spec is updated"
+          + " without resetting the supervisor. Stored state: [%s], Target state: [%s].",
           oldCommitMetadataFromDb,
           startMetadata
       ));

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -935,7 +935,12 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         new ObjectMetadata(ImmutableMap.of("foo", "bar")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
     );
-    Assert.assertEquals(SegmentPublishResult.fail("java.lang.RuntimeException: Failed to update the metadata Store. The new start metadata is ahead of last commited end state."), result1);
+    Assert.assertEquals(
+        SegmentPublishResult.fail(
+            "java.lang.RuntimeException: Failed to update the metadata Store."
+            + " The new start metadata is ahead of last commited end state."),
+        result1
+    );
 
     // Should only be tried once.
     Assert.assertEquals(1, metadataUpdateCounter.get());
@@ -956,10 +961,15 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         new ObjectMetadata(null),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
     );
-    Assert.assertEquals(SegmentPublishResult.fail("java.lang.RuntimeException: Inconsistent metadata state. This can " +
-        "happen if you update input topic in a spec without changing the supervisor name. " +
-        "Stored state: [ObjectMetadata{theObject={foo=baz}}], " +
-        "Target state: [ObjectMetadata{theObject=null}]."), result2);
+    Assert.assertEquals(
+        SegmentPublishResult.fail(
+            "java.lang.RuntimeException: Inconsistent metadata state. This can happen when the input topic"
+            + " in the supervisor spec is updated without resetting the supervisor. "
+            + "Stored state: [ObjectMetadata{theObject={foo=baz}}], "
+            + "Target state: [ObjectMetadata{theObject=null}]."
+        ),
+        result2
+    );
 
     // Should only be tried once per call.
     Assert.assertEquals(2, metadataUpdateCounter.get());
@@ -1026,10 +1036,14 @@ public class IndexerSQLMetadataStorageCoordinatorTest
         new ObjectMetadata(ImmutableMap.of("foo", "qux")),
         new ObjectMetadata(ImmutableMap.of("foo", "baz"))
     );
-    Assert.assertEquals(SegmentPublishResult.fail("java.lang.RuntimeException: Inconsistent metadata state. This can " +
-        "happen if you update input topic in a spec without changing the supervisor name. " +
-        "Stored state: [ObjectMetadata{theObject={foo=baz}}], " +
-        "Target state: [ObjectMetadata{theObject={foo=qux}}]."), result2);
+    Assert.assertEquals(
+        SegmentPublishResult.fail(
+            "java.lang.RuntimeException: Inconsistent metadata state. This can happen when the input topic"
+            + " in the supervisor spec is updated without resetting the supervisor. "
+            + "Stored state: [ObjectMetadata{theObject={foo=baz}}], " +
+            "Target state: [ObjectMetadata{theObject={foo=qux}}]."),
+        result2
+    );
 
     // Should only be tried once per call.
     Assert.assertEquals(2, metadataUpdateCounter.get());


### PR DESCRIPTION
Updating the topic name for a supervisor results in the following error:
```text
[java.lang.RuntimeException: Inconsistent metadata state. This can happen if you update input topic in a spec without changing the supervisor name. Stored state: ...
```

Changing the supervisor's name makes it a completely different supervisor.  Update the error message to instead suggest resetting the supervisor as the primary way to fix it when this happens. The updated error message is as follows:

```text
[java.lang.RuntimeException: Inconsistent metadata state. This can happen when the input topic in the supervisor spec is updated without resetting the supervisor. Stored state: ...
```

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
