### PR TITLE
MSQ: Fix issue where AUTO assignment would not respect maxWorkerCount.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/StripedReadablePartitions.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/StripedReadablePartitions.java
@@ -41,7 +41,11 @@ public class StripedReadablePartitions implements ReadablePartitions
   private final int numWorkers;
   private final IntSortedSet partitionNumbers;
 
-  StripedReadablePartitions(final int stageNumber, final int numWorkers, final IntSortedSet partitionNumbers)
+  /**
+   * Constructor. Most callers should use {@link ReadablePartitions#striped(int, int, int)} instead, which takes
+   * a partition count rather than a set of partition numbers.
+   */
+  public StripedReadablePartitions(final int stageNumber, final int numWorkers, final IntSortedSet partitionNumbers)
   {
     this.stageNumber = stageNumber;
     this.numWorkers = numWorkers;

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/WorkerAssignmentStrategy.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/WorkerAssignmentStrategy.java
@@ -90,7 +90,7 @@ public enum WorkerAssignmentStrategy
 
         final IntSet inputStages = stageDef.getInputStageNumbers();
         final OptionalInt maxInputStageWorkerCount = inputStages.intStream().map(stageWorkerCountMap).max();
-        final int workerCount = maxInputStageWorkerCount.orElse(1);
+        final int workerCount = Math.min(stageDef.getMaxWorkerCount(), maxInputStageWorkerCount.orElse(1));
         return slicer.sliceStatic(inputSpec, workerCount);
       }
     }


### PR DESCRIPTION
`WorkerAssignmentStrategy.AUTO` was missing a check for `maxWorkerCount` in the case where the inputs to a stage are not dynamically sliceable. A common case here is when the inputs to a stage are other stages.

This could manifest as an error message like `OffsetLimitFrameProcessorFactory must be configured with maxWorkerCount = 1` when a `LIMIT` is used along with `WorkerAssignmentStrategy.AUTO`.