### PR TITLE
Fix name of combining filtered aggregator factory.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FilteredAggregatorFactory.java
@@ -139,7 +139,14 @@ public class FilteredAggregatorFactory extends AggregatorFactory
   @Override
   public AggregatorFactory getCombiningFactory()
   {
-    return delegate.getCombiningFactory();
+    final AggregatorFactory delegateCombiningFactory = delegate.getCombiningFactory();
+    final String myName = getName();
+
+    if (myName.equals(delegateCombiningFactory.getName())) {
+      return delegateCombiningFactory;
+    } else {
+      return delegateCombiningFactory.withName(myName);
+    }
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/aggregation/FilteredAggregatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/FilteredAggregatorFactoryTest.java
@@ -49,6 +49,26 @@ public class FilteredAggregatorFactoryTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testNameOfCombiningFactory()
+  {
+    Assert.assertEquals("overrideName", new FilteredAggregatorFactory(
+        new CountAggregatorFactory("foo"),
+        TrueDimFilter.instance(),
+        "overrideName"
+    ).getCombiningFactory().getName());
+    Assert.assertEquals("delegateName", new FilteredAggregatorFactory(
+        new CountAggregatorFactory("delegateName"),
+        TrueDimFilter.instance(),
+        ""
+    ).getCombiningFactory().getName());
+    Assert.assertEquals("delegateName", new FilteredAggregatorFactory(
+        new CountAggregatorFactory("delegateName"),
+        TrueDimFilter.instance(),
+        null
+    ).getCombiningFactory().getName());
+  }
+
+  @Test
   public void testRequiredFields()
   {
     Assert.assertEquals(


### PR DESCRIPTION
The name of the combining filtered aggregator factory should be the same as the name of the original factory. However, it wasn't the same in the case where the original factory's name and the original delegate aggregator were inconsistently named. In this scenario, we should use the name of the original filtered aggregator, not the name of the original delegate aggregator.