### PR TITLE
Use created time from metadata store to list multiple active tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -810,7 +810,7 @@ public class OverlordResource
                   statusPlus.getId(),
                   statusPlus.getGroupId(),
                   statusPlus.getType(),
-                  runnerWorkItem.getCreatedTime(),
+                  statusPlus.getCreatedTime(),
                   runnerWorkItem.getQueueInsertionTime(),
                   statusPlus.getStatusCode(),
                   taskRunner.getRunnerTaskState(statusPlus.getId()), // this is racy for remoteTaskRunner


### PR DESCRIPTION
### Description

The web-console of getTasks API can return incorrect created times and durations afte the Overlord restarts. This is because we populate the field with the time at which the task was added to the TaskRunner for active tasks.

### Fix

The method now uses the created_date field from the metadata store as should have been the case for all tasks. No additional calls have been added.


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
