### PR TITLE
Moving object contains to Bound for string/object matchers

### DIFF
--- a/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
@@ -70,10 +70,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
     this.numChildren = (short) (header & 0x7FFF);
     final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int bitmapSize = data.getInt(sizePosition);
-    this.childrenOffset = initialOffset
-                          + offsetFromInitial
-                          + HEADER_NUM_BYTES
-                          + 2 * numDims * Float.BYTES
+    this.childrenOffset = sizePosition
                           + Integer.BYTES
                           + bitmapSize;
 
@@ -98,10 +95,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
     this.isLeaf = leaf;
     final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int bitmapSize = data.getInt(sizePosition);
-    this.childrenOffset = initialOffset
-                          + offsetFromInitial
-                          + HEADER_NUM_BYTES
-                          + 2 * numDims * Float.BYTES
+    this.childrenOffset = sizePosition
                           + Integer.BYTES
                           + bitmapSize;
 

--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/Bound.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/Bound.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.annotations.SubclassesMustOverrideEqualsAndHashCode;
 import org.apache.druid.collections.spatial.ImmutableNode;
 
+import javax.annotation.Nullable;
+
 /**
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -42,6 +44,8 @@ public interface Bound<TCoordinateArray, TPoint extends ImmutableNode<TCoordinat
   boolean overlaps(ImmutableNode<TCoordinateArray> node);
 
   boolean contains(TCoordinateArray coords);
+
+  boolean containsObj(@Nullable Object input);
 
   Iterable<TPoint> filter(Iterable<TPoint> points);
 

--- a/processing/src/main/java/org/apache/druid/collections/spatial/search/RectangularBound.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/search/RectangularBound.java
@@ -26,7 +26,9 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import org.apache.druid.collections.spatial.ImmutableFloatPoint;
 import org.apache.druid.collections.spatial.ImmutableNode;
+import org.apache.druid.segment.incremental.SpatialDimensionRowTransformer;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
@@ -116,6 +118,16 @@ public class RectangularBound implements Bound<float[], ImmutableFloatPoint>
     }
 
     return true;
+  }
+
+  @Override
+  public boolean containsObj(@Nullable Object input)
+  {
+    if (input instanceof String) {
+      final float[] coordinate = SpatialDimensionRowTransformer.decode((String) input);
+      return contains(coordinate);
+    }
+    return false;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/filter/SpatialFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/SpatialFilter.java
@@ -43,7 +43,6 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.column.ColumnIndexCapabilities;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
 import org.apache.druid.segment.column.SimpleColumnIndexCapabilities;
-import org.apache.druid.segment.incremental.SpatialDimensionRowTransformer;
 import org.apache.druid.segment.index.AllUnknownBitmapColumnIndex;
 import org.apache.druid.segment.index.BitmapColumnIndex;
 import org.apache.druid.segment.index.semantic.SpatialIndex;
@@ -174,8 +173,7 @@ public class SpatialFilter implements Filter
         if (input == null) {
           return DruidPredicateMatch.UNKNOWN;
         }
-        final float[] coordinate = SpatialDimensionRowTransformer.decode(input);
-        return DruidPredicateMatch.of(bound.contains(coordinate));
+        return DruidPredicateMatch.of(bound.containsObj(input));
       };
     }
 


### PR DESCRIPTION
Followup of https://github.com/apache/druid/pull/16029/files  + Addressing  @abhishekagarwal87 's comments from previous PR.

### Description
Creating a generic object contains interface in Spatial Bound filters for creating string/object matchers on top of the spatial column. SpatialFilter creates string matchers in case if we dont have indexes( Happens this in creating Incremental index), moving it to bound makes it extensible to have custom object matchers for given bound filter.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
