### PR TITLE
Feature configurable calcite bloat

### DIFF
--- a/docs/querying/query-context.md
+++ b/docs/querying/query-context.md
@@ -65,6 +65,7 @@ See [SQL query context](sql-query-context.md) for other query context parameters
 |`secondaryPartitionPruning`|`true`|Enable secondary partition pruning on the Broker. The Broker will always prune unnecessary segments from the input scan based on a filter on time intervals, but if the data is further partitioned with hash or range partitioning, this option will enable additional pruning based on a filter on secondary partition dimensions.|
 |`debug`| `false` | Flag indicating whether to enable debugging outputs for the query. When set to false, no additional logs will be produced (logs produced will be entirely dependent on your logging level). When set to true, the following addition logs will be produced:<br />- Log the stack trace of the exception (if any) produced by the query |
 |`setProcessingThreadNames`|`true`| Whether processing thread names will be set to `queryType_dataSource_intervals` while processing a query. This aids in interpreting thread dumps, and is on by default. Query overhead can be reduced slightly by setting this to `false`. This has a tiny effect in most scenarios, but can be meaningful in high-QPS, low-per-segment-processing-time scenarios. |
+|`sqlPlannerBloat`|`1000`|Calcite parameter which controls whether to merge two Project operators when inlining expressions causes complexity to increase. Implemented as a workaround to exception `There are not enough rules to produce a node with desired properties: convention=DRUID, sort=[]` thrown after rejecting the merge of two projects.|
 
 ## Parameters by query type
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -100,6 +100,10 @@ public class CalciteRulesManager
    * and {@link CoreRules#FILTER_INTO_JOIN}, which are part of {@link #FANCY_JOIN_RULES}.
    * 4) {@link CoreRules#PROJECT_FILTER_TRANSPOSE} because PartialDruidQuery would like to have the Project on top of the Filter -
    * this rule could create a lot of non-useful plans.
+   *
+   * {@link CoreRules#PROJECT_MERGE} includes configurable bloat parameter, as a workaround for Calcite exception
+   * (there are not enough rules to produce a node with desired properties) thrown while running complex sql-queries with
+   * big amount of subqueries. `druid.sql.planner.bloat` should be set in broker's `jvm.config` file.
    */
   private static final List<RelOptRule> BASE_RULES =
       ImmutableList.of(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -83,7 +83,7 @@ public class CalciteRulesManager
   private static final int HEP_DEFAULT_MATCH_LIMIT = Integer.parseInt(
       System.getProperty(HEP_DEFAULT_MATCH_LIMIT_CONFIG_STRING, "1200")
   );
-  public static final String BLOAT_PROPERTY = "sql.planner.bloat";
+  public static final String BLOAT_PROPERTY = "sqlPlannerBloat";
   public static final int DEFAULT_BLOAT = 1000;
 
   /**
@@ -440,11 +440,13 @@ public class CalciteRulesManager
                         .build();
   }
 
-  public List<RelOptRule> configurableRuleSet(PlannerContext plannerContext){
+  public List<RelOptRule> configurableRuleSet(PlannerContext plannerContext)
+  {
     return ImmutableList.of(ProjectMergeRule.Config.DEFAULT.withBloat(getBloatProperty(plannerContext)).toRule());
   }
 
-  private int getBloatProperty(PlannerContext plannerContext) {
+  private int getBloatProperty(PlannerContext plannerContext)
+  {
     final Integer bloat = plannerContext.queryContext().getInt(BLOAT_PROPERTY);
     return (bloat != null) ? bloat : DEFAULT_BLOAT;
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rel.metadata.DefaultRelMetadataProvider;
 import org.apache.calcite.rel.rules.CoreRules;
 import org.apache.calcite.rel.rules.DateRangeRules;
 import org.apache.calcite.rel.rules.JoinPushThroughJoinRule;
+import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
 import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
@@ -82,6 +83,10 @@ public class CalciteRulesManager
   private static final int HEP_DEFAULT_MATCH_LIMIT = Integer.parseInt(
       System.getProperty(HEP_DEFAULT_MATCH_LIMIT_CONFIG_STRING, "1200")
   );
+  private static final String BLOAT_PROPERTY = "druid.sql.planner.bloat";
+  private static final int BLOAT = Integer.parseInt(
+      System.getProperty(BLOAT_PROPERTY, "100")
+  );
 
   /**
    * Rules from {@link org.apache.calcite.plan.RelOptRules#BASE_RULES}, minus:
@@ -100,7 +105,7 @@ public class CalciteRulesManager
       ImmutableList.of(
           CoreRules.AGGREGATE_STAR_TABLE,
           CoreRules.AGGREGATE_PROJECT_STAR_TABLE,
-          CoreRules.PROJECT_MERGE,
+          ProjectMergeRule.Config.DEFAULT.withBloat(BLOAT).toRule(),
           CoreRules.FILTER_SCAN,
           CoreRules.FILTER_PROJECT_TRANSPOSE,
           CoreRules.JOIN_PUSH_EXPRESSIONS,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalciteRulesManager.java
@@ -85,7 +85,7 @@ public class CalciteRulesManager
   );
   private static final String BLOAT_PROPERTY = "druid.sql.planner.bloat";
   private static final int BLOAT = Integer.parseInt(
-      System.getProperty(BLOAT_PROPERTY, "100")
+      System.getProperty(BLOAT_PROPERTY, "1000")
   );
 
   /**

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
@@ -248,7 +248,8 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     assertBloat(contextWithoutBloat, DEFAULT_BLOAT);
   }
 
-  private void assertBloat(PlannerContext context, int expectedBloat) {
+  private void assertBloat(PlannerContext context, int expectedBloat)
+  {
     Optional<ProjectMergeRule> firstProjectMergeRule = injector.getInstance(CalciteRulesManager.class).baseRuleSet(context).stream()
             .filter(rule -> rule instanceof ProjectMergeRule)
             .map(rule -> (ProjectMergeRule) rule)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
@@ -30,6 +30,7 @@ import com.google.inject.multibindings.Multibinder;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.schema.Schema;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -61,10 +62,13 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.calcite.plan.RelOptRule.any;
 import static org.apache.calcite.plan.RelOptRule.operand;
+import static org.apache.druid.sql.calcite.planner.CalciteRulesManager.BLOAT_PROPERTY;
+import static org.apache.druid.sql.calcite.planner.CalciteRulesManager.DEFAULT_BLOAT;
 
 @ExtendWith(EasyMockExtension.class)
 public class CalcitePlannerModuleTest extends CalciteTestBase
@@ -72,6 +76,7 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
   private static final String SCHEMA_1 = "SCHEMA_1";
   private static final String SCHEMA_2 = "SCHEMA_2";
   private static final String DRUID_SCHEMA_NAME = "DRUID_SCHEMA_NAME";
+  private static final int BLOAT = 1200;
 
   @Mock
   private NamedSchema druidSchema1;
@@ -203,5 +208,51 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
                                          .druidConventionRuleSet(context)
                                          .contains(customRule);
     Assert.assertTrue(containsCustomRule);
+  }
+
+  @Test
+  public void testConfigurableBloat()
+  {
+    ObjectMapper mapper = new DefaultObjectMapper();
+    PlannerToolbox toolbox = new PlannerToolbox(
+            injector.getInstance(DruidOperatorTable.class),
+            macroTable,
+            mapper,
+            injector.getInstance(PlannerConfig.class),
+            rootSchema,
+            joinableFactoryWrapper,
+            CatalogResolver.NULL_RESOLVER,
+            "druid",
+            new CalciteRulesManager(ImmutableSet.of()),
+            CalciteTests.TEST_AUTHORIZER_MAPPER,
+            AuthConfig.newBuilder().build()
+    );
+
+    PlannerContext contextWithBloat = PlannerContext.create(
+            toolbox,
+            "SELECT 1",
+            new NativeSqlEngine(queryLifecycleFactory, mapper),
+            Collections.singletonMap(BLOAT_PROPERTY, BLOAT),
+            null
+    );
+
+    PlannerContext contextWithoutBloat = PlannerContext.create(
+            toolbox,
+            "SELECT 1",
+            new NativeSqlEngine(queryLifecycleFactory, mapper),
+            Collections.emptyMap(),
+            null
+    );
+
+    assertBloat(contextWithBloat, BLOAT);
+    assertBloat(contextWithoutBloat, DEFAULT_BLOAT);
+  }
+
+  private void assertBloat(PlannerContext context, int expectedBloat) {
+    Optional<ProjectMergeRule> firstProjectMergeRule = injector.getInstance(CalciteRulesManager.class).baseRuleSet(context).stream()
+            .filter(rule -> rule instanceof ProjectMergeRule)
+            .map(rule -> (ProjectMergeRule) rule)
+            .findAny();
+    Assert.assertTrue(firstProjectMergeRule.isPresent() && firstProjectMergeRule.get().config.bloat() == expectedBloat);
   }
 }


### PR DESCRIPTION
### Description

This pull request introduces a configurable `druid.sql.planner.bloat` parameter in CalciteRulesManager.

#### Fixed the problem when complicated nested sql queries which where working before Druid 29.0.0 (1.21.0 calcite version) are being rejected by calcite planner.

With exception:
`There are not enough rules to produce a node with desired properties: convention=DRUID, sort=[]`

Appears that the exceptiom is being thrown, when the root `RelNode` which initially is instance of `AbstractConverter` is being treated as `ProjectMergeRule`, which counts the result of merge not optimal and reject merging, which means that transformation of AbstractConverter [is not happening](https://github.com/apache/calcite/blob/75750b78b5ac692caa654f506fc1515d4d3991d6/core/src/main/java/org/apache/calcite/rel/rules/ProjectMergeRule.java#L129,), so at the end of the day this `AbstractConverter` instance keeps skipping bestCost initialization, because it returns default [infinite value](https://github.com/apache/calcite/blob/75750b78b5ac692caa654f506fc1515d4d3991d6/core/src/main/java/org/apache/calcite/plan/volcano/AbstractConverter.java#L75)  which is being skipped by  [VolcanoPlanner](https://github.com/apache/calcite/blob/75750b78b5ac692caa654f506fc1515d4d3991d6/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java#L984). That's why bestCost to root relNode is never set which is causing [exception](https://github.com/apache/calcite/blob/fe0da064dc3081b140e3c84e109aed63f202a4af/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java#L638) 
This issue is probably caused by lots of optimizations in `VolcanoPlanner `and `ProjectMergeRule` and looks like as a calcite bug.


#### Release note
Created workaround: configurable `druid.sql.planner.bloat` parameter, which should be set on broker `jvm.conf`,  it will adjust the limits of `ProjectMergeRule` result cost and could allow running complex queries(default value 100, suggested 1000, but it depends on data to be processed). 

<hr>

##### Key changed/added classes in this PR
 * `CalciteRulesManager`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.