### PR TITLE
change ownership of /opt/shared to druid user in Docker image

### DIFF
--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -94,7 +94,7 @@ RUN --mount=type=bind,from=builder,source=/opt,target=/builder/opt \
  mkdir -p /opt/druid/var /opt/shared \
  && cp -r /builder/opt/druid /opt/ \
  && /deduplicate_jars.sh /opt/druid \
- && chown -R druid:druid /opt/druid \
+ && chown -R druid:druid /opt/druid /opt/shared \
  && chmod 775 /opt/druid/var /opt/shared
 
 USER druid


### PR DESCRIPTION
Fixes a permissions issue that causes Coordinator and Broker containers to fail with the following error:

```
Error in custom provider, org.apache.druid.java.util.common.IAE: Unable to create storage connector [LocalFileStorageConnector] for base path [/opt/shared/intermediate]
2024-04-03 13:42:03   while locating org.apache.druid.storage.StorageConnectorProvider annotated with interface org.apache.druid.msq.guice.MultiStageQuery
2024-04-03 13:42:03   at org.apache.druid.msq.guice.MSQDurableStorageModule.configure(MSQDurableStorageModule.java:87) (via modules: com.google.inject.util.Modules$OverrideModule -> org.apache.druid.msq.guice.MSQDurableStorageModule)
```

### Description

[Some changes](https://github.com/apache/druid/commit/ddfc31d7ed0dbd9c0eb3c5c84956d5fb27880427) to the Dockerfile removed the change of ownership of the `/opt/shared/` directory from `root root` to `druid druid` . This change causes the Coordinator and Broker containers to fail when trying to create the directory `/opt/shared/intermediate`.

This change adds back the change of ownership for `/opt/shared/`

#### Release note

Fixes a permissions issue with the Docker image that would prevent Coordinator and Broker startup.



This PR has:

- [ x] been self-reviewed.
- [x ] been tested in a test Druid cluster.

cc: @sergioferragut @317brian 
