### PR TITLE
docs fix typo

### DIFF
--- a/docs/tutorials/tutorial-sql-null.md
+++ b/docs/tutorials/tutorial-sql-null.md
@@ -148,7 +148,7 @@ Druid returns 2. Both the empty string and null values are excluded.
 
 ## Numeric query examples
 
-Druid does does not count null values in numeric comparisons.
+Druid does not count null values in numeric comparisons.
 
 ```sql
 SELECT COUNT(*)


### PR DESCRIPTION
fixes a typo

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
