### PR TITLE
docs: Adds a redirect for flatten-json which was removed

### DIFF
--- a/docs/ingestion/flatten-json.md
+++ b/docs/ingestion/flatten-json.md
@@ -1,0 +1,28 @@
+---
+id: flatten-json
+title: "Redirecting"
+---
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+  <head>
+<script>window.location.replace("/docs/latest/ingestion/data-formats#flattenspec")</script>
+</head>
+<a href="/docs/latest/ingestion/data-formats#flattenspec">Click here if you are not redirected.</a>


### PR DESCRIPTION
Adds a redirect to address the following broken link within some versions of the web console link to /docs/latest/ingestion/flatten-json which no longer exists. 


This PR has:

- [x ] been self-reviewed.

