### PR TITLE
feature-13324 contol loading lookups in peons

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
@@ -58,6 +58,7 @@ import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.KubernetesClientApi;
 import org.apache.druid.k8s.overlord.common.PeonCommandContext;
+import org.apache.druid.query.lookup.LookupLoadingMode;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.tasklogs.TaskLogs;
@@ -448,6 +449,11 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     if (task.supportsQueries()) {
       command.add("--loadBroadcastSegments");
       command.add("true");
+    }
+
+    if (task.loadLookups() != LookupLoadingMode.ALL) {
+      command.add("--loadLookups");
+      command.add(task.loadLookups().name());
     }
 
     command.add("--taskId");

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -77,6 +77,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.lookup.LookupLoadingMode;
 import org.apache.druid.segment.DimensionHandler;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexSpec;
@@ -1522,5 +1523,11 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
           getNumPersistThreads()
       );
     }
+  }
+
+  @Override
+  public LookupLoadingMode loadLookups()
+  {
+    return LookupLoadingMode.NONE;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -41,6 +41,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.lookup.LookupLoadingMode;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
@@ -330,5 +331,17 @@ public interface Task
         taskInfo.getDataSource(),
         taskInfo.getTask().getMetadata()
     );
+  }
+
+  /**
+   * Permits to control how the task loads lookups
+   * <p>Specifically, can be used to disable lookups loading</p>
+   * <p>by default the task is loading lookups</p>
+   *
+   * @return lookups loading mode that the task is using
+   */
+  default LookupLoadingMode loadLookups()
+  {
+    return LookupLoadingMode.ALL;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -59,6 +59,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.query.lookup.LookupLoadingMode;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.server.metrics.MonitorsConfig;
@@ -377,6 +378,11 @@ public class ForkingTaskRunner
                         if (task.supportsQueries()) {
                           command.add("--loadBroadcastSegments");
                           command.add("true");
+                        }
+
+                        if (task.loadLookups() != LookupLoadingMode.ALL) {
+                          command.add("--loadLookups");
+                          command.add(task.loadLookups().name());
                         }
 
                         if (!taskFile.exists()) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -98,6 +98,7 @@ import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.query.aggregation.first.FloatFirstAggregatorFactory;
 import org.apache.druid.query.aggregation.last.DoubleLastAggregatorFactory;
 import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.lookup.LookupLoadingMode;
 import org.apache.druid.segment.DoubleDimensionHandler;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.IndexMergerV9;
@@ -418,6 +419,8 @@ public class CompactionTaskTest
         taskCreatedWithGranularitySpec.getSegmentGranularity(),
         taskCreatedWithSegmentGranularity.getSegmentGranularity()
     );
+
+    Assert.assertEquals(LookupLoadingMode.NONE, taskCreatedWithGranularitySpec.loadLookups());
   }
 
   @Test
@@ -621,6 +624,7 @@ public class CompactionTaskTest
     final byte[] bytes = OBJECT_MAPPER.writeValueAsBytes(task);
     final CompactionTask fromJson = OBJECT_MAPPER.readValue(bytes, CompactionTask.class);
     assertEquals(task, fromJson);
+    Assert.assertEquals(LookupLoadingMode.NONE, task.loadLookups());
   }
 
   @Test

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupLoadingMode.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupLoadingMode.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.lookup;
+
+/**
+ * This enum describes different modes of loading lookups
+ * <p>Each task might define if it needs to load lookups or not {@link org.apache.druid.indexing.common.task.Task#loadLookups}
+ * <p>Values:
+ * <ul>
+ * <li>ALL - represents regular mode of loading all lookups </li>
+ * <li>NONE - represents mode when no lookups will be loaded </li>
+ * <li>ON_DEMAND - currently not supported and will be used in the future </li>
+ * </ul>
+ */
+public enum LookupLoadingMode
+{
+  NONE, ALL //, ON_DEMAND
+}

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupSerdeModule.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupSerdeModule.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
+import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.guice.ExpressionModule;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.initialization.DruidModule;
@@ -58,6 +59,9 @@ public class LookupSerdeModule implements DruidModule
   public void configure(Binder binder)
   {
     JsonConfigProvider.bind(binder, LookupModule.PROPERTY_BASE, LookupConfig.class);
+    // Even though LookupSerdeModule will be used for processes that are not loading lookups, we need to bind LookupNodeService,
+    // so that TaskToolboxFactory and TaskToolbox will get their dependency. Binding it won't load lookups.
+    binder.bind(LookupNodeService.class).toInstance(new LookupNodeService(LookupListeningAnnouncerConfig.DEFAULT_TIER));
     binder.bind(LookupExtractorFactoryContainerProvider.class).to(NoopLookupExtractorFactoryContainerProvider.class);
     ExpressionModule.addExprMacro(binder, LookupExprMacro.class);
   }

--- a/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliPeonTest.java
@@ -22,6 +22,9 @@ package org.apache.druid.cli;
 import com.google.inject.Injector;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.query.lookup.LookupLoadingMode;
+import org.apache.druid.query.lookup.LookupModule;
+import org.apache.druid.query.lookup.LookupSerdeModule;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,6 +74,25 @@ public class CliPeonTest
     final Injector injector = GuiceInjectors.makeStartupInjector();
     injector.injectMembers(runnable);
     Assert.assertNotNull(runnable.makeInjector());
+  }
+
+  @Test
+  public void testResolveLookupModule() throws IOException
+  {
+    File file = temporaryFolder.newFile("task.json");
+    FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
+    FakeCliPeon peon = new FakeCliPeon(file.getParent(), "k8sAndWorker");
+    Assert.assertTrue(peon.resolveLookupModule() instanceof LookupModule);
+  }
+
+  @Test
+  public void testResolveSerdeLookupModule() throws IOException
+  {
+    File file = temporaryFolder.newFile("task.json");
+    FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
+    FakeCliPeon peon = new FakeCliPeon(file.getParent(), "k8sAndWorker");
+    peon.loadLookups = LookupLoadingMode.NONE;
+    Assert.assertTrue(peon.resolveLookupModule() instanceof LookupSerdeModule);
   }
 
   private static class FakeCliPeon extends CliPeon


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [#13324](https://github.com/apache/druid/issues/13324)

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Permits to disable lookups loading for some types of peons
for example compaction or kill tasks
this should improve memory footprint
e.g. for compaction we can use this memory for loading more rows into memory and thus improving throughput of compaction

I've followed same path as loadBroadcastSegments parameter works and reused LookupSerdeModule which already used in multiple services that doesn't need to load lookups 

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### The fix adds doesntNeedLookups method to interface of task with default of false

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `Task` - added doesntNeedLookups with default implementation that returns false, i.e. most of peons will continue to load lookups
 * `CompactionTask` - overrides it with true
 * `CliPeon` - refers to the process parameter and loads relevant lookup module(which either loads lookups or not)

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
