### PR TITLE
Upload openrewrite patch via GHA

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -163,8 +163,16 @@ jobs:
           ${MVN} install -q -ff -pl 'distribution' ${MAVEN_SKIP} ${MAVEN_SKIP_TESTS}
 
       - name: rewrite:dryRun
+        id: rewrite-dryRun
         run: |
           ${MVN} rewrite:dryRun ${MAVEN_SKIP}
+
+      - name: Upload open rewrite patch
+        if: ${{ failure() && steps.rewrite-dryRun.conclusion == 'failure' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: Rewrite patch
+          path: ./target/rewrite/rewrite.patch
 
   web-checks:
     strategy:


### PR DESCRIPTION
This patch adds a step to the openrewrite action, such that it uploads the correcting patch, in case it fails. 

I have tested that it's working as intended on my other PR, and the uploaded file is correct. 
![Screenshot 2024-04-12 at 1 00 17 PM](https://github.com/apache/druid/assets/30999375/2171c648-6b96-40d7-8d49-bb5472912b5f)
