### PR TITLE
Fix incorrect check of InvalidFieldException to InvalidFieldFault while generating MSQ Error Report

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -124,6 +124,7 @@ import org.apache.druid.msq.indexing.error.InsertCannotAllocateSegmentFault;
 import org.apache.druid.msq.indexing.error.InsertCannotBeEmptyFault;
 import org.apache.druid.msq.indexing.error.InsertLockPreemptedFault;
 import org.apache.druid.msq.indexing.error.InsertTimeOutOfBoundsFault;
+import org.apache.druid.msq.indexing.error.InvalidFieldFault;
 import org.apache.druid.msq.indexing.error.InvalidNullByteFault;
 import org.apache.druid.msq.indexing.error.MSQErrorReport;
 import org.apache.druid.msq.indexing.error.MSQException;
@@ -3139,17 +3140,17 @@ public class ControllerImpl implements Controller
                                   .build(),
           task.getQuerySpec().getColumnMappings()
       );
-    } else if (workerErrorReport.getFault() instanceof InvalidFieldException) {
-      InvalidFieldException ife = (InvalidFieldException) workerErrorReport.getFault();
+    } else if (workerErrorReport.getFault() instanceof InvalidFieldFault) {
+      InvalidFieldFault iff = (InvalidFieldFault) workerErrorReport.getFault();
       return MSQErrorReport.fromException(
           workerErrorReport.getTaskId(),
           workerErrorReport.getHost(),
           workerErrorReport.getStageNumber(),
           InvalidFieldException.builder()
-                               .source(ife.getSource())
-                               .rowNumber(ife.getRowNumber())
-                               .column(ife.getColumn())
-                               .errorMsg(ife.getErrorMsg())
+                               .source(iff.getSource())
+                               .rowNumber(iff.getRowNumber())
+                               .column(iff.getColumn())
+                               .errorMsg(iff.getErrorMsg())
                                .build(),
           task.getQuerySpec().getColumnMappings()
       );


### PR DESCRIPTION
`InvalidFieldFault` is incorrectly checked as `InvalidFieldException` in `mapQueryColumnNameToOutputColumnName`. Fix it to the correct check. 

Verified the generated MSQErrorReport by raising an empty RuntimeException in a custom build.

<img width="2269" alt="image" src="https://github.com/apache/druid/assets/2777634/0af043eb-905a-40f2-bed5-938b4d7dda33">

