### PR TITLE
Add configurable parameters for statsd client

### DIFF
--- a/docs/development/extensions-contrib/statsd.md
+++ b/docs/development/extensions-contrib/statsd.md
@@ -35,20 +35,20 @@ This extension emits druid metrics to a StatsD server.
 
 All the configuration parameters for the StatsD emitter are under `druid.emitter.statsd`.
 
-| property                                     |description|required?|default|
-|----------------------------------------------|-----------|---------|-----|
-| `druid.emitter.statsd.hostname`              |The hostname of the StatsD server.|yes|none|
-| `druid.emitter.statsd.port`                  |The port of the StatsD server.|yes|none|
-| `druid.emitter.statsd.prefix`                |Optional metric name prefix.|no|""|
-| `druid.emitter.statsd.separator`             |Metric name separator|no|.|
-| `druid.emitter.statsd.includeHost`           |Flag to include the hostname as part of the metric name.|no|false|
-| `druid.emitter.statsd.dimensionMapPath`      |JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|
-| `druid.emitter.statsd.blankHolder`           |The blank character replacement as StatsD does not support path with blank character|no|"-"|
-| `druid.emitter.statsd.queueSize`             |Maximum number of unprocessed messages in the queue. Can be increased if packets are being dropped|no|Default value of StatsD Client(4096)|
-| `druid.emitter.statsd.dogstatsd`             |Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
-| `druid.emitter.statsd.dogstatsdConstantTags` |If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
-| `druid.emitter.statsd.dogstatsdServiceAsTag` |If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.query.time`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
-| `druid.emitter.statsd.dogstatsdEvents`       |If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdEvents` are true, [Alert events](../../operations/alerts.md) are reported to DogStatsD.|no|false|
+|property|description|required?|default|
+|--------|-----------|---------|-------|
+|`druid.emitter.statsd.hostname`|The hostname of the StatsD server.|yes|none|
+|`druid.emitter.statsd.port`|The port of the StatsD server.|yes|none|
+|`druid.emitter.statsd.prefix`|Optional metric name prefix.|no|""|
+|`druid.emitter.statsd.separator`|Metric name separator|no|.|
+|`druid.emitter.statsd.includeHost`|Flag to include the hostname as part of the metric name.|no|false|
+|`druid.emitter.statsd.dimensionMapPath`|JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|
+|`druid.emitter.statsd.blankHolder`|The blank character replacement as StatsD does not support path with blank character|no|"-"|
+|`druid.emitter.statsd.queueSize`|Maximum number of unprocessed messages in the queue. Can be increased if packets are being dropped|no|Default value of StatsD Client(4096)|
+|`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
+|`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
+|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.query.time`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
+|`druid.emitter.statsd.dogstatsdEvents`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdEvents` are true, [Alert events](../../operations/alerts.md) are reported to DogStatsD.|no|false|
 
 ### Druid to StatsD Event Converter
 

--- a/docs/development/extensions-contrib/statsd.md
+++ b/docs/development/extensions-contrib/statsd.md
@@ -35,19 +35,20 @@ This extension emits druid metrics to a StatsD server.
 
 All the configuration parameters for the StatsD emitter are under `druid.emitter.statsd`.
 
-|property|description|required?|default|
-|--------|-----------|---------|-------|
-|`druid.emitter.statsd.hostname`|The hostname of the StatsD server.|yes|none|
-|`druid.emitter.statsd.port`|The port of the StatsD server.|yes|none|
-|`druid.emitter.statsd.prefix`|Optional metric name prefix.|no|""|
-|`druid.emitter.statsd.separator`|Metric name separator|no|.|
-|`druid.emitter.statsd.includeHost`|Flag to include the hostname as part of the metric name.|no|false|
-|`druid.emitter.statsd.dimensionMapPath`|JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|
-|`druid.emitter.statsd.blankHolder`|The blank character replacement as StatsD does not support path with blank character|no|"-"|
-|`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
-|`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
-|`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.query.time`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
-|`druid.emitter.statsd.dogstatsdEvents`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdEvents` are true, [Alert events](../../operations/alerts.md) are reported to DogStatsD.|no|false|
+| property                                     |description|required?|default|
+|----------------------------------------------|-----------|---------|-----|
+| `druid.emitter.statsd.hostname`              |The hostname of the StatsD server.|yes|none|
+| `druid.emitter.statsd.port`                  |The port of the StatsD server.|yes|none|
+| `druid.emitter.statsd.prefix`                |Optional metric name prefix.|no|""|
+| `druid.emitter.statsd.separator`             |Metric name separator|no|.|
+| `druid.emitter.statsd.includeHost`           |Flag to include the hostname as part of the metric name.|no|false|
+| `druid.emitter.statsd.dimensionMapPath`      |JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|
+| `druid.emitter.statsd.blankHolder`           |The blank character replacement as StatsD does not support path with blank character|no|"-"|
+| `druid.emitter.statsd.queueSize`             |Maximum number of unprocessed messages in the queue. Can be increased if packets are being dropped|no|Default value of StatsD Client(4096)|
+| `druid.emitter.statsd.dogstatsd`             |Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
+| `druid.emitter.statsd.dogstatsdConstantTags` |If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
+| `druid.emitter.statsd.dogstatsdServiceAsTag` |If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.query.time`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|
+| `druid.emitter.statsd.dogstatsdEvents`       |If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdEvents` are true, [Alert events](../../operations/alerts.md) are reported to DogStatsD.|no|false|
 
 ### Druid to StatsD Event Converter
 

--- a/docs/development/extensions-contrib/statsd.md
+++ b/docs/development/extensions-contrib/statsd.md
@@ -44,7 +44,10 @@ All the configuration parameters for the StatsD emitter are under `druid.emitter
 |`druid.emitter.statsd.includeHost`|Flag to include the hostname as part of the metric name.|no|false|
 |`druid.emitter.statsd.dimensionMapPath`|JSON file defining the StatsD type, and desired dimensions for every Druid metric|no|Default mapping provided. See below.|
 |`druid.emitter.statsd.blankHolder`|The blank character replacement as StatsD does not support path with blank character|no|"-"|
-|`druid.emitter.statsd.queueSize`|Maximum number of unprocessed messages in the queue. Can be increased if packets are being dropped|no|Default value of StatsD Client(4096)|
+|`druid.emitter.statsd.queueSize`|Maximum number of unprocessed messages in the message queue.|no|Default value of StatsD Client(4096)|
+|`druid.emitter.statsd.poolSize`|Network packet buffer pool size.|no|Default value of StatsD Client(512)|
+|`druid.emitter.statsd.processorWorkers`|The number of processor worker threads assembling buffers for submission.|no|Default value of StatsD Client(1)|
+|`druid.emitter.statsd.senderWorkers`|	The number of sender worker threads submitting buffers to the socket.|no|Default value of StatsD Client(1)|
 |`druid.emitter.statsd.dogstatsd`|Flag to enable [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) support. Causes dimensions to be included as tags, not as a part of the metric name. `convertRange` fields will be ignored.|no|false|
 |`druid.emitter.statsd.dogstatsdConstantTags`|If `druid.emitter.statsd.dogstatsd` is true, the tags in the JSON list of strings will be sent with every event.|no|[]|
 |`druid.emitter.statsd.dogstatsdServiceAsTag`|If `druid.emitter.statsd.dogstatsd` and `druid.emitter.statsd.dogstatsdServiceAsTag` are true, druid service (e.g. `druid/broker`, `druid/coordinator`, etc) is reported as a tag (e.g. `druid_service:druid/broker`) instead of being included in metric name (e.g. `druid.broker.query.time`) and `druid` is used as metric prefix (e.g. `druid.query.time`).|no|false|

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -64,6 +64,9 @@ public class StatsDEmitter implements Emitter
         .port(config.getPort())
         .constantTags(config.isDogstatsd() ? config.getDogstatsdConstantTags().toArray(new String[0]) : EMPTY_ARRAY)
         .queueSize(config.getQueueSize())
+        .bufferPoolSize(config.getPoolSize())
+        .processorWorkers(config.getProcessorWorkers())
+        .senderWorkers(config.getSenderWorkers())
         .errorHandler(new StatsDClientErrorHandler()
         {
           private int exceptionCount = 0;

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitter.java
@@ -63,6 +63,7 @@ public class StatsDEmitter implements Emitter
         .hostname(config.getHostname())
         .port(config.getPort())
         .constantTags(config.isDogstatsd() ? config.getDogstatsdConstantTags().toArray(new String[0]) : EMPTY_ARRAY)
+        .queueSize(config.getQueueSize())
         .errorHandler(new StatsDClientErrorHandler()
         {
           private int exceptionCount = 0;

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.emitter.statsd;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.timgroup.statsd.NonBlockingStatsDClient;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -56,6 +57,8 @@ public class StatsDEmitterConfig
   private final Boolean dogstatsdServiceAsTag;
   @JsonProperty
   private final Boolean dogstatsdEvents;
+  @JsonProperty
+  private final Integer queueSize;
 
   @JsonCreator
   public StatsDEmitterConfig(
@@ -69,7 +72,8 @@ public class StatsDEmitterConfig
       @JsonProperty("dogstatsd") @Nullable Boolean dogstatsd,
       @JsonProperty("dogstatsdConstantTags") @Nullable List<String> dogstatsdConstantTags,
       @JsonProperty("dogstatsdServiceAsTag") @Nullable Boolean dogstatsdServiceAsTag,
-      @JsonProperty("dogstatsdEvents") @Nullable Boolean dogstatsdEvents
+      @JsonProperty("dogstatsdEvents") @Nullable Boolean dogstatsdEvents,
+      @JsonProperty("queueSize") @Nullable Integer queueSize
   )
   {
     this.hostname = Preconditions.checkNotNull(hostname, "StatsD hostname cannot be null.");
@@ -83,6 +87,7 @@ public class StatsDEmitterConfig
     this.dogstatsdConstantTags = dogstatsdConstantTags != null ? dogstatsdConstantTags : Collections.emptyList();
     this.dogstatsdServiceAsTag = dogstatsdServiceAsTag != null ? dogstatsdServiceAsTag : false;
     this.dogstatsdEvents = dogstatsdEvents != null ? dogstatsdEvents : false;
+    this.queueSize = queueSize != null ? queueSize : NonBlockingStatsDClient.DEFAULT_QUEUE_SIZE;
   }
 
   @Override
@@ -121,6 +126,9 @@ public class StatsDEmitterConfig
     if (!Objects.equals(dogstatsdServiceAsTag, that.dogstatsdServiceAsTag)) {
       return false;
     }
+    if (!Objects.equals(queueSize, that.queueSize)) {
+      return false;
+    }
     return Objects.equals(dogstatsdConstantTags, that.dogstatsdConstantTags);
   }
 
@@ -128,7 +136,7 @@ public class StatsDEmitterConfig
   public int hashCode()
   {
     return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath,
-            blankHolder, dogstatsd, dogstatsdConstantTags, dogstatsdServiceAsTag);
+            blankHolder, dogstatsd, dogstatsdConstantTags, dogstatsdServiceAsTag, queueSize);
   }
 
   @JsonProperty
@@ -196,5 +204,10 @@ public class StatsDEmitterConfig
   public Boolean isDogstatsdEvents()
   {
     return dogstatsdEvents;
+  }
+  @JsonProperty
+  public Integer getQueueSize()
+  {
+    return queueSize;
   }
 }

--- a/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
+++ b/extensions-contrib/statsd-emitter/src/main/java/org/apache/druid/emitter/statsd/StatsDEmitterConfig.java
@@ -59,6 +59,12 @@ public class StatsDEmitterConfig
   private final Boolean dogstatsdEvents;
   @JsonProperty
   private final Integer queueSize;
+  @JsonProperty
+  private final Integer poolSize;
+  @JsonProperty
+  private final Integer processorWorkers;
+  @JsonProperty
+  private final Integer senderWorkers;
 
   @JsonCreator
   public StatsDEmitterConfig(
@@ -73,7 +79,10 @@ public class StatsDEmitterConfig
       @JsonProperty("dogstatsdConstantTags") @Nullable List<String> dogstatsdConstantTags,
       @JsonProperty("dogstatsdServiceAsTag") @Nullable Boolean dogstatsdServiceAsTag,
       @JsonProperty("dogstatsdEvents") @Nullable Boolean dogstatsdEvents,
-      @JsonProperty("queueSize") @Nullable Integer queueSize
+      @JsonProperty("queueSize") @Nullable Integer queueSize,
+      @JsonProperty("poolSize") @Nullable Integer poolSize,
+      @JsonProperty("processorWorkers") @Nullable Integer processorWorkers,
+      @JsonProperty("senderWorkers") @Nullable Integer senderWorkers
   )
   {
     this.hostname = Preconditions.checkNotNull(hostname, "StatsD hostname cannot be null.");
@@ -88,6 +97,9 @@ public class StatsDEmitterConfig
     this.dogstatsdServiceAsTag = dogstatsdServiceAsTag != null ? dogstatsdServiceAsTag : false;
     this.dogstatsdEvents = dogstatsdEvents != null ? dogstatsdEvents : false;
     this.queueSize = queueSize != null ? queueSize : NonBlockingStatsDClient.DEFAULT_QUEUE_SIZE;
+    this.poolSize = poolSize != null ? poolSize : NonBlockingStatsDClient.DEFAULT_POOL_SIZE;
+    this.processorWorkers = processorWorkers != null ? processorWorkers : NonBlockingStatsDClient.DEFAULT_PROCESSOR_WORKERS;
+    this.senderWorkers = senderWorkers != null ? senderWorkers : NonBlockingStatsDClient.DEFAULT_SENDER_WORKERS;
   }
 
   @Override
@@ -129,6 +141,15 @@ public class StatsDEmitterConfig
     if (!Objects.equals(queueSize, that.queueSize)) {
       return false;
     }
+    if (!Objects.equals(poolSize, that.poolSize)) {
+      return false;
+    }
+    if (!Objects.equals(processorWorkers, that.processorWorkers)) {
+      return false;
+    }
+    if (!Objects.equals(senderWorkers, that.senderWorkers)) {
+      return false;
+    }
     return Objects.equals(dogstatsdConstantTags, that.dogstatsdConstantTags);
   }
 
@@ -136,7 +157,7 @@ public class StatsDEmitterConfig
   public int hashCode()
   {
     return Objects.hash(hostname, port, prefix, separator, includeHost, dimensionMapPath,
-            blankHolder, dogstatsd, dogstatsdConstantTags, dogstatsdServiceAsTag, queueSize);
+            blankHolder, dogstatsd, dogstatsdConstantTags, dogstatsdServiceAsTag, queueSize, poolSize, processorWorkers, senderWorkers);
   }
 
   @JsonProperty
@@ -209,5 +230,20 @@ public class StatsDEmitterConfig
   public Integer getQueueSize()
   {
     return queueSize;
+  }
+  @JsonProperty
+  public Integer getPoolSize()
+  {
+    return poolSize;
+  }
+  @JsonProperty
+  public Integer getProcessorWorkers()
+  {
+    return processorWorkers;
+  }
+  @JsonProperty
+  public Integer getSenderWorkers()
+  {
+    return senderWorkers;
   }
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -43,7 +43,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -60,7 +60,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -77,7 +77,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -103,7 +103,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -129,7 +129,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -156,7 +156,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -173,7 +173,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-            new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, null, null),
+            new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, null, null, null, null, null),
             new ObjectMapper(),
             client
     );
@@ -192,7 +192,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, true, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, true, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -240,7 +240,11 @@ public class StatsDEmitterTest
         ImmutableList.of("tag1", "value1"),
         true,
         true,
-        5100
+        5100,
+        512,
+        1,
+        1
+
     );
     try (StatsDEmitter emitter = StatsDEmitter.of(config, new ObjectMapper())) {
 

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -43,7 +43,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -60,7 +60,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, true, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -77,7 +77,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, null, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -103,7 +103,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -129,7 +129,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, "#", true, null, null, true, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -156,7 +156,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null, null, null),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, null, null, null, null, null),
         new ObjectMapper(),
         client
     );
@@ -173,7 +173,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-            new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, null),
+            new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, null, null),
             new ObjectMapper(),
             client
     );
@@ -192,7 +192,7 @@ public class StatsDEmitterTest
   {
     StatsDClient client = mock(StatsDClient.class);
     StatsDEmitter emitter = new StatsDEmitter(
-        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, true),
+        new StatsDEmitterConfig("localhost", 8888, null, null, true, null, null, true, null, true, true, null),
         new ObjectMapper(),
         client
     );
@@ -239,7 +239,8 @@ public class StatsDEmitterTest
         true,
         ImmutableList.of("tag1", "value1"),
         true,
-        true
+        true,
+        5100
     );
     try (StatsDEmitter emitter = StatsDEmitter.of(config, new ObjectMapper())) {
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.
Statsd client sometimes drops metrics when this [queueSize](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=java#client-instantiation-parameters) of statsd client with max unprocessed messages is completely full. This causes some high cardinality metrics like per partition lag being droppped. 
There are multiple [parameters](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=java#client-instantiation-parameters) of statsdclient that can be initialized and can help increase the load/capacity of client to not to drop metrics more frequently. 
Properties like `queueSize`, `poolSize`, `processorWorkers` and `senderWorkers` will now be configurable at runtime
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
