### PR TITLE
Consider max lag for kinesis while autoscaling

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -39,6 +39,7 @@ import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagMetric;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
 import org.apache.druid.indexing.seekablestream.SeekableStreamDataSourceMetadata;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
@@ -425,6 +426,12 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
         expiredPartitionIds,
         KinesisSequenceNumber.EXPIRED_MARKER
     );
+  }
+
+  @Override
+  public LagMetric getLagMetricForAutoScaler()
+  {
+    return LagMetric.MAX;
   }
 
   private SeekableStreamDataSourceMetadata<String, String> createDataSourceMetadataWithClosedOrExpiredPartitions(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScaler.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScaler.java
@@ -159,8 +159,8 @@ public class LagBasedAutoScaler implements SupervisorTaskAutoScaler
           if (lagStats == null) {
             lagMetricsQueue.offer(0L);
           } else {
-            long totalLags = lagStats.getTotalLag();
-            lagMetricsQueue.offer(totalLags > 0 ? totalLags : 0L);
+            long lag = lagStats.get(supervisor.getLagMetricForAutoScaler());
+            lagMetricsQueue.offer(lag > 0 ? lag : 0L);
           }
           log.debug("Current lags for dataSource[%s] are [%s].", dataSource, lagMetricsQueue);
         } else {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/LagStatsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/LagStatsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream.supervisor;
+
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagMetric;
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LagStatsTest
+{
+
+  @Test
+  public void lagStatsByMetric()
+  {
+    int max = 1;
+    int avg = 2;
+    int total = 3;
+    LagStats lag = new LagStats(max, total, avg);
+
+    Assert.assertEquals(max, lag.get(LagMetric.MAX));
+    Assert.assertEquals(total, lag.get(LagMetric.TOTAL));
+    Assert.assertEquals(avg, lag.get(LagMetric.AVERAGE));
+  }
+}

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagMetric;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
 import org.apache.druid.segment.incremental.ParseExceptionReport;
 
@@ -92,6 +93,14 @@ public interface Supervisor
    * Computes maxLag, totalLag and avgLag
    */
   LagStats computeLagStats();
+
+  /**
+   * Used by AutoScaler to either scale by max/total/avg.
+   */
+  default LagMetric getLagMetricForAutoScaler()
+  {
+    return LagMetric.TOTAL;
+  }
 
   int getActiveTaskGroupsCount();
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagMetric.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagMetric.java
@@ -19,44 +19,9 @@
 
 package org.apache.druid.indexing.overlord.supervisor.autoscaler;
 
-public class LagStats
+public enum LagMetric
 {
-  private final long maxLag;
-  private final long totalLag;
-  private final long avgLag;
-
-  public LagStats(long maxLag, long totalLag, long avgLag)
-  {
-    this.maxLag = maxLag;
-    this.totalLag = totalLag;
-    this.avgLag = avgLag;
-  }
-
-  public long getMaxLag()
-  {
-    return maxLag;
-  }
-
-  public long getTotalLag()
-  {
-    return totalLag;
-  }
-
-  public long getAvgLag()
-  {
-    return avgLag;
-  }
-
-  public long get(LagMetric metric)
-  {
-    switch (metric) {
-      case AVERAGE:
-        return avgLag;
-      case TOTAL:
-        return totalLag;
-      case MAX:
-        return maxLag;
-    }
-    throw new IllegalStateException("Unknown Metric");
-  }
+  TOTAL,
+  MAX,
+  AVERAGE;
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/LagStatsTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/LagStatsTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.druid.indexing.seekablestream.supervisor;
+package org.apache.druid.indexing.overlord.supervisor;
 
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagMetric;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;


### PR DESCRIPTION
### Description

In kinesis, lag is computed in minutes rather than count of records as done in kafka. If each shard has a lag of 1 min and there are 10 shards, we were computing that there was 10 mins of lag for auto scaling decisions, but we should be only looking at the max and make the auto scaling decisions. On the other hand, for kafka, the lag considered for autoscaling is total as previously.

#### Release note
For kinesis streams, autoscaling is now done on max lag per shard rather than the total lag for all shards.

<hr>

##### Key changed/added classes in this PR
 * `LagStats.java`
 * `LagMetric.java`
 * `LabBasedAutoScaler.java`
 * `Supervisor.java`

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
