### PR TITLE
Include exception message in errorMessage for failed task

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -428,7 +428,7 @@ public class TaskQueue
               errorMessage = e.getMessage();
             } else {
               errorMessage = "Failed while waiting for the task to be ready to run. "
-                                          + "See overlord logs for more details.";
+                             + "See overlord logs for more details. Error: " + e.getMessage();
             }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -427,10 +427,10 @@ public class TaskQueue
             if (e instanceof MaxAllowedLocksExceededException) {
               errorMessage = e.getMessage();
             } else {
-              errorMessage = StringUtils.format(
+              errorMessage = StringUtils.chop(StringUtils.format(
                   "Encountered error[%s] while waiting for task to be ready. See Overlord logs for more details.",
                   e.getMessage()
-              );
+              ), 100);
             }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -428,7 +428,7 @@ public class TaskQueue
               errorMessage = e.getMessage();
             } else {
               errorMessage = "Failed while waiting for the task to be ready to run. "
-                             + "See overlord logs for more details. Error: " + e.getMessage();
+                           errorMessage = StringUtils.format("Encountered error[%s] while waiting for task to be ready. See Overlord logs for more details.", e.getMessage());
             }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -427,10 +427,10 @@ public class TaskQueue
             if (e instanceof MaxAllowedLocksExceededException) {
               errorMessage = e.getMessage();
             } else {
-              errorMessage = StringUtils.chop(StringUtils.format(
+              errorMessage = StringUtils.format(
                   "Encountered error[%s] while waiting for task to be ready. See Overlord logs for more details.",
-                  e.getMessage()
-              ), 100);
+                  StringUtils.chop(e.getMessage(), 100)
+              );
             }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -427,8 +427,10 @@ public class TaskQueue
             if (e instanceof MaxAllowedLocksExceededException) {
               errorMessage = e.getMessage();
             } else {
-              errorMessage = "Failed while waiting for the task to be ready to run. "
-                           errorMessage = StringUtils.format("Encountered error[%s] while waiting for task to be ready. See Overlord logs for more details.", e.getMessage());
+              errorMessage = StringUtils.format(
+                  "Encountered error[%s] while waiting for task to be ready. See Overlord logs for more details.",
+                  e.getMessage()
+              );
             }
             notifyStatus(task, TaskStatus.failure(task.getId(), errorMessage), errorMessage);
             continue;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -298,12 +298,13 @@ public class TaskQueueTest extends IngestionTestBase
   @Test
   public void testExceptionInIsReadyFailsTask()
   {
+    final String exceptionMsg = "isReady failure test";
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"))
     {
       @Override
       public boolean isReady(TaskActionClient taskActionClient)
       {
-        throw new RuntimeException("isReady failure test");
+        throw new RuntimeException(exceptionMsg);
       }
     };
     taskQueue.add(task);
@@ -314,7 +315,7 @@ public class TaskQueueTest extends IngestionTestBase
     Assert.assertEquals(TaskState.FAILED, statusOptional.get().getStatusCode());
     Assert.assertNotNull(statusOptional.get().getErrorMsg());
     Assert.assertTrue(
-        statusOptional.get().getErrorMsg().startsWith("Failed while waiting for the task to be ready to run")
+        statusOptional.get().getErrorMsg().contains(exceptionMsg)
     );
   }
 


### PR DESCRIPTION
### Description
Following is an example of auto-compaction subtask failure we can see from task Status field in Druid console.
Now include the actual exception message in the task Status output to easily understand the failure instead of having to check from Overlord logs.
```
{
  "id": "partial_range_index_generate...",
  "groupId": "coordinator-issued_compact...",
  "type": "partial_range_index_generate",
  "createdTime": "2024-04-15T16:41:58.300Z",
  "queueInsertionTime": "1970-01-01T00:00:00.000Z",
  "statusCode": "FAILED",
  "status": "FAILED",
  "runnerStatusCode": "WAITING",
  "duration": -1,
  "location": {
    "host": null,
    "port": -1,
    "tlsPort": -1
  },
  "dataSource": "data_source",
  "errorMsg": "Failed while waiting for the task to be ready to run. See overlord logs for more details."
}
```

<hr>

##### Key changed/added classes in this PR
 * `TaskQueue.java` add exception message to errorMessage

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
