### PR TITLE
Fix incorrect class in BaseMacroFunctionExpr.equals.

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -172,7 +172,7 @@ public class ExprMacroTable
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      BaseScalarMacroFunctionExpr that = (BaseScalarMacroFunctionExpr) o;
+      BaseMacroFunctionExpr that = (BaseMacroFunctionExpr) o;
       return Objects.equals(macro, that.macro) &&
              Objects.equals(args, that.args);
     }


### PR DESCRIPTION
The equals method cast to the wrong class, potentially leading to ClassCastException.