### PR TITLE
Update documentation for exceptions to subquery limit.

### DIFF
--- a/docs/querying/query-execution.md
+++ b/docs/querying/query-execution.md
@@ -93,9 +93,9 @@ cannot exceed the [`druid.server.http.maxSubqueryRows`](../configuration/index.m
 [`druid.server.http.maxSubqueryBytes`](../configuration/index.md) if set. Otherwise, Druid throws a resource limit exceeded 
 exception.
 
-There is one exception: if the outer query and all subqueries are the [groupBy](groupbyquery.md) type, then subquery
-results can be processed in a streaming fashion and the `druid.server.http.maxSubqueryRows` and `druid.server.http.maxSubqueryBytes` 
-limits do not apply.
+There is one exception: if the outer query is of type [`groupBy`](groupbyquery.md), and has a `dataSource` of type
+`query` that is itself another `groupBy`, then subquery results can be processed in a streaming fashion. In this case
+the `druid.server.http.maxSubqueryRows` and `druid.server.http.maxSubqueryBytes` limits do not apply.
 
 ### `join`
 


### PR DESCRIPTION
The true exception for groupBy is somewhat more narrow than the docs suggest.