### PR TITLE
Web console: Fix the supervisor offset reset dialog.

### DIFF
--- a/web-console/src/components/query-error-pane/query-error-pane.tsx
+++ b/web-console/src/components/query-error-pane/query-error-pane.tsx
@@ -100,6 +100,7 @@ export const QueryErrorPane = React.memo(function QueryErrorPane(props: QueryErr
         </p>
       )}
       {error.errorClass && <p>{error.errorClass}</p>}
+      {error.host && <p>{`Host: ${error.host}`}</p>}
     </div>
   );
 });

--- a/web-console/src/dialogs/supervisor-reset-offsets-dialog/supervisor-reset-offsets-dialog.scss
+++ b/web-console/src/dialogs/supervisor-reset-offsets-dialog/supervisor-reset-offsets-dialog.scss
@@ -27,8 +27,6 @@
   }
 
   .new-offset-label {
-    margin-bottom: 0;
-    margin-top: 4px;
-    margin-right: 9px;
+    margin: 4px 9px 0 0 !important;
   }
 }

--- a/web-console/src/dialogs/supervisor-reset-offsets-dialog/supervisor-reset-offsets-dialog.scss
+++ b/web-console/src/dialogs/supervisor-reset-offsets-dialog/supervisor-reset-offsets-dialog.scss
@@ -26,7 +26,9 @@
     max-height: 80vh;
   }
 
-  .label-button {
-    pointer-events: none;
+  .new-offset-label {
+    margin-bottom: 0;
+    margin-top: 4px;
+    margin-right: 9px;
   }
 }

--- a/web-console/src/druid-models/index.ts
+++ b/web-console/src/druid-models/index.ts
@@ -36,6 +36,7 @@ export * from './metric-spec/metric-spec';
 export * from './overlord-dynamic-config/overlord-dynamic-config';
 export * from './query-context/query-context';
 export * from './stages/stages';
+export * from './supervisor-status/supervisor-status';
 export * from './task/task';
 export * from './time/time';
 export * from './timestamp-spec/timestamp-spec';

--- a/web-console/src/druid-models/supervisor-status/supervisor-status.ts
+++ b/web-console/src/druid-models/supervisor-status/supervisor-status.ts
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { NumberLike } from '../../utils';
+
+export type SupervisorOffsetMap = Record<string, NumberLike>;
+
+export interface SupervisorStatus {
+  generationTime: string;
+  id: string;
+  payload: {
+    dataSource: string;
+    stream: string;
+    partitions: number;
+    replicas: number;
+    durationSeconds: number;
+    activeTasks: SupervisorStatusTask[];
+    publishingTasks: SupervisorStatusTask[];
+    latestOffsets?: SupervisorOffsetMap;
+    minimumLag?: SupervisorOffsetMap;
+    aggregateLag: number;
+    offsetsLastUpdated: string;
+    suspended: boolean;
+    healthy: boolean;
+    state: string;
+    detailedState: string;
+    recentErrors: any[];
+  };
+}
+
+export interface SupervisorStatusTask {
+  id: string;
+  startingOffsets: SupervisorOffsetMap;
+  startTime: '2024-04-12T21:35:34.834Z';
+  remainingSeconds: number;
+  type: string;
+  currentOffsets: SupervisorOffsetMap;
+  lag: SupervisorOffsetMap;
+}

--- a/web-console/src/utils/basic-action.tsx
+++ b/web-console/src/utils/basic-action.tsx
@@ -26,19 +26,22 @@ export interface BasicAction {
   title: string;
   intent?: Intent;
   onAction: () => void;
+  disabledReason?: string;
 }
 
 export function basicActionsToMenu(basicActions: BasicAction[]): JSX.Element | undefined {
   if (!basicActions.length) return;
   return (
     <Menu>
-      {basicActions.map((action, i) => (
+      {basicActions.map(({ icon, title, intent, onAction, disabledReason }, i) => (
         <MenuItem
           key={i}
-          icon={action.icon}
-          text={action.title}
-          intent={action.intent}
-          onClick={action.onAction}
+          icon={icon}
+          text={title}
+          intent={intent}
+          onClick={onAction}
+          disabled={Boolean(disabledReason)}
+          title={disabledReason}
         />
       ))}
     </Menu>

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -33,6 +33,11 @@ export const EMPTY_ARRAY: any[] = [];
 
 export type NumberLike = number | bigint;
 
+export function isNumberLike(x: unknown): x is NumberLike {
+  const t = typeof x;
+  return t === 'number' || t === 'bigint';
+}
+
 export function isNumberLikeNaN(x: NumberLike): boolean {
   return isNaN(Number(x));
 }

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3260,7 +3260,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                       supervisor before starting it.
                     </p>
                     <p>
-                      You can configure the exact offsets that the supervisor will read from from
+You can configure the exact offsets that the supervisor will read from using the Actions menu on the Supervisors tab.
                       the action menu on the Supervisor tab after submitting a supervisor in a
                       suspended state.
                     </p>

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3256,9 +3256,10 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                     <p>Create a supervisor in a suspended state.</p>
                     <p>
                       Creating a supervisor in a suspended state can be helpful if you are not yet
-                      ready to begin ingesting data or if you prefer to configure the supervisor's
-                      metadata before submitting it. inserting data yet or if you want to precisely
-                      configure the metadata for the supervisor before starting it.
+                      ready to begin ingesting data or if you prefer to configure the
+                      supervisor&apos;s metadata before submitting it. inserting data yet or if you
+                      want to precisely configure the metadata for the supervisor before starting
+                      it.
                     </p>
                     <p>
                       You can configure the exact offsets that the supervisor will read from using

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3257,14 +3257,11 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                     <p>
                       Creating a supervisor in a suspended state can be helpful if you are not yet
                       ready to begin ingesting data or if you prefer to configure the
-                      supervisor&apos;s metadata before submitting it. inserting data yet or if you
-                      want to precisely configure the metadata for the supervisor before starting
-                      it.
+                      supervisor&apos;s metadata before starting it.
                     </p>
                     <p>
                       You can configure the exact offsets that the supervisor will read from using
-                      the Actions menu on the Supervisors tab. the action menu on the Supervisor tab
-                      after submitting a supervisor in a suspended state.
+                      the <Code>Actions</Code> menu on the <Code>Supervisors</Code> tab.
                     </p>
                   </>
                 ),

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3253,7 +3253,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                 defaultValue: false,
                 info: (
                   <>
-                    <p>Submit this supervisor in a suspended state.</p>
+                    <p>Create a supervisor in a suspended state.</p>
                     <p>
                       Adding a suspended supervisor is useful if you are not ready to start
                       inserting data yet or if you want to precisely configure the metadata for the

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3255,7 +3255,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   <>
                     <p>Create a supervisor in a suspended state.</p>
                     <p>
-                      Adding a suspended supervisor is useful if you are not ready to start
+Creating a supervisor in a suspended state can be helpful if you are not yet ready to begin ingesting data or if you prefer to configure the supervisor's metadata before submitting it.
                       inserting data yet or if you want to precisely configure the metadata for the
                       supervisor before starting it.
                     </p>

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3255,14 +3255,15 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   <>
                     <p>Create a supervisor in a suspended state.</p>
                     <p>
-Creating a supervisor in a suspended state can be helpful if you are not yet ready to begin ingesting data or if you prefer to configure the supervisor's metadata before submitting it.
-                      inserting data yet or if you want to precisely configure the metadata for the
-                      supervisor before starting it.
+                      Creating a supervisor in a suspended state can be helpful if you are not yet
+                      ready to begin ingesting data or if you prefer to configure the supervisor's
+                      metadata before submitting it. inserting data yet or if you want to precisely
+                      configure the metadata for the supervisor before starting it.
                     </p>
                     <p>
-You can configure the exact offsets that the supervisor will read from using the Actions menu on the Supervisors tab.
-                      the action menu on the Supervisor tab after submitting a supervisor in a
-                      suspended state.
+                      You can configure the exact offsets that the supervisor will read from using
+                      the Actions menu on the Supervisors tab. the action menu on the Supervisor tab
+                      after submitting a supervisor in a suspended state.
                     </p>
                   </>
                 ),

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3246,6 +3246,27 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
                   </>
                 ),
               },
+              {
+                name: 'suspended',
+                type: 'boolean',
+                defined: isStreamingSpec,
+                defaultValue: false,
+                info: (
+                  <>
+                    <p>Submit this supervisor in a suspended state.</p>
+                    <p>
+                      Adding a suspended supervisor is useful if you are not ready to start
+                      inserting data yet or if you want to precisely configure the metadata for the
+                      supervisor before starting it.
+                    </p>
+                    <p>
+                      You can configure the exact offsets that the supervisor will read from from
+                      the action menu on the Supervisor tab after submitting a supervisor in a
+                      suspended state.
+                    </p>
+                  </>
+                ),
+              },
             ]}
             model={spec}
             onChange={this.updateSpec}

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -343,14 +343,16 @@ GROUP BY 1, 2`;
       },
       {
         icon: IconNames.STEP_BACKWARD,
-        title: 'Set offsets',
+        title: `Set ${type === 'kinesis' ? 'sequence numbers' : 'offsets'}`,
         onAction: () => this.setState({ resetOffsetsSupervisorInfo: { id, type } }),
+        disabledReason: supervisorSuspended ? undefined : `Supervisor must be suspended`,
       },
       {
         icon: IconNames.STEP_BACKWARD,
         title: 'Hard reset',
         intent: Intent.DANGER,
         onAction: () => this.setState({ resetSupervisorId: id }),
+        disabledReason: supervisorSuspended ? undefined : `Supervisor must be suspended`,
       },
       {
         icon: IconNames.CROSS,


### PR DESCRIPTION
fixes the dialog implemented here https://github.com/apache/druid/pull/14863

Basically the old dialog relied on `latestOffsets` to be set to work. This version does not. In addition it provides a fallback JSON view so it is easy to paste in the metadata.

![image](https://github.com/apache/druid/assets/177816/43273dc1-7120-4390-8e06-062ad63b369a)

Also allows starting a supervisor in a suspended state