### PR TITLE
use PeekableIntIterator for OR filter "partial index" value matchers

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/SqlBenchmark.java
@@ -456,7 +456,9 @@ public class SqlBenchmark
       // 39: EARLIEST aggregator double
       "SELECT EARLIEST(double4) FROM foo",
       // 40: EARLIEST aggregator float
-      "SELECT EARLIEST(float3) FROM foo"
+      "SELECT EARLIEST(float3) FROM foo",
+      // 41: nested OR filter
+      "SELECT dimSequential, COUNT(*) from foo WHERE dimSequential = '1' AND (dimMultivalEnumerated IN ('Hello', 'World', 'Foo', 'Bar', 'Baz') OR sumLongSequential = 1) GROUP BY 1"
   );
 
   @Param({"5000000"})
@@ -520,7 +522,8 @@ public class SqlBenchmark
       "37",
       "38",
       "39",
-      "40"
+      "40",
+      "41"
   })
   private String query;
 


### PR DESCRIPTION
### Description
This PR switches the `OR` filter "partial index" value matchers to use `PeekableIntIterator` instead of `IntIterator` which can dramatically improve performance when these are used on top of an index offset which has a small number of set bits (since we can use `advanceIfNeeded` instead of looping to check `next` until we seek the correct offset). These matchers are used when some sub-filters support indexes we make a synthetic value matcher that checks the index instead of actually evaluating the matchers, which can be quite beneficial, but in certain scenarios can also be rather expensive.


The added benchmark is one such expensive scenario, where the OR filter is nested under an `AND` filter. The equality clause of the AND is rather selective, but the first clause of the `OR` matches all rows, so the while loop of the previous code needs to call `hasNext`/`next` quite a lot to seek to the next offset.

before:
```
Benchmark              (query)  (rowsPerSegment)  (schema)  (storageType)  (stringEncoding)  (vectorize)  Mode  Cnt   Score    Error  Units
SqlBenchmark.querySql       41           5000000  explicit           mmap              none        false  avgt    5  46.568 ± 18.771  ms/op
SqlBenchmark.querySql       41           5000000  explicit           mmap              none        force  avgt    5  13.940 ±  1.099  ms/op
```

after:
```
Benchmark              (query)  (rowsPerSegment)  (schema)  (storageType)  (stringEncoding)  (vectorize)  Mode  Cnt  Score   Error  Units
SqlBenchmark.querySql       41           5000000  explicit           mmap              none        false  avgt    5  2.877 ± 0.347  ms/op
SqlBenchmark.querySql       41           5000000  explicit           mmap              none        force  avgt    5  3.841 ± 1.413  ms/op
```

I should've known to do this in the first place given #8822 and done this as part of #15838, but the second best time is today or something.


<hr>


This PR has:

- [x] been self-reviewed.
- [ ] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
