### PR TITLE
Expose records throughput by partition in live reports

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1635,6 +1635,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
     payload.put("ingestionState", ingestionState);
     payload.put("unparseableEvents", events);
     payload.put("rowStats", doGetRowStats());
+    payload.put("recordsProcessed", partitionsThroughput);
 
     ingestionStatsAndErrors.put("taskId", task.getId());
     ingestionStatsAndErrors.put("payload", payload);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java
@@ -1635,7 +1635,7 @@ public abstract class SeekableStreamIndexTaskRunner<PartitionIdType, SequenceOff
     payload.put("ingestionState", ingestionState);
     payload.put("unparseableEvents", events);
     payload.put("rowStats", doGetRowStats());
-    payload.put("recordsProcessed", partitionsThroughput);
+    payload.put("recordsProcessed", getPartitionStats());
 
     ingestionStatsAndErrors.put("taskId", task.getId());
     ingestionStatsAndErrors.put("payload", payload);


### PR DESCRIPTION
### Description

`recordsProcessed` is already present in the completion task reports. Expose this field for live reports for ease of debugging/usage.

<hr>

##### Key changed/added classes in this PR
 * `SeekableStreamIndexTaskRunner.java`


<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
