### PR TITLE
[CVE Fixes] Update version of Nimbus.jose.jwt

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
-    <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
+    <nimbus.jose.jwt.version>9.37.2</nimbus.jose.jwt.version>
     <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>
   </properties>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -809,7 +809,7 @@ name: com.nimbusds nimbus-jose-jwt
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 8.22.1
+version: 9.37.2
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 


### PR DESCRIPTION
This PR updates the version of Nimbus.jose.jwt dependency. It is needed to remove the CVE https://avd.aquasec.com/nvd/2023/cve-2023-52428/



This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
