### PR TITLE
Fix `ForkingTaskRunnerTest`

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -493,7 +493,7 @@ public class ForkingTaskRunnerTest
                                               + task.getId()
                                               + " must be an array of strings.")
     );
-    Assert.assertEquals(1L, (long) forkingTaskRunner.getWorkerFailedTaskCount());
+    Assert.assertEquals(0L, (long) forkingTaskRunner.getWorkerFailedTaskCount());
     Assert.assertEquals(0L, (long) forkingTaskRunner.getWorkerSuccessfulTaskCount());
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -438,7 +438,6 @@ public class ForkingTaskRunnerTest
   @Test
   public void testInvalidTaskContextJavaOptsArray() throws JsonProcessingException
   {
-    ObjectMapper mapper = new DefaultObjectMapper();
     final String taskContent = "{\n"
                                + "  \"type\" : \"noop\",\n"
                                + "  \"id\" : \"noop_2022-03-25T05:17:34.929Z_3a074de1-74b8-4f6e-84b5-67996144f9ac\",\n"
@@ -463,7 +462,7 @@ public class ForkingTaskRunnerTest
         workerConfig,
         new Properties(),
         new NoopTaskLogs(),
-        mapper,
+        OBJECT_MAPPER,
         new DruidNode("middleManager", "host", false, 8091, null, true, false),
         new StartupLoggingConfig(),
         TaskStorageDirTracker.fromConfigs(workerConfig, taskConfig)


### PR DESCRIPTION
`ForkingTaskRunner` uses static fields to track task counts which are reported in metrics.
This causes some tests like `ForkingTaskRunnerTest.testInvalidTaskContextJavaOptsArray()` to give false positives if the variables had been set by a preceding test. 

Changes:
- Use non-static fields to track task counts in `ForkingTaskRunner`
- Update assertions in tests to ensure that the tests are idempotent.