### PR TITLE
Segment granularity must not be finer than query granularity

### DIFF
--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
@@ -209,7 +209,7 @@ public class GranularityPathSpecTest
             new AggregatorFactory[0],
             new UniformGranularitySpec(
                 Granularities.DAY,
-                Granularities.ALL,
+                Granularities.DAY,
                 ImmutableList.of(Intervals.of("2015-01-01T11Z/2015-01-02T05Z"))
             ),
             null,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1492,7 +1492,7 @@ public class CompactionTaskTest
         null,
         null,
         null,
-        new ClientCompactionTaskGranularitySpec(null, new PeriodGranularity(Period.months(3), null, null), null),
+        new ClientCompactionTaskGranularitySpec(null, Granularities.HOUR, null),
         COORDINATOR_CLIENT,
         segmentCacheManagerFactory,
         METRIC_BUILDER
@@ -1512,7 +1512,7 @@ public class CompactionTaskTest
         AGGREGATORS.stream().map(AggregatorFactory::getCombiningFactory).collect(Collectors.toList()),
         SEGMENT_INTERVALS,
         Granularities.MONTH,
-        new PeriodGranularity(Period.months(3), null, null),
+        Granularities.HOUR,
         BatchIOConfig.DEFAULT_DROP_EXISTING
     );
   }

--- a/server/src/main/java/org/apache/druid/segment/indexing/granularity/UniformGranularitySpec.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/granularity/UniformGranularitySpec.java
@@ -21,7 +21,7 @@ package org.apache.druid.segment.indexing.granularity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.granularity.IntervalsByGranularity;
 import org.joda.time.Interval;
@@ -48,14 +48,11 @@ public class UniformGranularitySpec extends BaseGranularitySpec
     this.queryGranularity = queryGranularity == null ? DEFAULT_QUERY_GRANULARITY : queryGranularity;
     this.segmentGranularity = segmentGranularity == null ? DEFAULT_SEGMENT_GRANULARITY : segmentGranularity;
     if (Granularity.IS_FINER_THAN.compare(this.segmentGranularity, this.queryGranularity) < 0) {
-      throw DruidException.forPersona(DruidException.Persona.USER)
-                          .ofCategory(DruidException.Category.INVALID_INPUT)
-                          .withErrorCode("invalidInput")
-                          .build(
-                              "SegmentGranularity[%s] must not be finer than QueryGranularity[%s].",
-                              this.segmentGranularity,
-                              this.queryGranularity
-                          );
+      throw InvalidInput.exception(
+          "segmentGranularity[%s] must not be finer than queryGranularity[%s].",
+          this.segmentGranularity,
+          this.queryGranularity
+      );
     }
     intervalsByGranularity = new IntervalsByGranularity(this.inputIntervals, segmentGranularity);
     lookupTableBucketByDateTime = new LookupIntervalBuckets(sortedBucketIntervals());

--- a/server/src/main/java/org/apache/druid/segment/indexing/granularity/UniformGranularitySpec.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/granularity/UniformGranularitySpec.java
@@ -49,7 +49,8 @@ public class UniformGranularitySpec extends BaseGranularitySpec
     this.segmentGranularity = segmentGranularity == null ? DEFAULT_SEGMENT_GRANULARITY : segmentGranularity;
     if (Granularity.IS_FINER_THAN.compare(this.segmentGranularity, this.queryGranularity) < 0) {
       throw DruidException.forPersona(DruidException.Persona.USER)
-                          .ofCategory(DruidException.Category.UNSUPPORTED)
+                          .ofCategory(DruidException.Category.INVALID_INPUT)
+                          .withErrorCode("invalidInput")
                           .build(
                               "SegmentGranularity[%s] must not be finer than QueryGranularity[%s].",
                               this.segmentGranularity,

--- a/server/src/test/java/org/apache/druid/segment/indexing/granularity/UniformGranularityTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/granularity/UniformGranularityTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -287,8 +288,8 @@ public class UniformGranularityTest
     notEqualsCheck(
         spec,
         new UniformGranularitySpec(
-            Granularities.DAY,
             Granularities.ALL,
+            Granularities.DAY,
             Lists.newArrayList(
                 Intervals.of("2012-01-08T00Z/2012-01-11T00Z"),
                 Intervals.of("2012-01-07T00Z/2012-01-08T00Z"),
@@ -356,6 +357,18 @@ public class UniformGranularityTest
     int count = Iterators.size(spec.sortedBucketIntervals().iterator());
     // account for three leap years...
     Assert.assertEquals(3600 * 24 * 365 * 10 + 3 * 24 * 3600, count);
+  }
+
+  @Test(expected = DruidException.class)
+  public void testCheckGranularityValidity()
+  {
+    new UniformGranularitySpec(
+        Granularities.SECOND,
+        Granularities.MINUTE,
+        Collections.singletonList(
+            Intervals.of("2012-01-01T00Z/P10Y")
+        )
+    );
   }
 
   private void notEqualsCheck(GranularitySpec spec1, GranularitySpec spec2)

--- a/server/src/test/java/org/apache/druid/segment/indexing/granularity/UniformGranularityTest.java
+++ b/server/src/test/java/org/apache/druid/segment/indexing/granularity/UniformGranularityTest.java
@@ -369,21 +369,25 @@ public class UniformGranularityTest
   {
     final Granularity secondGranularity = Granularities.SECOND;
     final Granularity secondDurationGranularity = new DurationGranularity(1000, 0);
-    try {
-      new UniformGranularitySpec(
-          secondGranularity,
-          secondGranularity,
-          Collections.emptyList()
-      );
-      new UniformGranularitySpec(
-          secondGranularity,
-          secondDurationGranularity,
-          Collections.emptyList()
-      );
-    }
-    catch (DruidException e) {
-      Assert.fail();
-    }
+    final GranularitySpec granularitySpec0 = new UniformGranularitySpec(
+        secondGranularity,
+        secondGranularity,
+        Collections.emptyList()
+    );
+    Assert.assertEquals(granularitySpec0.getSegmentGranularity(), granularitySpec0.getQueryGranularity());
+
+    final GranularitySpec granularitySpec1 = new UniformGranularitySpec(
+        secondGranularity,
+        secondDurationGranularity,
+        Collections.emptyList()
+    );
+    Assert.assertEquals(
+        0,
+        Granularity.IS_FINER_THAN.compare(
+            granularitySpec1.getQueryGranularity(),
+            granularitySpec1.getSegmentGranularity()
+        )
+    );
   }
 
   @Test
@@ -403,7 +407,7 @@ public class UniformGranularityTest
         ),
         DruidExceptionMatcher.invalidInput().expectMessageIs(
             StringUtils.format(
-                "SegmentGranularity[%s] must not be finer than QueryGranularity[%s].",
+                "segmentGranularity[%s] must not be finer than queryGranularity[%s].",
                 segmentGranularity,
                 queryGranularity
             )


### PR DESCRIPTION
A Task or Supervisor must not have its segment granularity strictly finer than its query granularity.

### Problem

Today, an appending task fails during segment allocation in cases of such misconfiguration. When such a supervisor is submitted, the tasks are spawned and failed repetitively and this leads to a waste of resources.

### Changes

This PR adds a check to ensure that the UniformGranularitySpec has a segment granularity equal to or coarser than its query granularity.

### Testing

Verified that tasks cannot be submitted with a segment granularity finer than the query granularity.
Similarly, verified that a new supervisor with such a misconfigured granularity spec cannot be submitted. Also, ensured that an existing supervisor is unaffected after attempting to submit such a supervisor with the same id.

#### Release note
Submission of ingestion tasks and supervisors having segment granularities strictly finer than their query granularities is now disallowed.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
