### PR TITLE
Fix log count when submitting kill tasks

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -239,7 +239,7 @@ public class KillUnusedSegments implements CoordinatorDuty
 
     log.info(
         "Submitted [%d] kill tasks for [%d] datasources. Remaining datasources to kill: %s",
-        submittedTasks, dataSourcesToKill.size(), remainingDatasourcesToKill
+        submittedTasks, dataSourcesToKill.size() - remainingDatasourcesToKill.size(), remainingDatasourcesToKill
     );
 
     stats.add(Stats.Kill.SUBMITTED_TASKS, submittedTasks);


### PR DESCRIPTION
### Description

While watching the auto-kill task logs, I noticed that the log count for the number of datasources affected by the auto-kill tasks can be wrong in case the kill task limit was hit.

This PR fixes that log message.

<hr>

This PR has:

- [x] been self-reviewed.
