### PR TITLE
Disable upload of coverage report to codecov.io

### DIFF
--- a/.github/scripts/unit_tests_script.sh
+++ b/.github/scripts/unit_tests_script.sh
@@ -74,5 +74,7 @@ then
   { printf "\n\n****FAILED****\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\nFor more details on how to run code coverage locally, follow instructions here - https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md#running-code-coverage-locally\n\n" && echo "coverage_failure=true" >> "$GITHUB_ENV" && false; }
 fi
 
+# Commented out as codecov visualizations are currently not being used in the Druid community
+# and cause PR failures due to rate limiting (see https://github.com/apache/druid/pull/16347)
 # { for i in 1 2 3; do curl -o codecov.sh -s https://codecov.io/bash && break || sleep 15; done }
 # { for i in 1 2 3; do bash codecov.sh -X gcov && break || sleep 15; done }

--- a/.github/scripts/unit_tests_script.sh
+++ b/.github/scripts/unit_tests_script.sh
@@ -74,5 +74,5 @@ then
   { printf "\n\n****FAILED****\nDiff code coverage check failed. To view coverage report, run 'mvn clean test jacoco:report' and open 'target/site/jacoco/index.html'\nFor more details on how to run code coverage locally, follow instructions here - https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md#running-code-coverage-locally\n\n" && echo "coverage_failure=true" >> "$GITHUB_ENV" && false; }
 fi
 
-{ for i in 1 2 3; do curl -o codecov.sh -s https://codecov.io/bash && break || sleep 15; done }
-{ for i in 1 2 3; do bash codecov.sh -X gcov && break || sleep 15; done }
+# { for i in 1 2 3; do curl -o codecov.sh -s https://codecov.io/bash && break || sleep 15; done }
+# { for i in 1 2 3; do bash codecov.sh -X gcov && break || sleep 15; done }


### PR DESCRIPTION
### Description 

Build of recent PRs is getting stuck due to rate limiting of the codecov.io API. The unit test job just keeps retrying to connect.

```sql
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 153 seconds.', code='throttled')}
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 0 seconds.', code='throttled')}
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 3598 seconds.', code='throttled')}
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 3598 seconds.', code='throttled')}
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected available in 0 seconds.', code='throttled')}
{'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue.
```

Sample failing job:
https://github.com/apache/druid/actions/runs/8875278501/job/24364864254?pr=15705

### Fix

In `unit_tests_script.sh` , disable upload of coverage report to codecov.io.

### Impact

No one in the Druid community seems to be using the codecov visualization to analyse code coverage.
Most contributors look at the reports generated by jacoco itself and use that to ensure full coverage.

In the future, if we feel the need to re-enable it we may uncomment the code.