### PR TITLE
Fix defaults of segment schema cleanup

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/DruidCoordinatorConfig.java
@@ -172,10 +172,10 @@ public abstract class DruidCoordinatorConfig
   public abstract boolean isSegmentSchemaKillEnabled();
 
   @Config("druid.coordinator.kill.segmentSchema.period")
-  @Default("PT1H")
+  @Default("P1D")
   public abstract Duration getSegmentSchemaKillPeriod();
 
   @Config("druid.coordinator.kill.segmentSchema.durationToRetain")
-  @Default("PT6H")
+  @Default("P90D")
   public abstract Duration getSegmentSchemaKillDurationToRetain();
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorConfigTest.java
@@ -39,11 +39,13 @@ public class DruidCoordinatorConfigTest
     Assert.assertEquals(new Duration("PT60s"), config.getCoordinatorPeriod());
     Assert.assertEquals(new Duration("PT1800s"), config.getCoordinatorIndexingPeriod());
     Assert.assertEquals(new Duration("PT1800s"), config.getCoordinatorKillPeriod());
-    Assert.assertEquals(new Duration("PT7776000s"), config.getCoordinatorKillDurationToRetain());
+    Assert.assertEquals(Duration.standardDays(90), config.getCoordinatorKillDurationToRetain());
     Assert.assertEquals(100, config.getCoordinatorKillMaxSegments());
     Assert.assertEquals(new Duration(15 * 60 * 1000), config.getLoadTimeoutDelay());
     Assert.assertFalse(config.getCoordinatorKillIgnoreDurationToRetain());
     Assert.assertEquals("http", config.getLoadQueuePeonType());
+    Assert.assertEquals(Duration.standardDays(1), config.getSegmentSchemaKillPeriod());
+    Assert.assertEquals(Duration.standardDays(90), config.getSegmentSchemaKillDurationToRetain());
   }
 
   @Test


### PR DESCRIPTION
These changes are to align with the default values of segment schema cleanup used in #15705 .

The current values of `period = 1 hour`, `durationToRetain = 6 hours` is too aggressive.
All other metadata cleanup configs use `period = 1 day`, `durationToRetain = 90 days`.
