### PR TITLE
update dependencies to address CVEs

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.19</version>
+                <version>1.2.23</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4223,7 +4223,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.11.4
+version: 1.12.0
 libraries:
   - com.azure: azure-identity
 
@@ -4234,9 +4234,20 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 12.25.4
+version: 12.21.4
 libraries:
   - com.azure: azure-storage-blob-batch
+
+---
+
+name: Microsoft Azure  Blob Storage SDK
+license_category: binary
+module: extensions/druid-azure-extensions
+license_name: MIT License
+copyright: Microsoft
+version: 12.25.4
+libraries:
+  - com.azure: azure-storage-blob
 
 ---
 
@@ -4256,7 +4267,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 12.10.3
+version: 12.10.4
 libraries:
   - com.azure: azure-storage-internal-avro
 
@@ -4270,6 +4281,17 @@ copyright: Microsoft
 version: 1.1.0
 libraries:
   - com.azure: azure-json
+
+---
+
+name: Microsoft Azure XML
+license_category: binary
+module: extensions/druid-azure-extensions
+license_name: MIT License
+copyright: Microsoft
+version: 1.0.0
+libraries:
+  - com.azure: azure-xml
 
 ---
 name: Microsoft Azure Netty Http
@@ -4299,7 +4321,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.14.0
+version: 1.15.0
 libraries:
   - com.microsoft.azure: msal4j
 
@@ -4310,7 +4332,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.2.0
+version: 1.3.0
 libraries:
   - com.microsoft.azure: msal4j-persistence-extension
 
@@ -4320,7 +4342,7 @@ name: NimbusDS Content Type
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 2.2
+version: 2.3
 libraries:
   - com.nimbusds: content-type
 
@@ -4330,7 +4352,7 @@ name: NimbusDS Jose
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 9.30.2
+version: 9.37.3
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 
@@ -4340,7 +4362,7 @@ name: NimbusDS Oauth
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 10.7.1
+version: 11.9.1
 libraries:
   - com.nimbusds: oauth2-oidc-sdk
 
@@ -4350,7 +4372,7 @@ name: Reactor Netty
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 1.0.39
+version: 1.0.43
 libraries:
   - io.projectreactor.netty: reactor-netty-core
   - io.projectreactor.netty: reactor-netty-http
@@ -4361,7 +4383,7 @@ name: Reactor Core
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 3.4.34
+version: 3.4.36
 libraries:
   - io.projectreactor: reactor-core
 ---

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -652,7 +652,7 @@ name: Apache Commons Configuration
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.8.0
+version: 2.10.1
 libraries:
   - org.apache.commons: commons-configuration2
 
@@ -1054,7 +1054,7 @@ name: org.bouncycastle bcprov-jdk18on
 license_category: binary
 module: extensions/druid-kubernetes-extensions
 license_name: MIT License
-version: "1.76"
+version: "1.78.1"
 libraries:
   - org.bouncycastle: bcprov-jdk18on
   - org.bouncycastle: bcprov-ext-jdk18on
@@ -4223,7 +4223,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.11.1
+version: 1.11.4
 libraries:
   - com.azure: azure-identity
 
@@ -4234,7 +4234,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 12.21.1
+version: 12.25.4
 libraries:
   - com.azure: azure-storage-blob-batch
 
@@ -4245,7 +4245,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 12.24.1
+version: 12.24.4
 libraries:
   - com.azure: azure-storage-common
 
@@ -4256,7 +4256,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 12.10.1
+version: 12.10.3
 libraries:
   - com.azure: azure-storage-internal-avro
 
@@ -4277,7 +4277,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.13.11
+version: 1.14.2
 libraries:
   - com.azure: azure-core-http-netty
 
@@ -4288,7 +4288,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.45.1
+version: 1.48.0
 libraries:
   - com.azure: azure-core
 

--- a/pom.xml
+++ b/pom.xml
@@ -405,6 +405,20 @@
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
             </dependency>
+            <!-- Transitive dependency of kubernetes-client java and docker-java-core
+            in kubernetes-extensions and it-integration tests -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.78.1</version>
+            </dependency>
+            <!-- Transitive dependency of hive-common in druid-kerberos, druid-ranger-security and
+            druid-iceberg-extension  -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.10.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>


### PR DESCRIPTION
### Description
Update dependencies:
- Azure POM from 1.2.19 to 1.2.23 to update transitive dependency nimbus-jose-jwt to address:  CVE-2023-52428
- commons-configuration2 from 2.8.0 to 2.10.1 to address: CVE-2024-29131 CVE-2024-29133
- bcpkix-jdk18on from 1.76 to 1.78.1 to address: CVE-2024-30172 CVE-2024-30171 CVE-2024-29857

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
