### PR TITLE
Use mutable Map for creating DruidPlanner in DruidViewMacro

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -59,6 +59,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -160,7 +161,7 @@ public class PlannerContext
     this.sql = sql;
     this.plannerConfig = Preconditions.checkNotNull(plannerConfig, "plannerConfig");
     this.engine = engine;
-    this.queryContext = queryContext;
+    this.queryContext = new HashMap<>(queryContext);
     this.localNow = Preconditions.checkNotNull(localNow, "localNow");
     this.stringifyArrays = stringifyArrays;
     this.useBoundsAndSelectors = useBoundsAndSelectors;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
@@ -32,7 +32,7 @@ import org.apache.druid.sql.calcite.planner.DruidPlanner;
 import org.apache.druid.sql.calcite.planner.PlannerFactory;
 import org.apache.druid.sql.calcite.schema.DruidSchemaName;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 
 public class DruidViewMacro implements TableMacro
@@ -61,7 +61,7 @@ public class DruidViewMacro implements TableMacro
              plannerFactory.createPlanner(
                  ViewSqlEngine.INSTANCE,
                  viewSql,
-                 new HashMap<>(),
+                 Collections.emptyMap(),
                  null
              )
     ) {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
@@ -32,7 +32,7 @@ import org.apache.druid.sql.calcite.planner.DruidPlanner;
 import org.apache.druid.sql.calcite.planner.PlannerFactory;
 import org.apache.druid.sql.calcite.schema.DruidSchemaName;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class DruidViewMacro implements TableMacro
@@ -61,7 +61,7 @@ public class DruidViewMacro implements TableMacro
              plannerFactory.createPlanner(
                  ViewSqlEngine.INSTANCE,
                  viewSql,
-                 Collections.emptyMap(),
+                 new HashMap<>(),
                  null
              )
     ) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/PlannerContextTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/PlannerContextTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.druid.query.QueryRunnerFactoryConglomerate;
+import org.apache.druid.query.QuerySegmentWalker;
+import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
+import org.apache.druid.sql.calcite.planner.CatalogResolver;
+import org.apache.druid.sql.calcite.planner.NoOpPlannerHook;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.planner.PlannerToolbox;
+import org.apache.druid.sql.calcite.run.NativeSqlEngine;
+import org.apache.druid.sql.calcite.schema.DruidSchema;
+import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
+import org.apache.druid.sql.calcite.schema.NamedDruidSchema;
+import org.apache.druid.sql.calcite.schema.NamedViewSchema;
+import org.apache.druid.sql.calcite.schema.ViewSchema;
+import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class PlannerContextTest
+{
+
+  private static final PlannerToolbox PLANNER_TOOLBOX = new PlannerToolbox(
+      CalciteTests.createOperatorTable(),
+      CalciteTests.createExprMacroTable(),
+      CalciteTests.getJsonMapper(),
+      new PlannerConfig(),
+      new DruidSchemaCatalog(
+          EasyMock.createMock(SchemaPlus.class),
+          ImmutableMap.of(
+              "druid", new NamedDruidSchema(EasyMock.createMock(DruidSchema.class), "druid"),
+              NamedViewSchema.NAME, new NamedViewSchema(EasyMock.createMock(ViewSchema.class))
+          )
+      ),
+      CalciteTests.createJoinableFactoryWrapper(),
+      CatalogResolver.NULL_RESOLVER,
+      "druid",
+      new CalciteRulesManager(ImmutableSet.of()),
+      CalciteTests.TEST_AUTHORIZER_MAPPER,
+      AuthConfig.newBuilder().build()
+  );
+
+  private static final NativeSqlEngine ENGINE = CalciteTests.createMockSqlEngine(
+      EasyMock.createMock(QuerySegmentWalker.class),
+      EasyMock.createMock(QueryRunnerFactoryConglomerate.class)
+  );
+
+  private static final String SQL = "SELECT 1";
+
+  @Test
+  public void testCreate()
+  {
+    PlannerContext plannerContext = PlannerContext.create(PLANNER_TOOLBOX,
+                                                          SQL, // The actual query isn't important for this test
+                                                          ENGINE,
+                                                          Collections.emptyMap(),
+                                                          null);
+
+    Assert.assertEquals(PLANNER_TOOLBOX, plannerContext.getPlannerToolbox());
+    Assert.assertEquals(SQL, plannerContext.getSql());
+    Assert.assertEquals(ENGINE, plannerContext.getEngine());
+    Assert.assertEquals(NoOpPlannerHook.INSTANCE, plannerContext.getPlannerHook());
+    Assert.assertTrue(plannerContext.queryContextMap().isEmpty());
+
+    // Validate that the map is mutable, even though an immutable map was passed during creation.
+    plannerContext.queryContextMap().put("test", "value");
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/PlannerContextTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/PlannerContextTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.sql.calcite.schema.ViewSchema;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.easymock.EasyMock;
 import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -74,21 +75,31 @@ public class PlannerContextTest
 
   private static final String SQL = "SELECT 1";
 
+  private static PlannerContext plannerContext;
+
+  @BeforeEach
+  public void setup()
+  {
+    plannerContext = PlannerContext.create(PLANNER_TOOLBOX,
+                          SQL, // The actual query isn't important for this test
+                          ENGINE,
+                          Collections.emptyMap(),
+                          null);
+  }
+
   @Test
   public void testCreate()
   {
-    PlannerContext plannerContext = PlannerContext.create(PLANNER_TOOLBOX,
-                                                          SQL, // The actual query isn't important for this test
-                                                          ENGINE,
-                                                          Collections.emptyMap(),
-                                                          null);
-
     Assert.assertEquals(PLANNER_TOOLBOX, plannerContext.getPlannerToolbox());
     Assert.assertEquals(SQL, plannerContext.getSql());
     Assert.assertEquals(ENGINE, plannerContext.getEngine());
     Assert.assertEquals(NoOpPlannerHook.INSTANCE, plannerContext.getPlannerHook());
     Assert.assertTrue(plannerContext.queryContextMap().isEmpty());
+  }
 
+  @Test
+  public void testMutabilityOfQueryContextMap()
+  {
     // Validate that the map is mutable, even though an immutable map was passed during creation.
     plannerContext.queryContextMap().put("test", "value");
   }


### PR DESCRIPTION
### Description

Currently, `DruidViewMacro` was using `Collections.emptyMap()`, that is, an immutable map for creating the DruidPlanner. This doesn't sit well with the contract of `PlannerContext#queryContextMap` which is expected to return a mutable map.

Currently, if anyone were to rely on getting a mutable map as per the contract, it can run into issues in code flows where the planner is being created using immutable map. For example, 500+ tests failed because of adding [this line](https://github.com/apache/druid/pull/16358/files#diff-630eb92856c1b8dd3034980b486124e31952c8eef0a9195bbacb9bbe310a3023R84) since I assumed the return type must be mutable.

This PR shifts away from the immutable map for creating planner to ensure everyone can rely on the returned map being mutable without breaking any code flows. With this PR, the planner's constructor creates a mutable map even if an immutable map was passed to it.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
