### PR TITLE
Web console change for Delta filter

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -1030,6 +1030,27 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           type: 'string',
           placeholder: '/path/to/deltaTable',
           required: true,
+          info: (
+            <>
+              <p>A full path to the Delta Lake table.</p>
+            </>
+          ),
+        },
+        {
+          name: 'inputSource.filter',
+          label: 'Delta filter',
+          type: 'json',
+          defaultValue: {},
+          info: (
+            <>
+              <ExternalLink
+                href={`${getLink('DOCS')}/ingestion/input-sources/#delta-filter-object`}
+              >
+                filter
+              </ExternalLink>
+              <p>A Delta filter json object to filter Delta Lake scan files.</p>
+            </>
+          ),
         },
       ];
 

--- a/web-console/src/druid-models/input-source/input-source.tsx
+++ b/web-console/src/druid-models/input-source/input-source.tsx
@@ -117,7 +117,8 @@ export type InputSourceDesc =
     }
   | {
       type: 'delta';
-      tablePath?: string;
+      tablePath: string;
+      filter?: string;
     }
   | {
       type: 'sql';
@@ -624,6 +625,27 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
     placeholder: '/path/to/deltaTable',
     defined: typeIsKnown(KNOWN_TYPES, 'delta'),
     required: true,
+    info: (
+      <>
+        <p>A full path to the Delta Lake table.</p>
+      </>
+    ),
+  },
+  {
+    name: 'filter',
+    label: 'Delta filter',
+    type: 'json',
+    placeholder: '{"type": "=", "column": "name", "value": "foo"}',
+    defined: inputSource => inputSource.type === 'delta' && deepGet(inputSource, 'filter'),
+    required: false,
+    info: (
+      <>
+        <ExternalLink href={`${getLink('DOCS')}/ingestion/input-sources/#delta-filter-object`}>
+          filter
+        </ExternalLink>
+        <p>A Delta filter json object to filter Delta Lake scan files.</p>
+      </>
+    ),
   },
 
   // sql


### PR DESCRIPTION
This patch adds a text box for the Delta Lake filter for the backend changes made in https://github.com/apache/druid/pull/16288.  The text box accepts an optional json object that is passed down as the `filter` to the delta input source: 

<img width="326" alt="CleanShot 2024-05-02 at 14 02 57@2x" src="https://github.com/apache/druid/assets/8687261/d605d7ab-ae92-4f54-b758-efbe233cc481">

The tooltip directs the user to the relevant documentation section on how to use the filter object for the delta input source (when the docs go live).

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
