### PR TITLE
Maintain a connection while exporting results with MSQ

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
@@ -142,7 +142,7 @@ public class ExportResultsFrameProcessor implements FrameProcessor<Object>
     }
   }
 
-  private void exportFrame(final Frame frame) throws IOException
+  private void exportFrame(final Frame frame)
   {
     final Sequence<Cursor> cursorSequence =
         new FrameStorageAdapter(frame, frameReader, Intervals.ETERNITY)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
@@ -202,7 +202,9 @@ public class ExportResultsFrameProcessor implements FrameProcessor<Object>
   {
     FrameProcessors.closeAll(inputChannels(), outputChannels());
 
-    exportWriter.writeResponseEnd();
-    exportWriter.close();
+    if (exportWriter != null) {
+      exportWriter.writeResponseEnd();
+      exportWriter.close();
+    }
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
@@ -128,7 +128,7 @@ public class ExportResultsFrameProcessor implements FrameProcessor<Object>
   }
 
   @Override
-  public ReturnOrAwait<Object> runIncrementally(IntSet readableInputs) throws IOException
+  public ReturnOrAwait<Object> runIncrementally(IntSet readableInputs)
   {
     if (readableInputs.isEmpty()) {
       return ReturnOrAwait.awaitAll(1);

--- a/processing/src/main/java/org/apache/druid/storage/StorageConnector.java
+++ b/processing/src/main/java/org/apache/druid/storage/StorageConnector.java
@@ -90,12 +90,13 @@ public interface StorageConnector
 
   /**
    * Open an {@link OutputStream} for writing data to the path in the underlying storage system.
-   * Most implementations prepend the input path with a basePath.
+   * Most implementations prepend the input path with a basePath. If an object exists at the path,
+   * the existing object will be overwritten by the write operation.
    * Callers are adivised to namespace there files as there might be race conditions.
    * The caller should take care of closing the stream when done or in case of error.
    *
-   * @param path
-   * @return
+   * @param path to write
+   * @return OutputStream to the path
    * @throws IOException
    */
   OutputStream write(String path) throws IOException;

--- a/processing/src/main/java/org/apache/druid/storage/local/LocalFileStorageConnector.java
+++ b/processing/src/main/java/org/apache/druid/storage/local/LocalFileStorageConnector.java
@@ -101,7 +101,7 @@ public class LocalFileStorageConnector implements StorageConnector
   {
     File toWrite = fileWithBasePath(path);
     FileUtils.mkdirp(toWrite.getParentFile());
-    return Files.newOutputStream(toWrite.toPath(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    return Files.newOutputStream(toWrite.toPath());
   }
 
   /**


### PR DESCRIPTION
Fixes a bug with exporting results with MSQ.

MSQ uses StorageConnectors to connect to external locations and write results during the export stage. However, certain implementations of storage connectors overwrite the older version of the file at the same path. This can result in files being overwritten during a single export query, ultimately causing missing results.

This PR aims to resolve this by maintaining a connection with the destination.

Testing with the PR locally, files do not get overwritten.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
