### PR TITLE
Remove stale references to `killAllDataSources`

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -266,12 +266,6 @@ public class CoordinatorDynamicConfig
     return maxKillTaskSlots;
   }
 
-  @JsonIgnore
-  public boolean isKillUnusedSegmentsInAllDataSources()
-  {
-    return specificDataSourcesToKillUnusedSegmentsIn.isEmpty();
-  }
-
   @JsonProperty("killPendingSegmentsSkipList")
   public Set<String> getDataSourcesToNotKillStalePendingSegmentsIn()
   {

--- a/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/CoordinatorDynamicConfigTest.java
@@ -263,7 +263,6 @@ public class CoordinatorDynamicConfigTest
         false,
         null
     );
-    Assert.assertTrue(config.isKillUnusedSegmentsInAllDataSources());
     Assert.assertTrue(config.getSpecificDataSourcesToKillUnusedSegmentsIn().isEmpty());
   }
 
@@ -290,7 +289,6 @@ public class CoordinatorDynamicConfigTest
         false,
         null
     );
-    Assert.assertFalse(config.isKillUnusedSegmentsInAllDataSources());
     Assert.assertEquals(ImmutableSet.of("test1"), config.getSpecificDataSourcesToKillUnusedSegmentsIn());
   }
 
@@ -469,60 +467,6 @@ public class CoordinatorDynamicConfigTest
   }
 
   @Test
-  public void testSerdeWithKillAllDataSources() throws Exception
-  {
-    String jsonStr = "{\n"
-                     + "  \"millisToWaitBeforeDeleting\": 1,\n"
-                     + "  \"mergeBytesLimit\": 1,\n"
-                     + "  \"mergeSegmentsLimit\" : 1,\n"
-                     + "  \"maxSegmentsToMove\": 1,\n"
-                     + "  \"replicantLifetime\": 1,\n"
-                     + "  \"replicationThrottleLimit\": 1,\n"
-                     + "  \"balancerComputeThreads\": 2, \n"
-                     + "  \"killAllDataSources\": true,\n"
-                     + "  \"maxSegmentsInNodeLoadingQueue\": 1\n"
-                     + "}\n";
-
-    CoordinatorDynamicConfig actual = mapper.readValue(
-        mapper.writeValueAsString(
-            mapper.readValue(jsonStr, CoordinatorDynamicConfig.class)
-        ),
-        CoordinatorDynamicConfig.class
-    );
-
-    assertConfig(
-        actual,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
-        2,
-        ImmutableSet.of(),
-        0.1,
-        Integer.MAX_VALUE,
-        true,
-        1,
-        ImmutableSet.of(),
-        false,
-        false
-    );
-
-    // killAllDataSources is a config in versions 0.22.x and older and is no longer used.
-    // This used to be an invalid config, but as of 0.23.0 the killAllDataSources flag no longer exsist,
-    // so this is a valid config
-    jsonStr = "{\n"
-              + "  \"killDataSourceWhitelist\": [\"test1\",\"test2\"],\n"
-              + "  \"killAllDataSources\": true\n"
-              + "}\n";
-    actual = mapper.readValue(jsonStr, CoordinatorDynamicConfig.class);
-
-    Assert.assertFalse(actual.isKillUnusedSegmentsInAllDataSources());
-    Assert.assertEquals(2, actual.getSpecificDataSourcesToKillUnusedSegmentsIn().size());
-  }
-
-  @Test
   public void testDeserializeWithoutMaxSegmentsInNodeLoadingQueue() throws Exception
   {
     String jsonStr = "{\n"
@@ -532,8 +476,7 @@ public class CoordinatorDynamicConfigTest
                      + "  \"maxSegmentsToMove\": 1,\n"
                      + "  \"replicantLifetime\": 1,\n"
                      + "  \"replicationThrottleLimit\": 1,\n"
-                     + "  \"balancerComputeThreads\": 2, \n"
-                     + "  \"killAllDataSources\": true\n"
+                     + "  \"balancerComputeThreads\": 2\n"
                      + "}\n";
 
     CoordinatorDynamicConfig actual = mapper.readValue(
@@ -691,7 +634,6 @@ public class CoordinatorDynamicConfigTest
         expectedSpecificDataSourcesToKillUnusedSegmentsIn,
         config.getSpecificDataSourcesToKillUnusedSegmentsIn()
     );
-    Assert.assertEquals(expectedKillUnusedSegmentsInAllDataSources, config.isKillUnusedSegmentsInAllDataSources());
     Assert.assertEquals(expectedKillTaskSlotRatio, config.getKillTaskSlotRatio(), 0.001);
     Assert.assertEquals((int) expectedMaxKillTaskSlots, config.getMaxKillTaskSlots());
     Assert.assertEquals(expectedMaxSegmentsInNodeLoadingQueue, config.getMaxSegmentsInNodeLoadingQueue());

--- a/web-console/src/druid-models/coordinator-dynamic-config/coordinator-dynamic-config.tsx
+++ b/web-console/src/druid-models/coordinator-dynamic-config/coordinator-dynamic-config.tsx
@@ -26,7 +26,6 @@ import { getLink } from '../../links';
 export interface CoordinatorDynamicConfig {
   maxSegmentsToMove?: number;
   balancerComputeThreads?: number;
-  killAllDataSources?: boolean;
   killDataSourceWhitelist?: string[];
   killTaskSlotRatio?: number;
   maxKillTaskSlots?: number;


### PR DESCRIPTION
The coordinator dynamic config `killAllDataSources` has been removed since Druid 0.23.0: https://github.com/apache/druid/pull/12187.

As we can see in this patch, the configuration was used only in tests, with no real usage. But since it has been many releases, this patch removes all stale references to it to avoid any confusion.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
