### PR TITLE
Fix the bug in Immutable RTree object strategy

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/ImmutableRTreeObjectStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ImmutableRTreeObjectStrategy.java
@@ -63,6 +63,7 @@ public class ImmutableRTreeObjectStrategy implements ObjectStrategy<ImmutableRTr
   @Override
   public ImmutableRTree fromByteBuffer(ByteBuffer buffer, int numBytes)
   {
+    // always create the duplicate buffer for creating the objects as original buffer may have mutations somewhere else which can corrupt objects
     ByteBuffer duplicateBuf = buffer.duplicate();
     duplicateBuf.limit(duplicateBuf.position() + numBytes);
     return new ImmutableRTree(duplicateBuf, bitmapFactory);

--- a/processing/src/main/java/org/apache/druid/segment/data/ImmutableRTreeObjectStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ImmutableRTreeObjectStrategy.java
@@ -63,8 +63,9 @@ public class ImmutableRTreeObjectStrategy implements ObjectStrategy<ImmutableRTr
   @Override
   public ImmutableRTree fromByteBuffer(ByteBuffer buffer, int numBytes)
   {
-    buffer.limit(buffer.position() + numBytes);
-    return new ImmutableRTree(buffer, bitmapFactory);
+    ByteBuffer duplicateBuf = buffer.duplicate();
+    duplicateBuf.limit(duplicateBuf.position() + numBytes);
+    return new ImmutableRTree(duplicateBuf, bitmapFactory);
   }
 
   @Override


### PR DESCRIPTION

### Description

This PR fixes the bug in the ImmutableRTreeObjectStrategy deserializing fromByteBuffer was violating the contract, it only happens intermittently on realtime nodes where rTree gets updating on the merge phase. I have added unit test case to simulate the scenario.  
```
java.lang.IndexOutOfBoundsException: null
	at java.nio.Buffer.checkIndex(Buffer.java:693) ~[?:?]
	at java.nio.DirectByteBuffer.getInt(DirectByteBuffer.java:758) ~[?:?]
	at org.roaringbitmap.buffer.ImmutableRoaringArray.getOffsetContainer(ImmutableRoaringArray.java:335) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.ImmutableRoaringArray.computeSerializedSizeInBytes(ImmutableRoaringArray.java:136) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.ImmutableRoaringArray.<init>(ImmutableRoaringArray.java:52) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.ImmutableRoaringBitmap.<init>(ImmutableRoaringBitmap.java:1057) ~[RoaringBitmap-0.9.49.jar:?]
	at org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap.<init>(WrappedImmutableRoaringBitmap.java:38) ~[druid-processing-2024.01.3-lts-iap.jar:2024.01.3-lts-iap]
	at org.apache.druid.collections.bitmap.RoaringBitmapFactory.mapImmutableBitmap(RoaringBitmapFactory.java:126) ~[druid-processing-2024.01.3-lts-iap.jar:2024.01.3-lts-iap]
	at org.apache.druid.collections.spatial.ImmutableNode.getImmutableBitmap(ImmutableNode.java:153) ~[druid-processing-2024.01.3-lts-iap.jar:2024.01.3-lts-iap]
	at org.apache.druid.collections.spatial.search.GutmanSearchStrategy$2.apply(GutmanSearchStrategy.java:57) ~[druid-processing-2024.01.3-lts-iap.jar:2024.01.3-lts-iap]
	at org.apache.druid.collections.spatial.search.GutmanSearchStrategy$2.apply(GutmanSearchStrategy.java:53) ~[druid-processing-2024.01.3-lts-iap.jar:2024.01.3-lts-iap]
	at com.google.common.collect.Iterators$6.transform(Iterators.java:828) ~[guava-32.0.1-jre.jar:?]
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52) ~[guava-32.0.1-jre.jar:?]
```

Thank you very much  @gianm @cheddar for your help.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
