### PR TITLE
fix capacity issue for category aware

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+import org.apache.druid.guice.annotations.PublicApi;
+
+import java.util.List;
+
+
+/**
+ * A snapshot of all Worker and its current state.
+ */
+@PublicApi
+public class CategoryCapacityInfo
+{
+  private final List<String> taskTypeList;
+  private final int capacity;
+
+  @JsonCreator
+  public CategoryCapacityInfo(
+      @JsonProperty("taskType") List<String> taskTypeList,
+      @JsonProperty("capacity") int capacity
+  )
+  {
+    this.taskTypeList = taskTypeList;
+    this.capacity = capacity;
+  }
+
+  @JsonProperty("taskType")
+  public List<String> getTaskTypeList()
+  {
+    return taskTypeList;
+  }
+
+  @JsonProperty("capacity")
+  public int getCapacity()
+  {
+    return capacity;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CategoryCapacityInfo that = (CategoryCapacityInfo) o;
+
+    if (!taskTypeList.equals(that.taskTypeList)) {
+      return false;
+    }
+    if (capacity != that.capacity) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hashCode(taskTypeList, capacity);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "CapacityInfo{" +
+           ", taskTypeList=" + taskTypeList.toString() +
+           ", capacity=" + capacity;
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
@@ -22,9 +22,8 @@ package org.apache.druid.indexing.overlord;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import org.apache.druid.guice.annotations.PublicApi;
-
-import java.util.List;
 
 
 /**
@@ -33,12 +32,12 @@ import java.util.List;
 @PublicApi
 public class CategoryCapacityInfo
 {
-  private final List<String> taskTypeList;
+  private ImmutableList<String> taskTypeList;
   private final int capacity;
 
   @JsonCreator
   public CategoryCapacityInfo(
-      @JsonProperty("taskType") List<String> taskTypeList,
+      @JsonProperty("taskType") ImmutableList<String> taskTypeList,
       @JsonProperty("capacity") int capacity
   )
   {
@@ -47,9 +46,14 @@ public class CategoryCapacityInfo
   }
 
   @JsonProperty("taskType")
-  public List<String> getTaskTypeList()
+  public ImmutableList<String> getTaskTypeList()
   {
     return taskTypeList;
+  }
+
+  public void setTaskTypeList(ImmutableList<String> taskTypeList)
+  {
+    this.taskTypeList = taskTypeList;
   }
 
   @JsonProperty("capacity")
@@ -90,7 +94,7 @@ public class CategoryCapacityInfo
   public String toString()
   {
     return "CapacityInfo{" +
-           ", taskTypeList=" + taskTypeList.toString() +
+           ", taskTypeList=" + taskTypeList +
            ", capacity=" + capacity;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CategoryCapacityInfo.java
@@ -21,9 +21,10 @@ package org.apache.druid.indexing.overlord;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.guice.annotations.PublicApi;
+
+import java.util.Objects;
 
 
 /**
@@ -73,21 +74,19 @@ public class CategoryCapacityInfo
     }
 
     CategoryCapacityInfo that = (CategoryCapacityInfo) o;
-
-    if (!taskTypeList.equals(that.taskTypeList)) {
+    if (!Objects.equals(taskTypeList, that.taskTypeList)) {
       return false;
     }
     if (capacity != that.capacity) {
       return false;
     }
-
     return true;
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hashCode(taskTypeList, capacity);
+    return Objects.hash(taskTypeList, capacity);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -44,6 +44,7 @@ import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionHolder;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -541,8 +542,17 @@ public class OverlordResource
           workerBehaviorConfig.getClass().getSimpleName()
       );
       maximumCapacity = -1;
+      ImmutableMap<String, CategoryCapacityInfo> categoryCapacityInfos = workerBehaviorConfig.getSelectStrategy()
+                                                                                             .getWorkerCategoryCapacity(
+                                                                                                 workers);
+      return Response.ok(new TotalWorkerCapacityResponse(
+          currentCapacity,
+          maximumCapacity,
+          usedCapacity,
+          categoryCapacityInfos
+      )).build();
     }
-    return Response.ok(new TotalWorkerCapacityResponse(currentCapacity, maximumCapacity, usedCapacity)).build();
+    return Response.ok(new TotalWorkerCapacityResponse(currentCapacity, maximumCapacity, usedCapacity, null)).build();
   }
 
   // default value is used for backwards compatibility

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/TotalWorkerCapacityResponse.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/TotalWorkerCapacityResponse.java
@@ -21,6 +21,10 @@ package org.apache.druid.indexing.overlord.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
+
+import javax.annotation.Nullable;
+import java.util.Map;
 
 /**
  * Should be synchronized with org.apache.druid.client.indexing.IndexingTotalWorkerCapacityInfo
@@ -42,17 +46,24 @@ public class TotalWorkerCapacityResponse
    * it cannot be determined.
    */
   private final int usedClusterCapacity;
+  /**
+   * Used total category capacity of the current state of the cluster. This can be null if
+   * it cannot be determined.
+   */
+  private final Map<String, CategoryCapacityInfo> categoryCapacity;
 
   @JsonCreator
   public TotalWorkerCapacityResponse(
       @JsonProperty("currentClusterCapacity") int currentClusterCapacity,
       @JsonProperty("maximumCapacityWithAutoScale") int maximumCapacityWithAutoScale,
-      @JsonProperty("usedClusterCapacity") int usedClusterCapacity
+      @JsonProperty("usedClusterCapacity") int usedClusterCapacity,
+      @Nullable @JsonProperty("categoryCapacity") Map<String, CategoryCapacityInfo> categorycapacityinfos
   )
   {
     this.currentClusterCapacity = currentClusterCapacity;
     this.maximumCapacityWithAutoScale = maximumCapacityWithAutoScale;
     this.usedClusterCapacity = usedClusterCapacity;
+    this.categoryCapacity = categorycapacityinfos;
   }
 
   @JsonProperty
@@ -71,5 +82,11 @@ public class TotalWorkerCapacityResponse
   public int getUsedClusterCapacity()
   {
     return usedClusterCapacity;
+  }
+
+  @JsonProperty
+  public Map<String, CategoryCapacityInfo> getCategoryCapacity()
+  {
+    return categoryCapacity;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategy.java
@@ -23,10 +23,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import javax.annotation.Nullable;
+
+import java.util.Collection;
 import java.util.Objects;
 
 public class EqualDistributionWithCategorySpecWorkerSelectStrategy implements WorkerSelectStrategy
@@ -62,6 +65,15 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategy implements Wo
         workerCategorySpec,
         EqualDistributionWorkerSelectStrategy::selectFromEligibleWorkers
     );
+  }
+
+  @Nullable
+  @Override
+  public ImmutableMap<String, CategoryCapacityInfo> getWorkerCategoryCapacity(
+      Collection<ImmutableWorkerInfo> workers
+  )
+  {
+    return WorkerSelectUtils.getWorkerCategoryCapacity(workers, workerCategorySpec);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategy.java
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Objects;
 
 public class FillCapacityWithCategorySpecWorkerSelectStrategy implements WorkerSelectStrategy
@@ -62,6 +64,15 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategy implements WorkerS
         workerCategorySpec,
         FillCapacityWorkerSelectStrategy::selectFromEligibleWorkers
     );
+  }
+
+  @Nullable
+  @Override
+  public ImmutableMap<String, CategoryCapacityInfo> getWorkerCategoryCapacity(
+      Collection<ImmutableWorkerInfo> workers
+  )
+  {
+    return WorkerSelectUtils.getWorkerCategoryCapacity(workers, workerCategorySpec);
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectStrategy.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectStrategy.java
@@ -24,10 +24,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 
 /**
  * The {@link org.apache.druid.indexing.overlord.RemoteTaskRunner} uses this class to select a worker to assign tasks to.
@@ -60,4 +62,12 @@ public interface WorkerSelectStrategy
       ImmutableMap<String, ImmutableWorkerInfo> zkWorkers,
       Task task
   );
+
+  @Nullable
+  default ImmutableMap<String, CategoryCapacityInfo> getWorkerCategoryCapacity(
+      Collection<ImmutableWorkerInfo> workers
+  )
+  {
+    return null;
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/setup/WorkerSelectUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.indexing.overlord.setup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.druid.indexing.common.task.Task;
@@ -28,10 +29,8 @@ import org.apache.druid.indexing.overlord.config.WorkerTaskRunnerConfig;
 import org.apache.druid.indexing.worker.Worker;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -166,17 +165,19 @@ public class WorkerSelectUtils
         String taskType = entry.getKey();
         String category = entry.getValue().getDefaultCategory();
         if (!categoryCapacityMap.containsKey(category)) {
-          final List<String> taskTypes = new ArrayList<>();
-          taskTypes.add(taskType);
           final CategoryCapacityInfo categoryCapacityInfo = new CategoryCapacityInfo(
-              taskTypes,
+              ImmutableList.of(taskType),
               categoryToCapacityMap.get(category)
           );
           categoryCapacityMap.put(category, categoryCapacityInfo);
         } else {
           final CategoryCapacityInfo categoryCapacityInfo = categoryCapacityMap.get(category);
           if (!categoryCapacityInfo.getTaskTypeList().contains(taskType)) {
-            categoryCapacityInfo.getTaskTypeList().add(taskType);
+            ImmutableList<String> taskTypes = ImmutableList.<String>builder()
+                         .addAll(categoryCapacityInfo.getTaskTypeList())
+                         .add(taskType)
+                         .build();
+            categoryCapacityInfo.setTaskTypeList(taskTypes);
           }
         }
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/CategoryCapacityInfoTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/CategoryCapacityInfoTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CategoryCapacityInfoTest
+{
+  @Test
+  public void testSerde() throws Exception
+  {
+    CategoryCapacityInfo categoryCapacityInfo = new CategoryCapacityInfo(
+        ImmutableList.of("kill", "compact"),
+        10
+    );
+    ObjectMapper mapper = new DefaultObjectMapper();
+    final CategoryCapacityInfo serde = mapper.readValue(
+        mapper.writeValueAsString(categoryCapacityInfo),
+        CategoryCapacityInfo.class
+    );
+    Assert.assertEquals(categoryCapacityInfo, serde);
+  }
+
+  @Test
+  public void testEqualsAndSerde()
+  {
+    // Everything equal
+    assertEqualsAndHashCode(new CategoryCapacityInfo(
+
+        ImmutableList.of("kill", "compact"),
+        10
+    ), new CategoryCapacityInfo(
+        ImmutableList.of("kill", "compact"),
+        10
+    ), true);
+
+    // same task type different
+    assertEqualsAndHashCode(new CategoryCapacityInfo(
+
+        ImmutableList.of("kill", "compact1"),
+        10
+    ), new CategoryCapacityInfo(
+        ImmutableList.of("kill", "compact"),
+        10
+    ), false);
+
+    // capacity different
+    assertEqualsAndHashCode(new CategoryCapacityInfo(
+
+        ImmutableList.of("kill", "compact"),
+        10
+    ), new CategoryCapacityInfo(
+        ImmutableList.of("kill", "compact"),
+        11
+    ), false);
+
+    // capacity and task type different
+    assertEqualsAndHashCode(new CategoryCapacityInfo(
+
+        ImmutableList.of("kill", "compact1"),
+        10
+    ), new CategoryCapacityInfo(
+        ImmutableList.of("kill", "compact"),
+        11
+    ), false);
+  }
+
+  private void assertEqualsAndHashCode(CategoryCapacityInfo o1, CategoryCapacityInfo o2, boolean shouldMatch)
+  {
+    if (shouldMatch) {
+      Assert.assertTrue(o1.equals(o2));
+      Assert.assertEquals(o1.hashCode(), o2.hashCode());
+    } else {
+      Assert.assertFalse(o1.equals(o2));
+      Assert.assertNotEquals(o1.hashCode(), o2.hashCode());
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -1567,7 +1567,7 @@ public class OverlordResourceTest
         "xxx_category",
         secondCategoryCapacityInfo
     );
-    EasyMock.expect(categoryStrategy.getWorkerCategoryCapacity(EasyMock.<Collection<ImmutableWorkerInfo>>anyObject()))
+    EasyMock.expect(categoryStrategy.getWorkerCategoryCapacity(EasyMock.anyObject()))
             .andReturn(mockCategoryCapacity);
     EasyMock.expect(workerBehaviorConfig.getSelectStrategy()).andReturn(categoryStrategy);
     AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference = new AtomicReference<>(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/EqualDistributionWithCategorySpecWorkerSelectStrategyTest.java
@@ -19,8 +19,10 @@
 
 package org.apache.druid.indexing.overlord.setup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
 import org.apache.druid.indexing.worker.Worker;
@@ -172,6 +174,88 @@ public class EqualDistributionWithCategorySpecWorkerSelectStrategyTest
 
     ImmutableWorkerInfo worker = selectWorker(workerCategorySpec);
     Assert.assertNull(worker);
+  }
+
+  @Test
+  public void testWorkerCategoryCapacity()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "kill",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "compact",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "single_phase_sub_task",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_dimension_cardinality",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_index_generate",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_index_generic_merge",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_range_index_generate",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_dimension_distribution",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "index_kafka",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of()
+            )
+        ),
+        true
+    );
+    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy = new EqualDistributionWithCategorySpecWorkerSelectStrategy(
+        workerCategorySpec);
+
+    ImmutableMap<String, CategoryCapacityInfo> categoryCapacity = strategy.getWorkerCategoryCapacity(
+        WORKERS_FOR_TIER_TESTS.values()
+    );
+    Assert.assertEquals(3, categoryCapacity.get("c1").getCapacity());
+    Assert.assertArrayEquals(
+        ImmutableList.of(
+            "kill",
+            "compact",
+            "single_phase_sub_task",
+            "partial_dimension_cardinality",
+            "partial_index_generate",
+            "partial_index_generic_merge",
+            "partial_range_index_generate",
+            "partial_dimension_distribution"
+        ).toArray(),
+        categoryCapacity.get("c1").getTaskTypeList().toArray()
+    );
+    Assert.assertEquals(7, categoryCapacity.get("c2").getCapacity());
+    Assert.assertArrayEquals(
+        ImmutableList.of(
+            "index_kafka"
+        ).toArray(),
+        categoryCapacity.get("c2").getTaskTypeList().toArray()
+    );
   }
 
   private ImmutableWorkerInfo selectWorker(WorkerCategorySpec workerCategorySpec)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
@@ -243,7 +243,7 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
         ),
         true
     );
-    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy = new EqualDistributionWithCategorySpecWorkerSelectStrategy(
+    final FillCapacityWithCategorySpecWorkerSelectStrategy strategy = new FillCapacityWithCategorySpecWorkerSelectStrategy(
         workerCategorySpec);
 
     ImmutableMap<String, CategoryCapacityInfo> categoryCapacity = strategy.getWorkerCategoryCapacity(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/setup/FillCapacityWithCategorySpecWorkerSelectStrategyTest.java
@@ -19,8 +19,10 @@
 
 package org.apache.druid.indexing.overlord.setup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.overlord.CategoryCapacityInfo;
 import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
 import org.apache.druid.indexing.worker.Worker;
@@ -186,5 +188,87 @@ public class FillCapacityWithCategorySpecWorkerSelectStrategyTest
     );
 
     return worker;
+  }
+
+  @Test
+  public void testWorkerCategoryCapacity()
+  {
+    final WorkerCategorySpec workerCategorySpec = new WorkerCategorySpec(
+        ImmutableMap.of(
+            "kill",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "compact",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "single_phase_sub_task",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_dimension_cardinality",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_index_generate",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_index_generic_merge",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_range_index_generate",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "partial_dimension_distribution",
+            new WorkerCategorySpec.CategoryConfig(
+                "c1",
+                ImmutableMap.of()
+            ),
+            "index_kafka",
+            new WorkerCategorySpec.CategoryConfig(
+                "c2",
+                ImmutableMap.of()
+            )
+        ),
+        true
+    );
+    final EqualDistributionWithCategorySpecWorkerSelectStrategy strategy = new EqualDistributionWithCategorySpecWorkerSelectStrategy(
+        workerCategorySpec);
+
+    ImmutableMap<String, CategoryCapacityInfo> categoryCapacity = strategy.getWorkerCategoryCapacity(
+        WORKERS_FOR_TIER_TESTS.values()
+    );
+    Assert.assertEquals(10, categoryCapacity.get("c1").getCapacity());
+    Assert.assertArrayEquals(
+        ImmutableList.of(
+            "kill",
+            "compact",
+            "single_phase_sub_task",
+            "partial_dimension_cardinality",
+            "partial_index_generate",
+            "partial_index_generic_merge",
+            "partial_range_index_generate",
+            "partial_dimension_distribution"
+        ).toArray(),
+        categoryCapacity.get("c1").getTaskTypeList().toArray()
+    );
+    Assert.assertEquals(10, categoryCapacity.get("c2").getCapacity());
+    Assert.assertArrayEquals(
+        ImmutableList.of(
+            "index_kafka"
+        ).toArray(),
+        categoryCapacity.get("c2").getTaskTypeList().toArray()
+    );
   }
 }

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
@@ -84,7 +84,7 @@ public class IndexingCategoryCapacityInfo
   public String toString()
   {
     return "IndexingCategoryCapacityInfo{" +
-           "taskTypeList=" + taskTypeList.toString() +
+           "taskTypeList=" + taskTypeList +
            ", capacity=" + capacity;
   }
 }

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
@@ -21,9 +21,9 @@ package org.apache.druid.client.indexing;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import java.util.List;
+import java.util.Objects;
 
 public class IndexingCategoryCapacityInfo
 {
@@ -63,21 +63,19 @@ public class IndexingCategoryCapacityInfo
     }
 
     IndexingCategoryCapacityInfo that = (IndexingCategoryCapacityInfo) o;
-
-    if (!taskTypeList.equals(that.taskTypeList)) {
+    if (!Objects.equals(taskTypeList, that.taskTypeList)) {
       return false;
     }
     if (capacity != that.capacity) {
       return false;
     }
-
     return true;
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hashCode(taskTypeList, capacity);
+    return Objects.hash(taskTypeList, capacity);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingCategoryCapacityInfo.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client.indexing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+import java.util.List;
+
+public class IndexingCategoryCapacityInfo
+{
+  private final List<String> taskTypeList;
+  private final int capacity;
+
+  @JsonCreator
+  public IndexingCategoryCapacityInfo(
+      @JsonProperty("taskType") List<String> taskTypeList,
+      @JsonProperty("capacity") int capacity
+  )
+  {
+    this.taskTypeList = taskTypeList;
+    this.capacity = capacity;
+  }
+
+  @JsonProperty("taskType")
+  public List<String> getTaskTypeList()
+  {
+    return taskTypeList;
+  }
+
+  @JsonProperty("capacity")
+  public int getCapacity()
+  {
+    return capacity;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    IndexingCategoryCapacityInfo that = (IndexingCategoryCapacityInfo) o;
+
+    if (!taskTypeList.equals(that.taskTypeList)) {
+      return false;
+    }
+    if (capacity != that.capacity) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hashCode(taskTypeList, capacity);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "IndexingCategoryCapacityInfo{" +
+           "taskTypeList=" + taskTypeList.toString() +
+           ", capacity=" + capacity;
+  }
+}

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingTotalWorkerCapacityInfo.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingTotalWorkerCapacityInfo.java
@@ -22,6 +22,8 @@ package org.apache.druid.client.indexing;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -40,20 +42,34 @@ public class IndexingTotalWorkerCapacityInfo
    */
   private final int maximumCapacityWithAutoScale;
 
+  /**
+   * Used total category capacity of the current state of the cluster. This can be null if
+   * it cannot be determined.
+   */
+  private final Map<String, IndexingCategoryCapacityInfo> categoryCapacity;
+
   @JsonCreator
   public IndexingTotalWorkerCapacityInfo(
       @JsonProperty("currentClusterCapacity") int currentClusterCapacity,
-      @JsonProperty("maximumCapacityWithAutoScale") int maximumCapacityWithAutoScale
+      @JsonProperty("maximumCapacityWithAutoScale") int maximumCapacityWithAutoScale,
+      @Nullable @JsonProperty("categoryCapacity") Map<String, IndexingCategoryCapacityInfo> categorycapacity
   )
   {
     this.currentClusterCapacity = currentClusterCapacity;
     this.maximumCapacityWithAutoScale = maximumCapacityWithAutoScale;
+    this.categoryCapacity = categorycapacity;
   }
 
   @JsonProperty
   public int getCurrentClusterCapacity()
   {
     return currentClusterCapacity;
+  }
+
+  @JsonProperty
+  public Map<String, IndexingCategoryCapacityInfo> getCategoryCapacity()
+  {
+    return categoryCapacity;
   }
 
   @JsonProperty
@@ -71,9 +87,11 @@ public class IndexingTotalWorkerCapacityInfo
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
+
     IndexingTotalWorkerCapacityInfo that = (IndexingTotalWorkerCapacityInfo) o;
     return currentClusterCapacity == that.currentClusterCapacity
-           && maximumCapacityWithAutoScale == that.maximumCapacityWithAutoScale;
+           && maximumCapacityWithAutoScale == that.maximumCapacityWithAutoScale
+           && Objects.equals(categoryCapacity, that.categoryCapacity);
   }
 
   @Override
@@ -88,6 +106,7 @@ public class IndexingTotalWorkerCapacityInfo
     return "IndexingTotalWorkerCapacityInfo{" +
            "currentClusterCapacity=" + currentClusterCapacity +
            ", maximumCapacityWithAutoScale=" + maximumCapacityWithAutoScale +
+           ", categorycapacityinfos=" + categoryCapacity +
            '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/client/indexing/IndexingWorker.java
+++ b/server/src/main/java/org/apache/druid/client/indexing/IndexingWorker.java
@@ -34,6 +34,7 @@ public class IndexingWorker
   private final String ip;
   private final int capacity;
   private final String version;
+  private final String category;
 
   @JsonCreator
   public IndexingWorker(
@@ -41,7 +42,8 @@ public class IndexingWorker
       @JsonProperty("host") String host,
       @JsonProperty("ip") String ip,
       @JsonProperty("capacity") int capacity,
-      @JsonProperty("version") String version
+      @JsonProperty("version") String version,
+      @JsonProperty("category") String category
   )
   {
     this.scheme = scheme;
@@ -49,6 +51,7 @@ public class IndexingWorker
     this.ip = ip;
     this.capacity = capacity;
     this.version = version;
+    this.category = category;
   }
 
   @JsonProperty
@@ -81,6 +84,12 @@ public class IndexingWorker
     return version;
   }
 
+  @JsonProperty
+  public String getCategory()
+  {
+    return category;
+  }
+
   @Override
   public boolean equals(Object o)
   {
@@ -94,13 +103,13 @@ public class IndexingWorker
     return capacity == that.capacity && Objects.equals(scheme, that.scheme) && Objects.equals(
         host,
         that.host
-    ) && Objects.equals(ip, that.ip) && Objects.equals(version, that.version);
+    ) && Objects.equals(ip, that.ip) && Objects.equals(version, that.version) && Objects.equals(category, that.category);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(scheme, host, ip, capacity, version);
+    return Objects.hash(scheme, host, ip, capacity, version, category);
   }
 
   @Override
@@ -112,6 +121,7 @@ public class IndexingWorker
            ", ip='" + ip + '\'' +
            ", capacity=" + capacity +
            ", version='" + version + '\'' +
+           ", category='" + category + '\'' +
            '}';
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -320,10 +320,14 @@ public class CompactSegments implements CoordinatorCustomDuty
 
   private int getCompactionTaskCapacity(CoordinatorCompactionConfig dynamicConfig)
   {
-    int totalWorkerCapacity = CoordinatorDutyUtils.getTotalWorkerCapacity(overlordClient);
+    int totalWorkerCapacity = CoordinatorDutyUtils.getTotalWorkerCapacity(
+        overlordClient,
+        dynamicConfig.getCompactionTaskSlotRatio(),
+        "compact"
+    );
 
     return Math.min(
-        (int) (totalWorkerCapacity * dynamicConfig.getCompactionTaskSlotRatio()),
+        totalWorkerCapacity,
         dynamicConfig.getMaxCompactionTaskSlots()
     );
   }

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CoordinatorDutyUtils.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CoordinatorDutyUtils.java
@@ -68,7 +68,10 @@ public class CoordinatorDutyUtils
         totalWorkerCapacity = workerCapacityInfo.getCurrentClusterCapacity();
       }
       if (workerCapacityInfo.getCategoryCapacity() != null && taskType != null) {
-        int totalCapacity = workerCapacityInfo.getCategoryCapacity().get(taskType).getCapacity();
+        int totalCapacity = workerCapacityInfo.getCategoryCapacity().values().stream()
+                                              .filter(category -> category.getTaskTypeList().contains(taskType))
+                                              .mapToInt(category -> category.getCapacity())
+                                              .sum();
         return Math.min(
             totalCapacity,
             (int) (totalWorkerCapacity * taskSlotRatio)

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/KillUnusedSegments.java
@@ -265,7 +265,7 @@ public class KillUnusedSegments implements CoordinatorDuty
   private int getAvailableKillTaskSlots(final CoordinatorDynamicConfig config, final CoordinatorRunStats stats)
   {
     final int killTaskCapacity = Math.min(
-        (int) (CoordinatorDutyUtils.getTotalWorkerCapacity(overlordClient) * Math.min(config.getKillTaskSlotRatio(), 1.0)),
+        (int) (CoordinatorDutyUtils.getTotalWorkerCapacity(overlordClient, Math.min(config.getKillTaskSlotRatio(), 1.0), "kill")),
         config.getMaxKillTaskSlots()
     );
 

--- a/server/src/test/java/org/apache/druid/indexing/IndexingCategoryCapacityInfoTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/IndexingCategoryCapacityInfoTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.client.indexing.IndexingCategoryCapacityInfo;
+import org.junit.Test;
+
+public class IndexingCategoryCapacityInfoTest
+{
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(IndexingCategoryCapacityInfo.class).usingGetClass().verify();
+  }
+}

--- a/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
+++ b/server/src/test/java/org/apache/druid/rpc/indexing/OverlordClientImplTest.java
@@ -361,7 +361,8 @@ public class OverlordClientImplTest
     // Mock response for /druid/indexer/v1/totalWorkerCapacity
     final IndexingTotalWorkerCapacityInfo indexingTotalWorkerCapacityInfo = new IndexingTotalWorkerCapacityInfo(
         currentClusterCapacity,
-        maximumCapacityWithAutoScale
+        maximumCapacityWithAutoScale,
+        null
     );
 
     serviceClient.expectAndRespond(
@@ -382,7 +383,7 @@ public class OverlordClientImplTest
   {
     final List<IndexingWorkerInfo> workers = ImmutableList.of(
         new IndexingWorkerInfo(
-            new IndexingWorker("http", "localhost", "1.2.3.4", 3, "2"),
+            new IndexingWorker("http", "localhost", "1.2.3.4", 3, "2", ""),
             0,
             Collections.emptySet(),
             Collections.emptyList(),

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.client.indexing.ClientCompactionTaskGranularitySpec;
 import org.apache.druid.client.indexing.ClientCompactionTaskQuery;
 import org.apache.druid.client.indexing.ClientCompactionTaskQueryTuningConfig;
 import org.apache.druid.client.indexing.ClientTaskQuery;
+import org.apache.druid.client.indexing.IndexingCategoryCapacityInfo;
 import org.apache.druid.client.indexing.IndexingTotalWorkerCapacityInfo;
 import org.apache.druid.client.indexing.NoopOverlordClient;
 import org.apache.druid.client.indexing.TaskPayloadResponse;
@@ -2017,7 +2018,15 @@ public class CompactSegmentsTest
     @Override
     public ListenableFuture<IndexingTotalWorkerCapacityInfo> getTotalWorkerCapacity()
     {
-      return Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(5, 10, null));
+      return Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(
+          5,
+          10,
+          ImmutableMap.of(
+              "c1",
+              new IndexingCategoryCapacityInfo(ImmutableList.of("compact"),
+                                               10)
+          )
+      ));
     }
 
     private void compactSegments(

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/CompactSegmentsTest.java
@@ -1098,7 +1098,7 @@ public class CompactSegmentsTest
     Mockito.when(mockClient.cancelTask(conflictTaskId))
            .thenReturn(Futures.immediateFuture(null));
     Mockito.when(mockClient.getTotalWorkerCapacity())
-           .thenReturn(Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(0, 0)));
+           .thenReturn(Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(0, 0, null)));
     Mockito.when(mockClient.taskPayload(ArgumentMatchers.eq(conflictTaskId)))
            .thenReturn(Futures.immediateFuture(runningConflictCompactionTaskPayload));
 
@@ -2017,7 +2017,7 @@ public class CompactSegmentsTest
     @Override
     public ListenableFuture<IndexingTotalWorkerCapacityInfo> getTotalWorkerCapacity()
     {
-      return Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(5, 10));
+      return Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(5, 10, null));
     }
 
     private void compactSegments(
@@ -2193,7 +2193,7 @@ public class CompactSegmentsTest
     Mockito.when(mockClient.findLockedIntervals(ArgumentMatchers.any()))
            .thenReturn(Futures.immediateFuture(Collections.emptyMap()));
     Mockito.when(mockClient.getTotalWorkerCapacity())
-           .thenReturn(Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(0, 0)));
+           .thenReturn(Futures.immediateFuture(new IndexingTotalWorkerCapacityInfo(0, 0, null)));
     Mockito.when(mockClient.runTask(ArgumentMatchers.anyString(), payloadCaptor.capture()))
            .thenReturn(Futures.immediateFuture(null));
     return payloadCaptor;

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/KillUnusedSegmentsTest.java
@@ -783,12 +783,12 @@ public class KillUnusedSegmentsTest
 
     TestOverlordClient()
     {
-      capcityInfo = new IndexingTotalWorkerCapacityInfo(5, 10);
+      capcityInfo = new IndexingTotalWorkerCapacityInfo(5, 10, null);
     }
 
     TestOverlordClient(final int currentClusterCapacity, final int maxWorkerCapacity)
     {
-      capcityInfo = new IndexingTotalWorkerCapacityInfo(currentClusterCapacity, maxWorkerCapacity);
+      capcityInfo = new IndexingTotalWorkerCapacityInfo(currentClusterCapacity, maxWorkerCapacity, null);
     }
 
     static String getTaskId(final String idPrefix, final String dataSource, final Interval interval)
@@ -855,7 +855,7 @@ public class KillUnusedSegmentsTest
       return Futures.immediateFuture(
           ImmutableList.of(
               new IndexingWorkerInfo(
-                  new IndexingWorker("http", "localhost", "1.2.3.4", 3, "2"),
+                  new IndexingWorker("http", "localhost", "1.2.3.4", 3, "2", ""),
                   0,
                   Collections.emptySet(),
                   Collections.emptyList(),


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #15847.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Fix the bug of capacity api which is not category aware
The proposal solution is following:

1. If current WorkerSelectStrategy is category based strategy(FillCapacityWithCategorySpecWorkerSelectStrategy and EqualDistributionWithCategorySpecWorkerSelectStrategy),  we will calculate the capacity group by category in getWorkerCategoryCapacity method.
2. if current WorkerSelectStrategy is not category based strategy, the getWorkerCategoryCapacity will return null.
3. In OverlordResource#getTotalWorkerCapacity method, get the capacity group by category from WorkerSelectStrategy#getWorkerCategoryCapacity
4. In CoordinatorDutyUtils#getTotalWorkerCapacity if overlordClient.getTotalWorkerCapacity() return category based capacity, return  Math.min(totalCapacity, (int) (totalWorkerCapacity * taskSlotRatio)); here totalCapacity is category capacity.
Summary: according to the WorkerSelectStrategy(category based or not), set the category capacity in TotalWorkerCapacityResponse, in client side, compare the category capacity and totalWorkerCapacity * taskSlotRatio, take the smaller one


#### Fixed the bug 15847

#### Release note
##### Fix the bug of getCompactionTaskCapacity which is not category aware
##### Update the getTotalWorkerCapacity of OverlordResource
if WorkerSelectStrategy is category based strategy(FillCapacityWithCategorySpecWorkerSelectStrategy and EqualDistributionWithCategorySpecWorkerSelectStrategy),  TotalWorkerCapacityResponse will contains the capacity group by category.

<hr>

##### Key changed/added classes in this PR
 * `CategoryCapacityInfo`
 * `OverlordResource`
 * `TotalWorkerCapacityResponse`
 * `EqualDistributionWithCategorySpecWorkerSelectStrategy`
 * `FillCapacityWithCategorySpecWorkerSelectStrategy`
 * `WorkerSelectStrategy`
 * `WorkerSelectUtils`
 * `OverlordResourceTest`
 * `EqualDistributionWithCategorySpecWorkerSelectStrategyTest`
 * `FillCapacityWithCategorySpecWorkerSelectStrategyTest`
 * `IndexingCategoryCapacityInfo`
 * `IndexingTotalWorkerCapacityInfo`
 * `IndexingWorker`
 * `CompactSegments`
 * `CoordinatorDutyUtils`
 * `KillUnusedSegments`
 * `OverlordClientImplTest`
 * `CompactSegmentsTest`
 * `KillUnusedSegmentsTest`
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
