### PR TITLE
Fix script and improve documentation

### DIFF
--- a/distribution/bin/find-missing-backports.py
+++ b/distribution/bin/find-missing-backports.py
@@ -67,6 +67,7 @@ def find_next_url(links):
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-branch> <current-release-branch> <milestone-number>\n')
   sys.stderr.write("  e.g., program myusername 0.17.0 0.18.0 30")
+  sys.stderr.write("  e.g., The milestone number for Druid 30 is 56, since the milestone has the url https://github.com/apache/druid/milestone/56\n")
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
   sys.exit(1)
 

--- a/distribution/bin/tag-missing-milestones.py
+++ b/distribution/bin/tag-missing-milestones.py
@@ -24,6 +24,7 @@ import requests
 if len(sys.argv) != 5:
   sys.stderr.write('usage: program <github-username> <previous-release-commit> <new-release-commit> <milestone-number-to-tag>\n')
   sys.stderr.write("  e.g., program myusername 75c70c2ccc 29f3a328da 30\n")
+  sys.stderr.write("  e.g., The milestone number for Druid 30 is 56, since the milestone has the url https://github.com/apache/druid/milestone/56\n")
   sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.\n")
   sys.exit(1)
 
@@ -56,7 +57,7 @@ for sha in all_commits.splitlines():
         url = "https://api.github.com/repos/apache/druid/issues/{}".format(pr_number)
         requests.patch(url, json=milestone_json, auth=(github_username, os.environ["GIT_TOKEN"]))
       else:
-        print("Skipping Pull Request {} since it's already tagged with milestone {}".format(pr_number, milestone))
+        print("Skipping Pull Request {} since it's already tagged with milestone {}".format(pr_number, pr['milestone']['number']))
 
   except Exception as e:
     print("Got exception for commit: {}  ex: {}".format(sha, e))


### PR DESCRIPTION
Fixes a few minor issues with scripts.

- Add additional information around <milestone-number> since it was confusing, and not clear that the number was the ID from github and not just the major version number.
- Fix an issue where the milestone displayed in an output message was the milestone supplied as an argument, instead of the number of the milestone the PR is already tagged against in Github, from the sent request.