### PR TITLE
Disable loading lookups by default in CompactionTask

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -55,7 +55,7 @@ import org.apache.druid.rpc.ServiceClientFactory;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.segment.realtime.firehose.ChatHandler;
 import org.apache.druid.server.DruidNode;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -271,16 +271,16 @@ public class IndexerControllerContext implements ControllerContext
         .put(MultiStageQueryContext.CTX_MAX_CONCURRENT_STAGES, queryKernelConfig.getMaxConcurrentStages());
 
     // Put the lookup loading info in the task context to facilitate selective loading of lookups.
-    if (controllerTaskContext.get(PlannerContext.CTX_LOOKUP_LOADING_MODE) != null) {
+    if (controllerTaskContext.get(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE) != null) {
       taskContextOverridesBuilder.put(
-          PlannerContext.CTX_LOOKUP_LOADING_MODE,
-          controllerTaskContext.get(PlannerContext.CTX_LOOKUP_LOADING_MODE)
+          LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE,
+          controllerTaskContext.get(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE)
       );
     }
-    if (controllerTaskContext.get(PlannerContext.CTX_LOOKUPS_TO_LOAD) != null) {
+    if (controllerTaskContext.get(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD) != null) {
       taskContextOverridesBuilder.put(
-          PlannerContext.CTX_LOOKUPS_TO_LOAD,
-          controllerTaskContext.get(PlannerContext.CTX_LOOKUPS_TO_LOAD)
+          LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD,
+          controllerTaskContext.get(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD)
       );
     }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
-import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
@@ -38,13 +37,9 @@ import org.apache.druid.msq.exec.MSQTasks;
 import org.apache.druid.msq.exec.Worker;
 import org.apache.druid.msq.exec.WorkerContext;
 import org.apache.druid.msq.exec.WorkerImpl;
-import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -189,27 +184,5 @@ public class MSQWorkerTask extends AbstractTask
   public int hashCode()
   {
     return Objects.hash(super.hashCode(), controllerTaskId, workerNumber, retryCount, worker);
-  }
-
-  @Override
-  public LookupLoadingSpec getLookupLoadingSpec()
-  {
-    final Object lookupModeValue = getContext().get(PlannerContext.CTX_LOOKUP_LOADING_MODE);
-    if (lookupModeValue == null) {
-      return LookupLoadingSpec.ALL;
-    }
-
-    final LookupLoadingSpec.Mode lookupLoadingMode = LookupLoadingSpec.Mode.valueOf(lookupModeValue.toString());
-    if (lookupLoadingMode == LookupLoadingSpec.Mode.NONE) {
-      return LookupLoadingSpec.NONE;
-    } else if (lookupLoadingMode == LookupLoadingSpec.Mode.ONLY_REQUIRED) {
-      Collection<String> lookupsToLoad = (Collection<String>) getContext().get(PlannerContext.CTX_LOOKUPS_TO_LOAD);
-      if (lookupsToLoad == null || lookupsToLoad.isEmpty()) {
-        throw InvalidInput.exception("Set of lookups to load cannot be %s for mode[ONLY_REQUIRED].", lookupsToLoad);
-      }
-      return LookupLoadingSpec.loadOnly(new HashSet<>(lookupsToLoad));
-    } else {
-      return LookupLoadingSpec.ALL;
-    }
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
@@ -285,9 +285,9 @@ public class MSQTaskQueryMaker implements QueryMaker
     MSQTaskQueryMakerUtils.validateRealtimeReindex(querySpec);
 
     final Map<String, Object> context = new HashMap<>();
-    context.put(PlannerContext.CTX_LOOKUP_LOADING_MODE, plannerContext.getLookupLoadingSpec().getMode());
+    context.put(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, plannerContext.getLookupLoadingSpec().getMode());
     if (plannerContext.getLookupLoadingSpec().getMode() == LookupLoadingSpec.Mode.ONLY_REQUIRED) {
-      context.put(PlannerContext.CTX_LOOKUPS_TO_LOAD, plannerContext.getLookupLoadingSpec().getLookupsToLoad());
+      context.put(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, plannerContext.getLookupLoadingSpec().getLookupsToLoad());
     }
 
     final MSQControllerTask controllerTask = new MSQControllerTask(

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQControllerTaskTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQControllerTaskTest.java
@@ -38,7 +38,6 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Test;
@@ -114,8 +113,8 @@ public class MSQControllerTaskTest
                    .dataSource("target")
                    .context(
                        ImmutableMap.of(
-                           PlannerContext.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookupName1", "lookupName2"),
-                           PlannerContext.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED)
+                           LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookupName1", "lookupName2"),
+                           LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED)
                    )
                    .build()
         )

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQWorkerTaskTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
-import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -125,7 +124,7 @@ public class MSQWorkerTaskTest
   @Test
   public void testGetLookupLoadingWithModeNoneInContext()
   {
-    final ImmutableMap<String, Object> context = ImmutableMap.of(PlannerContext.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE);
+    final ImmutableMap<String, Object> context = ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE);
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
     Assert.assertEquals(LookupLoadingSpec.NONE, msqWorkerTask.getLookupLoadingSpec());
   }
@@ -134,8 +133,8 @@ public class MSQWorkerTaskTest
   public void testGetLookupLoadingSpecWithLookupListInContext()
   {
     final ImmutableMap<String, Object> context = ImmutableMap.of(
-        PlannerContext.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookupName1", "lookupName2"),
-        PlannerContext.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
+        LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookupName1", "lookupName2"),
+        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
     MSQWorkerTask msqWorkerTask = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
     Assert.assertEquals(LookupLoadingSpec.Mode.ONLY_REQUIRED, msqWorkerTask.getLookupLoadingSpec().getMode());
     Assert.assertEquals(ImmutableSet.of("lookupName1", "lookupName2"), msqWorkerTask.getLookupLoadingSpec().getLookupsToLoad());
@@ -145,10 +144,10 @@ public class MSQWorkerTaskTest
   public void testGetLookupLoadingSpecWithInvalidInput()
   {
     final HashMap<String, Object> context = new HashMap<>();
-    context.put(PlannerContext.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
+    context.put(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
 
     // Setting CTX_LOOKUPS_TO_LOAD as null
-    context.put(PlannerContext.CTX_LOOKUPS_TO_LOAD, null);
+    context.put(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, null);
 
     MSQWorkerTask taskWithNullLookups = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
     DruidException exception = Assert.assertThrows(
@@ -160,7 +159,7 @@ public class MSQWorkerTaskTest
         exception.getMessage());
 
     // Setting CTX_LOOKUPS_TO_LOAD as empty list
-    context.put(PlannerContext.CTX_LOOKUPS_TO_LOAD, Collections.emptyList());
+    context.put(LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Collections.emptyList());
 
     MSQWorkerTask taskWithEmptyLookups = new MSQWorkerTask(controllerTaskId, dataSource, workerNumber, context, retryCount);
     exception = Assert.assertThrows(

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -854,7 +854,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
     protected CompactionState expectedLastCompactionState = null;
     protected Set<Interval> expectedTombstoneIntervals = null;
     protected List<Object[]> expectedResultRows = null;
-    protected LookupLoadingSpec expectedLookupLoadingSpec = null;
+    protected LookupLoadingSpec expectedLookupLoadingSpec = LookupLoadingSpec.NONE;
     protected Matcher<Throwable> expectedValidationErrorMatcher = null;
     protected List<Pair<Predicate<MSQTaskReportPayload>, String>> adhocReportAssertionAndReasons = new ArrayList<>();
     protected Matcher<Throwable> expectedExecutionErrorMatcher = null;
@@ -1020,19 +1020,8 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
     protected void verifyLookupLoadingInfoInTaskContext(Map<String, Object> context)
     {
-      String lookupLoadingMode = context.get(PlannerContext.CTX_LOOKUP_LOADING_MODE).toString();
-      List<String> lookupsToLoad = (List<String>) context.get(PlannerContext.CTX_LOOKUPS_TO_LOAD);
-      if (expectedLookupLoadingSpec != null) {
-        Assert.assertEquals(expectedLookupLoadingSpec.getMode().toString(), lookupLoadingMode);
-        if (expectedLookupLoadingSpec.getMode().equals(LookupLoadingSpec.Mode.ONLY_REQUIRED)) {
-          Assert.assertEquals(new ArrayList<>(expectedLookupLoadingSpec.getLookupsToLoad()), lookupsToLoad);
-        } else {
-          Assert.assertNull(lookupsToLoad);
-        }
-      } else {
-        Assert.assertEquals(LookupLoadingSpec.Mode.NONE.toString(), lookupLoadingMode);
-        Assert.assertNull(lookupsToLoad);
-      }
+      LookupLoadingSpec specFromContext = LookupLoadingSpec.getSpecFromContext(context, LookupLoadingSpec.ALL);
+      Assert.assertEquals(expectedLookupLoadingSpec, specFromContext);
     }
 
     protected void verifyWorkerCount(CounterSnapshotsTree counterSnapshotsTree)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -1020,7 +1020,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
     protected void verifyLookupLoadingInfoInTaskContext(Map<String, Object> context)
     {
-      LookupLoadingSpec specFromContext = LookupLoadingSpec.getSpecFromContext(context, LookupLoadingSpec.ALL);
+      LookupLoadingSpec specFromContext = LookupLoadingSpec.createFromContext(context, LookupLoadingSpec.ALL);
       Assert.assertEquals(expectedLookupLoadingSpec, specFromContext);
     }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -1531,10 +1531,4 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
       );
     }
   }
-
-  @Override
-  public LookupLoadingSpec getLookupLoadingSpec()
-  {
-    return LookupLoadingSpec.createFromContext(getContext(), transformSpec == null ? LookupLoadingSpec.NONE : LookupLoadingSpec.ALL);
-  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -251,11 +251,8 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     this.partitionConfigurationManager = new PartitionConfigurationManager(this.tuningConfig);
     this.segmentCacheManagerFactory = segmentCacheManagerFactory;
 
-    // Unless context has been overridden to load lookups differently, we want to load no lookups by default in any task spawned
-    // up by the CompactionTask. We achieve this by populating this info in the context which is passed to the spawned tasks.
-    if (context == null || !context.containsKey(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE)) {
-      addToContext(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString());
-    }
+    // By default, do not load any lookups in sub-tasks launched by compaction task.
+    addToContextIfAbsent(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString());
   }
 
   @VisibleForTesting
@@ -1533,6 +1530,6 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
   @Override
   public LookupLoadingSpec getLookupLoadingSpec()
   {
-    return LookupLoadingSpec.getSpecFromContext(getContext(), LookupLoadingSpec.NONE);
+    return LookupLoadingSpec.createFromContext(getContext(), LookupLoadingSpec.NONE);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -334,9 +334,13 @@ public interface Task
     );
   }
 
+  /**
+   * Fetch lookup loading spec based on the task context, defaulting to loading all lookups if context does not have overridden configuration.
+   * @return lookup loading spec
+   */
   @Nullable
   default LookupLoadingSpec getLookupLoadingSpec()
   {
-    return LookupLoadingSpec.ALL;
+    return LookupLoadingSpec.getSpecFromContext(getContext(), LookupLoadingSpec.ALL);
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -335,12 +335,13 @@ public interface Task
   }
 
   /**
-   * Fetch lookup loading spec based on the task context, defaulting to loading all lookups if context does not have overridden configuration.
-   * @return lookup loading spec
+   * Specifies the list of lookups to load for this task. Tasks load ALL lookups by default.
+   * This behaviour can be overridden by passing parameters {@link LookupLoadingSpec#CTX_LOOKUP_LOADING_MODE}
+   * and {@link LookupLoadingSpec#CTX_LOOKUPS_TO_LOAD} in the task context.
    */
   @Nullable
   default LookupLoadingSpec getLookupLoadingSpec()
   {
-    return LookupLoadingSpec.getSpecFromContext(getContext(), LookupLoadingSpec.ALL);
+    return LookupLoadingSpec.createFromContext(getContext(), LookupLoadingSpec.ALL);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -365,7 +365,7 @@ public class ClientCompactionTaskQuerySerdeTest
     Assert.assertEquals(expected.getDimensionsSpec(), actual.getDimensionsSpec());
     Assert.assertEquals(expected.getIoConfig(), actual.getIoConfig());
     Assert.assertEquals(expected.getTransformSpec(), actual.getTransformSpec());
-    Assert.assertEquals(expected.getMetricsSpec(), actual.getMetricsSpec());
+    Assert.assertArrayEquals(expected.getMetricsSpec(), actual.getMetricsSpec());
     Assert.assertEquals(expected.getTuningConfig(), actual.getTuningConfig());
     Assert.assertEquals(ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString()), actual.getContext());
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -84,7 +84,7 @@ public class ClientCompactionTaskQuerySerdeTest
   @Test
   public void testClientCompactionTaskQueryToCompactionTask() throws IOException
   {
-    Map<String, Object> context = ImmutableMap.of("key", "value");
+    final Map<String, Object> context = ImmutableMap.of("key", "value");
     final ObjectMapper mapper = setupInjectablesInObjectMapper(new DefaultObjectMapper());
     final ClientCompactionTaskQuery query = new ClientCompactionTaskQuery(
         "id",
@@ -236,9 +236,11 @@ public class ClientCompactionTaskQuerySerdeTest
         task.getMetricsSpec()
     );
 
+    // Verify values of context keys originally present in the ClientCompactionTaskQuery
     for (String key : context.keySet()) {
       Assert.assertEquals(context.get(key), task.getContext().get(key));
     }
+    // Verify values of context parameters added by the CompactionTask
     Assert.assertEquals(LookupLoadingSpec.Mode.NONE.toString(), task.getContext().get(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE));
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -133,6 +133,7 @@ import org.apache.druid.segment.realtime.firehose.ChatHandlerProvider;
 import org.apache.druid.segment.realtime.firehose.NoopChatHandlerProvider;
 import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ResourceAction;
@@ -1736,6 +1737,20 @@ public class CompactionTaskTest
         null
     );
     Assert.assertNull(chooseFinestGranularityHelper(input));
+  }
+
+  @Test
+  public void testGetDefaultLookupLoadingSpec()
+  {
+    final Builder builder = new Builder(
+        DATA_SOURCE,
+        segmentCacheManagerFactory,
+        RETRY_POLICY_FACTORY
+    );
+    final CompactionTask task = builder
+        .interval(Intervals.of("2000-01-01/2000-01-02"))
+        .build();
+    Assert.assertEquals(LookupLoadingSpec.NONE, task.getLookupLoadingSpec());
   }
 
   private Granularity chooseFinestGranularityHelper(List<Granularity> granularities)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1753,6 +1753,21 @@ public class CompactionTaskTest
     Assert.assertEquals(LookupLoadingSpec.NONE, task.getLookupLoadingSpec());
   }
 
+  @Test
+  public void testGetDefaultLookupLoadingSpecWithTransformSpec()
+  {
+    final Builder builder = new Builder(
+        DATA_SOURCE,
+        segmentCacheManagerFactory,
+        RETRY_POLICY_FACTORY
+    );
+    final CompactionTask task = builder
+        .interval(Intervals.of("2000-01-01/2000-01-02"))
+        .transformSpec(new ClientCompactionTaskTransformSpec(new SelectorDimFilter("dim1", "foo", null)))
+        .build();
+    Assert.assertEquals(LookupLoadingSpec.ALL, task.getLookupLoadingSpec());
+  }
+
   private Granularity chooseFinestGranularityHelper(List<Granularity> granularities)
   {
     SettableSupplier<Granularity> queryGranularity = new SettableSupplier<>();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
+import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -127,5 +128,11 @@ public class TaskTest
         UOE.class,
         TASK::getInputSourceResources
     );
+  }
+
+  @Test
+  public void testGetLookupLoadingSpec()
+  {
+    Assert.assertEquals(LookupLoadingSpec.ALL, TASK.getLookupLoadingSpec());
   }
 }

--- a/server/src/main/java/org/apache/druid/server/lookup/cache/LookupLoadingSpec.java
+++ b/server/src/main/java/org/apache/druid/server/lookup/cache/LookupLoadingSpec.java
@@ -119,7 +119,8 @@ public class LookupLoadingSpec
         lookupsToLoad = (Collection<String>) context.get(CTX_LOOKUPS_TO_LOAD);
       }
       catch (ClassCastException e) {
-        throw InvalidInput.exception("Invalid value of %s[%s]. Please provide a comma-separated list of lookup names.",
+        throw InvalidInput.exception("Invalid value of %s[%s]. Please provide a comma-separated list of "
+                                     + "lookup names. For example: [\"lookupName1\", \"lookupName2\"]",
                                      CTX_LOOKUPS_TO_LOAD, context.get(CTX_LOOKUPS_TO_LOAD));
       }
 

--- a/server/src/main/java/org/apache/druid/server/lookup/cache/LookupLoadingSpec.java
+++ b/server/src/main/java/org/apache/druid/server/lookup/cache/LookupLoadingSpec.java
@@ -88,7 +88,7 @@ public class LookupLoadingSpec
     return lookupsToLoad;
   }
 
-  public static LookupLoadingSpec getSpecFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec)
+  public static LookupLoadingSpec createFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec)
   {
     if (context == null) {
       return defaultSpec;

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -19,11 +19,18 @@
 
 package org.apache.druid.server.lookup.cache;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 public class LookupLoadingSpecTest
@@ -58,5 +65,63 @@ public class LookupLoadingSpecTest
   {
     DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.loadOnly(null));
     Assert.assertEquals("Expected non-null set of lookups to load.", exception.getMessage());
+  }
+
+  @MethodSource("provideParamsForTestGetSpecFromContext")
+  @ParameterizedTest
+  public void testGetLookupLoadingSpecFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec, LookupLoadingSpec expectedSpec)
+  {
+    LookupLoadingSpec specFromContext = LookupLoadingSpec.getSpecFromContext(context, defaultSpec);
+    Assert.assertEquals(expectedSpec.getMode(), specFromContext.getMode());
+    Assert.assertEquals(expectedSpec.getLookupsToLoad(), specFromContext.getLookupsToLoad());
+  }
+
+  public static Collection<Object[]> provideParamsForTestGetSpecFromContext()
+  {
+    ImmutableSet<String> lookupsToLoad = ImmutableSet.of("lookupName1", "lookupName2");
+    final ImmutableMap<String, Object> contextWithModeOnlyRequired = ImmutableMap.of(
+        LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, new ArrayList<>(lookupsToLoad),
+        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
+    final ImmutableMap<String, Object> contextWithModeNone = ImmutableMap.of(
+        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE);
+    final ImmutableMap<String, Object> contextWithModeAll = ImmutableMap.of(
+        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ALL);
+    final ImmutableMap<String, Object> contextWithoutLookupKeys = ImmutableMap.of();
+
+    // Return params: <context, default LookupLoadingSpec, expected LookupLoadingSpec>
+    Object[][] params = new Object[][]{
+        // Default spec is returned in the case of context not having the lookup keys.
+        {
+            contextWithoutLookupKeys,
+            LookupLoadingSpec.ALL,
+            LookupLoadingSpec.ALL
+        },
+        // Default spec is returned in the case of context not having the lookup keys.
+        {
+            contextWithoutLookupKeys,
+            LookupLoadingSpec.NONE,
+            LookupLoadingSpec.NONE
+        },
+        // Only required lookups are returned in the case of context having the lookup keys.
+        {
+            contextWithModeOnlyRequired,
+            LookupLoadingSpec.ALL,
+            LookupLoadingSpec.loadOnly(lookupsToLoad)
+        },
+        // No lookups are returned in the case of context having mode=NONE, irrespective of the default spec.
+        {
+            contextWithModeAll,
+            LookupLoadingSpec.NONE,
+            LookupLoadingSpec.ALL
+        },
+        // All lookups are returned in the case of context having mode=ALL, irrespective of the default spec.
+        {
+            contextWithModeNone,
+            LookupLoadingSpec.ALL,
+            LookupLoadingSpec.NONE
+        }
+    };
+
+    return Arrays.asList(params);
   }
 }

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Set;

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -24,13 +24,8 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Map;
 import java.util.Set;
 
 public class LookupLoadingSpecTest
@@ -67,66 +62,67 @@ public class LookupLoadingSpecTest
     Assert.assertEquals("Expected non-null set of lookups to load.", exception.getMessage());
   }
 
-  @MethodSource("provideParamsForTestCreateFromContext")
-  @ParameterizedTest
-  public void testGetLookupLoadingSpecFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec, LookupLoadingSpec expectedSpec)
-  {
-    LookupLoadingSpec specFromContext = LookupLoadingSpec.createFromContext(context, defaultSpec);
-    Assert.assertEquals(expectedSpec, specFromContext);
-  }
-
-  public static Collection<Object[]> provideParamsForTestCreateFromContext()
+  @Test
+  public void testCreateLookupLoadingSpecFromContext()
   {
     ImmutableSet<String> lookupsToLoad = ImmutableSet.of("lookupName1", "lookupName2");
-    final ImmutableMap<String, Object> contextWithModeOnlyRequired = ImmutableMap.of(
-        LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, new ArrayList<>(lookupsToLoad),
-        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED);
-    final ImmutableMap<String, Object> contextWithModeNone = ImmutableMap.of(
-        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE);
-    final ImmutableMap<String, Object> contextWithModeAll = ImmutableMap.of(
-        LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ALL);
-    final ImmutableMap<String, Object> contextWithoutLookupKeys = ImmutableMap.of();
 
-    // Return params: <context, default LookupLoadingSpec, expected LookupLoadingSpec>
-    Object[][] params = new Object[][]{
-        // Default spec is returned in the case of context not having the lookup keys.
-        {
-            contextWithoutLookupKeys,
-            LookupLoadingSpec.ALL,
+    // Default spec is returned in the case of context not having the lookup keys.
+    Assert.assertEquals(
+        LookupLoadingSpec.ALL,
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(),
             LookupLoadingSpec.ALL
-        },
-        // Default spec is returned in the case of context not having the lookup keys.
-        {
-            contextWithoutLookupKeys,
-            LookupLoadingSpec.NONE,
+        )
+    );
+
+    // Default spec is returned in the case of context not having the lookup keys.
+    Assert.assertEquals(
+        LookupLoadingSpec.NONE,
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(),
             LookupLoadingSpec.NONE
-        },
-        // Only required lookups are returned in the case of context having the lookup keys.
-        {
-            contextWithModeOnlyRequired,
-            LookupLoadingSpec.ALL,
-            LookupLoadingSpec.loadOnly(lookupsToLoad)
-        },
-        // No lookups are returned in the case of context having mode=NONE, irrespective of the default spec.
-        {
-            contextWithModeAll,
-            LookupLoadingSpec.NONE,
+        )
+    );
+
+    // Only required lookups are returned in the case of context having the lookup keys.
+    Assert.assertEquals(
+        LookupLoadingSpec.loadOnly(lookupsToLoad),
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(
+                LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, new ArrayList<>(lookupsToLoad),
+                LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED
+            ),
             LookupLoadingSpec.ALL
-        },
-        // All lookups are returned in the case of context having mode=ALL, irrespective of the default spec.
-        {
-            contextWithModeNone,
-            LookupLoadingSpec.ALL,
+        )
+    );
+
+    // No lookups are returned in the case of context having mode=NONE, irrespective of the default spec.
+    Assert.assertEquals(
+        LookupLoadingSpec.NONE,
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(
+                LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE),
+            LookupLoadingSpec.ALL
+        )
+    );
+
+    // All lookups are returned in the case of context having mode=ALL, irrespective of the default spec.
+    Assert.assertEquals(
+        LookupLoadingSpec.ALL,
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ALL),
             LookupLoadingSpec.NONE
-        },
-        // Default spec is returned in the case of context=null.
-        {
+        )
+    );
+
+    // Default spec is returned in the case of context=null.
+    Assert.assertEquals(
+        LookupLoadingSpec.NONE,
+        LookupLoadingSpec.createFromContext(
             null,
-            LookupLoadingSpec.NONE,
             LookupLoadingSpec.NONE
-        }
-    };
-
-    return Arrays.asList(params);
+        )
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -72,8 +72,7 @@ public class LookupLoadingSpecTest
   public void testGetLookupLoadingSpecFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec, LookupLoadingSpec expectedSpec)
   {
     LookupLoadingSpec specFromContext = LookupLoadingSpec.getSpecFromContext(context, defaultSpec);
-    Assert.assertEquals(expectedSpec.getMode(), specFromContext.getMode());
-    Assert.assertEquals(expectedSpec.getLookupsToLoad(), specFromContext.getLookupsToLoad());
+    Assert.assertEquals(expectedSpec, specFromContext);
   }
 
   public static Collection<Object[]> provideParamsForTestGetSpecFromContext()
@@ -118,6 +117,12 @@ public class LookupLoadingSpecTest
         {
             contextWithModeNone,
             LookupLoadingSpec.ALL,
+            LookupLoadingSpec.NONE
+        },
+        // Default spec is returned in the case of context=null.
+        {
+            null,
+            LookupLoadingSpec.NONE,
             LookupLoadingSpec.NONE
         }
     };

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -82,6 +82,7 @@ public class LookupLoadingSpecTest
         )
     );
   }
+
   @Test
   public void testCreateLookupLoadingSpecFromNullContext()
   {

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -67,15 +67,15 @@ public class LookupLoadingSpecTest
     Assert.assertEquals("Expected non-null set of lookups to load.", exception.getMessage());
   }
 
-  @MethodSource("provideParamsForTestGetSpecFromContext")
+  @MethodSource("provideParamsForTestCreateFromContext")
   @ParameterizedTest
   public void testGetLookupLoadingSpecFromContext(Map<String, Object> context, LookupLoadingSpec defaultSpec, LookupLoadingSpec expectedSpec)
   {
-    LookupLoadingSpec specFromContext = LookupLoadingSpec.getSpecFromContext(context, defaultSpec);
+    LookupLoadingSpec specFromContext = LookupLoadingSpec.createFromContext(context, defaultSpec);
     Assert.assertEquals(expectedSpec, specFromContext);
   }
 
-  public static Collection<Object[]> provideParamsForTestGetSpecFromContext()
+  public static Collection<Object[]> provideParamsForTestCreateFromContext()
   {
     ImmutableSet<String> lookupsToLoad = ImmutableSet.of("lookupName1", "lookupName2");
     final ImmutableMap<String, Object> contextWithModeOnlyRequired = ImmutableMap.of(

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -179,7 +179,8 @@ public class LookupLoadingSpecTest
                 LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED),
             LookupLoadingSpec.ALL)
     );
-    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Please provide a comma-separated list of lookup names.",
-                                      LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad), exception.getMessage());
+    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Please provide a comma-separated list of "
+                                           + "lookup names. For example: [\"lookupName1\", \"lookupName2\"]",
+                                           LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad), exception.getMessage());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -21,13 +21,17 @@ package org.apache.druid.server.lookup.cache;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.druid.error.DruidException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Set;
 
+@RunWith(JUnitParamsRunner.class)
 public class LookupLoadingSpecTest
 {
   @Test
@@ -137,5 +141,44 @@ public class LookupLoadingSpecTest
             LookupLoadingSpec.NONE
         )
     );
+  }
+
+  @Test
+  @Parameters(
+      {
+          "NONE1",
+          "A",
+          "Random mode",
+          "all",
+          "only required",
+          "none"
+      }
+  )
+  public void testCreateLookupLoadingSpecFromInvalidModeInContext(String mode)
+  {
+    DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
+        ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), LookupLoadingSpec.ALL));
+    Assert.assertEquals(String.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
+                                      LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), exception.getMessage());
+  }
+
+  @Test
+  @Parameters(
+      {
+          "foo bar",
+          "foo]"
+      }
+  )
+  public void testCreateLookupLoadingSpecFromInvalidLookupsInContext(Object lookupsToLoad)
+  {
+    DruidException exception = Assert.assertThrows(DruidException.class, () ->
+        LookupLoadingSpec.createFromContext(
+            ImmutableMap.of(
+                LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad,
+                LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED),
+            LookupLoadingSpec.ALL)
+    );
+    Assert.assertEquals(String.format("Invalid value of %s[%s]. Please provide a comma-separated list of lookup names.",
+                                      LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad), exception.getMessage());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -25,7 +25,7 @@ import org.apache.druid.error.DruidException;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Set;
 
 public class LookupLoadingSpecTest
@@ -63,10 +63,8 @@ public class LookupLoadingSpecTest
   }
 
   @Test
-  public void testCreateLookupLoadingSpecFromContext()
+  public void testCreateLookupLoadingSpecFromEmptyContext()
   {
-    ImmutableSet<String> lookupsToLoad = ImmutableSet.of("lookupName1", "lookupName2");
-
     // Default spec is returned in the case of context not having the lookup keys.
     Assert.assertEquals(
         LookupLoadingSpec.ALL,
@@ -76,7 +74,6 @@ public class LookupLoadingSpecTest
         )
     );
 
-    // Default spec is returned in the case of context not having the lookup keys.
     Assert.assertEquals(
         LookupLoadingSpec.NONE,
         LookupLoadingSpec.createFromContext(
@@ -84,13 +81,37 @@ public class LookupLoadingSpecTest
             LookupLoadingSpec.NONE
         )
     );
+  }
+  @Test
+  public void testCreateLookupLoadingSpecFromNullContext()
+  {
+    // Default spec is returned in the case of context=null.
+    Assert.assertEquals(
+        LookupLoadingSpec.NONE,
+        LookupLoadingSpec.createFromContext(
+            null,
+            LookupLoadingSpec.NONE
+        )
+    );
 
+    Assert.assertEquals(
+        LookupLoadingSpec.ALL,
+        LookupLoadingSpec.createFromContext(
+            null,
+            LookupLoadingSpec.ALL
+        )
+    );
+  }
+
+  @Test
+  public void testCreateLookupLoadingSpecFromContext()
+  {
     // Only required lookups are returned in the case of context having the lookup keys.
     Assert.assertEquals(
-        LookupLoadingSpec.loadOnly(lookupsToLoad),
+        LookupLoadingSpec.loadOnly(ImmutableSet.of("lookup1", "lookup2")),
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(
-                LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, new ArrayList<>(lookupsToLoad),
+                LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, Arrays.asList("lookup1", "lookup2"),
                 LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED
             ),
             LookupLoadingSpec.ALL
@@ -112,15 +133,6 @@ public class LookupLoadingSpecTest
         LookupLoadingSpec.ALL,
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ALL),
-            LookupLoadingSpec.NONE
-        )
-    );
-
-    // Default spec is returned in the case of context=null.
-    Assert.assertEquals(
-        LookupLoadingSpec.NONE,
-        LookupLoadingSpec.createFromContext(
-            null,
             LookupLoadingSpec.NONE
         )
     );

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -156,7 +156,7 @@ public class LookupLoadingSpecTest
   )
   public void testCreateLookupLoadingSpecFromInvalidModeInContext(String mode)
   {
-    DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
+    final DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
         ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), LookupLoadingSpec.ALL));
     Assert.assertEquals(String.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
                                       LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), exception.getMessage());
@@ -171,7 +171,7 @@ public class LookupLoadingSpecTest
   )
   public void testCreateLookupLoadingSpecFromInvalidLookupsInContext(Object lookupsToLoad)
   {
-    DruidException exception = Assert.assertThrows(DruidException.class, () ->
+    final DruidException exception = Assert.assertThrows(DruidException.class, () ->
         LookupLoadingSpec.createFromContext(
             ImmutableMap.of(
                 LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad,

--- a/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
+++ b/server/src/test/java/org/apache/druid/server/lookup/cache/LookupLoadingSpecTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -158,8 +159,8 @@ public class LookupLoadingSpecTest
   {
     final DruidException exception = Assert.assertThrows(DruidException.class, () -> LookupLoadingSpec.createFromContext(
         ImmutableMap.of(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), LookupLoadingSpec.ALL));
-    Assert.assertEquals(String.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
-                                      LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), exception.getMessage());
+    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Allowed values are [ALL, NONE, ONLY_REQUIRED]",
+                                           LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, mode), exception.getMessage());
   }
 
   @Test
@@ -178,7 +179,7 @@ public class LookupLoadingSpecTest
                 LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.ONLY_REQUIRED),
             LookupLoadingSpec.ALL)
     );
-    Assert.assertEquals(String.format("Invalid value of %s[%s]. Please provide a comma-separated list of lookup names.",
+    Assert.assertEquals(StringUtils.format("Invalid value of %s[%s]. Please provide a comma-separated list of lookup names.",
                                       LookupLoadingSpec.CTX_LOOKUPS_TO_LOAD, lookupsToLoad), exception.getMessage());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -80,8 +80,6 @@ public class PlannerContext
   public static final String CTX_SQL_CURRENT_TIMESTAMP = "sqlCurrentTimestamp";
   public static final String CTX_SQL_TIME_ZONE = "sqlTimeZone";
   public static final String CTX_SQL_JOIN_ALGORITHM = "sqlJoinAlgorithm";
-  public static final String CTX_LOOKUP_LOADING_MODE = "lookupLoadingMode";
-  public static final String CTX_LOOKUPS_TO_LOAD = "lookupsToLoad";
   private static final JoinAlgorithm DEFAULT_SQL_JOIN_ALGORITHM = JoinAlgorithm.BROADCAST;
 
   /**
@@ -357,7 +355,7 @@ public class PlannerContext
   }
 
   /**
-   * Returns the lookup to load for a given task.
+   * Returns the lookup loading spec for a given task.
    */
   public LookupLoadingSpec getLookupLoadingSpec()
   {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -355,7 +355,7 @@ public class PlannerContext
   }
 
   /**
-   * Returns the lookup loading spec for a given task.
+   * Lookup loading spec used if this context corresponds to an MSQ task.
    */
   public LookupLoadingSpec getLookupLoadingSpec()
   {


### PR DESCRIPTION
## Description

This PR updates CompactionTask to not load any lookups by default, unless `transformSpec` is present.

If transformSpec is present, we will make the decision based on context values, loading all lookups by default. This is done to ensure backward compatibility since transformSpec can reference lookups.
If transform spec is not present and no context value is passed, we donot load any lookup.

This behavior can be overridden by supplying `lookupLoadingMode` and `lookupsToLoad` in the task context.

Other changes/refactoring:
1. Moved CTX_LOOKUP_LOADING_MODE and CTX_LOOKUPS_TO_LOAD constants from PlannerContext to LookupLoadingSpec, as PlannerContext wasn't available in the indexing module.
2. Moved logic for evaluating the context and creating LookupLoadingSpec based on that to `LookupLoadingSpec#getSpecFromContext`.
3. Updated `Task#getLookupLoadingSpec` to return `LookupLoadingSpec.getSpecFromContext(getContext(), LookupLoadingSpec.ALL)`. The default `ALL` ensures that no existing behavior is broken, unless context has been overridden. Making this change in `Task` interface prevents us from having to make this change in a bunch of tasks that are spawned by CompactionTask.

## Test Plan

1. Tried manual compaction with all 3 partitioning modes (dynamic, range, hash) - validated that no lookups are loaded in the compaction task, as well as all the other spawned tasks.
2. Repeated (1) with overriding task context with combination of `lookupLoadingMode` and `lookupsToLoad` - validated that the lookups in all tasks (compaction + spawned) were loaded as per the overridden context. This would help achieve any use-cases where lookups are needed during compaction.
3. Validated that auto-compaction also doesn't load any lookups by default.
4. Also tried ingestion in all 3 partitioning modes (dynamic, range, hash) to ensure this behavior is unaffected.
5. Validated different types of MSQ queries and ingestion to make sure their behavior is unaffected.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
