### PR TITLE
[Backport] Downgrade the version of Apache Curator from 5.5.0 to 5.3.0 to avoid a bug in the new version

### DIFF
--- a/extensions-contrib/ddsketch/pom.xml
+++ b/extensions-contrib/ddsketch/pom.xml
@@ -128,7 +128,6 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-client</artifactId>
-      <version>5.5.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/integration-tests-ex/cases/pom.xml
+++ b/integration-tests-ex/cases/pom.xml
@@ -297,7 +297,6 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
-            <version>5.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1655,7 +1655,7 @@ name: Apache Curator
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 5.5.0
+version: 5.3.0
 libraries:
   - org.apache.curator: curator-client
   - org.apache.curator: curator-framework

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <java.version>8</java.version>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
-        <apache.curator.version>5.5.0</apache.curator.version>
+        <apache.curator.version>5.3.0</apache.curator.version>
         <apache.kafka.version>3.6.1</apache.kafka.version>
         <!-- when updating apache ranger, verify the usage of aws-bundle-sdk vs aws-logs-sdk
         and update as needed in extensions-core/druid-ranger-security/pm.xml  -->


### PR DESCRIPTION
Backport of #16425 to 30.0.0.