### PR TITLE
Replace if-return with Assume API from Junit in `DecimalParquetInputTest`

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.indexer.HadoopDruidIndexerConfig;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,8 +32,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.junit.Assume.assumeFalse;
-
 @RunWith(Parameterized.class)
 public class DecimalParquetInputTest extends BaseParquetInputTest
 {
@@ -40,8 +39,8 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
-            new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
-            new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
+          new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
+          new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
     );
   }
 
@@ -56,12 +55,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimalFixedLen() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+    Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-            "example/decimals/dec_in_fix_len.json",
-            parserType,
-            true
+          "example/decimals/dec_in_fix_len.json",
+          parserType,
+          true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -102,12 +101,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimali32() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+    Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-            "example/decimals/dec_in_i32.json",
-            parserType,
-            true
+          "example/decimals/dec_in_i32.json",
+          parserType,
+          true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -148,12 +147,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimali64() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+    Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-            "example/decimals/dec_in_i64.json",
-            parserType,
-            true
+          "example/decimals/dec_in_i64.json",
+          parserType,
+          true
     );
     /*
     The raw data in the parquet file has the following columns:

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
@@ -39,8 +39,8 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
-          new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
-          new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
+        new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
+        new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
     );
   }
 
@@ -58,9 +58,9 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
     Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-          "example/decimals/dec_in_fix_len.json",
-          parserType,
-          true
+        "example/decimals/dec_in_fix_len.json",
+        parserType,
+        true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -104,9 +104,9 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
     Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-          "example/decimals/dec_in_i32.json",
-          parserType,
-          true
+        "example/decimals/dec_in_i32.json",
+        parserType,
+        true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -150,9 +150,9 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
     Assume.assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
 
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-          "example/decimals/dec_in_i64.json",
-          parserType,
-          true
+        "example/decimals/dec_in_i64.json",
+        parserType,
+        true
     );
     /*
     The raw data in the parquet file has the following columns:

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetInputTest.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 
+import static org.junit.Assume.assumeFalse;
+
 @RunWith(Parameterized.class)
 public class DecimalParquetInputTest extends BaseParquetInputTest
 {
@@ -38,8 +40,8 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
-        new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
-        new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
+            new Object[]{ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE},
+            new Object[]{ParquetExtensionsModule.PARQUET_SIMPLE_INPUT_PARSER_TYPE}
     );
   }
 
@@ -54,13 +56,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimalFixedLen() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    if (parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE)) {
-      return;
-    }
+    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-        "example/decimals/dec_in_fix_len.json",
-        parserType,
-        true
+            "example/decimals/dec_in_fix_len.json",
+            parserType,
+            true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -101,13 +102,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimali32() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    if (parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE)) {
-      return;
-    }
+    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-        "example/decimals/dec_in_i32.json",
-        parserType,
-        true
+            "example/decimals/dec_in_i32.json",
+            parserType,
+            true
     );
     /*
     The raw data in the parquet file has the following columns:
@@ -148,13 +148,12 @@ public class DecimalParquetInputTest extends BaseParquetInputTest
   public void testReadParquetDecimali64() throws IOException, InterruptedException
   {
     // parquet-avro does not correctly convert decimal types
-    if (parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE)) {
-      return;
-    }
+    assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
+
     HadoopDruidIndexerConfig config = transformHadoopDruidIndexerConfig(
-        "example/decimals/dec_in_i64.json",
-        parserType,
-        true
+            "example/decimals/dec_in_i64.json",
+            parserType,
+            true
     );
     /*
     The raw data in the parquet file has the following columns:


### PR DESCRIPTION
Fixes #12926.

### Description

This PR improves the test cases in `DecimalParquetInputTest` by replacing the if-return blocks that check for unsupported parser types with `assumeFalse`-- Assume API from Junit. 

#### Replaced if-return blocks with assumeFalse
The existing test cases used if-return blocks like this to skip tests for unsupported parser types:

```java
// parquet-avro does not correctly convert decimal types
if (parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE)) {  
  return;
}
```

This made the test logic implicit. It's preferable to make unsupported preconditions explicit using JUnit's `assume` methods. The assume function, introduced after JUnit 4, is designed to check for test pre-condition. As [mentioned in the document](https://junit.org/junit4/javadoc/4.12/org/junit/Assume.html):

> Assume functions is a set of methods useful for stating assumptions about the conditions in which a test is meaningful. A failed assumption does not mean the code is broken, but that the test provides no useful information.

I replaced the if-return blocks with equivalent `assumeFalse` assertions:

```java
// parquet-avro does not correctly convert decimal types
assumeFalse(parserType.equals(ParquetExtensionsModule.PARQUET_AVRO_INPUT_PARSER_TYPE));
```

A failed assumption will cause the test to be skipped, while still allowing the test to run for supported parser types. This makes the preconditions clearer without changing the test behavior.

**This refactoring resolves the silent quit issue by using the Assume API to provide explicit output when tests are skipped.**

I applied this change to all three test cases in `DecimalParquetInputTest`:
- `testReadParquetDecimalFixedLen` 
- `testReadParquetDecimali32`
- `testReadParquetDecimali64`

This is a straightforward refactoring that improves test readability without altering functionality. No other code changes were made.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
