### PR TITLE
[Backport] Support sorting on complex columns in MSQ

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/frame/FrameChannelMergerBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/frame/FrameChannelMergerBenchmark.java
@@ -37,6 +37,8 @@ import org.apache.druid.frame.processor.FrameProcessorExecutor;
 import org.apache.druid.frame.read.FrameReader;
 import org.apache.druid.frame.testutil.FrameSequenceBuilder;
 import org.apache.druid.frame.write.FrameWriters;
+import org.apache.druid.guice.NestedDataModule;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.java.util.common.StringUtils;
@@ -47,6 +49,7 @@ import org.apache.druid.segment.RowBasedSegment;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.timeline.SegmentId;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -82,6 +85,7 @@ public class FrameChannelMergerBenchmark
 {
   static {
     NullHandling.initializeForTests();
+    NestedDataModule.registerHandlersAndSerde();
   }
 
   private static final String KEY = "key";
@@ -98,6 +102,9 @@ public class FrameChannelMergerBenchmark
 
   @Param({"100"})
   private int rowLength;
+
+  @Param({"string", "nested"})
+  private String columnType;
 
   /**
    * Linked to {@link KeyGenerator}.
@@ -121,13 +128,20 @@ public class FrameChannelMergerBenchmark
      */
     RANDOM {
       @Override
-      public String generateKey(int rowNumber, int keyLength)
+      public Comparable generateKey(int rowNumber, int keyLength, String columnType)
       {
         final StringBuilder builder = new StringBuilder(keyLength);
         for (int i = 0; i < keyLength; i++) {
           builder.append((char) ('a' + ThreadLocalRandom.current().nextInt(26)));
         }
-        return builder.toString();
+        String str = builder.toString();
+        if ("string".equals(columnType)) {
+          return str;
+        } else if ("nested".equals(columnType)) {
+          return StructuredData.wrap(str);
+        } else {
+          throw new IAE("unsupported column type");
+        }
       }
     },
 
@@ -136,13 +150,20 @@ public class FrameChannelMergerBenchmark
      */
     SEQUENTIAL {
       @Override
-      public String generateKey(int rowNumber, int keyLength)
+      public Comparable generateKey(int rowNumber, int keyLength, String columnType)
       {
-        return StringUtils.format("%0" + keyLength + "d", rowNumber);
+        String str = StringUtils.format("%0" + keyLength + "d", rowNumber);
+        if ("string".equals(columnType)) {
+          return str;
+        } else if ("nested".equals(columnType)) {
+          return StructuredData.wrap(str);
+        } else {
+          throw new IAE("unsupported column type");
+        }
       }
     };
 
-    public abstract String generateKey(int rowNumber, int keyLength);
+    public abstract Comparable generateKey(int rowNumber, int keyLength, String columnType);
   }
 
   /**
@@ -176,13 +197,9 @@ public class FrameChannelMergerBenchmark
     public abstract int getChannelNumber(int rowNumber, int numRows, int numChannels);
   }
 
-  private final RowSignature signature =
-      RowSignature.builder()
-                  .add(KEY, ColumnType.STRING)
-                  .add(VALUE, ColumnType.STRING)
-                  .build();
+  private RowSignature signature;
+  private FrameReader frameReader;
 
-  private final FrameReader frameReader = FrameReader.create(signature);
   private final List<KeyColumn> sortKey = ImmutableList.of(new KeyColumn(KEY, KeyOrder.ASCENDING));
 
   private List<List<Frame>> channelFrames;
@@ -200,6 +217,14 @@ public class FrameChannelMergerBenchmark
   @Setup(Level.Trial)
   public void setupTrial()
   {
+    signature =
+        RowSignature.builder()
+                    .add(KEY, createKeyColumnTypeFromTypeString(columnType))
+                    .add(VALUE, ColumnType.STRING)
+                    .build();
+
+    frameReader = FrameReader.create(signature);
+
     exec = new FrameProcessorExecutor(
         MoreExecutors.listeningDecorator(
             Execs.singleThreaded(StringUtils.encodeForFormat(getClass().getSimpleName()))
@@ -211,14 +236,15 @@ public class FrameChannelMergerBenchmark
         ChannelDistribution.valueOf(StringUtils.toUpperCase(channelDistributionString));
 
     // Create channelRows which holds rows for each channel.
-    final List<List<NonnullPair<String, String>>> channelRows = new ArrayList<>();
+    final List<List<NonnullPair<Comparable, String>>> channelRows = new ArrayList<>();
     channelFrames = new ArrayList<>();
     for (int channelNumber = 0; channelNumber < numChannels; channelNumber++) {
       channelRows.add(new ArrayList<>());
       channelFrames.add(new ArrayList<>());
     }
 
-    // Create "valueString", a string full of spaces to pad out the row.
+    // Create "valueString", a string full of spaces to pad out the row. Nested columns wrap up strings with the
+    // corresponding keyLength, therefore the padding works out for the nested types as well.
     final StringBuilder valueStringBuilder = new StringBuilder();
     for (int i = 0; i < rowLength - keyLength; i++) {
       valueStringBuilder.append(' ');
@@ -227,20 +253,20 @@ public class FrameChannelMergerBenchmark
 
     // Populate "channelRows".
     for (int rowNumber = 0; rowNumber < numRows; rowNumber++) {
-      final String keyString = keyGenerator.generateKey(rowNumber, keyLength);
-      final NonnullPair<String, String> row = new NonnullPair<>(keyString, valueString);
+      final Comparable keyObject = keyGenerator.generateKey(rowNumber, keyLength, columnType);
+      final NonnullPair<Comparable, String> row = new NonnullPair<>(keyObject, valueString);
       channelRows.get(channelDistribution.getChannelNumber(rowNumber, numRows, numChannels)).add(row);
     }
 
     // Sort each "channelRows".
-    for (List<NonnullPair<String, String>> rows : channelRows) {
+    for (List<NonnullPair<Comparable, String>> rows : channelRows) {
       rows.sort(Comparator.comparing(row -> row.lhs));
     }
 
     // Populate each "channelFrames".
     for (int channelNumber = 0; channelNumber < numChannels; channelNumber++) {
-      final List<NonnullPair<String, String>> rows = channelRows.get(channelNumber);
-      final RowBasedSegment<NonnullPair<String, String>> segment =
+      final List<NonnullPair<Comparable, String>> rows = channelRows.get(channelNumber);
+      final RowBasedSegment<NonnullPair<Comparable, String>> segment =
           new RowBasedSegment<>(
               SegmentId.dummy("__dummy"),
               Sequences.simple(rows),
@@ -349,5 +375,15 @@ public class FrameChannelMergerBenchmark
     if (FutureUtils.getUnchecked(retVal, true) != numRows) {
       throw new ISE("Incorrect numRows[%s], expected[%s]", FutureUtils.getUncheckedImmediately(retVal), numRows);
     }
+  }
+
+  private ColumnType createKeyColumnTypeFromTypeString(final String columnTypeString)
+  {
+    if ("string".equals(columnTypeString)) {
+      return ColumnType.STRING;
+    } else if ("nested".equals(columnTypeString)) {
+      return ColumnType.NESTED_DATA;
+    }
+    throw new IAE("Unsupported type [%s]", columnTypeString);
   }
 }

--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -54,6 +54,7 @@ org.apache.calcite.sql.type.OperandTypes#NULLABLE_LITERAL @ Create an instance o
 org.apache.commons.io.FileUtils#getTempDirectory() @ Use org.junit.rules.TemporaryFolder for tests instead
 org.apache.commons.io.FileUtils#deleteDirectory(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils#deleteDirectory()
 org.apache.commons.io.FileUtils#forceMkdir(java.io.File) @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
+org.apache.datasketches.memory.Memory#wrap(byte[], int, int, java.nio.ByteOrder) @ The implementation isn't correct in datasketches-memory-2.2.0. Please refer to https://github.com/apache/datasketches-memory/issues/178. Use wrap(byte[]) and modify the offset by the callers instead
 java.lang.Class#getCanonicalName() @ Class.getCanonicalName can return null for anonymous types, use Class.getName instead.
 java.util.concurrent.Executors#newFixedThreadPool(int) @ Executor is non-daemon and can prevent JVM shutdown, use org.apache.druid.java.util.common.concurrent.Execs#multiThreaded(int, java.lang.String) instead.
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImpl.java
@@ -67,6 +67,7 @@ public class ClusterByStatisticsCollectorImpl implements ClusterByStatisticsColl
 
   private ClusterByStatisticsCollectorImpl(
       final ClusterBy clusterBy,
+      final RowSignature rowSignature,
       final RowKeyReader keyReader,
       final KeyCollectorFactory<?, ?> keyCollectorFactory,
       final long maxRetainedBytes,
@@ -78,7 +79,7 @@ public class ClusterByStatisticsCollectorImpl implements ClusterByStatisticsColl
     this.keyReader = keyReader;
     this.keyCollectorFactory = keyCollectorFactory;
     this.maxRetainedBytes = maxRetainedBytes;
-    this.buckets = new TreeMap<>(clusterBy.bucketComparator());
+    this.buckets = new TreeMap<>(clusterBy.bucketComparator(rowSignature));
     this.maxBuckets = maxBuckets;
     this.checkHasMultipleValues = checkHasMultipleValues;
     this.hasMultipleValues = checkHasMultipleValues ? new boolean[clusterBy.getColumns().size()] : null;
@@ -98,10 +99,12 @@ public class ClusterByStatisticsCollectorImpl implements ClusterByStatisticsColl
   )
   {
     final RowKeyReader keyReader = clusterBy.keyReader(signature);
-    final KeyCollectorFactory<?, ?> keyCollectorFactory = KeyCollectors.makeStandardFactory(clusterBy, aggregate);
+    final KeyCollectorFactory<?, ?> keyCollectorFactory =
+        KeyCollectors.makeStandardFactory(clusterBy, aggregate, signature);
 
     return new ClusterByStatisticsCollectorImpl(
         clusterBy,
+        signature,
         keyReader,
         keyCollectorFactory,
         maxRetainedBytes,

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollectorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollectorFactory.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.Object2LongRBTreeMap;
 import org.apache.druid.collections.SerializablePair;
 import org.apache.druid.frame.key.ClusterBy;
 import org.apache.druid.frame.key.RowKey;
+import org.apache.druid.segment.column.RowSignature;
 
 import java.util.Comparator;
 import java.util.stream.Collectors;
@@ -36,9 +37,9 @@ public class DistinctKeyCollectorFactory implements KeyCollectorFactory<Distinct
     this.comparator = comparator;
   }
 
-  static DistinctKeyCollectorFactory create(final ClusterBy clusterBy)
+  static DistinctKeyCollectorFactory create(final ClusterBy clusterBy, RowSignature rowSignature)
   {
-    return new DistinctKeyCollectorFactory(clusterBy.keyComparator());
+    return new DistinctKeyCollectorFactory(clusterBy.keyComparator(rowSignature));
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/KeyCollectors.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/KeyCollectors.java
@@ -20,6 +20,7 @@
 package org.apache.druid.msq.statistics;
 
 import org.apache.druid.frame.key.ClusterBy;
+import org.apache.druid.segment.column.RowSignature;
 
 public class KeyCollectors
 {
@@ -33,19 +34,20 @@ public class KeyCollectors
    */
   public static KeyCollectorFactory<?, ?> makeStandardFactory(
       final ClusterBy clusterBy,
-      final boolean aggregate
+      final boolean aggregate,
+      final RowSignature rowSignature
   )
   {
     final KeyCollectorFactory<?, ?> baseFactory;
 
     if (aggregate) {
-      baseFactory = DistinctKeyCollectorFactory.create(clusterBy);
+      baseFactory = DistinctKeyCollectorFactory.create(clusterBy, rowSignature);
     } else {
-      baseFactory = QuantilesSketchKeyCollectorFactory.create(clusterBy);
+      baseFactory = QuantilesSketchKeyCollectorFactory.create(clusterBy, rowSignature);
     }
 
     // Wrap in DelegateOrMinKeyCollectorFactory, so we are guaranteed to be able to downsample to a single key. This
     // is important because it allows us to better handle large numbers of small buckets.
-    return new DelegateOrMinKeyCollectorFactory<>(clusterBy.keyComparator(), baseFactory);
+    return new DelegateOrMinKeyCollectorFactory<>(clusterBy.keyComparator(rowSignature), baseFactory);
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorFactory.java
@@ -27,6 +27,7 @@ import org.apache.datasketches.memory.WritableMemory;
 import org.apache.datasketches.quantiles.ItemsSketch;
 import org.apache.druid.frame.key.ClusterBy;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.RowSignature;
 
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -46,9 +47,9 @@ public class QuantilesSketchKeyCollectorFactory
     this.comparator = comparator;
   }
 
-  static QuantilesSketchKeyCollectorFactory create(final ClusterBy clusterBy)
+  static QuantilesSketchKeyCollectorFactory create(final ClusterBy clusterBy, final RowSignature rowSignature)
   {
-    return new QuantilesSketchKeyCollectorFactory(clusterBy.byteKeyComparator());
+    return new QuantilesSketchKeyCollectorFactory(clusterBy.byteKeyComparator(rowSignature));
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.exec;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.data.input.impl.JsonInputFormat;
+import org.apache.druid.data.input.impl.LocalInputSource;
+import org.apache.druid.data.input.impl.systemfield.SystemFields;
+import org.apache.druid.guice.NestedDataModule;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.msq.indexing.MSQSpec;
+import org.apache.druid.msq.indexing.MSQTuningConfig;
+import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
+import org.apache.druid.msq.test.MSQTestBase;
+import org.apache.druid.msq.util.MultiStageQueryContext;
+import org.apache.druid.query.DataSource;
+import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.scan.ScanQuery;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.nested.StructuredData;
+import org.apache.druid.sql.calcite.external.ExternalDataSource;
+import org.apache.druid.sql.calcite.filtration.Filtration;
+import org.apache.druid.sql.calcite.planner.ColumnMapping;
+import org.apache.druid.sql.calcite.planner.ColumnMappings;
+import org.apache.druid.timeline.SegmentId;
+import org.apache.druid.utils.CompressionUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MSQComplexGroupByTest extends MSQTestBase
+{
+  static {
+    NestedDataModule.registerHandlersAndSerde();
+  }
+
+  private String dataFileNameJsonString;
+  private String dataFileSignatureJsonString;
+  private DataSource dataFileExternalDataSource;
+
+  public static Collection<Object[]> data()
+  {
+    Object[][] data = new Object[][]{
+        {DEFAULT, DEFAULT_MSQ_CONTEXT},
+        {DURABLE_STORAGE, DURABLE_STORAGE_MSQ_CONTEXT},
+        {FAULT_TOLERANCE, FAULT_TOLERANCE_MSQ_CONTEXT},
+        {PARALLEL_MERGE, PARALLEL_MERGE_MSQ_CONTEXT}
+    };
+    return Arrays.asList(data);
+  }
+
+  @BeforeEach
+  public void setup() throws IOException
+  {
+    File dataFile = newTempFile("dataFile");
+    final InputStream resourceStream = this.getClass().getClassLoader()
+                                                                .getResourceAsStream(NestedDataTestUtils.ALL_TYPES_TEST_DATA_FILE);
+    final InputStream decompressing = CompressionUtils.decompress(
+        resourceStream,
+        "nested-all-types-test-data.json"
+    );
+    Files.copy(decompressing, dataFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    decompressing.close();
+
+    dataFileNameJsonString = queryFramework().queryJsonMapper().writeValueAsString(dataFile);
+
+    RowSignature dataFileSignature = RowSignature.builder()
+                                                 .add("timestamp", ColumnType.STRING)
+                                                 .add("obj", ColumnType.NESTED_DATA)
+                                                 .build();
+    dataFileSignatureJsonString = queryFramework().queryJsonMapper().writeValueAsString(dataFileSignature);
+
+    dataFileExternalDataSource = new ExternalDataSource(
+        new LocalInputSource(null, null, ImmutableList.of(dataFile), SystemFields.none()),
+        new JsonInputFormat(null, null, null, null, null),
+        dataFileSignature
+    );
+
+    objectMapper.registerModules(NestedDataModule.getJacksonModulesList());
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}:with context {0}")
+  public void testInsertWithoutRollupOnNestedData(String contextName, Map<String, Object> context)
+  {
+    testIngestQuery().setSql("INSERT INTO foo1 SELECT\n"
+                             + " obj,\n"
+                             + " COUNT(*) as cnt\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + dataFileNameJsonString + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"obj\", \"type\": \"COMPLEX<json>\"}]'\n"
+                             + "   )\n"
+                             + " )\n"
+                             + " GROUP BY 1\n"
+                             + " PARTITIONED BY ALL")
+                     .setQueryContext(context)
+                     .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(RowSignature.builder()
+                                                          .add("__time", ColumnType.LONG)
+                                                          .add("obj", ColumnType.NESTED_DATA)
+                                                          .add("cnt", ColumnType.LONG)
+                                                          .build())
+                     .setExpectedResultRows(ImmutableList.of(
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 500,
+                                     "b", ImmutableMap.of(
+                                         "x", "e",
+                                         "z", ImmutableList.of(1, 2, 3, 4)
+                                     ),
+                                     "v", "a"
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 100,
+                                     "b", ImmutableMap.of(
+                                         "x", "a",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(1, 2, 3, 4)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 700,
+                                     "b", ImmutableMap.of(
+                                         "x", "g",
+                                         "y", 1.1,
+                                         "z", Arrays.asList(9, null, 9, 9)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 200,
+                                     "b", ImmutableMap.of(
+                                         "x", "b",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(2, 4, 6)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 600,
+                                     "b", ImmutableMap.of(
+                                         "x", "f",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(6, 7, 8, 9)
+                                     ),
+                                     "v", "b"
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 400,
+                                     "b", ImmutableMap.of(
+                                         "x", "d",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(3, 4)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(ImmutableMap.of("a", 300)),
+                             1L
+                         }
+                     ))
+                     .setQueryContext(context)
+                     .verifyResults();
+
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}:with context {0}")
+  public void testInsertWithRollupOnNestedData(String contextName, Map<String, Object> context)
+  {
+    final Map<String, Object> adjustedContext = new HashMap<>(context);
+    adjustedContext.put(GroupByQueryConfig.CTX_KEY_ENABLE_MULTI_VALUE_UNNESTING, false);
+    adjustedContext.put(MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS, false);
+    testIngestQuery().setSql("INSERT INTO foo1 SELECT\n"
+                             + " obj,\n"
+                             + " COUNT(*) as cnt\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + dataFileNameJsonString + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"obj\", \"type\": \"COMPLEX<json>\"}]'\n"
+                             + "   )\n"
+                             + " )\n"
+                             + " GROUP BY 1\n"
+                             + " PARTITIONED BY ALL")
+                     .setQueryContext(adjustedContext)
+                     .setExpectedSegment(ImmutableSet.of(SegmentId.of("foo1", Intervals.ETERNITY, "test", 0)))
+                     .setExpectedDataSource("foo1")
+                     .setExpectedRowSignature(RowSignature.builder()
+                                                          .add("__time", ColumnType.LONG)
+                                                          .add("obj", ColumnType.NESTED_DATA)
+                                                          .add("cnt", ColumnType.LONG)
+                                                          .build())
+                     .addExpectedAggregatorFactory(new LongSumAggregatorFactory("cnt", "cnt"))
+                     .setExpectedResultRows(ImmutableList.of(
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 500,
+                                     "b", ImmutableMap.of(
+                                         "x", "e",
+                                         "z", ImmutableList.of(1, 2, 3, 4)
+                                     ),
+                                     "v", "a"
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 100,
+                                     "b", ImmutableMap.of(
+                                         "x", "a",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(1, 2, 3, 4)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 700,
+                                     "b", ImmutableMap.of(
+                                         "x", "g",
+                                         "y", 1.1,
+                                         "z", Arrays.asList(9, null, 9, 9)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 200,
+                                     "b", ImmutableMap.of(
+                                         "x", "b",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(2, 4, 6)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 600,
+                                     "b", ImmutableMap.of(
+                                         "x", "f",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(6, 7, 8, 9)
+                                     ),
+                                     "v", "b"
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(
+                                 ImmutableMap.of(
+                                     "a", 400,
+                                     "b", ImmutableMap.of(
+                                         "x", "d",
+                                         "y", 1.1,
+                                         "z", ImmutableList.of(3, 4)
+                                     ),
+                                     "v", Collections.emptyList()
+                                 )
+                             ),
+                             1L
+                         },
+                         new Object[]{
+                             0L,
+                             StructuredData.wrap(ImmutableMap.of("a", 300)),
+                             1L
+                         }
+                     ))
+                     .setExpectedRollUp(true)
+                     .setQueryContext(adjustedContext)
+                     .verifyResults();
+
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}:with context {0}")
+  public void testSortingOnNestedData(String contextName, Map<String, Object> context)
+  {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("obj", ColumnType.NESTED_DATA)
+                                            .build();
+    testSelectQuery().setSql("SELECT\n"
+                             + " obj\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + dataFileNameJsonString + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"obj\", \"type\": \"COMPLEX<json>\"}]'\n"
+
+                             + "   )\n"
+                             + " )\n"
+                             + " ORDER BY 1")
+                     .setQueryContext(ImmutableMap.of())
+                     .setExpectedMSQSpec(MSQSpec
+                                             .builder()
+                                             .query(newScanQueryBuilder()
+                                                        .dataSource(dataFileExternalDataSource)
+                                                        .intervals(querySegmentSpec(Filtration.eternity()))
+                                                        .columns("obj")
+                                                        .context(defaultScanQueryContext(context, rowSignature))
+                                                        .orderBy(Collections.singletonList(new ScanQuery.OrderBy("obj", ScanQuery.Order.ASCENDING)))
+                                                        .build()
+                                             )
+                                             .columnMappings(new ColumnMappings(ImmutableList.of(
+                                                 new ColumnMapping("obj", "obj")
+                                             )))
+                                             .tuningConfig(MSQTuningConfig.defaultConfig())
+                                             .destination(TaskReportMSQDestination.INSTANCE)
+                                             .build()
+                     )
+                     .setExpectedRowSignature(rowSignature)
+                     .setQueryContext(context)
+                     .setExpectedResultRows(ImmutableList.of(
+                         new Object[]{"{\"a\":500,\"b\":{\"x\":\"e\",\"z\":[1,2,3,4]},\"v\":\"a\"}"},
+                         new Object[]{"{\"a\":100,\"b\":{\"x\":\"a\",\"y\":1.1,\"z\":[1,2,3,4]},\"v\":[]}"},
+                         new Object[]{"{\"a\":700,\"b\":{\"x\":\"g\",\"y\":1.1,\"z\":[9,null,9,9]},\"v\":[]}"},
+                         new Object[]{"{\"a\":200,\"b\":{\"x\":\"b\",\"y\":1.1,\"z\":[2,4,6]},\"v\":[]}"},
+                         new Object[]{"{\"a\":600,\"b\":{\"x\":\"f\",\"y\":1.1,\"z\":[6,7,8,9]},\"v\":\"b\"}"},
+                         new Object[]{"{\"a\":400,\"b\":{\"x\":\"d\",\"y\":1.1,\"z\":[3,4]},\"v\":[]}"},
+                         new Object[]{"{\"a\":300}"}
+                     ))
+                     .verifyResults();
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/ClusterByStatisticsCollectorImplTest.java
@@ -108,7 +108,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
                   .iterator();
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -157,7 +157,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     }
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -208,7 +208,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     }
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -267,7 +267,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     }
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -331,7 +331,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     }
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -402,7 +402,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
     }
 
     final NavigableMap<RowKey, List<Integer>> sortedKeyWeights =
-        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator());
+        computeSortedKeyWeightsFromUnweightedKeys(keys, clusterBy.keyComparator(SIGNATURE));
 
     doTest(
         clusterBy,
@@ -551,7 +551,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
       final BiConsumer<String, ClusterByStatisticsCollectorImpl> testFn
   )
   {
-    final Comparator<RowKey> comparator = clusterBy.keyComparator();
+    final Comparator<RowKey> comparator = clusterBy.keyComparator(SIGNATURE);
 
     // Load into single collector, sorted order.
     final ClusterByStatisticsCollectorImpl sortedCollector = makeCollector(clusterBy, aggregate);
@@ -649,7 +649,7 @@ public class ClusterByStatisticsCollectorImplTest extends InitializedNullHandlin
         testName,
         partitions,
         sortedKeyWeights.firstKey(),
-        clusterBy.keyComparator()
+        clusterBy.keyComparator(SIGNATURE)
     );
     verifyPartitionWeights(testName, clusterBy, partitions, sortedKeyWeights, aggregate, expectedPartitionSize);
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DelegateOrMinKeyCollectorTest.java
@@ -41,7 +41,7 @@ public class DelegateOrMinKeyCollectorTest
 {
   private final ClusterBy clusterBy = new ClusterBy(ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)), 0);
   private final RowSignature signature = RowSignature.builder().add("x", ColumnType.LONG).build();
-  private final Comparator<RowKey> comparator = clusterBy.keyComparator();
+  private final Comparator<RowKey> comparator = clusterBy.keyComparator(signature);
 
   static {
     NullHandling.initializeForTests();
@@ -53,7 +53,7 @@ public class DelegateOrMinKeyCollectorTest
     final DelegateOrMinKeyCollector<QuantilesSketchKeyCollector> collector =
         new DelegateOrMinKeyCollectorFactory<>(
             comparator,
-            QuantilesSketchKeyCollectorFactory.create(clusterBy)
+            QuantilesSketchKeyCollectorFactory.create(clusterBy, signature)
         ).newKeyCollector();
 
     Assert.assertTrue(collector.getDelegate().isPresent());
@@ -69,8 +69,8 @@ public class DelegateOrMinKeyCollectorTest
   {
     ClusterBy clusterBy = ClusterBy.none();
     new DelegateOrMinKeyCollector<>(
-        clusterBy.keyComparator(),
-        QuantilesSketchKeyCollectorFactory.create(clusterBy).newKeyCollector(),
+        clusterBy.keyComparator(RowSignature.empty()),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, RowSignature.empty()).newKeyCollector(),
         RowKey.empty()
     );
   }
@@ -81,7 +81,7 @@ public class DelegateOrMinKeyCollectorTest
     final DelegateOrMinKeyCollector<QuantilesSketchKeyCollector> collector =
         new DelegateOrMinKeyCollectorFactory<>(
             comparator,
-            QuantilesSketchKeyCollectorFactory.create(clusterBy)
+            QuantilesSketchKeyCollectorFactory.create(clusterBy, signature)
         ).newKeyCollector();
 
     RowKey key = createKey(1L);
@@ -100,7 +100,7 @@ public class DelegateOrMinKeyCollectorTest
     final DelegateOrMinKeyCollector<QuantilesSketchKeyCollector> collector =
         new DelegateOrMinKeyCollectorFactory<>(
             comparator,
-            QuantilesSketchKeyCollectorFactory.create(clusterBy)
+            QuantilesSketchKeyCollectorFactory.create(clusterBy, signature)
         ).newKeyCollector();
 
     RowKey key = createKey(1L);
@@ -128,7 +128,7 @@ public class DelegateOrMinKeyCollectorTest
     final DelegateOrMinKeyCollector<QuantilesSketchKeyCollector> collector =
         new DelegateOrMinKeyCollectorFactory<>(
             comparator,
-            QuantilesSketchKeyCollectorFactory.create(clusterBy)
+            QuantilesSketchKeyCollectorFactory.create(clusterBy, signature)
         ).newKeyCollector();
 
     RowKey key = createKey(1L);

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
@@ -28,6 +28,8 @@ import org.apache.druid.frame.key.KeyColumn;
 import org.apache.druid.frame.key.KeyOrder;
 import org.apache.druid.frame.key.RowKey;
 import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -42,7 +44,8 @@ import java.util.NoSuchElementException;
 public class DistinctKeyCollectorTest
 {
   private final ClusterBy clusterBy = new ClusterBy(ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)), 0);
-  private final Comparator<RowKey> comparator = clusterBy.keyComparator();
+  private final RowSignature signature = RowSignature.builder().add("x", ColumnType.LONG).build();
+  private final Comparator<RowKey> comparator = clusterBy.keyComparator(signature);
   private final int numKeys = 500_000;
 
   static {
@@ -53,7 +56,7 @@ public class DistinctKeyCollectorTest
   public void test_empty()
   {
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         Collections.emptyList(),
         comparator,
         (testName, collector) -> {
@@ -77,7 +80,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -95,7 +98,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -113,7 +116,7 @@ public class DistinctKeyCollectorTest
   @Test(expected = IllegalArgumentException.class)
   public void test_generateWithNegativeTargetWeight_throwsException()
   {
-    DistinctKeyCollector distinctKeyCollector = DistinctKeyCollectorFactory.create(clusterBy).newKeyCollector();
+    DistinctKeyCollector distinctKeyCollector = DistinctKeyCollectorFactory.create(clusterBy, signature).newKeyCollector();
     distinctKeyCollector.generatePartitionsWithTargetWeight(-1);
   }
 
@@ -125,7 +128,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator).firstKey();
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -161,7 +164,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -184,7 +187,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -211,7 +214,7 @@ public class DistinctKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        DistinctKeyCollectorFactory.create(clusterBy),
+        DistinctKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/QuantilesSketchKeyCollectorTest.java
@@ -43,7 +43,8 @@ import java.util.NoSuchElementException;
 public class QuantilesSketchKeyCollectorTest
 {
   private final ClusterBy clusterBy = new ClusterBy(ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)), 0);
-  private final Comparator<RowKey> comparator = clusterBy.keyComparator();
+  private final RowSignature signature = RowSignature.builder().add("x", ColumnType.LONG).build();
+  private final Comparator<RowKey> comparator = clusterBy.keyComparator(signature);
   private final int numKeys = 500_000;
 
   static {
@@ -54,7 +55,7 @@ public class QuantilesSketchKeyCollectorTest
   public void test_empty()
   {
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         Collections.emptyList(),
         comparator,
         (testName, collector) -> {
@@ -78,7 +79,7 @@ public class QuantilesSketchKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -96,7 +97,7 @@ public class QuantilesSketchKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -114,7 +115,7 @@ public class QuantilesSketchKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator).firstKey();
 
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -147,7 +148,7 @@ public class QuantilesSketchKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {
@@ -169,8 +170,8 @@ public class QuantilesSketchKeyCollectorTest
   public void testAverageKeyLength()
   {
     final QuantilesSketchKeyCollector collector =
-        QuantilesSketchKeyCollectorFactory.create(clusterBy).newKeyCollector();
-    final QuantilesSketchKeyCollector other = QuantilesSketchKeyCollectorFactory.create(clusterBy).newKeyCollector();
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature).newKeyCollector();
+    final QuantilesSketchKeyCollector other = QuantilesSketchKeyCollectorFactory.create(clusterBy, signature).newKeyCollector();
 
     RowSignature smallKeySignature = KeyTestUtils.createKeySignature(
         new ClusterBy(ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)), 0).getColumns(),
@@ -219,7 +220,7 @@ public class QuantilesSketchKeyCollectorTest
         ClusterByStatisticsCollectorImplTest.computeSortedKeyWeightsFromWeightedKeys(keyWeights, comparator);
 
     KeyCollectorTestUtils.doTest(
-        QuantilesSketchKeyCollectorFactory.create(clusterBy),
+        QuantilesSketchKeyCollectorFactory.create(clusterBy, signature),
         keyWeights,
         comparator,
         (testName, collector) -> {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteMSQTestsHelper.java
@@ -76,6 +76,7 @@ import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFacto
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.coordination.DataSegmentAnnouncer;
 import org.apache.druid.server.coordination.NoopDataSegmentAnnouncer;
+import org.apache.druid.sql.calcite.CalciteNestedDataQueryTest;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.timeline.DataSegment;
@@ -284,6 +285,101 @@ public class CalciteMSQTestsHelper
                                 ResourceInputSource.of(
                                     NestedDataTestUtils.class.getClassLoader(),
                                     NestedDataTestUtils.ARRAY_TYPES_DATA_FILE
+                                )
+                            )
+                            .inputFormat(TestDataBuilder.DEFAULT_JSON_INPUT_FORMAT)
+                            .inputTmpDir(tempFolderProducer.apply("tmpDir"))
+                            .buildMMappedIndex();
+        break;
+      case CalciteNestedDataQueryTest.DATA_SOURCE:
+      case CalciteNestedDataQueryTest.DATA_SOURCE_MIXED:
+        if (segmentId.getPartitionNum() == 0) {
+          index = IndexBuilder.create()
+                              .tmpDir(tempFolderProducer.apply("tmpDir"))
+                              .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+                              .schema(
+                                  new IncrementalIndexSchema.Builder()
+                                      .withMetrics(
+                                          new CountAggregatorFactory("cnt")
+                                      )
+                                      .withDimensionsSpec(CalciteNestedDataQueryTest.ALL_JSON_COLUMNS.getDimensionsSpec())
+                                      .withRollup(false)
+                                      .build()
+                              )
+                              .rows(CalciteNestedDataQueryTest.ROWS)
+                              .buildMMappedIndex();
+        } else if (segmentId.getPartitionNum() == 1) {
+          index = IndexBuilder.create()
+                              .tmpDir(tempFolderProducer.apply("tmpDir"))
+                              .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+                              .schema(
+                                  new IncrementalIndexSchema.Builder()
+                                      .withMetrics(
+                                          new CountAggregatorFactory("cnt")
+                                      )
+                                      .withDimensionsSpec(CalciteNestedDataQueryTest.JSON_AND_SCALAR_MIX.getDimensionsSpec())
+                                      .withRollup(false)
+                                      .build()
+                              )
+                              .rows(CalciteNestedDataQueryTest.ROWS_MIX)
+                              .buildMMappedIndex();
+        } else {
+          throw new ISE("Cannot query segment %s in test runner", segmentId);
+        }
+        break;
+      case CalciteNestedDataQueryTest.DATA_SOURCE_MIXED_2:
+        if (segmentId.getPartitionNum() == 0) {
+          index = IndexBuilder.create()
+                              .tmpDir(tempFolderProducer.apply("tmpDir"))
+                              .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+                              .schema(
+                                  new IncrementalIndexSchema.Builder()
+                                      .withMetrics(
+                                          new CountAggregatorFactory("cnt")
+                                      )
+                                      .withDimensionsSpec(CalciteNestedDataQueryTest.JSON_AND_SCALAR_MIX.getDimensionsSpec())
+                                      .withRollup(false)
+                                      .build()
+                              )
+                              .rows(CalciteNestedDataQueryTest.ROWS_MIX)
+                              .buildMMappedIndex();
+        } else if (segmentId.getPartitionNum() == 1) {
+          index = IndexBuilder.create()
+                      .tmpDir(tempFolderProducer.apply("tmpDir"))
+                      .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+                      .schema(
+                          new IncrementalIndexSchema.Builder()
+                              .withMetrics(
+                                  new CountAggregatorFactory("cnt")
+                              )
+                              .withDimensionsSpec(CalciteNestedDataQueryTest.ALL_JSON_COLUMNS.getDimensionsSpec())
+                              .withRollup(false)
+                              .build()
+                      )
+                      .rows(CalciteNestedDataQueryTest.ROWS)
+                      .buildMMappedIndex();
+        } else {
+          throw new ISE("Cannot query segment %s in test runner", segmentId);
+        }
+        break;
+      case CalciteNestedDataQueryTest.DATA_SOURCE_ALL:
+        index = IndexBuilder.create()
+                            .tmpDir(tempFolderProducer.apply("tmpDir"))
+                            .segmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+                            .schema(
+                                new IncrementalIndexSchema.Builder()
+                                    .withTimestampSpec(NestedDataTestUtils.AUTO_SCHEMA.getTimestampSpec())
+                                    .withDimensionsSpec(NestedDataTestUtils.AUTO_SCHEMA.getDimensionsSpec())
+                                    .withMetrics(
+                                        new CountAggregatorFactory("cnt")
+                                    )
+                                    .withRollup(false)
+                                    .build()
+                            )
+                            .inputSource(
+                                ResourceInputSource.of(
+                                    NestedDataTestUtils.class.getClassLoader(),
+                                    NestedDataTestUtils.ALL_TYPES_TEST_DATA_FILE
                                 )
                             )
                             .inputFormat(TestDataBuilder.DEFAULT_JSON_INPUT_FORMAT)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteNestedDataQueryMSQTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteNestedDataQueryMSQTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import org.apache.druid.guice.DruidInjectorBuilder;
+import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.msq.exec.WorkerMemoryParameters;
+import org.apache.druid.msq.sql.MSQTaskSqlEngine;
+import org.apache.druid.query.groupby.TestGroupByBuffers;
+import org.apache.druid.server.QueryLifecycleFactory;
+import org.apache.druid.sql.calcite.CalciteNestedDataQueryTest;
+import org.apache.druid.sql.calcite.QueryTestBuilder;
+import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
+import org.apache.druid.sql.calcite.TempDirProducer;
+import org.apache.druid.sql.calcite.run.SqlEngine;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Runs {@link CalciteNestedDataQueryTest} but with MSQ engine
+ */
+@SqlTestFrameworkConfig.ComponentSupplier(CalciteNestedDataQueryMSQTest.NestedDataQueryMSQComponentSupplier.class)
+public class CalciteNestedDataQueryMSQTest extends CalciteNestedDataQueryTest
+{
+
+  public static class NestedDataQueryMSQComponentSupplier extends NestedComponentSupplier
+  {
+    public NestedDataQueryMSQComponentSupplier(TempDirProducer tempFolderProducer)
+    {
+      super(tempFolderProducer);
+    }
+
+    @Override
+    public void configureGuice(DruidInjectorBuilder builder)
+    {
+      super.configureGuice(builder);
+      builder.addModules(
+          CalciteMSQTestsHelper.fetchModules(tempDirProducer::newTempFolder, TestGroupByBuffers.createDefault()).toArray(new Module[0])
+      );
+    }
+
+    @Override
+    public SqlEngine createEngine(
+        QueryLifecycleFactory qlf,
+        ObjectMapper queryJsonMapper,
+        Injector injector
+    )
+    {
+      final WorkerMemoryParameters workerMemoryParameters =
+          WorkerMemoryParameters.createInstance(
+              WorkerMemoryParameters.PROCESSING_MINIMUM_BYTES * 50,
+              2,
+              10,
+              2,
+              0,
+              0
+          );
+      final MSQTestOverlordServiceClient indexingServiceClient = new MSQTestOverlordServiceClient(
+          queryJsonMapper,
+          injector,
+          new MSQTestTaskActionClient(queryJsonMapper, injector),
+          workerMemoryParameters,
+          ImmutableList.of()
+      );
+      return new MSQTaskSqlEngine(indexingServiceClient, queryJsonMapper);
+    }
+  }
+
+  @Override
+  protected QueryTestBuilder testBuilder()
+  {
+    return new QueryTestBuilder(new CalciteTestConfig(true))
+        .addCustomRunner(new ExtractResultsFactory(() -> (MSQTestOverlordServiceClient) ((MSQTaskSqlEngine) queryFramework().engine()).overlordClient()))
+        .skipVectorize(true)
+        .verifyNativeQueries(new VerifyMSQSupportedNativeQueriesPredicate());
+  }
+
+  @Override
+  @Test
+  public void testJoinOnNestedColumnThrows()
+  {
+    Assertions.assertThrows(ISE.class, () -> {
+      testQuery(
+          "SELECT * FROM druid.nested a INNER JOIN druid.nested b ON a.nester = b.nester",
+          ImmutableList.of(),
+          ImmutableList.of()
+      );
+    });
+  }
+
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/ExtractResultsFactory.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/ExtractResultsFactory.java
@@ -20,8 +20,10 @@
 package org.apache.druid.msq.test;
 
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.msq.indexing.report.MSQResultsReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.QueryTestRunner;
 import org.junit.Assert;
@@ -55,6 +57,7 @@ public class ExtractResultsFactory implements QueryTestRunner.QueryRunStepFactor
     return new QueryTestRunner.BaseExecuteQuery(builder)
     {
       final List<QueryTestRunner.QueryResults> extractedResults = new ArrayList<>();
+      final RowSignature resultsSignature = null;
 
       final MSQTestOverlordServiceClient overlordClient = overlordClientSupplier.get();
 
@@ -99,7 +102,10 @@ public class ExtractResultsFactory implements QueryTestRunner.QueryRunStepFactor
           if (resultRows == null) {
             throw new ISE("Results report not present in the task's report payload");
           }
-          extractedResults.add(results.withResults(resultRows));
+          extractedResults.add(
+              results.withSignatureAndResults(
+                  convertColumnAndTypeToRowSignature(payload.getResults().getSignature()), resultRows)
+          );
         }
       }
 
@@ -107,6 +113,15 @@ public class ExtractResultsFactory implements QueryTestRunner.QueryRunStepFactor
       public List<QueryTestRunner.QueryResults> results()
       {
         return extractedResults;
+      }
+
+      private RowSignature convertColumnAndTypeToRowSignature(final List<MSQResultsReport.ColumnAndType> columnAndTypes)
+      {
+        final RowSignature.Builder builder = RowSignature.builder();
+        for (MSQResultsReport.ColumnAndType columnAndType : columnAndTypes) {
+          builder.add(columnAndType.getName(), columnAndType.getType());
+        }
+        return builder.build();
       }
     };
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -1199,7 +1199,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
           // assert rollup
           Assert.assertEquals(expectedRollUp, queryableIndex.getMetadata().isRollup());
 
-          // asset query granularity
+          // assert query granularity
           Assert.assertEquals(expectedQueryGranularity, queryableIndex.getMetadata().getQueryGranularity());
 
           // assert aggregator factories
@@ -1231,7 +1231,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
                                                                        .collect(Collectors.toList());
 
         log.info(
-            "Found rows which are sorted forcefully %s",
+            "Found rows which are sorted forcefully\n%s",
             transformedOutputRows.stream().map(Arrays::deepToString).collect(Collectors.joining("\n"))
         );
 

--- a/processing/src/main/java/org/apache/druid/frame/field/FieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/FieldReader.java
@@ -56,9 +56,4 @@ public interface FieldReader
    * Whether the provided memory position points to a null value.
    */
   boolean isNull(Memory memory, long position);
-
-  /**
-   * Whether this field is comparable. Comparable fields can be compared as unsigned bytes.
-   */
-  boolean isComparable();
 }

--- a/processing/src/main/java/org/apache/druid/frame/field/NumericArrayFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/NumericArrayFieldReader.java
@@ -50,10 +50,4 @@ public abstract class NumericArrayFieldReader implements FieldReader
     final byte firstByte = memory.getByte(position);
     return firstByte == NumericArrayFieldWriter.NULL_ROW;
   }
-
-  @Override
-  public boolean isComparable()
-  {
-    return true;
-  }
 }

--- a/processing/src/main/java/org/apache/druid/frame/field/NumericFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/NumericFieldReader.java
@@ -76,13 +76,6 @@ public abstract class NumericFieldReader implements FieldReader
     return memory.getByte(position) == nullIndicatorByte;
   }
 
-
-  @Override
-  public boolean isComparable()
-  {
-    return true;
-  }
-
   /**
    * Creates a column value selector for the element written at fieldPointer's position in the memory.
    * The nullilty check is handled by the nullIndicatorByte

--- a/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
@@ -123,12 +123,6 @@ public class StringFieldReader implements FieldReader
     }
   }
 
-  @Override
-  public boolean isComparable()
-  {
-    return true;
-  }
-
   /**
    * Selector that reads a value from a location pointed to by {@link ReadableFieldPointer}.
    */

--- a/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/ClusterBy.java
@@ -152,29 +152,29 @@ public class ClusterBy
   /**
    * Comparator that compares keys for this instance using the given signature.
    */
-  public Comparator<RowKey> keyComparator()
+  public Comparator<RowKey> keyComparator(RowSignature rowSignature)
   {
-    return RowKeyComparator.create(columns);
+    return RowKeyComparator.create(columns, rowSignature);
   }
 
   /**
    * Comparator that compares byte arrays of keys for this instance using the given signature directly.
    */
-  public Comparator<byte[]> byteKeyComparator()
+  public Comparator<byte[]> byteKeyComparator(RowSignature rowSignature)
   {
-    return ByteRowKeyComparator.create(columns);
+    return ByteRowKeyComparator.create(columns, rowSignature);
   }
 
   /**
    * Comparator that compares bucket keys for this instance. Bucket keys are retrieved by calling
    * {@link RowKeyReader#trim(RowKey, int)} with {@link #getBucketByCount()}.
    */
-  public Comparator<RowKey> bucketComparator()
+  public Comparator<RowKey> bucketComparator(final RowSignature rowSignature)
   {
     if (bucketByCount == 0) {
       return Comparators.alwaysEqual();
     } else {
-      return RowKeyComparator.create(columns.subList(0, bucketByCount));
+      return RowKeyComparator.create(columns.subList(0, bucketByCount), rowSignature);
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/frame/key/KeyColumn.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/KeyColumn.java
@@ -69,8 +69,8 @@ public class KeyColumn
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    KeyColumn that = (KeyColumn) o;
-    return order == that.order && Objects.equals(columnName, that.columnName);
+    KeyColumn keyColumn = (KeyColumn) o;
+    return Objects.equals(columnName, keyColumn.columnName) && order == keyColumn.order;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/frame/key/RowKey.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/RowKey.java
@@ -27,6 +27,16 @@ import java.util.Arrays;
 
 /**
  * Represents a specific sorting or hashing key. Instances of this class wrap a byte array in row-based frame format.
+ *
+ * Following is the layout of the RowKey with n fields
+ *
+ * Header section
+ * byte[1..4] - End of field 1
+ * byte[5..8] - End of field 2
+ * ...
+ * byte[4(n-1)..4n] - End of field n
+ * Key section
+ * byte[headerEnd+1..headerEnd+1+fieldSize1] - Data of field1
  */
 public class RowKey
 {

--- a/processing/src/main/java/org/apache/druid/frame/key/RowKeyComparisonRunLengths.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/RowKeyComparisonRunLengths.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.column.ValueType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Denotes the ascending-descending run lengths of the fields of the keycolumns that can be compared together.
+ * It analyses the key columns and their types. It coalesces the adjacent key columns if they are:
+ * a. Byte comparable, i.e. the fields won't need to be deserialized before comparing. It doesn't care about the types
+ * b. Have same order
+ *
+ * All the primitive and the primitive arrays are byte comparable. The complex types are not byte comparable, and nested arrays
+ * and arrays of complex objects are not supported by MSQ right now.
+ *
+ * Consider a row with the key columns like:
+ *
+ * ColumnName       ColumnType        Order
+ * ==========================================
+ * longAsc1         LONG              ASC
+ * stringAsc1       STRING            ASC
+ * stringDesc1      STRING            DESC
+ * longDesc1        LONG              DESC
+ * complexDesc1     COMPLEX           DESC
+ * complexAsc1      COMPLEX           ASC
+ * complexAsc2      COMPLEX           ASC
+ * stringAsc2       STRING            ASC
+ *
+ * The run lengths generated would be:
+ *
+ * RunLengthEntry        Run length   Order     Is byte comparable    Explanation
+ * ====================================================================================================================
+ * RunLengthEntry#1      2            ASC       true                  Even though longAsc1 and stringAsc1 had different types,
+ *                                                                    both types are byte comparable and have same direction. Therefore,
+ *                                                                    they can be byte-compared together
+ *
+ * RunLengthEntry#2      2            DESC      true                  stringDesc1 can't be clubed with the previous stringAsc1 due to
+ *                                                                    different ordering. It is clubbed with the following longDesc1 due
+ *                                                                    to the reason stated above
+ * RunLengthEntry#3      1            DESC      false                 Non byte comparable types cannot be clubbed with anything
+ * RunLengthEntry#4      1            ASC       false                 Non byte comparable types cannot be clubbed with anything
+ * RunLengthEntry#5      1            ASC       false                 Non byte comparable types cannot be clubbed with anything despite
+ *                                                                    the previous key column having same order and the type
+ * RunLengthEntry#6      1            ASC       true                  Cannot be clubbed with previous entry. It is own entry
+ *
+ */
+public class RowKeyComparisonRunLengths
+{
+  private final RunLengthEntry[] runLengthEntries;
+
+  private RowKeyComparisonRunLengths(final RunLengthEntry[] runLengthEntries)
+  {
+    this.runLengthEntries = runLengthEntries;
+  }
+
+  public static RowKeyComparisonRunLengths create(final List<KeyColumn> keyColumns, RowSignature rowSignature)
+  {
+    final List<RunLengthEntryBuilder> runLengthEntryBuilders = new ArrayList<>();
+    for (KeyColumn keyColumn : keyColumns) {
+      if (keyColumn.order() == KeyOrder.NONE) {
+        throw DruidException.defensive(
+            "Cannot sort on column [%s] when the sorting order isn't provided",
+            keyColumn.columnName()
+        );
+      }
+
+      ColumnType columnType = rowSignature.getColumnType(keyColumn.columnName())
+                                          .orElseThrow(() -> DruidException.defensive("Need column types"));
+
+      // First key column to be processed
+      if (runLengthEntryBuilders.size() == 0) {
+        final boolean isByteComparable = isByteComparable(columnType);
+        runLengthEntryBuilders.add(
+            new RunLengthEntryBuilder(isByteComparable, keyColumn.order())
+        );
+        continue;
+      }
+
+      // There is atleast one RunLengthEntry present in the array. Check if we can find a way to merge the current entry
+      // with the previous one
+      boolean isCurrentColumnByteComparable = isByteComparable(columnType);
+      RunLengthEntryBuilder lastRunLengthEntryBuilder = runLengthEntryBuilders.get(runLengthEntryBuilders.size() - 1);
+      if (lastRunLengthEntryBuilder.byteComparable
+          && isCurrentColumnByteComparable
+          && lastRunLengthEntryBuilder.order.equals(keyColumn.order())
+      ) {
+        lastRunLengthEntryBuilder.runLength++;
+      } else {
+        runLengthEntryBuilders.add(
+            new RunLengthEntryBuilder(
+                isCurrentColumnByteComparable,
+                keyColumn.order()
+            )
+        );
+      }
+    }
+
+    RunLengthEntry[] runLengthEntries = new RunLengthEntry[runLengthEntryBuilders.size()];
+    for (int i = 0; i < runLengthEntryBuilders.size(); ++i) {
+      runLengthEntries[i] = runLengthEntryBuilders.get(i).build();
+    }
+
+    return new RowKeyComparisonRunLengths(runLengthEntries);
+  }
+
+  private static boolean isByteComparable(final ColumnType columnType)
+  {
+    if (columnType.is(ValueType.COMPLEX)) {
+      if (columnType.getComplexTypeName() == null) {
+        throw DruidException.defensive("Cannot sort unknown complex types");
+      }
+      // Complex types with known types are not byte comparable and must be deserialized for comparison
+      return false;
+    } else if (columnType.isArray() && !columnType.isPrimitiveArray()) {
+      // Nested arrays aren't allowed directly in the frames - they are materialized as nested types.
+      // Nested arrays aren't byte comparable, if they find a way to creep in.
+      throw DruidException.defensive("Nested arrays aren't supported in row based frames");
+    }
+    return true;
+  }
+
+  public RunLengthEntry[] getRunLengthEntries()
+  {
+    return runLengthEntries;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RowKeyComparisonRunLengths that = (RowKeyComparisonRunLengths) o;
+    return Arrays.equals(runLengthEntries, that.runLengthEntries);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Arrays.hashCode(runLengthEntries);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "RowKeyComparisonRunLengths{" +
+           "runLengthEntries=" + Arrays.toString(runLengthEntries) +
+           '}';
+  }
+
+  /**
+   * Builder for {@link RunLengthEntry}. Contains mutable state, therefore it isn't suitable for equality and hashCode.
+   */
+  private static class RunLengthEntryBuilder
+  {
+    private final boolean byteComparable;
+    private final KeyOrder order;
+    private int runLength;
+
+    public RunLengthEntryBuilder(
+        final boolean byteComparable,
+        final KeyOrder order
+    )
+    {
+      this.byteComparable = byteComparable;
+      this.order = order;
+      this.runLength = 1;
+    }
+
+    public RunLengthEntry build()
+    {
+      return new RunLengthEntry(byteComparable, order, runLength);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/key/RunLengthEntry.java
+++ b/processing/src/main/java/org/apache/druid/frame/key/RunLengthEntry.java
@@ -19,34 +19,37 @@
 
 package org.apache.druid.frame.key;
 
-import org.apache.druid.segment.column.RowSignature;
-
-import java.util.Comparator;
-import java.util.List;
+import java.util.Objects;
 
 /**
- * Comparator for {@link RowKey} instances.
- *
- * Delegates the comparing to a {@link ByteRowKeyComparator}.
+ * Information about a continguous run of keys, that has the same sorting order
  */
-public class RowKeyComparator implements Comparator<RowKey>
+public class RunLengthEntry
 {
-  private final ByteRowKeyComparator byteRowKeyComparatorDelegate;
+  private final boolean byteComparable;
+  private final KeyOrder order;
+  private final int runLength;
 
-  private RowKeyComparator(final ByteRowKeyComparator byteRowKeyComparatorDelegate)
+  RunLengthEntry(final boolean byteComparable, final KeyOrder order, final int runLength)
   {
-    this.byteRowKeyComparatorDelegate = byteRowKeyComparatorDelegate;
+    this.byteComparable = byteComparable;
+    this.order = order;
+    this.runLength = runLength;
   }
 
-  public static RowKeyComparator create(final List<KeyColumn> keyColumns, RowSignature rowSignature)
+  public boolean isByteComparable()
   {
-    return new RowKeyComparator(ByteRowKeyComparator.create(keyColumns, rowSignature));
+    return byteComparable;
   }
 
-  @Override
-  public int compare(final RowKey key1, final RowKey key2)
+  public int getRunLength()
   {
-    return byteRowKeyComparatorDelegate.compare(key1.array(), key2.array());
+    return runLength;
+  }
+
+  public KeyOrder getOrder()
+  {
+    return order;
   }
 
   @Override
@@ -58,21 +61,23 @@ public class RowKeyComparator implements Comparator<RowKey>
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    RowKeyComparator that = (RowKeyComparator) o;
-    return byteRowKeyComparatorDelegate.equals(that.byteRowKeyComparatorDelegate);
+    RunLengthEntry that = (RunLengthEntry) o;
+    return byteComparable == that.byteComparable && runLength == that.runLength && order == that.order;
   }
 
   @Override
   public int hashCode()
   {
-    return byteRowKeyComparatorDelegate.hashCode();
+    return Objects.hash(byteComparable, order, runLength);
   }
 
   @Override
   public String toString()
   {
-    return "RowKeyComparator{" +
-           "byteRowKeyComparatorDelegate=" + byteRowKeyComparatorDelegate +
+    return "RunLengthEntry{" +
+           "byteComparable=" + byteComparable +
+           ", order=" + order +
+           ", runLength=" + runLength +
            '}';
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/read/FrameReaderUtils.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/FrameReaderUtils.java
@@ -22,12 +22,15 @@ package org.apache.druid.frame.read;
 import com.google.common.primitives.Ints;
 import org.apache.datasketches.memory.Memory;
 import org.apache.druid.frame.allocation.MemoryRange;
+import org.apache.druid.frame.field.ComplexFieldReader;
 import org.apache.druid.frame.segment.row.FrameColumnSelectorFactory;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.serde.ComplexMetricSerde;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -215,6 +218,52 @@ public class FrameReaderUtils
 
     return Integer.compare(length1, length2);
   }
+
+  public static int compareComplexTypes(
+      final byte[] array1,
+      final int position1,
+      final byte[] array2,
+      final int position2,
+      final ColumnType columnType,
+      final ComplexMetricSerde complexMetricSerde
+  )
+  {
+    return columnType.getNullableStrategy().compare(
+        ComplexFieldReader.readFieldFromByteArray(complexMetricSerde, array1, position1),
+        ComplexFieldReader.readFieldFromByteArray(complexMetricSerde, array2, position2)
+    );
+  }
+
+  public static int compareComplexTypes(
+      final Memory memory,
+      final long position1,
+      final byte[] array,
+      final int position2,
+      final ColumnType columnType,
+      final ComplexMetricSerde complexMetricSerde
+  )
+  {
+    return columnType.getNullableStrategy().compare(
+        ComplexFieldReader.readFieldFromMemory(complexMetricSerde, memory, position1),
+        ComplexFieldReader.readFieldFromByteArray(complexMetricSerde, array, position2)
+    );
+  }
+
+  public static int compareComplexTypes(
+      final Memory memory1,
+      final long position1,
+      final Memory memory2,
+      final long position2,
+      final ColumnType columnType,
+      final ComplexMetricSerde complexMetricSerde
+  )
+  {
+    return columnType.getNullableStrategy().compare(
+        ComplexFieldReader.readFieldFromMemory(complexMetricSerde, memory1, position1),
+        ComplexFieldReader.readFieldFromMemory(complexMetricSerde, memory2, position2)
+    );
+  }
+
 
   /**
    * Returns whether a {@link ColumnSelectorFactory} may be able to provide a {@link MemoryRange}. This enables

--- a/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/FrameWriterUtils.java
@@ -22,7 +22,6 @@ package org.apache.druid.frame.write;
 import org.apache.datasketches.memory.WritableMemory;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.frame.FrameType;
-import org.apache.druid.frame.field.FieldReaders;
 import org.apache.druid.frame.key.KeyColumn;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
@@ -236,8 +235,8 @@ public class FrameWriterUtils
     for (final KeyColumn keyColumn : keyColumns) {
       final ColumnType columnType = signature.getColumnType(keyColumn.columnName()).orElse(null);
 
-      if (columnType == null || !FieldReaders.create(keyColumn.columnName(), columnType).isComparable()) {
-        throw new IAE("Sort column [%s] is not comparable (type = %s)", keyColumn.columnName(), columnType);
+      if (columnType == null) {
+        throw new IAE("Sort column [%s] type is unknown", keyColumn.columnName());
       }
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
@@ -179,20 +179,38 @@ public interface TypeStrategy<T> extends Comparator<Object>, Hash.Strategy<T>
    * true or false, depending on whether the semantics and implementation of the type naturally leads to groupability
    * or not. For example, it makes sense for JSON columns to be groupable, however there is little sense in grouping
    * sketches (before finalizing).
-   *
-   * If a type is groupable, it MUST implement the {@link #hashCode} and {@link #equals} correctly
+   * <p>
+   * If a type is groupable, following statements MUST hold:
+   * <p>
+   * a. {@link #equals(Object, Object)} must be implemented. It should return true if and only if two objects are equal
+   *    and can be grouped together.
+   * <p>
+   * b. {@link #hashCode(Object)} must be implemented, and must be consistent with equals. It should return a hashCode
+   *    for the given object. For two objects that are equal, it must return the same hash value. For two objects that are
+   *    not equal, it can return the same hash value (or not). A conscious effort must be made to minimise collisions between
+   *    the hash values of two non-equal objects for faster grouping.
+   * <p>
+   * c. {@link #compare(Object, Object)} must be consistent with equals. Apart from abiding by the definition of
+   *    {@link Comparator#compare}, it must not return 0 for two objects that are not equals, and converse must also hold,
+   *    i.e. if the value returned by compare is not zero, then the arguments must not be equal.
    */
   default boolean groupable()
   {
     return false;
   }
 
+  /**
+   * @see #groupable()
+   */
   @Override
   default int hashCode(T o)
   {
     throw DruidException.defensive("Not implemented. Check groupable() first");
   }
 
+  /**
+   * @see #groupable()
+   */
   @Override
   default boolean equals(T a, T b)
   {

--- a/processing/src/test/java/org/apache/druid/frame/key/ByteRowKeyComparatorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/ByteRowKeyComparatorTest.java
@@ -20,10 +20,16 @@
 package org.apache.druid.frame.key;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Hashing;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.hll.HyperLogLogCollector;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
+import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,20 +41,161 @@ import java.util.stream.Collectors;
 
 public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
 {
-  static final RowSignature SIGNATURE =
+
+  static {
+    ComplexMetrics.registerSerde(HyperUniquesSerde.TYPE_NAME, new HyperUniquesSerde());
+  }
+
+  static final RowSignature NO_COMPLEX_SIGNATURE =
       RowSignature.builder()
                   .add("1", ColumnType.LONG)
                   .add("2", ColumnType.STRING)
                   .add("3", ColumnType.LONG)
                   .add("4", ColumnType.DOUBLE)
                   .build();
-  private static final Object[] OBJECTS1 = new Object[]{-1L, "foo", 2L, -1.2};
-  private static final Object[] OBJECTS2 = new Object[]{-1L, null, 2L, 1.2d};
-  private static final Object[] OBJECTS3 = new Object[]{-1L, "bar", 2L, 1.2d};
-  private static final Object[] OBJECTS4 = new Object[]{-1L, "foo", 2L, 1.2d};
-  private static final Object[] OBJECTS5 = new Object[]{-1L, "foo", 3L, 1.2d};
-  private static final Object[] OBJECTS6 = new Object[]{-1L, "foo", 2L, 1.3d};
-  private static final Object[] OBJECTS7 = new Object[]{1L, "foo", 2L, -1.2d};
+
+  static final RowSignature SIGNATURE =
+      RowSignature.builder()
+                  .add("1", HyperUniquesAggregatorFactory.TYPE)
+                  .add("2", ColumnType.LONG)
+                  .add("3", ColumnType.STRING)
+                  .add("4", HyperUniquesAggregatorFactory.TYPE)
+                  .add("5", ColumnType.LONG)
+                  .add("6", ColumnType.DOUBLE)
+                  .add("7", HyperUniquesAggregatorFactory.TYPE)
+                  .add("8", HyperUniquesAggregatorFactory.TYPE)
+                  .build();
+
+  private static final Object[] OBJECTS1_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, "foo", 2L, -1.2};
+  private static final Object[] OBJECTS2_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, null, 2L, 1.2d};
+  private static final Object[] OBJECTS3_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, "bar", 2L, 1.2d};
+  private static final Object[] OBJECTS4_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, "foo", 2L, 1.2d};
+  private static final Object[] OBJECTS5_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, "foo", 3L, 1.2d};
+  private static final Object[] OBJECTS6_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{-1L, "foo", 2L, 1.3d};
+  private static final Object[] OBJECTS7_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{1L, "foo", 2L, -1.2d};
+  private static final Object[] OBJECTS8_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{1L, "foo", 2L, -1.2d};
+  private static final Object[] OBJECTS9_WITHOUT_COMPLEX_COLUMN =
+      new Object[]{1L, "foo", 2L, -1.2d};
+
+  private static final Object[] OBJECTS1 =
+      new Object[]{
+          null,
+          -1L,
+          "foo",
+          makeHllCollector(5),
+          2L,
+          -1.2,
+          makeHllCollector(5),
+          makeHllCollector(1)
+      };
+  private static final Object[] OBJECTS2 =
+      new Object[]{
+          null,
+          -1L,
+          null,
+          null,
+          2L,
+          1.2d,
+          makeHllCollector(50),
+          makeHllCollector(5)
+      };
+  private static final Object[] OBJECTS3 =
+      new Object[]{
+          makeHllCollector(50),
+          -1L,
+          "bar",
+          makeHllCollector(5),
+          2L,
+          1.2d,
+          makeHllCollector(5),
+          makeHllCollector(50)
+      };
+  private static final Object[] OBJECTS4 =
+      new Object[]{
+          makeHllCollector(50),
+          -1L,
+          "foo",
+          makeHllCollector(100),
+          2L,
+          1.2d,
+          makeHllCollector(1),
+          makeHllCollector(5)
+      };
+  private static final Object[] OBJECTS5 =
+      new Object[]{
+          makeHllCollector(1),
+          -1L,
+          "foo",
+          makeHllCollector(5),
+          3L,
+          1.2d,
+          null,
+          makeHllCollector(5)
+      };
+  private static final Object[] OBJECTS6 =
+      new Object[]{
+          makeHllCollector(5),
+          -1L,
+          "foo",
+          makeHllCollector(100),
+          2L,
+          1.3d,
+          makeHllCollector(100),
+          makeHllCollector(20)
+      };
+  private static final Object[] OBJECTS7 =
+      new Object[]{
+          makeHllCollector(100),
+          1L,
+          "foo",
+          makeHllCollector(5),
+          2L,
+          -1.2d,
+          null,
+          null
+      };
+  private static final Object[] OBJECTS8 =
+      new Object[]{
+          makeHllCollector(5),
+          1L,
+          "foo",
+          makeHllCollector(50),
+          2L,
+          -1.2d,
+          makeHllCollector(500),
+          makeHllCollector(100)
+      };
+  private static final Object[] OBJECTS9 =
+      new Object[]{
+          makeHllCollector(5),
+          1L,
+          "foo",
+          makeHllCollector(50),
+          2L,
+          -1.2d,
+          makeHllCollector(500),
+          makeHllCollector(10)
+      };
+
+  static final List<Object[]> KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN = Arrays.asList(
+      OBJECTS1_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS2_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS3_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS4_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS5_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS6_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS7_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS8_WITHOUT_COMPLEX_COLUMN,
+      OBJECTS9_WITHOUT_COMPLEX_COLUMN
+  );
 
   static final List<Object[]> ALL_KEY_OBJECTS = Arrays.asList(
       OBJECTS1,
@@ -57,11 +204,13 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
       OBJECTS4,
       OBJECTS5,
       OBJECTS6,
-      OBJECTS7
+      OBJECTS7,
+      OBJECTS8,
+      OBJECTS9
   );
 
   @Test
-  public void test_compare_AAAA() // AAAA = all ascending
+  public void test_compare_AAAA_without_complex_column() // AAAA = all ascending, no complex column
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -70,13 +219,13 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DDDD() // DDDD = all descending
+  public void test_compare_DDDD_without_complex_column() // DDDD = all descending, no complex columns
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.ASCENDING),
@@ -85,13 +234,13 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DAAD()
+  public void test_compare_DAAD_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.ASCENDING),
@@ -100,13 +249,13 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_ADDA()
+  public void test_compare_ADDA_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -115,13 +264,13 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DADA()
+  public void test_compare_DADA_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -130,8 +279,103 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DDDDDDDD() // DDDDDDDD = all descending
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.DESCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.DESCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.DESCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.DESCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_AAAAAAAA() // AAAAAAAA = all ascending
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_ADDADDAA()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.DESCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.DESCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DAADAADD()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.DESCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.DESCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DADADADA()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
   }
 
@@ -143,16 +387,24 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
                   .verify();
   }
 
-  private List<RowKey> sortUsingByteKeyComparator(final List<KeyColumn> keyColumns, final List<Object[]> objectss)
+  private static List<RowKey> sortUsingByteKeyComparator(
+      final List<KeyColumn> keyColumns,
+      final List<Object[]> objectss,
+      final RowSignature rowSignature
+  )
   {
     return objectss.stream()
-                   .map(objects -> KeyTestUtils.createKey(SIGNATURE, objects).array())
-                   .sorted(ByteRowKeyComparator.create(keyColumns))
+                   .map(objects -> KeyTestUtils.createKey(rowSignature, objects).array())
+                   .sorted(ByteRowKeyComparator.create(keyColumns, rowSignature))
                    .map(RowKey::wrap)
                    .collect(Collectors.toList());
   }
 
-  private List<RowKey> sortUsingObjectComparator(final List<KeyColumn> keyColumns, final List<Object[]> objectss)
+  private static List<RowKey> sortUsingObjectComparator(
+      final List<KeyColumn> keyColumns,
+      final List<Object[]> objectss,
+      final RowSignature rowSignature
+  )
   {
     final List<Object[]> sortedObjectssCopy = objectss.stream().sorted(
         (o1, o2) -> {
@@ -174,9 +426,20 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
     final List<RowKey> sortedKeys = new ArrayList<>();
 
     for (final Object[] objects : sortedObjectssCopy) {
-      sortedKeys.add(KeyTestUtils.createKey(SIGNATURE, objects));
+      sortedKeys.add(KeyTestUtils.createKey(rowSignature, objects));
     }
 
     return sortedKeys;
+  }
+
+  public static HyperLogLogCollector makeHllCollector(final int estimatedCardinality)
+  {
+    final HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
+
+    for (int i = 0; i < estimatedCardinality; ++i) {
+      collector.add(Hashing.murmur3_128().hashBytes(StringUtils.toUtf8(String.valueOf(i))).asBytes());
+    }
+
+    return collector;
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/key/ClusterByTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/ClusterByTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.frame.key;
 import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.guava.Comparators;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,21 +39,30 @@ public class ClusterByTest
         new KeyColumn("y", KeyOrder.ASCENDING)
     );
 
+    final RowSignature rowSignature = RowSignature.builder()
+                                                  .add("x", ColumnType.LONG)
+                                                  .add("y", ColumnType.LONG)
+                                                  .build();
+
     Assert.assertEquals(
-        RowKeyComparator.create(keyColumns),
-        new ClusterBy(keyColumns, 1).keyComparator()
+        RowKeyComparator.create(keyColumns, rowSignature),
+        new ClusterBy(keyColumns, 1).keyComparator(rowSignature)
     );
   }
 
   @Test
   public void test_bucketComparator_noKey()
   {
-    Assert.assertSame(Comparators.alwaysEqual(), ClusterBy.none().bucketComparator());
+    Assert.assertSame(Comparators.alwaysEqual(), ClusterBy.none().bucketComparator(RowSignature.empty()));
   }
 
   @Test
   public void test_bucketComparator_noBucketKey()
   {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("x", ColumnType.LONG)
+                                            .add("y", ColumnType.LONG)
+                                            .build();
     Assert.assertSame(
         Comparators.alwaysEqual(),
         new ClusterBy(
@@ -60,22 +71,30 @@ public class ClusterByTest
                 new KeyColumn("y", KeyOrder.ASCENDING)
             ),
             0
-        ).bucketComparator()
+        ).bucketComparator(rowSignature)
     );
   }
 
   @Test
   public void test_bucketComparator_withBucketKey()
   {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("x", ColumnType.LONG)
+                                            .add("y", ColumnType.LONG)
+                                            .build();
     Assert.assertEquals(
-        RowKeyComparator.create(ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING))),
+        RowKeyComparator.create(
+            ImmutableList.of(new KeyColumn("x", KeyOrder.ASCENDING)),
+            rowSignature
+
+        ),
         new ClusterBy(
             ImmutableList.of(
                 new KeyColumn("x", KeyOrder.ASCENDING),
                 new KeyColumn("y", KeyOrder.ASCENDING)
             ),
             1
-        ).bucketComparator()
+        ).bucketComparator(rowSignature)
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/key/FrameComparisonWidgetImplTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/FrameComparisonWidgetImplTest.java
@@ -44,31 +44,215 @@ import java.util.stream.Collectors;
 
 public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
 {
-  private Frame frame;
+  private Frame frameWithoutComplexColumns;
+  private Frame frameWithComplexColumns;
 
   @Before
   public void setUp()
   {
-    final StorageAdapter rowBasedAdapter = new RowBasedSegment<>(
+    final StorageAdapter rowBasedAdapterWithoutComplexColumn = new RowBasedSegment<>(
         SegmentId.dummy("test"),
-        Sequences.simple(RowKeyComparatorTest.ALL_KEY_OBJECTS),
+        Sequences.simple(ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN),
         columnName -> {
-          final int idx = RowKeyComparatorTest.SIGNATURE.getColumnNames().indexOf(columnName);
+          final int idx = ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE.getColumnNames().indexOf(columnName);
           if (idx < 0) {
             return row -> null;
           } else {
             return row -> row[idx];
           }
         },
-        RowKeyComparatorTest.SIGNATURE
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
     ).asStorageAdapter();
 
-    frame = Iterables.getOnlyElement(
-        FrameSequenceBuilder.fromAdapter(rowBasedAdapter)
+    frameWithoutComplexColumns = Iterables.getOnlyElement(
+        FrameSequenceBuilder.fromAdapter(rowBasedAdapterWithoutComplexColumn)
                             .frameType(FrameType.ROW_BASED)
                             .frames()
                             .toList()
     );
+
+    final StorageAdapter rowBasedAdapterWithComplexColumn = new RowBasedSegment<>(
+        SegmentId.dummy("test"),
+        Sequences.simple(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS),
+        columnName -> {
+          final int idx = ByteRowKeyComparatorTest.SIGNATURE.getColumnNames().indexOf(columnName);
+          if (idx < 0) {
+            return row -> null;
+          } else {
+            return row -> row[idx];
+          }
+        },
+        ByteRowKeyComparatorTest.SIGNATURE
+    ).asStorageAdapter();
+
+    frameWithComplexColumns = Iterables.getOnlyElement(
+        FrameSequenceBuilder.fromAdapter(rowBasedAdapterWithComplexColumn)
+                            .frameType(FrameType.ROW_BASED)
+                            .frames()
+                            .toList()
+    );
+  }
+
+  @Test
+  public void test_noComplexColumns_isPartiallyNullKey_someColumns()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING)
+    );
+
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithoutComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
+    );
+
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
+      final boolean isAllNonNull =
+          Arrays.stream(ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i))
+                .limit(3)
+                .allMatch(Objects::nonNull);
+
+      // null key part, if any, is always the second one (1)
+      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[0]));
+      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{0, 2}));
+      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
+      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{1}));
+    }
+  }
+
+  @Test
+  public void test_noComplexColumns_isPartiallyNullKey_allColumns()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING)
+    );
+
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithoutComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
+    );
+
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
+      final boolean isAllNonNull =
+          Arrays.stream(ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i)).allMatch(Objects::nonNull);
+      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3}));
+    }
+  }
+
+  @Test
+  public void test_noComplexColumns_readKey_someColumns()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING)
+    );
+
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithoutComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
+    );
+
+    final RowSignature signature =
+        RowSignature.builder()
+                    .add("1", ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE.getColumnType("1").orElse(null))
+                    .add("2", ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE.getColumnType("2").orElse(null))
+                    .add("3", ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE.getColumnType("3").orElse(null))
+                    .build();
+
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
+      final Object[] expectedKeyArray = new Object[keyColumns.size()];
+      System.arraycopy(
+          ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i),
+          0,
+          expectedKeyArray,
+          0,
+          keyColumns.size()
+      );
+      Assert.assertEquals(
+          KeyTestUtils.createKey(signature, expectedKeyArray),
+          widget.readKey(i)
+      );
+    }
+  }
+
+  @Test
+  public void test_noComplexColumns_readKey_allColumns()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING)
+    );
+
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithoutComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
+    );
+
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
+      Assert.assertEquals(
+          KeyTestUtils.createKey(
+              ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE,
+              ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i)
+          ),
+          widget.readKey(i)
+      );
+    }
+  }
+
+  @Test
+  public void test_noComplexColumns_compare_frameToKey()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING)
+    );
+
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithoutComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE
+    );
+
+    // Compare self-to-self should be equal.
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
+      Assert.assertEquals(
+          0,
+          widget.compare(
+              i,
+              KeyTestUtils.createKey(
+                  ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE,
+                  ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i)
+              )
+          )
+      );
+    }
+
+    // Check some other comparators.
+    final RowKey firstKey = KeyTestUtils.createKey(
+        ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE,
+        ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(0)
+    );
+
+    MatcherAssert.assertThat(widget.compare(0, firstKey), Matchers.equalTo(0));
+    MatcherAssert.assertThat(widget.compare(1, firstKey), Matchers.lessThan(0));
+    MatcherAssert.assertThat(widget.compare(2, firstKey), Matchers.lessThan(0));
+    MatcherAssert.assertThat(widget.compare(3, firstKey), Matchers.greaterThan(0));
+    MatcherAssert.assertThat(widget.compare(4, firstKey), Matchers.greaterThan(0));
+    MatcherAssert.assertThat(widget.compare(5, firstKey), Matchers.greaterThan(0));
+    MatcherAssert.assertThat(widget.compare(6, firstKey), Matchers.greaterThan(0));
   }
 
   @Test
@@ -80,17 +264,24 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.ASCENDING)
     );
 
-    final FrameComparisonWidget widget = createComparisonWidget(keyColumns);
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.SIGNATURE
+    );
 
-    for (int i = 0; i < frame.numRows(); i++) {
+    for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
       final boolean isAllNonNull =
-          Arrays.stream(RowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).limit(3).allMatch(Objects::nonNull);
+          Arrays.stream(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).limit(3).allMatch(Objects::nonNull);
 
-      // null key part, if any, is always the second one (1)
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[0]));
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{0, 2}));
+      // Only second is non-null throughout
+      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
+      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
       Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{1}));
+      Assert.assertEquals(
+          isAllNonNull,
+          widget.hasNonNullKeyParts(i, new int[]{0}) && widget.hasNonNullKeyParts(i, new int[]{2})
+      );
     }
   }
 
@@ -101,15 +292,23 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
         new KeyColumn("1", KeyOrder.ASCENDING),
         new KeyColumn("2", KeyOrder.ASCENDING),
         new KeyColumn("3", KeyOrder.ASCENDING),
-        new KeyColumn("4", KeyOrder.ASCENDING)
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
     );
 
-    final FrameComparisonWidget widget = createComparisonWidget(keyColumns);
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.SIGNATURE
+    );
 
-    for (int i = 0; i < frame.numRows(); i++) {
+    for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
       final boolean isAllNonNull =
-          Arrays.stream(RowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).allMatch(Objects::nonNull);
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3}));
+          Arrays.stream(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).allMatch(Objects::nonNull);
+      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3, 4, 5, 6, 7}));
     }
   }
 
@@ -122,18 +321,22 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.ASCENDING)
     );
 
-    final FrameComparisonWidget widget = createComparisonWidget(keyColumns);
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.SIGNATURE
+    );
 
     final RowSignature signature =
         RowSignature.builder()
-                    .add("1", RowKeyComparatorTest.SIGNATURE.getColumnType("1").orElse(null))
-                    .add("2", RowKeyComparatorTest.SIGNATURE.getColumnType("2").orElse(null))
-                    .add("3", RowKeyComparatorTest.SIGNATURE.getColumnType("3").orElse(null))
+                    .add("1", ByteRowKeyComparatorTest.SIGNATURE.getColumnType("1").orElse(null))
+                    .add("2", ByteRowKeyComparatorTest.SIGNATURE.getColumnType("2").orElse(null))
+                    .add("3", ByteRowKeyComparatorTest.SIGNATURE.getColumnType("3").orElse(null))
                     .build();
 
-    for (int i = 0; i < frame.numRows(); i++) {
+    for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
       final Object[] expectedKeyArray = new Object[keyColumns.size()];
-      System.arraycopy(RowKeyComparatorTest.ALL_KEY_OBJECTS.get(i), 0, expectedKeyArray, 0, keyColumns.size());
+      System.arraycopy(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i), 0, expectedKeyArray, 0, keyColumns.size());
       Assert.assertEquals(
           KeyTestUtils.createKey(signature, expectedKeyArray),
           widget.readKey(i)
@@ -148,14 +351,22 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
         new KeyColumn("1", KeyOrder.ASCENDING),
         new KeyColumn("2", KeyOrder.ASCENDING),
         new KeyColumn("3", KeyOrder.ASCENDING),
-        new KeyColumn("4", KeyOrder.ASCENDING)
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
     );
 
-    final FrameComparisonWidget widget = createComparisonWidget(keyColumns);
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.SIGNATURE
+    );
 
-    for (int i = 0; i < frame.numRows(); i++) {
+    for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
       Assert.assertEquals(
-          KeyTestUtils.createKey(RowKeyComparatorTest.SIGNATURE, RowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)),
+          KeyTestUtils.createKey(ByteRowKeyComparatorTest.SIGNATURE, ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)),
           widget.readKey(i)
       );
     }
@@ -168,20 +379,28 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
         new KeyColumn("1", KeyOrder.ASCENDING),
         new KeyColumn("2", KeyOrder.ASCENDING),
         new KeyColumn("3", KeyOrder.ASCENDING),
-        new KeyColumn("4", KeyOrder.ASCENDING)
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
     );
 
-    final FrameComparisonWidget widget = createComparisonWidget(keyColumns);
+    final FrameComparisonWidget widget = createComparisonWidget(
+        frameWithComplexColumns,
+        keyColumns,
+        ByteRowKeyComparatorTest.SIGNATURE
+    );
 
     // Compare self-to-self should be equal.
-    for (int i = 0; i < frame.numRows(); i++) {
+    for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
       Assert.assertEquals(
           0,
           widget.compare(
               i,
               KeyTestUtils.createKey(
-                  RowKeyComparatorTest.SIGNATURE,
-                  RowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)
+                  ByteRowKeyComparatorTest.SIGNATURE,
+                  ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)
               )
           )
       );
@@ -189,30 +408,43 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
 
     // Check some other comparators.
     final RowKey firstKey = KeyTestUtils.createKey(
-        RowKeyComparatorTest.SIGNATURE,
-        RowKeyComparatorTest.ALL_KEY_OBJECTS.get(0)
+        ByteRowKeyComparatorTest.SIGNATURE,
+        ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(0)
     );
 
     MatcherAssert.assertThat(widget.compare(0, firstKey), Matchers.equalTo(0));
     MatcherAssert.assertThat(widget.compare(1, firstKey), Matchers.lessThan(0));
-    MatcherAssert.assertThat(widget.compare(2, firstKey), Matchers.lessThan(0));
+    MatcherAssert.assertThat(widget.compare(2, firstKey), Matchers.greaterThan(0));
     MatcherAssert.assertThat(widget.compare(3, firstKey), Matchers.greaterThan(0));
     MatcherAssert.assertThat(widget.compare(4, firstKey), Matchers.greaterThan(0));
     MatcherAssert.assertThat(widget.compare(5, firstKey), Matchers.greaterThan(0));
     MatcherAssert.assertThat(widget.compare(6, firstKey), Matchers.greaterThan(0));
+    MatcherAssert.assertThat(widget.compare(7, firstKey), Matchers.greaterThan(0));
+    MatcherAssert.assertThat(widget.compare(8, firstKey), Matchers.greaterThan(0));
+
+    final RowKey eighthKey = KeyTestUtils.createKey(
+        ByteRowKeyComparatorTest.SIGNATURE,
+        ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(7)
+    );
+
+    MatcherAssert.assertThat(widget.compare(8, eighthKey), Matchers.lessThan(0));
   }
 
-  private FrameComparisonWidget createComparisonWidget(final List<KeyColumn> keyColumns)
+  private FrameComparisonWidget createComparisonWidget(
+      final Frame frame,
+      final List<KeyColumn> keyColumns,
+      final RowSignature rowSignature
+  )
   {
     return FrameComparisonWidgetImpl.create(
         frame,
-        RowKeyComparatorTest.SIGNATURE,
+        rowSignature,
         keyColumns,
         keyColumns.stream().map(
             keyColumn ->
                 FieldReaders.create(
                     keyColumn.columnName(),
-                    RowKeyComparatorTest.SIGNATURE.getColumnType(keyColumn.columnName()).get()
+                    rowSignature.getColumnType(keyColumn.columnName()).get()
                 )
         ).collect(Collectors.toList())
     );

--- a/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparatorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparatorTest.java
@@ -22,46 +22,30 @@ package org.apache.druid.frame.key;
 import com.google.common.collect.ImmutableList;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.guava.Comparators;
-import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.apache.druid.frame.key.ByteRowKeyComparatorTest.ALL_KEY_OBJECTS;
+import static org.apache.druid.frame.key.ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN;
+import static org.apache.druid.frame.key.ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE;
+import static org.apache.druid.frame.key.ByteRowKeyComparatorTest.SIGNATURE;
+
 public class RowKeyComparatorTest extends InitializedNullHandlingTest
 {
-  static final RowSignature SIGNATURE =
-      RowSignature.builder()
-                  .add("1", ColumnType.LONG)
-                  .add("2", ColumnType.STRING)
-                  .add("3", ColumnType.LONG)
-                  .add("4", ColumnType.DOUBLE)
-                  .build();
-  private static final Object[] OBJECTS1 = new Object[]{-1L, "foo", 2L, -1.2};
-  private static final Object[] OBJECTS2 = new Object[]{-1L, null, 2L, 1.2d};
-  private static final Object[] OBJECTS3 = new Object[]{-1L, "bar", 2L, 1.2d};
-  private static final Object[] OBJECTS4 = new Object[]{-1L, "foo", 2L, 1.2d};
-  private static final Object[] OBJECTS5 = new Object[]{-1L, "foo", 3L, 1.2d};
-  private static final Object[] OBJECTS6 = new Object[]{-1L, "foo", 2L, 1.3d};
-  private static final Object[] OBJECTS7 = new Object[]{1L, "foo", 2L, -1.2d};
-
-  static final List<Object[]> ALL_KEY_OBJECTS = Arrays.asList(
-      OBJECTS1,
-      OBJECTS2,
-      OBJECTS3,
-      OBJECTS4,
-      OBJECTS5,
-      OBJECTS6,
-      OBJECTS7
-  );
+  static {
+    ComplexMetrics.registerSerde(HyperUniquesSerde.TYPE_NAME, new HyperUniquesSerde());
+  }
 
   @Test
-  public void test_compare_AAAA() // AAAA = all ascending
+  public void test_compare_AAAA_without_complex_column() // AAAA = all ascending, no complex column
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -70,13 +54,13 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DDDD() // DDDD = all descending
+  public void test_compare_DDDD_without_complex_column() // DDDD = all descending, no complex columns
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.ASCENDING),
@@ -85,13 +69,13 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DAAD()
+  public void test_compare_DAAD_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.ASCENDING),
@@ -100,13 +84,13 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_ADDA()
+  public void test_compare_ADDA_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -115,13 +99,13 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
   }
 
   @Test
-  public void test_compare_DADA()
+  public void test_compare_DADA_without_complex_column()
   {
     final List<KeyColumn> keyColumns = ImmutableList.of(
         new KeyColumn("1", KeyOrder.DESCENDING),
@@ -130,8 +114,103 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
     Assert.assertEquals(
-        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS),
-        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS)
+        sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
+        sortUsingKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DDDDDDDD() // DDDDDDDD = all descending
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.DESCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.DESCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.DESCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.DESCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_AAAAAAAA() // AAAAAAAA = all ascending
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_ADDADDAA()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.ASCENDING),
+        new KeyColumn("2", KeyOrder.DESCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.DESCENDING),
+        new KeyColumn("7", KeyOrder.ASCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DAADAADD()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.ASCENDING),
+        new KeyColumn("4", KeyOrder.DESCENDING),
+        new KeyColumn("5", KeyOrder.ASCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.DESCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
+    );
+  }
+
+  @Test
+  public void test_compare_DADADADA()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("1", KeyOrder.DESCENDING),
+        new KeyColumn("2", KeyOrder.ASCENDING),
+        new KeyColumn("3", KeyOrder.DESCENDING),
+        new KeyColumn("4", KeyOrder.ASCENDING),
+        new KeyColumn("5", KeyOrder.DESCENDING),
+        new KeyColumn("6", KeyOrder.ASCENDING),
+        new KeyColumn("7", KeyOrder.DESCENDING),
+        new KeyColumn("8", KeyOrder.ASCENDING)
+    );
+    Assert.assertEquals(
+        sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
+        sortUsingKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
   }
 
@@ -144,19 +223,27 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
                   .verify();
   }
 
-  private List<RowKey> sortUsingKeyComparator(final List<KeyColumn> keyColumns, final List<Object[]> objectss)
+  private static List<RowKey> sortUsingKeyComparator(
+      final List<KeyColumn> keyColumns,
+      final List<Object[]> objectss,
+      final RowSignature rowSignature
+  )
   {
     final List<RowKey> sortedKeys = new ArrayList<>();
 
     for (final Object[] objects : objectss) {
-      sortedKeys.add(KeyTestUtils.createKey(SIGNATURE, objects));
+      sortedKeys.add(KeyTestUtils.createKey(rowSignature, objects));
     }
 
-    sortedKeys.sort(RowKeyComparator.create(keyColumns));
+    sortedKeys.sort(RowKeyComparator.create(keyColumns, rowSignature));
     return sortedKeys;
   }
 
-  private List<RowKey> sortUsingObjectComparator(final List<KeyColumn> keyColumns, final List<Object[]> objectss)
+  private static List<RowKey> sortUsingObjectComparator(
+      final List<KeyColumn> keyColumns,
+      final List<Object[]> objectss,
+      final RowSignature rowSignature
+  )
   {
     final List<Object[]> sortedObjectssCopy = objectss.stream().sorted(
         (o1, o2) -> {
@@ -178,7 +265,7 @@ public class RowKeyComparatorTest extends InitializedNullHandlingTest
     final List<RowKey> sortedKeys = new ArrayList<>();
 
     for (final Object[] objects : sortedObjectssCopy) {
-      sortedKeys.add(KeyTestUtils.createKey(SIGNATURE, objects));
+      sortedKeys.add(KeyTestUtils.createKey(rowSignature, objects));
     }
 
     return sortedKeys;

--- a/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparisonRunLengthsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparisonRunLengthsTest.java
@@ -1,0 +1,809 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.key;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class RowKeyComparisonRunLengthsTest
+{
+
+  @Test
+  public void testRunLengthsWithNoKeyColumns()
+  {
+    final List<KeyColumn> keyColumns = Collections.emptyList();
+    final RowSignature signature = RowSignature.empty();
+    final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
+    Assert.assertEquals(0, runLengths.getRunLengthEntries().length);
+  }
+
+  @Test
+  public void testRunLengthsWithInvalidOrder()
+  {
+    final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.NONE));
+    final RowSignature signature = RowSignature.builder()
+                                               .add("a", ColumnType.LONG)
+                                               .build();
+    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
+  }
+
+  @Test
+  public void testRunLengthsWithIncompleteRowSignature()
+  {
+    final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.NONE));
+    final RowSignature signature = RowSignature.empty();
+    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
+  }
+
+  @Test
+  public void testRunLengthsWithEmptyType()
+  {
+    final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.NONE));
+    final RowSignature signature1 = RowSignature.builder()
+                                                .add("a", null)
+                                                .build();
+    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature1));
+
+    final RowSignature signature2 = RowSignature.builder()
+                                                .add("a", ColumnType.UNKNOWN_COMPLEX)
+                                                .build();
+    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature2));
+  }
+
+  @Test
+  public void testRunLengthsWithByteComparableTypes()
+  {
+    final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.ASCENDING));
+    final List<ColumnType> byteComparableTypes = ImmutableList.of(
+        ColumnType.LONG,
+        ColumnType.FLOAT,
+        ColumnType.DOUBLE,
+        ColumnType.STRING,
+        ColumnType.LONG_ARRAY,
+        ColumnType.FLOAT_ARRAY,
+        ColumnType.DOUBLE_ARRAY,
+        ColumnType.STRING_ARRAY
+    );
+
+    for (final ColumnType columnType : byteComparableTypes) {
+      final RowSignature signature = RowSignature.builder()
+                                                 .add("a", columnType)
+                                                 .build();
+      final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
+      Assert.assertEquals(1, runLengths.getRunLengthEntries().length);
+      Assert.assertTrue(runLengths.getRunLengthEntries()[0].isByteComparable());
+      Assert.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
+      Assert.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
+    }
+  }
+
+  @Test
+  public void testRunLengthsWithNonByteComparableTypes()
+  {
+    final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.ASCENDING));
+    // Any known complex type
+    final List<ColumnType> byteComparableTypes = ImmutableList.of(ColumnType.NESTED_DATA);
+
+    for (final ColumnType columnType : byteComparableTypes) {
+      final RowSignature signature = RowSignature.builder()
+                                                 .add("a", columnType)
+                                                 .build();
+      final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
+      Assert.assertEquals(1, runLengths.getRunLengthEntries().length);
+      Assert.assertFalse(runLengths.getRunLengthEntries()[0].isByteComparable());
+      Assert.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
+      Assert.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
+    }
+  }
+
+  @Test
+  public void testRunLengthsWithMultipleColumns()
+  {
+    final List<KeyColumn> keyColumns = ImmutableList.of(
+        new KeyColumn("longAsc1", KeyOrder.ASCENDING),
+        new KeyColumn("stringAsc1", KeyOrder.ASCENDING),
+        new KeyColumn("stringDesc1", KeyOrder.DESCENDING),
+        new KeyColumn("longDesc1", KeyOrder.DESCENDING),
+        new KeyColumn("complexDesc1", KeyOrder.DESCENDING),
+        new KeyColumn("complexAsc1", KeyOrder.ASCENDING),
+        new KeyColumn("complexAsc2", KeyOrder.ASCENDING),
+        new KeyColumn("stringAsc2", KeyOrder.ASCENDING)
+    );
+
+    final RowSignature signature = RowSignature.builder()
+                                               .add("longAsc1", ColumnType.LONG)
+                                               .add("stringAsc1", ColumnType.STRING)
+                                               .add("stringDesc1", ColumnType.STRING)
+                                               .add("longDesc1", ColumnType.LONG)
+                                               .add("complexDesc1", ColumnType.NESTED_DATA)
+                                               .add("complexAsc1", ColumnType.NESTED_DATA)
+                                               .add("complexAsc2", ColumnType.NESTED_DATA)
+                                               .add("stringAsc2", ColumnType.STRING)
+                                               .build();
+
+    final RunLengthEntry[] runLengthEntries =
+        RowKeyComparisonRunLengths.create(keyColumns, signature).getRunLengthEntries();
+
+    // Input keyColumns
+    // long ASC, string ASC, string DESC, long DESC, complex DESC, complex ASC, complex ASC, string ASC
+
+    // Output runLengthEntries would be
+    // (long, string ASC) (string, long DESC) (complex DESC) (complex ASC) (complex ASC) (string ASC)
+
+    Assert.assertEquals(6, runLengthEntries.length);
+
+    Assert.assertTrue(runLengthEntries[0].isByteComparable());
+    Assert.assertEquals(2, runLengthEntries[0].getRunLength());
+    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[0].getOrder());
+
+    Assert.assertTrue(runLengthEntries[1].isByteComparable());
+    Assert.assertEquals(2, runLengthEntries[1].getRunLength());
+    Assert.assertEquals(KeyOrder.DESCENDING, runLengthEntries[1].getOrder());
+
+    Assert.assertFalse(runLengthEntries[2].isByteComparable());
+    Assert.assertEquals(1, runLengthEntries[2].getRunLength());
+    Assert.assertEquals(KeyOrder.DESCENDING, runLengthEntries[2].getOrder());
+
+    Assert.assertFalse(runLengthEntries[3].isByteComparable());
+    Assert.assertEquals(1, runLengthEntries[3].getRunLength());
+    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[3].getOrder());
+
+    Assert.assertFalse(runLengthEntries[4].isByteComparable());
+    Assert.assertEquals(1, runLengthEntries[4].getRunLength());
+    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[4].getOrder());
+
+    Assert.assertTrue(runLengthEntries[5].isByteComparable());
+    Assert.assertEquals(1, runLengthEntries[5].getRunLength());
+    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[5].getOrder());
+  }
+
+  /**
+   * This tests the creation of the run lengths with all the permutations of the key columns from the following space:
+   * a. The KeyColumn can be either String or Complex (string is byte-comparable, nested data is not)
+   * b. The KeyColumn can be either ASC or DESC
+   *
+   * Therefore, each key column can be one of (string ASC, string DESC, complex ASC, complex DESC). There are 64 test
+   * case for all the permutations of the key columns, because there are 3 key columns, each of which can take one of
+   * the 4 different configurations..
+   *
+   * Test cases are generated programatically. For index i from [0..64), we build the base-4 representation of the index,
+   * and each digit in the representation corresponds to one of the key columns.
+   */
+  @Test
+  public void testRunLengthsWithAllPermutationsOfThreeLengthKeyColumns()
+  {
+
+    ImmutableList.Builder<RunLengthEntry[]> expectedResultsBuilder = ImmutableList.builder();
+
+    // index = 0; KeyColumns = STRING ASC, STRING ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 3)
+        }
+    );
+
+    // index = 1; KeyColumns = STRING DESC, STRING ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2)
+        }
+    );
+
+    // index = 2; KeyColumns = COMPLEX ASC, STRING ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2)
+        }
+    );
+
+    // index = 3; KeyColumns = COMPLEX DESC, STRING ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2)
+        }
+    );
+
+    // index = 4; KeyColumns = STRING ASC, STRING DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 5; KeyColumns = STRING DESC, STRING DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 6; KeyColumns = COMPLEX ASC, STRING DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 7; KeyColumns = COMPLEX DESC, STRING DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 8; KeyColumns = STRING ASC, COMPLEX ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 9; KeyColumns = STRING DESC, COMPLEX ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 10; KeyColumns = COMPLEX ASC, COMPLEX ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+        }
+    );
+
+    // index = 11; KeyColumns = COMPLEX DESC, COMPLEX ASC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 12; KeyColumns = STRING ASC, COMPLEX DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 13; KeyColumns = STRING DESC, COMPLEX DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 14; KeyColumns = COMPLEX ASC, COMPLEX DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            }
+    );
+
+    // index = 15; KeyColumns = COMPLEX DESC, COMPLEX DESC, STRING ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 16; KeyColumns = STRING ASC, STRING ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+        }
+    );
+
+    // index = 17; KeyColumns = STRING DESC, STRING ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 18; KeyColumns = COMPLEX ASC, STRING ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 19; KeyColumns = COMPLEX DESC, STRING ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 20; KeyColumns = STRING ASC, STRING DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2)
+        }
+    );
+
+    // index = 21; KeyColumns = STRING DESC, STRING DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 3)
+        }
+    );
+
+    // index = 22; KeyColumns = COMPLEX ASC, STRING DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2)
+        }
+    );
+
+    // index = 23; KeyColumns = COMPLEX DESC, STRING DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2)
+        }
+    );
+
+    // index = 24; KeyColumns = STRING ASC, COMPLEX ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 25; KeyColumns = STRING DESC, COMPLEX ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 26; KeyColumns = COMPLEX ASC, COMPLEX ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            }
+    );
+
+    // index = 27; KeyColumns = COMPLEX DESC, COMPLEX ASC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 28; KeyColumns = STRING ASC, COMPLEX DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 29; KeyColumns = STRING DESC, COMPLEX DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 30; KeyColumns = COMPLEX ASC, COMPLEX DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            }
+    );
+
+    // index = 31; KeyColumns = COMPLEX DESC, COMPLEX DESC, STRING DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 32; KeyColumns = STRING ASC, STRING ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 33; KeyColumns = STRING DESC, STRING ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 34; KeyColumns = COMPLEX ASC, STRING ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 35; KeyColumns = COMPLEX DESC, STRING ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 36; KeyColumns = STRING ASC, STRING DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 37; KeyColumns = STRING DESC, STRING DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 38; KeyColumns = COMPLEX ASC, STRING DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 39; KeyColumns = COMPLEX DESC, STRING DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 40; KeyColumns = STRING ASC, COMPLEX ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 41; KeyColumns = STRING DESC, COMPLEX ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 42; KeyColumns = COMPLEX ASC, COMPLEX ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            }
+    );
+
+    // index = 43; KeyColumns = COMPLEX DESC, COMPLEX ASC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 44; KeyColumns = STRING ASC, COMPLEX DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 45; KeyColumns = STRING DESC, COMPLEX DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+    // index = 46; KeyColumns = COMPLEX ASC, COMPLEX DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            }
+    );
+
+    // index = 47; KeyColumns = COMPLEX DESC, COMPLEX DESC, COMPLEX ASC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1)
+        }
+    );
+
+
+    // index = 48; KeyColumns = STRING ASC, STRING ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 2),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 49; KeyColumns = STRING DESC, STRING ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 50; KeyColumns = COMPLEX ASC, STRING ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 51; KeyColumns = COMPLEX DESC, STRING ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 52; KeyColumns = STRING ASC, STRING DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 53; KeyColumns = STRING DESC, STRING DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 2),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 54; KeyColumns = COMPLEX ASC, STRING DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 55; KeyColumns = COMPLEX DESC, STRING DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 56; KeyColumns = STRING ASC, COMPLEX ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 57; KeyColumns = STRING DESC, COMPLEX ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 58; KeyColumns = COMPLEX ASC, COMPLEX ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            }
+    );
+
+    // index = 59; KeyColumns = COMPLEX DESC, COMPLEX ASC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 60; KeyColumns = STRING ASC, COMPLEX DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 61; KeyColumns = STRING DESC, COMPLEX DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(true, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    // index = 62; KeyColumns = COMPLEX ASC, COMPLEX DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.ASCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            }
+    );
+
+    // index = 63; KeyColumns = COMPLEX DESC, COMPLEX DESC, COMPLEX DESC
+    expectedResultsBuilder.add(
+        new RunLengthEntry[]{
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1),
+            new RunLengthEntry(false, KeyOrder.DESCENDING, 1)
+        }
+    );
+
+    List<RunLengthEntry[]> expectedResults = expectedResultsBuilder.build();
+
+    final List<Pair<ColumnType, KeyOrder>> columnTypeAndKeyOrder = ImmutableList.of(
+        Pair.of(ColumnType.STRING, KeyOrder.ASCENDING),
+        Pair.of(ColumnType.STRING, KeyOrder.DESCENDING),
+        Pair.of(ColumnType.NESTED_DATA, KeyOrder.ASCENDING),
+        Pair.of(ColumnType.NESTED_DATA, KeyOrder.DESCENDING)
+    );
+
+
+    for (int i = 0; i < 64; ++i) {
+      Pair<List<KeyColumn>, RowSignature> keyColumnsAndRowSignature = generateKeyColumns(columnTypeAndKeyOrder, i);
+      RunLengthEntry[] actualEntries = RowKeyComparisonRunLengths
+          .create(keyColumnsAndRowSignature.lhs, keyColumnsAndRowSignature.rhs)
+          .getRunLengthEntries();
+      Assert.assertArrayEquals(StringUtils.format("Result %d incorrect", i), expectedResults.get(i), actualEntries);
+    }
+  }
+
+  private Pair<List<KeyColumn>, RowSignature> generateKeyColumns(
+      final List<Pair<ColumnType, KeyOrder>> columnTypeAndKeyOrder,
+      int index
+  )
+  {
+    final List<KeyColumn> keyColumns = new ArrayList<>();
+    final RowSignature.Builder builder = RowSignature.builder();
+
+    int firstKeyColumn = index % 4;
+    keyColumns.add(new KeyColumn("a", columnTypeAndKeyOrder.get(firstKeyColumn).rhs));
+    builder.add("a", columnTypeAndKeyOrder.get(firstKeyColumn).lhs);
+    index /= 4;
+
+    int secondKeyColumn = index % 4;
+    keyColumns.add(new KeyColumn("b", columnTypeAndKeyOrder.get(secondKeyColumn).rhs));
+    builder.add("b", columnTypeAndKeyOrder.get(secondKeyColumn).lhs);
+    index /= 4;
+
+    int thirdKeyColumn = index % 4; // Should be no-op, since index < 64
+    keyColumns.add(new KeyColumn("c", columnTypeAndKeyOrder.get(thirdKeyColumn).rhs));
+    builder.add("c", columnTypeAndKeyOrder.get(thirdKeyColumn).lhs);
+
+    return Pair.of(keyColumns, builder.build());
+  }
+}

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -290,7 +290,7 @@ public class SuperSorterTest
           maxBytesPerFrame
       ) : new FileOutputChannelFactory(tempFolder, maxBytesPerFrame, null);
       final RowKeyReader keyReader = clusterBy.keyReader(signature);
-      final Comparator<RowKey> keyComparator = clusterBy.keyComparator();
+      final Comparator<RowKey> keyComparator = clusterBy.keyComparator(signature);
       final SettableFuture<ClusterByPartitions> clusterByPartitionsFuture = SettableFuture.create();
       final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
 

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTestData.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTestData.java
@@ -20,19 +20,19 @@
 package org.apache.druid.frame.write;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.hash.Hashing;
 import it.unimi.dsi.fastutil.objects.ObjectArrays;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.frame.key.ByteRowKeyComparatorTest;
 import org.apache.druid.frame.key.KeyOrder;
 import org.apache.druid.hll.HyperLogLogCollector;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.nested.StructuredData;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -266,13 +266,32 @@ public class FrameWriterTestData
   );
   //CHECKSTYLE.ON: Regexp
 
-  public static final Dataset<HyperLogLogCollector> TEST_COMPLEX = new Dataset<>(
+  public static final Dataset<HyperLogLogCollector> TEST_COMPLEX_HLL = new Dataset<>(
       HyperUniquesAggregatorFactory.TYPE,
       Arrays.asList(
           null,
-          makeHllCollector(null),
-          makeHllCollector("foo")
+          ByteRowKeyComparatorTest.makeHllCollector(1),
+          ByteRowKeyComparatorTest.makeHllCollector(10),
+          ByteRowKeyComparatorTest.makeHllCollector(50)
       )
+  );
+
+  // Sortedness of structured data depends on the hash value computed for the objects inside.
+  public static final Dataset<StructuredData> TEST_COMPLEX_NESTED = new Dataset<>(
+      ColumnType.NESTED_DATA,
+      Stream.of(
+          null,
+          StructuredData.create("foo"),
+          StructuredData.create("bar"),
+          StructuredData.create(ImmutableMap.of("a", 100, "b", 200)),
+          StructuredData.create(ImmutableMap.of("a", 100, "b", ImmutableList.of("x", "y"))),
+          StructuredData.create(ImmutableMap.of("a", 100, "b", ImmutableMap.of("x", "y"))),
+          StructuredData.wrap(100.1D),
+          StructuredData.wrap(ImmutableList.of("p", "q", "r")),
+          StructuredData.wrap(100),
+          StructuredData.wrap(ImmutableList.of("p", "q", "r")),
+          StructuredData.wrap(1000)
+      ).sorted(Comparators.naturalNullsFirst()).collect(Collectors.toList())
   );
 
   /**
@@ -289,19 +308,9 @@ public class FrameWriterTestData
                    .add(TEST_ARRAYS_LONG)
                    .add(TEST_ARRAYS_FLOAT)
                    .add(TEST_ARRAYS_DOUBLE)
-                   .add(TEST_COMPLEX)
+                   .add(TEST_COMPLEX_HLL)
+                   .add(TEST_COMPLEX_NESTED)
                    .build();
-
-  private static HyperLogLogCollector makeHllCollector(@Nullable final String value)
-  {
-    final HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
-
-    if (value != null) {
-      collector.add(Hashing.murmur3_128().hashBytes(StringUtils.toUtf8(value)).asBytes());
-    }
-
-    return collector;
-  }
 
   public static class Dataset<T>
   {

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWritersTest.java
@@ -24,12 +24,9 @@ import org.apache.druid.frame.allocation.ArenaMemoryAllocatorFactory;
 import org.apache.druid.frame.key.KeyColumn;
 import org.apache.druid.frame.key.KeyOrder;
 import org.apache.druid.frame.write.columnar.ColumnarFrameWriterFactory;
-import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesAggregatorFactory;
-import org.apache.druid.query.aggregation.hyperloglog.HyperUniquesSerde;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.filter.AllNullColumnSelectorFactory;
-import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -101,32 +98,6 @@ public class FrameWritersTest extends InitializedNullHandlingTest
 
     Assert.assertEquals("x", e.getColumnName());
     Assert.assertEquals(ColumnType.ofArray(ColumnType.LONG_ARRAY), e.getColumnType());
-  }
-
-  @Test
-  public void test_rowBased_unsupportedSortColumnType()
-  {
-    // Register, but don't unregister at the end of this test, because many other tests out there expect this to exist
-    // even though they don't explicitly register it.
-    ComplexMetrics.registerSerde(HyperUniquesSerde.TYPE_NAME, new HyperUniquesSerde());
-
-    final IllegalArgumentException e = Assert.assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            FrameWriters.makeFrameWriterFactory(
-                FrameType.ROW_BASED,
-                new ArenaMemoryAllocatorFactory(ALLOCATOR_CAPACITY),
-                RowSignature.builder().add("x", HyperUniquesAggregatorFactory.TYPE).build(),
-                Collections.singletonList(new KeyColumn("x", KeyOrder.ASCENDING))
-            )
-    );
-
-    MatcherAssert.assertThat(
-        e,
-        ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.containsString("Sort column [x] is not comparable (type = COMPLEX<hyperUnique>)")
-        )
-    );
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -1155,16 +1155,12 @@ public class BaseCalciteQueryTest extends CalciteTestBase
 
     final List<ValueType> types = new ArrayList<>();
 
-    final boolean isMSQ = isMSQRowType(queryResults.signature);
-
-    if (!isMSQ) {
-      for (int i = 0; i < queryResults.signature.getColumnNames().size(); i++) {
-        Optional<ColumnType> columnType = queryResults.signature.getColumnType(i);
-        if (columnType.isPresent()) {
-          types.add(columnType.get().getType());
-        } else {
-          types.add(null);
-        }
+    for (int i = 0; i < queryResults.signature.getColumnNames().size(); i++) {
+      Optional<ColumnType> columnType = queryResults.signature.getColumnType(i);
+      if (columnType.isPresent()) {
+        types.add(columnType.get().getType());
+      } else {
+        types.add(null);
       }
     }
 
@@ -1181,17 +1177,11 @@ public class BaseCalciteQueryTest extends CalciteTestBase
         matchMode.validate(
             row,
             i,
-            isMSQ ? null : types.get(i),
+            types.get(i),
             expectedCell,
             resultCell);
       }
     }
-  }
-
-  private boolean isMSQRowType(RowSignature signature)
-  {
-    List<String> colNames = signature.getColumnNames();
-    return colNames.size() == 1 && "TASK".equals(colNames.get(0));
   }
 
   public void assertResultsEquals(String sql, List<Object[]> expectedResults, List<Object[]> results)
@@ -1338,6 +1328,11 @@ public class BaseCalciteQueryTest extends CalciteTestBase
   protected void msqIncompatible()
   {
     assumeFalse(testBuilder().config.isRunningMSQ(), "test case is not MSQ compatible");
+  }
+
+  protected boolean isRunningMSQ()
+  {
+    return testBuilder().config.isRunningMSQ();
   }
 
   protected static boolean isRewriteJoinToFilter(final Map<String, Object> queryContext)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -88,13 +88,13 @@ import java.util.stream.Collectors;
 
 public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
 {
-  private static final String DATA_SOURCE = "nested";
-  private static final String DATA_SOURCE_MIXED = "nested_mix";
-  private static final String DATA_SOURCE_MIXED_2 = "nested_mix_2";
-  private static final String DATA_SOURCE_ARRAYS = "arrays";
-  private static final String DATA_SOURCE_ALL = "all_auto";
+  public static final String DATA_SOURCE = "nested";
+  public static final String DATA_SOURCE_MIXED = "nested_mix";
+  public static final String DATA_SOURCE_MIXED_2 = "nested_mix_2";
+  public static final String DATA_SOURCE_ARRAYS = "arrays";
+  public static final String DATA_SOURCE_ALL = "all_auto";
 
-  private static final List<ImmutableMap<String, Object>> RAW_ROWS = ImmutableList.of(
+  public static final List<ImmutableMap<String, Object>> RAW_ROWS = ImmutableList.of(
       ImmutableMap.<String, Object>builder()
                   .put("t", "2000-01-01")
                   .put("string", "aaa")
@@ -146,7 +146,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                   .build()
   );
 
-  private static final InputRowSchema ALL_JSON_COLUMNS = new InputRowSchema(
+  public static final InputRowSchema ALL_JSON_COLUMNS = new InputRowSchema(
       new TimestampSpec("t", "iso", null),
       DimensionsSpec.builder().setDimensions(
           ImmutableList.<DimensionSchema>builder()
@@ -160,7 +160,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
       null
   );
 
-  private static final InputRowSchema JSON_AND_SCALAR_MIX = new InputRowSchema(
+  public static final InputRowSchema JSON_AND_SCALAR_MIX = new InputRowSchema(
       new TimestampSpec("t", "iso", null),
       DimensionsSpec.builder().setDimensions(
           ImmutableList.<DimensionSchema>builder()
@@ -173,10 +173,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
       ).build(),
       null
   );
-  private static final List<InputRow> ROWS =
+  public static final List<InputRow> ROWS =
       RAW_ROWS.stream().map(raw -> TestDataBuilder.createRow(raw, ALL_JSON_COLUMNS)).collect(Collectors.toList());
 
-  private static final List<InputRow> ROWS_MIX =
+  public static final List<InputRow> ROWS_MIX =
       RAW_ROWS.stream().map(raw -> TestDataBuilder.createRow(raw, JSON_AND_SCALAR_MIX)).collect(Collectors.toList());
 
   @Override
@@ -1074,6 +1074,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testGroupByRootSingleTypeStringMixed2SparseJsonValueNonExistentPath()
   {
+    // Fails while planning for MSQ because MSQ expects a defined type for the virtual column while planning (to figure
+    // out the scanSignature) whereas the NestedFieldVirtualColumn cannot determine the type for the non-existant path,
+    // due to which it returns null
+    msqIncompatible();
     testQuery(
         "SELECT "
         + "JSON_VALUE(string_sparse, '$[1]'), "
@@ -2686,6 +2690,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testJsonAndArrayAgg()
   {
+    // MSQ cannot handle non-primitive arrays
+    msqIncompatible();
     cannotVectorize();
     testQuery(
         "SELECT "
@@ -5411,6 +5417,49 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   public void testScanStringNotNullCast()
   {
     skipVectorize();
+    final List<Object[]> expectedResults;
+    if (NullHandling.sqlCompatible()) {
+      expectedResults = ImmutableList.of(
+          new Object[]{10L},
+          new Object[]{10L}
+      );
+    } else {
+      if (isRunningMSQ()) {
+        expectedResults = ImmutableList.of(
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{10L},
+            new Object[]{10L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L}
+        );
+      } else {
+        expectedResults = ImmutableList.of(
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{10L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{10L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L},
+            new Object[]{0L}
+        );
+      }
+    }
     testQuery(
         "SELECT "
         + "CAST(string_sparse as BIGINT)"
@@ -5428,27 +5477,7 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
                   .legacy(false)
                   .build()
         ),
-        NullHandling.sqlCompatible() ?
-        ImmutableList.of(
-            new Object[]{10L},
-            new Object[]{10L}
-        ) :
-        ImmutableList.of(
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{10L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{10L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L},
-            new Object[]{0L}
-        ),
+        expectedResults,
         RowSignature.builder()
                     .add("EXPR$0", ColumnType.LONG)
                     .build()
@@ -5903,6 +5932,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testScanAllTypesAuto()
   {
+    // Variant types are not supported by MSQ.
+    msqIncompatible();
     skipVectorize();
     testQuery(
         "SELECT * FROM druid.all_auto",
@@ -6841,6 +6872,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testJsonQueryArrayNullArray()
   {
+    // Array complex JSON isn't supported
+    msqIncompatible();
     cannotVectorize();
     testBuilder()
         .sql("SELECT JSON_QUERY_ARRAY(arrayObject, '$.') FROM druid.arrays where arrayObject is null limit 1")
@@ -7060,6 +7093,10 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testJsonValueNestedEmptyArray()
   {
+    // The data set has empty arrays, however MSQ returns nulls. The root cause of the issue is the incorrect
+    // capabilities returned by NestedFieldVirtualColumn when planning which causes MSQ to treat the nested path
+    // as STRING, even though it is an array.
+    msqIncompatible();
     // test for regression
     skipVectorize();
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/QueryTestRunner.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/QueryTestRunner.java
@@ -149,6 +149,26 @@ public class QueryTestRunner
     public QueryResults(
         final Map<String, Object> queryContext,
         final String vectorizeOption,
+        final RowSignature rowSignature,
+        final List<Object[]> results,
+        final List<Query<?>> recordedQueries,
+        final PlannerCaptureHook capture
+    )
+    {
+      this.queryContext = queryContext;
+      this.vectorizeOption = vectorizeOption;
+      this.sqlSignature = null;
+      this.signature = rowSignature;
+      this.results = results;
+      this.recordedQueries = recordedQueries;
+      this.resourceActions = null;
+      this.exception = null;
+      this.capture = capture;
+    }
+
+    public QueryResults(
+        final Map<String, Object> queryContext,
+        final String vectorizeOption,
         final RuntimeException exception
     )
     {
@@ -163,9 +183,9 @@ public class QueryTestRunner
       this.sqlSignature = null;
     }
 
-    public QueryResults withResults(List<Object[]> newResults)
+    public QueryResults withSignatureAndResults(final RowSignature rowSignature, final List<Object[]> newResults)
     {
-      return new QueryResults(queryContext, vectorizeOption, sqlSignature, newResults, recordedQueries, capture);
+      return new QueryResults(queryContext, vectorizeOption, rowSignature, newResults, recordedQueries, capture);
     }
   }
 


### PR DESCRIPTION
Backport of #16322 to 30.0.0.

There were conflicts in the cherry-pick, due to changes in the test framework in master. Fixed the conflicts by converting the code to use the older framework instead.

- Fixed conflicts tests 