### PR TITLE
Fix IndexOutOfBoundsException when storage locations are empty

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLoaderConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.loading;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.utils.JvmUtils;
 
 import java.io.File;
@@ -120,7 +121,14 @@ public class SegmentLoaderConfig
   public File getInfoDir()
   {
     if (infoDir == null) {
-      infoDir = new File(locations.get(0).getPath(), "info_dir");
+      if (locations.isEmpty()) {
+        throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+            .ofCategory(DruidException.Category.NOT_FOUND)
+            .build("storage locations are empty. At least one storage path must be specified "
+                   + "in 'druid.segmentCache.locations'.");
+      } else {
+        infoDir = new File(locations.get(0).getPath(), "info_dir");
+      }
     }
     return infoDir;
   }

--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeStatus.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentChangeStatus.java
@@ -21,9 +21,10 @@ package org.apache.druid.server.coordination;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
+import org.apache.druid.error.DruidException;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * Contains {@link State} of a {@link DataSegmentChangeRequest} and failure
@@ -54,7 +55,10 @@ public class SegmentChangeStatus
       @JsonProperty("failureCause") @Nullable String failureCause
   )
   {
-    this.state = Preconditions.checkNotNull(state, "state must be non-null");
+    if (state == null) {
+      throw DruidException.defensive("state must be non-null");
+    }
+    this.state = state;
     this.failureCause = failureCause;
   }
 
@@ -69,6 +73,25 @@ public class SegmentChangeStatus
   public String getFailureCause()
   {
     return failureCause;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SegmentChangeStatus that = (SegmentChangeStatus) o;
+    return state == that.state && Objects.equals(failureCause, that.failureCause);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(state, failureCause);
   }
 
   @Override


### PR DESCRIPTION
Storage locations can be empty if not configured on a server. If left unconfigured, this can cause an `IndexOutOfBoundsException` when segments are assigned to a server by the coordinator. 

```
org.apache.druid.server.coordination.SegmentLoadDropHandler - Failed to load segment for dataSource: {exceptionType=java.lang.IndexOutOfBoundsException, exceptionMessage=Index: 0, class=org.apache.druid.server.coordination.SegmentLoadDropHandler, segment=DataSegment{binaryVersion=9, id=foo_2024-03-01T00:00:00.000Z_2024-03-02T00:00:00.000Z_2024-04-30T01:56:26.606Z,.., size=1063}}
java.lang.IndexOutOfBoundsException: Index: 0
	at java.base/java.util.Collections$EmptyList.get(Collections.java:4586) ~[?:?]
	at org.apache.druid.segment.loading.SegmentLoaderConfig.getInfoDir(SegmentLoaderConfig.java:123) ~[druid-server-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at org.apache.druid.server.coordination.SegmentLoadDropHandler.loadSegment(SegmentLoadDropHandler.java:290) ~[druid-server-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at org.apache.druid.server.coordination.SegmentLoadDropHandler.loadSegment(SegmentLoadDropHandler.java:263) ~[druid-server-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at org.apache.druid.server.coordination.SegmentLoadDropHandler.addSegment(SegmentLoadDropHandler.java:340) ~[druid-server-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at org.apache.druid.server.coordination.SegmentLoadDropHandler$1.lambda$addSegment$1(SegmentLoadDropHandler.java:569) ~[druid-server-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
```
#### Changes:
- Add a check to fail if `locations.isEmpty()` in `getInfoDir()`. I'm not sure there exists a meaningful default we can assume when locations is not configured.
- Add a unit test that fails with the above exception without this patch.
- Add `equals()` and `hashCode()` implementations in `SegmentChangeStatus` to validate equality.
- Change `Preconditions.checkNotNull()` to a `DruidException.defensive()`.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
