### PR TITLE
Bump org.openrewrite.maven:rewrite-maven-plugin from 5.27.0 to 5.30.0

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -656,7 +656,7 @@
                             </properties>
                             <argLine>
                                 ${jdk.strong.encapsulation.argLine}
-                                -Xmx128m
+                                -Xmx512m
                                 -Duser.timezone=UTC
                                 -Dfile.encoding=UTF-8
                                 -Ddruid.test.config.dockerIp=${env.DOCKER_IP}

--- a/pom.xml
+++ b/pom.xml
@@ -1371,7 +1371,7 @@
             <plugin>
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.27.0</version>
+                <version>5.30.0</version>
                 <configuration>
                     <activeRecipes>
                         <recipe>org.apache.druid.RewriteRules</recipe>


### PR DESCRIPTION
Bump org.openrewrite.maven:rewrite-maven-plugin from 5.27.0 to 5.30.0

Fixes #16418


### Description
Bump org.openrewrite.maven:rewrite-maven-plugin from 5.27.0 to 5.30.0
I have tested integration-tests successfully locally using ```-Dgroups=query-erro```

#### Upgrade rewrite-maven-plugin 

#### Release note
Upgrade org.openrewrite.maven:rewrite-maven-plugin from 5.27.0 to 5.30.0

<hr>

##### Key changed/added classes in this PR
 * `pom.xml`

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
