### PR TITLE
Add Conditional Helpers to DruidException / InvalidInput

### DIFF
--- a/processing/src/main/java/org/apache/druid/error/DruidException.java
+++ b/processing/src/main/java/org/apache/druid/error/DruidException.java
@@ -47,7 +47,7 @@ import java.util.Map;
  * no change should occur.
  * <p>
  * <h3>Notes about exception messages:</h3>
- *
+ * <p>
  * Firstly, exception messages should always be written with the notions from the style conventions covered in
  * {@code dev/style-conventions.md}.  Whenever possible, we should also try to provide an action to take to resolve
  * the issue.
@@ -174,6 +174,22 @@ public class DruidException extends RuntimeException
   public static DruidException defensive(String format, Object... args)
   {
     return defensive().build(format, args);
+  }
+
+  /**
+   * Build a "defensive" exception, this is an exception that should never actually be triggered. Throw to
+   * allow messages to be seen by developers
+   *
+   * @param condition - boolean condition to validate
+   * @param msg - passed through to InvalidInput.exception()
+   * @param args - passed through to InvalidInput.exception()
+   */
+  @SuppressWarnings("unused")
+  public static void conditionalDefensive(boolean condition, String msg, Object... args)
+  {
+    if (!condition) {
+      throw defensive(msg, args);
+    }
   }
 
   private final Persona targetPersona;

--- a/processing/src/main/java/org/apache/druid/error/InvalidInput.java
+++ b/processing/src/main/java/org/apache/druid/error/InvalidInput.java
@@ -35,6 +35,37 @@ public class InvalidInput extends BaseFailure
     return DruidException.fromFailure(new InvalidInput(t, msg, args));
   }
 
+  /**
+   * evalues a condition. If it's false, it throws the appropriate DruidException
+   *
+   * @param condition - boolean condition to validate
+   * @param msg - passed through to DruidException.exception()
+   * @param args - passed through to DruidException.exception()
+   */
+  public static void conditionalException(boolean condition, String msg, Object... args)
+  {
+    if (!condition) {
+      throw exception(msg, args);
+    }
+  }
+
+  /**
+   * evalues a condition. If it's false, it throws the appropriate DruidException with a given cause
+   *
+   * @param condition - boolean condition to validate
+   * @param t - throwable to pass to InvalidInput.exception()
+   * @param msg - passed through to InvalidInput.exception()
+   * @param args - passed through to InvalidInput.exception()
+   */
+
+  public static void conditionalException(boolean condition, Throwable t, String msg, Object... args)
+  {
+    if (!condition) {
+      throw exception(t, msg, args);
+    }
+  }
+
+
   public InvalidInput(
       Throwable t,
       String msg,

--- a/processing/src/test/java/org/apache/druid/error/InvalidInputTest.java
+++ b/processing/src/test/java/org/apache/druid/error/InvalidInputTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.error;
+
+
+import org.junit.Test;
+
+public class InvalidInputTest
+{
+  @Test
+  public void testConditionalNoThrow()
+  {
+    InvalidInput.conditionalException(true, "This should not throw");
+  }
+
+  @Test(expected = DruidException.class)
+  public void testConditionalThrow()
+  {
+    InvalidInput.conditionalException(false, "This should throw");
+  }
+
+  @Test
+  public void testConditionalNoThrowWithCause()
+  {
+    InvalidInput.conditionalException(true, new RuntimeException(), "This should not throw");
+  }
+
+  @Test(expected = DruidException.class)
+  public void testConditionalThrowWithCause()
+  {
+    InvalidInput.conditionalException(false, new RuntimeException(), "This should throw");
+  }
+}


### PR DESCRIPTION
As title says, added versions of

DruidException.defensive(String, Object...)
InvalidInput.exception(String, Object...)
InvalidInput.exception(Throwable, String, Object...)

the versions add a boolean as the first arg and only create and throw an exception if it's false. It can be used similar to Preconditions.checkState/checkArgument

### Description

Added helper functions to make conditional creation of DruidException's easier. Removes superfluous if-statements



#### Release note
None yet. The functions aren't yet used. One generates user-visible errors, the other developer-only.

##### Key changed/added classes in this PR
 * `DruidException`
 * `InvalidInput`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
