### PR TITLE
Cleanup usages of stopwatch

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/Stopwatch.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/Stopwatch.java
@@ -25,11 +25,8 @@ import org.joda.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Thread-safe wrapper over {@link com.google.common.base.Stopwatch}.
- * <p>
- * Thread safety has been limited to the start/stop methods for now as they are
- * the only ones that can throw an exception in an illegal state and are thus
- * vulnerable to race conditions.
+ * Wrapper over {@link com.google.common.base.Stopwatch} to provide some utility
+ * methods such as {@link #millisElapsed()}, {@link #restart()}, {@link #hasElapsed(Duration)}.
  */
 public class Stopwatch
 {
@@ -55,17 +52,17 @@ public class Stopwatch
     this.delegate = delegate;
   }
 
-  public synchronized void start()
+  public void start()
   {
     delegate.start();
   }
 
-  public synchronized void stop()
+  public void stop()
   {
     delegate.stop();
   }
 
-  public synchronized void reset()
+  public void reset()
   {
     delegate.reset();
   }
@@ -73,12 +70,12 @@ public class Stopwatch
   /**
    * Invokes {@code reset().start()} on the underlying {@link com.google.common.base.Stopwatch}.
    */
-  public synchronized void restart()
+  public void restart()
   {
     delegate.reset().start();
   }
 
-  public synchronized boolean isRunning()
+  public boolean isRunning()
   {
     return delegate.isRunning();
   }

--- a/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/DruidLeaderClient.java
@@ -67,9 +67,9 @@ public class DruidLeaderClient
 
   private final String leaderRequestPath;
 
-  private LifecycleLock lifecycleLock = new LifecycleLock();
+  private final LifecycleLock lifecycleLock = new LifecycleLock();
   private DruidNodeDiscovery druidNodeDiscovery;
-  private AtomicReference<String> currentKnownLeader = new AtomicReference<>();
+  private final AtomicReference<String> currentKnownLeader = new AtomicReference<>();
 
   public DruidLeaderClient(
       HttpClient httpClient,

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -71,12 +71,9 @@ import org.skife.jdbi.v2.Query;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.TransactionCallback;
 import org.skife.jdbi.v2.TransactionStatus;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1036,9 +1033,8 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     final Stopwatch stopwatch = Stopwatch.createStarted();
     log.info("Starting polling of segment table.");
 
-    // some databases such as PostgreSQL require auto-commit turned off
+    // Some databases such as PostgreSQL require auto-commit turned off
     // to stream results back, enabling transactions disables auto-commit
-    //
     // setting connection to read-only will allow some database such as MySQL
     // to automatically use read-only transaction mode, further optimizing the query
     final List<DataSegment> segments = connector.inReadOnlyTransaction(
@@ -1067,11 +1063,13 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
     if (segments.isEmpty()) {
       log.info("No segments found in the database!");
     } else {
-      log.info("Polled and found [%,d] segments in the database in [%,d] ms.", segments.size(), stopwatch.millisElapsed());
+      log.info(
+          "Polled and found [%,d] segments in the database in [%,d] ms.",
+          segments.size(), stopwatch.millisElapsed()
+      );
     }
-    stopwatch.restart();
 
-    createDatasourcesSnapshot(stopwatch, segments);
+    createDatasourcesSnapshot(segments);
   }
 
   private void doPollSegmentAndSchema()

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataManager.java
@@ -1171,7 +1171,7 @@ public class SqlSegmentsMetadataManager implements SegmentsMetadataManager
       log.info("No segments found in the database!");
     } else {
       log.info(
-          "Polled and found total [%,d] segments and [%,d] schema in the database in [%,d] ms.",
+          "Polled and found [%,d] segments and [%,d] schemas in the database in [%,d] ms.",
           segments.size(), schemaMap.size(), stopwatch.millisElapsed()
       );
     }

--- a/server/src/main/java/org/apache/druid/segment/metadata/SegmentSchemaBackFillQueue.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/SegmentSchemaBackFillQueue.java
@@ -28,6 +28,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.SchemaPayload;
 import org.apache.druid.segment.SchemaPayloadPlus;
@@ -159,13 +160,11 @@ public class SegmentSchemaBackFillQueue
       return;
     }
 
-    Stopwatch stopwatch = Stopwatch.createStarted();
+    final Stopwatch stopwatch = Stopwatch.createStarted();
+    log.info("Backfilling segment schema. Queue size is [%s].", queue.size());
 
-    log.info("Backfilling segment schema. Queue size is [%s]", queue.size());
-
-    int itemsToProcess = Math.min(MAX_BATCH_SIZE, queue.size());
-
-    Map<String, List<SegmentSchemaMetadataPlus>> polled = new HashMap<>();
+    final int itemsToProcess = Math.min(MAX_BATCH_SIZE, queue.size());
+    final Map<String, List<SegmentSchemaMetadataPlus>> polled = new HashMap<>();
     for (int i = 0; i < itemsToProcess; i++) {
       SegmentSchemaMetadataPlus item = queue.poll();
       if (item != null) {
@@ -175,21 +174,29 @@ public class SegmentSchemaBackFillQueue
 
     for (Map.Entry<String, List<SegmentSchemaMetadataPlus>> entry : polled.entrySet()) {
       try {
-        segmentSchemaManager.persistSchemaAndUpdateSegmentsTable(entry.getKey(), entry.getValue(), CentralizedDatasourceSchemaConfig.SCHEMA_VERSION);
+        segmentSchemaManager.persistSchemaAndUpdateSegmentsTable(
+            entry.getKey(),
+            entry.getValue(),
+            CentralizedDatasourceSchemaConfig.SCHEMA_VERSION
+        );
+
         // Mark the segments as published in the cache.
         for (SegmentSchemaMetadataPlus plus : entry.getValue()) {
           segmentSchemaCache.markMetadataQueryResultPublished(plus.getSegmentId());
         }
         emitter.emit(
             ServiceMetricEvent.builder()
-                                       .setDimension("dataSource", entry.getKey())
-                                       .setMetric("metadatacache/backfill/count", entry.getValue().size())
+                              .setDimension(DruidMetrics.DATASOURCE, entry.getKey())
+                              .setMetric("metadatacache/backfill/count", entry.getValue().size())
         );
       }
       catch (Exception e) {
-        log.error(e, "Exception persisting schema and updating segments table for datasource [%s].", entry.getKey());
+        log.error(e, "Exception persisting schema and updating segments table for datasource[%s].", entry.getKey());
       }
     }
-    emitter.emit(ServiceMetricEvent.builder().setMetric("metadatacache/backfill/time", stopwatch.millisElapsed()));
+    emitter.emit(
+        ServiceMetricEvent.builder()
+                          .setMetric("metadatacache/backfill/time", stopwatch.millisElapsed())
+    );
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncer.java
@@ -96,7 +96,7 @@ public class ChangeRequestHttpSyncer<T>
   private final String logIdentity;
   private int consecutiveFailedAttemptCount = 0;
 
-  // All stopwatches are guarded by the the startStopLock
+  // All stopwatches are guarded by the startStopLock
   private final Stopwatch sinceSyncerStart = Stopwatch.createUnstarted();
   private final Stopwatch sinceLastSyncRequest = Stopwatch.createUnstarted();
   private final Stopwatch sinceLastSyncSuccess = Stopwatch.createUnstarted();


### PR DESCRIPTION
### Description

The Druid `Stopwatch` currently exposes synchronized `start()` and `stop()` methods but this is not adequate as `start()` may still be called before `stop()` has been called throwing an exception `This stopwatch is already running`.

Moreover, there doesn't seem to be a typical use case of a `Stopwatch` that requires thread safety in the first place. In Druid, `ChangeRequestHttpSyncer` seems to be the only place that may use the stopwatch in an unsafe manner. All other usages simply create a fresh instance in a method.

All the usages in `ChangeRequestHttpSyncer` are always accessed inside a `startStopLock`. The two places which were not synchronized on the `startStopLock` have been updated to do so.
