### PR TITLE
fix cds-coordinator-metadata-query-disabled

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -54,6 +54,7 @@ jobs:
       build_jdk: 8
       runtime_jdk: 8
       testing_groups: -Dgroups=${{ matrix.testing_group }}
+      override_config_path: ./environment-configs/test-groups/prepopulated-data
       use_indexer: middleManager
       group: ${{ matrix.testing_group }}
 

--- a/integration-tests/docker/docker-compose.cds-task-schema-publish-disabled.yml
+++ b/integration-tests/docker/docker-compose.cds-task-schema-publish-disabled.yml
@@ -63,7 +63,6 @@ services:
       service: druid-historical
     environment:
       - DRUID_INTEGRATION_TEST_GROUP=${DRUID_INTEGRATION_TEST_GROUP}
-      - AWS_REGION=us-west-2
     depends_on:
       - druid-zookeeper-kafka
 

--- a/integration-tests/docker/environment-configs/test-groups/prepopulated-data
+++ b/integration-tests/docker/environment-configs/test-groups/prepopulated-data
@@ -20,7 +20,7 @@
 AWS_REGION=us-east-1
 
 # If you are making a change in load list below, make the necessary changes in github actions too
-druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-integration-tests"]
+druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-integration-tests","druid-protobuf-extensions","druid-orc-extensions","druid-kafka-indexing-service"]
 
 # Setting s3 credentials and region to use pre-populated data for testing.
 druid_s3_accessKey=AKIAT2GGLKKJQCMG64V4

--- a/integration-tests/docker/environment-configs/test-groups/prepopulated-data
+++ b/integration-tests/docker/environment-configs/test-groups/prepopulated-data
@@ -20,7 +20,7 @@
 AWS_REGION=us-east-1
 
 # If you are making a change in load list below, make the necessary changes in github actions too
-druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-integration-tests","druid-protobuf-extensions","druid-orc-extensions","druid-kafka-indexing-service"]
+druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-integration-tests","druid-parquet-extensions","druid-avro-extensions","druid-protobuf-extensions","druid-orc-extensions","druid-kafka-indexing-service"]
 
 # Setting s3 credentials and region to use pre-populated data for testing.
 druid_s3_accessKey=AKIAT2GGLKKJQCMG64V4

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -129,7 +129,6 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
-
     this.jsonMapper = jsonMapper;
     this.dbTables = dbTables;
     this.connector = connector;


### PR DESCRIPTION
fixes the issue with the newly enabled `cds-coordiantor-metadata-query-disabled` [split](https://github.com/apache/druid/pull/16468)
* configures to use `prepopulated-data` environment things to configure `S3` for access 
* this is needed because these tests use a [dataset which is loaded from s3](https://github.com/apache/druid/blob/master/integration-tests/docker/test-data/cds-coordinator-metadata-query-disabled-sample-data.sql)
* also undoes the previous [fix](https://github.com/apache/druid/pull/16469) of setting the aws region explicitly as this is a more complete solution - and configuring `prepopulated-data` also sets the region; so that's not needed anymore

