### PR TITLE
Web console: more robust durable storage setting detection

### DIFF
--- a/docs/operations/durable-storage.md
+++ b/docs/operations/durable-storage.md
@@ -67,12 +67,12 @@ Depending on the size of the results you're expecting, saving the final results 
 
 By default, Druid saves the final results for queries from deep storage to task reports. Generally, this is acceptable for smaller result sets but may lead to timeouts for larger result sets. 
 
-When you run a query, include the context parameter `selectDestination` and set it to `DURABLESTORAGE`:
+When you run a query, include the context parameter `selectDestination` and set it to `durableStorage`:
 
 ```json
     "context":{
         ...
-        "selectDestination": "DURABLESTORAGE"
+        "selectDestination": "durableStorage"
     }
 ```
 

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -36,7 +36,7 @@ import * as JSONBig from 'json-bigint-native';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { RowColumn } from '../../utils';
-import { deleteKeys } from '../../utils';
+import { caseInsensitiveEquals, deleteKeys } from '../../utils';
 import type { DruidEngine } from '../druid-engine/druid-engine';
 import { validDruidEngine } from '../druid-engine/druid-engine';
 import type { LastExecution } from '../execution/execution';
@@ -512,7 +512,11 @@ export class WorkbenchQuery {
     }
 
     const ingestQuery = this.isIngestQuery();
-    if (!unlimited && !ingestQuery && queryContext.selectDestination !== 'durableStorage') {
+    if (
+      !unlimited &&
+      !ingestQuery &&
+      !caseInsensitiveEquals(queryContext.selectDestination, 'durableStorage')
+    ) {
       apiQuery.context ||= {};
       apiQuery.context.sqlOuterLimit = 1001;
     }

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -18,6 +18,7 @@
 
 import {
   arrangeWithPrefixSuffix,
+  caseInsensitiveEquals,
   formatBytes,
   formatBytesCompact,
   formatInteger,
@@ -194,6 +195,16 @@ describe('general', () => {
         row: 2,
         column: 7,
       });
+    });
+  });
+
+  describe('caseInsensitiveEquals', () => {
+    it('works', () => {
+      expect(caseInsensitiveEquals(undefined, undefined)).toEqual(true);
+      expect(caseInsensitiveEquals(undefined, 'x')).toEqual(false);
+      expect(caseInsensitiveEquals('x', undefined)).toEqual(false);
+      expect(caseInsensitiveEquals('x', 'X')).toEqual(true);
+      expect(caseInsensitiveEquals(undefined, '')).toEqual(false);
     });
   });
 });

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -89,6 +89,10 @@ export function addOrUpdate<T>(xs: readonly T[], x: T, keyFn: (x: T) => string |
 
 // ----------------------------
 
+export function caseInsensitiveEquals(str1: string | undefined, str2: string | undefined): boolean {
+  return str1?.toLowerCase() === str2?.toLowerCase();
+}
+
 export function caseInsensitiveContains(testString: string, searchString: string): boolean {
   if (!searchString) return true;
   return testString.toLowerCase().includes(searchString.toLowerCase());


### PR DESCRIPTION
Right now the docs tell people to set `"selectDestination": "DURABLESTORAGE"` (which works) but the console check for `durableStorage`. Fix the docs and make the console check more robust.