### PR TITLE
Use typecasting comparator for numeric "any" aggregations.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/FloatSumAggregator.java
@@ -28,7 +28,7 @@ import java.util.Comparator;
  */
 public class FloatSumAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = new Ordering()
+  public static final Comparator COMPARATOR = new Ordering()
   {
     @Override
     public int compare(Object o, Object o1)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregator.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/LongSumAggregator.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
  */
 public class LongSumAggregator implements Aggregator
 {
-  static final Comparator COMPARATOR = new Ordering()
+  public static final Comparator COMPARATOR = new Ordering()
   {
     @Override
     public int compare(Object o, Object o1)

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregatorFactory.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.DoubleSumAggregator;
 import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.BaseDoubleColumnValueSelector;
@@ -48,8 +49,6 @@ import java.util.Objects;
 
 public class DoubleAnyAggregatorFactory extends AggregatorFactory
 {
-  private static final Comparator<Double> VALUE_COMPARATOR = Comparator.nullsFirst(Double::compare);
-
   private static final Aggregator NIL_AGGREGATOR = new DoubleAnyAggregator(
       NilColumnValueSelector.instance()
   )
@@ -136,7 +135,7 @@ public class DoubleAnyAggregatorFactory extends AggregatorFactory
   @Override
   public Comparator getComparator()
   {
-    return VALUE_COMPARATOR;
+    return DoubleSumAggregator.COMPARATOR;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/FloatAnyAggregatorFactory.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.FloatSumAggregator;
 import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.BaseFloatColumnValueSelector;
@@ -47,8 +48,6 @@ import java.util.Objects;
 
 public class FloatAnyAggregatorFactory extends AggregatorFactory
 {
-  private static final Comparator<Float> VALUE_COMPARATOR = Comparator.nullsFirst(Float::compare);
-
   private static final Aggregator NIL_AGGREGATOR = new FloatAnyAggregator(
       NilColumnValueSelector.instance()
   )
@@ -133,7 +132,7 @@ public class FloatAnyAggregatorFactory extends AggregatorFactory
   @Override
   public Comparator getComparator()
   {
-    return VALUE_COMPARATOR;
+    return FloatSumAggregator.COMPARATOR;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/any/LongAnyAggregatorFactory.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.AggregatorUtil;
 import org.apache.druid.query.aggregation.BufferAggregator;
+import org.apache.druid.query.aggregation.LongSumAggregator;
 import org.apache.druid.query.aggregation.VectorAggregator;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.BaseLongColumnValueSelector;
@@ -46,8 +47,6 @@ import java.util.List;
 
 public class LongAnyAggregatorFactory extends AggregatorFactory
 {
-  private static final Comparator<Long> VALUE_COMPARATOR = Comparator.nullsFirst(Long::compare);
-
   private static final Aggregator NIL_AGGREGATOR = new LongAnyAggregator(
       NilColumnValueSelector.instance()
   )
@@ -132,7 +131,7 @@ public class LongAnyAggregatorFactory extends AggregatorFactory
   @Override
   public Comparator getComparator()
   {
-    return VALUE_COMPARATOR;
+    return LongSumAggregator.COMPARATOR;
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/any/DoubleAnyAggregationTest.java
@@ -118,6 +118,17 @@ public class DoubleAnyAggregationTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testComparatorWithTypeMismatch()
+  {
+    Long n1 = 3L;
+    Double n2 = 4.0;
+    Comparator comparator = doubleAnyAggFactory.getComparator();
+    Assert.assertEquals(0, comparator.compare(n1, n1));
+    Assert.assertEquals(-1, comparator.compare(n1, n2));
+    Assert.assertEquals(1, comparator.compare(n2, n1));
+  }
+
+  @Test
   public void testDoubleAnyCombiningAggregator()
   {
     Aggregator agg = combiningAggFactory.factorize(colSelectorFactory);

--- a/processing/src/test/java/org/apache/druid/query/aggregation/any/FloatAnyAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/any/FloatAnyAggregationTest.java
@@ -118,6 +118,17 @@ public class FloatAnyAggregationTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testComparatorWithTypeMismatch()
+  {
+    Long n1 = 3L;
+    Float n2 = 4.0f;
+    Comparator comparator = floatAnyAggFactory.getComparator();
+    Assert.assertEquals(0, comparator.compare(n1, n1));
+    Assert.assertEquals(-1, comparator.compare(n1, n2));
+    Assert.assertEquals(1, comparator.compare(n2, n1));
+  }
+
+  @Test
   public void testFloatAnyCombiningAggregator()
   {
     Aggregator agg = combiningAggFactory.factorize(colSelectorFactory);

--- a/processing/src/test/java/org/apache/druid/query/aggregation/any/LongAnyAggregationTest.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/any/LongAnyAggregationTest.java
@@ -119,6 +119,17 @@ public class LongAnyAggregationTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testComparatorWithTypeMismatch()
+  {
+    Integer n1 = 3;
+    Long n2 = 4L;
+    Comparator comparator = longAnyAggFactory.getComparator();
+    Assert.assertEquals(0, comparator.compare(n1, n1));
+    Assert.assertEquals(-1, comparator.compare(n1, n2));
+    Assert.assertEquals(1, comparator.compare(n2, n1));
+  }
+
+  @Test
   public void testLongAnyCombiningAggregator()
   {
     Aggregator agg = combiningAggFactory.factorize(colSelectorFactory);


### PR DESCRIPTION
This brings them in line with the behavior of other numeric aggregations. It is important because otherwise ClassCastExceptions can arise if comparing different numeric types that may arise from deserialization.