### PR TITLE
Throw soft exception in case of empty signature while building Scan Query

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1602,7 +1602,8 @@ public class DruidQuery
 
     if (outputRowSignature.size() == 0) {
       // Should never do a scan query without any columns that we're interested in. This is probably a planner bug.
-      throw new ISE("Cannot convert to Scan query without any columns.");
+      this.plannerContext.setPlanningError("Cannot convert to Scan query without any columns.");
+      return null;
     }
 
     final Pair<DataSource, Filtration> dataSourceFiltrationPair = getFiltration(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1600,6 +1600,12 @@ public class DruidQuery
       return null;
     }
 
+    if (outputRowSignature.size() == 0) {
+      // Should never do a scan query without any columns that we're interested in. This is probably a planner bug.
+      this.plannerContext.setPlanningError("Cannot convert to Scan query without any columns.");
+      return null;
+    }
+
     final Pair<DataSource, Filtration> dataSourceFiltrationPair = getFiltration(
         dataSource,
         filter,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1600,12 +1600,6 @@ public class DruidQuery
       return null;
     }
 
-    if (outputRowSignature.size() == 0) {
-      // Should never do a scan query without any columns that we're interested in. This is probably a planner bug.
-      this.plannerContext.setPlanningError("Cannot convert to Scan query without any columns.");
-      return null;
-    }
-
     final Pair<DataSource, Filtration> dataSourceFiltrationPair = getFiltration(
         dataSource,
         filter,

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteWindowQueryTest.java
@@ -234,22 +234,48 @@ public class CalciteWindowQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testEmptyWindowInSubquery()
+  {
+    testBuilder()
+        .sql(
+            "select c from (\n"
+            + "  select channel, row_number() over () as c\n"
+            + "  from wikipedia\n"
+            + "  group by channel\n"
+            + ") LIMIT 5"
+        )
+        .queryContext(ImmutableMap.of(
+            PlannerContext.CTX_ENABLE_WINDOW_FNS, true,
+            QueryContexts.ENABLE_DEBUG, true,
+            QueryContexts.WINDOWING_STRICT_VALIDATION, false
+        ))
+        .expectedResults(ImmutableList.of(
+            new Object[]{1L},
+            new Object[]{2L},
+            new Object[]{3L},
+            new Object[]{4L},
+            new Object[]{5L}
+        ))
+        .run();
+  }
+
+  @Test
   public void testWindow()
   {
     testBuilder()
-            .sql("SELECT\n" +
-                    "(rank() over (order by count(*) desc)),\n" +
-                    "(rank() over (order by count(*) desc))\n" +
-                    "FROM \"wikipedia\"")
-            .queryContext(ImmutableMap.of(
-                    PlannerContext.CTX_ENABLE_WINDOW_FNS, true,
-                    QueryContexts.ENABLE_DEBUG, true,
-                    QueryContexts.WINDOWING_STRICT_VALIDATION, false
-            ))
-            .expectedResults(ImmutableList.of(
-                    new Object[]{1L, 1L}
-            ))
-            .run();
+        .sql("SELECT\n" +
+             "(rank() over (order by count(*) desc)),\n" +
+             "(rank() over (order by count(*) desc))\n" +
+             "FROM \"wikipedia\"")
+        .queryContext(ImmutableMap.of(
+            PlannerContext.CTX_ENABLE_WINDOW_FNS, true,
+            QueryContexts.ENABLE_DEBUG, true,
+            QueryContexts.WINDOWING_STRICT_VALIDATION, false
+        ))
+        .expectedResults(ImmutableList.of(
+            new Object[]{1L, 1L}
+        ))
+        .run();
   }
 
   private WindowOperatorQuery getWindowOperatorQuery(List<Query<?>> queries)


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

For a queries like :
`select c from (
  select row_number() over () as c
  from table
  group by column
)`
`select row_number() over () from table group by column`

when we get to scan on empty window, it appears to create an empty output signature for the outer scan query while planning.
So, softening the exception rather than throwing ISE 

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->



##### Key changed/added classes in this PR
 * `DruidQuery`

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
