### PR TITLE
Add limit to task payload size

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1125,7 +1125,7 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 |`druid.indexer.queue.startDelay`|Sleep this long before starting Overlord queue management. This can be useful to give a cluster time to re-orient itself (for example, after a widespread network issue).|`PT1M`|
 |`druid.indexer.queue.restartDelay`|Sleep this long when Overlord queue management throws an exception before trying again.|`PT30S`|
 |`druid.indexer.queue.storageSyncRate`|Sync Overlord state this often with an underlying task persistence mechanism.|`PT1M`|
-|`druid.indexer.queue.maxTaskPayloadSize`|Maximum size in bytes of a single task payload.|`62914560`|
+|`druid.indexer.queue.maxTaskPayloadSize`|Maximum size in bytes of a single task payload.|`64 MiB`|
 
 The following configs only apply if the Overlord is running in remote mode. For a description of local vs. remote mode, see [Overlord service](../design/overlord.md).
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1125,6 +1125,7 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 |`druid.indexer.queue.startDelay`|Sleep this long before starting Overlord queue management. This can be useful to give a cluster time to re-orient itself (for example, after a widespread network issue).|`PT1M`|
 |`druid.indexer.queue.restartDelay`|Sleep this long when Overlord queue management throws an exception before trying again.|`PT30S`|
 |`druid.indexer.queue.storageSyncRate`|Sync Overlord state this often with an underlying task persistence mechanism.|`PT1M`|
+|`druid.indexer.queue.maxTaskPayloadSize`|Maximum size in bytes of a single task payload.|`62914560`|
 
 The following configs only apply if the Overlord is running in remote mode. For a description of local vs. remote mode, see [Overlord service](../design/overlord.md).
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1125,7 +1125,7 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 |`druid.indexer.queue.startDelay`|Sleep this long before starting Overlord queue management. This can be useful to give a cluster time to re-orient itself (for example, after a widespread network issue).|`PT1M`|
 |`druid.indexer.queue.restartDelay`|Sleep this long when Overlord queue management throws an exception before trying again.|`PT30S`|
 |`druid.indexer.queue.storageSyncRate`|Sync Overlord state this often with an underlying task persistence mechanism.|`PT1M`|
-|`druid.indexer.queue.maxTaskPayloadSize`|Maximum size in bytes of a single task payload.|`64 MiB`|
+|`druid.indexer.queue.maxTaskPayloadSize`|Maximum allowed size in bytes of a single task payload accepted by the Overlord.|none (allow all task payload sizes)|
 
 The following configs only apply if the Overlord is running in remote mode. For a description of local vs. remote mode, see [Overlord service](../design/overlord.md).
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -1038,13 +1038,10 @@ public class TaskQueue
       }
 
       if (config.getMaxTaskPayloadSize() != null && config.getMaxTaskPayloadSize().getBytesInInt() < payload.length()) {
-        throw DruidException.forPersona(DruidException.Persona.OPERATOR)
-            .ofCategory(DruidException.Category.INVALID_INPUT)
-            .build(
-                "Task payload size was [%d] but max size is [%d]. " +
-                    "Reduce the size of the task or increase 'druid.indexer.queue.maxTaskPayloadSize'.",
-                payload.length(),
-                config.getMaxTaskPayloadSize()
+        throw InvalidInput.exception(
+                "Task[%s] has payload of size[%d] but max allowed size is [%d]. " +
+                    "Reduce the size of the task payload or increase 'druid.indexer.queue.maxTaskPayloadSize'.",
+                task.getId(), payload.length(), config.getMaxTaskPayloadSize()
             );
       }
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -1037,7 +1037,8 @@ public class TaskQueue
       } else if (payload.length() > TASK_SIZE_WARNING_THRESHOLD) {
         log.warn(
             "Task[%s] of datasource[%s] has payload size[%d] larger than the recommended maximum[%d]. " +
-                "Large task payloads may cause stability issues in the Overlord and may fail while persisting to the metadata store.",
+                "Large task payloads may cause stability issues in the Overlord and may fail while persisting to the metadata store." +
+                "These large payloads will be rejected by the overlord in the future.",
             task.getId(),
             task.getDataSource(),
             payload.length(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -516,14 +516,13 @@ public class TaskQueue
     catch (JsonProcessingException ignored) {
     }
     if (payload != null && payload.length() > config.getMaxTaskPayloadSize()) {
-      throw DruidException.forPersona(DruidException.Persona.OPERATOR)
-          .ofCategory(DruidException.Category.INVALID_INPUT)
-          .build(
-              "Task payload size was [%d] but max size is [%d]. " +
-                  "Reduce the size of the task or increase 'druid.indexer.queue.maxTaskPayloadSize'.",
-              payload.length(),
-              config.getMaxTaskPayloadSize()
-          );
+      log.warn("Received a task payload > [%d] with id [%s]. and datasource [%s]" +
+              " There may be downstream issues caused by managing this large payload." +
+              "Increase druid.indexer.queue.maxTaskPayloadSize to ignore this warning.",
+          config.getMaxTaskPayloadSize(),
+          task.getId(),
+          task.getDataSource()
+      );
     }
 
     // Set forceTimeChunkLock before adding task spec to taskStorage, so that we can see always consistent task spec.

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -1038,7 +1038,7 @@ public class TaskQueue
         log.warn(
             "Task[%s] of datasource[%s] has payload size[%d] larger than the recommended maximum[%d]. " +
                 "Large task payloads may cause stability issues in the Overlord and may fail while persisting to the metadata store." +
-                "These large payloads will be rejected by the overlord in the future.",
+                "Such tasks may be rejected by the Overlord in future Druid versions.",
             task.getId(),
             task.getDataSource(),
             payload.length(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -509,6 +509,23 @@ public class TaskQueue
       throw EntryAlreadyExists.exception("Task[%s] already exists", task.getId());
     }
 
+    String payload = null;
+    try {
+      payload = passwordRedactingMapper.writeValueAsString(task);
+    }
+    catch (JsonProcessingException ignored) {
+    }
+    if (payload != null && payload.length() > config.getMaxTaskPayloadSize()) {
+      throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+          .ofCategory(DruidException.Category.INVALID_INPUT)
+          .build(
+              "Task payload size was [%d] but max size is [%d]. " +
+                  "Reduce the size of the task or increase 'druid.indexer.queue.maxTaskPayloadSize'.",
+              payload.length(),
+              config.getMaxTaskPayloadSize()
+          );
+    }
+
     // Set forceTimeChunkLock before adding task spec to taskStorage, so that we can see always consistent task spec.
     task.addToContextIfAbsent(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockConfig.isForceTimeChunkLock());
     defaultTaskConfig.getContext().forEach(task::addToContextIfAbsent);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
@@ -60,9 +60,7 @@ public class TaskQueueConfig
     this.startDelay = defaultDuration(startDelay, "PT1M");
     this.restartDelay = defaultDuration(restartDelay, "PT30S");
     this.storageSyncRate = defaultDuration(storageSyncRate, "PT1M");
-
-    // 60 MB default limit since 64 MB is the default max_allowed_packet size in MySQL 8+
-    this.maxTaskPayloadSize = Configs.valueOrDefault(maxTaskPayloadSize, 60 * 1024 * 1024);
+    this.maxTaskPayloadSize = maxTaskPayloadSize;
   }
 
   public int getMaxSize()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
@@ -22,8 +22,11 @@ package org.apache.druid.indexing.overlord.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.common.config.Configs;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.joda.time.Duration;
 import org.joda.time.Period;
+
+import javax.annotation.Nullable;
 
 public class TaskQueueConfig
 {
@@ -43,7 +46,7 @@ public class TaskQueueConfig
   private int taskCompleteHandlerNumThreads;
 
   @JsonProperty
-  private Long maxTaskPayloadSize;
+  private HumanReadableBytes maxTaskPayloadSize;
 
   @JsonCreator
   public TaskQueueConfig(
@@ -52,7 +55,7 @@ public class TaskQueueConfig
       @JsonProperty("restartDelay") final Period restartDelay,
       @JsonProperty("storageSyncRate") final Period storageSyncRate,
       @JsonProperty("taskCompleteHandlerNumThreads") final Integer taskCompleteHandlerNumThreads,
-      @JsonProperty("maxTaskPayloadSize") final Long maxTaskPayloadSize
+      @JsonProperty("maxTaskPayloadSize") @Nullable final HumanReadableBytes maxTaskPayloadSize
   )
   {
     this.maxSize = Configs.valueOrDefault(maxSize, Integer.MAX_VALUE);
@@ -88,7 +91,7 @@ public class TaskQueueConfig
     return storageSyncRate;
   }
 
-  public Long getMaxTaskPayloadSize()
+  public HumanReadableBytes getMaxTaskPayloadSize()
   {
     return maxTaskPayloadSize;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskQueueConfig.java
@@ -42,13 +42,17 @@ public class TaskQueueConfig
   @JsonProperty
   private int taskCompleteHandlerNumThreads;
 
+  @JsonProperty
+  private Long maxTaskPayloadSize;
+
   @JsonCreator
   public TaskQueueConfig(
       @JsonProperty("maxSize") final Integer maxSize,
       @JsonProperty("startDelay") final Period startDelay,
       @JsonProperty("restartDelay") final Period restartDelay,
       @JsonProperty("storageSyncRate") final Period storageSyncRate,
-      @JsonProperty("taskCompleteHandlerNumThreads") final Integer taskCompleteHandlerNumThreads
+      @JsonProperty("taskCompleteHandlerNumThreads") final Integer taskCompleteHandlerNumThreads,
+      @JsonProperty("maxTaskPayloadSize") final Long maxTaskPayloadSize
   )
   {
     this.maxSize = Configs.valueOrDefault(maxSize, Integer.MAX_VALUE);
@@ -56,6 +60,9 @@ public class TaskQueueConfig
     this.startDelay = defaultDuration(startDelay, "PT1M");
     this.restartDelay = defaultDuration(restartDelay, "PT30S");
     this.storageSyncRate = defaultDuration(storageSyncRate, "PT1M");
+
+    // 60 MB default limit since 64 MB is the default max_allowed_packet size in MySQL 8+
+    this.maxTaskPayloadSize = Configs.valueOrDefault(maxTaskPayloadSize, 60 * 1024 * 1024);
   }
 
   public int getMaxSize()
@@ -81,6 +88,11 @@ public class TaskQueueConfig
   public Duration getStorageSyncRate()
   {
     return storageSyncRate;
+  }
+
+  public Long getMaxTaskPayloadSize()
+  {
+    return maxTaskPayloadSize;
   }
 
   private static Duration defaultDuration(final Period period, final String theDefault)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
@@ -138,7 +138,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     );
     taskQueue = new TaskQueue(
         new TaskLockConfig(),
-        new TaskQueueConfig(null, new Period(0L), null, null, null),
+        new TaskQueueConfig(null, new Period(0L), null, null, null, null),
         new DefaultTaskConfig(),
         getTaskStorage(),
         taskRunner,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndStreamingAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndStreamingAppendTest.java
@@ -151,7 +151,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
     );
     taskQueue = new TaskQueue(
         new TaskLockConfig(),
-        new TaskQueueConfig(null, new Period(0L), null, null, null),
+        new TaskQueueConfig(null, new Period(0L), null, null, null, null),
         new DefaultTaskConfig(),
         getTaskStorage(),
         taskRunner,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
@@ -109,7 +109,7 @@ public class TaskLockConfigTest
     } else {
       lockConfig = new TaskLockConfig();
     }
-    final TaskQueueConfig queueConfig = new TaskQueueConfig(null, null, null, null, null);
+    final TaskQueueConfig queueConfig = new TaskQueueConfig(null, null, null, null, null, null);
     final TaskRunner taskRunner = EasyMock.createNiceMock(RemoteTaskRunner.class);
     final TaskActionClientFactory actionClientFactory = EasyMock.createNiceMock(LocalTaskActionClientFactory.class);
     final TaskLockbox lockbox = new TaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
@@ -122,7 +122,7 @@ public class TaskQueueScaleTest
 
     taskQueue = new TaskQueue(
         new TaskLockConfig(),
-        new TaskQueueConfig(null, Period.millis(1), null, null, null),
+        new TaskQueueConfig(null, Period.millis(1), null, null, null, null),
         new DefaultTaskConfig(),
         taskStorage,
         taskRunner,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -281,26 +281,6 @@ public class TaskQueueTest extends IngestionTestBase
   }
 
   @Test
-  public void testUserProvidedTaskContextOverrideDefaultLineageBasedSegmentAllocation()
-  {
-    final Task task = new TestTask(
-        "t1",
-        Intervals.of("2021-01-01/P1D"),
-        ImmutableMap.of(
-            SinglePhaseParallelIndexTaskRunner.CTX_USE_LINEAGE_BASED_SEGMENT_ALLOCATION_KEY,
-            false
-        )
-    );
-    taskQueue.add(task);
-    final List<Task> tasks = taskQueue.getTasks();
-    Assert.assertEquals(1, tasks.size());
-    final Task queuedTask = tasks.get(0);
-    Assert.assertFalse(
-        queuedTask.getContextValue(SinglePhaseParallelIndexTaskRunner.CTX_USE_LINEAGE_BASED_SEGMENT_ALLOCATION_KEY)
-    );
-  }
-
-  @Test
   public void testLockConfigTakePrecedenceThanDefaultTaskContext()
   {
     defaultTaskContext.put(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, false);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -71,6 +71,7 @@ import org.apache.druid.indexing.worker.TaskAnnouncement;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
@@ -218,7 +219,7 @@ public class TaskQueueTest extends IngestionTestBase
   @Test
   public void testAddThrowsExceptionWhenPayloadIsTooLarge()
   {
-    Long maxPayloadSize = 1024L * 1024L * 10L;
+    HumanReadableBytes maxPayloadSize = HumanReadableBytes.valueOf(10 * 1024 * 1024);
     TaskQueue maxPayloadTaskQueue = new TaskQueue(
         new TaskLockConfig(),
         new TaskQueueConfig(3, null, null, null, null, maxPayloadSize),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -247,6 +247,26 @@ public class TaskQueueTest extends IngestionTestBase
   }
 
   @Test
+  public void testUserProvidedTaskContextOverrideDefaultLineageBasedSegmentAllocation()
+  {
+    final Task task = new TestTask(
+        "t1",
+        Intervals.of("2021-01-01/P1D"),
+        ImmutableMap.of(
+            SinglePhaseParallelIndexTaskRunner.CTX_USE_LINEAGE_BASED_SEGMENT_ALLOCATION_KEY,
+            false
+        )
+    );
+    taskQueue.add(task);
+    final List<Task> tasks = taskQueue.getTasks();
+    Assert.assertEquals(1, tasks.size());
+    final Task queuedTask = tasks.get(0);
+    Assert.assertFalse(
+        queuedTask.getContextValue(SinglePhaseParallelIndexTaskRunner.CTX_USE_LINEAGE_BASED_SEGMENT_ALLOCATION_KEY)
+    );
+  }
+
+  @Test
   public void testLockConfigTakePrecedenceThanDefaultTaskContext()
   {
     defaultTaskContext.put(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, false);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -216,40 +216,6 @@ public class TaskQueueTest extends IngestionTestBase
   }
 
   @Test
-  public void testAddThrowsExceptionWhenPayloadIsTooLarge()
-  {
-    // 1 MB is not too large by default
-    char[] context = new char[1024 * 1024];
-    Arrays.fill(context, 'a');
-    taskQueue.add(
-        new TestTask(
-            "tx",
-            Intervals.of("2021-01/P1M"),
-            ImmutableMap.of(
-                "contextKey", new String(context)
-            )
-        )
-    );
-
-    // 100 MB is too large by default
-    char[] contextLarge = new char[100 * 1024 * 1024];
-    Arrays.fill(contextLarge, 'a');
-
-    Assert.assertThrows(
-        DruidException.class,
-        () -> taskQueue.add(
-            new TestTask(
-                "tx2",
-                Intervals.of("2021-01/P1M"),
-                ImmutableMap.of(
-                    "contextKey", new String(contextLarge)
-                )
-          )
-        )
-    );
-  }
-
-  @Test
   public void testAddedTaskUsesLineageBasedSegmentAllocationByDefault()
   {
     final Task task = new TestTask("t1", Intervals.of("2021-01-01/P1D"));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -219,10 +219,10 @@ public class TaskQueueTest extends IngestionTestBase
   @Test
   public void testAddThrowsExceptionWhenPayloadIsTooLarge()
   {
-    HumanReadableBytes maxPayloadSize = HumanReadableBytes.valueOf(10 * 1024 * 1024);
+    HumanReadableBytes maxPayloadSize10Mib = HumanReadableBytes.valueOf(10 * 1024 * 1024);
     TaskQueue maxPayloadTaskQueue = new TaskQueue(
         new TaskLockConfig(),
-        new TaskQueueConfig(3, null, null, null, null, maxPayloadSize),
+        new TaskQueueConfig(3, null, null, null, null, maxPayloadSize10Mib),
         new DefaultTaskConfig()
         {
           @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -236,7 +236,7 @@ public class OverlordTest
 
     taskMaster = new TaskMaster(
         new TaskLockConfig(),
-        new TaskQueueConfig(null, new Period(1), null, new Period(10), null),
+        new TaskQueueConfig(null, new Period(1), null, new Period(10), null, null),
         new DefaultTaskConfig(),
         taskLockbox,
         taskStorage,


### PR DESCRIPTION
Currently it's possible to submit a really big task payload and have it OOM the overlord if the request fails and logs the whole thing in SQLMetadataStorageActionHandler.insertEntryWithHandle.

If the request happens to be larger than max_allowed_packet for a mysql metadata store it will always fail. Since really large task payloads seem to cause overlord instability in general I think it makes sense to limit the size of task payloads at the task queue level.

### Description
Add a new config that sets a limit for task payload sizes. Throw a exception if the limit is exceeded.

The default limit of 60 MB is based on the 64 MB default value of max_allowed_packet in MySQL 8+.

I would ideally like to use the http request content-length header to calculate the size of the task payload rather than re-serializing it in memory but we also call taskQueue.add directly from supervisors so that would bypass the check. If others think this is acceptable and it would be better to check Content-Length in OverlordResource I am fine with changing this logic.

#### Release note
- Adding a new guardrail for submitting tasks that are too large

##### Key changed/added classes in this PR
 * `TaskQueue`

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ X added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
