### PR TITLE
Upgrade Delta Kernel dependency from 3.1.0 to 3.2.0

### DIFF
--- a/extensions-contrib/druid-deltalake-extensions/pom.xml
+++ b/extensions-contrib/druid-deltalake-extensions/pom.xml
@@ -35,7 +35,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <delta-kernel.version>3.1.0</delta-kernel.version>
+    <delta-kernel.version>3.2.0</delta-kernel.version>
   </properties>
 
   <dependencies>

--- a/extensions-contrib/druid-deltalake-extensions/src/main/java/org/apache/druid/delta/input/RowSerde.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/main/java/org/apache/druid/delta/input/RowSerde.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.defaults.internal.data.DefaultJsonRow;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.types.BooleanType;
@@ -84,13 +84,12 @@ public class RowSerde
   /**
    * Utility method to deserialize a {@link Row} object from the JSON form.
    */
-  public static Row deserializeRowFromJson(TableClient tableClient, String jsonRowWithSchema)
+  public static Row deserializeRowFromJson(Engine engine, String jsonRowWithSchema)
   {
     try {
       JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonRowWithSchema);
       JsonNode schemaNode = jsonNode.get("schema");
-      StructType schema =
-          tableClient.getJsonHandler().deserializeStructType(schemaNode.asText());
+      StructType schema = engine.getJsonHandler().deserializeStructType(schemaNode.asText());
       return parseRowFromJsonWithSchema((ObjectNode) jsonNode.get("row"), schema);
     }
     catch (JsonProcessingException e) {

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaTestUtils.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaTestUtils.java
@@ -23,19 +23,19 @@ import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.Table;
-import io.delta.kernel.TableNotFoundException;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.types.StructType;
 
 public class DeltaTestUtils
 {
-  public static Scan getScan(final TableClient tableClient, final String deltaTablePath) throws TableNotFoundException
+  public static Scan getScan(final Engine engine, final String deltaTablePath) throws TableNotFoundException
   {
-    final Table table = Table.forPath(tableClient, deltaTablePath);
-    final Snapshot snapshot = table.getLatestSnapshot(tableClient);
-    final StructType readSchema = snapshot.getSchema(tableClient);
-    final ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient)
-                                            .withReadSchema(tableClient, readSchema);
+    final Table table = Table.forPath(engine, deltaTablePath);
+    final Snapshot snapshot = table.getLatestSnapshot(engine);
+    final StructType readSchema = snapshot.getSchema(engine);
+    final ScanBuilder scanBuilder = snapshot.getScanBuilder(engine)
+                                            .withReadSchema(engine, readSchema);
     return scanBuilder.build();
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/RowSerdeTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/RowSerdeTest.java
@@ -20,11 +20,11 @@
 package org.apache.druid.delta.input;
 
 import io.delta.kernel.Scan;
-import io.delta.kernel.TableNotFoundException;
 import io.delta.kernel.data.Row;
-import io.delta.kernel.defaults.client.DefaultTableClient;
+import io.delta.kernel.defaults.engine.DefaultEngine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -46,13 +46,13 @@ public class RowSerdeTest
   @ParameterizedTest(name = "{index}:with context {0}")
   public void testSerializeDeserializeRoundtrip(final String tablePath) throws TableNotFoundException
   {
-    final DefaultTableClient tableClient = DefaultTableClient.create(new Configuration());
-    final Scan scan = DeltaTestUtils.getScan(tableClient, tablePath);
-    final Row scanState = scan.getScanState(tableClient);
+    final DefaultEngine engine = DefaultEngine.create(new Configuration());
+    final Scan scan = DeltaTestUtils.getScan(engine, tablePath);
+    final Row scanState = scan.getScanState(engine);
 
     final String rowJson = RowSerde.serializeRowToJson(scanState);
-    final Row row = RowSerde.deserializeRowFromJson(tableClient, rowJson);
+    final Row row = RowSerde.deserializeRowFromJson(engine, rowJson);
 
-    Assert.assertEquals(scanState.getSchema(), row.getSchema());
+    Assertions.assertEquals(scanState.getSchema(), row.getSchema());
   }
 }


### PR DESCRIPTION
Delta 3.2.0 released recently: https://github.com/delta-io/delta/releases/tag/v3.2.0

- Upgrade the Delta Kernel dependency to 3.2.0.
- Notable breaking changes introduced in the upstream that affect the Druid extension:
    - Rename `TableClient` to `Engine`.
    - Rename `DefaultTableClient` to `DefaultEngine`.
    - `Table.getPath()` no longer throws a `TableNotFoundException`; instead, the exception is thrown when getting snapshot info from the `Table` object.
    - Exceptions moved to a separate package.
   

Note that none of the above breaking changes are user-facing.

The upstream 3.2.0 release includes a new feature to read arbitrary snapshots. Currently, the Druid extension only supports reading the latest snapshots, which is a [documented limitation](https://druid.apache.org/docs/latest/development/extensions-contrib/delta-lake/#known-limitations). We can remove the limitation once we add support for that in this extension.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
