### PR TITLE
Optimise indexer resource usage based on CPU profile

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -322,7 +322,7 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
     if (encodedValueSerializer instanceof ColumnarMultiIntsSerializer) {
       ((ColumnarMultiIntsSerializer) encodedValueSerializer).addValues(row);
     } else {
-      int value = row.size() == 0 ? 0 : row.get(0);
+      int value = rowSize == 0 ? 0 : row.get(0);
       ((SingleValueColumnarIntsSerializer) encodedValueSerializer).addValue(value);
     }
     rowCount++;

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -83,7 +83,7 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
   public EncodedKeyComponent<int[]> processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {
     final int[] encodedDimensionValues;
-    volatile boolean dictionaryChanged = false;
+    boolean dictionaryChanged = false;
     final long oldDictSizeInBytes = useMaxMemoryEstimates ? 0 : dimLookup.sizeInBytes();
 
     // expressions which operate on multi-value string inputs as arrays might spit out arrays, coerce to list

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -83,7 +83,7 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
   public EncodedKeyComponent<int[]> processRowValsToUnsortedEncodedKeyComponent(@Nullable Object dimValues, boolean reportParseExceptions)
   {
     final int[] encodedDimensionValues;
-    final int oldDictSize = dimLookup.size();
+    boolean dictionaryChanged = false;
     final long oldDictSizeInBytes = useMaxMemoryEstimates ? 0 : dimLookup.sizeInBytes();
 
     // expressions which operate on multi-value string inputs as arrays might spit out arrays, coerce to list
@@ -94,13 +94,21 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     if (dimValues == null) {
       final int nullId = dimLookup.getId(null);
       encodedDimensionValues = nullId == DimensionDictionary.ABSENT_VALUE_ID ? new int[]{dimLookup.add(null)} : new int[]{nullId};
+      if (nullId == DimensionDictionary.ABSENT_VALUE_ID) {
+        encodedDimensionValues = new int[]{dimLookup.add(null)};
+        dictionaryChanged = true;
+      } else {
+        encodedDimensionValues = new int[]{nullId};
+      }
     } else if (dimValues instanceof List) {
       List<Object> dimValuesList = (List<Object>) dimValues;
       if (dimValuesList.isEmpty()) {
         dimLookup.add(null);
+        dictionaryChanged = true;
         encodedDimensionValues = IntArrays.EMPTY_ARRAY;
       } else if (dimValuesList.size() == 1) {
         encodedDimensionValues = new int[]{dimLookup.add(emptyToNullIfNeeded(dimValuesList.get(0)))};
+        dictionaryChanged = true;
       } else {
         hasMultipleValues = true;
         final String[] dimensionValues = new String[dimValuesList.size()];
@@ -119,9 +127,11 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
         for (String dimensionValue : dimensionValues) {
           if (multiValueHandling != MultiValueHandling.SORTED_SET) {
             retVal[pos++] = dimLookup.add(dimensionValue);
+            dictionaryChanged = true;
             continue;
           }
           int index = dimLookup.add(dimensionValue);
+          dictionaryChanged = true;
           if (index != prevId) {
             prevId = retVal[pos++] = index;
           }
@@ -132,12 +142,14 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     } else if (dimValues instanceof byte[]) {
       encodedDimensionValues =
           new int[]{dimLookup.add(emptyToNullIfNeeded(StringUtils.encodeBase64String((byte[]) dimValues)))};
+      dictionaryChanged = true;
     } else {
       encodedDimensionValues = new int[]{dimLookup.add(emptyToNullIfNeeded(dimValues))};
+      dictionaryChanged = true;
     }
 
     // If dictionary size has changed, the sorted lookup is no longer valid.
-    if (oldDictSize != dimLookup.size()) {
+    if (dictionaryChanged) {
       sortedLookup = null;
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -93,7 +93,6 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
 
     if (dimValues == null) {
       final int nullId = dimLookup.getId(null);
-      encodedDimensionValues = nullId == DimensionDictionary.ABSENT_VALUE_ID ? new int[]{dimLookup.add(null)} : new int[]{nullId};
       if (nullId == DimensionDictionary.ABSENT_VALUE_ID) {
         encodedDimensionValues = new int[]{dimLookup.add(null)};
         dictionaryChanged = true;


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

![image](https://github.com/apache/druid/assets/111732128/7c4aa673-97df-487f-aa98-8b5a21e9dfff)


Checking the size of the dimension lookup dictionary is expensive as it involves locks. This was seen in one of the CPU profiles taken on indexers.
The fix for this is to have a flag which tracks changes to the dimension lookup dictionary and use that value at the end instead of checking the dimension lookup dictionary again.


![image](https://github.com/apache/druid/assets/111732128/b5ade0f6-e099-4f20-8dc4-535bb05a0b19)
Even in `DictionaryEncodedColumnMerger::processMergedRow`, the size() method on the row is expensive and its called twice when the same value which was computed in the beginning can be reused.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * [CHANGED] processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer::processRowValsToUnsortedEncodedKeyComponent
 * [CHANGED] processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger::processMergedRow

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
