### PR TITLE
Do minor cleanup of AutoCompactionSnapshot.Builder

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/AutoCompactionSnapshot.java
@@ -35,27 +35,32 @@ public class AutoCompactionSnapshot
   }
 
   @JsonProperty
-  private String dataSource;
+  private final String dataSource;
   @JsonProperty
-  private AutoCompactionScheduleStatus scheduleStatus;
+  private final AutoCompactionScheduleStatus scheduleStatus;
   @JsonProperty
-  private long bytesAwaitingCompaction;
+  private final long bytesAwaitingCompaction;
   @JsonProperty
-  private long bytesCompacted;
+  private final long bytesCompacted;
   @JsonProperty
-  private long bytesSkipped;
+  private final long bytesSkipped;
   @JsonProperty
-  private long segmentCountAwaitingCompaction;
+  private final long segmentCountAwaitingCompaction;
   @JsonProperty
-  private long segmentCountCompacted;
+  private final long segmentCountCompacted;
   @JsonProperty
-  private long segmentCountSkipped;
+  private final long segmentCountSkipped;
   @JsonProperty
-  private long intervalCountAwaitingCompaction;
+  private final long intervalCountAwaitingCompaction;
   @JsonProperty
-  private long intervalCountCompacted;
+  private final long intervalCountCompacted;
   @JsonProperty
-  private long intervalCountSkipped;
+  private final long intervalCountSkipped;
+
+  public static Builder builder(String dataSource)
+  {
+    return new Builder(dataSource, AutoCompactionScheduleStatus.RUNNING);
+  }
 
   @JsonCreator
   public AutoCompactionSnapshot(
@@ -185,8 +190,9 @@ public class AutoCompactionSnapshot
 
   public static class Builder
   {
-    private String dataSource;
-    private AutoCompactionScheduleStatus scheduleStatus;
+    private final String dataSource;
+    private final AutoCompactionScheduleStatus scheduleStatus;
+
     private long bytesAwaitingCompaction;
     private long bytesCompacted;
     private long bytesSkipped;
@@ -197,12 +203,18 @@ public class AutoCompactionSnapshot
     private long intervalCountCompacted;
     private long intervalCountSkipped;
 
-
-    public Builder(
+    private Builder(
         @NotNull String dataSource,
         @NotNull AutoCompactionScheduleStatus scheduleStatus
     )
     {
+      if (dataSource == null || dataSource.isEmpty()) {
+        throw new ISE("Invalid dataSource name");
+      }
+      if (scheduleStatus == null) {
+        throw new ISE("scheduleStatus cannot be null");
+      }
+
       this.dataSource = dataSource;
       this.scheduleStatus = scheduleStatus;
       this.bytesAwaitingCompaction = 0;
@@ -272,12 +284,6 @@ public class AutoCompactionSnapshot
 
     public AutoCompactionSnapshot build()
     {
-      if (dataSource == null || dataSource.isEmpty()) {
-        throw new ISE("Invalid dataSource name");
-      }
-      if (scheduleStatus == null) {
-        throw new ISE("scheduleStatus cannot be null");
-      }
       return new AutoCompactionSnapshot(
           dataSource,
           scheduleStatus,

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -376,17 +376,16 @@ public class CompactSegments implements CoordinatorCustomDuty
       // As these segments will be compacted, we will aggregate the statistic to the Compacted statistics
       AutoCompactionSnapshot.Builder snapshotBuilder = currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
           dataSourceName,
-          k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+          AutoCompactionSnapshot::builder
       );
-      snapshotBuilder.incrementBytesCompacted(
-          segmentsToCompact.stream().mapToLong(DataSegment::getSize).sum()
-      );
-      snapshotBuilder.incrementIntervalCountCompacted(
-          segmentsToCompact.stream()
-                           .map(DataSegment::getInterval)
-                           .distinct().count()
-      );
-      snapshotBuilder.incrementSegmentCountCompacted(segmentsToCompact.size());
+      snapshotBuilder
+          .incrementBytesCompacted(
+              segmentsToCompact.stream().mapToLong(DataSegment::getSize).sum()
+          )
+          .incrementIntervalCountCompacted(
+              segmentsToCompact.stream().map(DataSegment::getInterval).distinct().count()
+          )
+          .incrementSegmentCountCompacted(segmentsToCompact.size());
 
       final DataSourceCompactionConfig config = compactionConfigs.get(dataSourceName);
 
@@ -519,20 +518,16 @@ public class CompactSegments implements CoordinatorCustomDuty
         final String dataSourceName = segmentsToCompact.get(0).getDataSource();
         AutoCompactionSnapshot.Builder snapshotBuilder = currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
             dataSourceName,
-            k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+            AutoCompactionSnapshot::builder
         );
-        snapshotBuilder.incrementBytesAwaitingCompaction(
-            segmentsToCompact.stream()
-                             .mapToLong(DataSegment::getSize)
-                             .sum()
-        );
-        snapshotBuilder.incrementIntervalCountAwaitingCompaction(
-            segmentsToCompact.stream()
-                             .map(DataSegment::getInterval)
-                             .distinct()
-                             .count()
-        );
-        snapshotBuilder.incrementSegmentCountAwaitingCompaction(segmentsToCompact.size());
+        snapshotBuilder
+            .incrementBytesAwaitingCompaction(
+                segmentsToCompact.stream().mapToLong(DataSegment::getSize).sum()
+            )
+            .incrementIntervalCountAwaitingCompaction(
+                segmentsToCompact.stream().map(DataSegment::getInterval).distinct().count()
+            )
+            .incrementSegmentCountAwaitingCompaction(segmentsToCompact.size());
       }
     }
 
@@ -543,7 +538,7 @@ public class CompactSegments implements CoordinatorCustomDuty
       final CompactionStatistics dataSourceCompactedStatistics = compactionStatisticsEntry.getValue();
       AutoCompactionSnapshot.Builder builder = currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
           dataSource,
-          k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+          AutoCompactionSnapshot::builder
       );
       builder.incrementBytesCompacted(dataSourceCompactedStatistics.getTotalBytes());
       builder.incrementSegmentCountCompacted(dataSourceCompactedStatistics.getNumSegments());
@@ -557,11 +552,11 @@ public class CompactSegments implements CoordinatorCustomDuty
       final CompactionStatistics dataSourceSkippedStatistics = compactionStatisticsEntry.getValue();
       AutoCompactionSnapshot.Builder builder = currentRunAutoCompactionSnapshotBuilders.computeIfAbsent(
           dataSource,
-          k -> new AutoCompactionSnapshot.Builder(k, AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING)
+          AutoCompactionSnapshot::builder
       );
-      builder.incrementBytesSkipped(dataSourceSkippedStatistics.getTotalBytes());
-      builder.incrementSegmentCountSkipped(dataSourceSkippedStatistics.getNumSegments());
-      builder.incrementIntervalCountSkipped(dataSourceSkippedStatistics.getNumIntervals());
+      builder.incrementBytesSkipped(dataSourceSkippedStatistics.getTotalBytes())
+             .incrementSegmentCountSkipped(dataSourceSkippedStatistics.getNumSegments())
+             .incrementIntervalCountSkipped(dataSourceSkippedStatistics.getNumIntervals());
     }
 
     final Map<String, AutoCompactionSnapshot> currentAutoCompactionSnapshotPerDataSource = new HashMap<>();

--- a/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/AutoCompactionSnapshotTest.java
@@ -28,25 +28,22 @@ public class AutoCompactionSnapshotTest
   public void testAutoCompactionSnapshotBuilder()
   {
     final String expectedDataSource = "data";
-    final AutoCompactionSnapshot.AutoCompactionScheduleStatus expectedStatus = AutoCompactionSnapshot.AutoCompactionScheduleStatus.RUNNING;
-    AutoCompactionSnapshot.Builder builder = new AutoCompactionSnapshot.Builder(expectedDataSource, expectedStatus);
+    final AutoCompactionSnapshot.Builder builder = AutoCompactionSnapshot.builder(expectedDataSource);
 
     // Increment every stats twice
     for (int i = 0; i < 2; i++) {
-      builder.incrementIntervalCountSkipped(13);
-      builder.incrementBytesSkipped(13);
-      builder.incrementSegmentCountSkipped(13);
-
-      builder.incrementIntervalCountCompacted(13);
-      builder.incrementBytesCompacted(13);
-      builder.incrementSegmentCountCompacted(13);
-
-      builder.incrementIntervalCountAwaitingCompaction(13);
-      builder.incrementBytesAwaitingCompaction(13);
-      builder.incrementSegmentCountAwaitingCompaction(13);
+      builder.incrementIntervalCountSkipped(13)
+             .incrementBytesSkipped(13)
+             .incrementSegmentCountSkipped(13)
+             .incrementIntervalCountCompacted(13)
+             .incrementBytesCompacted(13)
+             .incrementSegmentCountCompacted(13)
+             .incrementIntervalCountAwaitingCompaction(13)
+             .incrementBytesAwaitingCompaction(13)
+             .incrementSegmentCountAwaitingCompaction(13);
     }
 
-    AutoCompactionSnapshot actual = builder.build();
+    final AutoCompactionSnapshot actual = builder.build();
 
     Assert.assertNotNull(actual);
     Assert.assertEquals(26, actual.getSegmentCountSkipped());


### PR DESCRIPTION
### Changes
- Use `final` modifier for immutable fields
- Use builder methods for chaining
- Shorter lambda syntax