### PR TITLE
Fix a deadlock that can happen when mutliple stages execute parallelly in a worker

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <p>
  * The class performs the work of a "bouncer", limiting the number of threads that can concurrently access the guarded
  * critical sections by the bouncer. The bouncer is initialized with the max number of threads that can enter the
- * gaurded section(s) at a time.
+ * guarded section(s) at a time.
  * <p>
  * The entering thread must ask for a {@link #ticket()} from the bouncer. The bouncer provides a future that resolves
  * with the ticket when it becomes available:

--- a/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/Bouncer.java
@@ -46,7 +46,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * requesting the ticket is first in the queue, and the bouncer gets a ticket back from the previous holders.
  * <p>
  * This class is designed to be used by {@link FrameProcessorExecutor#runAllFully} to limit the number of outstanding processors.
- * This class's design must be assessed before using it for any other purpose.
+ * The callback's to the ticket's future handed out by the bouncer execute within the bouncer's lock, which can deteriorate the
+ * performance if the callback is computationally intensive. This class's design must be assessed before using it for
+ * any other purpose.
  */
 public class Bouncer
 {
@@ -158,7 +160,6 @@ public class Bouncer
           if (nextFuture.set(new Ticket())) {
             return;
           }
-
         }
       }
     }


### PR DESCRIPTION
### Description

This PR fixes up a deadlock that can happen when a worker executes multiple stages in parallel. The deadlock happens because, under the above circumstance, there are multiple instances of `RunAllFullyWidget` sharing a single `Bouncer`. 

The deadlock happens as follows:
The bouncer hands out tickets to `RunAllFullyWidget1` and `RunAllFullyWidget2`. Two threads call `cleanup()` on the two widgets at the same time:

Thread1 has the lock on `RunAllFullyWidget1` and Thread2 has the lock on `RunAllFullyWidget2` (since they have entered the `cleanup()` method). 

`cleanup()` gives back the tickets that the widgets have acquired to the bouncer. 

Thread1 giving back the ticket triggers the listener on the `RunAllFullyWidget2` to acquire the ticket. 
Thread2 giving back the ticket triggers the listener on the `RunAllFullyWidget1` to acquire the ticket.

However, the above operations can't succeed, since each thread holds up the lock the other thread needs.


Jstack of the deadlock. Thanks @Akshat-Jain for providing the JStack 
```
  51 "processing-8":
  51         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.lambda$run$3(RunAllFullyWidget.java:234)
  49         - waiting to lock <0x00000006dab7d578> (a java.lang.Object)
  48         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable$$Lambda$717/0x0000000800a4e840.run(Unknown Source)
  47         at org.apache.druid.java.util.common.concurrent.DirectExecutorService.execute(DirectExecutorService.java:81)
  46         at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
  45         at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
  44         at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:782)
  43         at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:49)
  42         at org.apache.druid.frame.processor.Bouncer$Ticket.giveBack(Bouncer.java:117)
  41         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.cleanup(RunAllFullyWidget.java:365)
  40         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.cleanupIfNoMoreProcessors(RunAllFullyWidget.java:344)
  39         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.run(RunAllFullyWidget.java:208)
  38         - locked <0x00000006dab87378> (a java.lang.Object)
  37         at org.apache.druid.msq.exec.WorkerImpl$1$2.run(WorkerImpl.java:836)
  36         at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.22/Executors.java:515)
  35         at java.util.concurrent.FutureTask.run$$$capture(java.base@11.0.22/FutureTask.java:264)
  34         at java.util.concurrent.FutureTask.run(java.base@11.0.22/FutureTask.java)
  33         at org.apache.druid.query.PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:259)
  32         at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.22/ThreadPoolExecutor.java:1128)
  31         at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.22/ThreadPoolExecutor.java:628)
  30         at java.lang.Thread.run(java.base@11.0.22/Thread.java:829)
  29 "processing-5":
  28         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.lambda$run$3(RunAllFullyWidget.java:234)
  27         - waiting to lock <0x00000006dab87378> (a java.lang.Object)
  26         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable$$Lambda$717/0x0000000800a4e840.run(Unknown Source)
  25         at org.apache.druid.java.util.common.concurrent.DirectExecutorService.execute(DirectExecutorService.java:81)
  24         at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
  23         at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
  22         at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:782)
  21         at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:49)
  20         at org.apache.druid.frame.processor.Bouncer$Ticket.giveBack(Bouncer.java:117)
  19         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.lambda$run$3(RunAllFullyWidget.java:236)
  18         - locked <0x00000006dab7d578> (a java.lang.Object)
  17         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable$$Lambda$717/0x0000000800a4e840.run(Unknown Source)
  16         at org.apache.druid.java.util.common.concurrent.DirectExecutorService.execute(DirectExecutorService.java:81)
  15         at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1286)
  14         at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:1055)
  13         at com.google.common.util.concurrent.AbstractFuture.set(AbstractFuture.java:782)
  12         at com.google.common.util.concurrent.SettableFuture.set(SettableFuture.java:49)
  11         at org.apache.druid.frame.processor.Bouncer$Ticket.giveBack(Bouncer.java:117)
  10         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.cleanup(RunAllFullyWidget.java:365)
   9         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.cleanupIfNoMoreProcessors(RunAllFullyWidget.java:344)
   8         at org.apache.druid.frame.processor.RunAllFullyWidget$RunAllFullyRunnable.run(RunAllFullyWidget.java:208)
   7         - locked <0x00000006dab7d578> (a java.lang.Object)
   6         at org.apache.druid.msq.exec.WorkerImpl$1$2.run(WorkerImpl.java:836)
   5         at java.util.concurrent.Executors$RunnableAdapter.call(java.base@11.0.22/Executors.java:515)
   4         at java.util.concurrent.FutureTask.run$$$capture(java.base@11.0.22/FutureTask.java:264)
   3         at java.util.concurrent.FutureTask.run(java.base@11.0.22/FutureTask.java)
   2         at org.apache.druid.query.PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:259)
   1         at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.22/ThreadPoolExecutor.java:1128)
5038         at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.22/ThreadPoolExecutor.java:628)
   1         at java.lang.Thread.run(java.base@11.0.22/Thread.java:829)
```

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
