### PR TITLE
Fix race in AzureClient factory fetch

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureClientFactory.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureClientFactory.java
@@ -32,8 +32,8 @@ import org.apache.druid.java.util.common.Pair;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Factory class for generating BlobServiceClient objects used for deep storage.
@@ -47,7 +47,7 @@ public class AzureClientFactory
   public AzureClientFactory(AzureAccountConfig config)
   {
     this.config = config;
-    this.cachedBlobServiceClients = new HashMap<>();
+    this.cachedBlobServiceClients = new ConcurrentHashMap<>();
   }
 
   // It's okay to store clients in a map here because all the configs for specifying azure retries are static, and there are only 2 of them.

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureClientFactoryTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureClientFactoryTest.java
@@ -205,7 +205,7 @@ public class AzureClientFactoryTest
 
     final CountDownLatch latch = new CountDownLatch(threads);
     ExecutorService executorService = Execs.multiThreaded(threads, "azure-client-fetcher-%d");
-    final AtomicReference<Exception> failureExecption = new AtomicReference<>();
+    final AtomicReference<Exception> failureException = new AtomicReference<>();
     for (int i = 0; i < threads; i++) {
       final int retry = i % 2;
       executorService.submit(() -> {
@@ -216,13 +216,13 @@ public class AzureClientFactoryTest
           Assert.assertEquals(expectedAccountUrl.toString(), blobServiceClient.getAccountUrl());
         }
         catch (Exception e) {
-          failureExecption.compareAndSet(null, e);
+          failureException.compareAndSet(null, e);
         }
       });
     }
     executorService.awaitTermination(1000, TimeUnit.MICROSECONDS);
-    if (failureExecption.get() != null) {
-      throw failureExecption.get();
+    if (failureException.get() != null) {
+      throw failureException.get();
     }
   }
 }

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureClientFactoryTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureClientFactoryTest.java
@@ -24,6 +24,7 @@ import com.azure.core.http.policy.BearerTokenAuthenticationPolicy;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.concurrent.Execs;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,7 +32,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -204,7 +204,7 @@ public class AzureClientFactoryTest
     );
 
     final CountDownLatch latch = new CountDownLatch(threads);
-    ExecutorService executorService = Executors.newFixedThreadPool(threads);
+    ExecutorService executorService = Execs.multiThreaded(threads, "azure-client-fetcher-%d");
     final AtomicReference<Exception> failureExecption = new AtomicReference<>();
     for (int i = 0; i < threads; i++) {
       final int retry = i % 2;


### PR DESCRIPTION
Found a regression in Azure connector due to #15287  which resulted in a race. When multiple threads are fetching the azureClient, the hashmap throws a `ConcurrentModificationException`

```
 UnknownError: java.util.ConcurrentModificationException
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1135)
	at org.apache.druid.storage.azure.AzureClientFactory.getBlobServiceClient(AzureClientFactory.java:58)
	at org.apache.druid.storage.azure.AzureStorage.getBlobServiceClient(AzureStorage.java:269)
	at org.apache.druid.storage.azure.AzureStorage.getOrCreateBlobContainerClient(AzureStorage.java:303)
	at org.apache.druid.storage.azure.AzureStorage.getBlockBlobOutputStream(AzureStorage.java:131)
	at org.apache.druid.storage.azure.output.AzureStorageConnector.write(AzureStorageConnector.java:140)
	at org.apache.druid.msq.shuffle.output.DurableStorageTaskOutputChannelFactory.openChannel(DurableStorageTaskOutputChannelFactory.java:100)
	at org.apache.druid.msq.indexing.CountingOutputChannelFactory.openChannel(CountingOutputChannelFactory.java:47)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder.lambda$mix$0(WorkerImpl.java:1452)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder.lambda$push$13(WorkerImpl.java:1804)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder$3.apply(WorkerImpl.java:1825)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder$3.apply(WorkerImpl.java:1821)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:223)
	at com.google.common.util.concurrent.AbstractTransformFuture$AsyncTransformFuture.doTransform(AbstractTransformFuture.java:210)
	at com.google.common.util.concurrent.AbstractTransformFuture.run(AbstractTransformFuture.java:123)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at com.google.common.util.concurrent.ImmediateFuture.addListener(ImmediateFuture.java:49)
	at com.google.common.util.concurrent.AbstractTransformFuture.create(AbstractTransformFuture.java:44)
	at com.google.common.util.concurrent.Futures.transformAsync(Futures.java:453)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder.pushAsync(WorkerImpl.java:1818)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder.push(WorkerImpl.java:1802)
	at org.apache.druid.msq.exec.WorkerImpl$ShufflePipelineBuilder.mix(WorkerImpl.java:1450)
	at org.apache.druid.msq.exec.WorkerImpl$RunWorkOrder.makeAndRunShuffleProcessors(WorkerImpl.java:1255)
	at org.apache.druid.msq.exec.WorkerImpl$RunWorkOrder.start(WorkerImpl.java:1078)
	at org.apache.druid.msq.exec.WorkerImpl$RunWorkOrder.access$100(WorkerImpl.java:1024)
	at org.apache.druid.msq.exec.WorkerImpl.runTask(WorkerImpl.java:412)
	at org.apache.druid.msq.exec.WorkerImpl.run(WorkerImpl.java:259)
	at org.apache.druid.msq.indexing.MSQWorkerTask.runTask(MSQWorkerTask.java:140)
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:179)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:478)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:450)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

Fixed the issue using a ConcurrentHashMap and added a test which fails without this patch.
 