### PR TITLE
Clean up allocation and supervisor logs for easier debugging

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -268,7 +268,7 @@ public class SegmentAllocationQueue
       catch (Throwable t) {
         currentBatch.failPendingRequests(t);
         processed = true;
-        log.error(t, "Error while processing batch[%s]", currentBatch.key);
+        log.error(t, "Error while processing batch[%s].", currentBatch.key);
       }
 
       // Requeue if not fully processed yet

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -268,7 +268,7 @@ public class SegmentAllocationQueue
       catch (Throwable t) {
         currentBatch.failPendingRequests(t);
         processed = true;
-        log.error(t, "Error while processing batch [%s]", currentBatch.key);
+        log.error(t, "Error while processing batch[%s]: [%s]", currentBatch.key, t.getMessage());
       }
 
       // Requeue if not fully processed yet
@@ -619,7 +619,7 @@ public class SegmentAllocationQueue
     void failPendingRequests(Throwable cause)
     {
       if (!requestToFuture.isEmpty()) {
-        log.warn("Failing [%d] requests in batch [%s], reason [%s].", size(), cause.getMessage(), key);
+        log.warn("Failing [%d] requests in batch[%s], reason[%s].", size(), key, cause.getMessage());
         requestToFuture.values().forEach(future -> future.completeExceptionally(cause));
         requestToFuture.keySet().forEach(
             request -> emitTaskMetric("task/action/failed/count", 1L, request)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -268,7 +268,7 @@ public class SegmentAllocationQueue
       catch (Throwable t) {
         currentBatch.failPendingRequests(t);
         processed = true;
-        log.error(t, "Error while processing batch[%s]: [%s]", currentBatch.key, t.getMessage());
+        log.error(t, "Error while processing batch[%s]", currentBatch.key);
       }
 
       // Requeue if not fully processed yet

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -657,7 +657,7 @@ public class TaskLockbox
         }
 
       } else {
-        log.debug("Task[%s] already present in TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
+        log.debug("Task[%s] already present in TaskLock[%s].", task.getId(), posseToUse.getTaskLock().getGroupId());
       }
       return posseToUse;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -657,7 +657,7 @@ public class TaskLockbox
         }
 
       } else {
-        log.info("Task[%s] already present in TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
+        log.debug("Task[%s] already present in TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
       }
       return posseToUse;
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -83,6 +83,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.RetryUtils;
+import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.emitter.EmittingLogger;
@@ -96,13 +97,12 @@ import org.apache.druid.segment.incremental.ParseExceptionReport;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1203,19 +1203,17 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                   }
 
                   try {
-                    Instant handleNoticeStartTime = Instant.now();
+                    final Stopwatch noticeHandleTime = Stopwatch.createStarted();
                     notice.handle();
-                    Instant handleNoticeEndTime = Instant.now();
-                    Duration timeElapsed = Duration.between(handleNoticeStartTime, handleNoticeEndTime);
                     String noticeType = notice.getType();
+                    emitNoticeProcessTime(noticeType, noticeHandleTime.millisElapsed());
                     if (log.isDebugEnabled()) {
                       log.debug(
-                          "Handled notice [%s] from notices queue in [%d] ms, "
-                              + "current notices queue size [%d] for datasource [%s]",
-                          noticeType, timeElapsed.toMillis(), getNoticesQueueSize(), dataSource
+                          "Handled notice[%s] from notices queue in [%d] ms, "
+                              + "current notices queue size [%d] for datasource[%s].",
+                          noticeType, noticeHandleTime.millisElapsed(), getNoticesQueueSize(), dataSource
                       );
                     }
-                    emitNoticeProcessTime(noticeType, timeElapsed.toMillis());
                   }
                   catch (Throwable e) {
                     stateManager.recordThrowableEvent(e);
@@ -3161,9 +3159,9 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     final List<ListenableFuture<Map<PartitionIdType, SequenceOffsetType>>> futures = new ArrayList<>();
     final List<Integer> futureGroupIds = new ArrayList<>();
 
-    boolean stopTasksEarly;
+    final boolean stopTasksEarly;
     if (earlyStopTime != null && (earlyStopTime.isBeforeNow() || earlyStopTime.isEqualNow())) {
-      log.info("Early stop requested - signalling tasks to complete");
+      log.info("Early stop requested, signalling tasks to complete.");
 
       earlyStopTime = null;
       stopTasksEarly = true;
@@ -3171,7 +3169,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       stopTasksEarly = false;
     }
 
-    AtomicInteger stoppedTasks = new AtomicInteger();
+    final AtomicInteger stoppedTasks = new AtomicInteger();
     // Sort task groups by start time to prioritize early termination of earlier groups, then iterate for processing
     activelyReadingTaskGroups
         .entrySet().stream().sorted(
@@ -3183,30 +3181,36 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           Integer groupId = entry.getKey();
           TaskGroup group = entry.getValue();
 
+          final DateTime earliestTaskStart = computeEarliestTaskStartTime(group);
+          final Duration runDuration = Duration.millis(DateTimes.nowUtc().getMillis() - earliestTaskStart.getMillis());
           if (stopTasksEarly) {
             log.info(
-                "Stopping task group [%d] early. It has run for [%s]",
-                groupId,
-                ioConfig.getTaskDuration()
+                "Stopping taskGroup[%d] early after running for duration[%s].",
+                groupId, runDuration
             );
             futureGroupIds.add(groupId);
             futures.add(checkpointTaskGroup(group, true));
+          } else if (group.getHandoffEarly()) {
+            // If shutdownEarly has been set, stop tasks irrespective of stopTaskCount
+            log.info(
+                "Stopping taskGroup[%d] after running for duration[%s] as early handoff has been requested.",
+                groupId, runDuration
+            );
+            futureGroupIds.add(groupId);
+            futures.add(checkpointTaskGroup(group, true));
+            stoppedTasks.getAndIncrement();
           } else {
-            DateTime earliestTaskStart = computeEarliestTaskStartTime(group);
-
-            if (earliestTaskStart.plus(ioConfig.getTaskDuration()).isBeforeNow() || group.getHandoffEarly()) {
+            if (earliestTaskStart.plus(ioConfig.getTaskDuration()).isBeforeNow()) {
               // if this task has run longer than the configured duration
               // as long as the pending task groups are less than the configured stop task count.
-              // If shutdownEarly has been set, ignore stopTaskCount since this is a manual operator action.
               if (pendingCompletionTaskGroups.values()
                                              .stream()
                                              .mapToInt(CopyOnWriteArrayList::size)
                                              .sum() + stoppedTasks.get()
-                  < ioConfig.getMaxAllowedStops() || group.getHandoffEarly()) {
+                  < ioConfig.getMaxAllowedStops()) {
                 log.info(
-                    "Task group [%d] has run for [%s]. Stopping.",
-                    groupId,
-                    ioConfig.getTaskDuration()
+                    "Stopping taskGroup[%d] as it has already run for duration[%s], configured task duration[%s].",
+                    groupId, runDuration, ioConfig.getTaskDuration()
                 );
                 futureGroupIds.add(groupId);
                 futures.add(checkpointTaskGroup(group, true));
@@ -3384,7 +3388,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
               if (endOffsets.equals(taskGroup.checkpointSequences.lastEntry().getValue())) {
                 log.warn(
-                    "Checkpoint [%s] is same as the start sequences [%s] of latest sequence for the task group [%d]",
+                    "Checkpoint[%s] is same as the start sequences[%s] of latest sequence for the taskGroup[%d]",
                     endOffsets,
                     taskGroup.checkpointSequences.lastEntry().getValue(),
                     taskGroup.groupId
@@ -3579,7 +3583,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       //   2) Remove any tasks that have failed from the list
       //   3) If any task completed successfully, stop all the tasks in this group and move to the next group
 
-      log.debug("Task group [%d] pre-pruning: %s", groupId, taskGroup.taskIds());
+      log.debug("taskGroup[%d] pre-pruning: %s", groupId, taskGroup.taskIds());
 
       Iterator<Entry<String, TaskData>> iTasks = taskGroup.tasks.entrySet().iterator();
       while (iTasks.hasNext()) {
@@ -3589,7 +3593,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
         // stop and remove bad tasks from the task group
         if (!isTaskCurrent(groupId, taskId, activeTaskMap)) {
-          log.info("Stopping task [%s] which does not match the expected sequence range and ingestion spec", taskId);
+          log.info("Stopping task[%s] as it does not match the expected sequence range and ingestion spec.", taskId);
           futures.add(stopTask(taskId, false));
           iTasks.remove();
           continue;
@@ -3613,7 +3617,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
           break;
         }
       }
-      log.debug("Task group [%d] post-pruning: %s", groupId, taskGroup.taskIds());
+      log.debug("After pruning, taskGroup[%d] has tasks[%s].", groupId, taskGroup.taskIds());
     }
 
     // Ignore return value; just await.
@@ -3627,10 +3631,9 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
 
     Map<PartitionIdType, SequenceOffsetType> latestSequencesFromStream = getLatestSequencesFromStream();
-    long nowTime = Instant.now().toEpochMilli();
-    boolean idle;
-    long idleTime;
-
+    final long nowTime = DateTimes.nowUtc().getMillis();
+    final boolean idle;
+    final long idleTime;
     if (lastActiveTimeMillis > 0
         && previousSequencesFromStream.equals(latestSequencesFromStream)
         && computeTotalLag() == 0) {
@@ -3684,7 +3687,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     // check that there is a current task group for each group of partitions in [partitionGroups]
     for (Integer groupId : partitionGroups.keySet()) {
       if (!activelyReadingTaskGroups.containsKey(groupId)) {
-        log.info("Creating new task group [%d] for partitions %s", groupId, partitionGroups.get(groupId));
+        log.info("Creating new taskGroup[%d] for partitions[%s].", groupId, partitionGroups.get(groupId));
         Optional<DateTime> minimumMessageTime;
         if (ioConfig.getLateMessageRejectionStartDateTime().isPresent()) {
           minimumMessageTime = Optional.of(ioConfig.getLateMessageRejectionStartDateTime().get());
@@ -3771,13 +3774,13 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       if (taskGroup.startingSequences == null ||
           taskGroup.startingSequences.size() == 0 ||
           taskGroup.startingSequences.values().stream().allMatch(x -> x == null || isEndOfShard(x))) {
-        log.debug("Nothing to read in any partition for taskGroup [%d], skipping task creation", groupId);
+        log.debug("Nothing to read in any partition for taskGroup[%d], skipping task creation", groupId);
         continue;
       }
 
       if (ioConfig.getReplicas() > taskGroup.tasks.size()) {
         log.info(
-            "Number of tasks [%d] does not match configured numReplicas [%d] in task group [%d], creating more tasks",
+            "Number of tasks[%d] does not match configured numReplicas[%d] in taskGroup[%d], creating more tasks.",
             taskGroup.tasks.size(), ioConfig.getReplicas(), groupId
         );
         createTasksForGroup(groupId, ioConfig.getReplicas() - taskGroup.tasks.size());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -3374,7 +3374,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
               if (endOffsets.equals(taskGroup.checkpointSequences.lastEntry().getValue())) {
                 log.warn(
-                    "Checkpoint[%s] is same as the start sequences[%s] of latest sequence for the taskGroup[%d]",
+                    "Checkpoint[%s] is same as the start sequences[%s] of latest sequence for the taskGroup[%d].",
                     endOffsets,
                     taskGroup.checkpointSequences.lastEntry().getValue(),
                     taskGroup.groupId
@@ -3569,7 +3569,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       //   2) Remove any tasks that have failed from the list
       //   3) If any task completed successfully, stop all the tasks in this group and move to the next group
 
-      log.debug("taskGroup[%d] pre-pruning: %s", groupId, taskGroup.taskIds());
+      log.debug("taskGroup[%d] pre-pruning: %s.", groupId, taskGroup.taskIds());
 
       Iterator<Entry<String, TaskData>> iTasks = taskGroup.tasks.entrySet().iterator();
       while (iTasks.hasNext()) {
@@ -3760,7 +3760,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
       if (taskGroup.startingSequences == null ||
           taskGroup.startingSequences.size() == 0 ||
           taskGroup.startingSequences.values().stream().allMatch(x -> x == null || isEndOfShard(x))) {
-        log.debug("Nothing to read in any partition for taskGroup[%d], skipping task creation", groupId);
+        log.debug("Nothing to read in any partition for taskGroup[%d], skipping task creation.", groupId);
         continue;
       }
 

--- a/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidLeaderSelector.java
+++ b/server/src/main/java/org/apache/druid/curator/discovery/CuratorDruidLeaderSelector.java
@@ -36,7 +36,7 @@ import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -48,7 +48,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
 
   private final LifecycleLock lifecycleLock = new LifecycleLock();
 
-  private final DruidNode self;
+  private final String selfId;
   private final CuratorFramework curator;
   private final String latchPath;
 
@@ -56,6 +56,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
 
   private DruidLeaderSelector.Listener listener = null;
   private final AtomicReference<LeaderLatch> leaderLatch = new AtomicReference<>();
+  private final AtomicInteger latchIdCounter = new AtomicInteger(0);
 
   private volatile boolean leader = false;
   private volatile int term = 0;
@@ -63,7 +64,7 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
   public CuratorDruidLeaderSelector(CuratorFramework curator, @Self DruidNode self, String latchPath)
   {
     this.curator = curator;
-    this.self = self;
+    this.selfId = self.getServiceScheme() + "://" + self.getHostAndPortToUse();
     this.latchPath = latchPath;
 
     // Creating a LeaderLatch here allows us to query for the current leader. We will not be considered for leadership
@@ -74,12 +75,13 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
 
   private LeaderLatch createNewLeaderLatch()
   {
-    return new LeaderLatch(curator, latchPath, self.getServiceScheme() + "://" + self.getHostAndPortToUse());
+    return new LeaderLatch(curator, latchPath, selfId);
   }
 
   private LeaderLatch createNewLeaderLatchWithListener()
   {
     final LeaderLatch newLeaderLatch = createNewLeaderLatch();
+    final int latchId = latchIdCounter.incrementAndGet();
 
     newLeaderLatch.addListener(
         new LeaderLatchListener()
@@ -88,9 +90,14 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
           public void isLeader()
           {
             try {
-              if (leader) {
-                log.warn("I'm being asked to become leader. But I am already the leader. Ignored event.");
+              if (newLeaderLatch.getState() == LeaderLatch.State.CLOSED) {
+                log.warn("[%s][%d] Ignoring request to become leader as latch is already closed.", selfId, latchId);
                 return;
+              } else if (leader) {
+                log.warn("[%s][%d] I'm being asked to become leader. But I am already the leader. Ignored event.", selfId, latchId);
+                return;
+              } else {
+                log.info("[%s][%d] I am now the leader. Latch state[%s]", selfId, latchId, newLeaderLatch.getState());
               }
 
               leader = true;
@@ -98,26 +105,8 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
               listener.becomeLeader();
             }
             catch (Exception ex) {
-              log.makeAlert(ex, "listener becomeLeader() failed. Unable to become leader").emit();
-
-              // give others a chance to become leader.
-              CloseableUtils.closeAndSuppressExceptions(
-                  createNewLeaderLatchWithListener(),
-                  e -> log.warn("Could not close old leader latch; continuing with new one anyway.")
-              );
-
-              leader = false;
-              try {
-                //Small delay before starting the latch so that others waiting are chosen to become leader.
-                Thread.sleep(ThreadLocalRandom.current().nextInt(1000, 5000));
-                leaderLatch.get().start();
-              }
-              catch (Exception e) {
-                // If an exception gets thrown out here, then the node will zombie out 'cause it won't be looking for
-                // the latch anymore.  I don't believe it's actually possible for an Exception to throw out here, but
-                // Curator likes to have "throws Exception" on methods so it might happen...
-                log.makeAlert(e, "I am a zombie").emit();
-              }
+              log.makeAlert(ex, "[%s] listener becomeLeader() failed. Unable to become leader", selfId).emit();
+              giveUpLeadershipAndRecreateLatch(-1);
             }
           }
 
@@ -126,15 +115,19 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
           {
             try {
               if (!leader) {
-                log.warn("I'm being asked to stop being leader. But I am not the leader. Ignored event.");
+                log.warn("[%s][%d] I'm being asked to stop being leader. But I am not the leader. Ignored event.", selfId, latchId);
                 return;
+              } else {
+                log.info("[%s][%d] Giving up leadership", selfId, latchId);
               }
 
               leader = false;
               listener.stopBeingLeader();
+
+              giveUpLeadershipAndRecreateLatch(latchId);
             }
             catch (Exception ex) {
-              log.makeAlert(ex, "listener.stopBeingLeader() failed. Unable to stopBeingLeader").emit();
+              log.makeAlert(ex, "[%s] listener.stopBeingLeader() failed. Unable to stopBeingLeader", selfId).emit();
             }
           }
         },
@@ -142,6 +135,33 @@ public class CuratorDruidLeaderSelector implements DruidLeaderSelector
     );
 
     return leaderLatch.getAndSet(newLeaderLatch);
+  }
+
+  /**
+   * Recreates the leader latch and allows other nodes to become leader.
+   */
+  private void giveUpLeadershipAndRecreateLatch(int latchId)
+  {
+    // give others a chance to become leader.
+    log.info("[%s][%d] Recreating leader latch to allow other nodes to become leader.", selfId, latchId);
+    final LeaderLatch oldLatch = createNewLeaderLatchWithListener();
+    CloseableUtils.closeAndSuppressExceptions(
+        oldLatch,
+        e -> log.warn("[%s] Could not close old leader latch; continuing with new one anyway.", selfId)
+    );
+
+    leader = false;
+    try {
+      // Small delay before starting the latch so that others waiting are chosen to become leader.
+      Thread.sleep(20000);
+      log.info("[%s][%d] Now starting the latch", selfId, latchId);
+      leaderLatch.get().start();
+    }
+    catch (Exception e) {
+      // An exception can be caught here if interrupted while sleeping or if start() fails.
+      // If that happens, the node will zombie out as it won't be looking for the latch anymore.
+      log.makeAlert(e, "[%s] I am a zombie", selfId).emit();
+    }
   }
 
   @Nullable


### PR DESCRIPTION
### Changes
- Use string `taskGroup` consistently to easily search for a task group
- Clean up other logs
- No change in any logic