### PR TITLE
Add `README` to Azure extensions with link to docs

### DIFF
--- a/extensions-core/azure-extensions/README.md
+++ b/extensions-core/azure-extensions/README.md
@@ -1,0 +1,21 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+This extension provides an integration between Druid and Azure. For more details read
+the Azure extension docs [here](../../docs/development/extensions-core/azure.md).


### PR DESCRIPTION
### Description

This PR adds a small README to the `druid-azure-extensions` module that links to the docs (similar to the S3 extension).

<hr>

This PR has:

- [x] been self-reviewed.