### PR TITLE
Add interface method for returning canonical lookup name

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/JoinAndLookupBenchmark.java
@@ -305,6 +305,12 @@ public class JoinAndLookupBenchmark
                       return Optional.empty();
                     }
                   }
+
+                  @Override
+                  public String getCanonicalLookupName(String lookupName)
+                  {
+                    return lookupName;
+                  }
                 }
             )
         )

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactoryContainerProvider.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactoryContainerProvider.java
@@ -42,7 +42,7 @@ public interface LookupExtractorFactoryContainerProvider
   Optional<LookupExtractorFactoryContainer> get(String lookupName);
 
   /**
-   * Returns the canonical lookup name from a lookup name.
+   * Returns the canonical lookup name from a given lookup name, if special syntax exists.
    */
   String getCanonicalLookupName(String lookupName);
 }

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactoryContainerProvider.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupExtractorFactoryContainerProvider.java
@@ -40,4 +40,9 @@ public interface LookupExtractorFactoryContainerProvider
    * Returns a lookup container for the provided lookupName, if it exists.
    */
   Optional<LookupExtractorFactoryContainer> get(String lookupName);
+
+  /**
+   * Returns the canonical lookup name from a lookup name.
+   */
+  String getCanonicalLookupName(String lookupName);
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -53,6 +53,12 @@ public class LookupExprMacroTest extends MacroTestBase
           {
             return Optional.empty();
           }
+
+          @Override
+          public String getCanonicalLookupName(String lookupName)
+          {
+            return lookupName;
+          }
         })
     );
   }

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupReferencesManager.java
@@ -332,6 +332,12 @@ public class LookupReferencesManager implements LookupExtractorFactoryContainerP
     return stateRef.get().lookupMap.keySet();
   }
 
+  @Override
+  public String getCanonicalLookupName(String lookupName)
+  {
+    return lookupName;
+  }
+
   // Note that this should ensure that "toLoad" and "toDrop" are disjoint.
   LookupsState<LookupExtractorFactoryContainer> getAllLookupsState()
   {

--- a/server/src/main/java/org/apache/druid/query/lookup/LookupSerdeModule.java
+++ b/server/src/main/java/org/apache/druid/query/lookup/LookupSerdeModule.java
@@ -79,5 +79,11 @@ public class LookupSerdeModule implements DruidModule
     {
       return Optional.empty();
     }
+
+    @Override
+    public String getCanonicalLookupName(String lookupName)
+    {
+      return lookupName;
+    }
   }
 }

--- a/server/src/test/java/org/apache/druid/query/expression/LookupEnabledTestExprMacroTable.java
+++ b/server/src/test/java/org/apache/druid/query/expression/LookupEnabledTestExprMacroTable.java
@@ -95,6 +95,12 @@ public class LookupEnabledTestExprMacroTable extends ExprMacroTable
           return Optional.empty();
         }
       }
+
+      @Override
+      public String getCanonicalLookupName(String lookupName)
+      {
+        return lookupName;
+      }
     };
   }
 

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupReferencesManagerTest.java
@@ -580,6 +580,13 @@ public class LookupReferencesManagerTest
   }
 
   @Test
+  public void testGetCanonicalLookupName()
+  {
+    String lookupName = "lookupName1";
+    Assert.assertEquals(lookupName, lookupReferencesManager.getCanonicalLookupName(lookupName));
+  }
+
+  @Test
   public void testGetAllLookupsState() throws Exception
   {
     LookupExtractorFactoryContainer container1 = new LookupExtractorFactoryContainer(

--- a/server/src/test/java/org/apache/druid/query/lookup/LookupSerdeModuleTest.java
+++ b/server/src/test/java/org/apache/druid/query/lookup/LookupSerdeModuleTest.java
@@ -117,4 +117,12 @@ public class LookupSerdeModuleTest
         objectMapper.readValue(objectMapper.writeValueAsBytes(transform), ExpressionTransform.class)
     );
   }
+
+  @Test
+  public void testGetCanonicalLookupName()
+  {
+    LookupExtractorFactoryContainerProvider instance = injector.getInstance(LookupExtractorFactoryContainerProvider.class);
+    String lookupName = "lookupName1";
+    Assert.assertEquals(lookupName, instance.getCanonicalLookupName(lookupName));
+  }
 }

--- a/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/LookupSegmentWranglerTest.java
@@ -67,6 +67,12 @@ public class LookupSegmentWranglerTest
             return Optional.empty();
           }
         }
+
+        @Override
+        public String getCanonicalLookupName(String lookupName)
+        {
+          return lookupName;
+        }
       }
   );
 

--- a/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/segment/join/LookupJoinableFactoryTest.java
@@ -79,6 +79,12 @@ public class LookupJoinableFactoryTest
                 return Optional.empty();
               }
             }
+
+            @Override
+            public String getCanonicalLookupName(String lookupName)
+            {
+              return lookupName;
+            }
           }
       );
     }

--- a/server/src/test/java/org/apache/druid/server/SpecificSegmentsQuerySegmentWalker.java
+++ b/server/src/test/java/org/apache/druid/server/SpecificSegmentsQuerySegmentWalker.java
@@ -89,6 +89,12 @@ public class SpecificSegmentsQuerySegmentWalker implements QuerySegmentWalker, C
         {
           return Optional.empty();
         }
+
+        @Override
+        public String getCanonicalLookupName(String lookupName)
+        {
+          return lookupName;
+        }
       };
 
   public static SpecificSegmentsQuerySegmentWalker createWalker(

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -481,6 +481,12 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       {
         return Optional.empty();
       }
+
+      @Override
+      public String getCanonicalLookupName(String lookupName)
+      {
+        return lookupName;
+      }
     }
 
     final TimeseriesQuery query =

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/QueryLookupOperatorConversion.java
@@ -84,7 +84,7 @@ public class QueryLookupOperatorConversion implements SqlOperatorConversion
           final String lookupName = (String) lookupNameExpr.getLiteralValue();
 
           // Add the lookup name to the set of lookups to selectively load.
-          plannerContext.addLookupToLoad(lookupName);
+          plannerContext.addLookupToLoad(lookupExtractorFactoryContainerProvider.getCanonicalLookupName(lookupName));
 
           if (arg.isSimpleExtraction() && lookupNameExpr.isLiteral()) {
             return arg.getSimpleExtraction().cascade(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/TestLookupProvider.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/TestLookupProvider.java
@@ -55,4 +55,10 @@ public class TestLookupProvider implements LookupExtractorFactoryContainerProvid
       return Optional.empty();
     }
   }
+
+  @Override
+  public String getCanonicalLookupName(String lookupName)
+  {
+    return lookupName;
+  }
 }


### PR DESCRIPTION
### Description

This PR adds support for returning canonical lookup name in `LookupExtractorFactoryContainerProvider` interface. This would allow the implementations to return a different canonical name for the lookup if needed.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
