### PR TITLE
Only create container in `AzureStorage` for write operations

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/data/input/azure/AzureInputSource.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/data/input/azure/AzureInputSource.java
@@ -20,7 +20,6 @@
 package org.apache.druid.data.input.azure;
 
 import com.azure.storage.blob.models.BlobStorageException;
-import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -161,12 +160,7 @@ public class AzureInputSource extends CloudObjectInputSource
       public long getObjectSize(CloudObjectLocation location)
       {
         try {
-          final BlockBlobClient blobWithAttributes = storage.getBlockBlobReferenceWithAttributes(
-              location.getBucket(),
-              location.getPath()
-          );
-
-          return blobWithAttributes.getProperties().getBlobSize();
+          return storage.getBlockBlobLength(location.getBucket(), location.getPath());
         }
         catch (BlobStorageException e) {
           throw new RuntimeException(e);

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/data/input/azure/AzureStorageAccountInputSource.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/data/input/azure/AzureStorageAccountInputSource.java
@@ -20,7 +20,6 @@
 package org.apache.druid.data.input.azure;
 
 import com.azure.storage.blob.models.BlobStorageException;
-import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -180,12 +179,7 @@ public class AzureStorageAccountInputSource extends CloudObjectInputSource
         try {
           AzureStorage azureStorage = new AzureStorage(azureIngestClientFactory, location.getBucket());
           Pair<String, String> locationInfo = getContainerAndPathFromObjectLocation(location);
-          final BlockBlobClient blobWithAttributes = azureStorage.getBlockBlobReferenceWithAttributes(
-              locationInfo.lhs,
-              locationInfo.rhs
-          );
-
-          return blobWithAttributes.getProperties().getBlobSize();
+          return azureStorage.getBlockBlobLength(locationInfo.lhs, locationInfo.rhs);
         }
         catch (BlobStorageException e) {
           throw new RuntimeException(e);
@@ -246,7 +240,9 @@ public class AzureStorageAccountInputSource extends CloudObjectInputSource
   public static Pair<String, String> getContainerAndPathFromObjectLocation(CloudObjectLocation location)
   {
     String[] pathParts = location.getPath().split("/", 2);
-    // If there is no path specified, use a empty path as azure will throw a exception that is more clear than a index error.
+
+    // If there is no path specified, use an empty path as Azure will throw an exception
+    // that is more clear than an index error.
     return Pair.of(pathParts[0], pathParts.length == 2 ? pathParts[1] : "");
   }
 }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureDataSegmentKiller.java
@@ -43,7 +43,6 @@ import java.util.Map;
 public class AzureDataSegmentKiller implements DataSegmentKiller
 {
   private static final Logger log = new Logger(AzureDataSegmentKiller.class);
-  private static final Integer MAX_MULTI_OBJECT_DELETE_SIZE = 256; // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch?tabs=microsoft-entra-id
 
   private final AzureDataSegmentConfig segmentConfig;
   private final AzureInputDataConfig inputDataConfig;

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -56,11 +56,10 @@ import java.util.stream.Collectors;
  */
 public class AzureStorage
 {
-
   // Default value from Azure library
   private static final int DELTA_BACKOFF_MS = 30_000;
 
-  // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch?tabs=microsoft-entra-id
+  // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch#request-body
   private static final Integer MAX_MULTI_OBJECT_DELETE_SIZE = 256;
 
 

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -62,8 +62,7 @@ public class AzureStorage
   // https://learn.microsoft.com/en-us/rest/api/storageservices/blob-batch#request-body
   private static final Integer MAX_MULTI_OBJECT_DELETE_SIZE = 256;
 
-
-  private static final Logger log = new Logger(AzureStorage.class);
+  private static final Logger LOG = new Logger(AzureStorage.class);
 
   private final AzureClientFactory azureClientFactory;
   private final String defaultStorageAccount;
@@ -101,7 +100,7 @@ public class AzureStorage
     });
 
     if (deletedFiles.isEmpty()) {
-      log.warn("No files were deleted on the following Azure path: [%s]", virtualDirPath);
+      LOG.warn("No files were deleted on the following Azure path: [%s]", prefix);
     }
 
     return deletedFiles;
@@ -205,34 +204,37 @@ public class AzureStorage
     );
     for (List<String> chunkOfKeys : keysChunks) {
       try {
-        log.info(
-                "Removing from container [%s] the following files: [%s]",
-                containerName,
-                chunkOfKeys
+        LOG.info(
+            "Removing from container [%s] the following files: [%s]",
+            containerName,
+            chunkOfKeys
         );
         // We have to call forEach on the response because this is the only way azure batch will throw an exception on a operation failure.
         blobBatchClient.deleteBlobs(
                 chunkOfKeys,
                 DeleteSnapshotsOptionType.INCLUDE
         ).forEach(response ->
-                log.debug("Deleting blob with URL %s completed with status code %d%n",
-                        response.getRequest().getUrl(), response.getStatusCode())
+                      LOG.debug("Deleting blob with URL %s completed with status code %d%n",
+                                response.getRequest().getUrl(), response.getStatusCode()
+                      )
         );
       }
       catch (BlobStorageException | BlobBatchStorageException e) {
         hadException = true;
-        log.noStackTrace().warn(e,
-                "Unable to delete from container [%s], the following keys [%s]",
-                containerName,
-                chunkOfKeys
+        LOG.noStackTrace().warn(
+            e,
+            "Unable to delete from container [%s], the following keys [%s]",
+            containerName,
+            chunkOfKeys
         );
       }
       catch (Exception e) {
         hadException = true;
-        log.noStackTrace().warn(e,
-                "Unexpected exception occurred when deleting from container [%s], the following keys [%s]",
-                containerName,
-                chunkOfKeys
+        LOG.noStackTrace().warn(
+            e,
+            "Unexpected exception occurred when deleting from container [%s], the following keys [%s]",
+            containerName,
+            chunkOfKeys
         );
       }
     }

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -63,11 +63,11 @@ public class AzureStorage
   private static final Logger LOG = new Logger(AzureStorage.class);
 
   private final AzureClientFactory azureClientFactory;
-  @Nullable private final String defaultStorageAccount;
+  private final String defaultStorageAccount;
 
   public AzureStorage(
       final AzureClientFactory azureClientFactory,
-      @Nullable final String defaultStorageAccount
+      final String defaultStorageAccount
   )
   {
     this.azureClientFactory = azureClientFactory;

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -148,10 +148,15 @@ public class AzureStorage
     return getOrCreateBlobContainerClient(containerName).getBlobClient(Utility.urlEncode(blobPath)).getBlockBlobClient();
   }
 
-  public long getBlockBlobLength(final String containerName, final String blobPath)
-      throws BlobStorageException
+  public long getBlockBlobLength(final String containerName, final String blobPath) throws BlobStorageException
   {
-    return getBlockBlobReferenceWithAttributes(containerName, blobPath).getProperties().getBlobSize();
+    return azureClientFactory
+        .getBlobServiceClient(null, defaultStorageAccount)
+        .getBlobContainerClient(containerName)
+        .getBlobClient(Utility.urlEncode(blobPath))
+        .getBlockBlobClient()
+        .getProperties()
+        .getBlobSize();
   }
 
   public InputStream getBlockBlobInputStream(final String containerName, final String blobPath)

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -65,6 +65,7 @@ public class AzureStorage
   private static final Logger LOG = new Logger(AzureStorage.class);
 
   private final AzureClientFactory azureClientFactory;
+  @Nullable
   private final String defaultStorageAccount;
 
   public AzureStorage(

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureUtils.java
@@ -37,8 +37,6 @@ import java.util.concurrent.TimeoutException;
  */
 public class AzureUtils
 {
-
-  public static final String DEFAULT_AZURE_ENDPOINT_SUFFIX = "core.windows.net";
   @VisibleForTesting
   static final String AZURE_STORAGE_HOST_ADDRESS = "blob.core.windows.net";
 

--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/output/AzureStorageConnector.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/output/AzureStorageConnector.java
@@ -196,7 +196,7 @@ public class AzureStorageConnector extends ChunkingStorageConnector<AzureInputRa
     final String prefixBasePath = objectPath(dirName);
     List<String> paths;
     try {
-      paths = azureStorage.listDir(config.getContainer(), prefixBasePath, config.getMaxRetry());
+      paths = azureStorage.listBlobs(config.getContainer(), prefixBasePath, null, config.getMaxRetry());
     }
     catch (BlobStorageException e) {
       throw new IOException(e);

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageTest.java
@@ -71,7 +71,7 @@ public class AzureStorageTest
   }
 
   @Test
-  public void testListDir_retriable() throws BlobStorageException
+  public void testListBlobs_retriable() throws BlobStorageException
   {
     BlobItem blobItem = new BlobItem().setName(BLOB_NAME).setProperties(new BlobItemProperties().setContentLength(10L));
     SettableSupplier<PagedResponse<BlobItem>> supplier = new SettableSupplier<>();
@@ -86,11 +86,14 @@ public class AzureStorageTest
     final Integer maxAttempts = 3;
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(maxAttempts, STORAGE_ACCOUNT);
 
-    assertEquals(ImmutableList.of(BLOB_NAME), azureStorage.listDir(CONTAINER, "", maxAttempts));
+    assertEquals(
+        ImmutableList.of(BLOB_NAME),
+        azureStorage.listBlobs(CONTAINER, "", null, maxAttempts)
+    );
   }
 
   @Test
-  public void testListDir_nullMaxAttempts() throws BlobStorageException
+  public void testListBlobs_nullMaxAttempts() throws BlobStorageException
   {
     BlobItem blobItem = new BlobItem().setName(BLOB_NAME).setProperties(new BlobItemProperties().setContentLength(10L));
     SettableSupplier<PagedResponse<BlobItem>> supplier = new SettableSupplier<>();
@@ -103,7 +106,10 @@ public class AzureStorageTest
     Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(null, STORAGE_ACCOUNT);
 
-    assertEquals(ImmutableList.of(BLOB_NAME), azureStorage.listDir(CONTAINER, "", null));
+    assertEquals(
+        ImmutableList.of(BLOB_NAME),
+        azureStorage.listBlobs(CONTAINER, "", null, null)
+    );
   }
 
   @Test

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/AzureStorageTest.java
@@ -81,7 +81,7 @@ public class AzureStorageTest
         ArgumentMatchers.any(),
         ArgumentMatchers.any()
     );
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
 
     final Integer maxAttempts = 3;
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(maxAttempts, STORAGE_ACCOUNT);
@@ -100,7 +100,7 @@ public class AzureStorageTest
         ArgumentMatchers.any(),
         ArgumentMatchers.any()
     );
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(null, STORAGE_ACCOUNT);
 
     assertEquals(ImmutableList.of(BLOB_NAME), azureStorage.listDir(CONTAINER, "", null));
@@ -118,7 +118,7 @@ public class AzureStorageTest
         ArgumentMatchers.any(),
         ArgumentMatchers.any()
     );
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(3, storageAccountCustom);
 
     azureStorage.listBlobsWithPrefixInContainerSegmented(
@@ -143,7 +143,7 @@ public class AzureStorageTest
     ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
 
     Mockito.doReturn(containerUrl).when(blobContainerClient).getBlobContainerUrl();
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(null, STORAGE_ACCOUNT);
     Mockito.doReturn(blobBatchClient).when(azureClientFactory).getBlobBatchClient(blobContainerClient);
     Mockito.doReturn(pagedIterable).when(blobBatchClient).deleteBlobs(
@@ -167,7 +167,7 @@ public class AzureStorageTest
     ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
 
     Mockito.doReturn(containerUrl).when(blobContainerClient).getBlobContainerUrl();
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(null, STORAGE_ACCOUNT);
     Mockito.doReturn(blobBatchClient).when(azureClientFactory).getBlobBatchClient(blobContainerClient);
     Mockito.doThrow(new RuntimeException()).when(blobBatchClient).deleteBlobs(
@@ -192,7 +192,7 @@ public class AzureStorageTest
     ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
 
     Mockito.doReturn(containerUrl).when(blobContainerClient).getBlobContainerUrl();
-    Mockito.doReturn(blobContainerClient).when(blobServiceClient).createBlobContainerIfNotExists(CONTAINER);
+    Mockito.doReturn(blobContainerClient).when(blobServiceClient).getBlobContainerClient(CONTAINER);
     Mockito.doReturn(blobServiceClient).when(azureClientFactory).getBlobServiceClient(null, STORAGE_ACCOUNT);
     Mockito.doReturn(blobBatchClient).when(azureClientFactory).getBlobBatchClient(blobContainerClient);
     Mockito.doReturn(pagedIterable).when(blobBatchClient).deleteBlobs(

--- a/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/output/AzureStorageConnectorTest.java
+++ b/extensions-core/azure-extensions/src/test/java/org/apache/druid/storage/azure/output/AzureStorageConnectorTest.java
@@ -195,7 +195,7 @@ public class AzureStorageConnectorTest
   public void testListDir() throws BlobStorageException, IOException
   {
     EasyMock.reset(azureStorage);
-    EasyMock.expect(azureStorage.listDir(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt()))
+    EasyMock.expect(azureStorage.listBlobs(EasyMock.anyString(), EasyMock.anyString(), EasyMock.anyInt(), EasyMock.anyInt()))
             .andReturn(ImmutableList.of(PREFIX + "/x/y/z/" + TEST_FILE, PREFIX + "/p/q/r/" + TEST_FILE));
     EasyMock.replay(azureStorage);
     List<String> ret = Lists.newArrayList(storageConnector.listDir(""));


### PR DESCRIPTION
- **Remove unused constants**
- **Refactor getBlockBlobLength**
- **Better link**
- **Upper-case log**
- **Mark defaultStorageAccount nullable**
- **Do not always create a new container if it doesn't exist**
- **Add lots of comments, group methods**
- **Revert "Mark defaultStorageAccount nullable"**

### Description

When ingesting data from Azure blob storage, you can currently only do so if your SAS token has `write` permissions, even though this is not required to list and read blob objects.

The source of this bug lies in the fact that all calls in `AzureStorage` get a container client by calling `createBlobContainerIfNotExists`. This SDK method actually performs an API call that needs `write` permissions.

#### Bugfix

To fix this issue, I updated the calls getting container clients in `AzureStorage` to only use `createBlobContainerIfNotExists` for write operations, where it makes sense.

Specifically, `getBlockBlobOutputStream` and `uploadBlockBlob` will continue to create a container if it doesn't exist. This is useful when using Azure blob storage for deep storage and/or task logs.

> That said, this behaviour is somewhat unique to the Azure extension. In S3 for example, I believe the bucket needs to exist. Maybe it would make sense to deprecate this behaviour in the future to be more consistent across Druid, and require the container to exist.

All the other calls (read blob storage, check if blob exists, list blobs in the container, delete blobs) will require the container to exist. I think this makes sense given the nature of these calls.

#### Other changes

I also cleaned up the `AzureStorage` class so it can be easier maintained in the future. Specifically, I

- used Azure terminology throughout the class (e.g. `prefix` vs `virtualDirPath`)
- added `@Nullable` annotations where parameters are optional
- added a whole bunch of Javadoc

<hr>

##### Key changed/added classes in this PR

 * `AzureStorage`

<hr>

This PR has:

- [ ] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] been tested in a test Druid cluster.
