### PR TITLE
Disable event hubs when kafka extensions isn't loaded

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -233,6 +233,9 @@ export function getIngestionDocLink(spec: Partial<IngestionSpec>): string {
 
 export function getRequiredModule(ingestionType: IngestionComboTypeWithExtra): string | undefined {
   switch (ingestionType) {
+    case 'azure-event-hubs':
+      return 'druid-kafka-indexing-service';
+
     case 'index_parallel:s3':
       return 'druid-s3-extensions';
 


### PR DESCRIPTION
Fixes #10342.

### Description

This PR disables the `Azure Event Hubs` tile in the web-console if the kafka extension isn't loaded.

<hr>

- [x] been self-reviewed.
