### PR TITLE
Log segment signature in AbstractSegmentMetadataCache at debug level

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -733,7 +733,7 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
           log.warn("Got analysis for segment [%s] we didn't ask for, ignoring.", analysis.getId());
         } else {
           final RowSignature rowSignature = analysisToRowSignature(analysis);
-          log.info("Segment[%s] has signature[%s].", segmentId, rowSignature);
+          log.debug("Segment[%s] has signature[%s].", segmentId, rowSignature);
 
           if (segmentMetadataQueryResultHandler(dataSource, segmentId, rowSignature, analysis)) {
             retVal.add(segmentId);


### PR DESCRIPTION
Logging signature for each segment could result in extensive logging, hence changing the log level to debug.  