### PR TITLE
[Backport] Fix backwards compatibility with centralized schema config in partial_index_merge tasks

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -441,9 +441,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
         ingestionSchema.getDataSchema(),
         ioConfigs,
         ingestionSchema.getTuningConfig(),
-        getContext(),
-        toolbox.getJsonMapper(),
-        toolbox.getCentralizedTableSchemaConfig()
+        getContext()
     );
   }
 
@@ -1620,7 +1618,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
     for (PushedSegmentsReport pushedSegmentsReport : completedSubtaskReports.values()) {
       TaskReport.ReportMap taskReport = pushedSegmentsReport.getTaskReport();
       if (taskReport == null || taskReport.isEmpty()) {
-        LOG.warn("Received an empty report from subtask[%s]" + pushedSegmentsReport.getTaskId());
+        LOG.warn("Received an empty report from sub-task[%s].", pushedSegmentsReport.getTaskId());
         continue;
       }
       RowIngestionMetersTotals rowIngestionMetersTotals = getBuildSegmentsStatsFromTaskReport(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeParallelIndexTaskRunner.java
@@ -19,12 +19,10 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 
 import java.util.Iterator;
 import java.util.List;
@@ -40,8 +38,6 @@ class PartialGenericSegmentMergeParallelIndexTaskRunner
 
   private final DataSchema dataSchema;
   private final List<PartialSegmentMergeIOConfig> mergeIOConfigs;
-  private final CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig;
-  private final ObjectMapper mapper;
 
   PartialGenericSegmentMergeParallelIndexTaskRunner(
       TaskToolbox toolbox,
@@ -51,17 +47,13 @@ class PartialGenericSegmentMergeParallelIndexTaskRunner
       DataSchema dataSchema,
       List<PartialSegmentMergeIOConfig> mergeIOConfigs,
       ParallelIndexTuningConfig tuningConfig,
-      Map<String, Object> context,
-      ObjectMapper mapper,
-      CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
+      Map<String, Object> context
   )
   {
     super(toolbox, taskId, groupId, baseSubtaskSpecName, tuningConfig, context);
 
     this.dataSchema = dataSchema;
     this.mergeIOConfigs = mergeIOConfigs;
-    this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
-    this.mapper = mapper;
   }
 
   @Override
@@ -110,9 +102,7 @@ class PartialGenericSegmentMergeParallelIndexTaskRunner
             subtaskSpecId,
             numAttempts,
             ingestionSpec,
-            getContext(),
-            centralizedDatasourceSchemaConfig,
-            mapper
+            getContext()
         );
       }
     };

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTask.java
@@ -19,11 +19,9 @@
 
 package org.apache.druid.indexing.common.task.batch.parallel;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableSet;
@@ -31,7 +29,6 @@ import com.google.common.collect.Table;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.ISE;
-import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.partition.BuildingShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
@@ -53,8 +50,6 @@ public class PartialGenericSegmentMergeTask extends PartialSegmentMergeTask<Buil
   private final PartialSegmentMergeIngestionSpec ingestionSchema;
   private final Table<Interval, Integer, BuildingShardSpec<?>> intervalAndIntegerToShardSpec;
 
-  private final CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig;
-
   @JsonCreator
   public PartialGenericSegmentMergeTask(
       // id shouldn't be null except when this task is created by ParallelIndexSupervisorTask
@@ -66,9 +61,7 @@ public class PartialGenericSegmentMergeTask extends PartialSegmentMergeTask<Buil
       @JsonProperty("subtaskSpecId") @Nullable final String subtaskSpecId,
       @JsonProperty("numAttempts") final int numAttempts, // zero-based counting
       @JsonProperty("spec") final PartialSegmentMergeIngestionSpec ingestionSchema,
-      @JsonProperty("context") final Map<String, Object> context,
-      @JsonProperty("centralizedDatasourceSchemaConfig") CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig,
-      @JacksonInject ObjectMapper mapper
+      @JsonProperty("context") final Map<String, Object> context
   )
   {
     super(
@@ -81,12 +74,9 @@ public class PartialGenericSegmentMergeTask extends PartialSegmentMergeTask<Buil
         ingestionSchema.getIOConfig(),
         ingestionSchema.getTuningConfig(),
         numAttempts,
-        context,
-        mapper,
-        centralizedDatasourceSchemaConfig
+        context
     );
 
-    this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     this.ingestionSchema = ingestionSchema;
     this.intervalAndIntegerToShardSpec = createIntervalAndIntegerToShardSpec(
         ingestionSchema.getIOConfig().getPartitionLocations()
@@ -125,12 +115,6 @@ public class PartialGenericSegmentMergeTask extends PartialSegmentMergeTask<Buil
   private PartialSegmentMergeIngestionSpec getIngestionSchema()
   {
     return ingestionSchema;
-  }
-
-  @JsonProperty("centralizedDatasourceSchemaConfig")
-  private CentralizedDatasourceSchemaConfig getCentralizedDatasourceSchemaConfig()
-  {
-    return centralizedDatasourceSchemaConfig;
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.segment.TestHelper;
-import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -104,9 +103,7 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
         ParallelIndexTestingFactory.SUBTASK_SPEC_ID,
         ParallelIndexTestingFactory.NUM_ATTEMPTS,
         ingestionSpec,
-        ParallelIndexTestingFactory.CONTEXT,
-        CentralizedDatasourceSchemaConfig.create(),
-        null
+        ParallelIndexTestingFactory.CONTEXT
     );
   }
 
@@ -143,9 +140,7 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
                 .partitionsSpec(partitionsSpec)
                 .build()
         ),
-        ParallelIndexTestingFactory.CONTEXT,
-        CentralizedDatasourceSchemaConfig.create(),
-        null
+        ParallelIndexTestingFactory.CONTEXT
     );
   }
 

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -733,7 +733,7 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
           log.warn("Got analysis for segment [%s] we didn't ask for, ignoring.", analysis.getId());
         } else {
           final RowSignature rowSignature = analysisToRowSignature(analysis);
-          log.info("Segment[%s] has signature[%s].", segmentId, rowSignature);
+          log.debug("Segment[%s] has signature[%s].", segmentId, rowSignature);
 
           if (segmentMetadataQueryResultHandler(dataSource, segmentId, rowSignature, analysis)) {
             retVal.add(segmentId);

--- a/server/src/main/java/org/apache/druid/segment/metadata/FingerprintGenerator.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/FingerprintGenerator.java
@@ -25,6 +25,7 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -71,13 +72,14 @@ public class FingerprintGenerator
     }
     catch (IOException e) {
       log.error(
-          "Exception generating fingerprint for payload [%s], datasource [%s], version [%s] with stacktrace [%s].",
-          schemaPayload,
-          dataSource,
-          version,
-          e
+          e,
+          "Exception generating schema fingerprint (version[%d]) for datasource[%s], payload[%s].",
+          version, dataSource, schemaPayload
       );
-      throw new RuntimeException(e);
+      throw DruidException.defensive(
+          "Could not generate schema fingerprint (version[%d]) for datasource[%s].",
+          dataSource, version
+      );
     }
   }
 }


### PR DESCRIPTION
Backports https://github.com/apache/druid/pull/16556 & https://github.com/apache/druid/pull/16565 to Druid 30.