### PR TITLE
docs: remove outdated druidversion var from a page

### DIFF
--- a/docs/querying/datasource.md
+++ b/docs/querying/datasource.md
@@ -365,7 +365,7 @@ GROUP BY
 Join datasources allow you to do a SQL-style join of two datasources. Stacking joins on top of each other allows
 you to join arbitrarily many datasources.
 
-In Druid {{DRUIDVERSION}}, joins in native queries are implemented with a broadcast hash-join algorithm. This means
+Joins in native queries are implemented with a broadcast hash-join algorithm. This means
 that all datasources other than the leftmost "base" datasource must fit in memory. In native queries, the join condition
 must be an equality. In SQL, any join condition is accepted, but only equalities of a certain form
 (see [Joins in SQL](#joins-in-sql)) execute efficiently as part of a native join. For other kinds of conditions, planner will try
@@ -431,7 +431,7 @@ and how to detect it.
 3. One common reason for implicit subquery generation is if the types of the two halves of an equality do not match.
 For example, since lookup keys are always strings, the condition `druid.d JOIN lookup.l ON d.field = l.field` will
 perform best if `d.field` is a string.
-4. As of Druid {{DRUIDVERSION}}, the join operator must evaluate the condition for each row. In the future, we expect
+4. The join operator must evaluate the condition for each row. In the future, we expect
 to implement both early and deferred condition evaluation, which we expect to improve performance considerably for
 common use cases.
 5. Currently, Druid does not support pushing down predicates (condition and filter) past a Join (i.e. into


### PR DESCRIPTION
The `{{DRUIDVERSION}}` bits on this page were added awhile ago:

https://github.com/apache/druid/blame/master/docs/querying/datasource.md

Line 368: last year (26.0.0)
Line 434: 4 years ago

I think they should have been hardcoded at the time since the statements mark a change in behavior. But since they were both so long ago, it seems like we can just remove them instead of trying to track down the version they correspond to.

At a minimum, I think we should remove the 4 yr old reference. If we wanted to, we can update line 368 to the actual version

This PR has:

- [x] been self-reviewed.
