### PR TITLE
Web console: fix pagination and filtering regression in supervisor view

### DIFF
--- a/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
+++ b/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
@@ -192,7 +192,7 @@ exports[`SupervisorsView matches snapshot 1`] = `
           "accessor": "detailed_state",
           "id": "detailed_state",
           "show": true,
-          "width": 130,
+          "width": 150,
         },
         {
           "Cell": [Function],
@@ -374,11 +374,12 @@ exports[`SupervisorsView matches snapshot 1`] = `
     indexKey="_index"
     loading={false}
     loadingText="Loading..."
+    manual={true}
     multiSort={true}
     nestingLevelKey="_nestingLevel"
     nextText="Next"
     noDataText=""
-    ofText="of"
+    ofText=""
     onFetchData={[Function]}
     onFilteredChange={[Function]}
     originalKey="_original"
@@ -391,6 +392,7 @@ exports[`SupervisorsView matches snapshot 1`] = `
       ]
     }
     pageText="Page"
+    pages={10000000}
     pivotDefaults={{}}
     pivotIDKey="_pivotID"
     pivotValKey="_pivotVal"
@@ -399,9 +401,9 @@ exports[`SupervisorsView matches snapshot 1`] = `
     resolveData={[Function]}
     rowsSelectorText="rows per page"
     rowsText="rows"
-    showPageJump={true}
+    showPageJump={false}
     showPageSizeOptions={true}
-    showPagination={false}
+    showPagination={true}
     showPaginationBottom={true}
     showPaginationTop={false}
     sortable={true}

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -19,6 +19,7 @@
 import { Icon, Intent, Menu, MenuItem, Position, Tag } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
+import { SqlExpression } from '@druid-toolkit/query';
 import * as JSONBig from 'json-bigint-native';
 import type { JSX } from 'react';
 import React from 'react';
@@ -65,6 +66,7 @@ import {
   assemble,
   checkedCircleIcon,
   deepGet,
+  filterMap,
   formatByteRate,
   formatBytes,
   formatInteger,
@@ -227,6 +229,12 @@ export class SupervisorsView extends React.PureComponent<
       ) => {
         let supervisors: SupervisorQueryResultRow[];
         if (capabilities.hasSql()) {
+          let filterClause = '';
+          const whereParts = filterMap(filtered, sqlQueryCustomTableFilter);
+          if (whereParts.length) {
+            filterClause = SqlExpression.and(...whereParts).toString();
+          }
+
           const sqlQuery = assemble(
             'WITH s AS (SELECT',
             '  "supervisor_id",',
@@ -238,9 +246,7 @@ export class SupervisorsView extends React.PureComponent<
             'FROM "sys"."supervisors")',
             'SELECT *',
             'FROM s',
-            filtered.length
-              ? `WHERE ${filtered.map(sqlQueryCustomTableFilter).join(' AND ')}`
-              : undefined,
+            filterClause ? `WHERE ${filterClause}` : undefined,
             sortedToOrderByClause(sorted),
             `LIMIT ${pageSize}`,
             page ? `OFFSET ${page * pageSize}` : undefined,
@@ -638,19 +644,23 @@ export class SupervisorsView extends React.PureComponent<
     return (
       <ReactTable
         data={supervisors}
+        pages={10000000} // Dummy, we are hiding the page selector
         loading={supervisorsState.loading}
         noDataText={
           supervisorsState.isEmpty() ? 'No supervisors' : supervisorsState.getErrorMessage() || ''
         }
+        manual
+        filterable
         filtered={filters}
         onFilteredChange={onFiltersChange}
-        filterable
         onFetchData={tableState => {
           this.fetchData(tableState);
         }}
+        showPageJump={false}
+        ofText=""
         defaultPageSize={SMALL_TABLE_PAGE_SIZE}
         pageSizeOptions={SMALL_TABLE_PAGE_SIZE_OPTIONS}
-        showPagination={supervisors.length > SMALL_TABLE_PAGE_SIZE}
+        showPagination
         columns={[
           {
             Header: twoLines('Supervisor ID', <i>(datasource)</i>),
@@ -684,11 +694,11 @@ export class SupervisorsView extends React.PureComponent<
           {
             Header: 'Status',
             id: 'detailed_state',
-            width: 130,
+            width: 150,
             accessor: 'detailed_state',
             Cell: ({ value }) => (
               <TableFilterableCell
-                field="status"
+                field="detailed_state"
                 value={value}
                 filters={filters}
                 onFiltersChange={onFiltersChange}


### PR DESCRIPTION
This PR fixes 3 bugs in the supervisor view introduced as part of https://github.com/apache/druid/pull/16318:
- Pagination will never show up because dynamically queried supervisors will never satisfy the `supervisors.length > SMALL_TABLE_PAGE_SIZE` condition
- Filtering on the `Status` column fails. This is due to a typo (internally the column is actually called `detailed_state`)
- Typing something into the filter then deleting it produces an invalid query with an empty `WHERE`