### PR TITLE
Update default value of `druid.indexer.tasklock.batchAllocationWaitTime` to zero

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1114,7 +1114,7 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 ##### Overlord operations
 
 |Property|Description|Default|
-|--------|-----------|-----|
+|--------|-----------|-------|
 |`druid.indexer.runner.type`|Indicates whether tasks should be run locally using `local` or in a distributed environment using `remote`. The recommended option is `httpRemote`, which is similar to `remote` but uses HTTP to interact with Middle Managers instead of ZooKeeper.|`httpRemote`|
 |`druid.indexer.storage.type`|Indicates whether incoming tasks should be stored locally (in heap) or in metadata storage. One of `local` or `metadata`. `local` is mainly for internal testing while `metadata` is recommended in production because storing incoming tasks in metadata storage allows for tasks to be resumed if the Overlord should fail.|`local`|
 |`druid.indexer.storage.recentlyFinishedThreshold`|Duration of time to store task results. Default is 24 hours. If you have hundreds of tasks running in a day, consider increasing this threshold.|`PT24H`|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1114,13 +1114,13 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 ##### Overlord operations
 
 |Property|Description|Default|
-|--------|-----------|-------|
+|--------|-----------|-----|
 |`druid.indexer.runner.type`|Indicates whether tasks should be run locally using `local` or in a distributed environment using `remote`. The recommended option is `httpRemote`, which is similar to `remote` but uses HTTP to interact with Middle Managers instead of ZooKeeper.|`httpRemote`|
 |`druid.indexer.storage.type`|Indicates whether incoming tasks should be stored locally (in heap) or in metadata storage. One of `local` or `metadata`. `local` is mainly for internal testing while `metadata` is recommended in production because storing incoming tasks in metadata storage allows for tasks to be resumed if the Overlord should fail.|`local`|
 |`druid.indexer.storage.recentlyFinishedThreshold`|Duration of time to store task results. Default is 24 hours. If you have hundreds of tasks running in a day, consider increasing this threshold.|`PT24H`|
 |`druid.indexer.tasklock.forceTimeChunkLock`|_**Setting this to false is still experimental**_<br/> If set, all tasks are enforced to use time chunk lock. If not set, each task automatically chooses a lock type to use. This configuration can be overwritten by setting `forceTimeChunkLock` in the [task context](../ingestion/tasks.md#context). See [Task Locking & Priority](../ingestion/tasks.md#context) for more details about locking in tasks.|true|
 |`druid.indexer.tasklock.batchSegmentAllocation`| If set to true, Druid performs segment allocate actions in batches to improve throughput and reduce the average `task/action/run/time`. See [batching `segmentAllocate` actions](../ingestion/tasks.md#batching-segmentallocate-actions) for details.|true|
-|`druid.indexer.tasklock.batchAllocationWaitTime`|Number of milliseconds after Druid adds the first segment allocate action to a batch, until it executes the batch. Allows the batch to add more requests and improve the average segment allocation run time. This configuration takes effect only if `batchSegmentAllocation` is enabled.|500|
+|`druid.indexer.tasklock.batchAllocationWaitTime`|Number of milliseconds after Druid adds the first segment allocate action to a batch, until it executes the batch. Allows the batch to add more requests and improve the average segment allocation run time. This configuration takes effect only if `batchSegmentAllocation` is enabled.|0|
 |`druid.indexer.task.default.context`|Default task context that is applied to all tasks submitted to the Overlord. Any default in this config does not override neither the context values the user provides nor `druid.indexer.tasklock.forceTimeChunkLock`.|empty context|
 |`druid.indexer.queue.maxSize`|Maximum number of active tasks at one time.|`Integer.MAX_VALUE`|
 |`druid.indexer.queue.startDelay`|Sleep this long before starting Overlord queue management. This can be useful to give a cluster time to re-orient itself (for example, after a widespread network issue).|`PT1M`|

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskLockConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/config/TaskLockConfig.java
@@ -34,7 +34,7 @@ public class TaskLockConfig
   private boolean batchSegmentAllocation = true;
 
   @JsonProperty
-  private long batchAllocationWaitTime = 500L;
+  private long batchAllocationWaitTime = 0L;
 
   public boolean isForceTimeChunkLock()
   {


### PR DESCRIPTION
### Description

The current default `batchAllocationWaitTime` is 500ms. This means that the `SegmentAllocationQueue`
waits for 500ms before a batch is processed to allow it to accumulate more requests.
In some cases, particularly MSQ tasks, this adds an unnecessary penalty to the task duration.

### Changes

With batch segment allocation enabled and `batchAllocationWaitTime=0`,
the segment allocation queue becomes more adaptive and exhibits the following behaviour:
- Process the first segment allocation request added to the queue immediately.
- While the first request is being processed, let any subsequent requests accumulate in the queue.
- Once the first request is processed, pick up the next batch in the queue for processing.

### Testing

We have had `batchAllocationWaitTime=0` in several of our production clusters for a couple of months now.
It has particularly helped with MSQ tasks, which don't really benefit from batching as segments are allocated serially.
Waiting 500ms for every allocation increased MSQ task durations leading to unnecessary compute costs.

### Release Note

Update default value of `druid.indexer.tasklock.batchAllocationWaitTime` to `0`.
Thus, a segment allocation request is processed immediately unless there are already some requests queued before this one. While in queue, a segment allocation request may get clubbed together with other similar requests into a batch to reduce load on the metadata store.