### PR TITLE
Fix the druid json_object issue

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -721,7 +721,7 @@ public class NestedDataOperatorConversions
 
   public static class JsonObjectOperatorConversion implements SqlOperatorConversion
   {
-    private static final String FUNCTION_NAME = "json_object";
+    private static final String FUNCTION_NAME = "JSON_OBJECT";
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
         .operatorBuilder(FUNCTION_NAME)
         .operandTypeChecker(OperandTypes.variadic(SqlOperandCountRanges.from(1)))

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -721,26 +721,7 @@ public class NestedDataOperatorConversions
 
   public static class JsonObjectOperatorConversion implements SqlOperatorConversion
   {
-    private static final String FUNCTION_NAME = "JSON_OBJECT";
-    private static final SqlFunction SQL_FUNCTION = OperatorConversions
-        .operatorBuilder(FUNCTION_NAME)
-        .operandTypeChecker(OperandTypes.variadic(SqlOperandCountRanges.from(1)))
-        .operandTypeInference((callBinding, returnType, operandTypes) -> {
-          RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
-          for (int i = 0; i < operandTypes.length; i++) {
-            if (i % 2 == 0) {
-              operandTypes[i] = typeFactory.createSqlType(SqlTypeName.VARCHAR);
-              continue;
-            }
-            operandTypes[i] = typeFactory.createTypeWithNullability(
-                typeFactory.createSqlType(SqlTypeName.ANY),
-                true
-            );
-          }
-        })
-        .returnTypeInference(NESTED_RETURN_TYPE_INFERENCE)
-        .functionCategory(SqlFunctionCategory.SYSTEM)
-        .build();
+    private static final SqlFunction SQL_FUNCTION = SqlStdOperatorTable.JSON_OBJECT;
 
     @Override
     public SqlOperator calciteOperator()

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
@@ -97,4 +97,20 @@ public class CalciteSysQueryTest extends BaseCalciteQueryTest
                              + "      LogicalTableScan(table=[[sys, tasks]])\n")
         .run();
   }
+
+  @Test
+  public void testJsonObject()
+  {
+    testBuilder()
+        .sql(
+            "select JSON_OBJECT('name': COLUMN_NAME, 'type': \"DATA_TYPE\")"
+            + "from INFORMATION_SCHEMA.COLUMNS order by COLUMN_NAME limit 1"
+        )
+        .expectedResults(
+            ImmutableList.of(
+                new Object[] {"{\"name\":\"CATALOG_NAME\",\"type\":\"VARCHAR\"}"}
+            )
+        )
+        .run();
+  }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #16356.

### Description
the dependence calcite [cr](https://github.com/apache/calcite/pull/3821) need to be review
the root case is that the operator is SqlFunction, but in the map, the key instance is SqlJsonObjectFunction, the type is not equals, so we can naver get from the map in the following code:
```
 public @Nullable RexCallImplementor get(final SqlOperator operator) {
    if (operator instanceof SqlUserDefinedFunction) {
      org.apache.calcite.schema.Function udf =
          ((SqlUserDefinedFunction) operator).getFunction();
      if (!(udf instanceof ImplementableFunction)) {
        throw new IllegalStateException("User defined function " + operator
            + " must implement ImplementableFunction");
      }
      CallImplementor implementor =
          ((ImplementableFunction) udf).getImplementor();
      return wrapAsRexCallImplementor(implementor);
    } else if (operator instanceof SqlTypeConstructorFunction) {
      return map.get(SqlStdOperatorTable.ROW);
    }
    return map.get(operator);
  }
```

#### Fixed the bug ...
#### Release note
Fix the SQL JSON_OBJECT() function results in RUNTIME_FAILURE when querying INFORMATION_SCHEMA.COLUMNS



<hr>

##### Key changed/added classes in this PR
 * `NestedDataOperatorConversions.java`

<hr>



This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
