### PR TITLE
modify equality and typed in filter behavior for numeric match values on string columns

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/RangeFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/RangeFilter.java
@@ -314,8 +314,7 @@ public class RangeFilter extends AbstractOptimizableDimFilter implements Filter
         final String upper = hasUpperBound() ? upperEval.asString() : null;
         return rangeIndexes.forRange(lower, lowerOpen, upper, upperOpen);
       }
-    }
-    if (matchValueType.isNumeric()) {
+    } else if (matchValueType.isNumeric()) {
       final NumericRangeIndexes rangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
       if (rangeIndexes != null) {
         final Number lower = (Number) lowerEval.value();

--- a/processing/src/main/java/org/apache/druid/query/filter/TypedInFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/TypedInFilter.java
@@ -36,20 +36,24 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeSet;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+import com.google.common.primitives.Doubles;
 import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleSet;
 import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectAVLTreeSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrays;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.Evals;
+import org.apache.druid.math.expr.ExprEval;
+import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.query.filter.vector.VectorValueMatcher;
 import org.apache.druid.query.filter.vector.VectorValueMatcherColumnProcessorFactory;
-import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.ColumnProcessors;
 import org.apache.druid.segment.ColumnSelectorFactory;
@@ -456,20 +460,20 @@ public class TypedInFilter extends AbstractOptimizableDimFilter implements Filte
   }
 
   @Nullable
-  private static Object coerceValue(@Nullable Object o, ColumnType matchValueType)
+  private static <T> T coerceValue(@Nullable Object o, ColumnType matchValueType)
   {
     if (o == null) {
       return null;
     }
     switch (matchValueType.getType()) {
       case STRING:
-        return DimensionHandlerUtils.convertObjectToString(o);
+        return (T) DimensionHandlerUtils.convertObjectToString(o);
       case LONG:
-        return DimensionHandlerUtils.convertObjectToLong(o);
+        return (T) DimensionHandlerUtils.convertObjectToLong(o);
       case FLOAT:
-        return DimensionHandlerUtils.convertObjectToFloat(o);
+        return (T) DimensionHandlerUtils.convertObjectToFloat(o);
       case DOUBLE:
-        return DimensionHandlerUtils.convertObjectToDouble(o);
+        return (T) DimensionHandlerUtils.convertObjectToDouble(o);
       default:
         throw InvalidInput.exception("Unsupported matchValueType[%s]", matchValueType);
     }
@@ -544,17 +548,51 @@ public class TypedInFilter extends AbstractOptimizableDimFilter implements Filte
         final int index = Collections.binarySearch(sortedValues, value, comparator);
         return DruidPredicateMatch.of(index >= 0);
       };
+    } else if (matchValueType.is(ValueType.LONG)) {
+      final LongSet valueSet = new LongOpenHashSet(sortedValues.size());
+      for (Object o : sortedValues) {
+        final Long l = DimensionHandlerUtils.convertObjectToLong(o);
+        if (l != null) {
+          valueSet.add(l.longValue());
+        }
+      }
+      return value -> {
+        if (value == null) {
+          return containsNull ? DruidPredicateMatch.TRUE : DruidPredicateMatch.UNKNOWN;
+        }
+        final Long castValue = GuavaUtils.tryParseLong(value);
+        if (castValue == null) {
+          return DruidPredicateMatch.FALSE;
+        }
+        return DruidPredicateMatch.of(valueSet.contains(castValue));
+      };
+    } else if (matchValueType.isNumeric()) {
+      // double or float
+      final DoubleSet valueSet = new DoubleOpenHashSet(sortedValues.size());
+      for (Object o : sortedValues) {
+        Double d = DimensionHandlerUtils.convertObjectToDouble(o);
+        if (d != null) {
+          valueSet.add(d.doubleValue());
+        }
+      }
+      return value -> {
+        if (value == null) {
+          return containsNull ? DruidPredicateMatch.TRUE : DruidPredicateMatch.UNKNOWN;
+        }
+
+        final Double d = Doubles.tryParse(value);
+        if (d == null) {
+          return DruidPredicateMatch.FALSE;
+        }
+        return DruidPredicateMatch.of(valueSet.contains(d));
+      };
     }
-    final Set<String> stringSet;
-    // when matching strings to numeric match values, use numeric comparator to implicitly cast the string to number
-    if (matchValueType.isNumeric()) {
-      stringSet = new ObjectAVLTreeSet<>(StringComparators.NUMERIC);
-    } else {
-      stringSet = Sets.newHashSetWithExpectedSize(sortedValues.size());
-    }
+
     // convert set to strings
+    final ExpressionType matchExpressionType = ExpressionType.fromColumnTypeStrict(matchValueType);
+    final Set<String> stringSet = Sets.newHashSetWithExpectedSize(sortedValues.size());
     for (Object o : sortedValues) {
-      stringSet.add(Evals.asString(o));
+      stringSet.add(ExprEval.ofType(matchExpressionType, o).castTo(ExpressionType.STRING).asString());
     }
     return value -> {
       if (value == null) {

--- a/processing/src/main/java/org/apache/druid/segment/index/IndexedUtf8ValueIndexes.java
+++ b/processing/src/main/java/org/apache/druid/segment/index/IndexedUtf8ValueIndexes.java
@@ -230,7 +230,7 @@ public final class IndexedUtf8ValueIndexes<TDictionary extends Indexed<ByteBuffe
         final Object minValueInColumn = dictionary.get(0);
         final int position = Collections.binarySearch(
             sortedValues,
-            StringUtils.fromUtf8((ByteBuffer) minValueInColumn),
+            StringUtils.fromUtf8Nullable((ByteBuffer) minValueInColumn),
             matchValueType.getNullableStrategy()
         );
         tailSet = baseSet.subList(position >= 0 ? position : -(position + 1), baseSet.size());

--- a/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
@@ -108,6 +108,12 @@ public class EqualityFilterTests
           NotDimFilter.of(new EqualityFilter("dim0", ColumnType.LONG, 1L, null)),
           ImmutableList.of("0", "2", "3", "4", "5")
       );
+
+      assertFilterMatches(new EqualityFilter("dim0", ColumnType.DOUBLE, 1, null), ImmutableList.of("1"));
+      assertFilterMatches(
+          NotDimFilter.of(new EqualityFilter("dim0", ColumnType.DOUBLE, 1, null)),
+          ImmutableList.of("0", "2", "3", "4", "5")
+      );
     }
 
     @Test

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
@@ -139,15 +139,28 @@ public class InFilterTests
           ImmutableList.of("a", "b", "c", "d", "f")
       );
 
-      assertTypedFilterMatches(
-          inFilter("dim1", ColumnType.LONG, Arrays.asList(2L, 10L)),
-          ImmutableList.of("b", "c")
-      );
+      if (NullHandling.sqlCompatible()) {
+        assertTypedFilterMatches(
+            inFilter("dim1", ColumnType.LONG, Arrays.asList(2L, 10L)),
+            ImmutableList.of("b", "c")
+        );
 
-      assertTypedFilterMatches(
-          inFilter("dim1", ColumnType.DOUBLE, Arrays.asList(2.0, 10.0)),
-          ImmutableList.of("b", "c")
-      );
+        assertTypedFilterMatches(
+            inFilter("dim1", ColumnType.DOUBLE, Arrays.asList(2.0, 10.0)),
+            ImmutableList.of("b", "c")
+        );
+      } else {
+        // in default value mode, we actually end up using a classic InDimFilter, it does not match numbers well
+        assertTypedFilterMatches(
+            inFilter("dim1", ColumnType.LONG, Arrays.asList(2L, 10L)),
+            ImmutableList.of("b", "c")
+        );
+
+        assertTypedFilterMatches(
+            inFilter("dim1", ColumnType.DOUBLE, Arrays.asList(2.0, 10.0)),
+            ImmutableList.of()
+        );
+      }
     }
     @Test
     public void testSingleValueStringColumnWithNulls()

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
@@ -138,6 +138,16 @@ public class InFilterTests
           NotDimFilter.of(inFilter("dim0", ColumnType.STRING, Arrays.asList("e", "x"))),
           ImmutableList.of("a", "b", "c", "d", "f")
       );
+
+      assertTypedFilterMatches(
+          inFilter("dim1", ColumnType.LONG, Arrays.asList(2L, 10L)),
+          ImmutableList.of("b", "c")
+      );
+
+      assertTypedFilterMatches(
+          inFilter("dim1", ColumnType.DOUBLE, Arrays.asList(2.0, 10.0)),
+          ImmutableList.of("b", "c")
+      );
     }
     @Test
     public void testSingleValueStringColumnWithNulls()


### PR DESCRIPTION
### Description
This PR changes `EqualityFilter` and `TypedInfilter` numeric match values against string columns to now cast the strings to numbers instead of converting the numeric values directly to string for pure string equality.  This  makes using these filters (the default in SQL compatible mode) behave consistently with 'default' value mode which uses the `BoundFilter` for numeric comparison of string values.

The added tests to cover numeric equality matching. Double match values in particular would fail to match the string values since `1.0` would become `'1.0'` which does not match `'1'`. 

I investigated an alternative of just having the SQL planner not eat `CAST` operators like it currently does, since a query like `... WHERE stringColumn = 1.0` ends up as `... WHERE CAST(stringColumn as DOUBLE) = 1.0` before we eat the cast, which makes the native layer a lot more explicit, however this change basically does the same thing and is a lot less disruptive.

It may still be worth investigating not eating casts during SQL planning, but I'll save that for follow-up work.

#### Release note
Modified behavior of using `EqualityFilter` and `TypedInFilter` to match numeric typed values (particularly DOUBLE) against string columns to effectively cast the strings to use numerical comparison, for more consistent Druid behavior between `sqlUseBoundAndSelectors` context flag. 

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
