### PR TITLE
Remove redundant check on optional in BlockingQueueFrameChannel.Writable#isClosed

### DIFF
--- a/processing/src/main/java/org/apache/druid/concurrent/TaskThreadPriority.java
+++ b/processing/src/main/java/org/apache/druid/concurrent/TaskThreadPriority.java
@@ -65,3 +65,4 @@ public class TaskThreadPriority
     }
     return finalPriority;
   }
+}

--- a/processing/src/main/java/org/apache/druid/concurrent/TaskThreadPriority.java
+++ b/processing/src/main/java/org/apache/druid/concurrent/TaskThreadPriority.java
@@ -65,4 +65,3 @@ public class TaskThreadPriority
     }
     return finalPriority;
   }
-}

--- a/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/BlockingQueueFrameChannel.java
@@ -197,7 +197,7 @@ public class BlockingQueueFrameChannel
     {
       synchronized (lock) {
         final Optional<Either<Throwable, FrameWithPartition>> lastElement = queue.peekLast();
-        return lastElement != null && END_MARKER.equals(lastElement);
+        return END_MARKER.equals(lastElement);
       }
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #16594

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
