### PR TITLE
Update the youtube link for druid presentations page

### DIFF
--- a/docs/misc/papers-and-talks.md
+++ b/docs/misc/papers-and-talks.md
@@ -36,7 +36,7 @@ title: "Papers"
 
 * [Not Exactly! Fast Queries via Approximation Algorithms](https://www.youtube.com/watch?v=Hpd3f_MLdXo) - Discusses how approximate algorithms work in Druid.
 
-* [Real-time Analytics with Open Source Technologies](https://www.youtube.com/watch?v=kJMYVpnW_AQ) - Discusses Lambda architectures with Druid.
+* [Real-time Analytics with Open Source Technologies](https://www.youtube.com/watch?v=TPrO78QjpOY) - Discusses Lambda architectures with Druid.
 
 * [Stories from the Trenches - The Challenges of Building an Analytics Stack](https://www.youtube.com/watch?v=Sz4w75xRrYM) - Discusses features that were added to scale Druid.
 

--- a/docs/misc/papers-and-talks.md
+++ b/docs/misc/papers-and-talks.md
@@ -36,8 +36,8 @@ title: "Papers"
 
 * [Not Exactly! Fast Queries via Approximation Algorithms](https://www.youtube.com/watch?v=Hpd3f_MLdXo) - Discusses how approximate algorithms work in Druid.
 
-* [Real-time Analytics with Open Source Technologies](https://www.youtube.com/watch?v=TPrO78QjpOY) - Discusses Lambda architectures with Druid.
+* [Real-time Analytics with Open Source Technologies](https://www.youtube.com/watch?v=3Qb_2GGRz24) - Discusses Lambda architectures with Druid.
 
-* [Stories from the Trenches - The Challenges of Building an Analytics Stack](https://www.youtube.com/watch?v=Sz4w75xRrYM) - Discusses features that were added to scale Druid.
+* [Stories from the Trenches - The Challenges of Building an Analytics Stack](https://www.youtube.com/watch?v=yuSLeIzG98w&t=55s) - Discusses features that were added to scale Druid.
 
 * [Building Interactive Applications at Scale](https://www.youtube.com/watch?v=bZ3LqG3iHbM) - Discusses building applications on top of Druid.


### PR DESCRIPTION

Fixes #14240

### Description

Update the druid video link from the official youtube channel
#### Fixed the bug ...

Update the druid video link to valid link
#### Release note
Update the druid video link to valid link

##### Key changed/added classes in this PR
 * `papers-and-talks.md`

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
