### PR TITLE
Use precomputed dictionary id ranking in RowBasedSerdeHelper only when applicable

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1339,7 +1339,7 @@ public class RowBasedGrouperHelper
     @Override
     public Grouper.BufferComparator bufferComparator()
     {
-      if (rankOfDictionaryIds == null) {
+      if (rankOfDictionaryIds == null && !enableRuntimeDictionaryGeneration) {
         initializeRankOfDictionaryIds();
       }
 
@@ -1781,11 +1781,12 @@ public class RowBasedGrouperHelper
       AbstractStringRowBasedKeySerdeHelper(
           int keyBufferPosition,
           boolean pushLimitDown,
-          @Nullable StringComparator stringComparator
+          @Nullable StringComparator stringComparator,
+          boolean enableRuntimeDictionaryGeneration
       )
       {
         this.keyBufferPosition = keyBufferPosition;
-        if (!pushLimitDown) {
+        if (!pushLimitDown && !enableRuntimeDictionaryGeneration) {
           bufferComparator = (lhsBuffer, rhsBuffer, lhsPosition, rhsPosition) -> Ints.compare(
               rankOfDictionaryIds[lhsBuffer.getInt(lhsPosition + keyBufferPosition)],
               rankOfDictionaryIds[rhsBuffer.getInt(rhsPosition + keyBufferPosition)]
@@ -1829,7 +1830,7 @@ public class RowBasedGrouperHelper
           @Nullable StringComparator stringComparator
       )
       {
-        super(keyBufferPosition, pushLimitDown, stringComparator);
+        super(keyBufferPosition, pushLimitDown, stringComparator, true);
       }
 
       @Override
@@ -1877,7 +1878,7 @@ public class RowBasedGrouperHelper
           @Nullable StringComparator stringComparator
       )
       {
-        super(keyBufferPosition, pushLimitDown, stringComparator);
+        super(keyBufferPosition, pushLimitDown, stringComparator, false);
       }
 
       @Override


### PR DESCRIPTION
### Description

The following exception was seen while trying to execute a query. 

```
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.apache.druid.query.groupby.epinephelinae.RowBasedGrouperHelper$RowBasedKeySerde$AbstractStringRowBasedKeySerdeHelper.lambda$new$0(RowBasedGrouperHelper.java:1790) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.GrouperBufferComparatorUtils$3.compare(GrouperBufferComparatorUtils.java:104) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.BufferHashGrouper.lambda$iterator$0(BufferHashGrouper.java:213) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at java.base/java.util.TimSort.countRunAndMakeAscending(TimSort.java:355) ~[?:?]
	at java.base/java.util.TimSort.sort(TimSort.java:234) ~[?:?]
	at java.base/java.util.Arrays.sort(Arrays.java:1441) ~[?:?]
	at java.base/java.util.List.sort(List.java:506) ~[?:?]
	at java.base/java.util.Collections.sort(Collections.java:179) ~[?:?]
	at org.apache.druid.query.groupby.epinephelinae.BufferHashGrouper.iterator(BufferHashGrouper.java:209) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.SpillingGrouper.iterator(SpillingGrouper.java:269) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.RowBasedGrouperHelper.makeGrouperIterator(RowBasedGrouperHelper.java:621) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.GroupByRowProcessor$3.make(GroupByRowProcessor.java:171) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org.apache.druid.query.groupby.epinephelinae.GroupByRowProcessor$3.make(GroupByRowProcessor.java:167) ~[druid-processing-2024.05.0-iap.jar:2024.05.0-iap]
	at org
```

This PR modifies the `AbstractStringRowBasedKeySerdeHelper` to use the pre-computed dictionary ID ranking only when we have a pre-computed dictionary (i.e. enableRuntimeDictionaryGeneration is false). Using the pre-computed ranking when it is not applicable in the `SpillingGrouper` seems like the cause for this. 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
