### PR TITLE
Add retries to handle connection reset errors for GZIPInputStream

### DIFF
--- a/processing/src/main/java/org/apache/druid/data/input/impl/RetryingGZIPInputStream.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/RetryingGZIPInputStream.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import com.google.common.base.Predicate;
+import org.apache.druid.java.util.common.RetryUtils;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+public class RetryingGZIPInputStream extends InputStream
+{
+  private static final Logger log = new Logger(RetryingGZIPInputStream.class);
+
+  private InputStream delegate;
+  private final InputStream in;
+  private long startOffset = 0;
+
+  private static final Predicate<Throwable> RETRY_CONDITION = e -> e.getMessage().equals("Unexpected end of ZLIB input stream");
+  private static final int GZIP_BUFFER_SIZE = 8192; // Default is 512
+  private static final int MAX_TRIES = 10;
+
+  // Used in tests to disable waiting.
+  private final boolean doWait;
+
+  public RetryingGZIPInputStream(InputStream delegate, InputStream in)
+  {
+    this(delegate, in, true);
+  }
+
+  public RetryingGZIPInputStream(InputStream delegate, InputStream in, boolean doWait)
+  {
+    this.delegate = delegate;
+    this.in = in;
+    this.doWait = doWait;
+  }
+
+  @Override
+  public int read() throws IOException
+  {
+    for (int nTry = 0; nTry < MAX_TRIES; nTry++) {
+      try {
+        int numBytes = delegate.read();
+        startOffset += numBytes;
+        return numBytes;
+      }
+      catch (Throwable t) {
+        waitOrThrow(t, nTry);
+      }
+    }
+
+    // Can't happen, because the final waitOrThrow would have thrown.
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException
+  {
+    for (int nTry = 0; nTry < MAX_TRIES; nTry++) {
+      try {
+        int numBytes = delegate.read(b);
+        startOffset += numBytes;
+        return numBytes;
+      }
+      catch (Throwable t) {
+        waitOrThrow(t, nTry);
+      }
+    }
+
+    // Can't happen, because the final waitOrThrow would have thrown.
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException
+  {
+    for (int nTry = 0; nTry < MAX_TRIES; nTry++) {
+      try {
+        int numBytes = delegate.read(b, off, len);
+        startOffset += numBytes;
+        return numBytes;
+      }
+      catch (Throwable t) {
+        waitOrThrow(t, nTry);
+      }
+    }
+
+    // Can't happen, because the final waitOrThrow would have thrown.
+    throw new IllegalStateException();
+  }
+
+  private void waitOrThrow(Throwable t, int nTry) throws IOException
+  {
+    log.info("Encountered an error while reading the input stream, attempt number: %d, error: %s", nTry, t.getMessage());
+    try {
+      delegate.close();
+    }
+    catch (IOException e) {
+      // ignore this exception
+      log.warn(e, "Error while closing the delegate input stream. Discarding.");
+    }
+    finally {
+      delegate = null;
+    }
+
+    final int nextTry = nTry + 1;
+
+    if (nextTry < MAX_TRIES && RETRY_CONDITION.apply(t)) {
+      try {
+        // Pause for some time and then re-open the input stream.
+        final String message = StringUtils.format("Stream interrupted at position [%d]", startOffset);
+
+        if (doWait) {
+          RetryUtils.awaitNextRetry(t, message, nextTry, MAX_TRIES, false);
+        }
+        openWithRetry(startOffset);
+      }
+      catch (InterruptedException | IOException e) {
+        t.addSuppressed(e);
+        RetryingInputStreamUtils.throwAsIOException(t);
+      }
+    } else {
+      RetryingInputStreamUtils.throwAsIOException(t);
+    }
+  }
+
+  private void openWithRetry(final long offset) throws IOException
+  {
+    for (int nTry = 0; nTry < MAX_TRIES; nTry++) {
+      try {
+        // Reset the underlying input stream as we need to start from the beginning to avoid mismatch in
+        // GZIP header magic number in GZIPInputStream#readHeader.
+        in.reset();
+
+        delegate = createGZIPInputStream(in);
+
+        // Skip the already processed bytes.
+        delegate.skip(startOffset);
+        break;
+      }
+      catch (Throwable t) {
+        RetryingInputStreamUtils.handleInputStreamOpenError(t, RETRY_CONDITION, nTry, MAX_TRIES, offset, doWait);
+      }
+    }
+  }
+
+  public static GZIPInputStream createGZIPInputStream(InputStream in) throws IOException
+  {
+    return new GZIPInputStream(
+        new FilterInputStream(in)
+        {
+          @Override
+          public int available() throws IOException
+          {
+            final int otherAvailable = super.available();
+            // Hack. Docs say available() should return an estimate,
+            // so we estimate about 1KiB to work around available == 0 bug in GZIPInputStream
+            return otherAvailable == 0 ? 1 << 10 : otherAvailable;
+          }
+        },
+        GZIP_BUFFER_SIZE
+    );
+  }
+}

--- a/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStream.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStream.java
@@ -252,7 +252,7 @@ public class RetryingInputStream<T> extends InputStream
   }
 
   @Override
-  public synchronized void reset() throws IOException
+  public synchronized void reset()
   {
     startOffset = 0;
     try {

--- a/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStreamUtils.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/RetryingInputStreamUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Throwables;
+import org.apache.druid.java.util.common.RetryUtils;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+
+import java.io.IOException;
+
+public class RetryingInputStreamUtils
+{
+  private static final Logger log = new Logger(RetryingInputStreamUtils.class);
+
+  protected static void handleInputStreamOpenError(
+      Throwable t,
+      Predicate<Throwable> retryCondition,
+      int nTry,
+      int maxTries,
+      long offset,
+      boolean doWait
+  ) throws IOException
+  {
+    log.info("Encountered an error while opening the input stream, attempt number: %d, error: %s", nTry, t.getMessage());
+    final int nextTry = nTry + 1;
+    if (nextTry < maxTries && retryCondition.apply(t)) {
+      final String message = StringUtils.format("Stream interrupted at position [%d]", offset);
+      try {
+        if (doWait) {
+          RetryUtils.awaitNextRetry(t, message, nextTry, maxTries, false);
+        }
+      }
+      catch (InterruptedException e) {
+        t.addSuppressed(e);
+        throwAsIOException(t);
+      }
+    } else {
+      throwAsIOException(t);
+    }
+  }
+
+  protected static void throwAsIOException(Throwable t) throws IOException
+  {
+    Throwables.propagateIfInstanceOf(t, IOException.class);
+    throw new IOException(t);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/data/input/impl/RetryingGZIPInputStreamTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/RetryingGZIPInputStreamTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.impl;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RetryingGZIPInputStreamTest
+{
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private File testFile;
+
+  private static final String ERROR_MESSAGE = "Unexpected end of ZLIB input stream";
+
+  @Before
+  public void setup() throws IOException
+  {
+    testFile = temporaryFolder.newFile();
+
+    try (FileOutputStream fos = new FileOutputStream(testFile);
+         GZIPOutputStream gos = new GZIPOutputStream(fos);
+         DataOutputStream dos = new DataOutputStream(gos)) {
+      for (int i = 0; i < 10000; i++) {
+        dos.writeInt(i);
+      }
+    }
+  }
+
+  @After
+  public void teardown() throws IOException
+  {
+    FileUtils.forceDelete(testFile);
+  }
+
+  @Test
+  public void testReadSingleByte() throws IOException
+  {
+    try (
+        InputStream inputStream = Files.newInputStream(testFile.toPath());
+        RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(RetryingGZIPInputStream.createGZIPInputStream(inputStream), null)) {
+
+      Assert.assertTrue(retryingInputStream.read() != -1);
+    }
+  }
+
+  @Test
+  public void testReadWithBuffer() throws IOException
+  {
+    try (InputStream inputStream = Files.newInputStream(testFile.toPath());
+         RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(RetryingGZIPInputStream.createGZIPInputStream(inputStream), null)) {
+
+      byte[] buffer = new byte[100];
+      int bytesRead = retryingInputStream.read(buffer);
+
+      assertEquals(100, bytesRead);
+    }
+  }
+
+  @Test
+  public void testReadWithOffsetAndLength() throws IOException
+  {
+    try (InputStream inputStream = Files.newInputStream(testFile.toPath());
+         RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(RetryingGZIPInputStream.createGZIPInputStream(inputStream), null)) {
+
+      byte[] buffer = new byte[200];
+      int offset = 50;
+      int length = 100;
+      int bytesRead = retryingInputStream.read(buffer, offset, length);
+
+      assertEquals(length, bytesRead);
+    }
+  }
+
+  @Test
+  public void testWaitOrThrowNonRetryableError() throws IOException
+  {
+    String nonRetryableErrorMessage = "Simulated IOException";
+    InputStream mockInputStream = mock(InputStream.class);
+    when(mockInputStream.read()).thenThrow(new IOException(nonRetryableErrorMessage));
+
+    try (RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(mockInputStream, null)) {
+      IOException ioException = assertThrows(IOException.class, retryingInputStream::read);
+      Assert.assertEquals(nonRetryableErrorMessage, ioException.getMessage());
+    }
+  }
+
+  @Test
+  public void testWaitOrThrowRetryableError() throws IOException
+  {
+    InputStream mockDelegate = mock(InputStream.class);
+    InputStream mockInputStream = mock(InputStream.class);
+    when(mockDelegate.read()).thenThrow(new IOException(ERROR_MESSAGE)).thenReturn(1);
+
+    try (MockedStatic<RetryingGZIPInputStream> mockedStatic = Mockito.mockStatic(RetryingGZIPInputStream.class)) {
+      mockedStatic.when(() -> RetryingGZIPInputStream.createGZIPInputStream(mockInputStream)).thenReturn(mock(GZIPInputStream.class));
+
+      try (RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(mockDelegate, mockInputStream, false)) {
+        retryingInputStream.read();
+      }
+
+      verify(mockInputStream, times(1)).reset();
+    }
+  }
+
+  @Test
+  public void testWaitOrThrowRetryableErrorExceedingMaxRetries222() throws IOException
+  {
+    InputStream mockInputStream = mock(InputStream.class);
+    InputStream mockDelegate = mock(InputStream.class);
+    when(mockDelegate.read()).thenThrow(new IOException(ERROR_MESSAGE));
+
+    try (MockedStatic<RetryingGZIPInputStream> mockedStatic = Mockito.mockStatic(RetryingGZIPInputStream.class)) {
+      mockedStatic.when(() -> RetryingGZIPInputStream.createGZIPInputStream(mockInputStream)).thenThrow(new IOException(ERROR_MESSAGE));
+
+      try (RetryingGZIPInputStream retryingInputStream = new RetryingGZIPInputStream(mockDelegate, mockInputStream, false)) {
+        IOException ioException = assertThrows(IOException.class, retryingInputStream::read);
+        Assert.assertEquals(ERROR_MESSAGE, ioException.getMessage());
+      }
+      verify(mockInputStream, times(10)).reset();
+    }
+  }
+}


### PR DESCRIPTION
### Description

This PR adds retries to handle connection reset errors during GZIPInputStream. We were running into the following error if the connection resets in the middle of ingesting a gz file, causing the ingestion task to fail:
```
java.lang.RuntimeException: java.lang.IllegalStateException: java.io.EOFException: Unexpected end of ZLIB input stream
	at org.apache.druid.java.util.common.Either.valueOrThrow(Either.java:95)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.runProcessorNow(FrameProcessorExecutor.java:259)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.run(FrameProcessorExecutor.java:138)
	at org.apache.druid.msq.exec.WorkerImpl$1$2.run(WorkerImpl.java:840)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.apache.druid.query.PrioritizedListenableFutureTask.run(PrioritizedExecutorService.java:259)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.IllegalStateException: java.io.EOFException: Unexpected end of ZLIB input stream
	at org.apache.druid.data.input.impl.FastLineIterator.readNextLine(FastLineIterator.java:124)
	at org.apache.druid.data.input.impl.FastLineIterator.hasNext(FastLineIterator.java:91)
	at org.apache.druid.data.input.TextReader$1.hasNext(TextReader.java:80)
	at org.apache.druid.data.input.IntermediateRowParsingReader$1.hasNext(IntermediateRowParsingReader.java:66)
	at org.apache.druid.java.util.common.parsers.CloseableIterator$2.findNextIteratorIfNecessary(CloseableIterator.java:72)
	at org.apache.druid.java.util.common.parsers.CloseableIterator$2.hasNext(CloseableIterator.java:93)
	at org.apache.druid.java.util.common.parsers.CloseableIterator$1.hasNext(CloseableIterator.java:42)
	at org.apache.druid.msq.input.external.ExternalSegment$1$1.hasNext(ExternalSegment.java:95)
	at org.apache.druid.java.util.common.guava.BaseSequence$1.next(BaseSequence.java:115)
	at org.apache.druid.segment.RowWalker.advance(RowWalker.java:75)
	at org.apache.druid.segment.RowBasedCursor.advanceUninterruptibly(RowBasedCursor.java:110)
	at org.apache.druid.segment.RowBasedCursor.advance(RowBasedCursor.java:103)
	at org.apache.druid.msq.querykit.scan.ScanQueryFrameProcessor.populateFrameWriterAndFlushIfNeeded(ScanQueryFrameProcessor.java:342)
	at org.apache.druid.msq.querykit.scan.ScanQueryFrameProcessor.populateFrameWriterAndFlushIfNeededWithExceptionHandling(ScanQueryFrameProcessor.java:309)
	at org.apache.druid.msq.querykit.scan.ScanQueryFrameProcessor.runWithSegment(ScanQueryFrameProcessor.java:248)
	at org.apache.druid.msq.querykit.BaseLeafFrameProcessor.runIncrementally(BaseLeafFrameProcessor.java:89)
	at org.apache.druid.msq.querykit.scan.ScanQueryFrameProcessor.runIncrementally(ScanQueryFrameProcessor.java:156)
	at org.apache.druid.frame.processor.FrameProcessors$1FrameProcessorWithBaggage.runIncrementally(FrameProcessors.java:75)
	at org.apache.druid.frame.processor.FrameProcessorExecutor$1ExecutorRunnable.runProcessorNow(FrameProcessorExecutor.java:230)
	... 8 more
Caused by: java.io.EOFException: Unexpected end of ZLIB input stream
	at java.base/java.util.zip.InflaterInputStream.fill(InflaterInputStream.java:245)
	at java.base/java.util.zip.InflaterInputStream.read(InflaterInputStream.java:159)
	at java.base/java.util.zip.GZIPInputStream.read(GZIPInputStream.java:118)
	at org.apache.druid.data.input.BytesCountingInputEntity$BytesCountingInputStream.read(BytesCountingInputEntity.java:108)
	at java.base/java.io.FilterInputStream.read(FilterInputStream.java:107)
	at org.apache.druid.data.input.impl.FastLineIterator.readNextLine(FastLineIterator.java:120)
	... 26 more
```

This PR wraps the GZIPInputStream in a retry wrapper using a new class `RetryingGZIPInputStream` that handles such connection failures, and tries to continue the operation using retries.

### Test plan

1. I setup a simple http server using Python’s utility: `python -m http.server 9333` - I had wikipedia.json.gz in the same directory for the server to serve.
2. I triggered an MSQ ingestion using HTTP source as `http://localhost:9333/wikipedia.json.gz`
3. I exited the Python process immediately after starting the ingestion.
4. I verified that the task was failing at this point prior to this PR's changes. But with this PR's changes, retry mechanism kicks in.
5. I re-ran the Python server in the middle of the ongoing retries.
6. Validated that the next retry iteration was able to continue and take the task to successful completion.
7. Verified that the number of rows ingested was correct. Also tried querying the data, works fine.

##### Key changed/added classes in this PR
 * `RetryingGZIPInputStream`: Class to facilitate retries over a GZIPInputStream.
 * `RetryingInputStreamUtils`: A utils class to extract common functionality between `RetryingGZIPInputStream` and `RetryingInputStream`.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
