### PR TITLE
The default `WHERE' filter for automatically generated SQL queries is returned

### DIFF
--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -20,7 +20,7 @@ import { Button, ButtonGroup, Intent, Menu, MenuDivider, MenuItem } from '@bluep
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
 import type { SqlQuery } from '@druid-toolkit/query';
-import { SqlExpression } from "@druid-toolkit/query";
+import { SqlExpression } from '@druid-toolkit/query';
 import classNames from 'classnames';
 import copy from 'copy-to-clipboard';
 import React from 'react';

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -20,6 +20,7 @@ import { Button, ButtonGroup, Intent, Menu, MenuDivider, MenuItem } from '@bluep
 import { IconNames } from '@blueprintjs/icons';
 import { Popover2 } from '@blueprintjs/popover2';
 import type { SqlQuery } from '@druid-toolkit/query';
+import { SqlExpression } from "@druid-toolkit/query";
 import classNames from 'classnames';
 import copy from 'copy-to-clipboard';
 import React from 'react';
@@ -62,6 +63,8 @@ import { TabRenameDialog } from './tab-rename-dialog/tab-rename-dialog';
 import { WorkbenchHistoryDialog } from './workbench-history-dialog/workbench-history-dialog';
 
 import './workbench-view.scss';
+
+const LAST_DAY = SqlExpression.parse(`__time >= CURRENT_TIMESTAMP - INTERVAL '1' DAY`);
 
 function cleanupTabEntry(tabEntry: TabEntry): void {
   const discardedId = tabEntry.id;
@@ -786,6 +789,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
             columnMetadata={columnMetadataState.data}
             onQueryChange={this.handleSqlQueryChange}
             defaultSchema={defaultSchema ? defaultSchema : 'druid'}
+            defaultWhere={LAST_DAY}
             defaultTable={defaultTable}
             highlightTable={undefined}
           />


### PR DESCRIPTION
Returned the default WHERE filter to auto-generated SQL queries, which was lost after web-console updates in druid version 24.0.0 ([#12919](https://github.com/apache/druid/pull/12919), [#13169](https://github.com/apache/druid/pull/13169))

![image](https://github.com/apache/druid/assets/81567675/bf9eaa7b-0e2c-45d5-ae83-7b402eb6b964)

![image](https://github.com/apache/druid/assets/81567675/ef69028d-0d06-4b85-83b5-eb9204e80d22)


This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
