### PR TITLE
Allow user to override/specify python exec to use for build

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -147,8 +147,9 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${project.basedir}/bin/generate-binary-license.py</executable>
+                                  <executable>${python.exec}</executable>
                                     <arguments>
+                                        <argument>${project.basedir}/bin/generate-binary-license.py</argument>
                                         <argument>${project.parent.basedir}/licenses/APACHE2</argument>
                                         <argument>${project.parent.basedir}/licenses.yaml</argument>
                                         <argument>${project.parent.basedir}/LICENSE.BINARY</argument>
@@ -162,8 +163,9 @@
                                     <goal>exec</goal>
                                 </goals>
                                 <configuration>
-                                    <executable>${project.basedir}/bin/generate-binary-notice.py</executable>
+                                  <executable>${python.exec}</executable>
                                     <arguments>
+                                        <argument>${project.basedir}/bin/generate-binary-notice.py</argument>
                                         <argument>${project.parent.basedir}/NOTICE</argument>
                                         <argument>${project.parent.basedir}/licenses.yaml</argument>
                                         <argument>${project.parent.basedir}/NOTICE.BINARY</argument>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     </scm>
 
     <properties>
+        <python.exec>python3</python.exec>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <java.version>8</java.version>


### PR DESCRIPTION
Allow user to override/specify python exec to use for build

### Description

Building Druid requires Python to execute some python script like generate-binary-notice.py and generate-binary-license.py. These scripts may require packages to be installed (i.e. pyyaml). Some build environments may have python3 available but prevent job (running on that worker) to install packages to the machine python. These environments requires Python venv to be setup. This PR allows such Python venv to be specify and use in the build process.

i.e. An example build step
```
python -m venv .venv
.venv/bin/pip install pyyaml
mvn clean install package -Dpython.exec=.venv/bin/python -Pbundle-contrib-exts -Pdist....
```

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
