### PR TITLE
Fix druid.router.http.requestBuffersize not pass to Router management proxy

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
+++ b/services/src/main/java/org/apache/druid/cli/RouterJettyServerInitializer.java
@@ -176,6 +176,7 @@ public class RouterJettyServerInitializer implements JettyServerInitializer
     sh.setInitParameter("maxConnections", Integer.toString(httpClientConfig.getNumConnections()));
     sh.setInitParameter("idleTimeout", Long.toString(httpClientConfig.getReadTimeout().getMillis()));
     sh.setInitParameter("timeout", Long.toString(httpClientConfig.getReadTimeout().getMillis()));
+    sh.setInitParameter("requestBufferSize", Integer.toString(httpClientConfig.getRequestBuffersize()));
 
     return sh;
   }


### PR DESCRIPTION
Fix druid.router.http.requestBuffersize not pass to Router management proxy

### Description

When router has management proxy enabled, we were not respecting the druid.router.http.requestBuffersize set in the Configuration. This PR fix the above issue by passing the value of druid.router.http.requestBuffersize from the config to the proxy servlet

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
