### PR TITLE
Fix task context fails with non string property value

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -314,10 +314,13 @@ public class ForkingTaskRunner
                         if (context != null) {
                           for (String propName : context.keySet()) {
                             if (propName.startsWith(CHILD_PROPERTY_PREFIX)) {
-                              command.addSystemProperty(
-                                  propName.substring(CHILD_PROPERTY_PREFIX.length()),
-                                  (Object) task.getContextValue(propName)
-                              );
+                              Object contextValue = task.getContextValue(propName);
+                              if (contextValue != null) {
+                                command.addSystemProperty(
+                                    propName.substring(CHILD_PROPERTY_PREFIX.length()),
+                                    String.valueOf(contextValue)
+                                );
+                              }
                             }
                           }
                         }
@@ -920,11 +923,6 @@ public class ForkingTaskRunner
     }
 
     public CommandListBuilder addSystemProperty(String property, boolean value)
-    {
-      return addSystemProperty(property, String.valueOf(value));
-    }
-
-    public CommandListBuilder addSystemProperty(String property, Object value)
     {
       return addSystemProperty(property, String.valueOf(value));
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -316,7 +316,7 @@ public class ForkingTaskRunner
                             if (propName.startsWith(CHILD_PROPERTY_PREFIX)) {
                               command.addSystemProperty(
                                   propName.substring(CHILD_PROPERTY_PREFIX.length()),
-                                  task.getContextValue(propName)
+                                  (Object) task.getContextValue(propName)
                               );
                             }
                           }
@@ -920,6 +920,11 @@ public class ForkingTaskRunner
     }
 
     public CommandListBuilder addSystemProperty(String property, boolean value)
+    {
+      return addSystemProperty(property, String.valueOf(value));
+    }
+
+    public CommandListBuilder addSystemProperty(String property, Object value)
     {
       return addSystemProperty(property, String.valueOf(value));
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/ForkingTaskRunnerTest.java
@@ -392,6 +392,7 @@ public class ForkingTaskRunnerTest
                                + "  \"firehose\" : null,\n"
                                + "  \"context\" : {\n"
                                + "    \"druid.indexer.runner.javaOptsArray\" : [ \"-Xmx10g\", \"-Xms10g\" ],\n"
+                               + "    \"druid.indexer.fork.property.druid.processing.numThreads\" : 4,\n"
                                + "    \"druid.indexer.runner.javaOpts\" : \"-Xmx1g -Xms1g\"\n"
                                + "  }\n"
                                + "}";


### PR DESCRIPTION
Fix task context fails with non string property value

### Description

This is a regression caused by https://github.com/apache/druid/pull/14239
The above PR introduces a new method `addSystemProperty` with String type in the method definition for the property value. (Previously, we were using `StringUtils.format` which takes in Object as argument). The problem is that `task.getContextValue(propName)` has a return type which is a generic type parameter ContextValueType. This means the method can return a value of any type specified at the time of invocation. When the value of the context property is not a String, Java is still trying to call the `addSystemProperty` with String type causing the task to fail. 
i.e. if we have something like
```
  "context": {
    "druid.indexer.fork.property.druid.processing.numThreads": 4
  }
```
we'll get the error: 
```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at org.apache.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:319) [druid-indexing-service-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at org.apache.druid.indexing.overlord.ForkingTaskRunner$1.call(ForkingTaskRunner.java:171) [druid-indexing-service-31.0.0-SNAPSHOT.jar:31.0.0-SNAPSHOT]
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131) [guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75) [guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82) [guava-32.0.1-jre.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_322]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_322]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]
```

This PR fix the issue by casting the return value from `task.getContextValue(propName)` to Object and then use `addSystemProperty` with Object type for the value parameter.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
