### PR TITLE
Add timestamp field to SegmentMetadataEvent

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
+++ b/processing/src/main/java/org/apache/druid/java/util/emitter/service/SegmentMetadataEvent.java
@@ -20,6 +20,7 @@
 package org.apache.druid.java.util.emitter.service;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.timeline.DataSegment;
@@ -85,7 +86,7 @@ public class SegmentMetadataEvent implements Event
   )
   {
     this.dataSource = dataSource;
-    this.createdTime = createdTime;
+    this.createdTime = createdTime != null ? createdTime : DateTimes.nowUtc();
     this.startTime = startTime;
     this.endTime = endTime;
     this.version = version;
@@ -104,6 +105,7 @@ public class SegmentMetadataEvent implements Event
 
     return EventMap.builder()
         .put(FEED, getFeed())
+        .put("timestamp", createdTime.toString())
         .put(DATASOURCE, dataSource)
         .put(CREATED_TIME, createdTime)
         .put(START_TIME, startTime)


### PR DESCRIPTION
Add timestamp field to SegmentMetadataEvent

### Description

Every other metrics emitted by Druid has a timestamp field. The fact that the SegmentMetadataEvent metric does not have a timestamp field can cause problem for the metric system like Druid. If you are ingesting Druid's emitted to Druid, then timestamp is very important. If you are running Druid version earlier than 27 (which doesn't have https://github.com/apache/druid/pull/14413), then ingestion will fail if there is no timestamp. While if you are running Druid version later than 27, you may be dropping these no timestamp metrics. (Note that the above is assuming you do not have missingValue set for your Druid's supervisor that is ingesting Druid emitted metrics).
Anyway, let's just add a timestamp so that all metrics are consistent. 

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
