### PR TITLE
Fix retry logic in `BrokerClient` and flakey `BrokerClientTest`

### DIFF
--- a/server/src/main/java/org/apache/druid/discovery/BrokerClient.java
+++ b/server/src/main/java/org/apache/druid/discovery/BrokerClient.java
@@ -33,7 +33,6 @@ import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -88,16 +87,15 @@ public class BrokerClient
             throw DruidException.forPersona(DruidException.Persona.OPERATOR)
                                 .ofCategory(DruidException.Category.RUNTIME_FAILURE)
                                 .build("Request to broker failed due to failed response status: [%s]", responseStatus);
-          } else if (responseStatus.getCode() != HttpServletResponse.SC_OK) {
-            throw DruidException.forPersona(DruidException.Persona.OPERATOR)
-                                .ofCategory(DruidException.Category.RUNTIME_FAILURE)
-                                .build("Request to broker failed due to failed response code: [%s]", responseStatus.getCode());
           }
           return fullResponseHolder.getContent();
         },
         (throwable) -> {
           if (throwable instanceof ExecutionException) {
             return throwable.getCause() instanceof IOException || throwable.getCause() instanceof ChannelException;
+          }
+          if (throwable instanceof DruidException) {
+            return ((DruidException) throwable).getCategory() == DruidException.Category.RUNTIME_FAILURE;
           }
           return throwable instanceof IOE;
         },

--- a/server/src/test/java/org/apache/druid/discovery/BrokerClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/BrokerClientTest.java
@@ -138,7 +138,6 @@ public class BrokerClientTest extends BaseJettyTest
     );
 
     Request request = brokerClient.makeRequest(HttpMethod.POST, "/simple/error");
-    request.setContent("hello".getBytes(StandardCharsets.UTF_8));
     Assert.assertEquals("", brokerClient.sendQuery(request));
   }
 
@@ -175,7 +174,7 @@ public class BrokerClientTest extends BaseJettyTest
     @POST
     @Path("/error")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response error(String input)
+    public Response error()
     {
       return Response.status(404).build();
     }

--- a/server/src/test/java/org/apache/druid/discovery/BrokerClientTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/BrokerClientTest.java
@@ -101,7 +101,7 @@ public class BrokerClientTest extends BaseJettyTest
   }
 
   @Test
-  public void testError() throws Exception
+  public void testRetryableError() throws Exception
   {
     DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
     EasyMock.expect(druidNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(discoveryDruidNode)).anyTimes();
@@ -119,6 +119,27 @@ public class BrokerClientTest extends BaseJettyTest
     Request request = brokerClient.makeRequest(HttpMethod.POST, "/simple/flakey");
     request.setContent("hello".getBytes(StandardCharsets.UTF_8));
     Assert.assertEquals("hello", brokerClient.sendQuery(request));
+  }
+
+  @Test
+  public void testNonRetryableError() throws Exception
+  {
+    DruidNodeDiscovery druidNodeDiscovery = EasyMock.createMock(DruidNodeDiscovery.class);
+    EasyMock.expect(druidNodeDiscovery.getAllNodes()).andReturn(ImmutableList.of(discoveryDruidNode)).anyTimes();
+
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForNodeRole(NodeRole.BROKER)).andReturn(druidNodeDiscovery);
+
+    EasyMock.replay(druidNodeDiscovery, druidNodeDiscoveryProvider);
+
+    BrokerClient brokerClient = new BrokerClient(
+        httpClient,
+        druidNodeDiscoveryProvider
+    );
+
+    Request request = brokerClient.makeRequest(HttpMethod.POST, "/simple/error");
+    request.setContent("hello".getBytes(StandardCharsets.UTF_8));
+    Assert.assertEquals("", brokerClient.sendQuery(request));
   }
 
   @Path("/simple")
@@ -149,6 +170,14 @@ public class BrokerClientTest extends BaseJettyTest
         attempt += 1;
         return Response.status(504).build();
       }
+    }
+
+    @POST
+    @Path("/error")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response error(String input)
+    {
+      return Response.status(404).build();
     }
   }
 }


### PR DESCRIPTION
`BrokerClientTest` was added in [PR #14322](https://github.com/apache/druid/pull/14322). When running this test from the IDE (outside of Maven), `testError()` reliably fails. However, it passes in CI due to the Maven setting `<surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>` in the [pom.xml](https://github.com/apache/druid/blob/master/pom.xml#L141). This setting allows Maven to retry the test up to three times, and the test ultimately passes because of the retry logic in the code, but maven treats it as "flaky".

### Changes
Looking into the error handling in `BrokerClient`, it was found that the retry logic doesn't effectively handle 5xx `DruidException` categories since the HTTP error codes are converted into `DruidException`s. So the retry logic didn't fully account transient errors and this patch fixes that. We could perhaps change the semantics of the method to just use the HTTP response, or write a service client that uses the built-in mechanisms, but it'll be a larger change.

Also, I removed the code that converts all non-200 error codes into retryable 5xx DruidException categories. For example, 4xx error codes shouldn't be retried. If there are additional 500 error codes we need to retry, we can add them explicitly similar to the ones that are currently handled.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
