### PR TITLE
Materialize scan results correctly when columns are not present in the segments

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/scan/ScanResultValueFramesIterableTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanResultValueFramesIterableTest.java
@@ -111,10 +111,10 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(1, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D},
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D}
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D},
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D}
         ),
         new FrameBasedInlineDataSource(frames, SIGNATURE1).getRowsAsSequence()
     );
@@ -167,10 +167,10 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
       Assert.assertEquals(1, frames.size());
       QueryToolChestTestHelper.assertArrayResultsEquals(
           ImmutableList.of(
-              new Object[]{1L, 1.0D},
-              new Object[]{2L, 2.0D},
-              new Object[]{1L, 1.0D},
-              new Object[]{2L, 2.0D}
+              new Object[]{1000L, 1100.0D},
+              new Object[]{1001L, 1101.0D},
+              new Object[]{1000L, 1100.0D},
+              new Object[]{1001L, 1101.0D}
           ),
           new FrameBasedInlineDataSource(frames, SIGNATURE1).getRowsAsSequence()
       );
@@ -191,17 +191,17 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(2, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D}
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(0)), SIGNATURE1).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(0, 1), SIGNATURE1).getRowsAsSequence()
     );
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{3.0D, 3L},
-            new Object[]{4.0D, 4L}
+            new Object[]{2000.0D, 2100L},
+            new Object[]{2001.0D, 2101L}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(1)), SIGNATURE2).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(1, 2), SIGNATURE2).getRowsAsSequence()
     );
   }
 
@@ -217,17 +217,17 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(2, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D}
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(0)), SIGNATURE1).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(0, 1), SIGNATURE1).getRowsAsSequence()
     );
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{5.0D, 5L},
-            new Object[]{6.0D, 6L}
+            new Object[]{3000.0D, 3100L},
+            new Object[]{3001.0D, 3101L}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(1)), SIGNATURE2).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(1, 2), SIGNATURE2).getRowsAsSequence()
     );
   }
 
@@ -248,17 +248,17 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(2, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D}
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(0)), SIGNATURE1).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(0, 1), SIGNATURE1).getRowsAsSequence()
     );
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{3.0D, 3L},
-            new Object[]{4.0D, 4L}
+            new Object[]{2000.0D, 2100L},
+            new Object[]{2001.0D, 2101L}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(1)), SIGNATURE2).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(1, 2), SIGNATURE2).getRowsAsSequence()
     );
   }
 
@@ -279,17 +279,17 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(2, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{1L, 1.0D},
-            new Object[]{2L, 2.0D}
+            new Object[]{1000L, 1100.0D},
+            new Object[]{1001L, 1101.0D}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(0)), SIGNATURE1).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(0, 1), SIGNATURE1).getRowsAsSequence()
     );
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{3.0D, 3L},
-            new Object[]{4.0D, 4L}
+            new Object[]{2000.0D, 2100L},
+            new Object[]{2001.0D, 2101L}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(1)), SIGNATURE2).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames.subList(1, 2), SIGNATURE2).getRowsAsSequence()
     );
   }
 
@@ -310,12 +310,12 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     Assert.assertEquals(1, frames.size());
     QueryToolChestTestHelper.assertArrayResultsEquals(
         ImmutableList.of(
-            new Object[]{5.0D, 5L},
-            new Object[]{6.0D, 6L},
-            new Object[]{7.0D, 7L},
-            new Object[]{8.0D, 8L}
+            new Object[]{3000.0D, 3100L},
+            new Object[]{3001.0D, 3101L},
+            new Object[]{4000.0D, 4100L},
+            new Object[]{4001.0D, 4101L}
         ),
-        new FrameBasedInlineDataSource(Collections.singletonList(frames.get(0)), SIGNATURE2).getRowsAsSequence()
+        new FrameBasedInlineDataSource(frames, SIGNATURE2).getRowsAsSequence()
     );
   }
 
@@ -357,7 +357,9 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     return new ScanResultValue(
         "dummy",
         ImmutableList.of("col1", "col2"),
-        IntStream.range(1, 1 + numRows).mapToObj(i -> new Object[]{i, (double) i}).collect(Collectors.toList()),
+        IntStream.range(1000, 1000 + numRows)
+                 .mapToObj(i -> new Object[]{i, (double) i + 100})
+                 .collect(Collectors.toList()),
         SIGNATURE1
     );
   }
@@ -368,7 +370,9 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     return new ScanResultValue(
         "dummy",
         ImmutableList.of("col1", "col2"),
-        IntStream.range(3, 3 + numRows).mapToObj(i -> new Object[]{(double) i, i}).collect(Collectors.toList()),
+        IntStream.range(2000, 2000 + numRows)
+                 .mapToObj(i -> new Object[]{(double) i, i + 100})
+                 .collect(Collectors.toList()),
         SIGNATURE2
     );
   }
@@ -379,7 +383,9 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     return new ScanResultValue(
         "dummy",
         ImmutableList.of("col1", "col2", "col3"),
-        IntStream.range(5, 5 + numRows).mapToObj(i -> new Object[]{(double) i, i, null}).collect(Collectors.toList()),
+        IntStream.range(3000, 3000 + numRows)
+                 .mapToObj(i -> new Object[]{(double) i, i + 100, null})
+                 .collect(Collectors.toList()),
         SIGNATURE3
     );
   }
@@ -390,7 +396,9 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     return new ScanResultValue(
         "dummy",
         ImmutableList.of("col1", "col3", "col2"),
-        IntStream.range(7, 7 + numRows).mapToObj(i -> new Object[]{(double) i, null, i}).collect(Collectors.toList()),
+        IntStream.range(4000, 4000 + numRows)
+                 .mapToObj(i -> new Object[]{(double) i, null, i + 100})
+                 .collect(Collectors.toList()),
         SIGNATURE4
     );
   }
@@ -401,7 +409,9 @@ public class ScanResultValueFramesIterableTest extends InitializedNullHandlingTe
     return new ScanResultValue(
         "dummy",
         ImmutableList.of("col1", "col3", "col2"),
-        IntStream.range(7, 7 + numRows).mapToObj(i -> new Object[]{(double) i, i, i}).collect(Collectors.toList()),
+        IntStream.range(5000, 5000 + numRows)
+                 .mapToObj(i -> new Object[]{(double) i, i + 100, i + 200})
+                 .collect(Collectors.toList()),
         SIGNATURE4
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/BaseCalciteQueryTest.java
@@ -256,6 +256,8 @@ public class BaseCalciteQueryTest extends CalciteTestBase
       ImmutableMap.<String, Object>builder()
                   .putAll(QUERY_CONTEXT_DEFAULT)
                   .put(QueryContexts.MAX_SUBQUERY_BYTES_KEY, "100000")
+                  // Disallows the fallback to row based limiting
+                  .put(QueryContexts.MAX_SUBQUERY_ROWS_KEY, "1")
                   .build();
 
   // Add additional context to the given context map for when the

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSubqueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSubqueryTest.java
@@ -213,8 +213,8 @@ public class CalciteSubqueryTest extends BaseCalciteQueryTest
                         .build()
         ),
         ImmutableList.of(
-            new Object[]{946684800000L, "abc", null, "def", 1L},
-            new Object[]{946684800000L, "foo", "bar", null, 1L}
+            new Object[]{946684800000L, "abc", NullHandling.defaultStringValue(), "def", 1L},
+            new Object[]{946684800000L, "foo", "bar", NullHandling.defaultStringValue(), 1L}
         )
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSubqueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSubqueryTest.java
@@ -1392,7 +1392,7 @@ public class CalciteSubqueryTest extends BaseCalciteQueryTest
   {
 
     private final TempDirProducer tmpDirProducer;
-    
+
     public SubqueryComponentSupplier(TempDirProducer tempDirProducer)
     {
       super(tempDirProducer);


### PR DESCRIPTION
### Description

The query engine is unable to estimate the correct size in bytes of the subquery results when the scan query has columns which are missing from the segments. This is because the ScanQueryEngine receives all the columns of the scan query, and populates the row signature with null type if its unable to find the column in the segment. 

This PR modifies the materializing logic to materialize the results of the columns whose types are known, and check that the columns whose types are unknown always have `null` values. This is helpful because:
a. If the type is unknown and the column contains all null values, we don't need to materialize the results
b. If the type is unknown and the column contains non-null values in any row, we are running into the case of missing types, and we should throw an error. 

#### Release note
Fixes a bug causing maxSubqueryBytes to not work when segments have missing columns. 

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
