### PR TITLE
Deserialize complex dimensions in group by queries to their respective types when reading from spilled files and cached results

### DIFF
--- a/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/AggregatorsModule.java
@@ -83,6 +83,16 @@ public class AggregatorsModule extends SimpleModule
   {
     super("AggregatorFactories");
 
+    registerComplexMetricsAndSerde();
+
+    setMixInAnnotation(AggregatorFactory.class, AggregatorFactoryMixin.class);
+    setMixInAnnotation(PostAggregator.class, PostAggregatorMixin.class);
+
+    addSerializer(DoubleMeanHolder.class, DoubleMeanHolder.Serializer.INSTANCE);
+  }
+
+  public static void registerComplexMetricsAndSerde()
+  {
     ComplexMetrics.registerSerde(HyperUniquesSerde.TYPE_NAME, new HyperUniquesSerde());
     ComplexMetrics.registerSerde(PreComputedHyperUniquesSerde.TYPE_NAME, new PreComputedHyperUniquesSerde());
     ComplexMetrics.registerSerde(
@@ -102,11 +112,6 @@ public class AggregatorsModule extends SimpleModule
         SerializablePairLongLongComplexMetricSerde.TYPE_NAME,
         new SerializablePairLongLongComplexMetricSerde()
     );
-
-    setMixInAnnotation(AggregatorFactory.class, AggregatorFactoryMixin.class);
-    setMixInAnnotation(PostAggregator.class, PostAggregatorMixin.class);
-
-    addSerializer(DoubleMeanHolder.class, DoubleMeanHolder.Serializer.INSTANCE);
   }
 
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
@@ -252,13 +252,7 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
   public abstract TypeReference<ResultType> getResultTypeReference();
 
   /**
-   * Returns a CacheStrategy to be used to load data into the cache and remove it from the cache.
-   * <p>
-   * This is optional.  If it returns null, caching is effectively disabled for the query.
    *
-   * @param query The query whose results might be cached
-   * @param <T>   The type of object that will be stored in the cache
-   * @return A CacheStrategy that can be used to populate and read from the Cache
    */
   @Nullable
   public <T> CacheStrategy<ResultType, T, QueryType> getCacheStrategy(QueryType query)
@@ -266,8 +260,19 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
     return null;
   }
 
+  /**
+   * Returns a CacheStrategy to be used to load data into the cache and remove it from the cache.
+   * <p>
+   * This is optional.  If it returns null, caching is effectively disabled for the query.
+   *
+   * @param query The query whose results might be cached
+   * @param mapper Object mapper to convert the deserialized generic java objectsto desired types. It can be nullable
+   *               to preserve backward compatibility.
+   * @param <T>   The type of object that will be stored in the cache
+   * @return A CacheStrategy that can be used to populate and read from the Cache
+   */
   @Nullable
-  public <T> CacheStrategy<ResultType, T, QueryType> getCacheStrategy(QueryType query, ObjectMapper mapper)
+  public <T> CacheStrategy<ResultType, T, QueryType> getCacheStrategy(QueryType query, @Nullable ObjectMapper mapper)
   {
     return getCacheStrategy(query);
   }

--- a/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
@@ -266,6 +266,12 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
     return null;
   }
 
+  @Nullable
+  public <T> CacheStrategy<ResultType, T, QueryType> getCacheStrategy(QueryType query, ObjectMapper mapper)
+  {
+    return getCacheStrategy(query);
+  }
+
   /**
    * Wraps a QueryRunner.  The input QueryRunner is the QueryRunner as it exists *before* being passed to
    * mergeResults().

--- a/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryToolChest.java
@@ -252,8 +252,14 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
   public abstract TypeReference<ResultType> getResultTypeReference();
 
   /**
-   *
+   * Like {@link #getCacheStrategy(Query, ObjectMapper)} but the caller doesn't supply the object mapper for deserializing
+   * and converting the cached data to desired type. It's upto the individual implementations to decide the appropriate action in that case.
+   * It can either throw an exception outright or decide if the query requires the object mapper for proper downstream processing and
+   * work with the generic java types if not.
+   * <p>
+   * @deprecated Use {@link #getCacheStrategy(Query, ObjectMapper)} instead
    */
+  @Deprecated
   @Nullable
   public <T> CacheStrategy<ResultType, T, QueryType> getCacheStrategy(QueryType query)
   {
@@ -266,7 +272,7 @@ public abstract class QueryToolChest<ResultType, QueryType extends Query<ResultT
    * This is optional.  If it returns null, caching is effectively disabled for the query.
    *
    * @param query The query whose results might be cached
-   * @param mapper Object mapper to convert the deserialized generic java objectsto desired types. It can be nullable
+   * @param mapper Object mapper to convert the deserialized generic java objects to desired types. It can be nullable
    *               to preserve backward compatibility.
    * @param <T>   The type of object that will be stored in the cache
    * @return A CacheStrategy that can be used to populate and read from the Cache

--- a/processing/src/main/java/org/apache/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/datasourcemetadata/DataSourceQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.datasourcemetadata;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.inject.Inject;
@@ -38,6 +39,7 @@ import org.apache.druid.query.aggregation.MetricManipulationFn;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.timeline.LogicalSegment;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -116,6 +118,12 @@ public class DataSourceQueryQueryToolChest
 
   @Override
   public CacheStrategy getCacheStrategy(DataSourceMetadataQuery query)
+  {
+    return null;
+  }
+
+  @Override
+  public CacheStrategy getCacheStrategy(DataSourceMetadataQuery query, @Nullable ObjectMapper mapper)
   {
     return null;
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -526,8 +526,6 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
           return ResultRow.of(objectArray);
         }
       }
-
-
     };
 
     class GroupByResultRowModule extends SimpleModule

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Grouper.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.groupby.epinephelinae;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -231,6 +232,11 @@ public interface Grouper<KeyType> extends Closeable
      * @return comparator for keys + aggs
      */
     BufferComparator bufferComparatorWithAggregators(AggregatorFactory[] aggregatorFactories, int[] aggregatorOffsets);
+
+    default ObjectMapper decorateObjectMapper(ObjectMapper spillMapper)
+    {
+      return spillMapper;
+    }
 
     /**
      * Reset the keySerde to its initial state. After this method is called, {@link #readFromByteBuffer}

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Grouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/Grouper.java
@@ -233,6 +233,11 @@ public interface Grouper<KeyType> extends Closeable
      */
     BufferComparator bufferComparatorWithAggregators(AggregatorFactory[] aggregatorFactories, int[] aggregatorOffsets);
 
+    /**
+     * Decorates the object mapper enabling it to read and write query results' grouping keys. It is used by the
+     * {@link SpillingGrouper} to preserve the types of the dimensions after serializing and deserializing them on the
+     * spilled files.
+     */
     default ObjectMapper decorateObjectMapper(ObjectMapper spillMapper)
     {
       return spillMapper;

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1398,17 +1398,9 @@ public class RowBasedGrouperHelper
                   "Insufficient serde helpers present"
               );
               // Read the dimension
-              if (serdeHelpers[dimsReadSoFar - timestampAdjustment].getComplexClazz() == null) {
-                objects[dimsReadSoFar] = codec.readValue(jp, Object.class);
-                if (objects[dimsReadSoFar] instanceof Integer) {
-                  objects[dimsReadSoFar] = ((Integer) objects[dimsReadSoFar]).longValue();
-                } else if (objects[dimsReadSoFar] instanceof Double) {
-                  objects[dimsReadSoFar] = ((Double) objects[dimsReadSoFar]).floatValue();
-                }
-              } else {
-                objects[dimsReadSoFar] =
-                    codec.readValue(jp, serdeHelpers[dimsReadSoFar - timestampAdjustment].getComplexClazz());
-              }
+              serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz();
+              objects[dimsReadSoFar] =
+                  codec.readValue(jp, serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz());
             }
 
             ++dimsReadSoFar;
@@ -1649,8 +1641,7 @@ public class RowBasedGrouperHelper
     {
       final BufferComparator bufferComparator;
       final String columnTypeName;
-      @Nullable
-      final Class complexClazz;
+      final Class clazz;
 
       final List<Object> dictionary;
       final Object2IntMap<Object> reverseDictionary;
@@ -1677,9 +1668,9 @@ public class RowBasedGrouperHelper
                 dictionary.get(rhsBuffer.getInt(rhsPosition + keyBufferPosition))
             );
         if (columnType.is(ValueType.COMPLEX)) {
-          complexClazz = columnType.getNullableStrategy().getClazz();
+          clazz = columnType.getNullableStrategy().getClazz();
         } else {
-          complexClazz = null;
+          clazz = Object.class;
         }
       }
 
@@ -1714,11 +1705,10 @@ public class RowBasedGrouperHelper
         return reverseDictionary;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return complexClazz;
+        return clazz;
       }
     }
 
@@ -1802,9 +1792,8 @@ public class RowBasedGrouperHelper
         return reverseDictionary;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
         return null;
       }
@@ -1853,11 +1842,10 @@ public class RowBasedGrouperHelper
         return reverseStringArrayDictionary;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return null;
+        return Object.class;
       }
     }
 
@@ -1909,11 +1897,10 @@ public class RowBasedGrouperHelper
         return bufferComparator;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return null;
+        return Object.class;
       }
     }
 
@@ -2034,11 +2021,10 @@ public class RowBasedGrouperHelper
         return bufferComparator;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return null;
+        return Long.class;
       }
     }
 
@@ -2086,11 +2072,10 @@ public class RowBasedGrouperHelper
         return bufferComparator;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return null;
+        return Float.class;
       }
     }
 
@@ -2138,11 +2123,10 @@ public class RowBasedGrouperHelper
         return bufferComparator;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return null;
+        return Double.class;
       }
     }
 
@@ -2200,11 +2184,10 @@ public class RowBasedGrouperHelper
         return comparator;
       }
 
-      @Nullable
       @Override
-      public Class<?> getComplexClazz()
+      public Class<?> getClazz()
       {
-        return delegate.getComplexClazz();
+        return delegate.getClazz();
       }
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1712,7 +1712,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return complexClazz;
       }
@@ -1800,7 +1800,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -1851,7 +1851,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -1907,7 +1907,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -2032,7 +2032,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -2084,7 +2084,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -2136,7 +2136,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return null;
       }
@@ -2198,7 +2198,7 @@ public class RowBasedGrouperHelper
 
       @Nullable
       @Override
-      public Class getComplexClazz()
+      public Class<?> getComplexClazz()
       {
         return delegate.getComplexClazz();
       }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1641,7 +1641,7 @@ public class RowBasedGrouperHelper
     {
       final BufferComparator bufferComparator;
       final String columnTypeName;
-      final Class clazz;
+      final Class<?> clazz;
 
       final List<Object> dictionary;
       final Object2IntMap<Object> reverseDictionary;
@@ -1795,7 +1795,7 @@ public class RowBasedGrouperHelper
       @Override
       public Class<?> getClazz()
       {
-        return null;
+        return Object.class;
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1398,7 +1398,7 @@ public class RowBasedGrouperHelper
           while (jp.currentToken() != JsonToken.END_ARRAY) {
 
             DruidException.conditionalDefensive(
-                dimsReadSoFar < dimsToRead,
+                dimsReadSoFar >= dimsToRead,
                 "More dimensions encountered than expected [%d]",
                 dimsToRead
             );

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1397,16 +1397,15 @@ public class RowBasedGrouperHelper
 
           while (jp.currentToken() != JsonToken.END_ARRAY) {
 
-            DruidException.conditionalDefensive(
-                dimsReadSoFar < dimsToRead,
-                "More dimensions encountered than expected [%d]",
-                dimsToRead
-            );
+            // TODO: Remove this
+            if (dimsReadSoFar >= dimsToRead) {
+              throw DruidException.defensive("For CodeQL");
+            }
 
-            DruidException.conditionalDefensive(
-                dimsReadSoFar - timestampAdjustment < serdeHelpers.length,
-                "Insufficient serde helpers present"
-            );
+            // TODO: Remove this
+            if (dimsReadSoFar - timestampAdjustment >= serdeHelpers.length) {
+              throw DruidException.defensive("For CodeQL");
+            }
 
             // Read the dimension
             serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1376,14 +1376,14 @@ public class RowBasedGrouperHelper
           if (!jp.isExpectedStartArrayToken()) {
             throw DruidException.defensive("Expected array start token, received [%s]", jp.getCurrentToken());
           }
-
           jp.nextToken();
-          ObjectCodec codec = jp.getCodec();
 
-          int timestampAdjustment = includeTimestamp ? 1 : 0;
-          int dimsToRead = timestampAdjustment + serdeHelpers.length;
+          final ObjectCodec codec = jp.getCodec();
+          final int timestampAdjustment = includeTimestamp ? 1 : 0;
+          final int dimsToRead = timestampAdjustment + serdeHelpers.length;
           int dimsReadSoFar = 0;
-          Object[] objects = new Object[dimsToRead];
+          final Object[] objects = new Object[dimsToRead];
+
           while (jp.currentToken() != JsonToken.END_ARRAY) {
             if (dimsReadSoFar >= dimsToRead) {
               throw DruidException.defensive("More dimensions encountered than expected [%d]", dimsToRead);
@@ -1393,6 +1393,10 @@ public class RowBasedGrouperHelper
               // Read the timestamp
               objects[dimsReadSoFar] = codec.readValue(jp, Long.class);
             } else {
+              DruidException.conditionalDefensive(
+                  dimsReadSoFar - timestampAdjustment < serdeHelpers.length,
+                  "Insufficient serde helpers present"
+              );
               // Read the dimension
               if (serdeHelpers[dimsReadSoFar - timestampAdjustment].getComplexClazz() == null) {
                 objects[dimsReadSoFar] = codec.readValue(jp, Object.class);

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1382,7 +1382,7 @@ public class RowBasedGrouperHelper
           int i = 0;
           Object[] objects = new Object[serdeHelpers.length];
           while (jp.currentToken() != JsonToken.END_ARRAY) {
-            if (i > serdeHelpers.length) {
+            if (i >= serdeHelpers.length) {
               throw DruidException.defensive("not enough serde helpers");
             }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -315,8 +315,7 @@ public class RowBasedGrouperHelper
         combining,
         includeTimestamp,
         columnSelectorFactory,
-        valueTypes,
-        spillMapper
+        valueTypes
     );
 
     final Predicate<ResultRow> rowPredicate;
@@ -516,8 +515,7 @@ public class RowBasedGrouperHelper
       final boolean combining,
       final boolean includeTimestamp,
       final ColumnSelectorFactory columnSelectorFactory,
-      final List<ColumnType> valueTypes,
-      final ObjectMapper spillMapper
+      final List<ColumnType> valueTypes
   )
   {
     final TimestampExtractFunction timestampExtractFn = includeTimestamp ?
@@ -1639,7 +1637,7 @@ public class RowBasedGrouperHelper
       final BufferComparator bufferComparator;
       final String columnTypeName;
       @Nullable
-      final Class clazz;
+      final Class complexClazz;
 
       final List<Object> dictionary;
       final Object2IntMap<Object> reverseDictionary;
@@ -1666,9 +1664,9 @@ public class RowBasedGrouperHelper
                 dictionary.get(rhsBuffer.getInt(rhsPosition + keyBufferPosition))
             );
         if (columnType.is(ValueType.COMPLEX)) {
-          clazz = columnType.getNullableStrategy().getClazz();
+          complexClazz = columnType.getNullableStrategy().getClazz();
         } else {
-          clazz = null;
+          complexClazz = null;
         }
       }
 
@@ -1707,7 +1705,7 @@ public class RowBasedGrouperHelper
       @Override
       public Class getComplexClazz()
       {
-        return clazz;
+        return complexClazz;
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1396,17 +1396,8 @@ public class RowBasedGrouperHelper
           }
 
           while (jp.currentToken() != JsonToken.END_ARRAY) {
-
-            int serdeHelpersIndex = dimsReadSoFar - timestampAdjustment;
-            // TODO: Remove this
-            if (serdeHelpersIndex >= serdeHelpers.length) {
-              throw DruidException.defensive("For CodeQL");
-            }
-
-            // Read the dimension
-            serdeHelpers[serdeHelpersIndex].getClazz();
             objects[dimsReadSoFar] =
-                codec.readValue(jp, serdeHelpers[serdeHelpersIndex].getClazz());
+                codec.readValue(jp, serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz());
 
             ++dimsReadSoFar;
             jp.nextToken();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1397,20 +1397,16 @@ public class RowBasedGrouperHelper
 
           while (jp.currentToken() != JsonToken.END_ARRAY) {
 
+            int serdeHelpersIndex = dimsReadSoFar - timestampAdjustment;
             // TODO: Remove this
-            if (dimsReadSoFar >= dimsToRead) {
-              throw DruidException.defensive("For CodeQL");
-            }
-
-            // TODO: Remove this
-            if (dimsReadSoFar - timestampAdjustment >= serdeHelpers.length) {
+            if (serdeHelpersIndex >= serdeHelpers.length) {
               throw DruidException.defensive("For CodeQL");
             }
 
             // Read the dimension
-            serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz();
+            serdeHelpers[serdeHelpersIndex].getClazz();
             objects[dimsReadSoFar] =
-                codec.readValue(jp, serdeHelpers[dimsReadSoFar - timestampAdjustment].getClazz());
+                codec.readValue(jp, serdeHelpers[serdeHelpersIndex].getClazz());
 
             ++dimsReadSoFar;
             jp.nextToken();

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedGrouperHelper.java
@@ -1398,7 +1398,7 @@ public class RowBasedGrouperHelper
           while (jp.currentToken() != JsonToken.END_ARRAY) {
 
             DruidException.conditionalDefensive(
-                dimsReadSoFar >= dimsToRead,
+                dimsReadSoFar < dimsToRead,
                 "More dimensions encountered than expected [%d]",
                 dimsToRead
             );

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
@@ -23,7 +23,6 @@ import org.apache.druid.query.groupby.epinephelinae.Grouper.BufferComparator;
 import org.apache.druid.query.groupby.epinephelinae.RowBasedGrouperHelper.RowBasedKey;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 interface RowBasedKeySerdeHelper
@@ -68,10 +67,7 @@ interface RowBasedKeySerdeHelper
   BufferComparator getBufferComparator();
 
   /**
-   * If the key(dimension) is complex, returns the expected class of the objects. The class is used to deserialize the
-   * objects correctly from the spilled files. Returns null if the dimension is not complex because all other dimensions
-   * work correctly when deserialized as generic java objects without type information.
+   * Returns the expected class of the key which used to deserialize the objects correctly from the spilled files.
    */
-  @Nullable
-  Class<?> getComplexClazz();
+  Class<?> getClazz();
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
@@ -72,7 +72,6 @@ interface RowBasedKeySerdeHelper
    * objects correctly from the spilled files. Returns null if the dimension is not complex because all other dimensions
    * work correctly when deserialized as generic java objects without type information.
    */
-  @SuppressWarnings("rawtypes")
   @Nullable
-  Class getComplexClazz();
+  Class<?> getComplexClazz();
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
@@ -67,6 +67,12 @@ interface RowBasedKeySerdeHelper
    */
   BufferComparator getBufferComparator();
 
+  /**
+   * If the key(dimension) is complex, returns the expected class of the objects. The class is used to deserialize the
+   * objects correctly from the spilled files. Returns null if the dimension is not complex because all other dimensions
+   * work correctly when deserialized as generic java objects without type information.
+   */
+  @SuppressWarnings("rawtypes")
   @Nullable
   Class getComplexClazz();
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/RowBasedKeySerdeHelper.java
@@ -23,6 +23,7 @@ import org.apache.druid.query.groupby.epinephelinae.Grouper.BufferComparator;
 import org.apache.druid.query.groupby.epinephelinae.RowBasedGrouperHelper.RowBasedKey;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
 interface RowBasedKeySerdeHelper
@@ -65,4 +66,7 @@ interface RowBasedKeySerdeHelper
    * Return a {@link BufferComparator} to compare keys stored in ByteBuffer.
    */
   BufferComparator getBufferComparator();
+
+  @Nullable
+  Class getComplexClazz();
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/SpillingGrouper.java
@@ -152,7 +152,7 @@ public class SpillingGrouper<KeyType> implements Grouper<KeyType>
     }
     this.aggregatorFactories = aggregatorFactories;
     this.temporaryStorage = temporaryStorage;
-    this.spillMapper = spillMapper;
+    this.spillMapper = keySerde.decorateObjectMapper(spillMapper);
     this.spillingAllowed = spillingAllowed;
     this.sortHasNonGroupingFields = sortHasNonGroupingFields;
   }

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.metadata;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
@@ -62,6 +63,7 @@ import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -184,6 +186,15 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
 
   @Override
   public CacheStrategy<SegmentAnalysis, SegmentAnalysis, SegmentMetadataQuery> getCacheStrategy(final SegmentMetadataQuery query)
+  {
+    return getCacheStrategy(query, null);
+  }
+
+  @Override
+  public CacheStrategy<SegmentAnalysis, SegmentAnalysis, SegmentMetadataQuery> getCacheStrategy(
+      final SegmentMetadataQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
   {
     return new CacheStrategy<SegmentAnalysis, SegmentAnalysis, SegmentMetadataQuery>()
     {

--- a/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.search;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
@@ -124,6 +125,15 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
 
   @Override
   public CacheStrategy<Result<SearchResultValue>, Object, SearchQuery> getCacheStrategy(final SearchQuery query)
+  {
+    return getCacheStrategy(query, null);
+  }
+
+  @Override
+  public CacheStrategy<Result<SearchResultValue>, Object, SearchQuery> getCacheStrategy(
+      final SearchQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
   {
 
     return new CacheStrategy<Result<SearchResultValue>, Object, SearchQuery>()

--- a/processing/src/main/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.timeboundary;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
@@ -47,6 +48,7 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.timeline.LogicalSegment;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
@@ -163,6 +165,16 @@ public class TimeBoundaryQueryQueryToolChest
 
   @Override
   public CacheStrategy<Result<TimeBoundaryResultValue>, Object, TimeBoundaryQuery> getCacheStrategy(final TimeBoundaryQuery query)
+  {
+    return getCacheStrategy(query, null);
+  }
+
+
+  @Override
+  public CacheStrategy<Result<TimeBoundaryResultValue>, Object, TimeBoundaryQuery> getCacheStrategy(
+      final TimeBoundaryQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
   {
     return new CacheStrategy<Result<TimeBoundaryResultValue>, Object, TimeBoundaryQuery>()
     {

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.timeseries;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -66,6 +67,7 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -277,6 +279,16 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
 
   @Override
   public CacheStrategy<Result<TimeseriesResultValue>, Object, TimeseriesQuery> getCacheStrategy(final TimeseriesQuery query)
+  {
+    return getCacheStrategy(query, null);
+  }
+
+
+  @Override
+  public CacheStrategy<Result<TimeseriesResultValue>, Object, TimeseriesQuery> getCacheStrategy(
+      final TimeseriesQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
   {
     return new CacheStrategy<Result<TimeseriesResultValue>, Object, TimeseriesQuery>()
     {

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.topn;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -65,6 +66,7 @@ import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.column.RowSignature;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -269,9 +271,18 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
     return TYPE_REFERENCE;
   }
 
+  @Nullable
+  @Override
+  public CacheStrategy<Result<TopNResultValue>, Object, TopNQuery> getCacheStrategy(TopNQuery query)
+  {
+    return getCacheStrategy(query, null);
+  }
 
   @Override
-  public CacheStrategy<Result<TopNResultValue>, Object, TopNQuery> getCacheStrategy(final TopNQuery query)
+  public CacheStrategy<Result<TopNResultValue>, Object, TopNQuery> getCacheStrategy(
+      final TopNQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
   {
     return new CacheStrategy<Result<TopNResultValue>, Object, TopNQuery>()
     {

--- a/processing/src/main/java/org/apache/druid/segment/column/ObjectStrategyComplexTypeStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ObjectStrategyComplexTypeStrategy.java
@@ -123,7 +123,7 @@ public class ObjectStrategyComplexTypeStrategy<T> implements TypeStrategy<T>
   public int hashCode(T o)
   {
     if (hashStrategy == null) {
-      throw DruidException.defensive("hashStrategy not provided");
+      throw DruidException.defensive("Type [%s] is not groupable", typeSignature.asTypeString());
     }
     return hashStrategy.hashCode(o);
   }
@@ -132,7 +132,7 @@ public class ObjectStrategyComplexTypeStrategy<T> implements TypeStrategy<T>
   public boolean equals(T a, T b)
   {
     if (hashStrategy == null) {
-      throw DruidException.defensive("hashStrategy not provided");
+      throw DruidException.defensive("Type [%s] is not groupable", typeSignature.asTypeString());
     }
     return hashStrategy.equals(a, b);
   }
@@ -141,7 +141,7 @@ public class ObjectStrategyComplexTypeStrategy<T> implements TypeStrategy<T>
   public Class<?> getClazz()
   {
     if (clazz == null) {
-      throw DruidException.defensive("hashStrategy not provided");
+      throw DruidException.defensive("Type [%s] is not groupable", typeSignature.asTypeString());
     }
     return clazz;
   }

--- a/processing/src/main/java/org/apache/druid/segment/column/TypeStrategies.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/TypeStrategies.java
@@ -299,6 +299,12 @@ public class TypeStrategies
     {
       return a.equals(b);
     }
+
+    @Override
+    public Class<?> getClazz()
+    {
+      return Long.class;
+    }
   }
 
   /**
@@ -367,6 +373,12 @@ public class TypeStrategies
     public boolean equals(Float a, Float b)
     {
       return a.equals(b);
+    }
+
+    @Override
+    public Class<?> getClazz()
+    {
+      return Float.class;
     }
   }
 
@@ -437,6 +449,12 @@ public class TypeStrategies
     public boolean equals(Double a, Double b)
     {
       return a.equals(b);
+    }
+
+    @Override
+    public Class<?> getClazz()
+    {
+      return Double.class;
     }
   }
 
@@ -518,6 +536,12 @@ public class TypeStrategies
     public boolean equals(String a, String b)
     {
       return a.equals(b);
+    }
+
+    @Override
+    public Class<?> getClazz()
+    {
+      return String.class;
     }
   }
 
@@ -663,6 +687,12 @@ public class TypeStrategies
       } else {
         return false;
       }
+    }
+
+    @Override
+    public Class<?> getClazz()
+    {
+      return Object[].class;
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/TypeStrategy.java
@@ -225,6 +225,6 @@ public interface TypeStrategy<T> extends Comparator<Object>, Hash.Strategy<T>
    */
   default Class<?> getClazz()
   {
-    throw DruidException.defensive("Not implemented. It is only implemented for complex dimensions which are groupable()");
+    throw DruidException.defensive("Not implemented. Check groupable() first");
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -766,7 +766,7 @@ public class AggregationTestHelper implements Closeable
           String resultStr = mapper.writer().writeValueAsString(yielder);
 
           List<ResultRow> resultRows = Lists.transform(
-              readQueryResultArrayFromString(resultStr),
+              readQueryResultArrayFromString(resultStr, queryPlus.getQuery()),
               toolChest.makePreComputeManipulatorFn(
                   queryPlus.getQuery(),
                   MetricManipulatorFns.deserializing()
@@ -798,11 +798,13 @@ public class AggregationTestHelper implements Closeable
     };
   }
 
-  private List readQueryResultArrayFromString(String str) throws Exception
+  private List readQueryResultArrayFromString(String str, Query query) throws Exception
   {
     List result = new ArrayList();
 
-    JsonParser jp = mapper.getFactory().createParser(str);
+    ObjectMapper decoratedMapper = toolChest.decorateObjectMapper(mapper, query);
+
+    JsonParser jp = decoratedMapper.getFactory().createParser(str);
 
     if (jp.nextToken() != JsonToken.START_ARRAY) {
       throw new IAE("not an array [%s]", str);

--- a/processing/src/test/java/org/apache/druid/query/groupby/ComplexGroupByTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/ComplexGroupByTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.groupby;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.aggregation.AggregationTestHelper;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.SerializablePairLongString;
+import org.apache.druid.query.aggregation.SerializablePairLongStringComplexMetricSerde;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.segment.RowBasedSegment;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.timeline.SegmentId;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(Parameterized.class)
+public class ComplexGroupByTest
+{
+
+  private final QueryContexts.Vectorize vectorize;
+  private final AggregationTestHelper helper;
+  private final List<Segment> segments;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+
+  public ComplexGroupByTest(GroupByQueryConfig config, String vectorize)
+  {
+    this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
+    this.helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+        Collections.emptyList(),
+        config,
+        tempFolder
+    );
+    Sequence<Object[]> rows = Sequences.simple(
+        ImmutableList.of(
+            new Object[]{new SerializablePairLongString(1L, "abc")},
+            new Object[]{new SerializablePairLongString(1L, "abc")},
+            new Object[]{new SerializablePairLongString(1L, "def")},
+            new Object[]{new SerializablePairLongString(1L, "abc")},
+            new Object[]{new SerializablePairLongString(1L, "ghi")},
+            new Object[]{new SerializablePairLongString(1L, "def")},
+            new Object[]{new SerializablePairLongString(1L, "abc")},
+            new Object[]{new SerializablePairLongString(1L, "pqr")},
+            new Object[]{new SerializablePairLongString(1L, "xyz")},
+            new Object[]{new SerializablePairLongString(1L, "foo")},
+            new Object[]{new SerializablePairLongString(1L, "bar")}
+        )
+    );
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add(
+                                                "pair",
+                                                ColumnType.ofComplex(SerializablePairLongStringComplexMetricSerde.TYPE_NAME)
+                                            )
+                                            .build();
+
+    this.segments = Collections.singletonList(
+        new RowBasedSegment<>(
+            SegmentId.dummy("dummy"),
+            rows,
+            columnName -> {
+              final int columnNumber = rowSignature.indexOf(columnName);
+              return row -> columnNumber >= 0 ? row[columnNumber] : null;
+            },
+            rowSignature
+        )
+    );
+  }
+
+  @Parameterized.Parameters(name = "config = {0}, vectorize = {1}")
+  public static Collection<?> constructorFeeder()
+  {
+    final List<Object[]> constructors = new ArrayList<>();
+    for (GroupByQueryConfig config : GroupByQueryRunnerTest.testConfigs()) {
+      for (String vectorize : new String[]{"false", "force"}) {
+        constructors.add(new Object[]{config, vectorize});
+      }
+    }
+    return constructors;
+  }
+
+  public Map<String, Object> getContext()
+  {
+    return ImmutableMap.of(
+        QueryContexts.VECTORIZE_KEY, vectorize.toString(),
+        QueryContexts.VECTORIZE_VIRTUAL_COLUMNS_KEY, "true"
+    );
+  }
+
+  @Test
+  public void testGroupByOnPairClass()
+  {
+    if (vectorize == QueryContexts.Vectorize.FORCE) {
+      expectedException.expect(RuntimeException.class);
+      expectedException.expectMessage(
+          "Cannot vectorize!"
+      );
+    }
+
+    GroupByQuery groupQuery = GroupByQuery.builder()
+                                          .setDataSource("test_datasource")
+                                          .setGranularity(Granularities.ALL)
+                                          .setInterval(Intervals.ETERNITY)
+                                          .setDimensions(new DefaultDimensionSpec(
+                                              "pair",
+                                              "pair",
+                                              ColumnType.ofComplex(SerializablePairLongStringComplexMetricSerde.TYPE_NAME)
+                                          ))
+                                          .setAggregatorSpecs(new CountAggregatorFactory("count"))
+                                          .setContext(getContext())
+                                          .build();
+
+    List<ResultRow> resultRows = helper.runQueryOnSegmentsObjs(segments, groupQuery).toList();
+
+    Assert.assertArrayEquals(
+        new ResultRow[]{
+            ResultRow.of(new SerializablePairLongString(1L, "abc"), 4L),
+            ResultRow.of(new SerializablePairLongString(1L, "bar"), 1L),
+            ResultRow.of(new SerializablePairLongString(1L, "def"), 2L),
+            ResultRow.of(new SerializablePairLongString(1L, "foo"), 1L),
+            ResultRow.of(new SerializablePairLongString(1L, "ghi"), 1L),
+            ResultRow.of(new SerializablePairLongString(1L, "pqr"), 1L),
+            ResultRow.of(new SerializablePairLongString(1L, "xyz"), 1L)
+        },
+        resultRows.toArray()
+    );
+
+
+  }
+
+}

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChestTest.java
@@ -98,8 +98,7 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
   public static void setUpClass()
   {
     NullHandling.initializeForTests();
-    //noinspection ResultOfObjectAllocationIgnored
-    new AggregatorsModule();
+    AggregatorsModule.registerComplexMetricsAndSerde();
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChestTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query.groupby;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.google.common.base.Supplier;
@@ -134,11 +133,13 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
+
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -194,11 +195,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         )
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -256,11 +258,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setHavingSpec(new GreaterThanHavingSpec(QueryRunnerTestHelper.UNIQUE_METRIC, 10))
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -340,11 +343,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setHavingSpec(andHavingSpec2)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -431,11 +435,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setHavingSpec(havingSpec2)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -494,11 +499,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         ))
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertTrue(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -584,8 +590,9 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     CacheStrategy<ResultRow, Object, GroupByQuery> strategy =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     // test timestamps that result in integer size millis
     final ResultRow result1 = ResultRow.of(
@@ -1100,8 +1107,9 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     CacheStrategy<ResultRow, Object, GroupByQuery> strategy =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     // test timestamps that result in integer size millis
     final ResultRow result1 = ResultRow.of(
@@ -1193,11 +1201,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertFalse(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertFalse(Arrays.equals(
@@ -1229,11 +1238,12 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         .overrideContext(ImmutableMap.of(GroupByQueryConfig.CTX_KEY_APPLY_LIMIT_PUSH_DOWN, "false"))
         .build();
 
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy1 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query1, mapper);
 
     final CacheStrategy<ResultRow, Object, GroupByQuery> strategy2 =
-        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2);
+        new GroupByQueryQueryToolChest(null, null).getCacheStrategy(query2, mapper);
 
     Assert.assertFalse(Arrays.equals(strategy1.computeCacheKey(query1), strategy2.computeCacheKey(query2)));
     Assert.assertTrue(
@@ -1291,7 +1301,8 @@ public class GroupByQueryQueryToolChestTest extends InitializedNullHandlingTest
         QueryRunnerTestHelper.NOOP_QUERYWATCHER
     );
     final GroupByQueryQueryToolChest queryToolChest = new GroupByQueryQueryToolChest(groupingEngine, groupByResourcesReservationPool);
-    CacheStrategy<ResultRow, Object, GroupByQuery> cacheStrategy = queryToolChest.getCacheStrategy(query);
+    final ObjectMapper mapper = TestHelper.makeJsonMapper();
+    CacheStrategy<ResultRow, Object, GroupByQuery> cacheStrategy = queryToolChest.getCacheStrategy(query, mapper);
     Assert.assertTrue(
         "result level cache on broker server for GroupByStrategyV2 should be enabled",
         cacheStrategy.isCacheable(query, false, false)

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Sets;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.Row;
 import org.apache.druid.data.input.Rows;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IAE;
@@ -9931,7 +9932,6 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
   @Test
   public void testGroupByComplexColumn()
   {
-    cannotVectorize();
     GroupByQuery query = makeQueryBuilder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
@@ -9945,7 +9945,8 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
         .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
         .build();
 
-    expectedException.expect(RuntimeException.class);
+    expectedException.expect(DruidException.class);
+    expectedException.expectMessage("Type [COMPLEX<hyperUnique>] is not groupable");
     GroupByQueryRunnerTestHelper.runQuery(factory, runner, query);
   }
 

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -275,7 +275,7 @@ public class CachingClusteredClient implements QuerySegmentWalker
       this.responseContext = responseContext;
       this.query = queryPlus.getQuery();
       this.toolChest = warehouse.getToolChest(query);
-      this.strategy = toolChest.getCacheStrategy(query);
+      this.strategy = toolChest.getCacheStrategy(query, objectMapper);
       this.dataSourceAnalysis = query.getDataSource().getAnalysis();
 
       this.useCache = CacheUtil.isUseSegmentCache(query, strategy, cacheConfig, CacheUtil.ServerType.BROKER);

--- a/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
@@ -86,7 +86,7 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
   public Sequence<T> run(QueryPlus<T> queryPlus, ResponseContext responseContext)
   {
     Query<T> query = queryPlus.getQuery();
-    final CacheStrategy strategy = toolChest.getCacheStrategy(query);
+    final CacheStrategy strategy = toolChest.getCacheStrategy(query, mapper);
     final boolean populateCache = canPopulateCache(query, strategy);
     final boolean useCache = canUseCache(query, strategy);
 

--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -73,7 +73,7 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
     this.cache = cache;
     this.cacheConfig = cacheConfig;
     this.query = query;
-    this.strategy = queryToolChest.getCacheStrategy(query);
+    this.strategy = queryToolChest.getCacheStrategy(query, objectMapper);
     this.populateResultCache = CacheUtil.isPopulateResultCache(
         query,
         strategy,

--- a/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingQueryRunnerTest.java
@@ -68,6 +68,7 @@ import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.query.topn.TopNQueryQueryToolChest;
 import org.apache.druid.query.topn.TopNResultValue;
+import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.junit.Assert;
@@ -90,7 +91,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @RunWith(Parameterized.class)
-public class CachingQueryRunnerTest
+public class CachingQueryRunnerTest extends InitializedNullHandlingTest
 {
   @Parameterized.Parameters(name = "numBackgroundThreads={0}")
   public static Iterable<Object[]> constructorFeeder()
@@ -222,8 +223,8 @@ public class CachingQueryRunnerTest
     Cache cache = EasyMock.mock(Cache.class);
     EasyMock.replay(cache);
     CachingQueryRunner queryRunner = makeCachingQueryRunner(null, cache, toolchest, Sequences.empty());
-    Assert.assertFalse(queryRunner.canPopulateCache(query, toolchest.getCacheStrategy(query)));
-    Assert.assertFalse(queryRunner.canUseCache(query, toolchest.getCacheStrategy(query)));
+    Assert.assertFalse(queryRunner.canPopulateCache(query, toolchest.getCacheStrategy(query, null)));
+    Assert.assertFalse(queryRunner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
     queryRunner.run(QueryPlus.wrap(query));
     EasyMock.verifyUnexpectedCalls(cache);
   }
@@ -243,7 +244,7 @@ public class CachingQueryRunnerTest
 
     QueryToolChest toolchest = EasyMock.mock(QueryToolChest.class);
     Cache cache = EasyMock.mock(Cache.class);
-    EasyMock.expect(toolchest.getCacheStrategy(query)).andReturn(null);
+    EasyMock.expect(toolchest.getCacheStrategy(EasyMock.eq(query), EasyMock.anyObject())).andReturn(null);
     EasyMock.replay(cache, toolchest);
     CachingQueryRunner queryRunner = makeCachingQueryRunner(new byte[0], cache, toolchest, Sequences.empty());
     Assert.assertFalse(queryRunner.canPopulateCache(query, null));
@@ -339,7 +340,7 @@ public class CachingQueryRunnerTest
         resultSeq
     );
 
-    CacheStrategy cacheStrategy = toolchest.getCacheStrategy(query);
+    CacheStrategy cacheStrategy = toolchest.getCacheStrategy(query, null);
     Cache.NamedKey cacheKey = CacheUtil.computeSegmentCacheKey(
         CACHE_ID,
         SEGMENT_DESCRIPTOR,
@@ -383,7 +384,7 @@ public class CachingQueryRunnerTest
 
     byte[] cacheKeyPrefix = RandomUtils.nextBytes(10);
 
-    CacheStrategy cacheStrategy = toolchest.getCacheStrategy(query);
+    CacheStrategy cacheStrategy = toolchest.getCacheStrategy(query, null);
     Cache.NamedKey cacheKey = CacheUtil.computeSegmentCacheKey(
         CACHE_ID,
         SEGMENT_DESCRIPTOR,
@@ -399,7 +400,7 @@ public class CachingQueryRunnerTest
         toolchest,
         Sequences.empty()
     );
-    Assert.assertTrue(runner.canUseCache(query, toolchest.getCacheStrategy(query)));
+    Assert.assertTrue(runner.canUseCache(query, toolchest.getCacheStrategy(query, null)));
     List<Result> results = runner.run(QueryPlus.wrap(query)).toList();
     Assert.assertEquals(expectedResults.toString(), results.toString());
   }


### PR DESCRIPTION
### Description

Like https://github.com/apache/druid/pull/16511, but for keys that have been spilled or cached during the grouping process. This was not caught in the original PR since there aren't tests for it. This PR adds the necessary deserialization, as well as the tests that fail if this patch and https://github.com/apache/druid/pull/16511 aren't in.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
