### PR TITLE
update dependencies to clear CVEs

### DIFF
--- a/extensions-core/azure-extensions/pom.xml
+++ b/extensions-core/azure-extensions/pom.xml
@@ -54,6 +54,8 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
+            <!-- fixing the version here while we wait for an updated azure-sdk-bom -->
+            <version>1.12.2</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/extensions-core/druid-ranger-security/pom.xml
+++ b/extensions-core/druid-ranger-security/pom.xml
@@ -41,6 +41,12 @@
                 <artifactId>woodstox-core</artifactId>
                 <version>6.4.0</version>
             </dependency>
+            <!-- override the solrj dependency version to address: CVE-2023-50298 -->
+            <dependency>
+                <groupId>org.apache.solr</groupId>
+                <artifactId>solr-solrj</artifactId>
+                <version>8.11.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4209,7 +4209,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.12.0
+version: 1.12.2
 libraries:
   - com.azure: azure-identity
 
@@ -4307,7 +4307,7 @@ license_category: binary
 module: extensions/druid-azure-extensions
 license_name: MIT License
 copyright: Microsoft
-version: 1.15.0
+version: 1.15.1
 libraries:
   - com.microsoft.azure: msal4j
 
@@ -4871,7 +4871,7 @@ libraries:
 
 name: org.apache.solr solr-solrj
 license_category: binary
-version: 8.11.2
+version: 8.11.3
 module: druid-ranger-security
 license_name: Apache License version 2.0
 libraries:


### PR DESCRIPTION
### Description
Update dependencies:
solrj from 8.11.2 to 8.11.3 to address: CVE-2023-50298
azure-identity from 1.11.4 to 1.12.2 to address: CVE-2024-35255

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
