### PR TITLE
Fix malformed period throwing `ADMIN` persona error

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/expression/ExprUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ExprUtils.java
@@ -60,7 +60,9 @@ public class ExprUtils
     catch (IllegalArgumentException iae) {
       throw InvalidInput.exception(
           "Invalid period[%s] specified for expression[%s]: [%s]",
-          periodArg.stringify(), wrappingExpr.stringify(), iae.getMessage()
+          periodArg.stringify(), 
+          wrappingExpr.stringify(),
+          iae.getMessage()
       );
     }
     final DateTime origin;

--- a/processing/src/main/java/org/apache/druid/query/expression/ExprUtils.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/ExprUtils.java
@@ -46,7 +46,7 @@ public class ExprUtils
   }
 
   static PeriodGranularity toPeriodGranularity(
-      final Expr timeExpressionArg,
+      final Expr wrappingExpr,
       final Expr periodArg,
       @Nullable final Expr originArg,
       @Nullable final Expr timeZoneArg,
@@ -60,7 +60,7 @@ public class ExprUtils
     catch (IllegalArgumentException iae) {
       throw InvalidInput.exception(
           "Invalid period[%s] specified for expression[%s]: [%s]",
-          periodArg.eval(bindings).asString(), timeExpressionArg, iae.getMessage()
+          periodArg.stringify(), wrappingExpr.stringify(), iae.getMessage()
       );
     }
     final DateTime origin;

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
@@ -63,7 +63,7 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
     TimestampCeilExpr(final TimestampCeilExprMacro macro, final List<Expr> args)
     {
       super(macro, args);
-      this.granularity = getGranularity(args, InputBindings.nilBindings());
+      this.granularity = getGranularity(this, args, InputBindings.nilBindings());
     }
 
     @Nonnull
@@ -113,10 +113,14 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
     }
   }
 
-  private static PeriodGranularity getGranularity(final List<Expr> args, final Expr.ObjectBinding bindings)
+  private static PeriodGranularity getGranularity(
+      final Expr expr,
+      final List<Expr> args,
+      final Expr.ObjectBinding bindings
+  )
   {
     return ExprUtils.toPeriodGranularity(
-        args.get(0),
+        expr,
         args.get(1),
         args.size() > 2 ? args.get(2) : null,
         args.size() > 3 ? args.get(3) : null,
@@ -136,7 +140,7 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
     @Override
     public ExprEval eval(final ObjectBinding bindings)
     {
-      final PeriodGranularity granularity = getGranularity(args, bindings);
+      final PeriodGranularity granularity = getGranularity(this, args, bindings);
       long argTime = args.get(0).eval(bindings).asLong();
       long bucketStartTime = granularity.bucketStart(argTime);
       if (argTime == bucketStartTime) {

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampCeilExprMacro.java
@@ -116,6 +116,7 @@ public class TimestampCeilExprMacro implements ExprMacroTable.ExprMacro
   private static PeriodGranularity getGranularity(final List<Expr> args, final Expr.ObjectBinding bindings)
   {
     return ExprUtils.toPeriodGranularity(
+        args.get(0),
         args.get(1),
         args.size() > 2 ? args.get(2) : null,
         args.size() > 3 ? args.get(3) : null,

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
@@ -59,6 +59,7 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
   private static PeriodGranularity computeGranularity(final List<Expr> args, final Expr.ObjectBinding bindings)
   {
     return ExprUtils.toPeriodGranularity(
+        args.get(0),
         args.get(1),
         args.size() > 2 ? args.get(2) : null,
         args.size() > 3 ? args.get(3) : null,

--- a/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/TimestampFloorExprMacro.java
@@ -56,10 +56,14 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
     }
   }
 
-  private static PeriodGranularity computeGranularity(final List<Expr> args, final Expr.ObjectBinding bindings)
+  private static PeriodGranularity computeGranularity(
+      final Expr expr,
+      final List<Expr> args,
+      final Expr.ObjectBinding bindings
+  )
   {
     return ExprUtils.toPeriodGranularity(
-        args.get(0),
+        expr,
         args.get(1),
         args.size() > 2 ? args.get(2) : null,
         args.size() > 3 ? args.get(3) : null,
@@ -74,7 +78,7 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
     TimestampFloorExpr(final TimestampFloorExprMacro macro, final List<Expr> args)
     {
       super(macro, args);
-      this.granularity = computeGranularity(args, InputBindings.nilBindings());
+      this.granularity = computeGranularity(this, args, InputBindings.nilBindings());
     }
 
     /**
@@ -171,7 +175,7 @@ public class TimestampFloorExprMacro implements ExprMacroTable.ExprMacro
     @Override
     public ExprEval eval(final ObjectBinding bindings)
     {
-      final PeriodGranularity granularity = computeGranularity(args, bindings);
+      final PeriodGranularity granularity = computeGranularity(this, args, bindings);
       return ExprEval.of(granularity.bucketStart(args.get(0).eval(bindings).asLong()));
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlanner.java
@@ -200,7 +200,7 @@ public class CalcitePlanner implements Planner, ViewExpander
 
     state = CalcitePlanner.State.STATE_2_READY;
 
-    // If user specify own traitDef, instead of default default trait,
+    // If user specifies own traitDef, instead of default trait,
     // register the trait def specified in traitDefs.
     if (this.traitDefs == null) {
       planner.addRelTraitDef(ConventionTraitDef.INSTANCE);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.sql.calcite;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -127,6 +128,28 @@ public class CalciteSelectQueryTest extends BaseCalciteQueryTest
                 .build()
         ),
         ImmutableList.of(new Object[]{"[\"Hello\",null]"})
+    );
+  }
+
+  @Test
+  public void testTimeFloorContainingInvalidPeriod()
+  {
+    testQueryThrows(
+        "SELECT TIME_FLOOR(__time, 'PT1D') FROM foo",
+        DruidExceptionMatcher.invalidInput().expectMessageContains(
+            "Invalid period[PT1D] specified for expression[__time]"
+        )
+    );
+  }
+
+  @Test
+  public void testTimeFloorContainingInvalidPeriod2()
+  {
+    testQueryThrows(
+        "SELECT TIME_FLOOR(CURRENT_TIMESTAMP, 'PT1Y')",
+        DruidExceptionMatcher.invalidInput().expectMessageContains(
+            "Invalid period[PT1Y] specified for expression[946684800000]"
+        )
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSelectQueryTest.java
@@ -132,23 +132,23 @@ public class CalciteSelectQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testTimeFloorContainingInvalidPeriod()
+  public void testTimeCeilExpressionContainingInvalidPeriod()
   {
     testQueryThrows(
-        "SELECT TIME_FLOOR(__time, 'PT1D') FROM foo",
+        "SELECT TIME_CEIL(__time, 'PT1Y') FROM foo",
         DruidExceptionMatcher.invalidInput().expectMessageContains(
-            "Invalid period[PT1D] specified for expression[__time]"
+            "Invalid period['PT1Y'] specified for expression[timestamp_ceil(\"__time\", 'PT1Y', null, 'UTC')]"
         )
     );
   }
 
   @Test
-  public void testTimeFloorContainingInvalidPeriod2()
+  public void testTimeFloorExpressionContainingInvalidPeriod()
   {
     testQueryThrows(
-        "SELECT TIME_FLOOR(CURRENT_TIMESTAMP, 'PT1Y')",
+        "SELECT TIME_FLOOR(TIMESTAMPADD(DAY, -1, __time), 'PT1D') FROM foo",
         DruidExceptionMatcher.invalidInput().expectMessageContains(
-            "Invalid period[PT1Y] specified for expression[946684800000]"
+            "Invalid period['PT1D'] specified for expression[timestamp_floor((\"__time\" + -86400000), 'PT1D', null, 'UTC')]"
         )
     );
   }


### PR DESCRIPTION
@amaechler found out that when an invalid period is specified to the `TIME_FLOOR` function, the `DruidException` thrown by the Calcite planner targets the `ADMIN` persona rather than `USER`. This is easy to reproduce by running: `"SELECT TIME_FLOOR(CURRENT_TIMESTAMP, 'PT1Y')"` in the web-console.

This PR fixes the persona by explicitly handling the `IllegalArgumentException` thrown during the Joda Time period instantiation, and make the exception user-facing. Also, the error message is now decorated with more context.


This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
