### PR TITLE
Docs: update link and title of quickstart 

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 id: index
 title: "Local quickstart"
-sidebar_label: Local Quickstart
+sidebar_label: Local quickstart
 ---
 
 <!--

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,7 +1,7 @@
 ---
 id: index
-title: "Quickstart (local)"
-sidebar_label: Quickstart (local)
+title: "Local quickstart"
+sidebar_label: Local Quickstart
 ---
 
 <!--
@@ -53,7 +53,7 @@ dedicated user account for running Druid.
 
 ## Install Druid
 
-Download the [{{DRUIDVERSION}} release](https://www.apache.org/dyn/closer.cgi?path=/druid/{{DRUIDVERSION}}/apache-druid-{{DRUIDVERSION}}-bin.tar.gz) from Apache Druid. 
+Download the [{{DRUIDVERSION}} release](https://druid.apache.org/downloads/) from Apache Druid. 
 
 In your terminal, extract the file and change directories to the distribution directory:
 

--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,5 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "replace-in-file": "^4.3.1"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -39,5 +39,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "replace-in-file": "^4.3.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Updates the download link in the quickstart to use the internal download page rather than route to external domain. Also updates title to be "Local quickstart" instead of "Quickstart (local)"
This PR has:
- [x] been self-reviewed.