### PR TITLE
Fix flaky test in RetryableS3OutputStreamTest

### DIFF
--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -304,14 +304,8 @@ public class RetryableS3OutputStreamTest
       Set<Integer> partNumbersFromRequest = partRequests.stream().map(UploadPartRequest::getPartNumber).collect(Collectors.toSet());
       Assert.assertEquals(partRequests.size(), partNumbersFromRequest.size());
 
-      int numChunksOfChunkSize = 0;
-      long fileSize = expectedFileSize;
-      while (fileSize - chunkSize >= 0) {
-        fileSize -= chunkSize;
-        numChunksOfChunkSize++;
-      }
-
-      final int numChunksOfSmallerSize = fileSize == 0 ? 0 : 1;
+      final long numChunksOfChunkSize = expectedFileSize / chunkSize;
+      final int numChunksOfSmallerSize = expectedFileSize % chunkSize == 0 ? 0 : 1;
 
       // Validate part sizes
       final long numOfExactChunks = partRequests.stream().filter(part -> part.getPartSize() == chunkSize).count();

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -175,8 +175,7 @@ public class RetryableS3OutputStreamTest
   public void testWriteSmallBufferExactChunkSizeShouldSucceed() throws IOException
   {
     chunkSize = 128;
-    final int numChunks = 5;
-    final long fileSize = chunkSize * numChunks;
+    final int fileSize = 128 * 5;
     try (RetryableS3OutputStream out = new RetryableS3OutputStream(
         config,
         s3,
@@ -188,7 +187,7 @@ public class RetryableS3OutputStreamTest
       }
     }
     // each chunk 128 bytes, so there should be 5 chunks.
-    Assert.assertEquals(numChunks, s3.partRequests.size());
+    Assert.assertEquals(5, s3.partRequests.size());
     s3.assertCompleted(chunkSize, fileSize);
   }
 
@@ -312,11 +311,11 @@ public class RetryableS3OutputStreamTest
         numChunksOfChunkSize++;
       }
 
-      int numChunksOfSmallerSize = fileSize == 0 ? 0 : 1;
+      final int numChunksOfSmallerSize = fileSize == 0 ? 0 : 1;
 
       // Validate part sizes
-      long numOfExactChunks = partRequests.stream().filter(part -> part.getPartSize() == chunkSize).count();
-      long numOfSmallerChunks = partRequests.stream().filter(part -> part.getPartSize() < chunkSize).count();
+      final long numOfExactChunks = partRequests.stream().filter(part -> part.getPartSize() == chunkSize).count();
+      final long numOfSmallerChunks = partRequests.stream().filter(part -> part.getPartSize() < chunkSize).count();
 
       Assert.assertEquals(numChunksOfChunkSize, numOfExactChunks);
       Assert.assertEquals(numChunksOfSmallerSize, numOfSmallerChunks);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -304,10 +304,9 @@ public class RetryableS3OutputStreamTest
       Set<Integer> partNumbersFromRequest = partRequests.stream().map(UploadPartRequest::getPartNumber).collect(Collectors.toSet());
       Assert.assertEquals(partRequests.size(), partNumbersFromRequest.size());
 
+      // Validate number of chunks uploaded.
       final long numChunksOfChunkSize = expectedFileSize / chunkSize;
       final int numChunksOfSmallerSize = expectedFileSize % chunkSize == 0 ? 0 : 1;
-
-      // Validate part sizes
       final long numOfExactChunks = partRequests.stream().filter(part -> part.getPartSize() == chunkSize).count();
       final long numOfSmallerChunks = partRequests.stream().filter(part -> part.getPartSize() < chunkSize).count();
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -172,6 +172,27 @@ public class RetryableS3OutputStreamTest
   }
 
   @Test
+  public void testWriteSmallBufferExactChunkSizeShouldSucceed() throws IOException
+  {
+    chunkSize = 128;
+    final int numChunks = 5;
+    final long fileSize = chunkSize * numChunks;
+    try (RetryableS3OutputStream out = new RetryableS3OutputStream(
+        config,
+        s3,
+        path,
+        s3UploadManager
+    )) {
+      for (int i = 0; i < fileSize; i++) {
+        out.write(i);
+      }
+    }
+    // each chunk 128 bytes, so there should be 5 chunks.
+    Assert.assertEquals(numChunks, s3.partRequests.size());
+    s3.assertCompleted(chunkSize, fileSize);
+  }
+
+  @Test
   public void testSuccessToUploadAfterRetry() throws IOException
   {
     final TestAmazonS3 s3 = new TestAmazonS3(1);
@@ -284,13 +305,22 @@ public class RetryableS3OutputStreamTest
       Set<Integer> partNumbersFromRequest = partRequests.stream().map(UploadPartRequest::getPartNumber).collect(Collectors.toSet());
       Assert.assertEquals(partRequests.size(), partNumbersFromRequest.size());
 
-      for (int i = 0; i < partRequests.size(); i++) {
-        if (i < partRequests.size() - 1) {
-          Assert.assertEquals(chunkSize, partRequests.get(i).getPartSize());
-        } else {
-          Assert.assertTrue(chunkSize >= partRequests.get(i).getPartSize());
-        }
+      int numChunksOfChunkSize = 0;
+      long fileSize = expectedFileSize;
+      while (fileSize - chunkSize >= 0) {
+        fileSize -= chunkSize;
+        numChunksOfChunkSize++;
       }
+
+      int numChunksOfSmallerSize = fileSize == 0 ? 0 : 1;
+
+      // Validate part sizes
+      long numOfExactChunks = partRequests.stream().filter(part -> part.getPartSize() == chunkSize).count();
+      long numOfSmallerChunks = partRequests.stream().filter(part -> part.getPartSize() < chunkSize).count();
+
+      Assert.assertEquals(numChunksOfChunkSize, numOfExactChunks);
+      Assert.assertEquals(numChunksOfSmallerSize, numOfSmallerChunks);
+
       final List<PartETag> eTags = completeRequest.getPartETags();
       Assert.assertEquals(partRequests.size(), eTags.size());
       Assert.assertEquals(


### PR DESCRIPTION
### Description

As part of https://github.com/apache/druid/pull/16481, we have started uploading the chunks in parallel. That means that it's not necessary for the `part that was uploaded at the last` to be less than or equal to the `chunkSize` (as the final part could've been uploaded earlier).

This made a test in RetryableS3OutputStreamTest flaky where we were asserting that the final part should be smaller than chunk size.

This PR fixes the test, and also adds another test where the file size is such that all chunk sizes would be of equal size.

<hr>

This PR has:

-  [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
