### PR TITLE
fix greatest/least function non-vectorized processing to ignore null argument types

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -622,11 +622,10 @@ public interface Function extends NamedFunction
         ExprEval<?> exprEval = expr.eval(bindings);
         ExpressionType exprType = exprEval.type();
 
-        if (isValidType(exprType)) {
-          outputType = ExpressionTypeConversion.function(outputType, exprType);
-        }
-
         if (exprEval.value() != null) {
+          if (isValidType(exprType)) {
+            outputType = ExpressionTypeConversion.function(outputType, exprType);
+          }
           evals.add(exprEval);
         }
       }

--- a/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -677,6 +677,7 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("greatest()", null);
     assertExpr("greatest(null, null)", null);
     assertExpr("greatest(1, null, 'A')", "A");
+    assertExpr("greatest(1.0, 1, null)", 1.0);
   }
 
   @Test
@@ -703,6 +704,7 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("least()", null);
     assertExpr("least(null, null)", null);
     assertExpr("least(1, null, 'A')", "1");
+    assertExpr("least(1.0, 1, null)", 1.0);
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/GreatestExpressionTest.java
@@ -214,7 +214,7 @@ public class GreatestExpressionTest extends CalciteTestBase
   }
 
   @Test
-  public void testDecimalWithNullShouldReturnString()
+  public void testDecimalWithNullShouldNotReturnString()
   {
     testExpression(
         Arrays.asList(
@@ -227,7 +227,7 @@ public class GreatestExpressionTest extends CalciteTestBase
             null,
             3.4
         ),
-        "3.4"
+        3.4
     );
   }
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/LeastExpressionTest.java
@@ -214,7 +214,7 @@ public class LeastExpressionTest extends CalciteTestBase
   }
 
   @Test
-  public void testDecimalWithNullShouldReturnString()
+  public void testDecimalWithNullShouldNotReturnString()
   {
     testExpression(
         Arrays.asList(
@@ -227,7 +227,7 @@ public class LeastExpressionTest extends CalciteTestBase
             3.4,
             null
         ),
-        "1.2"
+        1.2
     );
   }
 


### PR DESCRIPTION
### Description
Fixes a flaw in `greatest` and `least` functions non-vectorized expression processing to ignore `null` valued arguments for determining the output type. For example, given an expression like `least(1.0, 1, null)`, the `getOutputType` method correctly chooses `DOUBLE` as the output type, however during non-vectorized processing, we incorrectly consider it, which ends up with the default `STRING` output type, resulting in incorrectly using the `STRING` comparator instead of the double comparator as expected. This can cause odd effects and incorrect results because values like `1.0` and `1` are considered distinct when using the string comparator, while the same when using a numeric comparator.

The added tests fail without the changes in this PR.

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
