### PR TITLE
Fix Intellij inspection error (exception never thrown)

### DIFF
--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -3257,7 +3257,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   }
 
   @Test
-  public void testRetrieveUnusedSegmentsForExactIntervalAndVersion() throws Exception
+  public void testRetrieveUnusedSegmentsForExactIntervalAndVersion()
   {
     DataSegment unusedForDifferentVersion = createSegment(
         Intervals.of("2024/2025"),


### PR DESCRIPTION
Noticed the following Intellij inspection error in https://github.com/apache/druid/actions/runs/9656925855/job/26635255971 on my PR:
```
Error:  server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java:3260 -- The declared exception <code>Exception</code> is never thrown
Error: Process completed with exit code 1.
```

I also see this Intellij check failure in the merge commit of https://github.com/apache/druid/pull/16602 on master (strangely the check succeeded on the PR branch itself 😅).


This PR has:

- [x] been self-reviewed.