### PR TITLE
Fix RuntimeException during ordered scan MSQ query

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
@@ -185,7 +185,7 @@ public class ScanQueryKit implements QueryKit<ScanQuery>
                          .inputs(new StageInputSpec(firstStageNumber))
                          .signature(signatureToUse)
                          .maxWorkerCount(1)
-                         .shuffleSpec(null) // no shuffling should be required after a limit processor.
+                         .shuffleSpec(MixShuffleSpec.instance()) // no shuffling should be required after a limit processor.
                          .processorFactory(
                              new OffsetLimitFrameProcessorFactory(
                                  queryToRun.getScanRowsOffset(),


### PR DESCRIPTION
Resolved a runtime exception triggered by executing limited and ordered scan queries via the MSQ engine. 

![image](https://github.com/apache/druid/assets/81567675/5b7b0b1c-56b2-4cd0-b9aa-a31fea932874)

```
java.lang.RuntimeException: org.apache.druid.java.util.common.IOE: Encountered error while reading the output of stage [1], partition [1] for worker [0]
	at org.apache.druid.msq.exec.ControllerImpl.lambda$getFinalResultsYielder$18(ControllerImpl.java:1729)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at org.apache.druid.msq.exec.ControllerImpl.getFinalResultsYielder(ControllerImpl.java:1732)
	at org.apache.druid.msq.exec.ControllerImpl.runTask(ControllerImpl.java:437)
	at org.apache.druid.msq.exec.ControllerImpl.run(ControllerImpl.java:372)
	at org.apache.druid.msq.indexing.MSQControllerTask.runTask(MSQControllerTask.java:258)
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:179)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:478)
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:450)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.druid.java.util.common.IOE: Encountered error while reading the output of stage [1], partition [1] for worker [0]
	at org.apache.druid.msq.shuffle.input.DurableStorageInputChannelFactory.openChannel(DurableStorageInputChannelFactory.java:132)
	at org.apache.druid.msq.indexing.InputChannelsImpl.openChannels(InputChannelsImpl.java:188)
	at org.apache.druid.msq.indexing.InputChannelsImpl.openUnsorted(InputChannelsImpl.java:158)
	at org.apache.druid.msq.indexing.InputChannelsImpl.openChannel(InputChannelsImpl.java:100)
	at org.apache.druid.msq.exec.ControllerImpl.lambda$getFinalResultsYielder$18(ControllerImpl.java:1720)
	... 21 more
Caused by: org.apache.druid.java.util.common.ISE: Could not find remote outputs of stage [1] partition [1] for worker [0] at the path [query-results/controller_query-42c2151c-5655-4fc0-b7da-e5e30551f00f/stage_1/worker_0/taskId_query-42c2151c-5655-4fc0-b7da-e5e30551f00f-worker0_0/part_1]
	at org.apache.druid.msq.shuffle.input.DurableStorageInputChannelFactory.openChannel(DurableStorageInputChannelFactory.java:113)
	... 25 more
```

The main problem was that the system [expected multiple partitions](https://github.com/apache/druid/blob/b772277d3b86022759178a5e310d7bdbef332c6a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java#L2921) to be made, but in reality, [only one partition was created by the OffsetLimitFrameProcessorFactory](https://github.com/apache/druid/blob/990fd5f5fbbc0140c8ff7f17af84216ce45b53f0/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/common/OffsetLimitFrameProcessorFactory.java#L114). 
During  [handling process caused by ShuffleSpec == null](https://github.com/apache/druid/blob/b772277d3b86022759178a5e310d7bdbef332c6a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerStageTracker.java#L932), expected partitions were counted based on workerInputs, which were created based on slicer from the [stageTracker of previous stage](https://github.com/apache/druid/blob/b772277d3b86022759178a5e310d7bdbef332c6a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/controller/ControllerQueryKernel.java#L370).

When using MixShuffleSpec at the limit stage, it results in creating just one partition for the stage's outcomes, which seems to be the behavior we expect.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
