### PR TITLE
fix vector grouping expression deferred evaluation to only consider dictionary encoded strings as fixed width

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
@@ -71,7 +71,7 @@ public enum DeferExpressionDimensions
           return false;
         }
 
-        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedScalarString(capabilities)) {
+        if (!capabilities.isNumeric() && !isDictionaryEncodedScalarString(capabilities)) {
           // Not fixed-width.
           return false;
         }
@@ -106,7 +106,7 @@ public enum DeferExpressionDimensions
 
         allNumericInputs = allNumericInputs && capabilities.isNumeric();
 
-        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedScalarString(capabilities)) {
+        if (!capabilities.isNumeric() && !isDictionaryEncodedScalarString(capabilities)) {
           // Not fixed-width.
           return false;
         }

--- a/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
@@ -71,7 +71,7 @@ public enum DeferExpressionDimensions
           return false;
         }
 
-        if (!capabilities.isNumeric() && !capabilities.isDictionaryEncoded().isTrue()) {
+        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedString(capabilities)) {
           // Not fixed-width.
           return false;
         }
@@ -106,7 +106,7 @@ public enum DeferExpressionDimensions
 
         allNumericInputs = allNumericInputs && capabilities.isNumeric();
 
-        if (!capabilities.isNumeric() && !capabilities.isDictionaryEncoded().isTrue()) {
+        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedString(capabilities)) {
           // Not fixed-width.
           return false;
         }
@@ -160,6 +160,16 @@ public enum DeferExpressionDimensions
   public String toString()
   {
     return jsonName;
+  }
+
+
+  /**
+   * {@link VectorColumnSelectorFactory} currently can only make dictionary encoded selectors for string types, so
+   * we can only consider them as fixed width
+   */
+  private static boolean isDictionaryEncodedString(ColumnCapabilities capabilities)
+  {
+    return capabilities.isDictionaryEncoded().isTrue() && capabilities.is(ValueType.STRING);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/DeferExpressionDimensions.java
@@ -71,7 +71,7 @@ public enum DeferExpressionDimensions
           return false;
         }
 
-        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedString(capabilities)) {
+        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedScalarString(capabilities)) {
           // Not fixed-width.
           return false;
         }
@@ -106,7 +106,7 @@ public enum DeferExpressionDimensions
 
         allNumericInputs = allNumericInputs && capabilities.isNumeric();
 
-        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedString(capabilities)) {
+        if (!capabilities.isNumeric() && !DeferExpressionDimensions.isDictionaryEncodedScalarString(capabilities)) {
           // Not fixed-width.
           return false;
         }
@@ -165,11 +165,20 @@ public enum DeferExpressionDimensions
 
   /**
    * {@link VectorColumnSelectorFactory} currently can only make dictionary encoded selectors for string types, so
-   * we can only consider them as fixed width
+   * we can only consider them as fixed width. Additionally, to err on the side of safety, multi-value string columns
+   * are also not considered fixed width because expressions process multi-value dimensions as single rows, so we would
+   * need all dictionary ids to be present in the combined key.
+   *
+   * At the time of this javadoc, vector group by does not support multi-value dimensions anyway, so this isn't really
+   * a problem, but if it did, we could consider allowing them if we ensure that all multi-value inputs are used as
+   * scalars and so the expression can be applied separately to each individual dictionary id (e.g. the equivalent of
+   * {@link ExpressionPlan.Trait#SINGLE_INPUT_MAPPABLE} but for all multi-value string inputs of the expression).
    */
-  private static boolean isDictionaryEncodedString(ColumnCapabilities capabilities)
+  private static boolean isDictionaryEncodedScalarString(ColumnCapabilities capabilities)
   {
-    return capabilities.isDictionaryEncoded().isTrue() && capabilities.is(ValueType.STRING);
+    return capabilities.isDictionaryEncoded().isTrue() &&
+           capabilities.is(ValueType.STRING) &&
+           capabilities.hasMultipleValues().isFalse();
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.expression.TestExprMacroTable;
+import org.apache.druid.query.groupby.DeferExpressionDimensions;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
@@ -234,6 +235,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertNull(thePlan.getOutputType());
     Assert.assertNull(thePlan.inferColumnCapabilities(null));
     // no we cannot
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -269,6 +292,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
     Assert.assertFalse(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -348,6 +393,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
     Assert.assertFalse(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -386,6 +452,30 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
     Assert.assertTrue(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    // innately deferrable
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+
 
     // multiple input columns
     thePlan = plan("concat(scalar_dictionary_string, scalar_dictionary_string_nonunique)");
@@ -430,6 +520,29 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertFalse(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
 
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+
+
     // array output of dictionary encoded string are not considered single scalar/mappable, nor vectorizable
     thePlan = plan("array(scalar_dictionary_string)");
     Assert.assertTrue(
@@ -446,6 +559,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
             ExpressionPlan.Trait.VECTORIZABLE
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
         )
     );
   }
@@ -481,6 +615,29 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertTrue(inferred.hasBitmapIndexes());
     Assert.assertFalse(inferred.hasSpatialIndexes());
 
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+
+
     thePlan = plan("concat(scalar_string, multi_dictionary_string_nonunique)");
     Assert.assertTrue(
         thePlan.is(
@@ -509,6 +666,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertNotNull(inferred);
     Assert.assertEquals(ValueType.STRING, inferred.getType());
     Assert.assertTrue(inferred.hasMultipleValues().isTrue());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     thePlan = plan("concat(multi_dictionary_string, multi_dictionary_string_nonunique)");
     Assert.assertTrue(
@@ -541,6 +720,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertEquals(ValueType.STRING, inferred.getType());
     Assert.assertTrue(inferred.hasMultipleValues().isTrue());
 
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+
     thePlan = plan("array_append(multi_dictionary_string, 'foo')");
     Assert.assertTrue(
         thePlan.is(
@@ -554,6 +755,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
             ExpressionPlan.Trait.NON_SCALAR_INPUTS,
             ExpressionPlan.Trait.VECTORIZABLE
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
         )
     );
   }
@@ -582,6 +804,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     thePlan = plan("concat(multi_dictionary_string, multi_dictionary_string_nonunique)");
     Assert.assertTrue(
@@ -631,6 +874,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     // incomplete and unknown skip output type since we don't reliably know
     Assert.assertNull(thePlan.getOutputType());
     Assert.assertNull(thePlan.inferColumnCapabilities(null));
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -667,14 +932,78 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     Assert.assertEquals("array_append(\"scalar_string\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
     Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
 
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+
     // multi-valued are cool too
     thePlan = plan("array_append(multi_dictionary_string, 'x')");
     assertArrayInAndOut(thePlan);
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     // what about incomplete inputs with arrays? they are not reported as incomplete because they are treated as arrays
     thePlan = plan("array_append(string_unknown, 'x')");
     assertArrayInAndOut(thePlan);
     Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     // what about if it is the scalar argument? there it is
     thePlan = plan("array_append(multi_dictionary_string, string_unknown)");
@@ -696,13 +1025,76 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
     // incomplete and unknown skip output type since we don't reliably know
     Assert.assertNull(thePlan.getOutputType());
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     // array types are cool too
     thePlan = plan("array_append(string_array_1, 'x')");
     assertArrayInAndOut(thePlan);
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     thePlan = plan("array_append(string_array_1, 'x')");
     assertArrayInAndOut(thePlan);
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
 
@@ -731,6 +1123,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
     Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
 
     // what about a multi-valued input
     thePlan = plan("array_to_string(array_append(scalar_string, multi_dictionary_string), ',')");
@@ -761,6 +1175,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
     // why is this null
     Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -864,6 +1300,29 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         ColumnType.NESTED_DATA.getComplexTypeName(),
         inferred.getComplexTypeName()
     );
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    // all numeric inputs so these are true
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertTrue(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   @Test
@@ -895,6 +1354,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         inferred.getType()
     );
     Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+
+    Assert.assertFalse(
+        DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
+    Assert.assertFalse(
+        DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
+            thePlan,
+            thePlan.getAnalysis().getRequiredBindingsList(),
+            SYNTHETIC_INSPECTOR
+        )
+    );
   }
 
   private static ExpressionPlan plan(String expression)


### PR DESCRIPTION
Follow up to #16338, modifies the logic to only consider `STRING` type columns as dictionary encoded instead of anything with `ColumnCapabilities.isDictionaryEncoded` set to true. This was a problem because currently `VectorColumnSelectorFactory` can only make dictionary encoded selectors for `STRING` typed columns, so any other type that is non-numeric but dictionary encoded cannot currently take advantage of this functionality.