### PR TITLE
docs: add redirect for kafka lookups

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -21,6 +21,10 @@
 
 const Redirects=[
   {
+    "from": "/docs/latest/development/extensions-core/kafka-extraction-namespace/",
+    "to": "/docs/latest/querying/kafka-extraction-namespace"
+  },
+  {
     "from": [
       "/docs/latest/configuration/auth.html",
       "/docs/latest/design/auth.html"


### PR DESCRIPTION
Adds a redirect since the file was moved in a separate PR.

To test, launch a local version of a production build,e.g.

```
localhost:8084/docs/latest/development/extensions-core/kafka-extraction-namespace/
```

Should redirect properly to `docs/latest/querying/kafka-extraction-namespace`

Will also backport this to the 30 branch

This PR has:

- [x] been self-reviewed.
