### PR TITLE
Addition to subquery limit migration guide

### DIFF
--- a/docs/release-info/migr-subquery-limit.md
+++ b/docs/release-info/migr-subquery-limit.md
@@ -52,7 +52,7 @@ This property takes precedence over `maxSubqueryRows`.
 You can set both `maxSubqueryRows` and `maxSubqueryBytes` at cluster level and override them in individual queries. 
 See [Overriding default query context values](../configuration#overriding-default-query-context-values) for more information.
 
-Make sure you enable `SubqueryCountStatsMonitor` so that Druid emits metrics for subquery statistics.
+Make sure you enable the Broker monitor `SubqueryCountStatsMonitor` so that Druid emits metrics for subquery statistics.
 To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your `common.runtime.properties` configuration file.
 See [Metrics monitors](../configuration#metrics-monitors) for more information.
 

--- a/docs/release-info/migr-subquery-limit.md
+++ b/docs/release-info/migr-subquery-limit.md
@@ -53,7 +53,7 @@ You can set both `maxSubqueryRows` and `maxSubqueryBytes` at cluster level and o
 See [Overriding default query context values](../configuration#overriding-default-query-context-values) for more information.
 
 Make sure you enable the Broker monitor `SubqueryCountStatsMonitor` so that Druid emits metrics for subquery statistics.
-To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your `common.runtime.properties` configuration file.
+To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your Broker's `runtime.properties` configuration file.
 See [Metrics monitors](../configuration#metrics-monitors) for more information.
 
 ## Learn more

--- a/docs/release-info/migr-subquery-limit.md
+++ b/docs/release-info/migr-subquery-limit.md
@@ -52,6 +52,10 @@ This property takes precedence over `maxSubqueryRows`.
 You can set both `maxSubqueryRows` and `maxSubqueryBytes` at cluster level and override them in individual queries. 
 See [Overriding default query context values](../configuration#overriding-default-query-context-values) for more information.
 
+Make sure you enable `SubqueryCountStatsMonitor` so that Druid emits these metrics.
+To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your `common.runtime.properties` configuration file.
+See [Metrics monitors](../configuration#metrics-monitors) for more information.
+
 ## Learn more
 
 See the following topics for more information:

--- a/docs/release-info/migr-subquery-limit.md
+++ b/docs/release-info/migr-subquery-limit.md
@@ -52,7 +52,7 @@ This property takes precedence over `maxSubqueryRows`.
 You can set both `maxSubqueryRows` and `maxSubqueryBytes` at cluster level and override them in individual queries. 
 See [Overriding default query context values](../configuration#overriding-default-query-context-values) for more information.
 
-Make sure you enable `SubqueryCountStatsMonitor` so that Druid emits these metrics.
+Make sure you enable `SubqueryCountStatsMonitor` so that Druid emits metrics for subquery statistics.
 To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your `common.runtime.properties` configuration file.
 See [Metrics monitors](../configuration#metrics-monitors) for more information.
 

--- a/docs/release-info/migr-subquery-limit.md
+++ b/docs/release-info/migr-subquery-limit.md
@@ -54,7 +54,7 @@ See [Overriding default query context values](../configuration#overriding-defaul
 
 Make sure you enable the Broker monitor `SubqueryCountStatsMonitor` so that Druid emits metrics for subquery statistics.
 To do this, add `org.apache.druid.server.metrics.SubqueryCountStatsMonitor` to the `druid.monitoring.monitors` property in your Broker's `runtime.properties` configuration file.
-See [Metrics monitors](../configuration#metrics-monitors) for more information.
+See [Metrics monitors](../configuration/index.md#metrics-monitors) for more information.
 
 ## Learn more
 


### PR DESCRIPTION
Addition to subquery limit migration guide to provide information on configuring Druid to emit the appropriate metrics.
Suggestion made on PR https://github.com/apache/druid/pull/16519.

This PR has:
- [x] been self-reviewed.