### PR TITLE
docs: Separates description of data types into standard and complex types

### DIFF
--- a/docs/querying/sql-data-types.md
+++ b/docs/querying/sql-data-types.md
@@ -34,12 +34,23 @@ Druid associates each column with a specific data type. This topic describes sup
 
 Druid natively supports the following basic column types:
 
-* LONG: 64-bit signed int
-* FLOAT: 32-bit float
-* DOUBLE: 64-bit float
-* STRING: UTF-8 encoded strings and string arrays
-* COMPLEX: non-standard data types, such as nested JSON, hyperUnique and approxHistogram, and DataSketches
-* ARRAY: arrays composed of any of these types
+* `LONG`: 64-bit signed int
+* `FLOAT`: 32-bit float
+* `DOUBLE`: 64-bit float
+* `STRING`: UTF-8 encoded strings and string arrays
+* `ARRAY`: arrays composed of any of these types
+
+## Complex types
+
+Druid natively supports the following complex types:
+* `COMPLEX<JSON>`: stores a copy of structured data in JSON format and specialized internal columns and indexes for nested basic types. Click here to learn more about [`COMPLEX<JSON>`](nested-columns.md)
+* `cardinality`: Data structure to compute the cardinality of Apache Druid dimensions using the HyperLogLog algorithm. Click here to learn more about [`cardinality`](hll-old.md#cardinality-aggregator)
+* `hyperUnique`: Data structure of aggregated values to estimate count distinct using a variant of the HyperLogLog approximation algorithm. Consider using HLL sketches for better accuracy in many cases. Click here to learn more about [`hyperUnique`](hll-old.md#hyperunique-aggregator)
+
+<!--DEPRECATED
+* `approxHistogram`: Data structure of aggregated values to estimate quantiles. Use `approxHistogram` to appoximate at ingestion time, and `approxHistogramFold` to approximate at query yime 
+-->
+
 
 Druid treats timestamps (including the `__time` column) as LONG, with the value being the number of
 milliseconds since 1970-01-01 00:00:00 UTC, not counting leap seconds. Therefore, timestamps in Druid do not carry any
@@ -64,7 +75,7 @@ The following table describes how Druid maps SQL types onto native types when ru
 |TIMESTAMP|LONG|`0`, meaning 1970-01-01 00:00:00 UTC|Druid's `__time` column is reported as TIMESTAMP. Casts between string and timestamp types assume standard SQL formatting, such as `2000-01-02 03:04:05`, not ISO 8601 formatting. For handling other formats, use one of the [time functions](sql-scalar.md#date-and-time-functions).|
 |DATE|LONG|`0`, meaning 1970-01-01|Casting TIMESTAMP to DATE rounds down the timestamp to the nearest day. Casts between string and date types assume standard SQL formatting&mdash;for example, `2000-01-02`. For handling other formats, use one of the [time functions](sql-scalar.md#date-and-time-functions).|
 |ARRAY|ARRAY|`NULL`|Druid native array types work as SQL arrays, and multi-value strings can be converted to arrays. See [Arrays](#arrays) for more information.|
-|OTHER|COMPLEX|none|May represent various Druid column types such as hyperUnique, approxHistogram, etc.|
+|OTHER|COMPLEX|none|May represent various Druid column types such as hyperUnique, cardinality, etc.|
 
 <sup>*</sup> 
 The default value is <code>NULL</code> for all types, except in the deprecated legacy mode (<code>druid.generic.useDefaultValueForNull = true</code>) which initialize a default value. 


### PR DESCRIPTION
### Description

- Updates description of data types to address basic and complex data types separately. 
- Before such as nested JSON, hyperUnique and approxHistogram, and DataSketches
- changes `nested JSON` to `COMPLEX<JSON>` for consistency with other pages
- added `cardinality` as a complex data type to be consistent with `hyperUnique`
- Added links and small explanation for each complex data type
- removes deprecated data type `approxHistogram` 

This PR has:
- [x] been self-reviewed.
  