### PR TITLE
Updates build documentation to not mention explicit Java version

### DIFF
--- a/docs/development/build.md
+++ b/docs/development/build.md
@@ -33,7 +33,7 @@ make sure it has `/master/` in the URL.
 
 ##### Installing Java and Maven
 
-- JDK 8, 8u92+ or JDK 11. See our [Java documentation](../operations/java.md) for information about obtaining a JDK.
+- See our [Java documentation](../operations/java.md) for information about obtaining a supported JDK
 - [Maven version 3.x](http://maven.apache.org/download.cgi)
 
 ##### Other dependencies


### PR DESCRIPTION
### Description

Updates build documentation to not mention explicit Java version as it was out of sync with the dedicated Java page.

This means there is one less place to keep information in sync.


I removed almost all of the PR template things as this is a trivial docs-only patch.
I _assume_ that the list of supported runtime Java versions is the same that is also supported for building and it was an oversight that JDK 17 was not added here.
If it is indeed the case that JDK 17 cannot be built but only used to run then this PR is invalid.