### PR TITLE
Preemptive restriction for queries with approximate count distinct on complex columns of unsupported type

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -152,6 +152,7 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
 
   /**
    * Validates whether the aggregator supports the input column type.
+   * Supported column types are complex types of HLLSketch, HLLSketchBuild, HLLSketchMerge, as well as UNKNOWN_COMPLEX.
    * @param capabilities
    */
   private void validateInputs(@Nullable ColumnCapabilities capabilities)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -37,9 +37,11 @@ import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 /**
  * This aggregator factory is for merging existing sketches.
@@ -112,9 +114,10 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
     ColumnCapabilities columnCapabilities = columnSelectorFactory.getColumnCapabilities(getFieldName());
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
-      System.out.println("type = " + type);
-      System.out.println("type.getComplexTypeName() = " + type.getComplexTypeName());
-      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type)) {
+      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) &&
+          !(ValueType.COMPLEX.equals(type.getType()) &&
+            (Objects.equals(type.getComplexTypeName(), "HLLSketch") ||
+             Objects.equals(type.getComplexTypeName(), "HLLSketchBuild")))) {
         throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),
@@ -133,9 +136,10 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
     ColumnCapabilities columnCapabilities = columnSelectorFactory.getColumnCapabilities(getFieldName());
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
-      System.out.println("type = " + type);
-      System.out.println("type.getComplexTypeName() = " + type.getComplexTypeName());
-      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type)) {
+      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) &&
+          !(ValueType.COMPLEX.equals(type.getType()) &&
+            (Objects.equals(type.getComplexTypeName(), "HLLSketch") ||
+             Objects.equals(type.getComplexTypeName(), "HLLSketchBuild")))) {
         throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),
@@ -164,7 +168,10 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
     ColumnCapabilities columnCapabilities = selectorFactory.getColumnCapabilities(getFieldName());
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
-      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type)) {
+      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) &&
+          !(ValueType.COMPLEX.equals(type.getType()) &&
+            (Objects.equals(type.getComplexTypeName(), "HLLSketch") ||
+             Objects.equals(type.getComplexTypeName(), "HLLSketchBuild")))) {
         throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactory.java
@@ -158,14 +158,21 @@ public class HllSketchMergeAggregatorFactory extends HllSketchAggregatorFactory
   {
     if (capabilities != null) {
       final ColumnType type = capabilities.toColumnType();
-      boolean isUnsupportedComplexType = ValueType.COMPLEX.equals(type.getType()) &&
-                                          (HllSketchModule.TYPE_NAME.equals(type.getComplexTypeName()) ||
-                                           HllSketchModule.BUILD_TYPE_NAME.equals(type.getComplexTypeName()));
-      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !isUnsupportedComplexType) {
+      boolean isSupportedComplexType = ValueType.COMPLEX.equals(type.getType()) &&
+                                          (
+                                              HllSketchModule.TYPE_NAME.equals(type.getComplexTypeName()) ||
+                                              HllSketchModule.BUILD_TYPE_NAME.equals(type.getComplexTypeName()) ||
+                                              HllSketchModule.MERGE_TYPE_NAME.equals(type.getComplexTypeName()) ||
+                                              type.getComplexTypeName() == null
+                                          );
+      if (!isSupportedComplexType) {
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.UNSUPPORTED)
-                            .build("Using aggregator [%s] is not supported for complex columns with type [%s].",
-                                   getIntermediateType().getComplexTypeName(), type);
+                            .build(
+                                "Using aggregator [%s] is not supported for complex columns with type [%s].",
+                                getIntermediateType().getComplexTypeName(),
+                                type
+                            );
       }
     }
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
@@ -21,28 +21,70 @@ package org.apache.druid.query.aggregation.datasketches.hll.sql;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.type.CastedLiteralOperandTypeCheckers;
 import org.apache.calcite.sql.type.InferTypes;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.druid.java.util.common.StringEncoding;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchBuildAggregatorFactory;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchMergeAggregatorFactory;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import java.util.Collections;
 
 public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlAggregator implements SqlAggregator
 {
   public static final String NAME = "APPROX_COUNT_DISTINCT_DS_HLL";
+
+  private static final SqlSingleOperandTypeChecker COLUMN_ALLOWED_TYPES = OperandTypes.or(
+      OperandTypes.STRING,
+      OperandTypes.NUMERIC,
+      RowSignatures.complexTypeChecker(HllSketchMergeAggregatorFactory.TYPE),
+      RowSignatures.complexTypeChecker(HllSketchBuildAggregatorFactory.TYPE)
+  );
+
   private static final SqlAggFunction FUNCTION_INSTANCE =
       OperatorConversions.aggregatorBuilder(NAME)
-                         .operandNames("column", "lgK", "tgtHllType")
-                         .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.NUMERIC, SqlTypeFamily.STRING)
                          .operandTypeInference(InferTypes.VARCHAR_1024)
-                         .requiredOperandCount(1)
-                         .literalOperands(1, 2)
+                         .operandTypeChecker(
+                             OperandTypes.or(
+                                 // APPROX_COUNT_DISTINCT_DS_HLL(column)
+                                 OperandTypes.and(
+                                     OperandTypes.sequence(
+                                         StringUtils.format("'%s(column)'", NAME),
+                                         COLUMN_ALLOWED_TYPES
+                                     ),
+                                     OperandTypes.family(SqlTypeFamily.ANY)
+                                 ),
+                                 // APPROX_COUNT_DISTINCT_DS_HLL(column, lgk)
+                                 OperandTypes.and(
+                                     OperandTypes.sequence(
+                                         StringUtils.format("'%s(column, lgk)'", NAME),
+                                         COLUMN_ALLOWED_TYPES,
+                                         CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL
+                                     ),
+                                     OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC)
+                                 ),
+                                 // APPROX_COUNT_DISTINCT_DS_HLL(column, lgk, tgtHllType)
+                                 OperandTypes.and(
+                                     OperandTypes.sequence(
+                                         StringUtils.format("'%s(column, lgk, tgtHllType)'", NAME),
+                                         COLUMN_ALLOWED_TYPES,
+                                         CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL,
+                                         OperandTypes.STRING
+                                     ),
+                                     OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.EXACT_NUMERIC)
+                                 )
+                             )
+                         )
                          .returnTypeNonNull(SqlTypeName.BIGINT)
                          .functionCategory(SqlFunctionCategory.NUMERIC)
                          .build();

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
@@ -61,7 +61,7 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
                          .operandTypeChecker(
                              OperandTypes.or(
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column)
-                                 OperandTypes.and(AGGREGATED_COLUMN_TYPE_CHECKER, OperandTypes.family(SqlTypeFamily.ANY)),
+                                 AGGREGATED_COLUMN_TYPE_CHECKER,
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column, lgk)
                                  OperandTypes.and(
                                      OperandTypes.sequence(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
@@ -40,11 +40,15 @@ import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import java.util.Collections;
 
+/**
+ * Approximate count distinct aggregator using HLL sketches.
+ * Supported column types: String, Numeric, HLLSketchMerge, HLLSketchBuild.
+ */
 public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlAggregator implements SqlAggregator
 {
   public static final String NAME = "APPROX_COUNT_DISTINCT_DS_HLL";
 
-  private static final SqlSingleOperandTypeChecker COLUMN_ALLOWED_TYPES = OperandTypes.or(
+  private static final SqlSingleOperandTypeChecker AGGREGATED_COLUMN_TYPE_CHECKER = OperandTypes.or(
       OperandTypes.STRING,
       OperandTypes.NUMERIC,
       RowSignatures.complexTypeChecker(HllSketchMergeAggregatorFactory.TYPE),
@@ -57,12 +61,12 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
                          .operandTypeChecker(
                              OperandTypes.or(
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column)
-                                 OperandTypes.and(COLUMN_ALLOWED_TYPES, OperandTypes.family(SqlTypeFamily.ANY)),
+                                 OperandTypes.and(AGGREGATED_COLUMN_TYPE_CHECKER, OperandTypes.family(SqlTypeFamily.ANY)),
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column, lgk)
                                  OperandTypes.and(
                                      OperandTypes.sequence(
                                          StringUtils.format("'%s(column, lgk)'", NAME),
-                                         COLUMN_ALLOWED_TYPES,
+                                         AGGREGATED_COLUMN_TYPE_CHECKER,
                                          CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL
                                      ),
                                      OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC)
@@ -71,7 +75,7 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
                                  OperandTypes.and(
                                      OperandTypes.sequence(
                                          StringUtils.format("'%s(column, lgk, tgtHllType)'", NAME),
-                                         COLUMN_ALLOWED_TYPES,
+                                         AGGREGATED_COLUMN_TYPE_CHECKER,
                                          CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL,
                                          OperandTypes.STRING
                                      ),

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchApproxCountDistinctSqlAggregator.java
@@ -57,13 +57,7 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
                          .operandTypeChecker(
                              OperandTypes.or(
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column)
-                                 OperandTypes.and(
-                                     OperandTypes.sequence(
-                                         StringUtils.format("'%s(column)'", NAME),
-                                         COLUMN_ALLOWED_TYPES
-                                     ),
-                                     OperandTypes.family(SqlTypeFamily.ANY)
-                                 ),
+                                 OperandTypes.and(COLUMN_ALLOWED_TYPES, OperandTypes.family(SqlTypeFamily.ANY)),
                                  // APPROX_COUNT_DISTINCT_DS_HLL(column, lgk)
                                  OperandTypes.and(
                                      OperandTypes.sequence(
@@ -81,7 +75,7 @@ public class HllSketchApproxCountDistinctSqlAggregator extends HllSketchBaseSqlA
                                          CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL,
                                          OperandTypes.STRING
                                      ),
-                                     OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.EXACT_NUMERIC)
+                                     OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC, SqlTypeFamily.STRING)
                                  )
                              )
                          )

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -116,7 +116,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
     if (columnArg.isDirectColumnAccess()
         && inputAccessor.getInputRowSignature()
                         .getColumnType(columnArg.getDirectColumn())
-                        .map(type -> type.is(ValueType.COMPLEX) && validateInputComplexTypeName(type))
+                        .map(type -> type.is(ValueType.COMPLEX) && validateInputType(type))
                         .orElse(false)) {
       aggregatorFactory = new HllSketchMergeAggregatorFactory(
           aggregatorName,
@@ -155,7 +155,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
       }
 
       if (inputType.is(ValueType.COMPLEX)) {
-        if (validateInputComplexTypeName(inputType)) {
+        if (validateInputType(inputType)) {
           aggregatorFactory = new HllSketchMergeAggregatorFactory(
               aggregatorName,
               dimensionSpec.getOutputName(),
@@ -206,7 +206,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
       AggregatorFactory aggregatorFactory
   );
 
-  private boolean validateInputComplexTypeName(ColumnType columnType)
+  private boolean validateInputType(ColumnType columnType)
   {
     return HllSketchMergeAggregatorFactory.TYPE.equals(columnType) ||
            HllSketchModule.TYPE_NAME.equals(columnType.getComplexTypeName()) ||

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -41,6 +41,7 @@ import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.rel.InputAccessor;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
@@ -158,9 +159,9 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
         if (!isValidComplexInputType(inputType)) {
           plannerContext.setPlanningError(
               "Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for"
-              + " column type [%s]. You can disable approximation, use COUNT(DISTINCT %s) and rerun the query.",
+              + " column type [%s]. You can disable approximation by setting [%s: false] in the query context.",
               columnArg.getDruidType(),
-              columnArg.getSimpleExtraction().getColumn()
+              PlannerConfig.CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT
           );
           return null;
         }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchBaseSqlAggregator.java
@@ -116,7 +116,7 @@ public abstract class HllSketchBaseSqlAggregator implements SqlAggregator
     if (columnArg.isDirectColumnAccess()
         && inputAccessor.getInputRowSignature()
                         .getColumnType(columnArg.getDirectColumn())
-                        .map(type -> type.is(ValueType.COMPLEX) && validateInputType(type))
+                        .map(this::validateInputType)
                         .orElse(false)) {
       aggregatorFactory = new HllSketchMergeAggregatorFactory(
           aggregatorName,

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -113,6 +113,11 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
 
   /**
    * Validates whether the aggregator supports the input column type.
+   * Unsupported column types are:
+   * <ul>
+   *   <li>Arrays</li>
+   *   <li>Complex types of thetaSketch, thetaSketchMerge, thetaSketchBuild.</li>
+   * </ul>
    * @param capabilities
    */
   private void validateInputs(@Nullable ColumnCapabilities capabilities)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -118,17 +118,21 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   private void validateInputs(@Nullable ColumnCapabilities capabilities)
   {
     if (capabilities != null) {
-      if (capabilities.isArray() || (capabilities.is(ValueType.COMPLEX) && !(
+      boolean isSupportedComplexType = capabilities.is(ValueType.COMPLEX) && !(
           SketchModule.THETA_SKETCH_TYPE.equals(capabilities.toColumnType()) ||
           SketchModule.MERGE_TYPE.equals(capabilities.toColumnType()) ||
-          SketchModule.BUILD_TYPE.equals(capabilities.toColumnType())))
-      ) {
+          SketchModule.BUILD_TYPE.equals(capabilities.toColumnType())
+      );
+
+      if (capabilities.isArray() || isSupportedComplexType) {
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.UNSUPPORTED)
-                            .build("Unsupported input [%s] of type [%s] for aggregator [%s].",
+                            .build(
+                                "Unsupported input [%s] of type [%s] for aggregator [%s].",
                                 getFieldName(),
                                 capabilities.asTypeString(),
-                                getIntermediateType());
+                                getIntermediateType()
+                            );
       }
     }
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -27,7 +27,6 @@ import org.apache.datasketches.common.Util;
 import org.apache.datasketches.theta.SetOperation;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.thetacommon.ThetaUtil;
-import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregateCombiner;
@@ -83,10 +82,6 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
     validateInputs(metricFactory.getColumnCapabilities(fieldName));
-    ColumnCapabilities capabilities = metricFactory.getColumnCapabilities(fieldName);
-    if (capabilities != null && capabilities.isArray()) {
-      throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
-    }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
     return new SketchAggregator(selector, size);
   }
@@ -95,10 +90,6 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   public AggregatorAndSize factorizeWithSize(ColumnSelectorFactory metricFactory)
   {
     validateInputs(metricFactory.getColumnCapabilities(fieldName));
-    ColumnCapabilities capabilities = metricFactory.getColumnCapabilities(fieldName);
-    if (capabilities != null && capabilities.isArray()) {
-      throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
-    }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
     final SketchAggregator aggregator = new SketchAggregator(selector, size);
     return new AggregatorAndSize(aggregator, aggregator.getInitialSizeBytes());
@@ -109,10 +100,6 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory)
   {
     validateInputs(metricFactory.getColumnCapabilities(fieldName));
-    ColumnCapabilities capabilities = metricFactory.getColumnCapabilities(fieldName);
-    if (capabilities != null && capabilities.isArray()) {
-      throw InvalidInput.exception("ARRAY types are not supported for theta sketch");
-    }
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
     return new SketchBufferAggregator(selector, size, getMaxIntermediateSizeWithNulls());
   }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactory.java
@@ -118,13 +118,13 @@ public abstract class SketchAggregatorFactory extends AggregatorFactory
   private void validateInputs(@Nullable ColumnCapabilities capabilities)
   {
     if (capabilities != null) {
-      boolean isSupportedComplexType = capabilities.is(ValueType.COMPLEX) && !(
+      boolean isUnsupportedComplexType = capabilities.is(ValueType.COMPLEX) && !(
           SketchModule.THETA_SKETCH_TYPE.equals(capabilities.toColumnType()) ||
           SketchModule.MERGE_TYPE.equals(capabilities.toColumnType()) ||
           SketchModule.BUILD_TYPE.equals(capabilities.toColumnType())
       );
 
-      if (capabilities.isArray() || isSupportedComplexType) {
+      if (capabilities.isArray() || isUnsupportedComplexType) {
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.UNSUPPORTED)
                             .build(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
@@ -21,27 +21,51 @@ package org.apache.druid.query.aggregation.datasketches.theta.sql;
 
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.type.CastedLiteralOperandTypeCheckers;
 import org.apache.calcite.sql.type.InferTypes;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.datasketches.theta.SketchModule;
 import org.apache.druid.query.aggregation.post.FinalizingFieldAccessPostAggregator;
 import org.apache.druid.sql.calcite.aggregation.Aggregation;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.OperatorConversions;
+import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import java.util.Collections;
 
 public class ThetaSketchApproxCountDistinctSqlAggregator extends ThetaSketchBaseSqlAggregator implements SqlAggregator
 {
   public static final String NAME = "APPROX_COUNT_DISTINCT_DS_THETA";
+
+  private static final SqlSingleOperandTypeChecker COLUMN_ALLOWED_TYPES = OperandTypes.or(
+      OperandTypes.STRING,
+      OperandTypes.NUMERIC,
+      RowSignatures.complexTypeChecker(SketchModule.THETA_SKETCH_TYPE)
+  );
+
   private static final SqlAggFunction FUNCTION_INSTANCE =
       OperatorConversions.aggregatorBuilder(NAME)
-                         .operandNames("column", "size")
-                         .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.NUMERIC)
                          .operandTypeInference(InferTypes.VARCHAR_1024)
-                         .requiredOperandCount(1)
-                         .literalOperands(1)
+                         .operandTypeChecker(
+                             OperandTypes.or(
+                                 // APPROX_COUNT_DISTINCT_DS_THETA(expr)
+                                 OperandTypes.and(COLUMN_ALLOWED_TYPES, OperandTypes.family(SqlTypeFamily.ANY)),
+                                 // APPROX_COUNT_DISTINCT_DS_THETA(expr, size)
+                                 OperandTypes.and(
+                                     OperandTypes.sequence(
+                                         StringUtils.format("'%s(expr, size)'", NAME),
+                                         COLUMN_ALLOWED_TYPES,
+                                         CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL
+                                     ),
+                                     OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC)
+                                 )
+                             )
+                         )
                          .returnTypeNonNull(SqlTypeName.BIGINT)
                          .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
                          .build();

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
@@ -38,11 +38,15 @@ import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import java.util.Collections;
 
+/**
+ * Approximate count distinct aggregator using theta sketches.
+ * Supported column types: String, Numeric, Theta Sketch.
+ */
 public class ThetaSketchApproxCountDistinctSqlAggregator extends ThetaSketchBaseSqlAggregator implements SqlAggregator
 {
   public static final String NAME = "APPROX_COUNT_DISTINCT_DS_THETA";
 
-  private static final SqlSingleOperandTypeChecker COLUMN_ALLOWED_TYPES = OperandTypes.or(
+  private static final SqlSingleOperandTypeChecker AGGREGATED_COLUMN_TYPE_CHECKER = OperandTypes.or(
       OperandTypes.STRING,
       OperandTypes.NUMERIC,
       RowSignatures.complexTypeChecker(SketchModule.THETA_SKETCH_TYPE)
@@ -54,12 +58,12 @@ public class ThetaSketchApproxCountDistinctSqlAggregator extends ThetaSketchBase
                          .operandTypeChecker(
                              OperandTypes.or(
                                  // APPROX_COUNT_DISTINCT_DS_THETA(expr)
-                                 OperandTypes.and(COLUMN_ALLOWED_TYPES, OperandTypes.family(SqlTypeFamily.ANY)),
+                                 OperandTypes.and(AGGREGATED_COLUMN_TYPE_CHECKER, OperandTypes.family(SqlTypeFamily.ANY)),
                                  // APPROX_COUNT_DISTINCT_DS_THETA(expr, size)
                                  OperandTypes.and(
                                      OperandTypes.sequence(
                                          StringUtils.format("'%s(expr, size)'", NAME),
-                                         COLUMN_ALLOWED_TYPES,
+                                         AGGREGATED_COLUMN_TYPE_CHECKER,
                                          CastedLiteralOperandTypeCheckers.POSITIVE_INTEGER_LITERAL
                                      ),
                                      OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.EXACT_NUMERIC)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchApproxCountDistinctSqlAggregator.java
@@ -58,7 +58,7 @@ public class ThetaSketchApproxCountDistinctSqlAggregator extends ThetaSketchBase
                          .operandTypeChecker(
                              OperandTypes.or(
                                  // APPROX_COUNT_DISTINCT_DS_THETA(expr)
-                                 OperandTypes.and(AGGREGATED_COLUMN_TYPE_CHECKER, OperandTypes.family(SqlTypeFamily.ANY)),
+                                 AGGREGATED_COLUMN_TYPE_CHECKER,
                                  // APPROX_COUNT_DISTINCT_DS_THETA(expr, size)
                                  OperandTypes.and(
                                      OperandTypes.sequence(

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -96,7 +96,7 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
     if (columnArg.isDirectColumnAccess()
         && inputAccessor.getInputRowSignature()
                         .getColumnType(columnArg.getDirectColumn())
-                        .map(type -> type.is(ValueType.COMPLEX) && (
+                        .map(type -> (
                             SketchModule.THETA_SKETCH_TYPE.equals(type) ||
                             SketchModule.MERGE_TYPE.equals(type) ||
                             SketchModule.BUILD_TYPE.equals(type)

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -39,6 +39,7 @@ import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.rel.InputAccessor;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
@@ -124,9 +125,9 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
       if (inputType.is(ValueType.COMPLEX)) {
         plannerContext.setPlanningError(
             "Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for"
-            + " column type [%s]. You can disable approximation, use COUNT(DISTINCT %s) and rerun the query.",
+            + " column type [%s]. You can disable approximation by setting [%s: false] in the query context.",
             columnArg.getDruidType(),
-            columnArg.getSimpleExtraction().getColumn()
+            PlannerConfig.CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT
         );
         return null;
       }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -146,7 +146,10 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
     }
 
     if (aggregatorFactory == null) {
-      plannerContext.setPlanningError("Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for %s column. You can disable approximation and use COUNT(DISTINCT %s) and run the query again.", columnArg.getDruidType(), columnArg.getSimpleExtraction().getColumn());
+      plannerContext.setPlanningError("Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) "
+                                      + "is not supported for %s column. You can disable approximation and use "
+                                      + "COUNT(DISTINCT %s) and run the query again.",
+                                      columnArg.getDruidType(), columnArg.getSimpleExtraction().getColumn());
       return null;
     }
 

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchBaseSqlAggregator.java
@@ -146,10 +146,12 @@ public abstract class ThetaSketchBaseSqlAggregator implements SqlAggregator
     }
 
     if (aggregatorFactory == null) {
-      plannerContext.setPlanningError("Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) "
-                                      + "is not supported for %s column. You can disable approximation and use "
-                                      + "COUNT(DISTINCT %s) and run the query again.",
-                                      columnArg.getDruidType(), columnArg.getSimpleExtraction().getColumn());
+      plannerContext.setPlanningError(
+          "Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for"
+          + " %s column. You can disable approximation, use COUNT(DISTINCT %s) and rerun the query.",
+          columnArg.getDruidType(),
+          columnArg.getSimpleExtraction().getColumn()
+      );
       return null;
     }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -317,7 +317,8 @@ public class HllSketchMergeAggregatorFactoryTest
     Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorize(metricFactory));
     Assert.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
-        exception.getMessage());
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -326,7 +327,8 @@ public class HllSketchMergeAggregatorFactoryTest
     Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorizeBuffered(metricFactory));
     Assert.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
-        exception.getMessage());
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -335,6 +337,7 @@ public class HllSketchMergeAggregatorFactoryTest
     Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorizeVector(vectorFactory));
     Assert.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
-        exception.getMessage());
+        exception.getMessage()
+    );
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -24,7 +24,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.DruidInjectorBuilder;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -86,6 +88,7 @@ import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.sql.guice.SqlModule;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.junit.Assert;
@@ -100,6 +103,10 @@ import java.util.stream.Collectors;
 @SqlTestFrameworkConfig.ComponentSupplier(HllSketchComponentSupplier.class)
 public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
 {
+  static {
+    NullHandling.initializeForTests();
+  }
+
   private static final boolean ROUND = true;
 
   // For testHllSketchPostAggsGroupBy, testHllSketchPostAggsTimeseries
@@ -300,6 +307,15 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
                      .size(0)
                      .build(),
           index
+      ).add(
+          DataSegment.builder()
+                     .dataSource(CalciteTests.WIKIPEDIA_FIRST_LAST)
+                     .interval(Intervals.of("2015-09-12/2015-09-13"))
+                     .version("1")
+                     .shardSpec(new NumberedShardSpec(0, 0))
+                     .size(0)
+                     .build(),
+          TestDataBuilder.makeWikipediaIndexWithAggregation(tempDirProducer.newTempFolder())
       );
     }
   }
@@ -506,6 +522,33 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
             new Object[]{"a", 2L}
         )
     );
+  }
+
+  @Test
+  public void testApproxCountDistinctOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
+                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
+                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
+                          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT APPROX_COUNT_DISTINCT_DS_HLL(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_COUNT_DISTINCT_DS_HLL' to arguments of type 'APPROX_COUNT_DISTINCT_DS_HLL(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
+    }
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -531,7 +531,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
         "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
         + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<serializablePairLongDouble>]."
-        + " You can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+        + " You can disable approximation by setting [useApproximateCountDistinct: false] in the query context."
     );
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -527,16 +527,12 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
-                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
-                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
-                          e.getMessage());
-    }
+    assertQueryIsUnplannable(
+        "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
+        "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
+        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You "
+        + "can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+    );
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -538,13 +538,17 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT APPROX_COUNT_DISTINCT_DS_HLL(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_COUNT_DISTINCT_DS_HLL' to arguments of type 'APPROX_COUNT_DISTINCT_DS_HLL(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
-    }
+    DruidException druidException = Assert.assertThrows(
+        DruidException.class,
+        () -> testQuery(
+            "SELECT APPROX_COUNT_DISTINCT_DS_HLL(double_first_added) FROM druid.wikipedia_first_last",
+            ImmutableList.of(),
+            ImmutableList.of()
+        )
+    );
+    Assert.assertTrue(druidException.getMessage().contains(
+        "Cannot apply 'APPROX_COUNT_DISTINCT_DS_HLL' to arguments of type 'APPROX_COUNT_DISTINCT_DS_HLL(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"
+    ));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -530,8 +530,8 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
     assertQueryIsUnplannable(
         "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
-        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You "
-        + "can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+        + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<serializablePairLongDouble>]."
+        + " You can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
     );
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.query.aggregation.datasketches.theta;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.aggregation.AggregatorAndSize;
@@ -33,10 +33,11 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
-import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.TestColumnSelectorFactory;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.segment.column.ValueType;
+import org.apache.druid.segment.vector.TestVectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -51,20 +52,15 @@ public class SketchAggregatorFactoryTest
   private static final SketchMergeAggregatorFactory AGGREGATOR_32768 =
       new SketchMergeAggregatorFactory("x", "x", 32768, null, false, null);
 
-  private final ColumnSelectorFactory metricFactory = EasyMock.mock(ColumnSelectorFactory.class);
-  private final VectorColumnSelectorFactory vectorFactory = EasyMock.mock(VectorColumnSelectorFactory.class);
-  private final ColumnCapabilities capabilities = EasyMock.mock(ColumnCapabilities.class);
+  private ColumnSelectorFactory metricFactory;
+  private VectorColumnSelectorFactory vectorFactory;
 
   @Before
   public void setup()
   {
-    EasyMock.expect(metricFactory.getColumnCapabilities(EasyMock.anyString())).andReturn(capabilities).anyTimes();
-    EasyMock.expect(vectorFactory.getColumnCapabilities(EasyMock.anyString())).andReturn(capabilities).anyTimes();
-    EasyMock.expect(capabilities.toColumnType()).andReturn(ColumnType.NESTED_DATA).anyTimes();
-    EasyMock.expect(capabilities.isArray()).andReturn(false).anyTimes();
-    EasyMock.expect(capabilities.is(EasyMock.eq(ValueType.COMPLEX))).andReturn(true).anyTimes();
-    EasyMock.expect(capabilities.asTypeString()).andReturn(ColumnType.NESTED_DATA.asTypeString()).anyTimes();
-    EasyMock.replay(metricFactory, vectorFactory, capabilities);
+    final ColumnCapabilitiesImpl columnCapabilities = ColumnCapabilitiesImpl.createDefault().setType(ColumnType.NESTED_DATA);
+    metricFactory = new TestColumnSelectorFactory().addCapabilities("x", columnCapabilities);
+    vectorFactory = new TestVectorColumnSelectorFactory().addCapabilities("x", columnCapabilities);
   }
 
   @Test
@@ -193,32 +189,28 @@ public class SketchAggregatorFactoryTest
   @Test
   public void testFactorizeOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(ISE.class, () -> AGGREGATOR_16384.factorize(metricFactory));
-    Assert.assertEquals("Invalid input [x] of type [COMPLEX<json>] for [COMPLEX<thetaSketchBuild>] aggregator [x]", exception.getMessage());
-    EasyMock.verify(metricFactory, capabilities);
+    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorize(metricFactory));
+    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeWithSizeOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(ISE.class, () -> AGGREGATOR_16384.factorizeWithSize(metricFactory));
-    Assert.assertEquals("Invalid input [x] of type [COMPLEX<json>] for [COMPLEX<thetaSketchBuild>] aggregator [x]", exception.getMessage());
-    EasyMock.verify(metricFactory, capabilities);
+    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeWithSize(metricFactory));
+    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeBufferedOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(ISE.class, () -> AGGREGATOR_16384.factorizeBuffered(metricFactory));
-    Assert.assertEquals("Invalid input [x] of type [COMPLEX<json>] for [COMPLEX<thetaSketchBuild>] aggregator [x]", exception.getMessage());
-    EasyMock.verify(metricFactory, capabilities);
+    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeBuffered(metricFactory));
+    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeVectorOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(ISE.class, () -> AGGREGATOR_16384.factorizeVector(vectorFactory));
-    Assert.assertEquals("Invalid input [x] of type [COMPLEX<json>] for [COMPLEX<thetaSketchBuild>] aggregator [x]", exception.getMessage());
-    EasyMock.verify(vectorFactory, capabilities);
+    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeVector(vectorFactory));
+    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -391,8 +391,8 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
     assertQueryIsUnplannable(
         "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
-        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You "
-        + "can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+        + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<serializablePairLongDouble>]."
+        + " You can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
     );
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -23,7 +23,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.DruidInjectorBuilder;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
@@ -71,6 +73,7 @@ import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.sql.guice.SqlModule;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.junit.Assert;
@@ -158,6 +161,15 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
                      .size(0)
                      .build(),
           index
+      ).add(
+          DataSegment.builder()
+                     .dataSource(CalciteTests.WIKIPEDIA_FIRST_LAST)
+                     .interval(Intervals.of("2015-09-12/2015-09-13"))
+                     .version("1")
+                     .shardSpec(new NumberedShardSpec(0, 0))
+                     .size(0)
+                     .build(),
+          TestDataBuilder.makeWikipediaIndexWithAggregation(tempDirProducer.newTempFolder())
       );
     }
   }
@@ -371,6 +383,33 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
         ),
         expectedResults
     );
+  }
+
+  @Test
+  public void testApproxCountDistinctOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
+                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
+                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
+                          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT APPROX_COUNT_DISTINCT_DS_THETA(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_COUNT_DISTINCT_DS_THETA' to arguments of type 'APPROX_COUNT_DISTINCT_DS_THETA(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
+    }
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -399,13 +399,17 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT APPROX_COUNT_DISTINCT_DS_THETA(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_COUNT_DISTINCT_DS_THETA' to arguments of type 'APPROX_COUNT_DISTINCT_DS_THETA(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
-    }
+    DruidException druidException = Assert.assertThrows(
+        DruidException.class,
+        () -> testQuery(
+            "SELECT APPROX_COUNT_DISTINCT_DS_THETA(double_first_added) FROM druid.wikipedia_first_last",
+            ImmutableList.of(),
+            ImmutableList.of()
+        )
+    );
+    Assert.assertTrue(druidException.getMessage().contains(
+        "Cannot apply 'APPROX_COUNT_DISTINCT_DS_THETA' to arguments of type 'APPROX_COUNT_DISTINCT_DS_THETA(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"
+    ));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -392,7 +392,7 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
         "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
         + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<serializablePairLongDouble>]."
-        + " You can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+        + " You can disable approximation by setting [useApproximateCountDistinct: false] in the query context."
     );
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -388,16 +388,12 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
-                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
-                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
-                          e.getMessage());
-    }
+    assertQueryIsUnplannable(
+        "SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last",
+        "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
+        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You "
+        + "can disable approximation, use COUNT(DISTINCT double_first_added) and rerun the query.]"
+    );
   }
 
   @Test

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -146,8 +146,11 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
       if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !PRECOMPUTED_TYPE.equals(type)) {
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.UNSUPPORTED)
-                            .build("Using aggregator [%s] is not supported for complex columns with type [%s].",
-                                   getIntermediateType().getComplexTypeName(), type);
+                            .build(
+                                "Using aggregator [%s] is not supported for complex columns with type [%s].",
+                                getIntermediateType().getComplexTypeName(),
+                                type
+                            );
       }
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -103,22 +103,22 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   @Override
   public Aggregator factorize(ColumnSelectorFactory metricFactory)
   {
-    validateInputs(metricFactory.getColumnCapabilities(fieldName));
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
     if (selector instanceof NilColumnValueSelector) {
       return NoopAggregator.instance();
     }
+    validateInputs(metricFactory.getColumnCapabilities(fieldName));
     return new HyperUniquesAggregator(selector);
   }
 
   @Override
   public BufferAggregator factorizeBuffered(ColumnSelectorFactory metricFactory)
   {
-    validateInputs(metricFactory.getColumnCapabilities(fieldName));
     BaseObjectColumnValueSelector selector = metricFactory.makeColumnValueSelector(fieldName);
     if (selector instanceof NilColumnValueSelector) {
       return NoopBufferAggregator.instance();
     }
+    validateInputs(metricFactory.getColumnCapabilities(fieldName));
     return new HyperUniquesBufferAggregator(selector);
   }
 
@@ -126,11 +126,10 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
   public VectorAggregator factorizeVector(final VectorColumnSelectorFactory selectorFactory)
   {
     final ColumnCapabilities columnCapabilities = selectorFactory.getColumnCapabilities(fieldName);
-    validateInputs(columnCapabilities);
-
     if (!Types.is(columnCapabilities, ValueType.COMPLEX)) {
       return NoopVectorAggregator.instance();
     } else {
+      validateInputs(columnCapabilities);
       return new HyperUniquesVectorAggregator(selectorFactory.makeObjectSelector(fieldName));
     }
   }

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -107,11 +107,10 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
       if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !PRECOMPUTED_TYPE.equals(type)) {
-        throw new UOE("Using aggregation type %s is not supported for %s<%s> column. "
+        throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),
-                      type,
-                      type.getComplexTypeName());
+                      type);
       }
     }
 
@@ -129,11 +128,10 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
       if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !PRECOMPUTED_TYPE.equals(type)) {
-        throw new UOE("Using aggregation type %s is not supported for %s<%s> column. "
+        throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),
-                      type,
-                      type.getComplexTypeName());
+                      type);
       }
     }
 
@@ -151,11 +149,10 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
     if (columnCapabilities != null) {
       final ColumnType type = columnCapabilities.toColumnType();
       if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !PRECOMPUTED_TYPE.equals(type)) {
-        throw new UOE("Using aggregation type %s is not supported for %s<%s> column. "
+        throw new UOE("Using aggregation type %s is not supported for %s column. "
                       + "Use a different aggregator type and run the query again.",
                       getIntermediateType().getComplexTypeName(),
-                      type,
-                      type.getComplexTypeName());
+                      type);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/hyperloglog/HyperUniquesAggregatorFactory.java
@@ -137,13 +137,14 @@ public class HyperUniquesAggregatorFactory extends AggregatorFactory
 
   /**
    * Validates whether the aggregator supports the input column type.
+   * Supported column types are complex types of hyperUnique, preComputedHyperUnique, as well as UNKNOWN_COMPLEX.
    * @param capabilities
    */
   private void validateInputs(@Nullable ColumnCapabilities capabilities)
   {
     if (capabilities != null) {
       final ColumnType type = capabilities.toColumnType();
-      if (!ColumnType.UNKNOWN_COMPLEX.equals(type) && !TYPE.equals(type) && !PRECOMPUTED_TYPE.equals(type)) {
+      if (!(ColumnType.UNKNOWN_COMPLEX.equals(type) || TYPE.equals(type) || PRECOMPUTED_TYPE.equals(type))) {
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.UNSUPPORTED)
                             .build(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/ApproxCountDistinctSqlAggregator.java
@@ -21,10 +21,7 @@ package org.apache.druid.sql.calcite.aggregation;
 
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.type.InferTypes;
-import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.Optionality;
@@ -44,20 +41,20 @@ import java.util.List;
  */
 public class ApproxCountDistinctSqlAggregator implements SqlAggregator
 {
-  private static final SqlAggFunction FUNCTION_INSTANCE = new ApproxCountDistinctSqlAggFunction();
   private static final String NAME = "APPROX_COUNT_DISTINCT";
-
+  private final SqlAggFunction delegateFunction;
   private final SqlAggregator delegate;
 
   public ApproxCountDistinctSqlAggregator(final SqlAggregator delegate)
   {
     this.delegate = delegate;
+    this.delegateFunction = new ApproxCountDistinctSqlAggFunction(delegate.calciteFunction());
   }
 
   @Override
   public SqlAggFunction calciteFunction()
   {
-    return FUNCTION_INSTANCE;
+    return delegateFunction;
   }
 
   @Nullable
@@ -85,16 +82,16 @@ public class ApproxCountDistinctSqlAggregator implements SqlAggregator
 
   private static class ApproxCountDistinctSqlAggFunction extends SqlAggFunction
   {
-    ApproxCountDistinctSqlAggFunction()
+    ApproxCountDistinctSqlAggFunction(SqlAggFunction delegate)
     {
       super(
           NAME,
           null,
           SqlKind.OTHER_FUNCTION,
           ReturnTypes.explicit(SqlTypeName.BIGINT),
-          InferTypes.VARCHAR_1024,
-          OperandTypes.ANY,
-          SqlFunctionCategory.STRING,
+          delegate.getOperandTypeInference(),
+          delegate.getOperandTypeChecker(),
+          delegate.getFunctionType(),
           false,
           false,
           Optionality.FORBIDDEN

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -49,6 +49,7 @@ import org.apache.druid.sql.calcite.planner.Calcites;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.rel.InputAccessor;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
+import org.apache.druid.sql.calcite.table.RowSignatures;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -161,7 +162,11 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
           SqlKind.OTHER_FUNCTION,
           ReturnTypes.explicit(SqlTypeName.BIGINT),
           InferTypes.VARCHAR_1024,
-          OperandTypes.ANY,
+          OperandTypes.or(
+              OperandTypes.STRING,
+              OperandTypes.NUMERIC,
+              RowSignatures.complexTypeChecker(HyperUniquesAggregatorFactory.TYPE)
+          ),
           SqlFunctionCategory.STRING,
           false,
           false,

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -96,7 +96,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
     if (arg.isDirectColumnAccess()
         && inputAccessor.getInputRowSignature()
             .getColumnType(arg.getDirectColumn())
-            .map(type -> type.is(ValueType.COMPLEX) && validateInputType(type))
+            .map(this::validateInputType)
             .orElse(false)) {
       aggregatorFactory = new HyperUniquesAggregatorFactory(aggregatorName, arg.getDirectColumn(), false, true);
     } else {

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -142,7 +142,10 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
     }
 
     if (aggregatorFactory == null) {
-      plannerContext.setPlanningError("Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for %s column. You can disable approximation and use COUNT(DISTINCT %s) and run the query again.", arg.getDruidType(), arg.getSimpleExtraction().getColumn());
+      plannerContext.setPlanningError("Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) "
+                                      + "is not supported for %s column. You can disable approximation and use "
+                                      + "COUNT(DISTINCT %s) and run the query again.",
+                                      arg.getDruidType(), arg.getSimpleExtraction().getColumn());
       return null;
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -96,7 +96,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
     if (arg.isDirectColumnAccess()
         && inputAccessor.getInputRowSignature()
             .getColumnType(arg.getDirectColumn())
-            .map(type -> type.is(ValueType.COMPLEX) && validateInputComplexTypeName(type))
+            .map(type -> type.is(ValueType.COMPLEX) && validateInputType(type))
             .orElse(false)) {
       aggregatorFactory = new HyperUniquesAggregatorFactory(aggregatorName, arg.getDirectColumn(), false, true);
     } else {
@@ -120,7 +120,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
       }
 
       if (inputType.is(ValueType.COMPLEX)) {
-        if (validateInputComplexTypeName(inputType)) {
+        if (validateInputType(inputType)) {
           aggregatorFactory = new HyperUniquesAggregatorFactory(
               aggregatorName,
               dimensionSpec.getOutputName(),
@@ -178,7 +178,7 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
     }
   }
 
-  private boolean validateInputComplexTypeName(ColumnType columnType)
+  private boolean validateInputType(ColumnType columnType)
   {
     return Objects.equals(columnType.getComplexTypeName(), HyperUniquesAggregatorFactory.TYPE.getComplexTypeName()) ||
            Objects.equals(columnType.getComplexTypeName(), HyperUniquesAggregatorFactory.PRECOMPUTED_TYPE.getComplexTypeName());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/aggregation/builtin/BuiltinApproxCountDistinctSqlAggregator.java
@@ -46,6 +46,7 @@ import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.DruidExpression;
 import org.apache.druid.sql.calcite.expression.Expressions;
 import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
 import org.apache.druid.sql.calcite.rel.InputAccessor;
 import org.apache.druid.sql.calcite.rel.VirtualColumnRegistry;
@@ -123,9 +124,9 @@ public class BuiltinApproxCountDistinctSqlAggregator implements SqlAggregator
         if (!isValidComplexInputType(inputType)) {
           plannerContext.setPlanningError(
               "Using APPROX_COUNT_DISTINCT() or enabling approximation with COUNT(DISTINCT) is not supported for"
-              + " column type [%s]. You can disable approximation, use COUNT(DISTINCT %s) and rerun the query.",
+              + " column type [%s]. You can disable approximation by setting [%s: false] in the query context.",
               arg.getDruidType(),
-              arg.getSimpleExtraction().getColumn()
+              PlannerConfig.CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT
           );
           return null;
         }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -7328,8 +7328,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
     assertQueryIsUnplannable(
         "SELECT COUNT(DISTINCT nester) FROM druid.nested",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
-        + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<json>]. You can disable "
-        + "approximation, use COUNT(DISTINCT nester) and rerun the query.]"
+        + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<json>]. "
+        + "You can disable approximation by setting [useApproximateCountDistinct: false] in the query context."
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -7328,8 +7328,8 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
     assertQueryIsUnplannable(
         "SELECT COUNT(DISTINCT nester) FROM druid.nested",
         "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
-        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<json> column. You can disable approximation,"
-        + " use COUNT(DISTINCT nester) and rerun the query.]"
+        + "approximation with COUNT(DISTINCT) is not supported for column type [COMPLEX<json>]. You can disable "
+        + "approximation, use COUNT(DISTINCT nester) and rerun the query.]"
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -7324,16 +7324,12 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT COUNT(DISTINCT nester) FROM druid.nested", ImmutableList.of(), ImmutableList.of());
-      Assertions.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assertions.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
-                          + "with COUNT(DISTINCT) is not supported for COMPLEX<json> column. You can disable"
-                          + " approximation and use COUNT(DISTINCT nester) and run the query again.]",
-                          e.getMessage());
-    }
+    assertQueryIsUnplannable(
+        "SELECT COUNT(DISTINCT nester) FROM druid.nested",
+        "Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling "
+        + "approximation with COUNT(DISTINCT) is not supported for COMPLEX<json> column. You can disable approximation,"
+        + " use COUNT(DISTINCT nester) and rerun the query.]"
+    );
   }
 
   @Test
@@ -7344,9 +7340,11 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
       Assertions.fail("query planning should fail");
     }
     catch (DruidException e) {
-      System.out.println("e.getMessage() = " + e.getMessage());
-      Assertions.assertTrue(e.getMessage().contains(
-          "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<JSON>>)'"));
+      Assertions.assertTrue(
+          e.getMessage().contains(
+              "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<JSON>>)'"
+          )
+      );
     }
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -7322,6 +7322,35 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testApproxCountDistinctOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT COUNT(DISTINCT nester) FROM druid.nested", ImmutableList.of(), ImmutableList.of());
+      Assertions.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assertions.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
+                          + "with COUNT(DISTINCT) is not supported for COMPLEX<json> column. You can disable"
+                          + " approximation and use COUNT(DISTINCT nester) and run the query again.]",
+                          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT APPROX_COUNT_DISTINCT(nester) FROM druid.nested", ImmutableList.of(), ImmutableList.of());
+      Assertions.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      System.out.println("e.getMessage() = " + e.getMessage());
+      Assertions.assertTrue(e.getMessage().contains(
+          "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<JSON>>)'"));
+    }
+  }
+
+  @Test
   public void testNvlJsonValueDoubleSometimesMissingEqualityFilter()
   {
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteNestedDataQueryTest.java
@@ -80,6 +80,7 @@ import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -7335,17 +7336,17 @@ public class CalciteNestedDataQueryTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
   {
-    try {
-      testQuery("SELECT APPROX_COUNT_DISTINCT(nester) FROM druid.nested", ImmutableList.of(), ImmutableList.of());
-      Assertions.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assertions.assertTrue(
-          e.getMessage().contains(
-              "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<JSON>>)'"
-          )
-      );
-    }
+    DruidException druidException = Assert.assertThrows(
+        DruidException.class,
+        () -> testQuery(
+            "SELECT APPROX_COUNT_DISTINCT(nester) FROM druid.nested",
+            ImmutableList.of(),
+            ImmutableList.of()
+        )
+    );
+    Assert.assertTrue(druidException.getMessage().contains(
+        "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<JSON>>)'"
+    ));
   }
 
   @Test

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -2675,34 +2675,6 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testApproxCountDistinctOnUnsupportedComplexColumn()
-  {
-    try {
-      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
-                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
-                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
-                          e.getMessage());
-    }
-  }
-
-  @Test
-  public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
-  {
-    try {
-      testQuery("SELECT APPROX_COUNT_DISTINCT(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
-      Assert.fail("query planning should fail");
-    }
-    catch (DruidException e) {
-      Assert.assertTrue(e.getMessage().contains(
-          "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
-    }
-  }
-
-  @Test
   public void testHavingOnExactCountDistinct()
   {
     testQuery(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -2675,6 +2675,34 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testApproxCountDistinctOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT COUNT(distinct double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertEquals("Query could not be planned. A possible reason is [Using APPROX_COUNT_DISTINCT() or enabling approximation "
+                          + "with COUNT(DISTINCT) is not supported for COMPLEX<serializablePairLongDouble> column. You can disable"
+                          + " approximation and use COUNT(DISTINCT double_first_added) and run the query again.]",
+                          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
+  {
+    try {
+      testQuery("SELECT APPROX_COUNT_DISTINCT(double_first_added) FROM druid.wikipedia_first_last", ImmutableList.of(), ImmutableList.of());
+      Assert.fail("query planning should fail");
+    }
+    catch (DruidException e) {
+      Assert.assertTrue(e.getMessage().contains(
+          "Cannot apply 'APPROX_COUNT_DISTINCT' to arguments of type 'APPROX_COUNT_DISTINCT(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"));
+    }
+  }
+
+  @Test
   public void testHavingOnExactCountDistinct()
   {
     testQuery(


### PR DESCRIPTION
### Description

Currently, we don't support `count (distinct complexColumn) + approximation` for unsupported types, and the query execution fails with a ClassCastException:
```
Caused by: java.lang.ClassCastException: class org.apache.druid.segment.nested.StructuredData cannot be cast to class org.apache.druid.hll.HyperLogLogCollector (org.apache.druid.segment.nested.StructuredData and org.apache.druid.hll.HyperLogLogCollector are in unnamed module of loader 'app')
```

This PR aims to check if the complex column being queried aligns with the supported types in the aggregator and aggregator factories, and throws a user-friendly error message if they don't.

The validation is added in 3 layers:
1. In the SQL operand type checker - This helps with the case of using APPROX_COUNT_DISTINCT() and other functions.
2. In the SQL layer - This helps with the case of doing `select count (distinct column)` type queries.
3. In the native layer - This helps with the case of doing native queries.

### Test plan

1. Manually verified the functionality of `APPROX_COUNT_DISTINCT`, `APPROX_COUNT_DISTINCT_DS_HLL`, `APPROX_COUNT_DISTINCT_DS_HLL_UTF8`, `APPROX_COUNT_DISTINCT_DS_THETA`
2. Manually verified the functionality of `select count (distinct column)`
3. Manually verified the functionality of native queries.

Sample error message after this PR's changes in sql layer:
![image](https://github.com/apache/druid/assets/31135861/cf26b1ea-e611-4646-afa0-64ffb30ee4fe)

Sample error message after this PR's changes in native layer:
![image](https://github.com/apache/druid/assets/31135861/01190c0a-01ec-440f-b4d8-6bb0cf650e53)

### Release Note

Queries like `SELECT COUNT(DISTINCT columnName) FROM tableName WHERE columnValue = 'non-existing-value'` will also stop working with these changes.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
