### PR TITLE
Better error handling when retrieving Avro schemas from registry

### DIFF
--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -36,10 +36,7 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.java.util.http.client.HttpClient;
-import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
-import org.asynchttpclient.util.HttpConstants;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
+++ b/extensions-core/avro-extensions/src/main/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoder.java
@@ -36,7 +36,10 @@ import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.java.util.common.parsers.ParseException;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
+import org.asynchttpclient.util.HttpConstants;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -139,11 +142,34 @@ public class SchemaRegistryBasedAvroBytesDecoder implements AvroBytesDecoder
       ParsedSchema parsedSchema = registry.getSchemaById(id);
       schema = parsedSchema instanceof AvroSchema ? ((AvroSchema) parsedSchema).rawSchema() : null;
     }
-    catch (IOException | RestClientException ex) {
-      throw new ParseException(null, ex, "Failed to fetch Avro schema id[%s] from registry. Check if the schema "
-                                         + "exists in the registry. Otherwise it could mean that there is "
-                                         + "malformed data in the stream or data that doesn't conform to the schema "
-                                         + "specified.", id);
+    catch (IOException ex1) {
+      throw new ParseException(
+          null,
+          ex1,
+          "Failed to fetch Avro schema id[%s] from registry. Check if the schema exists in the registry. Otherwise it"
+          + " could mean that there is malformed data in the stream or data that doesn't conform to the schema"
+          + " specified.",
+          id
+      );
+    }
+    catch (RestClientException ex2) {
+      if (ex2.getErrorCode() == 401) {
+        throw new ParseException(
+            null,
+            ex2,
+            "Failed to authenticate to schema registry for Avro schema id[%s]. Please check your credentials.",
+            id
+        );
+      }
+      // For all other errors, just include the code and message received from the library.
+      throw new ParseException(
+          null,
+          ex2,
+          "Failed to fetch Avro schema id[%s] from registry. Error code[%s] and message[%s].",
+          id,
+          ex2.getErrorCode(),
+          ex2.getMessage()
+      );
     }
     if (schema == null) {
       throw new ParseException(null, "No Avro schema id[%s] in registry", id);

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
@@ -32,7 +33,10 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.hamcrest.CoreMatchers;
@@ -61,15 +65,15 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   @Test
   public void testMultipleUrls() throws Exception
   {
+    // Given
     String json = "{\"urls\":[\"http://localhost\"],\"type\": \"schema_registry\"}";
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
-    SchemaRegistryBasedAvroBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
-        .readerFor(AvroBytesDecoder.class)
-        .readValue(json);
+
+    // When
+    SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
     Assert.assertNotEquals(decoder.hashCode(), 0);
@@ -78,15 +82,15 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   @Test
   public void testUrl() throws Exception
   {
+    // Given
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\"}";
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
-    SchemaRegistryBasedAvroBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
-        .readerFor(AvroBytesDecoder.class)
-        .readValue(json);
+
+    // When
+    SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
     Assert.assertNotEquals(decoder.hashCode(), 0);
@@ -95,15 +99,15 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   @Test
   public void testConfig() throws Exception
   {
+    // Given
     String json = "{\"url\":\"http://localhost\",\"type\": \"schema_registry\", \"config\":{}}";
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
-    SchemaRegistryBasedAvroBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
-        .readerFor(AvroBytesDecoder.class)
-        .readValue(json);
+
+    // When
+    SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
     Assert.assertNotEquals(decoder.hashCode(), 0);
@@ -121,20 +125,31 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 5).put((byte) 0).putInt(1234).put(bytes);
     bb.rewind();
     // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+    GenericRecord parse = new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+
+    // Then
+    Assert.assertEquals(schema, parse.getSchema());;
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testParseCorruptedNotEnoughBytesToEvenGetSchemaInfo()
   {
     // Given
     ByteBuffer bb = ByteBuffer.allocate(2).put((byte) 0).put(1, (byte) 1);
     bb.rewind();
-    // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+
+    // When / Then
+    final ParseException e = Assert.assertThrows(
+        ParseException.class,
+        () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
+    );
+    MatcherAssert.assertThat(
+        e.getMessage(),
+        CoreMatchers.containsString("Failed to decode avro message, not enough bytes to decode (2)")
+    );
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testParseCorruptedPartial() throws Exception
   {
     // Given
@@ -145,19 +160,30 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     byte[] bytes = getAvroDatum(schema, someAvroDatum);
     ByteBuffer bb = ByteBuffer.allocate(4 + 5).put((byte) 0).putInt(1234).put(bytes, 5, 4);
     bb.rewind();
-    // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+
+    // When / Then
+    final ParseException e = Assert.assertThrows(
+        ParseException.class,
+        () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
+    );
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
+    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("Failed to decode Avro message for schema id[1234]"));
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testParseWrongSchemaType() throws Exception
   {
     // Given
     Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234))).thenReturn(Mockito.mock(ParsedSchema.class));
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
-    // When
-    new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
+
+    // When / Then
+    final ParseException e = Assert.assertThrows(
+        ParseException.class,
+        () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
+    );
+    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("No Avro schema id[1234] in registry"));
   }
 
   @Test
@@ -167,7 +193,8 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     Mockito.when(registry.getSchemaById(ArgumentMatchers.anyInt())).thenThrow(new IOException("no pasaran"));
     ByteBuffer bb = ByteBuffer.allocate(5).put((byte) 0).putInt(1234);
     bb.rewind();
-    // When
+
+    // When / Then
     final ParseException e = Assert.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
@@ -187,17 +214,20 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   @Test
   public void testParseHeader() throws JsonProcessingException
   {
+    // Given
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{},\"headers\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.header.prop.2\":\"value.2\", \"registry.header.prop.3\":\"value.3\"}},\"registry.header.prop.1\":\"value.1\",\"registry.header.prop.2\":\"value.4\"}}";
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
-    SchemaRegistryBasedAvroBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
-        .readerFor(AvroBytesDecoder.class)
-        .readValue(json);
+    SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
-    Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
+    // When
+    Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(
+        decoder.getHeaders(),
+        SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY,
+        new DefaultObjectMapper()
+    );
 
     // Then
     Assert.assertEquals(3, header.size());
@@ -209,22 +239,78 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   @Test
   public void testParseConfig() throws JsonProcessingException
   {
+    // Given
     String json = "{\"url\":\"http://localhost\",\"type\":\"schema_registry\",\"config\":{\"druid.dynamic.config.provider\":{\"type\":\"mapString\", \"config\":{\"registry.config.prop.2\":\"value.2\", \"registry.config.prop.3\":\"value.3\"}},\"registry.config.prop.1\":\"value.1\",\"registry.config.prop.2\":\"value.4\"},\"headers\":{}}";
     ObjectMapper mapper = new DefaultObjectMapper();
     mapper.setInjectableValues(
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
-    SchemaRegistryBasedAvroBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedAvroBytesDecoder) mapper
-        .readerFor(AvroBytesDecoder.class)
-        .readValue(json);
+    SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
-    Map<String, ?> config = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getConfig(), SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
+    // When
+    Map<String, ?> config = DynamicConfigProviderUtils.extraConfigAndSetStringMap(
+        decoder.getConfig(),
+        SchemaRegistryBasedAvroBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY,
+        new DefaultObjectMapper()
+    );
 
     // Then
     Assert.assertEquals(3, config.size());
     Assert.assertEquals("value.1", config.get("registry.config.prop.1"));
     Assert.assertEquals("value.2", config.get("registry.config.prop.2"));
     Assert.assertEquals("value.3", config.get("registry.config.prop.3"));
+  }
+
+  @Test
+  public void testUnauthenticatedRestClientException() throws IOException, RestClientException
+  {
+    Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234)))
+           .thenThrow(new RestClientException("unauthenticated", 401, 401));
+    GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    Schema schema = SomeAvroDatum.getClassSchema();
+    byte[] bytes = getAvroDatum(schema, someAvroDatum);
+    ByteBuffer bb = ByteBuffer.allocate(4 + 5).put((byte) 0).putInt(1234).put(bytes, 5, 4);
+    bb.rewind();
+
+    // When / Then
+    final ParseException e = Assert.assertThrows(
+        ParseException.class,
+        () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
+    );
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
+    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.containsString("unauthenticated"));
+    MatcherAssert.assertThat(
+        e.getMessage(),
+        CoreMatchers.containsString(
+            "Failed to authenticate to schema registry for Avro schema id[1234]. Please check your credentials"
+        )
+    );
+  }
+
+  @Test
+  public void testRestClientException() throws IOException, RestClientException
+  {
+    Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234)))
+           .thenThrow(new RestClientException("resource doesn't exist", 404, 404));
+    GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
+    Schema schema = SomeAvroDatum.getClassSchema();
+    byte[] bytes = getAvroDatum(schema, someAvroDatum);
+    ByteBuffer bb = ByteBuffer.allocate(4 + 5).put((byte) 0).putInt(1234).put(bytes, 5, 4);
+    bb.rewind();
+
+    // When / Then
+    final ParseException e = Assert.assertThrows(
+        ParseException.class,
+        () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
+    );
+    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
+    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.containsString("resource doesn't exist"));
+    MatcherAssert.assertThat(
+        e.getMessage(),
+        CoreMatchers.containsString(
+            "Failed to fetch Avro schema id[1234] from registry."
+            + " Error code[404] and message[resource doesn't exist; error code: 404]."
+        )
+    );
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -33,10 +33,7 @@ import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.druid.data.input.AvroStreamInputRowParserTest;
 import org.apache.druid.data.input.SomeAvroDatum;
-import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.hamcrest.CoreMatchers;
@@ -124,11 +121,12 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     byte[] bytes = getAvroDatum(schema, someAvroDatum);
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 5).put((byte) 0).putInt(1234).put(bytes);
     bb.rewind();
+
     // When
     GenericRecord parse = new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
 
     // Then
-    Assert.assertEquals(schema, parse.getSchema());;
+    Assert.assertEquals(schema, parse.getSchema());
   }
 
   @Test

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -262,8 +262,9 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   }
 
   @Test
-  public void testUnauthenticatedRestClientException() throws IOException, RestClientException
+  public void testParseWhenUnauthenticatedException() throws IOException, RestClientException
   {
+    // Given
     Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234)))
            .thenThrow(new RestClientException("unauthenticated", 401, 401));
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();
@@ -288,8 +289,9 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
   }
 
   @Test
-  public void testRestClientException() throws IOException, RestClientException
+  public void testParseWhenResourceNotFoundException() throws IOException, RestClientException
   {
+    // Given
     Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234)))
            .thenThrow(new RestClientException("resource doesn't exist", 404, 404));
     GenericRecord someAvroDatum = AvroStreamInputRowParserTest.buildSomeAvroDatum();


### PR DESCRIPTION
Currently, when retrieving an Avro schema from the registry and if the request fails with an `IOException` or a `RestClientException`, we bubble this generic error up to the user:

```
"Failed to fetch Avro schema id[233323] from registry. Check if the schema exists in the registry. Otherwise it
could mean that there is malformed data in the stream or data that doesn't conform to the schema"
specified."
```

However, this error message is however misleading in cases where the rest client is throwing unauthorized/forbidden error codes.  So we now handle `IOException` and `RestClientException` separately so that we can bubble up more specific errors rather than the common template.

Added unit tests for the change and also cleaned up test annotations `@Test(expected = ParseException.class)` by adding better tests assertions.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
