### PR TITLE
fix unnest bugs

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteArraysQueryMSQTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteArraysQueryMSQTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.guice.DruidInjectorBuilder;
 import org.apache.druid.msq.exec.WorkerMemoryParameters;
 import org.apache.druid.msq.sql.MSQTaskSqlEngine;
@@ -34,6 +35,7 @@ import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.TempDirProducer;
 import org.apache.druid.sql.calcite.run.SqlEngine;
+import org.junit.jupiter.api.Test;
 
 /**
  * Runs {@link CalciteArraysQueryTest} but with MSQ engine
@@ -91,6 +93,35 @@ public class CalciteArraysQueryMSQTest extends CalciteArraysQueryTest
         .addCustomRunner(new ExtractResultsFactory(() -> (MSQTestOverlordServiceClient) ((MSQTaskSqlEngine) queryFramework().engine()).overlordClient()))
         .skipVectorize(true)
         .verifyNativeQueries(new VerifyMSQSupportedNativeQueriesPredicate());
+  }
+
+  @Override
+  @Test
+  public void testUnnestWithGroupByOrderByWithLimit()
+  {
+    // results differ from base test because group-by and topN handle empty multi-value dimensions differently
+    testBuilder()
+        .sql(
+            "SELECT d3, COUNT(*) FROM druid.numfoo, UNNEST(MV_TO_ARRAY(dim3)) AS unnested(d3) GROUP BY d3 ORDER BY d3 ASC LIMIT 4 "
+        )
+        .queryContext(QUERY_CONTEXT_UNNEST)
+        .expectedResults(
+            NullHandling.replaceWithDefault() ?
+            ImmutableList.of(
+                new Object[]{"", 3L},
+                new Object[]{"a", 1L},
+                new Object[]{"b", 2L},
+                new Object[]{"c", 1L}
+            ) :
+            ImmutableList.of(
+                new Object[]{null, 2L},
+                new Object[]{"", 1L},
+                new Object[]{"a", 1L},
+                new Object[]{"b", 2L}
+            )
+        )
+        .build()
+        .run();
   }
 }
 

--- a/processing/src/main/java/org/apache/druid/frame/field/FieldWriters.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/FieldWriters.java
@@ -132,7 +132,7 @@ public class FieldWriters
   {
     final DimensionSelector selector = selectorFactory.makeDimensionSelector(DefaultDimensionSpec.of(columnName));
     final ColumnCapabilities capabilities = selectorFactory.getColumnCapabilities(columnName);
-    return new StringFieldWriter(selector, removeNullBytes, capabilities != null && capabilities.hasMultipleValues().isTrue());
+    return new StringFieldWriter(selector, removeNullBytes, capabilities == null || capabilities.hasMultipleValues().isMaybeTrue());
   }
 
   private static FieldWriter makeStringArrayWriter(

--- a/processing/src/main/java/org/apache/druid/frame/field/FieldWriters.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/FieldWriters.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionSelector;
+import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.serde.ComplexMetricSerde;
 import org.apache.druid.segment.serde.ComplexMetrics;
@@ -130,7 +131,8 @@ public class FieldWriters
   )
   {
     final DimensionSelector selector = selectorFactory.makeDimensionSelector(DefaultDimensionSpec.of(columnName));
-    return new StringFieldWriter(selector, removeNullBytes);
+    final ColumnCapabilities capabilities = selectorFactory.getColumnCapabilities(columnName);
+    return new StringFieldWriter(selector, removeNullBytes, capabilities != null && capabilities.hasMultipleValues().isTrue());
   }
 
   private static FieldWriter makeStringArrayWriter(

--- a/processing/src/main/java/org/apache/druid/frame/field/StringFieldWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/StringFieldWriter.java
@@ -56,17 +56,19 @@ public class StringFieldWriter implements FieldWriter
 
   private final DimensionSelector selector;
   private final boolean removeNullBytes;
+  private final boolean multiValue;
 
-  public StringFieldWriter(final DimensionSelector selector, final boolean removeNullbytes)
+  public StringFieldWriter(final DimensionSelector selector, final boolean removeNullbytes, final boolean multiValue)
   {
     this.selector = selector;
     this.removeNullBytes = removeNullbytes;
+    this.multiValue = multiValue;
   }
 
   @Override
   public long writeTo(final WritableMemory memory, final long position, final long maxSize)
   {
-    final List<ByteBuffer> byteBuffers = FrameWriterUtils.getUtf8ByteBuffersFromStringSelector(selector, true);
+    final List<ByteBuffer> byteBuffers = FrameWriterUtils.getUtf8ByteBuffersFromStringSelector(selector, multiValue);
     return writeUtf8ByteBuffers(memory, position, maxSize, byteBuffers, removeNullBytes);
   }
 
@@ -95,7 +97,7 @@ public class StringFieldWriter implements FieldWriter
       final boolean removeNullBytes
   )
   {
-    if (byteBuffers == null) {
+    if (byteBuffers == null || byteBuffers.isEmpty()) {
       if (maxSize < NULL_ROW_SIZE) {
         return -1;
       }

--- a/processing/src/main/java/org/apache/druid/frame/field/StringFieldWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/StringFieldWriter.java
@@ -97,7 +97,7 @@ public class StringFieldWriter implements FieldWriter
       final boolean removeNullBytes
   )
   {
-    if (byteBuffers == null || byteBuffers.isEmpty()) {
+    if (byteBuffers == null) {
       if (maxSize < NULL_ROW_SIZE) {
         return -1;
       }

--- a/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestStorageAdapter.java
@@ -582,10 +582,12 @@ public class UnnestStorageAdapter implements StorageAdapter
       final TypeSignature<ValueType> outputType =
           capabilities.isArray() ? capabilities.getElementType() : capabilities.toColumnType();
 
+      final boolean useDimensionCursor = useDimensionCursor(capabilities);
       return ColumnCapabilitiesImpl.createDefault()
                                    .setType(outputType)
                                    .setHasMultipleValues(false)
-                                   .setDictionaryEncoded(useDimensionCursor(capabilities));
+                                   .setDictionaryEncoded(useDimensionCursor)
+                                   .setDictionaryValuesUnique(useDimensionCursor);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldWriterTest.java
@@ -65,8 +65,8 @@ public class StringFieldWriterTest extends InitializedNullHandlingTest
   public void setUp()
   {
     memory = WritableMemory.allocate(1000);
-    fieldWriter = new StringFieldWriter(selector, false);
-    fieldWriterUtf8 = new StringFieldWriter(selectorUtf8, false);
+    fieldWriter = new StringFieldWriter(selector, false, true);
+    fieldWriterUtf8 = new StringFieldWriter(selectorUtf8, false, true);
   }
 
   @After

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -182,12 +182,8 @@ public class FrameWriterTest extends InitializedNullHandlingTest
   {
     capabilitiesAdjustFn = capabilities -> capabilities.setHasMultipleValues(ColumnCapabilities.Capable.FALSE);
 
-    // When columnar frames are in multiValue = false mode, and when they see a dataset that is all single strings and
-    // empty arrays, they write a single-valued column, replacing the empty arrays with nulls.
     final FrameWriterTestData.Dataset<?> expectedReadDataset =
-        outputFrameType == FrameType.COLUMNAR
-        ? FrameWriterTestData.TEST_STRINGS_SINGLE_VALUE
-        : FrameWriterTestData.TEST_STRINGS_SINGLE_VALUE_WITH_EMPTY;
+        FrameWriterTestData.TEST_STRINGS_SINGLE_VALUE;
 
     testWithDataset(
         FrameWriterTestData.TEST_STRINGS_SINGLE_VALUE_WITH_EMPTY,
@@ -214,19 +210,15 @@ public class FrameWriterTest extends InitializedNullHandlingTest
   {
     capabilitiesAdjustFn = capabilities -> capabilities.setHasMultipleValues(ColumnCapabilities.Capable.FALSE);
 
-    if (outputFrameType == FrameType.COLUMNAR) {
-      final IllegalStateException e = Assert.assertThrows(
-          IllegalStateException.class,
-          () -> testWithDataset(FrameWriterTestData.TEST_STRINGS_MULTI_VALUE)
-      );
+    final Throwable e = Assert.assertThrows(
+        Throwable.class,
+        () -> testWithDataset(FrameWriterTestData.TEST_STRINGS_MULTI_VALUE)
+    );
 
-      MatcherAssert.assertThat(
-          e,
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Encountered unexpected multi-value row"))
-      );
-    } else {
-      testWithDataset(FrameWriterTestData.TEST_STRINGS_MULTI_VALUE);
-    }
+    MatcherAssert.assertThat(
+        e,
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Encountered unexpected multi-value row"))
+    );
   }
 
   @Test
@@ -567,7 +559,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
           null,
           inputFrameType,
           HeapMemoryAllocator.unlimited(),
-          null,
+          capabilitiesAdjustFn,
           rows,
           signature,
           Collections.emptyList()

--- a/processing/src/test/java/org/apache/druid/query/QueryRunnerTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/QueryRunnerTestHelper.java
@@ -524,8 +524,7 @@ public class QueryRunnerTestHelper
     final DataSource base = query.getDataSource();
 
     final SegmentReference segmentReference = base.createSegmentMapFunction(query, new AtomicLong())
-                                                  .apply(ReferenceCountingSegment.wrapRootGenerationSegment(
-                                                      adapter));
+                                                  .apply(ReferenceCountingSegment.wrapRootGenerationSegment(adapter));
     return makeQueryRunner(factory, segmentReference, runnerName);
   }
 

--- a/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/UnnestGroupByQueryRunnerTest.java
@@ -25,7 +25,10 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.data.input.ListBasedInputRow;
+import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.DirectQueryProcessingPool;
@@ -43,21 +46,29 @@ import org.apache.druid.query.extraction.StringFormatExtractionFn;
 import org.apache.druid.query.filter.EqualityFilter;
 import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
+import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.segment.IncrementalIndexSegment;
+import org.apache.druid.segment.IndexBuilder;
+import org.apache.druid.segment.QueryableIndex;
+import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.joda.time.DateTime;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,6 +88,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
 
   public UnnestGroupByQueryRunnerTest(
       GroupByQueryConfig config,
@@ -210,6 +224,11 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
   }
 
   private static ResultRow makeRow(final GroupByQuery query, final String timestamp, final Object... vals)
+  {
+    return GroupByQueryRunnerTestHelper.createExpectedRow(query, timestamp, vals);
+  }
+
+  private static ResultRow makeRow(final GroupByQuery query, final DateTime timestamp, final Object... vals)
   {
     return GroupByQueryRunnerTestHelper.createExpectedRow(query, timestamp, vals);
   }
@@ -423,6 +442,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy");
   }
 
   @Test
@@ -461,6 +483,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "missing-column");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "missing-column");
   }
 
@@ -537,6 +562,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-column");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-column");
   }
 
@@ -627,6 +655,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
   @Test
@@ -678,35 +709,244 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-columns");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
-  /**
-   * Use this method instead of makeQueryBuilder() to make sure the context is set properly. Also, avoid
-   * setContext in tests. Only use overrideContext.
-   */
-  private GroupByQuery.Builder makeQueryBuilder()
+  @Test
+  public void testGroupByOnUnnestedStringColumnWithNullStuff() throws IOException
   {
-    return GroupByQuery.builder().overrideContext(makeContext());
-  }
+    cannotVectorize();
 
-  private Iterable<ResultRow> runQuery(final GroupByQuery query, final IncrementalIndex index)
-  {
-    final QueryRunner<?> queryRunner = factory.mergeRunners(
-        DirectQueryProcessingPool.INSTANCE,
-        Collections.singletonList(
-            QueryRunnerTestHelper.makeQueryRunnerWithSegmentMapFn(
-                factory,
-                new IncrementalIndexSegment(
-                    index,
-                    QueryRunnerTestHelper.SEGMENT_ID
-                ),
-                query,
-                "rtIndexvc"
-            )
-        )
+    final String dim = "mvd";
+    final DateTime timestamp = DateTimes.nowUtc();
+    final RowSignature signature = RowSignature.builder()
+                                               .add(dim, ColumnType.STRING)
+                                               .build();
+    List<String> dims = Collections.singletonList(dim);
+    IndexBuilder bob =
+        IndexBuilder.create()
+                    .rows(
+                        ImmutableList.of(
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(ImmutableList.of("a", "b", "c"))),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of()),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(ImmutableList.of())),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(""))
+                        )
+                    );
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            "v0",
+            "mvd",
+            ColumnType.STRING,
+            TestExprMacroTable.INSTANCE
+        ),
+        null
     );
 
-    return GroupByQueryRunnerTestHelper.runQuery(factory, queryRunner, query);
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(Collections.singletonList(Intervals.ETERNITY)))
+        .setDimensions(new DefaultDimensionSpec("v0", "v0"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+    List<ResultRow> expectedResults = NullHandling.sqlCompatible() ? Arrays.asList(
+        makeRow(query, timestamp, "v0", null, "rows", 1L),
+        makeRow(query, timestamp, "v0", "", "rows", 1L),
+        makeRow(query, timestamp, "v0", "a", "rows", 1L),
+        makeRow(query, timestamp, "v0", "b", "rows", 1L),
+        makeRow(query, timestamp, "v0", "c", "rows", 1L)
+    ) : Arrays.asList(
+        makeRow(query, timestamp, "v0", null, "rows", 1L),
+        makeRow(query, timestamp, "v0", "a", "rows", 1L),
+        makeRow(query, timestamp, "v0", "b", "rows", 1L),
+        makeRow(query, timestamp, "v0", "c", "rows", 1L)
+    );
+
+    Iterable<ResultRow> results = runQuery(query, bob.buildIncrementalIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls");
+
+    results = runQuery(query, bob.tmpDir(tempFolder.newFolder()).buildMMappedIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls");
+  }
+
+  @Test
+  public void testGroupByOnUnnestedStringColumnWithMoreNullStuff() throws IOException
+  {
+    cannotVectorize();
+
+    final String dim = "mvd";
+    final DateTime timestamp = DateTimes.nowUtc();
+    final RowSignature signature = RowSignature.builder()
+                                               .add(dim, ColumnType.STRING)
+                                               .build();
+    List<String> dims = Collections.singletonList(dim);
+    IndexBuilder bob =
+        IndexBuilder.create()
+                    .rows(
+                        ImmutableList.of(
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(Arrays.asList("a", "b", "c"))),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.emptyList()),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(null)),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(Collections.emptyList())),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(Arrays.asList(null, null))),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(Collections.singletonList(null))),
+                            new ListBasedInputRow(signature, timestamp, dims, Collections.singletonList(Collections.singletonList("")))
+                        )
+                    );
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            "v0",
+            "mvd",
+            ColumnType.STRING,
+            TestExprMacroTable.INSTANCE
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(Collections.singletonList(Intervals.ETERNITY)))
+        .setDimensions(new DefaultDimensionSpec("v0", "v0"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+    List<ResultRow> expectedResults = NullHandling.sqlCompatible() ? Arrays.asList(
+        makeRow(query, timestamp, "v0", null, "rows", 3L),
+        makeRow(query, timestamp, "v0", "", "rows", 1L),
+        makeRow(query, timestamp, "v0", "a", "rows", 1L),
+        makeRow(query, timestamp, "v0", "b", "rows", 1L),
+        makeRow(query, timestamp, "v0", "c", "rows", 1L)
+    ) : Arrays.asList(
+        makeRow(query, timestamp, "v0", null, "rows", 3L),
+        makeRow(query, timestamp, "v0", "a", "rows", 1L),
+        makeRow(query, timestamp, "v0", "b", "rows", 1L),
+        makeRow(query, timestamp, "v0", "c", "rows", 1L)
+    );
+
+    Iterable<ResultRow> results = runQuery(query, bob.buildIncrementalIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls");
+
+    results = runQuery(query, bob.tmpDir(tempFolder.newFolder()).buildMMappedIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls");
+  }
+
+  @Test
+  public void testGroupByOnUnnestEmptyTable()
+  {
+    cannotVectorize();
+    IndexBuilder bob =
+        IndexBuilder.create()
+                    .rows(ImmutableList.of());
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            "v0",
+            "mvd",
+            ColumnType.STRING,
+            TestExprMacroTable.INSTANCE
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(unnestDataSource)
+        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(Collections.singletonList(Intervals.ETERNITY)))
+        .setDimensions(new DefaultDimensionSpec("v0", "v0"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+    List<ResultRow> expectedResults = Collections.emptyList();
+
+    Iterable<ResultRow> results = runQuery(query, bob.buildIncrementalIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-empty");
+
+    // can only test realtime since empty cannot be persisted
+  }
+
+  @Test
+  public void testGroupByOnUnnestedStringColumnDoubleUnnest() throws IOException
+  {
+    // not really a sane query to write, but it shouldn't behave differently than a single unnest
+    // the issue is that the dimension selector handles null differently than if arrays are used from a column value
+    // selector. the dimension selector cursor puts nulls in the output to be compatible with implict unnest used by
+    // group-by, while the column selector cursor
+    cannotVectorize();
+
+    final String dim = "mvd";
+    final DateTime timestamp = DateTimes.nowUtc();
+    final RowSignature signature = RowSignature.builder()
+                                               .add(dim, ColumnType.STRING)
+                                               .build();
+    List<String> dims = Collections.singletonList(dim);
+    IndexBuilder bob =
+        IndexBuilder.create()
+                    .rows(
+                        ImmutableList.of(
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(ImmutableList.of("a", "b", "c"))),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of()),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(ImmutableList.of())),
+                            new ListBasedInputRow(signature, timestamp, dims, ImmutableList.of(""))
+                        )
+                    );
+
+    final DataSource unnestDataSource = UnnestDataSource.create(
+        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+        new ExpressionVirtualColumn(
+            "v0",
+            "mvd",
+            ColumnType.STRING,
+            TestExprMacroTable.INSTANCE
+        ),
+        null
+    );
+    final DataSource extraUnnested = UnnestDataSource.create(
+        unnestDataSource,
+        new ExpressionVirtualColumn(
+            "v1",
+            "v0",
+            ColumnType.STRING,
+            TestExprMacroTable.INSTANCE
+        ),
+        null
+    );
+
+    GroupByQuery query = makeQueryBuilder()
+        .setDataSource(extraUnnested)
+        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(Collections.singletonList(Intervals.ETERNITY)))
+        .setDimensions(new DefaultDimensionSpec("v1", "v1"))
+        .setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT)
+        .setGranularity(QueryRunnerTestHelper.ALL_GRAN)
+        .build();
+
+    List<ResultRow> expectedResults = NullHandling.sqlCompatible() ? Arrays.asList(
+        makeRow(query, timestamp, "v1", null, "rows", 1L),
+        makeRow(query, timestamp, "v1", "", "rows", 1L),
+        makeRow(query, timestamp, "v1", "a", "rows", 1L),
+        makeRow(query, timestamp, "v1", "b", "rows", 1L),
+        makeRow(query, timestamp, "v1", "c", "rows", 1L)
+    ) : Arrays.asList(
+        makeRow(query, timestamp, "v1", null, "rows", 1L),
+        makeRow(query, timestamp, "v1", "a", "rows", 1L),
+        makeRow(query, timestamp, "v1", "b", "rows", 1L),
+        makeRow(query, timestamp, "v1", "c", "rows", 1L)
+    );
+
+    Iterable<ResultRow> results = runQuery(query, bob.buildIncrementalIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls-double-unnest");
+
+    results = runQuery(query, bob.tmpDir(tempFolder.newFolder()).buildMMappedIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "group-by-unnested-string-nulls-double-unnest");
   }
 
   @Test
@@ -750,6 +990,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
@@ -836,6 +1079,9 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     );
 
     Iterable<ResultRow> results = runQuery(query, TestIndex.getIncrementalTestIndex());
+    TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
+
+    results = runQuery(query, TestIndex.getMMappedTestIndex());
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
@@ -931,6 +1177,56 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
     TestHelper.assertExpectedObjects(expectedResults, results, "groupBy-on-unnested-virtual-column");
   }
 
+
+  /**
+   * Use this method instead of makeQueryBuilder() to make sure the context is set properly. Also, avoid
+   * setContext in tests. Only use overrideContext.
+   */
+  private GroupByQuery.Builder makeQueryBuilder()
+  {
+    return GroupByQuery.builder().overrideContext(makeContext());
+  }
+
+  private Iterable<ResultRow> runQuery(final GroupByQuery query, final IncrementalIndex index)
+  {
+    final QueryRunner<?> queryRunner = factory.mergeRunners(
+        DirectQueryProcessingPool.INSTANCE,
+        Collections.singletonList(
+            QueryRunnerTestHelper.makeQueryRunnerWithSegmentMapFn(
+                factory,
+                new IncrementalIndexSegment(
+                    index,
+                    QueryRunnerTestHelper.SEGMENT_ID
+                ),
+                query,
+                "rtIndexvc"
+            )
+        )
+    );
+
+    return GroupByQueryRunnerTestHelper.runQuery(factory, queryRunner, query);
+  }
+
+  private Iterable<ResultRow> runQuery(final GroupByQuery query, QueryableIndex index)
+  {
+    final QueryRunner<?> queryRunner = factory.mergeRunners(
+        DirectQueryProcessingPool.INSTANCE,
+        Collections.singletonList(
+            QueryRunnerTestHelper.makeQueryRunnerWithSegmentMapFn(
+                factory,
+                new QueryableIndexSegment(
+                    index,
+                    QueryRunnerTestHelper.SEGMENT_ID
+                ),
+                query,
+                "mmapIndexvc"
+            )
+        )
+    );
+
+    return GroupByQueryRunnerTestHelper.runQuery(factory, queryRunner, query);
+  }
+
   private Map<String, Object> makeContext()
   {
     return ImmutableMap.<String, Object>builder()
@@ -947,4 +1243,6 @@ public class UnnestGroupByQueryRunnerTest extends InitializedNullHandlingTest
       expectedException.expectMessage("Cannot vectorize!");
     }
   }
+
+
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/Projection.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.ExpressionPostAggregator;
@@ -152,7 +153,7 @@ public class Projection
       // because they would have been unnested, however, ARRAY_TO_MV is effectively CAST(array as VARCHAR) meaning it
       // can make multi-value string columns actually exist if array grouping was performed, so it is safer to just
       // fail to plan these into post-aggs which will result in a sub-query being planned instead
-      if (postAggregatorExpression.getExpression().toLowerCase().startsWith("array_to_mv")) {
+      if (StringUtils.toLowerCase(postAggregatorExpression.getExpression()).startsWith("array_to_mv")) {
         throw new CannotBuildQueryException(project, postAggregatorRexNode);
       }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -5137,13 +5137,13 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         ),
         useDefault ?
         ImmutableList.of(
-            new Object[]{"", 3L},
+            new Object[]{"", 2L},
             new Object[]{"a", 1L},
             new Object[]{"b", 2L},
             new Object[]{"c", 1L}
         ) :
         ImmutableList.of(
-            new Object[]{null, 2L},
+            new Object[]{null, 1L},
             new Object[]{"", 1L},
             new Object[]{"a", 1L},
             new Object[]{"b", 2L}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -47,7 +47,6 @@ import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.query.aggregation.ExpressionLambdaAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
-import org.apache.druid.query.aggregation.post.ExpressionPostAggregator;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.extraction.SubstringDimExtractionFn;
@@ -951,33 +950,33 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   public void testArrayOverlapFilterWithDynamicParameter()
   {
     Druids.ScanQueryBuilder builder = newScanQueryBuilder()
-            .dataSource(CalciteTests.DATASOURCE3)
-            .intervals(querySegmentSpec(Filtration.eternity()))
-            .filters(expressionFilter("array_overlap(array(1.0,1.7,null),array(\"d1\"))"))
-            .columns("dim3")
-            .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-            .limit(5)
-            .context(QUERY_CONTEXT_DEFAULT);
+        .dataSource(CalciteTests.DATASOURCE3)
+        .intervals(querySegmentSpec(Filtration.eternity()))
+        .filters(expressionFilter("array_overlap(array(1.0,1.7,null),array(\"d1\"))"))
+        .columns("dim3")
+        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+        .limit(5)
+        .context(QUERY_CONTEXT_DEFAULT);
 
     testQuery(
-            PLANNER_CONFIG_DEFAULT,
-            QUERY_CONTEXT_DEFAULT,
-            ImmutableList.of(
-                    new SqlParameter(SqlType.ARRAY, Arrays.asList(1.0, 1.7, null))
-            ),
-            "SELECT dim3 FROM druid.numfoo WHERE ARRAY_OVERLAP(?, ARRAY[d1]) LIMIT 5",
-            CalciteTests.REGULAR_USER_AUTH_RESULT,
-            ImmutableList.of(builder.build()),
-            NullHandling.sqlCompatible() ? ImmutableList.of(
-                    new Object[]{"[\"a\",\"b\"]"},
-                    new Object[]{"[\"b\",\"c\"]"},
-                    new Object[]{""},
-                    new Object[]{null},
-                    new Object[]{null}
-            ) : ImmutableList.of(
-                    new Object[]{"[\"a\",\"b\"]"},
-                    new Object[]{"[\"b\",\"c\"]"}
-            )
+        PLANNER_CONFIG_DEFAULT,
+        QUERY_CONTEXT_DEFAULT,
+        ImmutableList.of(
+            new SqlParameter(SqlType.ARRAY, Arrays.asList(1.0, 1.7, null))
+        ),
+        "SELECT dim3 FROM druid.numfoo WHERE ARRAY_OVERLAP(?, ARRAY[d1]) LIMIT 5",
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
+        ImmutableList.of(builder.build()),
+        NullHandling.sqlCompatible() ? ImmutableList.of(
+            new Object[]{"[\"a\",\"b\"]"},
+            new Object[]{"[\"b\",\"c\"]"},
+            new Object[]{""},
+            new Object[]{null},
+            new Object[]{null}
+        ) : ImmutableList.of(
+            new Object[]{"[\"a\",\"b\"]"},
+            new Object[]{"[\"b\",\"c\"]"}
+        )
     );
   }
 
@@ -1211,8 +1210,16 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                 .intervals(querySegmentSpec(Filtration.eternity()))
                 .columns("v0", "v1")
                 .virtualColumns(
-                    expressionVirtualColumn("v0", "array_contains(\"arrayStringNulls\",array('a','b'))", ColumnType.LONG),
-                    expressionVirtualColumn("v1", "array_contains(\"arrayStringNulls\",\"arrayString\")", ColumnType.LONG)
+                    expressionVirtualColumn(
+                        "v0",
+                        "array_contains(\"arrayStringNulls\",array('a','b'))",
+                        ColumnType.LONG
+                    ),
+                    expressionVirtualColumn(
+                        "v1",
+                        "array_contains(\"arrayStringNulls\",\"arrayString\")",
+                        ColumnType.LONG
+                    )
                 )
                 .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                 .limit(5)
@@ -1321,31 +1328,31 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   public void testArrayContainsFilterWithDynamicParameter()
   {
     Druids.ScanQueryBuilder builder = newScanQueryBuilder()
-            .dataSource(CalciteTests.DATASOURCE3)
-            .intervals(querySegmentSpec(Filtration.eternity()))
-            .filters(expressionFilter("array_contains(array(1,null),array((\"d1\" > 1)))"))
-            .columns("dim3")
-            .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-            .limit(5)
-            .context(QUERY_CONTEXT_DEFAULT);
+        .dataSource(CalciteTests.DATASOURCE3)
+        .intervals(querySegmentSpec(Filtration.eternity()))
+        .filters(expressionFilter("array_contains(array(1,null),array((\"d1\" > 1)))"))
+        .columns("dim3")
+        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+        .limit(5)
+        .context(QUERY_CONTEXT_DEFAULT);
 
     testQuery(
-            PLANNER_CONFIG_DEFAULT,
-            QUERY_CONTEXT_DEFAULT,
-            ImmutableList.of(
-                    new SqlParameter(SqlType.ARRAY, Arrays.asList(true, null))
-            ),
-            "SELECT dim3 FROM druid.numfoo WHERE ARRAY_CONTAINS(?, ARRAY[d1>1]) LIMIT 5",
-            CalciteTests.REGULAR_USER_AUTH_RESULT,
-            ImmutableList.of(builder.build()),
-            NullHandling.sqlCompatible() ? ImmutableList.of(
-                    new Object[]{"[\"b\",\"c\"]"},
-                    new Object[]{""},
-                    new Object[]{null},
-                    new Object[]{null}
-            ) : ImmutableList.of(
-                    new Object[]{"[\"b\",\"c\"]"}
-            )
+        PLANNER_CONFIG_DEFAULT,
+        QUERY_CONTEXT_DEFAULT,
+        ImmutableList.of(
+            new SqlParameter(SqlType.ARRAY, Arrays.asList(true, null))
+        ),
+        "SELECT dim3 FROM druid.numfoo WHERE ARRAY_CONTAINS(?, ARRAY[d1>1]) LIMIT 5",
+        CalciteTests.REGULAR_USER_AUTH_RESULT,
+        ImmutableList.of(builder.build()),
+        NullHandling.sqlCompatible() ? ImmutableList.of(
+            new Object[]{"[\"b\",\"c\"]"},
+            new Object[]{""},
+            new Object[]{null},
+            new Object[]{null}
+        ) : ImmutableList.of(
+            new Object[]{"[\"b\",\"c\"]"}
+        )
     );
   }
 
@@ -4095,16 +4102,16 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         QUERY_CONTEXT_UNNEST,
         ImmutableList.of(
             newScanQueryBuilder()
-                  .dataSource(UnnestDataSource.create(
-                      new TableDataSource(CalciteTests.ARRAYS_DATASOURCE),
-                      expressionVirtualColumn("j0.unnest", "\"arrayString\"", ColumnType.STRING_ARRAY),
-                      null
-                  ))
-                  .intervals(querySegmentSpec(Filtration.eternity()))
-                  .virtualColumns(expressionVirtualColumn("v0", "concat(\"j0.unnest\",'.txt')", ColumnType.STRING))
-                  .context(QUERY_CONTEXT_UNNEST)
-                  .columns(ImmutableList.of("v0"))
-                  .build()
+                .dataSource(UnnestDataSource.create(
+                    new TableDataSource(CalciteTests.ARRAYS_DATASOURCE),
+                    expressionVirtualColumn("j0.unnest", "\"arrayString\"", ColumnType.STRING_ARRAY),
+                    null
+                ))
+                .intervals(querySegmentSpec(Filtration.eternity()))
+                .virtualColumns(expressionVirtualColumn("v0", "concat(\"j0.unnest\",'.txt')", ColumnType.STRING))
+                .context(QUERY_CONTEXT_UNNEST)
+                .columns(ImmutableList.of("v0"))
+                .build()
         ),
         ImmutableList.of(
             new Object[]{"d.txt"},
@@ -4706,6 +4713,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         )
     );
   }
+
   @Test
   public void testUnnestThriceWithFiltersOnDimAndAllUnnestColumns()
   {
@@ -4934,32 +4942,32 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
               .dataSource(
                   UnnestDataSource.create(
                       FilteredDataSource.create(
-                        UnnestDataSource.create(
-                            FilteredDataSource.create(
-                                UnnestDataSource.create(
-                                    new TableDataSource(CalciteTests.ARRAYS_DATASOURCE),
-                                    expressionVirtualColumn(
-                                        "j0.unnest",
-                                        "\"arrayLongNulls\"",
-                                        ColumnType.LONG_ARRAY
-                                    ),
-                                    null
-                                ),
-                                NullHandling.sqlCompatible()
-                                ? equality("arrayString", ImmutableList.of("a", "b"), ColumnType.STRING_ARRAY)
-                                : expressionFilter("(\"arrayString\" == array('a','b'))")
-                            ),
-                            expressionVirtualColumn(
-                                "_j0.unnest",
-                                "\"arrayDoubleNulls\"",
-                                ColumnType.DOUBLE_ARRAY
-                            ),
-                            null
-                        ),
-                        or(
-                            equality("j0.unnest", 1, ColumnType.LONG),
-                            equality("_j0.unnest", 2.2, ColumnType.DOUBLE)
-                        )
+                          UnnestDataSource.create(
+                              FilteredDataSource.create(
+                                  UnnestDataSource.create(
+                                      new TableDataSource(CalciteTests.ARRAYS_DATASOURCE),
+                                      expressionVirtualColumn(
+                                          "j0.unnest",
+                                          "\"arrayLongNulls\"",
+                                          ColumnType.LONG_ARRAY
+                                      ),
+                                      null
+                                  ),
+                                  NullHandling.sqlCompatible()
+                                  ? equality("arrayString", ImmutableList.of("a", "b"), ColumnType.STRING_ARRAY)
+                                  : expressionFilter("(\"arrayString\" == array('a','b'))")
+                              ),
+                              expressionVirtualColumn(
+                                  "_j0.unnest",
+                                  "\"arrayDoubleNulls\"",
+                                  ColumnType.DOUBLE_ARRAY
+                              ),
+                              null
+                          ),
+                          or(
+                              equality("j0.unnest", 1, ColumnType.LONG),
+                              equality("_j0.unnest", 2.2, ColumnType.DOUBLE)
+                          )
                       ),
                       expressionVirtualColumn(
                           "__j0.unnest",
@@ -5339,6 +5347,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         )
     );
   }
+
   @Test
   public void testUnnestWithFilters()
   {
@@ -5423,9 +5432,11 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                       null
                   ))
                   .intervals(querySegmentSpec(Filtration.eternity()))
-                  .virtualColumns(expressionVirtualColumn("v0",
-                                                          "timestamp_floor(\"__time\",'PT1H',null,'UTC')",
-                                                          ColumnType.LONG))
+                  .virtualColumns(expressionVirtualColumn(
+                      "v0",
+                      "timestamp_floor(\"__time\",'PT1H',null,'UTC')",
+                      ColumnType.LONG
+                  ))
                   .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .legacy(false)
                   .context(QUERY_CONTEXT_UNNEST)
@@ -7214,7 +7225,7 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
-  public void testArrayToMvPostaggInline()
+  public void testArrayToMvDoesNotPlanToPostAgg()
   {
     cannotVectorize();
     testQuery(
@@ -7236,61 +7247,61 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         + "FROM \"ext\"\n"
         + "GROUP BY \"strings\", \"longs\"",
         ImmutableList.of(
-            GroupByQuery.builder()
-                        .setDataSource(
-                            InlineDataSource.fromIterable(
-                                Arrays.asList(
-                                    new Object[]{0L, "A<#>B", "1<#>2"},
-                                    new Object[]{0L, "C<#>D", "3<#>4"}
-                                ),
-                                RowSignature.builder()
-                                            .add("c0", ColumnType.LONG)
-                                            .add("c1", ColumnType.STRING)
-                                            .add("c2", ColumnType.STRING)
-                                            .build()
-                            )
-                        )
-                        .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.ETERNITY)))
-                        .setDimensions(
-                            new DefaultDimensionSpec("v0", "d0", ColumnType.STRING_ARRAY),
-                            new DefaultDimensionSpec("v1", "d1", ColumnType.LONG_ARRAY)
-                        )
-                        .setVirtualColumns(
-                            new ExpressionVirtualColumn(
-                                "v0",
-                                "string_to_array(\"c1\",'<#>')",
-                                ColumnType.STRING_ARRAY,
-                                TestExprMacroTable.INSTANCE
-                            ),
-                            new ExpressionVirtualColumn(
-                                "v1",
-                                "CAST(string_to_array(\"c2\",'<#>'), 'ARRAY<LONG>')",
-                                ColumnType.LONG_ARRAY,
-                                TestExprMacroTable.INSTANCE
-                            )
-                        )
-                        .setAggregatorSpecs(
-                            new CountAggregatorFactory("a0")
-                        )
-                        .setPostAggregatorSpecs(
-                            new ExpressionPostAggregator(
-                                "p0",
-                                "array_to_mv(\"d0\")",
-                                null,
-                                ColumnType.STRING,
-                                TestExprMacroTable.INSTANCE
-                            ),
-                            new ExpressionPostAggregator(
-                                "p1",
-                                "array_to_mv(\"d1\")",
-                                null,
-                                ColumnType.STRING,
-                                TestExprMacroTable.INSTANCE
-                            )
-                        )
-                        .setGranularity(Granularities.ALL)
-                        .setContext(QUERY_CONTEXT_DEFAULT)
-                        .build()
+            Druids.newScanQueryBuilder()
+                .eternityInterval()
+                .columns("a0", "v0", "v1")
+                  .dataSource(
+                      new QueryDataSource(
+                          GroupByQuery.builder()
+                                      .setDataSource(
+                                          InlineDataSource.fromIterable(
+                                              Arrays.asList(
+                                                  new Object[]{0L, "A<#>B", "1<#>2"},
+                                                  new Object[]{0L, "C<#>D", "3<#>4"}
+                                              ),
+                                              RowSignature.builder()
+                                                          .add("c0", ColumnType.LONG)
+                                                          .add("c1", ColumnType.STRING)
+                                                          .add("c2", ColumnType.STRING)
+                                                          .build()
+                                          )
+                                      )
+                                      .setQuerySegmentSpec(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.ETERNITY)))
+                                      .setDimensions(
+                                          new DefaultDimensionSpec("v0", "d0", ColumnType.STRING_ARRAY),
+                                          new DefaultDimensionSpec("v1", "d1", ColumnType.LONG_ARRAY)
+                                      )
+                                      .setVirtualColumns(
+                                          new ExpressionVirtualColumn(
+                                              "v0",
+                                              "string_to_array(\"c1\",'<#>')",
+                                              ColumnType.STRING_ARRAY,
+                                              TestExprMacroTable.INSTANCE
+                                          ),
+                                          new ExpressionVirtualColumn(
+                                              "v1",
+                                              "CAST(string_to_array(\"c2\",'<#>'), 'ARRAY<LONG>')",
+                                              ColumnType.LONG_ARRAY,
+                                              TestExprMacroTable.INSTANCE
+                                          )
+                                      )
+                                      .setAggregatorSpecs(
+                                          new CountAggregatorFactory("a0")
+                                      )
+                                      .setGranularity(Granularities.ALL)
+                                      .setContext(QUERY_CONTEXT_DEFAULT)
+                                      .build()
+                      )
+                  )
+                  .virtualColumns(
+                      expressionVirtualColumn("v0", "array_to_mv(\"d0\")", ColumnType.STRING),
+                      expressionVirtualColumn("v1", "array_to_mv(\"d1\")", ColumnType.STRING)
+                  )
+                  .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .legacy(false)
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .build()
+
         ),
         ImmutableList.of(
             new Object[]{"[\"A\",\"B\"]", "[\"1\",\"2\"]", 1L},
@@ -7436,9 +7447,9 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
                         .setGranularity(Granularities.ALL)
                         .setVirtualColumns(
                             expressionVirtualColumn(
-                            "v0",
-                            "array(1,\"c2\")",
-                            ColumnType.LONG_ARRAY
+                                "v0",
+                                "array(1,\"c2\")",
+                                ColumnType.LONG_ARRAY
                             )
                         )
                         .setDimensions(new DefaultDimensionSpec("c1", "d0", ColumnType.LONG))

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -89,7 +89,7 @@ import java.util.Map;
 @SqlTestFrameworkConfig.ComponentSupplier(ArraysComponentSupplier.class)
 public class CalciteArraysQueryTest extends BaseCalciteQueryTest
 {
-  private static final Map<String, Object> QUERY_CONTEXT_UNNEST =
+  public static final Map<String, Object> QUERY_CONTEXT_UNNEST =
       ImmutableMap.<String, Object>builder()
                   .putAll(QUERY_CONTEXT_DEFAULT)
                   .put(QueryContexts.CTX_SQL_STRINGIFY_ARRAYS, false)


### PR DESCRIPTION
This PR fixes a regression caused by #16551 which modified the `UnnestStorageAdapter` to return the _output_ capabilities of the unnest column instead of the capabilities pre-unnest, which was totally cool and correct but was leaving out setting `setDictionaryValuesUnique` which is also used by unnest to check if it can use a dimension cursor.

Though admittedly totally contrived, if used again in an UNNEST operator this would result in different behavior than prior to this change because the loss of `areDictionaryValuesUnique` would result in using the column value selector cursor instead of dimension selector based cursor which have different handling of null values due to the dimension cursors attempts to be compatible with the implicit unnest used by group-by and topN queries on mvds.

While writing tests for this, I found another bug that could happen for any mvd rows with 0 size against any segment where the null value was not dictionary id 0 (such as realtime segments or segments without null values in the column). I fixed this by reporting 0 as the size of the unnested row if the underlying row is 0, which aligns behavior with the implicit unnest done by group-by and topN queries (even though they are not consistent with each other, see #5897).

Finally, another bug with MSQ frames which has some mismatch where the writers are hard-coded with multi-value true while the window 'rows and columns' readers are hard-coded to use false, which results in some errors. It looks like window stuff doesn't really support multi-value strings so maybe the solution there is to just explode? But i didn't do that for now, in this case i just made the field writer detect if the input is multi-value or not so it isn't hard-coded to true (which handle 0 length rows differently than single valued)