### PR TITLE
unified the code style in NestedDataOperatorConversions

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/NestedDataOperatorConversions.java
@@ -92,8 +92,9 @@ public class NestedDataOperatorConversions
 
   public static class JsonPathsOperatorConversion implements SqlOperatorConversion
   {
+    private static final String FUNCTION_NAME = "json_paths";
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
-        .operatorBuilder("JSON_PATHS")
+        .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandTypeChecker(OperandTypes.ANY)
         .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
         .returnTypeArrayWithNullableElements(SqlTypeName.VARCHAR)
@@ -119,7 +120,7 @@ public class NestedDataOperatorConversions
           rexNode,
           druidExpressions -> DruidExpression.ofExpression(
               null,
-              DruidExpression.functionCall("json_paths"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           )
       );
@@ -128,8 +129,9 @@ public class NestedDataOperatorConversions
 
   public static class JsonKeysOperatorConversion implements SqlOperatorConversion
   {
+    private static final String FUNCTION_NAME = "json_keys";
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
-        .operatorBuilder("JSON_KEYS")
+        .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandNames("expr", "path")
         .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.STRING)
         .literalOperands(1)
@@ -158,7 +160,7 @@ public class NestedDataOperatorConversions
           rexNode,
           druidExpressions -> DruidExpression.ofExpression(
               ColumnType.STRING_ARRAY,
-              DruidExpression.functionCall("json_keys"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           )
       );
@@ -167,9 +169,9 @@ public class NestedDataOperatorConversions
 
   public static class JsonQueryOperatorConversion implements SqlOperatorConversion
   {
-    private static final String FUNCTION_NAME = StringUtils.toUpperCase("json_query");
+    private static final String FUNCTION_NAME = "json_query";
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
-        .operatorBuilder(FUNCTION_NAME)
+        .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandTypeChecker(
             OperandTypes.family(
                 SqlTypeFamily.ANY,
@@ -212,7 +214,7 @@ public class NestedDataOperatorConversions
       final Expr pathExpr = plannerContext.parseExpression(druidExpressions.get(1).getExpression());
       if (!pathExpr.isLiteral()) {
         // if path argument is not constant, just use a pure expression
-        return DruidExpression.ofFunctionCall(ColumnType.NESTED_DATA, "json_query", druidExpressions);
+        return DruidExpression.ofFunctionCall(ColumnType.NESTED_DATA, FUNCTION_NAME, druidExpressions);
       }
       // pre-normalize path so that the same expressions with different json path syntax are collapsed
       final String path = (String) pathExpr.eval(InputBindings.nilBindings()).value();
@@ -723,7 +725,7 @@ public class NestedDataOperatorConversions
   {
     private static final String FUNCTION_NAME = "json_object";
     private static final SqlFunction SQL_FUNCTION = OperatorConversions
-        .operatorBuilder(FUNCTION_NAME)
+        .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
         .operandTypeChecker(OperandTypes.variadic(SqlOperandCountRanges.from(1)))
         .operandTypeInference((callBinding, returnType, operandTypes) -> {
           RelDataTypeFactory typeFactory = callBinding.getTypeFactory();
@@ -756,7 +758,7 @@ public class NestedDataOperatorConversions
           DruidExpression.ofExpression(
               ColumnType.NESTED_DATA,
               null,
-              DruidExpression.functionCall("json_object"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           );
 
@@ -809,7 +811,7 @@ public class NestedDataOperatorConversions
           rexNode,
           druidExpressions -> DruidExpression.ofExpression(
               ColumnType.NESTED_DATA,
-              DruidExpression.functionCall("to_json_string"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           )
       );
@@ -847,7 +849,7 @@ public class NestedDataOperatorConversions
           rexNode,
           druidExpressions -> DruidExpression.ofExpression(
               ColumnType.NESTED_DATA,
-              DruidExpression.functionCall("parse_json"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           )
       );
@@ -885,7 +887,7 @@ public class NestedDataOperatorConversions
           rexNode,
           druidExpressions -> DruidExpression.ofExpression(
               ColumnType.NESTED_DATA,
-              DruidExpression.functionCall("try_parse_json"),
+              DruidExpression.functionCall(FUNCTION_NAME),
               druidExpressions
           )
       );


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

unified the code style in NestedDataOperatorConversions


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
There is some different code style in NestedDataOperatorConversions, unified it.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
improve the code style of NestedDataOperatorConversions, to be consistent for each SqlOperatorConversion



<hr>

##### Key changed/added classes in this PR
 * `NestedDataOperatorConversions.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
