### PR TITLE
kubernetes-overlord-extension: Fix tasks not being shutdown

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -254,15 +254,7 @@ public class KubernetesPeonLifecycle
     if we decide we need to change this later.
     **/
     if (taskLocation == null) {
-      Optional<Pod> maybePod = Optional.absent();
-      try {
-        maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
-      }
-      catch (Exception e) {
-        log.makeAlert("Unable to get location for task", e)
-           .addData("taskId", taskId);
-      }
-
+      Optional<Pod> maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
       if (!maybePod.isPresent()) {
         return TaskLocation.unknown();
       }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -254,7 +254,15 @@ public class KubernetesPeonLifecycle
     if we decide we need to change this later.
     **/
     if (taskLocation == null) {
-      Optional<Pod> maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
+      Optional<Pod> maybePod = Optional.absent();
+      try {
+        maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
+      }
+      catch (Exception e) {
+        log.makeAlert("Unable to get location for task", e)
+           .addData("taskId", taskId);
+      }
+
       if (!maybePod.isPresent()) {
         return TaskLocation.unknown();
       }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -443,17 +443,17 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   @Override
   public TaskLocation getTaskLocation(String taskId)
   {
-    final KubernetesWorkItem workItem = tasks.get(taskId);
-    if (workItem == null) {
-      return TaskLocation.unknown();
-    } else {
-      try {
+    try {
+      final KubernetesWorkItem workItem = tasks.get(taskId);
+      if (workItem == null) {
+        return TaskLocation.unknown();
+      } else {
         return workItem.getLocation();
       }
-      catch (Exception e) {
-        log.warn("Unable to find location for task [%s]", taskId);
-        return TaskLocation.unknown();
-      }
+    }
+    catch (Exception e) {
+      log.warn("Unable to find location for task [%s]", taskId);
+      return TaskLocation.unknown();
     }
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -447,7 +447,13 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
     if (workItem == null) {
       return TaskLocation.unknown();
     } else {
-      return workItem.getLocation();
+      try {
+        return workItem.getLocation();
+      }
+      catch (Exception e) {
+        log.warn("Unable to find location for task [%s]", taskId);
+        return TaskLocation.unknown();
+      }
     }
   }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -655,6 +655,24 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
   }
 
   @Test
+  public void test_getTaskLocation_throws()
+  {
+    KubernetesWorkItem workItem = new KubernetesWorkItem(task, null)
+    {
+      @Override
+      public TaskLocation getLocation()
+      {
+        throw new RuntimeException();
+      }
+    };
+
+    runner.tasks.put(task.getId(), workItem);
+
+    TaskLocation taskLocation = runner.getTaskLocation(task.getId());
+    Assert.assertEquals(TaskLocation.unknown(), taskLocation);
+  }
+
+  @Test
   public void test_getTaskLocation_noTaskFound()
   {
     TaskLocation taskLocation = runner.getTaskLocation(task.getId());


### PR DESCRIPTION
### Description

In rare cases when fabric client is unable to talk to the k8s server, TaskQueue is skipping the complete shutdown logic because of the exception thrown during figuring task location. This PR allows to continue the shutdown logic without populating the location on task status and thus allowing to clean up all the data structures.

<hr>

##### Key changed/added classes in this PR
 * `KubernetesPeonLifecycle`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
