### PR TITLE
Fix NPE in CompactSegments

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/CompactSegments.java
@@ -234,12 +234,13 @@ public class CompactSegments implements CoordinatorCustomDuty
     Granularity configuredSegmentGranularity = dataSourceCompactionConfig.getGranularitySpec()
                                                                          .getSegmentGranularity();
     Granularity taskSegmentGranularity = compactionTaskQuery.getGranularitySpec().getSegmentGranularity();
-    if (configuredSegmentGranularity.equals(taskSegmentGranularity)) {
+    if (configuredSegmentGranularity == null
+        || configuredSegmentGranularity.equals(taskSegmentGranularity)) {
       return false;
     }
 
     LOG.info(
-        "Cancelling task [%s] as task segmentGranularity is [%s] but compaction config segmentGranularity is [%s]",
+        "Cancelling task[%s] as task segmentGranularity[%s] differs from compaction config segmentGranularity[%s].",
         compactionTaskQuery.getId(), taskSegmentGranularity, configuredSegmentGranularity
     );
     overlordClient.cancelTask(compactionTaskQuery.getId());


### PR DESCRIPTION
The NPE causes `CompactSegments` duty to fail and thus not submit any compaction tasks.