### PR TITLE
minor adjustments for performance

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
@@ -211,7 +211,6 @@ public class GroupByQueryEngine
       final List<DimensionSpec> dimensions
   )
   {
-    boolean hasImplicitUnnest = false;
     for (DimensionSpec dimension : dimensions) {
       if (dimension.mustDecorate()) {
         // DimensionSpecs that decorate may turn singly-valued columns into multi-valued selectors.
@@ -219,17 +218,18 @@ public class GroupByQueryEngine
         return false;
       }
 
+      // if dimension spec type is array, skip it since we can handle array or multi-valued
       if (dimension.getOutputType().isArray()) {
         continue;
       }
 
       // Now check column capabilities, which must be present and explicitly not multi-valued and not arrays
       final ColumnCapabilities capabilities = inspector.getColumnCapabilities(dimension.getDimension());
-      if (capabilities != null && capabilities.hasMultipleValues().isMaybeTrue() && !capabilities.isArray()) {
+      if (capabilities == null || capabilities.hasMultipleValues().isMaybeTrue() || capabilities.isArray()) {
         return false;
       }
     }
-    return !hasImplicitUnnest;
+    return true;
   }
 
   private abstract static class GroupByEngineIterator<KeyType> implements Iterator<ResultRow>, Closeable

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
@@ -224,7 +224,7 @@ public class GroupByQueryEngine
 
       // Now check column capabilities, which must be present and explicitly not multi-valued and not arrays
       final ColumnCapabilities capabilities = inspector.getColumnCapabilities(dimension.getDimension());
-      if (capabilities != null && capabilities.hasMultipleValues().isFalse() && !capabilities.isArray()){
+      if (capabilities != null && capabilities.hasMultipleValues().isFalse() && !capabilities.isArray()) {
         return false;
       }
     }

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
@@ -211,24 +211,24 @@ public class GroupByQueryEngine
       final List<DimensionSpec> dimensions
   )
   {
-    return dimensions
-        .stream()
-        .allMatch(
-            dimension -> {
-              if (dimension.mustDecorate()) {
-                // DimensionSpecs that decorate may turn singly-valued columns into multi-valued selectors.
-                // To be safe, we must return false here.
-                return false;
-              }
+    for (DimensionSpec dimension : dimensions) {
+      if (dimension.mustDecorate()) {
+        // DimensionSpecs that decorate may turn singly-valued columns into multi-valued selectors.
+        // To be safe, we must return false here.
+        return false;
+      }
 
-              // Now check column capabilities, which must be present and explicitly not multi-valued and not arrays
-              final ColumnCapabilities columnCapabilities = inspector.getColumnCapabilities(dimension.getDimension());
-              return dimension.getOutputType().isArray()
-                     || (columnCapabilities != null
-                         && columnCapabilities.hasMultipleValues().isFalse()
-                         && !columnCapabilities.isArray()
-                     );
-            });
+      if (dimension.getOutputType().isArray()) {
+        return false;
+      }
+
+      // Now check column capabilities, which must be present and explicitly not multi-valued and not arrays
+      final ColumnCapabilities capabilities = inspector.getColumnCapabilities(dimension.getDimension());
+      if (capabilities != null && capabilities.hasMultipleValues().isFalse() && !capabilities.isArray()){
+        return false;
+      }
+    }
+    return true;
   }
 
   private abstract static class GroupByEngineIterator<KeyType> implements Iterator<ResultRow>, Closeable

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/GroupByQueryEngine.java
@@ -211,6 +211,7 @@ public class GroupByQueryEngine
       final List<DimensionSpec> dimensions
   )
   {
+    boolean hasImplicitUnnest = false;
     for (DimensionSpec dimension : dimensions) {
       if (dimension.mustDecorate()) {
         // DimensionSpecs that decorate may turn singly-valued columns into multi-valued selectors.
@@ -219,16 +220,16 @@ public class GroupByQueryEngine
       }
 
       if (dimension.getOutputType().isArray()) {
-        return false;
+        continue;
       }
 
       // Now check column capabilities, which must be present and explicitly not multi-valued and not arrays
       final ColumnCapabilities capabilities = inspector.getColumnCapabilities(dimension.getDimension());
-      if (capabilities != null && capabilities.hasMultipleValues().isFalse() && !capabilities.isArray()) {
+      if (capabilities != null && capabilities.hasMultipleValues().isMaybeTrue() && !capabilities.isArray()) {
         return false;
       }
     }
-    return true;
+    return !hasImplicitUnnest;
   }
 
   private abstract static class GroupByEngineIterator<KeyType> implements Iterator<ResultRow>, Closeable

--- a/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/epinephelinae/vector/VectorGroupByEngine.java
@@ -241,7 +241,7 @@ public class VectorGroupByEngine
     return true;
   }
 
-  private static boolean canVectorizeAggregators(
+  public static boolean canVectorizeAggregators(
       final ColumnInspector inspector,
       final List<AggregatorFactory> aggregatorFactories
   )

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryEngine.java
@@ -37,6 +37,7 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorAdapters;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.groupby.epinephelinae.vector.VectorGroupByEngine;
 import org.apache.druid.query.vector.VectorCursorGranularizer;
 import org.apache.druid.segment.ColumnInspector;
 import org.apache.druid.segment.SegmentMissingException;
@@ -103,7 +104,7 @@ public class TimeseriesQueryEngine
     final boolean doVectorize = query.context().getVectorize().shouldVectorize(
         adapter.canVectorize(filter, query.getVirtualColumns(), descending)
         && VirtualColumns.shouldVectorize(query, query.getVirtualColumns(), adapter)
-        && query.getAggregatorSpecs().stream().allMatch(aggregatorFactory -> aggregatorFactory.canVectorize(inspector))
+        && VectorGroupByEngine.canVectorizeAggregators(inspector, query.getAggregatorSpecs())
     );
 
     final Sequence<Result<TimeseriesResultValue>> result;

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 /**
  * Class allowing lookup and usage of virtual columns.
  */
-public class VirtualColumns implements Cacheable
+public final class VirtualColumns implements Cacheable
 {
   public static final VirtualColumns EMPTY = new VirtualColumns(
       ImmutableList.of(),
@@ -259,7 +259,12 @@ public class VirtualColumns implements Cacheable
   public boolean canVectorize(ColumnInspector columnInspector)
   {
     final ColumnInspector inspector = wrapInspector(columnInspector);
-    return virtualColumns.stream().allMatch(virtualColumn -> virtualColumn.canVectorize(inspector));
+    for (VirtualColumn virtualColumn : virtualColumns) {
+      if (!virtualColumn.canVectorize(inspector)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 /**
  * Class allowing lookup and usage of virtual columns.
  */
-public final class VirtualColumns implements Cacheable
+public class VirtualColumns implements Cacheable
 {
   public static final VirtualColumns EMPTY = new VirtualColumns(
       ImmutableList.of(),

--- a/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Doubles;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -915,13 +916,11 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
       );
       // we should check this someday soon, but for now just read it to push the buffer position ahead
       int flags = dataBuffer.getInt();
-      Preconditions.checkState(
-          flags == DictionaryEncodedColumnPartSerde.NO_FLAGS,
-          StringUtils.format(
-              "Unrecognized bits set in space reserved for future flags for field column [%s]",
-              field
-          )
-      );
+      if (flags != DictionaryEncodedColumnPartSerde.NO_FLAGS) {
+        throw DruidException.defensive(
+            "Unrecognized bits set in space reserved for future flags for field column [%s]", field
+        );
+      }
 
       final Supplier<FixedIndexed<Integer>> localDictionarySupplier = FixedIndexed.read(
           dataBuffer,

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumnSerializer.java
@@ -123,6 +123,6 @@ public abstract class NestedCommonFormatColumnSerializer implements GenericColum
    */
   public static String getInternalFileName(String fileNameBase, String field)
   {
-    return StringUtils.format("%s.%s", fileNameBase, field);
+    return fileNameBase + "." + field;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializerV4.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializerV4.java
@@ -27,7 +27,6 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
@@ -182,7 +181,7 @@ public class NestedDataColumnSerializerV4 implements GenericColumnSerializer<Str
     doubleDictionaryWriter.open();
 
     rawWriter = new CompressedVariableSizedBlobColumnSerializer(
-        getInternalFileName(name, RAW_FILE_NAME),
+        NestedCommonFormatColumnSerializer.getInternalFileName(name, RAW_FILE_NAME),
         segmentWriteOutMedium,
         indexSpec.getJsonCompression() != null ? indexSpec.getJsonCompression() : CompressionStrategy.LZ4
     );
@@ -390,14 +389,9 @@ public class NestedDataColumnSerializerV4 implements GenericColumnSerializer<Str
 
   private void writeInternal(FileSmoosher smoosher, Serializer serializer, String fileName) throws IOException
   {
-    final String internalName = getInternalFileName(name, fileName);
+    final String internalName = NestedCommonFormatColumnSerializer.getInternalFileName(name, fileName);
     try (SmooshedWriter smooshChannel = smoosher.addWithSmooshedWriter(internalName, serializer.getSerializedSize())) {
       serializer.writeTo(smooshChannel, smoosher);
     }
-  }
-
-  public static String getInternalFileName(String fileNameBase, String field)
-  {
-    return StringUtils.format("%s.%s", fileNameBase, field);
   }
 }


### PR DESCRIPTION
Minor adjustments of some stuff that stuck out a bit on a flame graph, things like removing `String.format` in hot places (since it uses a regex) moving from streams to loops, etc.

Nothing major, but every little bit helps.