### PR TITLE
#16717 defer provider instantiation in Kubernetes Module

### DIFF
--- a/extensions-core/kubernetes-extensions/pom.xml
+++ b/extensions-core/kubernetes-extensions/pom.xml
@@ -158,10 +158,12 @@
           <excludes>
             <!-- Initialization code -->
             <exclude>org/apache/druid/k8s/discovery/K8sDiscoveryModule*</exclude>
+            <exclude>org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorProvider*</exclude>
 
             <!-- K8S Api Glue, not unit testable -->
             <exclude>org/apache/druid/k8s/discovery/DefaultK8sApiClient*</exclude>
             <exclude>org/apache/druid/k8s/discovery/DefaultK8sLeaderElectorFactory*</exclude>
+
           </excludes>
         </configuration>
       </plugin>

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DruidLeaderSelectorProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DruidLeaderSelectorProvider.java
@@ -1,3 +1,22 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
 package org.apache.druid.k8s.discovery;
 
 import com.google.inject.Inject;

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DruidLeaderSelectorProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/DruidLeaderSelectorProvider.java
@@ -1,0 +1,72 @@
+package org.apache.druid.k8s.discovery;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.kubernetes.client.openapi.ApiClient;
+import org.apache.druid.discovery.DruidLeaderSelector;
+import org.apache.druid.guice.annotations.Self;
+import org.apache.druid.server.DruidNode;
+
+abstract public class DruidLeaderSelectorProvider implements Provider<DruidLeaderSelector>
+{
+  @Inject
+  @Self
+  private DruidNode druidNode;
+
+  @Inject
+  private PodInfo podInfo;
+
+  @Inject
+  private K8sDiscoveryConfig discoveryConfig;
+
+  @Inject
+  private Provider<ApiClient> k8sApiClientProvider;
+
+  private boolean isCoordinator;
+
+  DruidLeaderSelectorProvider(boolean isCoordinator)
+  {
+    this.isCoordinator = isCoordinator;
+  }
+
+  @Override
+  public DruidLeaderSelector get()
+  {
+    // Note: these can not be setup in the constructor because injected K8sDiscoveryConfig and PodInfo
+    // are not available at that time.
+    String lockResourceName;
+    String lockResourceNamespace;
+
+    if (isCoordinator) {
+      lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-coordinator";
+      lockResourceNamespace = discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace() == null ?
+                              podInfo.getPodNamespace() : discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace();
+    } else {
+      lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-overlord";
+      lockResourceNamespace = discoveryConfig.getOverlordLeaderElectionConfigMapNamespace() == null ?
+                              podInfo.getPodNamespace() : discoveryConfig.getOverlordLeaderElectionConfigMapNamespace();
+    }
+
+    return new K8sDruidLeaderSelector(
+        druidNode,
+        lockResourceName,
+        lockResourceNamespace,
+        discoveryConfig,
+        new DefaultK8sLeaderElectorFactory(k8sApiClientProvider.get(), discoveryConfig)
+    );
+  }
+
+  static class CoordinatorDruidLeaderSelectorProvider extends DruidLeaderSelectorProvider {
+    @Inject
+    public CoordinatorDruidLeaderSelectorProvider() {
+      super(true);
+    }
+  }
+
+  static class IndexingServiceDruidLeaderSelectorProvider extends DruidLeaderSelectorProvider {
+    @Inject
+    public IndexingServiceDruidLeaderSelectorProvider() {
+      super(false);
+    }
+  }
+}

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
@@ -84,14 +84,14 @@ public class K8sDiscoveryModule implements DruidModule
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, Coordinator.class))
             .addBinding(K8S_KEY)
             .toProvider(
-                DruidLeaderSelectorProvider.CoordinatorDruidLeaderSelectorProvider.class
+                K8sDruidLeaderSelectorProvider.K8sCoordinatorDruidLeaderSelectorProvider.class
             )
             .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, IndexingService.class))
             .addBinding(K8S_KEY)
             .toProvider(
-                DruidLeaderSelectorProvider.IndexingServiceDruidLeaderSelectorProvider.class
+                K8sDruidLeaderSelectorProvider.K8sIndexingServiceDruidLeaderSelectorProvider.class
             )
             .in(LazySingleton.class);
   }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryModule.java
@@ -21,9 +21,7 @@ package org.apache.druid.k8s.discovery;
 
 import com.fasterxml.jackson.databind.Module;
 import com.google.inject.Binder;
-import com.google.inject.Inject;
 import com.google.inject.Key;
-import com.google.inject.Provider;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.util.Config;
 import org.apache.druid.client.coordinator.Coordinator;
@@ -34,9 +32,7 @@ import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.PolyBind;
-import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.DruidModule;
-import org.apache.druid.server.DruidNode;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -88,65 +84,15 @@ public class K8sDiscoveryModule implements DruidModule
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, Coordinator.class))
             .addBinding(K8S_KEY)
             .toProvider(
-                new DruidLeaderSelectorProvider(true)
+                DruidLeaderSelectorProvider.CoordinatorDruidLeaderSelectorProvider.class
             )
             .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(DruidLeaderSelector.class, IndexingService.class))
             .addBinding(K8S_KEY)
             .toProvider(
-                new DruidLeaderSelectorProvider(false)
+                DruidLeaderSelectorProvider.IndexingServiceDruidLeaderSelectorProvider.class
             )
             .in(LazySingleton.class);
-  }
-
-  private static class DruidLeaderSelectorProvider implements Provider<DruidLeaderSelector>
-  {
-    @Inject
-    @Self
-    private DruidNode druidNode;
-
-    @Inject
-    private PodInfo podInfo;
-
-    @Inject
-    private K8sDiscoveryConfig discoveryConfig;
-
-    @Inject
-    private Provider<ApiClient> k8sApiClientProvider;
-
-    private boolean isCoordinator;
-
-    DruidLeaderSelectorProvider(boolean isCoordinator)
-    {
-      this.isCoordinator = isCoordinator;
-    }
-
-    @Override
-    public DruidLeaderSelector get()
-    {
-      // Note: these can not be setup in the constructor because injected K8sDiscoveryConfig and PodInfo
-      // are not available at that time.
-      String lockResourceName;
-      String lockResourceNamespace;
-
-      if (isCoordinator) {
-        lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-coordinator";
-        lockResourceNamespace = discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace() == null ?
-                                     podInfo.getPodNamespace() : discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace();
-      } else {
-        lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-overlord";
-        lockResourceNamespace = discoveryConfig.getOverlordLeaderElectionConfigMapNamespace() == null ?
-                                     podInfo.getPodNamespace() : discoveryConfig.getOverlordLeaderElectionConfigMapNamespace();
-      }
-
-      return new K8sDruidLeaderSelector(
-          druidNode,
-          lockResourceName,
-          lockResourceNamespace,
-          discoveryConfig,
-          new DefaultK8sLeaderElectorFactory(k8sApiClientProvider.get(), discoveryConfig)
-      );
-    }
   }
 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorProvider.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package org.apache.druid.k8s.discovery;
 
@@ -26,7 +26,7 @@ import org.apache.druid.discovery.DruidLeaderSelector;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.server.DruidNode;
 
-abstract public class DruidLeaderSelectorProvider implements Provider<DruidLeaderSelector>
+public abstract class K8sDruidLeaderSelectorProvider implements Provider<DruidLeaderSelector>
 {
   @Inject
   @Self
@@ -43,7 +43,7 @@ abstract public class DruidLeaderSelectorProvider implements Provider<DruidLeade
 
   private boolean isCoordinator;
 
-  DruidLeaderSelectorProvider(boolean isCoordinator)
+  K8sDruidLeaderSelectorProvider(boolean isCoordinator)
   {
     this.isCoordinator = isCoordinator;
   }
@@ -58,8 +58,10 @@ abstract public class DruidLeaderSelectorProvider implements Provider<DruidLeade
 
     if (isCoordinator) {
       lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-coordinator";
-      lockResourceNamespace = discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace() == null ?
-                              podInfo.getPodNamespace() : discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace();
+      lockResourceNamespace = discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace() == null
+                              ?
+                              podInfo.getPodNamespace()
+                              : discoveryConfig.getCoordinatorLeaderElectionConfigMapNamespace();
     } else {
       lockResourceName = discoveryConfig.getClusterIdentifier() + "-leaderelection-overlord";
       lockResourceNamespace = discoveryConfig.getOverlordLeaderElectionConfigMapNamespace() == null ?
@@ -75,16 +77,20 @@ abstract public class DruidLeaderSelectorProvider implements Provider<DruidLeade
     );
   }
 
-  static class CoordinatorDruidLeaderSelectorProvider extends DruidLeaderSelectorProvider {
+  static class K8sCoordinatorDruidLeaderSelectorProvider extends K8sDruidLeaderSelectorProvider
+  {
     @Inject
-    public CoordinatorDruidLeaderSelectorProvider() {
+    public K8sCoordinatorDruidLeaderSelectorProvider()
+    {
       super(true);
     }
   }
 
-  static class IndexingServiceDruidLeaderSelectorProvider extends DruidLeaderSelectorProvider {
+  static class K8sIndexingServiceDruidLeaderSelectorProvider extends K8sDruidLeaderSelectorProvider
+  {
     @Inject
-    public IndexingServiceDruidLeaderSelectorProvider() {
+    public K8sIndexingServiceDruidLeaderSelectorProvider()
+    {
       super(false);
     }
   }


### PR DESCRIPTION
Fixes #16717

### Description

Hadoop ingestion doesnt have access to K8s config. Provider not being pure lazy was making the HadoopIndexTask fail altho it doesnt really need K8s information on the Hadoop cluster.

This PR refactors the DruidLeaderSelectorProvider class so its creation can be deferred to Module instantiation, thus not happening on HadoopIndexTask

It creates 2 subclasses CoordinatorDruidLeaderSelectorProvider and IndexingServiceDruidLeaderSelectorProvider which can be properly referenced.


Was not sure about either overriding the get method on children or keep the parents, so i decided to take the option with less code changes.
Let me know if the other option id preferred.


#### Release note

<hr>

##### Key changed/added classes in this PR
 * Fixed: Hadoop ingestion now works on k8s deployments

<hr>


This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ X] been tested in a test Druid cluster.
