### PR TITLE
Tests: Add utility class TuningConfigBuilder to make IndexTask tests more readable and concise

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -39,6 +39,7 @@ import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.task.CompactionIntervalSpec;
 import org.apache.druid.indexing.common.task.CompactionTask;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -397,39 +398,17 @@ public class MSQCompactionRunnerTest
       PartitionsSpec partitionsSpec
   )
   {
-    return new CompactionTask.CompactionTuningConfig(
-        null,
-        null, // null to compute maxRowsPerSegment automatically
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        partitionsSpec,
-        indexSpec,
-        null,
-        null,
-        !(partitionsSpec instanceof DynamicPartitionsSpec),
-        false,
-        5000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    return TuningConfigBuilder
+        .forCompactionTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withMaxTotalRows(Long.MAX_VALUE)
+        .withPartitionsSpec(partitionsSpec)
+        .withIndexSpec(indexSpec)
+        .withForceGuaranteedRollup(!(partitionsSpec instanceof DynamicPartitionsSpec))
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .build();
   }
 
   private static IndexSpec createIndexSpec()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TestIndexTask.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TestIndexTask.java
@@ -31,6 +31,7 @@ import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.overlord.SegmentPublishResult;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.IndexSpec;
@@ -69,34 +70,13 @@ public class TestIndexTask extends IndexTask
                 false,
                 false
             ),
-
-            new IndexTask.IndexTuningConfig(
-                null,
-                null,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                new DynamicPartitionsSpec(10000, null),
-                IndexSpec.DEFAULT,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsInMemory(10)
+                               .withIndexSpec(IndexSpec.DEFAULT)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
+                               .withForceGuaranteedRollup(false)
+                               .withMaxPendingPersists(3)
+                               .build()
         ),
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -342,40 +342,27 @@ public class ClientCompactionTaskQuerySerdeTest
     )
         .inputSpec(new CompactionIntervalSpec(Intervals.of("2019/2020"), "testSha256OfSortedSegmentIds"), true)
         .tuningConfig(
-            new ParallelIndexTuningConfig(
-                null,
-                null,
-                new OnheapIncrementalIndex.Spec(true),
-                40000,
-                2000L,
-                null,
-                null,
-                null,
-                SEGMENTS_SPLIT_HINT_SPEC,
-                DYNAMIC_PARTITIONS_SPEC,
-                INDEX_SPEC,
-                INDEX_SPEC_FOR_INTERMEDIATE_PERSISTS,
-                2,
-                null,
-                null,
-                1000L,
-                TmpFileSegmentWriteOutMediumFactory.instance(),
-                null,
-                100,
-                5,
-                1000L,
-                new Duration(3000L),
-                7,
-                1000,
-                100,
-                null,
-                null,
-                null,
-                2,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder
+                .forParallelIndexTask()
+                .withAppendableIndexSpec(new OnheapIncrementalIndex.Spec(true))
+                .withMaxRowsInMemory(40000)
+                .withMaxBytesInMemory(2000L)
+                .withSplitHintSpec(SEGMENTS_SPLIT_HINT_SPEC)
+                .withPartitionsSpec(DYNAMIC_PARTITIONS_SPEC)
+                .withIndexSpec(INDEX_SPEC)
+                .withIndexSpecForIntermediatePersists(INDEX_SPEC_FOR_INTERMEDIATE_PERSISTS)
+                .withMaxPendingPersists(2)
+                .withPushTimeout(1000L)
+                .withSegmentWriteOutMediumFactory(TmpFileSegmentWriteOutMediumFactory.instance())
+                .withMaxNumConcurrentSubTasks(100)
+                .withMaxRetry(5)
+                .withTaskStatusCheckPeriodMs(1000L)
+                .withChatHandlerTimeout(new Duration(3000L))
+                .withChatHandlerNumRetries(7)
+                .withMaxNumSegmentsToMerge(1000)
+                .withTotalNumMergeTasks(100)
+                .withMaxColumnsToMerge(2)
+                .build()
         )
         .granularitySpec(CLIENT_COMPACTION_TASK_GRANULARITY_SPEC)
         .dimensionsSpec(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -51,7 +51,6 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
-import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.ISE;
@@ -354,40 +353,10 @@ public class CompactionTaskRunTest extends IngestionTestBase
     final CompactionTask compactionTask = builder
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .tuningConfig(
-            new ParallelIndexTuningConfig(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                new HashedPartitionsSpec(null, 3, null),
-                null,
-                null,
-                null,
-                true,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forParallelIndexTask()
+                               .withForceGuaranteedRollup(true)
+                               .withPartitionsSpec(new HashedPartitionsSpec(null, 3, null))
+                               .build()
         )
         .build();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -324,44 +324,21 @@ public class CompactionTaskTest
 
   private static CompactionTask.CompactionTuningConfig createTuningConfig()
   {
-    return new CompactionTask.CompactionTuningConfig(
-        null,
-        null, // null to compute maxRowsPerSegment automatically
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        5000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    return TuningConfigBuilder.forCompactionTask()
+        .withMaxRowsInMemory(500_000)
+        .withMaxBytesInMemory(1_000_000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .build();
   }
 
   @Rule
@@ -596,38 +573,21 @@ public class CompactionTaskTest
         null,
         null,
         null,
-        new IndexTuningConfig(
-            null,
-            null, // null to compute maxRowsPerSegment automatically
-            null,
-            500000,
-            1000000L,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            IndexSpec.builder()
-                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                     .withDimensionCompression(CompressionStrategy.LZ4)
-                     .withMetricCompression(CompressionStrategy.LZF)
-                     .withLongEncoding(LongEncodingStrategy.LONGS)
-                     .build(),
-            null,
-            null,
-            true,
-            false,
-            5000L,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ),
+        TuningConfigBuilder
+            .forIndexTask()
+            .withMaxRowsInMemory(500000)
+            .withIndexSpec(
+                IndexSpec.builder()
+                         .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                         .withDimensionCompression(CompressionStrategy.LZ4)
+                         .withMetricCompression(CompressionStrategy.LZF)
+                         .withLongEncoding(LongEncodingStrategy.LONGS)
+                         .build()
+            )
+            .withForceGuaranteedRollup(true)
+            .withReportParseExceptions(false)
+            .withPublishTimeout(5000L)
+            .build(),
         null,
         toolbox.getJsonMapper(),
         AuthTestUtils.TEST_AUTHORIZER_MAPPER,
@@ -676,77 +636,37 @@ public class CompactionTaskTest
   @Test
   public void testGetTuningConfigWithIndexTuningConfig()
   {
-    IndexTuningConfig indexTuningConfig = new IndexTuningConfig(
-        null,
-        null, // null to compute maxRowsPerSegment automatically
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    IndexTuningConfig indexTuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .build();
 
-    CompactionTask.CompactionTuningConfig compactionTuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    CompactionTask.CompactionTuningConfig compactionTuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .build();
 
     Assert.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(indexTuningConfig));
 
@@ -755,84 +675,39 @@ public class CompactionTaskTest
   @Test
   public void testGetTuningConfigWithParallelIndexTuningConfig()
   {
-    ParallelIndexTuningConfig parallelIndexTuningConfig = new ParallelIndexTuningConfig(
-        null,
-        null, // null to compute maxRowsPerSegment automatically
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        5000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    ParallelIndexTuningConfig parallelIndexTuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .build();
 
-    CompactionTask.CompactionTuningConfig compactionTuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null, // null to compute maxRowsPerSegment automatically
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        5000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    CompactionTask.CompactionTuningConfig compactionTuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .build();
 
     Assert.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(parallelIndexTuningConfig));
   }
@@ -909,44 +784,24 @@ public class CompactionTaskTest
   @Test
   public void testCreateIngestionSchemaWithTargetPartitionSize() throws IOException
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        100000,
-        null,
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        null,
-        null,
-        null,
-        10,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    final CompactionTask.CompactionTuningConfig tuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withTargetPartitionSize(100000)
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withMaxNumConcurrentSubTasks(10)
+        .build();
+
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
         toolbox,
         LockGranularity.TIME_CHUNK,
@@ -991,44 +846,24 @@ public class CompactionTaskTest
   @Test
   public void testCreateIngestionSchemaWithMaxTotalRows() throws IOException
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        500000,
-        1000000L,
-        null,
-        1000000L,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        false,
-        false,
-        5000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    final CompactionTask.CompactionTuningConfig tuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withMaxTotalRows(1000000L)
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(false)
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .build();
+
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
         toolbox,
         LockGranularity.TIME_CHUNK,
@@ -1073,44 +908,25 @@ public class CompactionTaskTest
   @Test
   public void testCreateIngestionSchemaWithNumShards() throws IOException
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        500000,
-        1000000L,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(null, 3, null),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        false,
-        5000L,
-        null,
-        null,
-        10,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    final CompactionTask.CompactionTuningConfig tuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withMaxRowsInMemory(500000)
+        .withMaxBytesInMemory(1000000L)
+        .withPartitionsSpec(new HashedPartitionsSpec(null, 3, null))
+        .withIndexSpec(
+            IndexSpec.builder()
+                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                     .withDimensionCompression(CompressionStrategy.LZ4)
+                     .withMetricCompression(CompressionStrategy.LZF)
+                     .withLongEncoding(LongEncodingStrategy.LONGS)
+                     .build()
+        )
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withPushTimeout(5000L)
+        .withMaxNumConcurrentSubTasks(10)
+        .build();
+
     final Map<Interval, DataSchema> dataSchemasForIntervals = CompactionTask.createDataSchemasForIntervals(
         toolbox,
         LockGranularity.TIME_CHUNK,
@@ -1821,44 +1637,24 @@ public class CompactionTaskTest
         expectedDimensionsSpecs,
         expectedMetricsSpec,
         expectedSegmentIntervals,
-        new CompactionTask.CompactionTuningConfig(
-            null,
-            null,
-            null,
-            500000,
-            1000000L,
-            null,
-            Long.MAX_VALUE,
-            null,
-            null,
-            new HashedPartitionsSpec(5000000, null, null), // automatically computed targetPartitionSize
-            IndexSpec.builder()
-                     .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                     .withDimensionCompression(CompressionStrategy.LZ4)
-                     .withMetricCompression(CompressionStrategy.LZF)
-                     .withLongEncoding(LongEncodingStrategy.LONGS)
-                     .build(),
-            null,
-            null,
-            true,
-            false,
-            5000L,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ),
+        TuningConfigBuilder
+            .forCompactionTask()
+            .withMaxRowsInMemory(500000)
+            .withMaxBytesInMemory(1000000L)
+            .withMaxTotalRows(Long.MAX_VALUE)
+            .withPartitionsSpec(new HashedPartitionsSpec(5000000, null, null))
+            .withIndexSpec(
+                IndexSpec.builder()
+                         .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                         .withDimensionCompression(CompressionStrategy.LZ4)
+                         .withMetricCompression(CompressionStrategy.LZF)
+                         .withLongEncoding(LongEncodingStrategy.LONGS)
+                         .build()
+            )
+            .withForceGuaranteedRollup(true)
+            .withReportParseExceptions(false)
+            .withPushTimeout(5000L)
+            .build(),
         expectedSegmentGranularity,
         expectedQueryGranularity,
         expectedDropExisting

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
@@ -22,30 +22,20 @@ package org.apache.druid.indexing.common.task;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.IndexSpec;
-import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
-import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.indexing.TuningConfig;
-import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
 public class CompactionTuningConfigTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setup()
@@ -56,142 +46,44 @@ public class CompactionTuningConfigTest
   @Test
   public void testSerdeDefault() throws IOException
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = CompactionTask.CompactionTuningConfig.defaultConfig();
+    final CompactionTask.CompactionTuningConfig tuningConfig =
+        CompactionTask.CompactionTuningConfig.defaultConfig();
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
-    final ParallelIndexTuningConfig fromJson = (CompactionTask.CompactionTuningConfig) mapper.readValue(json, TuningConfig.class);
+    final ParallelIndexTuningConfig fromJson =
+        (CompactionTask.CompactionTuningConfig) mapper.readValue(json, TuningConfig.class);
     Assert.assertEquals(fromJson, tuningConfig);
   }
 
   @Test
-  public void testSerdeWithNonZeroAwaitSegmentAvailabilityTimeoutMillis()
+  public void testConfigWithNonZeroAwaitSegmentAvailabilityTimeoutThrowsException()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("awaitSegmentAvailabilityTimeoutMillis is not supported for Compcation Task");
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        250,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        5L,
-        null
+    final Exception e = Assert.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder.forCompactionTask()
+                                 .withAwaitSegmentAvailabilityTimeoutMillis(5L)
+                                 .build()
+    );
+    Assert.assertEquals(
+        "awaitSegmentAvailabilityTimeoutMillis is not supported for Compcation Task",
+        e.getMessage()
     );
   }
 
   @Test
-  public void testSerdeWithZeroAwaitSegmentAvailabilityTimeoutMillis()
+  public void testConfigWithZeroAwaitSegmentAvailabilityTimeoutMillis()
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        250,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        0L,
-        null
-    );
+    final CompactionTask.CompactionTuningConfig tuningConfig = TuningConfigBuilder
+        .forCompactionTask()
+        .withAwaitSegmentAvailabilityTimeoutMillis(0L)
+        .build();
     Assert.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
 
   @Test
-  public void testSerdeWithNullAwaitSegmentAvailabilityTimeoutMillis()
+  public void testDefaultAwaitSegmentAvailabilityTimeoutMillis()
   {
-    final CompactionTask.CompactionTuningConfig tuningConfig = new CompactionTask.CompactionTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        250,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    final CompactionTask.CompactionTuningConfig tuningConfig =
+        TuningConfigBuilder.forCompactionTask().build();
     Assert.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
@@ -56,114 +56,38 @@ public class IndexTaskSerdeTest
   @Test
   public void testSerdeTuningConfigWithDynamicPartitionsSpec() throws IOException
   {
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        100,
-        2000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(1000, 2000L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        false,
-        null,
-        null,
-        100L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        true,
-        10,
-        100,
-        1234,
-        0L,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withPartitionsSpec(new DynamicPartitionsSpec(1000, 2000L))
+        .withForceGuaranteedRollup(false)
+        .build();
     assertSerdeTuningConfig(tuningConfig);
   }
 
   @Test
   public void testSerdeTuningConfigWithHashedPartitionsSpec() throws IOException
   {
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        100,
-        2000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(null, 10, ImmutableList.of("dim1", "dim2")),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        null,
-        null,
-        100L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        true,
-        10,
-        100,
-        null,
-        -1L,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+        .withForceGuaranteedRollup(true)
+        .build();
     assertSerdeTuningConfig(tuningConfig);
   }
 
   @Test
   public void testSerdeTuningConfigWithDeprecatedDynamicPartitionsSpec() throws IOException
   {
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        1000,
-        null,
-        100,
-        2000L,
-        null,
-        3000L,
-        null,
-        null,
-        null,
-        null,
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        false,
-        null,
-        null,
-        100L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        true,
-        10,
-        100,
-        null,
-        1L,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withMaxRowsPerSegment(1000)
+        .withMaxRowsInMemory(100)
+        .withMaxBytesInMemory(2000L)
+        .withMaxTotalRows(3000L)
+        .withForceGuaranteedRollup(false)
+        .withPushTimeout(100L)
+        .withAwaitSegmentAvailabilityTimeoutMillis(1L)
+        .build();
     assertSerdeTuningConfig(tuningConfig);
   }
 
@@ -210,38 +134,10 @@ public class IndexTaskSerdeTest
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("DynamicPartitionsSpec cannot be used for perfect rollup");
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        100,
-        2000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(1000, 2000L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        true,
-        null,
-        null,
-        100L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        true,
-        10,
-        100,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder.forIndexTask()
+                       .withForceGuaranteedRollup(true)
+                       .withPartitionsSpec(new DynamicPartitionsSpec(1000, 2000L))
+                       .build();
   }
 
   @Test
@@ -249,38 +145,10 @@ public class IndexTaskSerdeTest
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        100,
-        2000L,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(null, 10, ImmutableList.of("dim1", "dim2")),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.LZ4)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        null,
-        null,
-        false,
-        null,
-        null,
-        100L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        true,
-        10,
-        100,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder.forIndexTask()
+                       .withForceGuaranteedRollup(false)
+                       .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+                       .build();
   }
 
   private static void assertSerdeTuningConfig(IndexTuningConfig tuningConfig) throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -1499,33 +1499,16 @@ public class IndexTaskTest extends IngestionTestBase
       writer.write("this is not JSON\n"); // invalid JSON
     }
 
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(2, null, null),
-        INDEX_SPEC,
-        null,
-        null,
-        true,
-        false,
-        null,
-        null,
-        null,
-        true,
-        7,
-        7,
-        null,
-        null,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withPartitionsSpec(new HashedPartitionsSpec(2, null, null))
+        .withIndexSpec(INDEX_SPEC)
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withLogParseExceptions(true)
+        .withMaxParseExceptions(7)
+        .withMaxSavedParseExceptions(7)
+        .build();
 
     final TimestampSpec timestampSpec = new TimestampSpec("time", "auto", null);
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(
@@ -1668,33 +1651,16 @@ public class IndexTaskTest extends IngestionTestBase
     }
 
     // Allow up to 3 parse exceptions, and save up to 2 parse exceptions
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(2, null),
-        INDEX_SPEC,
-        null,
-        null,
-        false,
-        false,
-        null,
-        null,
-        null,
-        true,
-        2,
-        5,
-        null,
-        null,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withPartitionsSpec(new DynamicPartitionsSpec(2, null))
+        .withIndexSpec(INDEX_SPEC)
+        .withForceGuaranteedRollup(false)
+        .withReportParseExceptions(false)
+        .withLogParseExceptions(true)
+        .withMaxParseExceptions(2)
+        .withMaxSavedParseExceptions(5)
+        .build();
 
     final TimestampSpec timestampSpec = new TimestampSpec("time", "auto", null);
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(
@@ -1804,33 +1770,16 @@ public class IndexTaskTest extends IngestionTestBase
     }
 
     // Allow up to 3 parse exceptions, and save up to 2 parse exceptions
-    final IndexTuningConfig tuningConfig = new IndexTuningConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(2, null, null),
-        INDEX_SPEC,
-        null,
-        null,
-        true,
-        false,
-        null,
-        null,
-        null,
-        true,
-        2,
-        5,
-        null,
-        null,
-        null
-    );
+    final IndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forIndexTask()
+        .withPartitionsSpec(new HashedPartitionsSpec(2, null, null))
+        .withIndexSpec(INDEX_SPEC)
+        .withForceGuaranteedRollup(true)
+        .withReportParseExceptions(false)
+        .withLogParseExceptions(true)
+        .withMaxParseExceptions(2)
+        .withMaxSavedParseExceptions(5)
+        .build();
 
     final TimestampSpec timestampSpec = new TimestampSpec("time", "auto", null);
     final DimensionsSpec dimensionsSpec = new DimensionsSpec(
@@ -2611,33 +2560,17 @@ public class IndexTaskTest extends IngestionTestBase
       boolean reportParseException
   )
   {
-    return new IndexTuningConfig(
-        null,
-        maxRowsPerSegment,
-        null,
-        maxRowsInMemory,
-        null,
-        null,
-        maxTotalRows,
-        null,
-        null,
-        null,
-        partitionsSpec,
-        INDEX_SPEC,
-        null,
-        null,
-        forceGuaranteedRollup,
-        reportParseException,
-        null,
-        null,
-        null,
-        null,
-        null,
-        1,
-        null,
-        null,
-        null
-    );
+    return TuningConfigBuilder
+        .forIndexTask()
+        .withMaxRowsPerSegment(maxRowsPerSegment)
+        .withMaxRowsInMemory(maxRowsInMemory)
+        .withMaxTotalRows(maxTotalRows)
+        .withPartitionsSpec(partitionsSpec)
+        .withIndexSpec(INDEX_SPEC)
+        .withForceGuaranteedRollup(forceGuaranteedRollup)
+        .withReportParseExceptions(reportParseException)
+        .withMaxSavedParseExceptions(1)
+        .build();
   }
 
   @SuppressWarnings("unchecked")

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -243,33 +243,14 @@ public class TaskSerdeTest
                 null
             ),
             new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true, false),
-            new IndexTuningConfig(
-                null,
-                null,
-                null,
-                10,
-                null,
-                null,
-                null,
-                9999,
-                null,
-                null,
-                new DynamicPartitionsSpec(10000, null),
-                indexSpec,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                1L,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsInMemory(10)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
+                               .withIndexSpec(indexSpec)
+                               .withMaxPendingPersists(3)
+                               .withForceGuaranteedRollup(false)
+                               .withAwaitSegmentAvailabilityTimeoutMillis(1L)
+                               .build()
         ),
         null
     );
@@ -330,33 +311,13 @@ public class TaskSerdeTest
                 null
             ),
             new IndexIOConfig(null, new LocalInputSource(new File("lol"), "rofl"), new NoopInputFormat(), true, false),
-            new IndexTuningConfig(
-                null,
-                null,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                new DynamicPartitionsSpec(10000, null),
-                indexSpec,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsInMemory(10)
+                               .withForceGuaranteedRollup(false)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
+                               .withIndexSpec(indexSpec)
+                               .withMaxPendingPersists(3)
+                               .build()
         ),
         null
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TuningConfigBuilder.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TuningConfigBuilder.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task;
+
+import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
+import org.apache.druid.segment.IndexSpec;
+import org.apache.druid.segment.incremental.AppendableIndexSpec;
+import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import org.joda.time.Duration;
+
+/**
+ * Builder utility for various task tuning configs.
+ *
+ * @param <C> Type of config that is being built
+ * @see TuningConfigBuilder#forIndexTask()
+ * @see TuningConfigBuilder#forParallelIndexTask()
+ * @see TuningConfigBuilder#forCompactionTask()
+ */
+public abstract class TuningConfigBuilder<C>
+{
+  protected Integer targetPartitionSize;
+  protected Integer maxRowsPerSegment;
+  protected AppendableIndexSpec appendableIndexSpec;
+  protected Integer maxRowsInMemory;
+  protected Long maxBytesInMemory;
+  protected Boolean skipBytesInMemoryOverheadCheck;
+  protected Long maxTotalRows;
+  protected Integer numShards;
+  protected SplitHintSpec splitHintSpec;
+  protected PartitionsSpec partitionsSpec;
+  protected IndexSpec indexSpec;
+  protected IndexSpec indexSpecForIntermediatePersists;
+  protected Integer maxPendingPersists;
+  protected Boolean forceGuaranteedRollup;
+  protected Boolean reportParseExceptions;
+  protected Long publishTimeout;
+  protected Long pushTimeout;
+  protected SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
+  protected Integer maxNumSubTasks;
+  protected Integer maxNumConcurrentSubTasks;
+  protected Integer maxRetry;
+  protected Long taskStatusCheckPeriodMs;
+  protected Duration chatHandlerTimeout;
+  protected Integer chatHandlerNumRetries;
+  protected Integer maxNumSegmentsToMerge;
+  protected Integer totalNumMergeTasks;
+  protected Boolean logParseExceptions;
+  protected Integer maxParseExceptions;
+  protected Integer maxSavedParseExceptions;
+  protected Integer maxColumnsToMerge;
+  protected Long awaitSegmentAvailabilityTimeoutMillis;
+  protected Integer maxAllowedLockCount;
+  protected Integer numPersistThreads;
+
+  public TuningConfigBuilder<C> withTargetPartitionSize(Integer targetPartitionSize)
+  {
+    this.targetPartitionSize = targetPartitionSize;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxRowsPerSegment(Integer maxRowsPerSegment)
+  {
+    this.maxRowsPerSegment = maxRowsPerSegment;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withAppendableIndexSpec(AppendableIndexSpec appendableIndexSpec)
+  {
+    this.appendableIndexSpec = appendableIndexSpec;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxRowsInMemory(Integer maxRowsInMemory)
+  {
+    this.maxRowsInMemory = maxRowsInMemory;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxBytesInMemory(Long maxBytesInMemory)
+  {
+    this.maxBytesInMemory = maxBytesInMemory;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withSkipBytesInMemoryOverheadCheck(Boolean skipBytesInMemoryOverheadCheck)
+  {
+    this.skipBytesInMemoryOverheadCheck = skipBytesInMemoryOverheadCheck;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxTotalRows(Long maxTotalRows)
+  {
+    this.maxTotalRows = maxTotalRows;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withNumShards(Integer numShards)
+  {
+    this.numShards = numShards;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withSplitHintSpec(SplitHintSpec splitHintSpec)
+  {
+    this.splitHintSpec = splitHintSpec;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withPartitionsSpec(PartitionsSpec partitionsSpec)
+  {
+    this.partitionsSpec = partitionsSpec;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withIndexSpec(IndexSpec indexSpec)
+  {
+    this.indexSpec = indexSpec;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withIndexSpecForIntermediatePersists(IndexSpec indexSpecForIntermediatePersists)
+  {
+    this.indexSpecForIntermediatePersists = indexSpecForIntermediatePersists;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxPendingPersists(Integer maxPendingPersists)
+  {
+    this.maxPendingPersists = maxPendingPersists;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withForceGuaranteedRollup(Boolean forceGuaranteedRollup)
+  {
+    this.forceGuaranteedRollup = forceGuaranteedRollup;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withReportParseExceptions(Boolean reportParseExceptions)
+  {
+    this.reportParseExceptions = reportParseExceptions;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withPushTimeout(Long pushTimeout)
+  {
+    this.pushTimeout = pushTimeout;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withPublishTimeout(Long publishTimeout)
+  {
+    this.publishTimeout = publishTimeout;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withSegmentWriteOutMediumFactory(SegmentWriteOutMediumFactory segmentWriteOutMediumFactory)
+  {
+    this.segmentWriteOutMediumFactory = segmentWriteOutMediumFactory;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxNumSubTasks(Integer maxNumSubTasks)
+  {
+    this.maxNumSubTasks = maxNumSubTasks;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxNumConcurrentSubTasks(Integer maxNumConcurrentSubTasks)
+  {
+    this.maxNumConcurrentSubTasks = maxNumConcurrentSubTasks;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxRetry(Integer maxRetry)
+  {
+    this.maxRetry = maxRetry;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withTaskStatusCheckPeriodMs(Long taskStatusCheckPeriodMs)
+  {
+    this.taskStatusCheckPeriodMs = taskStatusCheckPeriodMs;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withChatHandlerTimeout(Duration chatHandlerTimeout)
+  {
+    this.chatHandlerTimeout = chatHandlerTimeout;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withChatHandlerNumRetries(Integer chatHandlerNumRetries)
+  {
+    this.chatHandlerNumRetries = chatHandlerNumRetries;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxNumSegmentsToMerge(Integer maxNumSegmentsToMerge)
+  {
+    this.maxNumSegmentsToMerge = maxNumSegmentsToMerge;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withTotalNumMergeTasks(Integer totalNumMergeTasks)
+  {
+    this.totalNumMergeTasks = totalNumMergeTasks;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withLogParseExceptions(Boolean logParseExceptions)
+  {
+    this.logParseExceptions = logParseExceptions;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxParseExceptions(Integer maxParseExceptions)
+  {
+    this.maxParseExceptions = maxParseExceptions;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxSavedParseExceptions(Integer maxSavedParseExceptions)
+  {
+    this.maxSavedParseExceptions = maxSavedParseExceptions;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxColumnsToMerge(Integer maxColumnsToMerge)
+  {
+    this.maxColumnsToMerge = maxColumnsToMerge;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withAwaitSegmentAvailabilityTimeoutMillis(Long awaitSegmentAvailabilityTimeoutMillis)
+  {
+    this.awaitSegmentAvailabilityTimeoutMillis = awaitSegmentAvailabilityTimeoutMillis;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withNumPersistThreads(Integer numPersistThreads)
+  {
+    this.numPersistThreads = numPersistThreads;
+    return this;
+  }
+
+  public TuningConfigBuilder<C> withMaxAllowedLockCount(Integer maxAllowedLockCount)
+  {
+    this.maxAllowedLockCount = maxAllowedLockCount;
+    return this;
+  }
+
+  public abstract C build();
+
+  /**
+   * Creates a new builder for {@link CompactionTask.CompactionTuningConfig}.
+   */
+  public static Compact forCompactionTask()
+  {
+    return new Compact();
+  }
+
+  /**
+   * Creates a new builder for {@link ParallelIndexTuningConfig}.
+   */
+  public static ParallelIndex forParallelIndexTask()
+  {
+    return new ParallelIndex();
+  }
+
+  /**
+   * Creates a new builder for {@link IndexTask.IndexTuningConfig}.
+   */
+  public static Index forIndexTask()
+  {
+    return new Index();
+  }
+
+  public static class Index extends TuningConfigBuilder<IndexTask.IndexTuningConfig>
+  {
+    @Override
+    public IndexTask.IndexTuningConfig build()
+    {
+      return new IndexTask.IndexTuningConfig(
+          targetPartitionSize,
+          maxRowsPerSegment,
+          appendableIndexSpec,
+          maxRowsInMemory,
+          maxBytesInMemory,
+          skipBytesInMemoryOverheadCheck,
+          maxTotalRows,
+          null,
+          numShards,
+          null,
+          partitionsSpec,
+          indexSpec,
+          indexSpecForIntermediatePersists,
+          maxPendingPersists,
+          forceGuaranteedRollup,
+          reportParseExceptions,
+          publishTimeout,
+          pushTimeout,
+          segmentWriteOutMediumFactory,
+          logParseExceptions,
+          maxParseExceptions,
+          maxSavedParseExceptions,
+          maxColumnsToMerge,
+          awaitSegmentAvailabilityTimeoutMillis,
+          numPersistThreads
+      );
+    }
+  }
+
+  public static class ParallelIndex extends TuningConfigBuilder<ParallelIndexTuningConfig>
+  {
+    @Override
+    public ParallelIndexTuningConfig build()
+    {
+      return new ParallelIndexTuningConfig(
+          targetPartitionSize,
+          maxRowsPerSegment,
+          appendableIndexSpec,
+          maxRowsInMemory,
+          maxBytesInMemory,
+          skipBytesInMemoryOverheadCheck,
+          maxTotalRows,
+          numShards,
+          splitHintSpec,
+          partitionsSpec,
+          indexSpec,
+          indexSpecForIntermediatePersists,
+          maxPendingPersists,
+          forceGuaranteedRollup,
+          reportParseExceptions,
+          pushTimeout,
+          segmentWriteOutMediumFactory,
+          maxNumSubTasks,
+          maxNumConcurrentSubTasks,
+          maxRetry,
+          taskStatusCheckPeriodMs,
+          chatHandlerTimeout,
+          chatHandlerNumRetries,
+          maxNumSegmentsToMerge,
+          totalNumMergeTasks,
+          logParseExceptions,
+          maxParseExceptions,
+          maxSavedParseExceptions,
+          maxColumnsToMerge,
+          awaitSegmentAvailabilityTimeoutMillis,
+          maxAllowedLockCount,
+          numPersistThreads
+      );
+    }
+  }
+
+  public static class Compact extends TuningConfigBuilder<CompactionTask.CompactionTuningConfig>
+  {
+    @Override
+    public CompactionTask.CompactionTuningConfig build()
+    {
+      return new CompactionTask.CompactionTuningConfig(
+          targetPartitionSize,
+          maxRowsPerSegment,
+          appendableIndexSpec,
+          maxRowsInMemory,
+          maxBytesInMemory,
+          skipBytesInMemoryOverheadCheck,
+          maxTotalRows,
+          numShards,
+          splitHintSpec,
+          partitionsSpec,
+          indexSpec,
+          indexSpecForIntermediatePersists,
+          maxPendingPersists,
+          forceGuaranteedRollup,
+          reportParseExceptions,
+          pushTimeout,
+          segmentWriteOutMediumFactory,
+          maxNumSubTasks,
+          maxNumConcurrentSubTasks,
+          maxRetry,
+          taskStatusCheckPeriodMs,
+          chatHandlerTimeout,
+          chatHandlerNumRetries,
+          maxNumSegmentsToMerge,
+          totalNumMergeTasks,
+          logParseExceptions,
+          maxParseExceptions,
+          maxSavedParseExceptions,
+          maxColumnsToMerge,
+          awaitSegmentAvailabilityTimeoutMillis,
+          numPersistThreads
+      );
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -66,6 +66,7 @@ import org.apache.druid.indexing.common.task.IngestionTestBase;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.indexing.worker.shuffle.IntermediaryDataManager;
@@ -165,40 +166,10 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       0
   );
   public static final ParallelIndexTuningConfig DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING =
-      new ParallelIndexTuningConfig(
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          2,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          5,
-          null,
-          null,
-          null,
-          null
-      );
+      TuningConfigBuilder.forParallelIndexTask()
+                         .withMaxNumConcurrentSubTasks(2)
+                         .withMaxParseExceptions(5)
+                         .build();
 
   protected static final double DEFAULT_TRANSIENT_TASK_FAILURE_RATE = 0.2;
   protected static final double DEFAULT_TRANSIENT_API_FAILURE_RATE = 0.2;
@@ -276,40 +247,13 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       boolean forceGuaranteedRollup
   )
   {
-    return new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        new MaxSizeSplitHintSpec(null, 1),
-        partitionsSpec,
-        null,
-        null,
-        null,
-        forceGuaranteedRollup,
-        null,
-        null,
-        null,
-        null,
-        maxNumConcurrentSubTasks,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        5,
-        null,
-        null,
-        null,
-        null
-    );
+    return TuningConfigBuilder.forParallelIndexTask()
+                              .withSplitHintSpec(new MaxSizeSplitHintSpec(null, 1))
+                              .withPartitionsSpec(partitionsSpec)
+                              .withForceGuaranteedRollup(forceGuaranteedRollup)
+                              .withMaxNumConcurrentSubTasks(maxNumConcurrentSubTasks)
+                              .withMaxParseExceptions(5)
+                              .build();
   }
 
   protected LocalOverlordClient getIndexingServiceClient()
@@ -329,12 +273,10 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     private volatile Future<TaskStatus> statusFuture;
     @MonotonicNonNull
     private volatile TestLocalTaskActionClient actionClient;
-    private final CountDownLatch taskFinishLatch;
 
-    private TaskContainer(Task task, CountDownLatch taskFinishLatch)
+    private TaskContainer(Task task)
     {
       this.task = task;
-      this.taskFinishLatch = taskFinishLatch;
     }
 
     public Task getTask()
@@ -461,7 +403,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
       final CountDownLatch taskFinishLatch = useTaskFinishLatches ? new CountDownLatch(1) : new CountDownLatch(0);
       allTaskLatches.add(taskFinishLatch);
 
-      final TaskContainer taskContainer = new TaskContainer(task, taskFinishLatch);
+      final TaskContainer taskContainer = new TaskContainer(task);
       if (tasks.put(task.getId(), taskContainer) != null) {
         throw new ISE("Duplicate task ID[%s]", task.getId());
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -168,7 +168,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   public static final ParallelIndexTuningConfig DEFAULT_TUNING_CONFIG_FOR_PARALLEL_INDEXING =
       TuningConfigBuilder.forParallelIndexTask()
                          .withMaxNumConcurrentSubTasks(2)
-                         .withMaxParseExceptions(5)
+                         .withMaxSavedParseExceptions(5)
                          .build();
 
   protected static final double DEFAULT_TRANSIENT_TASK_FAILURE_RATE = 0.2;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -163,40 +164,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
             null
         ),
         ioConfig,
-        new ParallelIndexTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            numTotalSubTasks,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
+        TuningConfigBuilder.forParallelIndexTask().withMaxNumConcurrentSubTasks(numTotalSubTasks).build()
     );
 
     // set up test tools

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -39,6 +39,7 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.task.AbstractTask;
 import org.apache.druid.indexing.common.task.SegmentAllocators;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTaskRunner.SubTaskSpecStatus;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
@@ -415,40 +416,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
             null
         ),
         ioConfig,
-        new ParallelIndexTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            NUM_SUB_TASKS,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        )
+        TuningConfigBuilder.forParallelIndexTask().withMaxNumConcurrentSubTasks(NUM_SUB_TASKS).build()
     );
 
     return new TestSupervisorTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -31,13 +31,13 @@ import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TaskResource;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -58,15 +58,8 @@ public class ParallelIndexSupervisorTaskSerdeTest
     NullHandling.initializeForTests();
   }
 
-  private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new TestUtils().getTestObjectMapper();
   private static final List<Interval> INTERVALS = Collections.singletonList(Intervals.of("2018/2019"));
-
-  private static ObjectMapper createObjectMapper()
-  {
-    TestUtils testUtils = new TestUtils();
-    ObjectMapper objectMapper = testUtils.getTestObjectMapper();
-    return objectMapper;
-  }
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -89,19 +82,18 @@ public class ParallelIndexSupervisorTaskSerdeTest
   @Test
   public void forceGuaranteedRollupWithHashPartitionsMissingNumShards()
   {
-    Integer numShards = null;
     ParallelIndexSupervisorTask task = new ParallelIndexSupervisorTaskBuilder()
         .ingestionSpec(
             new ParallelIndexIngestionSpecBuilder()
                 .forceGuaranteedRollup(true)
-                .partitionsSpec(new HashedPartitionsSpec(null, numShards, null))
+                .partitionsSpec(new HashedPartitionsSpec(null, null, null))
                 .inputIntervals(INTERVALS)
                 .build()
         )
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertThat(partitionsSpec, CoreMatchers.instanceOf(HashedPartitionsSpec.class));
+    Assert.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
   }
 
   @Test
@@ -119,7 +111,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertThat(partitionsSpec, CoreMatchers.instanceOf(HashedPartitionsSpec.class));
+    Assert.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
   }
 
   @Test
@@ -153,7 +145,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertThat(partitionsSpec, CoreMatchers.instanceOf(SingleDimensionPartitionsSpec.class));
+    Assert.assertTrue(partitionsSpec instanceof SingleDimensionPartitionsSpec);
   }
 
   private static class ParallelIndexSupervisorTaskBuilder
@@ -240,41 +232,11 @@ public class ParallelIndexSupervisorTaskSerdeTest
           null
       );
 
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          partitionsSpec,
-          null,
-          null,
-          null,
-          forceGuaranteedRollup,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-      );
-
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(partitionsSpec)
+          .withForceGuaranteedRollup(forceGuaranteedRollup)
+          .build();
       return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig);
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -37,6 +37,7 @@ import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.indexer.report.KillTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.indexing.common.TaskToolbox;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
@@ -64,6 +65,7 @@ import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
@@ -84,6 +86,7 @@ import java.util.stream.IntStream;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 
+@RunWith(Enclosed.class)
 public class ParallelIndexSupervisorTaskTest
 {
   @RunWith(Parameterized.class)
@@ -236,45 +239,32 @@ public class ParallelIndexSupervisorTaskTest
           appendToExisting,
           null
       );
-      final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-          null,
-          null,
-          null,
-          10,
-          1000L,
-          null,
-          null,
-          null,
-          null,
-          new HashedPartitionsSpec(null, 10, null),
-          IndexSpec.builder()
-                   .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                   .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                   .withMetricCompression(CompressionStrategy.LZF)
-                   .withLongEncoding(LongEncodingStrategy.LONGS)
-                   .build(),
-          IndexSpec.DEFAULT,
-          1,
-          forceGuaranteedRollup,
-          true,
-          10000L,
-          OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-          null,
-          10,
-          100,
-          20L,
-          new Duration(3600),
-          128,
-          null,
-          null,
-          false,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-      );
+      final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withMaxRowsInMemory(10)
+          .withMaxBytesInMemory(1000L)
+          .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+          .withIndexSpec(
+              IndexSpec.builder()
+                       .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                       .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
+                       .withMetricCompression(CompressionStrategy.LZF)
+                       .withLongEncoding(LongEncodingStrategy.LONGS)
+                       .build()
+          )
+          .withIndexSpecForIntermediatePersists(IndexSpec.DEFAULT)
+          .withMaxPendingPersists(1)
+          .withForceGuaranteedRollup(forceGuaranteedRollup)
+          .withReportParseExceptions(true)
+          .withPushTimeout(10000L)
+          .withSegmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+          .withMaxNumConcurrentSubTasks(10)
+          .withMaxRetry(100)
+          .withTaskStatusCheckPeriodMs(20L)
+          .withChatHandlerTimeout(new Duration(3600))
+          .withChatHandlerNumRetries(128)
+          .withLogParseExceptions(false)
+          .build();
       final ParallelIndexIngestionSpec indexIngestionSpec = new ParallelIndexIngestionSpec(
           new DataSchema(
               "datasource",
@@ -309,45 +299,32 @@ public class ParallelIndexSupervisorTaskTest
           false,
           null
       );
-      final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-          null,
-          null,
-          null,
-          10,
-          1000L,
-          null,
-          null,
-          null,
-          null,
-          new HashedPartitionsSpec(null, 10, null),
-          IndexSpec.builder()
-                   .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                   .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                   .withMetricCompression(CompressionStrategy.LZF)
-                   .withLongEncoding(LongEncodingStrategy.LONGS)
-                   .build(),
-          IndexSpec.DEFAULT,
-          1,
-          true,
-          true,
-          10000L,
-          OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-          null,
-          10,
-          100,
-          20L,
-          new Duration(3600),
-          128,
-          null,
-          null,
-          false,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-      );
+      final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withMaxRowsInMemory(10)
+          .withMaxBytesInMemory(1000L)
+          .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+          .withIndexSpec(
+              IndexSpec.builder()
+                       .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                       .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
+                       .withMetricCompression(CompressionStrategy.LZF)
+                       .withLongEncoding(LongEncodingStrategy.LONGS)
+                       .build()
+          )
+          .withIndexSpecForIntermediatePersists(IndexSpec.DEFAULT)
+          .withMaxPendingPersists(1)
+          .withForceGuaranteedRollup(true)
+          .withReportParseExceptions(true)
+          .withPushTimeout(10000L)
+          .withSegmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+          .withMaxNumConcurrentSubTasks(10)
+          .withMaxRetry(100)
+          .withTaskStatusCheckPeriodMs(20L)
+          .withChatHandlerTimeout(new Duration(3600))
+          .withChatHandlerNumRetries(128)
+          .withLogParseExceptions(false)
+          .build();
 
       expectedException.expect(IAE.class);
       expectedException.expectMessage("Cannot use parser and inputSource together. Try using inputFormat instead of parser.");
@@ -559,45 +536,33 @@ public class ParallelIndexSupervisorTaskTest
               appendToExisting,
               null
       );
-      final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-              null,
-              null,
-              null,
-              10,
-              1000L,
-              null,
-              null,
-              null,
-              null,
-              new HashedPartitionsSpec(null, 10, null),
+      final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withMaxRowsInMemory(10)
+          .withMaxBytesInMemory(1000L)
+          .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+          .withIndexSpec(
               IndexSpec.builder()
-                      .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                      .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                      .withMetricCompression(CompressionStrategy.LZF)
-                      .withLongEncoding(LongEncodingStrategy.LONGS)
-                      .build(),
-              IndexSpec.DEFAULT,
-              1,
-              forceGuaranteedRollup,
-              true,
-              10000L,
-              OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-              null,
-              10,
-              100,
-              20L,
-              new Duration(3600),
-              128,
-              null,
-              null,
-              false,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null
-      );
+                       .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
+                       .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
+                       .withMetricCompression(CompressionStrategy.LZF)
+                       .withLongEncoding(LongEncodingStrategy.LONGS)
+                       .build()
+          )
+          .withIndexSpecForIntermediatePersists(IndexSpec.DEFAULT)
+          .withMaxPendingPersists(1)
+          .withForceGuaranteedRollup(forceGuaranteedRollup)
+          .withReportParseExceptions(true)
+          .withPushTimeout(10000L)
+          .withSegmentWriteOutMediumFactory(OffHeapMemorySegmentWriteOutMediumFactory.instance())
+          .withMaxNumConcurrentSubTasks(10)
+          .withMaxRetry(100)
+          .withTaskStatusCheckPeriodMs(20L)
+          .withChatHandlerTimeout(new Duration(3600))
+          .withChatHandlerNumRetries(128)
+          .withLogParseExceptions(false)
+          .build();
+
       final ParallelIndexIngestionSpec indexIngestionSpec = new ParallelIndexIngestionSpec(
               new DataSchema(
                       "datasource",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -65,7 +65,6 @@ import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
@@ -86,7 +85,6 @@ import java.util.stream.IntStream;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
 
-@RunWith(Enclosed.class)
 public class ParallelIndexSupervisorTaskTest
 {
   @RunWith(Parameterized.class)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -28,28 +28,22 @@ import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.TimestampSpec;
-import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
-import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.ArbitraryGranularitySpec;
 import org.apache.druid.segment.indexing.granularity.GranularitySpec;
-import org.apache.druid.segment.realtime.appenderator.AppenderatorsManager;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.timeline.partition.BuildingHashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
 import org.easymock.EasyMock;
-import org.joda.time.Duration;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,20 +62,6 @@ class ParallelIndexTestingFactory
   static final String SUBTASK_SPEC_ID = "subtask-spec-id";
   static final int NUM_ATTEMPTS = 1;
   static final Map<String, Object> CONTEXT = Collections.emptyMap();
-  static final ParallelIndexSupervisorTaskClientProvider TASK_CLIENT_PROVIDER = TestUtils.TASK_CLIENT_PROVIDER;
-  static final AppenderatorsManager APPENDERATORS_MANAGER = TestUtils.APPENDERATORS_MANAGER;
-  static final ShuffleClient SHUFFLE_CLIENT = new ShuffleClient()
-  {
-    @Override
-    public File fetchSegmentFile(
-        File partitionDir,
-        String supervisorTaskId,
-        PartitionLocation location
-    )
-    {
-      return null;
-    }
-  };
   static final List<Interval> INPUT_INTERVALS = Collections.singletonList(Intervals.ETERNITY);
   static final String TASK_EXECUTOR_HOST = "task-executor-host";
   static final int TASK_EXECUTOR_PORT = 1;
@@ -111,83 +91,6 @@ class ParallelIndexTestingFactory
   static ObjectMapper createObjectMapper()
   {
     return TEST_UTILS.getTestObjectMapper();
-  }
-
-  static IndexIO getIndexIO()
-  {
-    return TEST_UTILS.getTestIndexIO();
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  static class TuningConfigBuilder
-  {
-    private PartitionsSpec partitionsSpec =
-        new HashedPartitionsSpec(null, 2, null);
-    private boolean forceGuaranteedRollup = true;
-    private boolean logParseExceptions = false;
-    private int maxParseExceptions = Integer.MAX_VALUE;
-
-    TuningConfigBuilder partitionsSpec(PartitionsSpec partitionsSpec)
-    {
-      this.partitionsSpec = partitionsSpec;
-      return this;
-    }
-
-    TuningConfigBuilder forceGuaranteedRollup(boolean forceGuaranteedRollup)
-    {
-      this.forceGuaranteedRollup = forceGuaranteedRollup;
-      return this;
-    }
-
-    TuningConfigBuilder logParseExceptions(boolean logParseExceptions)
-    {
-      this.logParseExceptions = logParseExceptions;
-      return this;
-    }
-
-    TuningConfigBuilder maxParseExceptions(int maxParseExceptions)
-    {
-      this.maxParseExceptions = maxParseExceptions;
-      return this;
-    }
-
-    ParallelIndexTuningConfig build()
-    {
-      return new ParallelIndexTuningConfig(
-          1,
-          null,
-          null,
-          3,
-          4L,
-          null,
-          5L,
-          6,
-          null,
-          partitionsSpec,
-          null,
-          null,
-          10,
-          forceGuaranteedRollup,
-          false,
-          14L,
-          null,
-          null,
-          16,
-          17,
-          18L,
-          Duration.ZERO,
-          20,
-          21,
-          22,
-          logParseExceptions,
-          maxParseExceptions,
-          25,
-          null,
-          null,
-          null,
-          2
-      );
-    }
   }
 
   static DataSchema createDataSchema(List<Interval> granularitySpecInputIntervals)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTestingFactory.java
@@ -26,9 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.impl.DimensionsSpec;
-import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.TimestampSpec;
-import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.java.util.common.Intervals;
@@ -40,10 +38,8 @@ import org.apache.druid.segment.indexing.granularity.GranularitySpec;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.timeline.partition.BuildingHashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
-import org.easymock.EasyMock;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -125,47 +121,6 @@ class ParallelIndexTestingFactory
     return new ParallelIndexIngestionSpec(dataSchema, ioConfig, tuningConfig);
   }
 
-  static class SingleDimensionPartitionsSpecBuilder
-  {
-    @Nullable
-    private String partitionDimension = SCHEMA_DIMENSION;
-    private boolean assumeGrouped = false;
-
-    SingleDimensionPartitionsSpecBuilder partitionDimension(@Nullable String partitionDimension)
-    {
-      this.partitionDimension = partitionDimension;
-      return this;
-    }
-
-    SingleDimensionPartitionsSpecBuilder assumeGrouped(boolean assumeGrouped)
-    {
-      this.assumeGrouped = assumeGrouped;
-      return this;
-    }
-
-    SingleDimensionPartitionsSpec build()
-    {
-      return new SingleDimensionPartitionsSpec(
-          1,
-          null,
-          partitionDimension,
-          assumeGrouped
-      );
-    }
-  }
-
-  static ParallelIndexSupervisorTaskClientProvider createTaskClientFactory()
-  {
-    return (supervisorTaskId, httpTimeout, numRetries) -> createTaskClient();
-  }
-
-  private static ParallelIndexSupervisorTaskClient createTaskClient()
-  {
-    ParallelIndexSupervisorTaskClient taskClient = EasyMock.niceMock(ParallelIndexSupervisorTaskClient.class);
-    EasyMock.replay(taskClient);
-    return taskClient;
-  }
-
   static String createRow(long timestamp, Object dimensionValue)
   {
     try {
@@ -189,10 +144,5 @@ class ParallelIndexTestingFactory
     catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
-  }
-
-  static InputFormat getInputFormat()
-  {
-    return new JsonInputFormat(null, null, null, null, null);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
@@ -22,17 +22,14 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
-import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.IndexSpec;
-import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
-import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.indexing.TuningConfig;
-import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -40,6 +37,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.util.Collections;
 
 public class ParallelIndexTuningConfigTest
 {
@@ -57,201 +55,53 @@ public class ParallelIndexTuningConfigTest
   @Test
   public void testSerdeDefault() throws IOException
   {
-    final ParallelIndexTuningConfig tuningConfig = ParallelIndexTuningConfig.defaultConfig();
-    final byte[] json = mapper.writeValueAsBytes(tuningConfig);
-    final ParallelIndexTuningConfig fromJson = (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    verifyConfigSerde(ParallelIndexTuningConfig.defaultConfig());
   }
 
   @Test
-  public void testSerdeWithMaxRowsPerSegment()
-      throws IOException
+  public void testSerdeWithNullMaxRowsPerSegment() throws IOException
   {
-    final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        250,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        2
-    );
-    final byte[] json = mapper.writeValueAsBytes(tuningConfig);
-    final ParallelIndexTuningConfig fromJson = (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withMaxRowsInMemory(10)
+        .withMaxBytesInMemory(1000L)
+        .withPartitionsSpec(new DynamicPartitionsSpec(100, 1000L))
+        .withForceGuaranteedRollup(false)
+        .build();
+    verifyConfigSerde(tuningConfig);
   }
 
   @Test
   public void testSerdeWithMaxNumConcurrentSubTasks() throws IOException
   {
-    final int maxNumConcurrentSubTasks = 250;
-    final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        maxNumConcurrentSubTasks,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        2
-    );
-    final byte[] json = mapper.writeValueAsBytes(tuningConfig);
-    final ParallelIndexTuningConfig fromJson = (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withMaxNumConcurrentSubTasks(250)
+        .build();
+    verifyConfigSerde(tuningConfig);
   }
 
   @Test
   public void testSerdeWithMaxNumSubTasks() throws IOException
   {
-    final int maxNumSubTasks = 250;
-    final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        maxNumSubTasks,
-        null,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        2
-    );
-    final byte[] json = mapper.writeValueAsBytes(tuningConfig);
-    final ParallelIndexTuningConfig fromJson = (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    final ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withMaxNumSubTasks(250)
+        .build();
+    verifyConfigSerde(tuningConfig);
   }
 
   @Test
-  public void testSerdeWithMaxNumSubTasksAndMaxNumConcurrentSubTasks()
+  public void testConfigWithBothMaxNumSubTasksAndMaxNumConcurrentSubTasksIsInvalid()
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("Can't use both maxNumSubTasks and maxNumConcurrentSubTasks");
     final int maxNumSubTasks = 250;
-    final ParallelIndexTuningConfig tuningConfig = new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, 100L),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        false,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        maxNumSubTasks,
-        maxNumSubTasks,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder
+        .forParallelIndexTask()
+        .withMaxNumSubTasks(maxNumSubTasks)
+        .withMaxNumConcurrentSubTasks(maxNumSubTasks)
+        .build();
   }
 
   @Test
@@ -259,46 +109,11 @@ public class ParallelIndexTuningConfigTest
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    final boolean forceGuaranteedRollup = false;
-    new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new HashedPartitionsSpec(null, 10, null),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        forceGuaranteedRollup,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        10,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder
+        .forParallelIndexTask()
+        .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+        .withForceGuaranteedRollup(false)
+        .build();
   }
 
   @Test
@@ -306,46 +121,11 @@ public class ParallelIndexTuningConfigTest
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    final boolean forceGuaranteedRollup = false;
-    new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new SingleDimensionPartitionsSpec(100, null, "dim", false),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        forceGuaranteedRollup,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        10,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder
+        .forParallelIndexTask()
+        .withPartitionsSpec(new DimensionRangePartitionsSpec(null, 100, Collections.singletonList("dim1"), false))
+        .withForceGuaranteedRollup(false)
+        .build();
   }
 
   @Test
@@ -353,46 +133,19 @@ public class ParallelIndexTuningConfigTest
   {
     expectedException.expect(IllegalArgumentException.class);
     expectedException.expectMessage("cannot be used for perfect rollup");
-    final boolean forceGuaranteedRollup = true;
-    new ParallelIndexTuningConfig(
-        null,
-        null,
-        null,
-        10,
-        1000L,
-        null,
-        null,
-        null,
-        null,
-        new DynamicPartitionsSpec(100, null),
-        IndexSpec.builder()
-                 .withBitmapSerdeFactory(RoaringBitmapSerdeFactory.getInstance())
-                 .withDimensionCompression(CompressionStrategy.UNCOMPRESSED)
-                 .withMetricCompression(CompressionStrategy.LZF)
-                 .withLongEncoding(LongEncodingStrategy.LONGS)
-                 .build(),
-        IndexSpec.DEFAULT,
-        1,
-        forceGuaranteedRollup,
-        true,
-        10000L,
-        OffHeapMemorySegmentWriteOutMediumFactory.instance(),
-        null,
-        10,
-        100,
-        20L,
-        new Duration(3600),
-        128,
-        null,
-        null,
-        false,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
-    );
+    TuningConfigBuilder
+        .forParallelIndexTask()
+        .withPartitionsSpec(new DynamicPartitionsSpec(100, null))
+        .withForceGuaranteedRollup(true)
+        .build();
+  }
+
+  private void verifyConfigSerde(ParallelIndexTuningConfig tuningConfig) throws IOException
+  {
+    final byte[] json = mapper.writeValueAsBytes(tuningConfig);
+    final ParallelIndexTuningConfig fromJson =
+        (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
+    Assert.assertEquals(fromJson, tuningConfig);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -31,12 +31,14 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InlineInputSource;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -52,20 +54,22 @@ import org.apache.druid.testing.junit.LoggerCaptureRule;
 import org.apache.logging.log4j.core.LogEvent;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.hamcrest.Matchers;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+@RunWith(Enclosed.class)
 public class PartialDimensionCardinalityTaskTest
 {
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
@@ -82,9 +86,10 @@ public class PartialDimensionCardinalityTaskTest
       exception.expect(IllegalArgumentException.class);
       exception.expectMessage("forceGuaranteedRollup must be set");
 
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .forceGuaranteedRollup(false)
-          .partitionsSpec(new DynamicPartitionsSpec(null, null))
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(new DynamicPartitionsSpec(null, null))
+          .withForceGuaranteedRollup(false)
           .build();
 
       new PartialDimensionCardinalityTaskBuilder()
@@ -100,7 +105,10 @@ public class PartialDimensionCardinalityTaskTest
 
       PartitionsSpec partitionsSpec = new SingleDimensionPartitionsSpec(null, 1, "a", false);
       ParallelIndexTuningConfig tuningConfig =
-          new ParallelIndexTestingFactory.TuningConfigBuilder().partitionsSpec(partitionsSpec).build();
+          TuningConfigBuilder.forParallelIndexTask()
+                             .withForceGuaranteedRollup(true)
+                             .withPartitionsSpec(partitionsSpec)
+                             .build();
 
       new PartialDimensionCardinalityTaskBuilder()
           .tuningConfig(tuningConfig)
@@ -136,7 +144,7 @@ public class PartialDimensionCardinalityTaskTest
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .id(ParallelIndexTestingFactory.AUTOMATIC_ID)
           .build();
-      Assert.assertThat(task.getId(), Matchers.startsWith(PartialDimensionCardinalityTask.TYPE));
+      Assert.assertTrue(task.getId().startsWith(PartialDimensionCardinalityTask.TYPE));
     }
   }
 
@@ -176,9 +184,11 @@ public class PartialDimensionCardinalityTaskTest
       exception.expect(IllegalArgumentException.class);
       exception.expectMessage("partitionDimensions must be specified");
 
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .partitionsSpec(
-              new ParallelIndexTestingFactory.SingleDimensionPartitionsSpecBuilder().partitionDimension(null).build()
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withForceGuaranteedRollup(true)
+          .withPartitionsSpec(
+              new DimensionRangePartitionsSpec(null, null, null, false)
           )
           .build();
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
@@ -195,9 +205,11 @@ public class PartialDimensionCardinalityTaskTest
       InputSource inlineInputSource = new InlineInputSource(
           ParallelIndexTestingFactory.createRow(invalidTimestamp, "a")
       );
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .partitionsSpec(HASHED_PARTITIONS_SPEC)
-          .logParseExceptions(true)
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(HASHED_PARTITIONS_SPEC)
+          .withForceGuaranteedRollup(true)
+          .withLogParseExceptions(true)
           .build();
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .inputSource(inlineInputSource)
@@ -209,15 +221,17 @@ public class PartialDimensionCardinalityTaskTest
       List<LogEvent> logEvents = logger.getLogEvents();
       Assert.assertEquals(1, logEvents.size());
       String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
-      Assert.assertThat(logMessage, Matchers.containsString("Encountered parse exception"));
+      Assert.assertTrue(logMessage.contains("Encountered parse exception"));
     }
 
     @Test
     public void doesNotLogParseExceptionsIfDisabled() throws Exception
     {
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .partitionsSpec(HASHED_PARTITIONS_SPEC)
-          .logParseExceptions(false)
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(HASHED_PARTITIONS_SPEC)
+          .withForceGuaranteedRollup(true)
+          .withLogParseExceptions(false)
           .build();
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .tuningConfig(tuningConfig)
@@ -231,9 +245,11 @@ public class PartialDimensionCardinalityTaskTest
     @Test
     public void failsWhenTooManyParseExceptions() throws Exception
     {
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .partitionsSpec(HASHED_PARTITIONS_SPEC)
-          .maxParseExceptions(0)
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(HASHED_PARTITIONS_SPEC)
+          .withForceGuaranteedRollup(true)
+          .withMaxParseExceptions(0)
           .build();
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .tuningConfig(tuningConfig)
@@ -273,11 +289,12 @@ public class PartialDimensionCardinalityTaskTest
           ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "b", "dim2", "3")) + "\n" +
           ParallelIndexTestingFactory.createRowFromMap(0, ImmutableMap.of("dim1", "b", "dim2", "4"))
       );
-      HashedPartitionsSpec partitionsSpec = new HashedPartitionsSpec(null, null,
-                                                                     Collections.singletonList("dim1")
-      );
-      ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-          .partitionsSpec(partitionsSpec)
+      HashedPartitionsSpec partitionsSpec =
+          new HashedPartitionsSpec(null, null, Collections.singletonList("dim1"));
+      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+          .forParallelIndexTask()
+          .withPartitionsSpec(partitionsSpec)
+          .withForceGuaranteedRollup(true)
           .build();
 
       PartialDimensionCardinalityTaskBuilder taskBuilder = new PartialDimensionCardinalityTaskBuilder()
@@ -361,8 +378,10 @@ public class PartialDimensionCardinalityTaskTest
 
     private String id = ParallelIndexTestingFactory.ID;
     private InputSource inputSource = new InlineInputSource("row-with-invalid-timestamp");
-    private ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-        .partitionsSpec(HASHED_PARTITIONS_SPEC)
+    private ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withPartitionsSpec(HASHED_PARTITIONS_SPEC)
+        .withForceGuaranteedRollup(true)
         .build();
     private DataSchema dataSchema =
         ParallelIndexTestingFactory

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
@@ -371,7 +372,7 @@ public class PartialDimensionCardinalityTaskTest
 
   private static class PartialDimensionCardinalityTaskBuilder
   {
-    private static final InputFormat INPUT_FORMAT = ParallelIndexTestingFactory.getInputFormat();
+    private static final InputFormat INPUT_FORMAT = new JsonInputFormat(null, null, null, null, null);
 
     private String id = ParallelIndexTestingFactory.ID;
     private InputSource inputSource = new InlineInputSource("row-with-invalid-timestamp");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -59,17 +59,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(Enclosed.class)
 public class PartialDimensionCardinalityTaskTest
 {
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -52,10 +52,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +64,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@RunWith(Enclosed.class)
 public class PartialDimensionDistributionTaskTest
 {
   private static final SingleDimensionPartitionsSpec SINGLE_DIM_PARTITIONS_SPEC =

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.StringTuple;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
@@ -67,7 +68,7 @@ import java.util.stream.IntStream;
 public class PartialDimensionDistributionTaskTest
 {
   private static final SingleDimensionPartitionsSpec SINGLE_DIM_PARTITIONS_SPEC =
-      new ParallelIndexTestingFactory.SingleDimensionPartitionsSpecBuilder().build();
+      new SingleDimensionPartitionsSpec(null, 1000, "dim", false);
 
   public static class ConstructorTest
   {
@@ -412,7 +413,7 @@ public class PartialDimensionDistributionTaskTest
 
   private static class PartialDimensionDistributionTaskBuilder
   {
-    private static final InputFormat INPUT_FORMAT = ParallelIndexTestingFactory.getInputFormat();
+    private static final InputFormat INPUT_FORMAT = new JsonInputFormat(null, null, null, null, null);
 
     private String id = ParallelIndexTestingFactory.ID;
     private InputSource inputSource = new InlineInputSource("row-with-invalid-timestamp");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.segment.TestHelper;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -38,7 +38,7 @@ import java.util.Collections;
 public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSupervisorTaskTest
 {
   @Parameterized.Parameters(name = "partitionLocation = {0}")
-  public static Iterable<? extends Object> data()
+  public static Iterable<?> data()
   {
     return Arrays.asList(
         GENERIC_PARTITION_LOCATION,
@@ -71,7 +71,6 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
   private PartialGenericSegmentMergeTask target;
   private PartialSegmentMergeIOConfig ioConfig;
   private HashedPartitionsSpec partitionsSpec;
-  private PartialSegmentMergeIngestionSpec ingestionSpec;
 
   public PartialGenericSegmentMergeTaskTest()
   {
@@ -88,12 +87,13 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
         1,
         Collections.emptyList()
     );
-    ingestionSpec = new PartialSegmentMergeIngestionSpec(
+    PartialSegmentMergeIngestionSpec ingestionSpec = new PartialSegmentMergeIngestionSpec(
         ParallelIndexTestingFactory.createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS),
         ioConfig,
-        new ParallelIndexTestingFactory.TuningConfigBuilder()
-            .partitionsSpec(partitionsSpec)
-            .build()
+        TuningConfigBuilder.forParallelIndexTask()
+                           .withForceGuaranteedRollup(true)
+                           .withPartitionsSpec(partitionsSpec)
+                           .build()
     );
     target = new PartialGenericSegmentMergeTask(
         ParallelIndexTestingFactory.AUTOMATIC_ID,
@@ -117,7 +117,7 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
   public void hasCorrectPrefixForAutomaticId()
   {
     String id = target.getId();
-    Assert.assertThat(id, Matchers.startsWith(PartialGenericSegmentMergeTask.TYPE));
+    Assert.assertTrue(id.startsWith(PartialGenericSegmentMergeTask.TYPE));
   }
 
   @Test
@@ -136,8 +136,9 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
         new PartialSegmentMergeIngestionSpec(
             ParallelIndexTestingFactory.createDataSchema(null),
             ioConfig,
-            new ParallelIndexTestingFactory.TuningConfigBuilder()
-                .partitionsSpec(partitionsSpec)
+            TuningConfigBuilder.forParallelIndexTask()
+                .withForceGuaranteedRollup(true)
+                .withPartitionsSpec(partitionsSpec)
                 .build()
         ),
         ParallelIndexTestingFactory.CONTEXT

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.common.task.batch.partition.HashPartitionAnalysis;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -53,7 +54,10 @@ public class PartialHashSegmentGenerateTaskTest
   private static final ParallelIndexIngestionSpec INGESTION_SPEC = ParallelIndexTestingFactory.createIngestionSpec(
       new LocalInputSource(new File("baseDir"), "filer"),
       new JsonInputFormat(null, null, null, null, null),
-      new ParallelIndexTestingFactory.TuningConfigBuilder().build(),
+      TuningConfigBuilder.forParallelIndexTask()
+                         .withForceGuaranteedRollup(true)
+                         .withPartitionsSpec(new HashedPartitionsSpec(null, 2, null))
+                         .build(),
       ParallelIndexTestingFactory.createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS)
   );
 
@@ -180,7 +184,10 @@ public class PartialHashSegmentGenerateTaskTest
         ParallelIndexTestingFactory.createIngestionSpec(
             new LocalInputSource(new File("baseDir"), "filer"),
             new JsonInputFormat(null, null, null, null, null),
-            new ParallelIndexTestingFactory.TuningConfigBuilder().build(),
+            TuningConfigBuilder.forParallelIndexTask()
+                               .withForceGuaranteedRollup(true)
+                               .withPartitionsSpec(new HashedPartitionsSpec(null, 2, null))
+                               .build(),
             ParallelIndexTestingFactory.createDataSchema(null)
         ),
         ParallelIndexTestingFactory.CONTEXT,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.StringTuple;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
@@ -132,7 +133,7 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   private static class PartialRangeSegmentGenerateTaskBuilder
   {
     private static final InputSource INPUT_SOURCE = new InlineInputSource("data");
-    private static final InputFormat INPUT_FORMAT = ParallelIndexTestingFactory.getInputFormat();
+    private static final InputFormat INPUT_FORMAT = new JsonInputFormat(null, null, null, null, null);
 
     private ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
         .forParallelIndexTask()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
@@ -24,9 +24,11 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.StringTuple;
 import org.apache.druid.data.input.impl.InlineInputSource;
+import org.apache.druid.indexer.partitions.DimensionRangePartitionsSpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.indexing.DataSchema;
@@ -35,7 +37,6 @@ import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,11 +61,10 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
     exception.expect(IllegalArgumentException.class);
     exception.expectMessage("range or single_dim partitionsSpec required");
 
-    ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-        .forceGuaranteedRollup(false)
-        .partitionsSpec(new DynamicPartitionsSpec(null, null))
+    ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withPartitionsSpec(new DynamicPartitionsSpec(null, null))
         .build();
-
     new PartialRangeSegmentGenerateTaskBuilder()
         .tuningConfig(tuningConfig)
         .build();
@@ -77,8 +77,11 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
     exception.expectMessage("range or single_dim partitionsSpec required");
 
     PartitionsSpec partitionsSpec = new HashedPartitionsSpec(null, 1, null);
-    ParallelIndexTuningConfig tuningConfig =
-        new ParallelIndexTestingFactory.TuningConfigBuilder().partitionsSpec(partitionsSpec).build();
+    ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withForceGuaranteedRollup(true)
+        .withPartitionsSpec(partitionsSpec)
+        .build();
 
     new PartialRangeSegmentGenerateTaskBuilder()
         .tuningConfig(tuningConfig)
@@ -123,7 +126,7 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   public void hasCorrectPrefixForAutomaticId()
   {
     PartialRangeSegmentGenerateTask task = new PartialRangeSegmentGenerateTaskBuilder().build();
-    Assert.assertThat(task.getId(), Matchers.startsWith(PartialRangeSegmentGenerateTask.TYPE));
+    Assert.assertTrue(task.getId().startsWith(PartialRangeSegmentGenerateTask.TYPE));
   }
 
   private static class PartialRangeSegmentGenerateTaskBuilder
@@ -131,8 +134,12 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
     private static final InputSource INPUT_SOURCE = new InlineInputSource("data");
     private static final InputFormat INPUT_FORMAT = ParallelIndexTestingFactory.getInputFormat();
 
-    private ParallelIndexTuningConfig tuningConfig = new ParallelIndexTestingFactory.TuningConfigBuilder()
-        .partitionsSpec(new ParallelIndexTestingFactory.SingleDimensionPartitionsSpecBuilder().build())
+    private ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+        .forParallelIndexTask()
+        .withForceGuaranteedRollup(true)
+        .withPartitionsSpec(
+            new DimensionRangePartitionsSpec(null, 1000, Collections.singletonList("dim"), false)
+        )
         .build();
     private DataSchema dataSchema =
         ParallelIndexTestingFactory.createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIOConfigTest.java
@@ -64,15 +64,6 @@ public class PartialSegmentMergeIOConfigTest
   }
 
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
-  private static final GenericPartitionLocation GENERIC_PARTITION_LOCATION = new GenericPartitionLocation(
-      ParallelIndexTestingFactory.HOST,
-      ParallelIndexTestingFactory.PORT,
-      ParallelIndexTestingFactory.USE_HTTPS,
-      ParallelIndexTestingFactory.SUBTASK_ID,
-      ParallelIndexTestingFactory.INTERVAL,
-      ParallelIndexTestingFactory.HASH_BASED_NUMBERED_SHARD_SPEC
-  );
-
   private PartialSegmentMergeIOConfig target;
 
   @Before

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIngestionSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIngestionSpecTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.segment.TestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class PartialSegmentMergeIngestionSpecTest
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
 
   @Parameterized.Parameters(name = "partitionLocation = {0}")
-  public static Iterable<? extends Object> data()
+  public static Iterable<?> data()
   {
     return Arrays.asList(
         GENERIC_PARTITION_LOCATION,
@@ -65,24 +66,21 @@ public class PartialSegmentMergeIngestionSpecTest
   );
 
   private PartialSegmentMergeIngestionSpec target;
-  private PartialSegmentMergeIOConfig ioConfig;
-  private HashedPartitionsSpec partitionsSpec;
 
   @Before
   public void setup()
   {
-    ioConfig = new PartialSegmentMergeIOConfig(Collections.singletonList(partitionLocation));
-    partitionsSpec = new HashedPartitionsSpec(
-        null,
-        1,
-        Collections.emptyList()
-    );
+    PartialSegmentMergeIOConfig ioConfig =
+        new PartialSegmentMergeIOConfig(Collections.singletonList(partitionLocation));
+    HashedPartitionsSpec partitionsSpec =
+        new HashedPartitionsSpec(null, 1, Collections.emptyList());
     target = new PartialSegmentMergeIngestionSpec(
         ParallelIndexTestingFactory.createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS),
         ioConfig,
-        new ParallelIndexTestingFactory.TuningConfigBuilder()
-            .partitionsSpec(partitionsSpec)
-            .build()
+        TuningConfigBuilder.forParallelIndexTask()
+                           .withForceGuaranteedRollup(true)
+                           .withPartitionsSpec(partitionsSpec)
+                           .build()
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -158,7 +158,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   @Test
   public void testIsReady() throws Exception
   {
-    final ParallelIndexSupervisorTask task = newTask(INTERVAL_TO_INDEX, false, true);
+    final ParallelIndexSupervisorTask task = newTask(INTERVAL_TO_INDEX, true);
     final TaskActionClient actionClient = createActionClient(task);
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
     prepareTaskForLocking(task);
@@ -535,7 +535,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   {
     final Interval interval = Intervals.of("2017-12/P1M");
     final boolean appendToExisting = false;
-    final ParallelIndexSupervisorTask task = newTask(interval, appendToExisting, false);
+    final ParallelIndexSupervisorTask task = newTask(interval, false);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
     Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
     assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
@@ -584,7 +584,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   @Test
   public void testPublishEmptySegments()
   {
-    final ParallelIndexSupervisorTask task = newTask(Intervals.of("2020-12/P1M"), false, true);
+    final ParallelIndexSupervisorTask task = newTask(Intervals.of("2020-12/P1M"), true);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
     Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
   }
@@ -916,11 +916,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
 
   private ParallelIndexSupervisorTask newTask(
       @Nullable Interval interval,
-      boolean appendToExisting,
       boolean splittableInputSource
   )
   {
-    return newTask(interval, Granularities.DAY, appendToExisting, splittableInputSource);
+    return newTask(interval, Granularities.DAY, false, splittableInputSource);
   }
 
   private ParallelIndexSupervisorTask newTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.Tasks;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -598,40 +599,9 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         Granularities.DAY,
         appendToExisting,
         true,
-        new ParallelIndexTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null
-        ),
+        TuningConfigBuilder.forParallelIndexTask()
+                           .withMaxNumConcurrentSubTasks(1)
+                           .build(),
         VALID_INPUT_SOURCE_FILTER
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
@@ -724,40 +694,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         Granularities.DAY,
         appendToExisting,
         true,
-        new ParallelIndexTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            1,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            0,
-            null
-        ),
+        TuningConfigBuilder.forParallelIndexTask()
+                           .withMaxNumConcurrentSubTasks(1)
+                           .withMaxAllowedLockCount(0)
+                           .build(),
         VALID_INPUT_SOURCE_FILTER
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
@@ -786,40 +726,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         Granularities.DAY,
         appendToExisting,
         true,
-        new ParallelIndexTuningConfig(
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            2,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            0,
-            null
-        ),
+        TuningConfigBuilder.forParallelIndexTask()
+                           .withMaxNumConcurrentSubTasks(2)
+                           .withMaxAllowedLockCount(0)
+                           .build(),
         VALID_INPUT_SOURCE_FILTER
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -76,7 +76,6 @@ import org.apache.druid.indexing.common.task.AbstractFixedIntervalTask;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIOConfig;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIngestionSpec;
-import org.apache.druid.indexing.common.task.IndexTask.IndexTuningConfig;
 import org.apache.druid.indexing.common.task.KillUnusedSegmentsTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.NoopTaskContextEnricher;
@@ -84,6 +83,7 @@ import org.apache.druid.indexing.common.task.NoopTestTaskReportFileWriter;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
+import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.overlord.config.DefaultTaskConfig;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
 import org.apache.druid.indexing.overlord.config.TaskQueueConfig;
@@ -730,33 +730,13 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null
             ),
             new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
-            new IndexTuningConfig(
-                null,
-                10000,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                indexSpec,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsPerSegment(10000)
+                               .withMaxRowsInMemory(100)
+                               .withIndexSpec(indexSpec)
+                               .withMaxPendingPersists(3)
+                               .withForceGuaranteedRollup(false)
+                               .build()
         ),
         null
     );
@@ -815,33 +795,13 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 mapper
             ),
             new IndexIOConfig(null, new MockExceptionInputSource(), new NoopInputFormat(), false, false),
-            new IndexTuningConfig(
-                null,
-                10000,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                indexSpec,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsPerSegment(10000)
+                               .withMaxRowsInMemory(10)
+                               .withIndexSpec(indexSpec)
+                               .withMaxPendingPersists(3)
+                               .withForceGuaranteedRollup(false)
+                               .build()
         ),
         null
     );
@@ -1259,33 +1219,11 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null
             ),
             new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
-            new IndexTuningConfig(
-                null,
-                10000,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                indexSpec,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsPerSegment(10000)
+                               .withMaxRowsInMemory(10)
+                               .withIndexSpec(indexSpec)
+                               .build()
         ),
         null
     );
@@ -1371,33 +1309,13 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
                 null
             ),
             new IndexIOConfig(null, new MockInputSource(), new NoopInputFormat(), false, false),
-            new IndexTuningConfig(
-                null,
-                10000,
-                null,
-                10,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                indexSpec,
-                null,
-                3,
-                false,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            TuningConfigBuilder.forIndexTask()
+                               .withMaxRowsPerSegment(10000)
+                               .withMaxRowsInMemory(10)
+                               .withIndexSpec(indexSpec)
+                               .withMaxPendingPersists(3)
+                               .withForceGuaranteedRollup(false)
+                               .build()
         ),
         null
     );


### PR DESCRIPTION
### Changes

- No functional change
- Add class `TuningConfigBuilder` to build `IndexTuningConfig`, `CompactionTuningConfig`
- Remove old class `ParallelIndexTestingFactory.TuningConfigBuilder`
- Remove some unused fields and methods