### PR TITLE
Web console: fix a few console bugs

### DIFF
--- a/web-console/src/components/action-cell/action-cell.spec.tsx
+++ b/web-console/src/components/action-cell/action-cell.spec.tsx
@@ -23,7 +23,7 @@ import { ActionCell } from './action-cell';
 
 describe('ActionCell', () => {
   it('matches snapshot', () => {
-    const actionCell = <ActionCell onDetail={() => {}} actions={[]} />;
+    const actionCell = <ActionCell onDetail={() => {}} actions={[]} menuTitle="item" />;
     const { container } = render(actionCell);
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/web-console/src/components/action-cell/action-cell.tsx
+++ b/web-console/src/components/action-cell/action-cell.tsx
@@ -34,12 +34,13 @@ export const ACTION_COLUMN_WIDTH = 70;
 export interface ActionCellProps {
   onDetail?: () => void;
   disableDetail?: boolean;
-  actions?: BasicAction[];
+  actions: BasicAction[];
+  menuTitle: string;
 }
 
 export const ActionCell = React.memo(function ActionCell(props: ActionCellProps) {
-  const { onDetail, disableDetail, actions } = props;
-  const actionsMenu = actions ? basicActionsToMenu(actions) : null;
+  const { onDetail, disableDetail, actions, menuTitle } = props;
+  const actionsMenu = basicActionsToMenu(actions, menuTitle);
 
   return (
     <div className="action-cell">

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -105,792 +105,800 @@ exports[`RetentionDialog matches snapshot 1`] = `
             </div>
           </div>
           <div
-            class="bp4-form-group"
+            class="rule-form"
           >
             <div
-              class="bp4-form-content"
+              class="rule-form-content"
             >
               <div
-                class="rule-editor"
+                class="bp4-form-group"
               >
                 <div
-                  class="title"
-                >
-                  <button
-                    class="bp4-button bp4-minimal left"
-                    type="button"
-                  >
-                    <span
-                      class="bp4-button-text"
-                    >
-                      loadByPeriod(P1000Y+future, 2x)
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="bp4-icon bp4-icon-caret-down"
-                      icon="caret-down"
-                    >
-                      <svg
-                        data-icon="caret-down"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <path
-                          d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                  <div
-                    class="spacer"
-                  />
-                  <button
-                    class="bp4-button bp4-minimal"
-                    type="button"
-                  >
-                    <span
-                      aria-hidden="true"
-                      class="bp4-icon bp4-icon-trash"
-                      icon="trash"
-                    >
-                      <svg
-                        data-icon="trash"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                      >
-                        <path
-                          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="bp4-collapse"
-                  style="height: auto; overflow-y: visible; transition: none;"
+                  class="bp4-form-content"
                 >
                   <div
-                    aria-hidden="false"
-                    class="bp4-collapse-body"
-                    style="transform: translateY(0); transition: none;"
+                    class="rule-editor"
                   >
                     <div
-                      class="bp4-card bp4-elevation-2"
+                      class="title"
+                    >
+                      <button
+                        class="bp4-button bp4-minimal left"
+                        type="button"
+                      >
+                        <span
+                          class="bp4-button-text"
+                        >
+                          loadByPeriod(P1000Y+future, 2x)
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="bp4-icon bp4-icon-caret-down"
+                          icon="caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="spacer"
+                      />
+                      <button
+                        class="bp4-button bp4-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp4-icon bp4-icon-trash"
+                          icon="trash"
+                        >
+                          <svg
+                            data-icon="trash"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                    <div
+                      class="bp4-collapse"
+                      style="height: auto; overflow-y: visible; transition: none;"
                     >
                       <div
-                        class="bp4-form-group"
+                        aria-hidden="false"
+                        class="bp4-collapse-body"
+                        style="transform: translateY(0); transition: none;"
                       >
                         <div
-                          class="bp4-form-content"
+                          class="bp4-card bp4-elevation-2"
                         >
                           <div
-                            class="bp4-control-group"
+                            class="bp4-form-group"
                           >
                             <div
-                              class="bp4-html-select"
-                            >
-                              <select>
-                                <option
-                                  value="loadForever"
-                                >
-                                  loadForever
-                                </option>
-                                <option
-                                  value="loadByInterval"
-                                >
-                                  loadByInterval
-                                </option>
-                                <option
-                                  value="loadByPeriod"
-                                >
-                                  loadByPeriod
-                                </option>
-                                <option
-                                  value="dropForever"
-                                >
-                                  dropForever
-                                </option>
-                                <option
-                                  value="dropByInterval"
-                                >
-                                  dropByInterval
-                                </option>
-                                <option
-                                  value="dropByPeriod"
-                                >
-                                  dropByPeriod
-                                </option>
-                                <option
-                                  value="dropBeforeByPeriod"
-                                >
-                                  dropBeforeByPeriod
-                                </option>
-                                <option
-                                  value="broadcastForever"
-                                >
-                                  broadcastForever
-                                </option>
-                                <option
-                                  value="broadcastByInterval"
-                                >
-                                  broadcastByInterval
-                                </option>
-                                <option
-                                  value="broadcastByPeriod"
-                                >
-                                  broadcastByPeriod
-                                </option>
-                              </select>
-                              <span
-                                class="bp4-icon bp4-icon-double-caret-vertical"
-                                icon="double-caret-vertical"
-                              >
-                                <svg
-                                  aria-labelledby="iconTitle-3"
-                                  data-icon="double-caret-vertical"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                >
-                                  <title
-                                    id="iconTitle-3"
-                                  >
-                                    Open dropdown
-                                  </title>
-                                  <path
-                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
-                            </div>
-                            <div
-                              class="formatted-input suggestible-input"
+                              class="bp4-form-content"
                             >
                               <div
-                                class="bp4-input-group"
+                                class="bp4-control-group"
                               >
-                                <input
-                                  class="bp4-input"
-                                  placeholder="P1D"
-                                  style="padding-right: 0px;"
-                                  type="text"
-                                  value="P1000Y"
-                                />
-                                <span
-                                  class="bp4-input-action"
+                                <div
+                                  class="bp4-html-select"
+                                >
+                                  <select>
+                                    <option
+                                      value="loadForever"
+                                    >
+                                      loadForever
+                                    </option>
+                                    <option
+                                      value="loadByInterval"
+                                    >
+                                      loadByInterval
+                                    </option>
+                                    <option
+                                      value="loadByPeriod"
+                                    >
+                                      loadByPeriod
+                                    </option>
+                                    <option
+                                      value="dropForever"
+                                    >
+                                      dropForever
+                                    </option>
+                                    <option
+                                      value="dropByInterval"
+                                    >
+                                      dropByInterval
+                                    </option>
+                                    <option
+                                      value="dropByPeriod"
+                                    >
+                                      dropByPeriod
+                                    </option>
+                                    <option
+                                      value="dropBeforeByPeriod"
+                                    >
+                                      dropBeforeByPeriod
+                                    </option>
+                                    <option
+                                      value="broadcastForever"
+                                    >
+                                      broadcastForever
+                                    </option>
+                                    <option
+                                      value="broadcastByInterval"
+                                    >
+                                      broadcastByInterval
+                                    </option>
+                                    <option
+                                      value="broadcastByPeriod"
+                                    >
+                                      broadcastByPeriod
+                                    </option>
+                                  </select>
+                                  <span
+                                    class="bp4-icon bp4-icon-double-caret-vertical"
+                                    icon="double-caret-vertical"
+                                  >
+                                    <svg
+                                      aria-labelledby="iconTitle-3"
+                                      data-icon="double-caret-vertical"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <title
+                                        id="iconTitle-3"
+                                      >
+                                        Open dropdown
+                                      </title>
+                                      <path
+                                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </div>
+                                <div
+                                  class="formatted-input suggestible-input"
+                                >
+                                  <div
+                                    class="bp4-input-group"
+                                  >
+                                    <input
+                                      class="bp4-input"
+                                      placeholder="P1D"
+                                      style="padding-right: 0px;"
+                                      type="text"
+                                      value="P1000Y"
+                                    />
+                                    <span
+                                      class="bp4-input-action"
+                                    >
+                                      <span
+                                        aria-haspopup="true"
+                                        class="bp4-popover2-target"
+                                      >
+                                        <button
+                                          class="bp4-button bp4-minimal"
+                                          type="button"
+                                        >
+                                          <span
+                                            aria-hidden="true"
+                                            class="bp4-icon bp4-icon-caret-down"
+                                            icon="caret-down"
+                                          >
+                                            <svg
+                                              data-icon="caret-down"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                            >
+                                              <path
+                                                d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                                                fill-rule="evenodd"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </button>
+                                      </span>
+                                    </span>
+                                  </div>
+                                </div>
+                                <label
+                                  class="bp4-control bp4-switch include-future"
+                                >
+                                  <input
+                                    checked=""
+                                    type="checkbox"
+                                  />
+                                  <span
+                                    class="bp4-control-indicator"
+                                  />
+                                  Include future
+                                </label>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="bp4-form-group"
+                          >
+                            <div
+                              class="bp4-form-content"
+                            >
+                              <div
+                                class="bp4-control-group"
+                              >
+                                <button
+                                  class="bp4-button bp4-minimal"
+                                  style="pointer-events: none;"
+                                  type="button"
                                 >
                                   <span
-                                    aria-haspopup="true"
-                                    class="bp4-popover2-target"
+                                    class="bp4-button-text"
+                                  >
+                                    Tier:
+                                  </span>
+                                </button>
+                                <div
+                                  class="bp4-html-select bp4-fill"
+                                >
+                                  <select>
+                                    <option
+                                      value="_default_tier"
+                                    >
+                                      _default_tier
+                                    </option>
+                                  </select>
+                                  <span
+                                    class="bp4-icon bp4-icon-double-caret-vertical"
+                                    icon="double-caret-vertical"
+                                  >
+                                    <svg
+                                      aria-labelledby="iconTitle-5"
+                                      data-icon="double-caret-vertical"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <title
+                                        id="iconTitle-5"
+                                      >
+                                        Open dropdown
+                                      </title>
+                                      <path
+                                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </div>
+                                <button
+                                  class="bp4-button bp4-minimal"
+                                  style="pointer-events: none;"
+                                  type="button"
+                                >
+                                  <span
+                                    class="bp4-button-text"
+                                  >
+                                    Replicants:
+                                  </span>
+                                </button>
+                                <div
+                                  class="bp4-control-group bp4-numeric-input"
+                                >
+                                  <div
+                                    class="bp4-input-group"
+                                  >
+                                    <input
+                                      aria-valuemax="256"
+                                      aria-valuemin="0"
+                                      aria-valuenow="2"
+                                      autocomplete="off"
+                                      class="bp4-input"
+                                      id="numericInput-0"
+                                      max="256"
+                                      min="0"
+                                      role="spinbutton"
+                                      type="text"
+                                      value="2"
+                                    />
+                                  </div>
+                                  <div
+                                    class="bp4-button-group bp4-vertical bp4-fixed"
                                   >
                                     <button
-                                      class="bp4-button bp4-minimal"
+                                      aria-controls="numericInput-0"
+                                      aria-label="increment"
+                                      class="bp4-button"
                                       type="button"
                                     >
                                       <span
                                         aria-hidden="true"
-                                        class="bp4-icon bp4-icon-caret-down"
-                                        icon="caret-down"
+                                        class="bp4-icon bp4-icon-chevron-up"
+                                        icon="chevron-up"
                                       >
                                         <svg
-                                          data-icon="caret-down"
+                                          data-icon="chevron-up"
                                           height="16"
                                           role="img"
                                           viewBox="0 0 16 16"
                                           width="16"
                                         >
                                           <path
-                                            d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                                            d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 001.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71z"
                                             fill-rule="evenodd"
                                           />
                                         </svg>
                                       </span>
                                     </button>
+                                    <button
+                                      aria-controls="numericInput-0"
+                                      aria-label="decrement"
+                                      class="bp4-button"
+                                      type="button"
+                                    >
+                                      <span
+                                        aria-hidden="true"
+                                        class="bp4-icon bp4-icon-chevron-down"
+                                        icon="chevron-down"
+                                      >
+                                        <svg
+                                          data-icon="chevron-down"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                        >
+                                          <path
+                                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
+                                <button
+                                  class="bp4-button"
+                                  type="button"
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    class="bp4-icon bp4-icon-trash"
+                                    icon="trash"
+                                  >
+                                    <svg
+                                      data-icon="trash"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <path
+                                        d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
                                   </span>
-                                </span>
+                                </button>
                               </div>
                             </div>
-                            <label
-                              class="bp4-control bp4-switch include-future"
-                            >
-                              <input
-                                checked=""
-                                type="checkbox"
-                              />
-                              <span
-                                class="bp4-control-indicator"
-                              />
-                              Include future
-                            </label>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="bp4-form-group"
-                      >
-                        <div
-                          class="bp4-form-content"
-                        >
                           <div
-                            class="bp4-control-group"
+                            class="bp4-form-group"
                           >
-                            <button
-                              class="bp4-button bp4-minimal"
-                              style="pointer-events: none;"
-                              type="button"
-                            >
-                              <span
-                                class="bp4-button-text"
-                              >
-                                Tier:
-                              </span>
-                            </button>
                             <div
-                              class="bp4-html-select bp4-fill"
+                              class="bp4-form-content"
                             >
-                              <select>
-                                <option
-                                  value="_default_tier"
-                                >
-                                  _default_tier
-                                </option>
-                              </select>
-                              <span
-                                class="bp4-icon bp4-icon-double-caret-vertical"
-                                icon="double-caret-vertical"
+                              <button
+                                class="bp4-button bp4-disabled bp4-minimal"
+                                disabled=""
+                                tabindex="-1"
+                                title="There are no tiers left to assign"
+                                type="button"
                               >
-                                <svg
-                                  aria-labelledby="iconTitle-5"
-                                  data-icon="double-caret-vertical"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
+                                <span
+                                  aria-hidden="true"
+                                  class="bp4-icon bp4-icon-plus"
+                                  icon="plus"
                                 >
-                                  <title
-                                    id="iconTitle-5"
+                                  <svg
+                                    data-icon="plus"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
                                   >
-                                    Open dropdown
-                                  </title>
-                                  <path
-                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
+                                    <path
+                                      d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                                      fill-rule="evenodd"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="bp4-button-text"
+                                >
+                                  Add historical tier replication
+                                </span>
+                              </button>
                             </div>
-                            <button
-                              class="bp4-button bp4-minimal"
-                              style="pointer-events: none;"
-                              type="button"
-                            >
-                              <span
-                                class="bp4-button-text"
-                              >
-                                Replicants:
-                              </span>
-                            </button>
-                            <div
-                              class="bp4-control-group bp4-numeric-input"
-                            >
-                              <div
-                                class="bp4-input-group"
-                              >
-                                <input
-                                  aria-valuemax="256"
-                                  aria-valuemin="0"
-                                  aria-valuenow="2"
-                                  autocomplete="off"
-                                  class="bp4-input"
-                                  id="numericInput-0"
-                                  max="256"
-                                  min="0"
-                                  role="spinbutton"
-                                  type="text"
-                                  value="2"
-                                />
-                              </div>
-                              <div
-                                class="bp4-button-group bp4-vertical bp4-fixed"
-                              >
-                                <button
-                                  aria-controls="numericInput-0"
-                                  aria-label="increment"
-                                  class="bp4-button"
-                                  type="button"
-                                >
-                                  <span
-                                    aria-hidden="true"
-                                    class="bp4-icon bp4-icon-chevron-up"
-                                    icon="chevron-up"
-                                  >
-                                    <svg
-                                      data-icon="chevron-up"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                    >
-                                      <path
-                                        d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 001.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71z"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </span>
-                                </button>
-                                <button
-                                  aria-controls="numericInput-0"
-                                  aria-label="decrement"
-                                  class="bp4-button"
-                                  type="button"
-                                >
-                                  <span
-                                    aria-hidden="true"
-                                    class="bp4-icon bp4-icon-chevron-down"
-                                    icon="chevron-down"
-                                  >
-                                    <svg
-                                      data-icon="chevron-down"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                    >
-                                      <path
-                                        d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                            <button
-                              class="bp4-button"
-                              type="button"
-                            >
-                              <span
-                                aria-hidden="true"
-                                class="bp4-icon bp4-icon-trash"
-                                icon="trash"
-                              >
-                                <svg
-                                  data-icon="trash"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                >
-                                  <path
-                                    d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
-                            </button>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="bp4-form-group"
-                      >
-                        <div
-                          class="bp4-form-content"
-                        >
-                          <button
-                            class="bp4-button bp4-disabled bp4-minimal"
-                            disabled=""
-                            tabindex="-1"
-                            title="There are no tiers left to assign"
-                            type="button"
-                          >
-                            <span
-                              aria-hidden="true"
-                              class="bp4-icon bp4-icon-plus"
-                              icon="plus"
-                            >
-                              <svg
-                                data-icon="plus"
-                                height="16"
-                                role="img"
-                                viewBox="0 0 16 16"
-                                width="16"
-                              >
-                                <path
-                                  d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
-                                  fill-rule="evenodd"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="bp4-button-text"
-                            >
-                              Add historical tier replication
-                            </span>
-                          </button>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              </div>
-              <div>
-                <button
-                  class="bp4-button"
-                  type="button"
-                >
-                  <span
-                    aria-hidden="true"
-                    class="bp4-icon bp4-icon-plus"
-                    icon="plus"
-                  >
-                    <svg
-                      data-icon="plus"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
+                  <div>
+                    <button
+                      class="bp4-button"
+                      type="button"
                     >
-                      <path
-                        d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
-                        fill-rule="evenodd"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="bp4-button-text"
-                  >
-                    New rule
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            class="bp4-divider"
-          />
-          <div
-            class="bp4-form-group"
-          >
-            <label
-              class="bp4-label"
-            >
-              Cluster defaults (
-              <a>
-                edit
-              </a>
-              )
-               
-              <span
-                class="bp4-text-muted"
-              />
-            </label>
-            <div
-              class="bp4-form-content"
-            >
-              <p>
-                The cluster default rules are evaluated if none of the above rules match.
-              </p>
-              <div
-                class="rule-editor"
-              >
-                <div
-                  class="title"
-                >
-                  <button
-                    class="bp4-button bp4-minimal left"
-                    type="button"
-                  >
-                    <span
-                      class="bp4-button-text"
-                    >
-                      loadForever(2x)
-                    </span>
-                    <span
-                      aria-hidden="true"
-                      class="bp4-icon bp4-icon-caret-down"
-                      icon="caret-down"
-                    >
-                      <svg
-                        data-icon="caret-down"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
+                      <span
+                        aria-hidden="true"
+                        class="bp4-icon bp4-icon-plus"
+                        icon="plus"
                       >
-                        <path
-                          d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
-                          fill-rule="evenodd"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                  <div
-                    class="spacer"
-                  />
+                        <svg
+                          data-icon="plus"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                        >
+                          <path
+                            d="M13 7H9V3c0-.55-.45-1-1-1s-1 .45-1 1v4H3c-.55 0-1 .45-1 1s.45 1 1 1h4v4c0 .55.45 1 1 1s1-.45 1-1V9h4c.55 0 1-.45 1-1s-.45-1-1-1z"
+                            fill-rule="evenodd"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="bp4-button-text"
+                      >
+                        New rule
+                      </span>
+                    </button>
+                  </div>
                 </div>
-                <div
-                  class="bp4-collapse"
-                  style="height: auto; overflow-y: visible; transition: none;"
+              </div>
+              <div
+                class="bp4-divider"
+              />
+              <div
+                class="bp4-form-group"
+              >
+                <label
+                  class="bp4-label"
                 >
+                  Cluster defaults (
+                  <a>
+                    edit
+                  </a>
+                  )
+                   
+                  <span
+                    class="bp4-text-muted"
+                  />
+                </label>
+                <div
+                  class="bp4-form-content"
+                >
+                  <p>
+                    The cluster default rules are evaluated if none of the above rules match.
+                  </p>
                   <div
-                    aria-hidden="false"
-                    class="bp4-collapse-body"
-                    style="transform: translateY(0); transition: none;"
+                    class="rule-editor"
                   >
                     <div
-                      class="bp4-card bp4-elevation-2"
+                      class="title"
+                    >
+                      <button
+                        class="bp4-button bp4-minimal left"
+                        type="button"
+                      >
+                        <span
+                          class="bp4-button-text"
+                        >
+                          loadForever(2x)
+                        </span>
+                        <span
+                          aria-hidden="true"
+                          class="bp4-icon bp4-icon-caret-down"
+                          icon="caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                      <div
+                        class="spacer"
+                      />
+                    </div>
+                    <div
+                      class="bp4-collapse"
+                      style="height: auto; overflow-y: visible; transition: none;"
                     >
                       <div
-                        class="bp4-form-group"
+                        aria-hidden="false"
+                        class="bp4-collapse-body"
+                        style="transform: translateY(0); transition: none;"
                       >
                         <div
-                          class="bp4-form-content"
+                          class="bp4-card bp4-elevation-2"
                         >
                           <div
-                            class="bp4-control-group"
+                            class="bp4-form-group"
                           >
                             <div
-                              class="bp4-html-select bp4-disabled"
+                              class="bp4-form-content"
                             >
-                              <select
-                                disabled=""
+                              <div
+                                class="bp4-control-group"
                               >
-                                <option
-                                  value="loadForever"
+                                <div
+                                  class="bp4-html-select bp4-disabled"
                                 >
-                                  loadForever
-                                </option>
-                                <option
-                                  value="loadByInterval"
-                                >
-                                  loadByInterval
-                                </option>
-                                <option
-                                  value="loadByPeriod"
-                                >
-                                  loadByPeriod
-                                </option>
-                                <option
-                                  value="dropForever"
-                                >
-                                  dropForever
-                                </option>
-                                <option
-                                  value="dropByInterval"
-                                >
-                                  dropByInterval
-                                </option>
-                                <option
-                                  value="dropByPeriod"
-                                >
-                                  dropByPeriod
-                                </option>
-                                <option
-                                  value="dropBeforeByPeriod"
-                                >
-                                  dropBeforeByPeriod
-                                </option>
-                                <option
-                                  value="broadcastForever"
-                                >
-                                  broadcastForever
-                                </option>
-                                <option
-                                  value="broadcastByInterval"
-                                >
-                                  broadcastByInterval
-                                </option>
-                                <option
-                                  value="broadcastByPeriod"
-                                >
-                                  broadcastByPeriod
-                                </option>
-                              </select>
-                              <span
-                                class="bp4-icon bp4-icon-double-caret-vertical"
-                                icon="double-caret-vertical"
-                              >
-                                <svg
-                                  aria-labelledby="iconTitle-12"
-                                  data-icon="double-caret-vertical"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                >
-                                  <title
-                                    id="iconTitle-12"
+                                  <select
+                                    disabled=""
                                   >
-                                    Open dropdown
-                                  </title>
-                                  <path
-                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
+                                    <option
+                                      value="loadForever"
+                                    >
+                                      loadForever
+                                    </option>
+                                    <option
+                                      value="loadByInterval"
+                                    >
+                                      loadByInterval
+                                    </option>
+                                    <option
+                                      value="loadByPeriod"
+                                    >
+                                      loadByPeriod
+                                    </option>
+                                    <option
+                                      value="dropForever"
+                                    >
+                                      dropForever
+                                    </option>
+                                    <option
+                                      value="dropByInterval"
+                                    >
+                                      dropByInterval
+                                    </option>
+                                    <option
+                                      value="dropByPeriod"
+                                    >
+                                      dropByPeriod
+                                    </option>
+                                    <option
+                                      value="dropBeforeByPeriod"
+                                    >
+                                      dropBeforeByPeriod
+                                    </option>
+                                    <option
+                                      value="broadcastForever"
+                                    >
+                                      broadcastForever
+                                    </option>
+                                    <option
+                                      value="broadcastByInterval"
+                                    >
+                                      broadcastByInterval
+                                    </option>
+                                    <option
+                                      value="broadcastByPeriod"
+                                    >
+                                      broadcastByPeriod
+                                    </option>
+                                  </select>
+                                  <span
+                                    class="bp4-icon bp4-icon-double-caret-vertical"
+                                    icon="double-caret-vertical"
+                                  >
+                                    <svg
+                                      aria-labelledby="iconTitle-12"
+                                      data-icon="double-caret-vertical"
+                                      height="16"
+                                      role="img"
+                                      viewBox="0 0 16 16"
+                                      width="16"
+                                    >
+                                      <title
+                                        id="iconTitle-12"
+                                      >
+                                        Open dropdown
+                                      </title>
+                                      <path
+                                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
+                                        fill-rule="evenodd"
+                                      />
+                                    </svg>
+                                  </span>
+                                </div>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <div
-                        class="bp4-form-group"
-                      >
-                        <div
-                          class="bp4-form-content"
-                        >
                           <div
-                            class="bp4-control-group"
+                            class="bp4-form-group"
                           >
-                            <button
-                              class="bp4-button bp4-disabled bp4-minimal"
-                              disabled=""
-                              style="pointer-events: none;"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <span
-                                class="bp4-button-text"
-                              >
-                                Tier:
-                              </span>
-                            </button>
                             <div
-                              class="bp4-html-select bp4-disabled bp4-fill"
-                            >
-                              <select
-                                disabled=""
-                              >
-                                <option
-                                  value="_default_tier"
-                                >
-                                  _default_tier
-                                </option>
-                              </select>
-                              <span
-                                class="bp4-icon bp4-icon-double-caret-vertical"
-                                icon="double-caret-vertical"
-                              >
-                                <svg
-                                  aria-labelledby="iconTitle-13"
-                                  data-icon="double-caret-vertical"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                >
-                                  <title
-                                    id="iconTitle-13"
-                                  >
-                                    Open dropdown
-                                  </title>
-                                  <path
-                                    d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
-                                    fill-rule="evenodd"
-                                  />
-                                </svg>
-                              </span>
-                            </div>
-                            <button
-                              class="bp4-button bp4-disabled bp4-minimal"
-                              disabled=""
-                              style="pointer-events: none;"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <span
-                                class="bp4-button-text"
-                              >
-                                Replicants:
-                              </span>
-                            </button>
-                            <div
-                              class="bp4-control-group bp4-numeric-input"
+                              class="bp4-form-content"
                             >
                               <div
-                                class="bp4-input-group bp4-disabled"
-                              >
-                                <input
-                                  aria-valuemax="256"
-                                  aria-valuemin="0"
-                                  aria-valuenow="2"
-                                  autocomplete="off"
-                                  class="bp4-input"
-                                  disabled=""
-                                  id="numericInput-1"
-                                  max="256"
-                                  min="0"
-                                  role="spinbutton"
-                                  type="text"
-                                  value="2"
-                                />
-                              </div>
-                              <div
-                                class="bp4-button-group bp4-vertical bp4-fixed"
+                                class="bp4-control-group"
                               >
                                 <button
-                                  aria-controls="numericInput-1"
-                                  aria-label="increment"
-                                  class="bp4-button bp4-disabled"
+                                  class="bp4-button bp4-disabled bp4-minimal"
                                   disabled=""
+                                  style="pointer-events: none;"
                                   tabindex="-1"
                                   type="button"
                                 >
                                   <span
-                                    aria-hidden="true"
-                                    class="bp4-icon bp4-icon-chevron-up"
-                                    icon="chevron-up"
+                                    class="bp4-button-text"
+                                  >
+                                    Tier:
+                                  </span>
+                                </button>
+                                <div
+                                  class="bp4-html-select bp4-disabled bp4-fill"
+                                >
+                                  <select
+                                    disabled=""
+                                  >
+                                    <option
+                                      value="_default_tier"
+                                    >
+                                      _default_tier
+                                    </option>
+                                  </select>
+                                  <span
+                                    class="bp4-icon bp4-icon-double-caret-vertical"
+                                    icon="double-caret-vertical"
                                   >
                                     <svg
-                                      data-icon="chevron-up"
+                                      aria-labelledby="iconTitle-13"
+                                      data-icon="double-caret-vertical"
                                       height="16"
                                       role="img"
                                       viewBox="0 0 16 16"
                                       width="16"
                                     >
+                                      <title
+                                        id="iconTitle-13"
+                                      >
+                                        Open dropdown
+                                      </title>
                                       <path
-                                        d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 001.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71z"
+                                        d="M5 7h6a1.003 1.003 0 00.71-1.71l-3-3C8.53 2.11 8.28 2 8 2s-.53.11-.71.29l-3 3A1.003 1.003 0 005 7zm6 2H5a1.003 1.003 0 00-.71 1.71l3 3c.18.18.43.29.71.29s.53-.11.71-.29l3-3A1.003 1.003 0 0011 9z"
                                         fill-rule="evenodd"
                                       />
                                     </svg>
                                   </span>
-                                </button>
+                                </div>
                                 <button
-                                  aria-controls="numericInput-1"
-                                  aria-label="decrement"
-                                  class="bp4-button bp4-disabled"
+                                  class="bp4-button bp4-disabled bp4-minimal"
                                   disabled=""
+                                  style="pointer-events: none;"
                                   tabindex="-1"
                                   type="button"
                                 >
                                   <span
-                                    aria-hidden="true"
-                                    class="bp4-icon bp4-icon-chevron-down"
-                                    icon="chevron-down"
+                                    class="bp4-button-text"
                                   >
-                                    <svg
-                                      data-icon="chevron-down"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                    >
-                                      <path
-                                        d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
-                                        fill-rule="evenodd"
-                                      />
-                                    </svg>
+                                    Replicants:
                                   </span>
                                 </button>
+                                <div
+                                  class="bp4-control-group bp4-numeric-input"
+                                >
+                                  <div
+                                    class="bp4-input-group bp4-disabled"
+                                  >
+                                    <input
+                                      aria-valuemax="256"
+                                      aria-valuemin="0"
+                                      aria-valuenow="2"
+                                      autocomplete="off"
+                                      class="bp4-input"
+                                      disabled=""
+                                      id="numericInput-1"
+                                      max="256"
+                                      min="0"
+                                      role="spinbutton"
+                                      type="text"
+                                      value="2"
+                                    />
+                                  </div>
+                                  <div
+                                    class="bp4-button-group bp4-vertical bp4-fixed"
+                                  >
+                                    <button
+                                      aria-controls="numericInput-1"
+                                      aria-label="increment"
+                                      class="bp4-button bp4-disabled"
+                                      disabled=""
+                                      tabindex="-1"
+                                      type="button"
+                                    >
+                                      <span
+                                        aria-hidden="true"
+                                        class="bp4-icon bp4-icon-chevron-up"
+                                        icon="chevron-up"
+                                      >
+                                        <svg
+                                          data-icon="chevron-up"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                        >
+                                          <path
+                                            d="M12.71 9.29l-4-4C8.53 5.11 8.28 5 8 5s-.53.11-.71.29l-4 4a1.003 1.003 0 001.42 1.42L8 7.41l3.29 3.29c.18.19.43.3.71.3a1.003 1.003 0 00.71-1.71z"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </button>
+                                    <button
+                                      aria-controls="numericInput-1"
+                                      aria-label="decrement"
+                                      class="bp4-button bp4-disabled"
+                                      disabled=""
+                                      tabindex="-1"
+                                      type="button"
+                                    >
+                                      <span
+                                        aria-hidden="true"
+                                        class="bp4-icon bp4-icon-chevron-down"
+                                        icon="chevron-down"
+                                      >
+                                        <svg
+                                          data-icon="chevron-down"
+                                          height="16"
+                                          role="img"
+                                          viewBox="0 0 16 16"
+                                          width="16"
+                                        >
+                                          <path
+                                            d="M12 5c-.28 0-.53.11-.71.29L8 8.59l-3.29-3.3a1.003 1.003 0 00-1.42 1.42l4 4c.18.18.43.29.71.29s.53-.11.71-.29l4-4A1.003 1.003 0 0012 5z"
+                                            fill-rule="evenodd"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.scss
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.scss
@@ -29,8 +29,24 @@
     display: flex;
     flex-direction: column;
 
-    .rule-editor {
+    .rule-form {
+      position: relative;
+      flex: 1;
+
+      .rule-form-content {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+      }
+    }
+
+    .rule-editor:not(:last-child) {
       margin-bottom: 15px;
+    }
+
+    .json-input {
+      margin-bottom: 10px;
     }
 
     .no-rules-message {

--- a/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
+++ b/web-console/src/dialogs/retention-dialog/retention-dialog.tsx
@@ -114,6 +114,24 @@ ORDER BY 1`,
     setCurrentRules(swapElements(currentRules, index, index + direction));
   }
 
+  const defaultRuleRender =
+    datasource !== CLUSTER_DEFAULT_FAKE_DATASOURCE ? (
+      <FormGroup
+        label={
+          <>
+            Cluster defaults (<a onClick={onEditDefaults}>edit</a>)
+          </>
+        }
+      >
+        <p>The cluster default rules are evaluated if none of the above rules match.</p>
+        {currentTab === 'form' ? (
+          defaultRules.map((rule, index) => <RuleEditor key={index} rule={rule} tiers={tiers} />)
+        ) : (
+          <JsonInput value={defaultRules} />
+        )}
+      </FormGroup>
+    ) : undefined;
+
   return (
     <SnitchDialog
       className="retention-dialog"
@@ -142,61 +160,51 @@ ORDER BY 1`,
         }}
       />
       {currentTab === 'form' ? (
-        <FormGroup>
-          {currentRules.length ? (
-            currentRules.map((rule, index) => (
-              <RuleEditor
-                key={index}
-                rule={rule}
-                tiers={tiers}
-                onChange={r => changeRule(r, index)}
-                onDelete={() => deleteRule(index)}
-                moveUp={index > 0 ? () => moveRule(index, -1) : undefined}
-                moveDown={index < currentRules.length - 1 ? () => moveRule(index, 1) : undefined}
-              />
-            ))
-          ) : datasource !== CLUSTER_DEFAULT_FAKE_DATASOURCE ? (
-            <p className="no-rules-message">
-              This datasource currently has no rules, it will use the cluster defaults.
-            </p>
-          ) : undefined}
-          <div>
-            <Button
-              icon={IconNames.PLUS}
-              onClick={addRule}
-              intent={currentRules.length ? undefined : Intent.PRIMARY}
-            >
-              New rule
-            </Button>
+        <div className="rule-form">
+          <div className="rule-form-content">
+            <FormGroup>
+              {currentRules.length ? (
+                currentRules.map((rule, index) => (
+                  <RuleEditor
+                    key={index}
+                    rule={rule}
+                    tiers={tiers}
+                    onChange={r => changeRule(r, index)}
+                    onDelete={() => deleteRule(index)}
+                    moveUp={index > 0 ? () => moveRule(index, -1) : undefined}
+                    moveDown={
+                      index < currentRules.length - 1 ? () => moveRule(index, 1) : undefined
+                    }
+                  />
+                ))
+              ) : datasource !== CLUSTER_DEFAULT_FAKE_DATASOURCE ? (
+                <p className="no-rules-message">
+                  This datasource currently has no rules, it will use the cluster defaults.
+                </p>
+              ) : undefined}
+              <div>
+                <Button
+                  icon={IconNames.PLUS}
+                  onClick={addRule}
+                  intent={currentRules.length ? undefined : Intent.PRIMARY}
+                >
+                  New rule
+                </Button>
+              </div>
+            </FormGroup>
+            {defaultRuleRender && <Divider />}
+            {defaultRuleRender}
           </div>
-        </FormGroup>
+        </div>
       ) : (
-        <JsonInput
-          value={currentRules}
-          onChange={setCurrentRules}
-          setError={setJsonError}
-          height="100%"
-        />
-      )}
-      {datasource !== CLUSTER_DEFAULT_FAKE_DATASOURCE && (
         <>
-          <Divider />
-          <FormGroup
-            label={
-              <>
-                Cluster defaults (<a onClick={onEditDefaults}>edit</a>)
-              </>
-            }
-          >
-            <p>The cluster default rules are evaluated if none of the above rules match.</p>
-            {currentTab === 'form' ? (
-              defaultRules.map((rule, index) => (
-                <RuleEditor key={index} rule={rule} tiers={tiers} />
-              ))
-            ) : (
-              <JsonInput value={defaultRules} />
-            )}
-          </FormGroup>
+          <JsonInput
+            value={currentRules}
+            onChange={setCurrentRules}
+            setError={setJsonError}
+            height="100%"
+          />
+          {defaultRuleRender}
         </>
       )}
     </SnitchDialog>

--- a/web-console/src/druid-models/stages/stages.spec.ts
+++ b/web-console/src/druid-models/stages/stages.spec.ts
@@ -27,8 +27,7 @@ describe('Stages', () => {
 
   describe('#getByPartitionCountersForStage', () => {
     it('works for input', () => {
-      expect(STAGES.getByPartitionCountersForStage(STAGES.stages[2], 'input'))
-        .toMatchInlineSnapshot(`
+      expect(STAGES.getByPartitionCountersForStage(STAGES.stages[2], 'in')).toMatchInlineSnapshot(`
         [
           {
             "index": 0,
@@ -45,8 +44,7 @@ describe('Stages', () => {
     });
 
     it('works for output', () => {
-      expect(STAGES.getByPartitionCountersForStage(STAGES.stages[2], 'output'))
-        .toMatchInlineSnapshot(`
+      expect(STAGES.getByPartitionCountersForStage(STAGES.stages[2], 'out')).toMatchInlineSnapshot(`
         [
           {
             "index": 0,

--- a/web-console/src/druid-models/stages/stages.ts
+++ b/web-console/src/druid-models/stages/stages.ts
@@ -22,8 +22,10 @@ import { deleteKeys, filterMap, oneOf, zeroDivide } from '../../utils';
 import type { InputFormat } from '../input-format/input-format';
 import type { InputSource } from '../input-source/input-source';
 
-const SORT_WEIGHT = 0.5;
-const READING_INPUT_WITH_SORT_WEIGHT = 1 - SORT_WEIGHT;
+const SHUFFLE_WEIGHT = 0.5;
+const READING_INPUT_WITH_SHUFFLE_WEIGHT = 1 - SHUFFLE_WEIGHT;
+
+export type InOut = 'in' | 'out';
 
 export type StageInput =
   | {
@@ -261,13 +263,13 @@ export class Stages {
     return Stages.stageType(stage) !== 'segmentGenerator';
   }
 
-  stageHasSort(stage: StageDefinition): boolean {
+  stageHasShuffle(stage: StageDefinition): boolean {
     if (!this.stageHasOutput(stage)) return false;
-    return Boolean(stage.sort);
+    return Boolean(stage.sort) || this.hasCounterForStage(stage, 'shuffle');
   }
 
-  stageOutputCounterName(stage: StageDefinition): ChannelCounterName {
-    return this.stageHasSort(stage) ? 'shuffle' : 'output';
+  stageFinalCounterName(stage: StageDefinition): ChannelCounterName {
+    return this.stageHasShuffle(stage) ? 'shuffle' : 'output';
   }
 
   overallProgress(): number {
@@ -286,12 +288,14 @@ export class Stages {
     switch (stage.phase) {
       case 'READING_INPUT':
         return (
-          (this.stageHasSort(stage) ? READING_INPUT_WITH_SORT_WEIGHT : 1) *
+          (this.stageHasShuffle(stage) ? READING_INPUT_WITH_SHUFFLE_WEIGHT : 1) *
           this.readingInputPhaseProgress(stage)
         );
 
       case 'POST_READING':
-        return READING_INPUT_WITH_SORT_WEIGHT + SORT_WEIGHT * this.postReadingPhaseProgress(stage);
+        return (
+          READING_INPUT_WITH_SHUFFLE_WEIGHT + SHUFFLE_WEIGHT * this.postReadingPhaseProgress(stage)
+        );
 
       case 'RESULTS_READY':
       case 'FINISHED':
@@ -415,7 +419,7 @@ export class Stages {
   }
 
   getTotalOutputForStage(stage: StageDefinition, field: 'frames' | 'rows' | 'bytes'): number {
-    return this.getTotalCounterForStage(stage, this.stageOutputCounterName(stage), field);
+    return this.getTotalCounterForStage(stage, this.stageFinalCounterName(stage), field);
   }
 
   getSortProgressForStage(stage: StageDefinition): number {
@@ -445,7 +449,7 @@ export class Stages {
 
     const channelCounters = definition.input.map((_, i) => `input${i}` as ChannelCounterName);
     if (this.stageHasOutput(stage)) channelCounters.push('output');
-    if (this.stageHasSort(stage)) channelCounters.push('shuffle');
+    if (this.stageHasShuffle(stage)) channelCounters.push('shuffle');
     return channelCounters;
   }
 
@@ -479,9 +483,9 @@ export class Stages {
 
   getPartitionChannelCounterNamesForStage(
     stage: StageDefinition,
-    type: 'input' | 'output',
+    inOut: InOut,
   ): ChannelCounterName[] {
-    if (type === 'input') {
+    if (inOut === 'in') {
       const { input, broadcast } = stage.definition;
       return filterMap(input, (input, i) =>
         input.type === 'stage' && !broadcast?.includes(i)
@@ -489,31 +493,28 @@ export class Stages {
           : undefined,
       );
     } else {
-      return [this.stageOutputCounterName(stage)];
+      return [this.stageFinalCounterName(stage)];
     }
   }
 
-  getByPartitionCountersForStage(
-    stage: StageDefinition,
-    type: 'input' | 'output',
-  ): SimpleWideCounter[] {
-    const counterNames = this.getPartitionChannelCounterNamesForStage(stage, type);
+  getByPartitionCountersForStage(stage: StageDefinition, inOut: InOut): SimpleWideCounter[] {
+    const counterNames = this.getPartitionChannelCounterNamesForStage(stage, inOut);
     if (!counterNames.length) return [];
 
     if (!this.hasCounterForStage(stage, counterNames[0])) return [];
     const stageCounters = this.getCountersForStage(stage);
 
-    const { partitionCount } = stage;
-    const partitionNumber =
-      type === 'output'
-        ? partitionCount
-        : max(stageCounters, stageCounter =>
-            max(counterNames, counterName => {
-              const channelCounter = stageCounter[counterName];
-              if (channelCounter?.type !== 'channel') return 0;
-              return channelCounter.rows?.length || 0;
-            }),
-          );
+    let partitionNumber = max(stageCounters, stageCounter =>
+      max(counterNames, counterName => {
+        const channelCounter = stageCounter[counterName];
+        if (channelCounter?.type !== 'channel') return 0;
+        return channelCounter.rows?.length || 0;
+      }),
+    );
+
+    if (inOut === 'out') {
+      partitionNumber = Math.max(partitionNumber || 0, stage.partitionCount || 0);
+    }
 
     if (!partitionNumber) return [];
 

--- a/web-console/src/utils/basic-action.tsx
+++ b/web-console/src/utils/basic-action.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { IconName, Intent } from '@blueprintjs/core';
-import { Menu, MenuItem } from '@blueprintjs/core';
+import { Menu, MenuDivider, MenuItem } from '@blueprintjs/core';
 import type { JSX } from 'react';
 import React from 'react';
 
@@ -29,10 +29,14 @@ export interface BasicAction {
   disabledReason?: string;
 }
 
-export function basicActionsToMenu(basicActions: BasicAction[]): JSX.Element | undefined {
+export function basicActionsToMenu(
+  basicActions: BasicAction[],
+  title?: string,
+): JSX.Element | undefined {
   if (!basicActions.length) return;
   return (
     <Menu>
+      {title && <MenuDivider title={title} />}
       {basicActions.map(({ icon, title, intent, onAction, disabledReason }, i) => (
         <MenuItem
           key={i}

--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -1212,7 +1212,7 @@ GROUP BY 1, 2`;
                       num_segments !== num_zero_replica_segments
                         ? `Fully ${descriptor}`
                         : undefined,
-                      hasZeroReplicationRule ? `${percentZeroReplica}% async only` : '',
+                      hasZeroReplicationRule ? `${percentZeroReplica}% deep storage only` : '',
                     ).join(', ')}{' '}
                     ({segmentsEl})
                   </span>
@@ -1228,7 +1228,7 @@ GROUP BY 1, 2`;
                       {numAvailableSegments ? '\u25cf' : '\u25cb'}&nbsp;
                     </span>
                     {`${percentAvailable}% ${descriptor}${
-                      hasZeroReplicationRule ? `, ${percentZeroReplica}% async only` : ''
+                      hasZeroReplicationRule ? `, ${percentZeroReplica}% deep storage only` : ''
                     }`}{' '}
                     ({segmentsEl})
                   </span>

--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -1614,6 +1614,7 @@ GROUP BY 1, 2`;
                   }}
                   disableDetail={unused}
                   actions={datasourceActions}
+                  menuTitle={datasource}
                 />
               );
             },

--- a/web-console/src/views/lookups-view/lookups-view.tsx
+++ b/web-console/src/views/lookups-view/lookups-view.tsx
@@ -464,6 +464,7 @@ export class LookupsView extends React.PureComponent<LookupsViewProps, LookupsVi
                     this.onDetail(original);
                   }}
                   actions={lookupActions}
+                  menuTitle={lookupId}
                 />
               );
             },

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -886,6 +886,7 @@ END AS "time_span"`,
                     this.onDetail(id, datasource);
                   }}
                   actions={this.getSegmentActions(id, datasource)}
+                  menuTitle={id}
                 />
               );
             },

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -656,7 +656,7 @@ ORDER BY
               const { worker } = value;
               const disabled = worker.version === '';
               const workerActions = this.getWorkerActions(worker.host, disabled);
-              return <ActionCell actions={workerActions} />;
+              return <ActionCell actions={workerActions} menuTitle={worker.host} />;
             },
             Aggregated: () => '',
           },

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -898,6 +898,7 @@ export class SupervisorsView extends React.PureComponent<
                 <ActionCell
                   onDetail={() => this.onSupervisorDetail(row.original)}
                   actions={supervisorActions}
+                  menuTitle={id}
                 />
               );
             },

--- a/web-console/src/views/tasks-view/tasks-view.tsx
+++ b/web-console/src/views/tasks-view/tasks-view.tsx
@@ -505,6 +505,7 @@ ORDER BY
                 <ActionCell
                   onDetail={() => this.onTaskDetail(row.original)}
                   actions={this.getTaskActions(id, datasource, status, type, true)}
+                  menuTitle={id}
                 />
               );
             },

--- a/web-console/src/views/workbench-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/workbench-view/column-tree/column-tree.tsx
@@ -339,7 +339,8 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                                       F.max(C('__time')).as('max_time'),
                                     ])
                                     .changeGroupByExpressions([])
-                                    .changeWhereExpression(getWhere(true)),
+                                    .changeWhereExpression(getWhere(true))
+                                    .removeColumnFromWhere('__time'),
                                   true,
                                 );
                               }}

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -32,6 +32,7 @@ import type {
   ClusterBy,
   CounterName,
   Execution,
+  InOut,
   SegmentGenerationProgressFields,
   SimpleWideCounter,
   StageDefinition,
@@ -179,9 +180,9 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
     const phaseIsWorking = oneOf(phase, 'NEW', 'READING_INPUT', 'POST_READING');
     return (
       <div className="execution-stage-detail-pane">
-        {detailedCountersForPartitions(stage, 'input', phase === 'READING_INPUT')}
+        {detailedCountersForPartitions(stage, 'in', phase === 'READING_INPUT')}
         {detailedCountersForWorkers(stage)}
-        {detailedCountersForPartitions(stage, 'output', phaseIsWorking)}
+        {detailedCountersForPartitions(stage, 'out', phaseIsWorking)}
       </div>
     );
   }
@@ -320,15 +321,15 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
 
   function detailedCountersForPartitions(
     stage: StageDefinition,
-    type: 'input' | 'output',
+    inOut: InOut,
     inProgress: boolean,
   ) {
-    const wideCounters = stages.getByPartitionCountersForStage(stage, type);
+    const wideCounters = stages.getByPartitionCountersForStage(stage, inOut);
     if (!wideCounters.length) return;
 
     const counterNames: ChannelCounterName[] = stages.getPartitionChannelCounterNamesForStage(
       stage,
-      type,
+      inOut,
     );
 
     const bracesRows: Record<ChannelCounterName, string[]> = {} as any;
@@ -349,7 +350,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
         showPagination={wideCounters.length > MAX_DETAIL_ROWS}
         columns={[
           {
-            Header: `${capitalizeFirst(type)} partitions` + (inProgress ? '*' : ''),
+            Header: `${capitalizeFirst(inOut)} partitions` + (inProgress ? '*' : ''),
             id: 'partition',
             accessor: d => d.index,
             className: 'padded',


### PR DESCRIPTION
- Make this shortcut remove the filter clause on `__time` because it is not helpful

  <img width="611" alt="image" src="https://github.com/user-attachments/assets/d60564cc-418e-47e1-af5a-57783d86d035">

- Fix scrolling in the loadRules editor
- Add titles to action menus
- Fix bug in MSQ counter calculation