### PR TITLE
Replace with a more secure hash algorithm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <!--
             The base calcite parser was copied into the project; when updating Calcite run dev/upgrade-calcite-parser to adopt upstream changes
           -->
+        <bcpkix.version>1.78.1</bcpkix.version>
         <calcite.version>1.37.0</calcite.version>
         <confluent.version>6.2.12</confluent.version>
         <datasketches.version>4.2.0</datasketches.version>
@@ -409,7 +410,7 @@
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
-                <version>1.78.1</version>
+                <version>${bcpkix.version}</version>
             </dependency>
             <!-- Transitive dependency of hive-common in druid-kerberos, druid-ranger-security and
             druid-iceberg-extension  -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -59,6 +59,7 @@
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
@@ -463,6 +464,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bcpkix.version}</version>
         </dependency>
     </dependencies>
 

--- a/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
@@ -641,14 +641,14 @@ public class MemcachedCache implements Cache
 
   public static final int MAX_PREFIX_LENGTH =
       MemcachedClientIF.MAX_KEY_LENGTH
-      - 40 // length of namespace hash
-      - 40 // length of key hash
+      - 64 // length of namespace hash
+      - 64 // length of key hash
       - 2; // length of separators
 
   private static String computeKeyHash(String memcachedPrefix, NamedKey key)
   {
     // hash keys to keep things under 250 characters for memcached
-    return memcachedPrefix + ":" + DigestUtils.sha1Hex(key.namespace) + ":" + DigestUtils.sha1Hex(key.key);
+    return memcachedPrefix + ":" + DigestUtils.sha256Hex(key.namespace) + ":" + DigestUtils.sha256Hex(key.key);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
+++ b/server/src/main/java/org/apache/druid/client/cache/MemcachedCache.java
@@ -42,7 +42,6 @@ import net.spy.memcached.metrics.MetricCollector;
 import net.spy.memcached.metrics.MetricType;
 import net.spy.memcached.ops.LinkedOperationQueueFactory;
 import net.spy.memcached.ops.OperationQueueFactory;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.collections.StupidResourceHolder;
 import org.apache.druid.java.util.common.StringUtils;
@@ -51,6 +50,8 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Hex;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
@@ -62,7 +63,10 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Security;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -80,7 +84,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MemcachedCache implements Cache
 {
   private static final Logger log = new Logger(MemcachedCache.class);
-
+  private static final String TIGER_HASH_ALGORITHM = "Tiger";
+  private static final String HASH_LIBRARY = "BC";
+  private static MessageDigest MESSAGE_DIGEST = null;
   /**
    * Default hash algorithm for cache distribution.
    *
@@ -155,6 +161,11 @@ public class MemcachedCache implements Cache
           }
         };
     try {
+      if (MESSAGE_DIGEST == null) {
+        Security.addProvider(new BouncyCastleProvider());
+        MESSAGE_DIGEST = MessageDigest.getInstance(TIGER_HASH_ALGORITHM, HASH_LIBRARY);
+      }
+
       LZ4Transcoder transcoder = new LZ4Transcoder(config.getMaxObjectSize());
 
       // always use compression
@@ -379,7 +390,7 @@ public class MemcachedCache implements Cache
 
       return new MemcachedCache(clientSupplier, config, monitor);
     }
-    catch (IOException | NoSuchAlgorithmException e) {
+    catch (IOException | NoSuchAlgorithmException | NoSuchProviderException e) {
       throw new RuntimeException(e);
     }
     catch (KeyStoreException e) {
@@ -432,16 +443,15 @@ public class MemcachedCache implements Cache
 
   private final int timeout;
   private final int expiration;
+
   private final String memcachedPrefix;
 
   private final Supplier<ResourceHolder<MemcachedClientIF>> client;
-
   private final AtomicLong hitCount = new AtomicLong(0);
   private final AtomicLong missCount = new AtomicLong(0);
   private final AtomicLong timeoutCount = new AtomicLong(0);
   private final AtomicLong errorCount = new AtomicLong(0);
   private final AbstractMonitor monitor;
-
 
   MemcachedCache(
       Supplier<ResourceHolder<MemcachedClientIF>> client,
@@ -641,14 +651,18 @@ public class MemcachedCache implements Cache
 
   public static final int MAX_PREFIX_LENGTH =
       MemcachedClientIF.MAX_KEY_LENGTH
-      - 64 // length of namespace hash
-      - 64 // length of key hash
+      - 48 // length of namespace hash
+      - 48 // length of key hash
       - 2; // length of separators
 
   private static String computeKeyHash(String memcachedPrefix, NamedKey key)
   {
     // hash keys to keep things under 250 characters for memcached
-    return memcachedPrefix + ":" + DigestUtils.sha256Hex(key.namespace) + ":" + DigestUtils.sha256Hex(key.key);
+    return memcachedPrefix
+           + ":"
+           + Hex.toHexString(MESSAGE_DIGEST.digest(key.namespace.getBytes(StandardCharsets.UTF_8)))
+           + ":"
+           + Hex.toHexString(MESSAGE_DIGEST.digest(key.key));
   }
 
   @Override


### PR DESCRIPTION
Fixes #16568.



### Description
+ Replace with a more secure hash algorithm
+ hash keys to keep things under 250 characters for memcached

#### Fixed the bug ...


#### Release note
Replace with a more secure hash algorithm


<hr>

##### Key changed/added classes in this PR
 * `MemcachedCache`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
