### PR TITLE
[docs] Updating Rollup tutorial

### DIFF
--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -76,8 +76,8 @@ GROUP BY 1, 2, 3
 PARTITIONED BY DAY
 ```
 
-In the query, you group by dimensions, the `timestamp`, `srcIP`, and `dstIP` columns. Note that the query uses the `FLOOR` function to bucket rows based on MINUTE granularity.
-You apply aggregations for the metrics, specifically to sum the `bytes` and `packets` columns and to add a column that counts the number of rows that get rolled up.
+In the query, you group by dimensions, `timestamp`, `srcIP`, and `dstIP`. Note that the query uses the `FLOOR` function to bucket rows based on MINUTE granularity.
+For the metrics, you apply aggregations to sum the `bytes` and `packets` columns and add a column that counts the number of rows that get rolled up.
 
 After the ingestion completes, you can query the data.
 
@@ -119,7 +119,7 @@ Druid combines the three rows into one during rollup:
 
 Before the grouping occurs, the `FLOOR(TIME_PARSE("timestamp") TO MINUTE)` expression buckets (floors) the timestamp column of the original input by minute.
 
-The input rows are then grouped by the timestamp and dimension columns `{timestamp, srcIP, dstIP}` with sum aggregations on the metric columns `packets` and `bytes`. The `count` metric shows how many rows from the original input data contributed to the final "rolled up" row.
+The input rows are grouped because they have the same values for their dimension columns `{timestamp, srcIP, dstIP}`. The metric columns calculate the sum aggregation of the grouped rows for `packets` and `bytes`. The `count` metric shows how many rows from the original input data contributed to the final "rolled up" row.
 
 Now, consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -76,8 +76,11 @@ GROUP BY 1, 2, 3
 PARTITIONED BY DAY
 ```
 
-In the query, you group by dimensions, `timestamp`, `srcIP`, and `dstIP`. Note that the query uses the `FLOOR` function to bucket rows based on MINUTE granularity.
-For the metrics, you apply aggregations to sum the `bytes` and `packets` columns and add a column that counts the number of rows that get rolled-up.
+Note the following aspects of the ingestion statement:
+* You transform the timestamp field using the `FLOOR` function to round timestamps down to the minute.
+* You group by the dimensions `timestamp`, `srcIP`, and `dstIP`.
+* You create the `bytes` and `packets` metrics, which are summed from their respective input fields.
+* You also create the `count` metric that records the number of rows that get rolled-up per each row in the datasource.
 
 After the ingestion completes, you can query the data.
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -152,17 +152,11 @@ Therefore, no rollup takes place:
 | `2018-01-01T01:03:00.000Z` | `1.1.1.1` | `2.2.2.2` | `10,204` | `1` | `49` |
 
 
-## Learn More
+## Learn more
 
 See the following topics for more information:
 
-* [SQL-based ingestion query examples](../multi-stage-query/examples.md/#insert-with-rollup) for another example of data rollup during ingestion.
-
-* [SQL-based ingestion concepts](../multi-stage-query/concepts/#rollup) for more details on the concept of rollup.
-
-* [Data rollup](../ingestion/rollup/) for suggestions and best practices when performing rollup.
-
-
+* [SQL-based ingestion query examples](../multi-stage-query/examples.md#insert-with-rollup) for another example of data rollup during ingestion.  
+* [SQL-based ingestion concepts](../multi-stage-query/concepts.md#rollup) for more details on the concept of rollup.  
+* [Data rollup](../ingestion/rollup.md) for suggestions and best practices when performing rollup.  
 * [Druid schema model](../ingestion/schema-model.md) to go over more details on timestamp, dimensions, and metrics.
-
-

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -104,6 +104,9 @@ Returns the following:
 | `2018-01-02T21:33:00.000Z` | `7.7.7.7` | `8.8.8.8` | `100,288` | `2` | `161` |
 | `2018-01-02T21:35:00.000Z` | `7.7.7.7` | `8.8.8.8` | `2,818` | `1` | `12` |
 
+Notice there are only six rows as opposed to the nine rows of the example data. The next section covers how ingestion with rollup acomplishes this.
+
+## View rollup in action
 
 Consider the three events in the original input data that occur over the course of minute `2018-01-01T01:01`:
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -100,7 +100,7 @@ Returns the following:
 | `2018-01-02T21:35:00.000Z` | `7.7.7.7` | `8.8.8.8` | `2,818` | `1` | `12` |
 
 
-Let's look at the three events in the original input data that occurred during `2018-01-01T01:01`:
+Consider the three events in the original input data that occur over the course of minute `2018-01-01T01:01`:
 
 ```json
 {"timestamp":"2018-01-01T01:01:35Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":20,"bytes":9024}
@@ -108,7 +108,7 @@ Let's look at the three events in the original input data that occurred during `
 {"timestamp":"2018-01-01T01:01:59Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":11,"bytes":5780}
 ```
 
-These three rows have been "rolled up" into the following row:
+Apache Druid combines the three rows into the following using rollup:
 
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |
@@ -118,22 +118,26 @@ The input rows have been grouped by the timestamp and dimension columns `{timest
 
 Before the grouping occurs, the timestamps of the original input data are bucketed/floored by minute, due to the `"queryGranularity":"minute"` setting in the ingestion spec.
 
-Likewise, these two events that occurred during `2018-01-01T01:02` have been rolled up:
+Likewise, consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
 
 ```json
 {"timestamp":"2018-01-01T01:02:14Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":38,"bytes":6289}
 {"timestamp":"2018-01-01T01:02:29Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":377,"bytes":359971}
 ```
 
+The rows have been grouped into the following:
+
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |
 | `2018-01-01T01:02:00.000Z` | `1.1.1.1` | `2.2.2.2` | `366,260` | `2` | `415` |
 
-For the last event recording traffic between 1.1.1.1 and 2.2.2.2, no rollup took place, because this was the only event that occurred during `2018-01-01T01:03`:
+In the original input data, only one event occurs over the course of minute `2018-01-01T01:03`:
 
 ```json
 {"timestamp":"2018-01-01T01:03:29Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":49,"bytes":10204}
 ```
+
+Therefor no rollup takes place:
 
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -26,7 +26,7 @@ sidebar_label: Aggregate data with rollup
 
 Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup." [Rollup](../ingestion/rollup.md) is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
-This tutorial demonstrates the effects of rollup on an example dataset. See [ingesting with rollup](https://druid.apache.org/docs/latest/multi-stage-query/concepts/#rollup) to learn more. 
+The tutorial demonstrates how to apply rollup at ingestion and shows the effect of rollup at query time. See [ingesting with rollup](https://druid.apache.org/docs/latest/multi-stage-query/concepts/#rollup) to learn more. 
 
 ## Prerequisites
 
@@ -52,11 +52,7 @@ The data contains packet and byte counts from a source IP address to a destinati
 {"timestamp":"2018-01-02T21:35:45Z","srcIP":"7.7.7.7", "dstIP":"8.8.8.8","packets":12,"bytes":2818}
 ```
 
-The tutorial demonstrates how to apply rollup at ingestion and shows the effect of rollup at query time.
-
-Load the sample dataset using the [`INSERT INTO`](../multi-stage-query/reference.md/#insert) statement and the [`EXTERN`](../multi-stage-query/reference.md/#extern-function) function to read data provided inline with the query.
-
-In the [Druid web console](../operations/web-console.md), go to the **Query** view and run the following query:
+Load the sample dataset using the [`INSERT INTO`](../multi-stage-query/reference.md/#insert) statement and the [`EXTERN`](../multi-stage-query/reference.md/#extern-function) function to ingest the data inline. In the [Druid web console](../operations/web-console.md), go to the **Query** view and run the following query:
 
 ```sql
 INSERT INTO "rollup_tutorial"
@@ -80,9 +76,8 @@ GROUP BY 1, 2, 3
 PARTITIONED BY DAY
 ```
 
-Note that the query uses the `FLOOR` function to combine rows based on MINUTE granularity.
-In the query, you group by dimensions, the `timestamp`, `srcIP`, and `dstIP` columns.
-You apply aggregations for the metrics, specifically to sum the `bytes` and `packets` columns and to add a column to count the number of rows that get rolled up.
+In the query, you group by dimensions, the `timestamp`, `srcIP`, and `dstIP` columns. Note that the query uses the `FLOOR` function to bucket rows based on MINUTE granularity.
+You apply aggregations for the metrics, specifically to sum the `bytes` and `packets` columns and to add a column that counts the number of rows that get rolled up.
 
 After the ingestion completes, you can query the data.
 
@@ -104,7 +99,7 @@ Returns the following:
 | `2018-01-02T21:33:00.000Z` | `7.7.7.7` | `8.8.8.8` | `100,288` | `2` | `161` |
 | `2018-01-02T21:35:00.000Z` | `7.7.7.7` | `8.8.8.8` | `2,818` | `1` | `12` |
 
-Notice there are only six rows as opposed to the nine rows of the example data. The next section covers how ingestion with rollup acomplishes this.
+Notice there are only six rows as opposed to the nine rows in the example data. The next section covers how ingestion with rollup accomplishes this.
 
 ## View rollup in action
 
@@ -126,7 +121,7 @@ The input rows were grouped by the timestamp and dimension columns `{timestamp, 
 
 Before the grouping occurs, the timestamps of the original input data are bucketed (floored) by minute, due to the `FLOOR(TIME_PARSE("timestamp") TO MINUTE)` expression in the query.
 
-Consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
+Now, consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
 
 ```json
 {"timestamp":"2018-01-01T01:02:14Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":38,"bytes":6289}

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -82,6 +82,9 @@ Note the following aspects of the ingestion statement:
 * You create the `bytes` and `packets` metrics, which are summed from their respective input fields.
 * You also create the `count` metric that records the number of rows that get rolled-up per each row in the datasource.
 
+With rollup, Druid combines rows with identical timestamp and dimension values after the timestamp truncation.
+Druid computes and stores the metric values using the specified aggregation function over each set of rolled-up rows.
+
 After the ingestion completes, you can query the data.
 
 ## Query the example data
@@ -102,7 +105,7 @@ Returns the following:
 | `2018-01-02T21:33:00.000Z` | `7.7.7.7` | `8.8.8.8` | `100,288` | `2` | `161` |
 | `2018-01-02T21:35:00.000Z` | `7.7.7.7` | `8.8.8.8` | `2,818` | `1` | `12` |
 
-Notice there are only six rows as opposed to the nine rows in the example data. The next section covers how ingestion with rollup accomplishes this.
+Notice there are only six rows as opposed to the nine rows in the example data. In the next section, you explore the components of the rolled-up rows.
 
 ## View rollup in action
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -26,7 +26,7 @@ sidebar_label: Aggregate data with rollup
 
 Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup". Rollup is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
-This tutorial demonstrate the effects of rollup on an example dataset.
+This tutorial demonstrates the effects of rollup on an example dataset.
 
 For this tutorial, you should have Druid downloaded as described in
 the [single-machine quickstart](index.md) and have it running on your local machine. The examples in the tutorial use the [multi-stage query](../multi-stage-query/index.md) (MSQ) task engine to execute SQL statements.

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -82,8 +82,7 @@ Note the following aspects of the ingestion statement:
 * You create the `bytes` and `packets` metrics, which are summed from their respective input fields.
 * You also create the `count` metric that records the number of rows that get rolled-up per each row in the datasource.
 
-With rollup, Druid combines rows with identical timestamp and dimension values after the timestamp truncation.
-Druid computes and stores the metric values using the specified aggregation function over each set of rolled-up rows.
+With rollup, Druid combines rows with identical timestamp and dimension values after the timestamp truncation. Druid computes and stores the metric values using the specified aggregation function over each set of rolled-up rows.
 
 After the ingestion completes, you can query the data.
 
@@ -105,7 +104,7 @@ Returns the following:
 | `2018-01-02T21:33:00.000Z` | `7.7.7.7` | `8.8.8.8` | `100,288` | `2` | `161` |
 | `2018-01-02T21:35:00.000Z` | `7.7.7.7` | `8.8.8.8` | `2,818` | `1` | `12` |
 
-Notice there are only six rows as opposed to the nine rows in the example data. In the next section, you explore the components of the rolled-up rows.
+Notice there are only five rows as opposed to the nine rows in the example data. In the next section, you explore the components of the rolled-up rows.
 
 ## View rollup in action
 
@@ -151,5 +150,19 @@ Therefore, no rollup takes place:
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |
 | `2018-01-01T01:03:00.000Z` | `1.1.1.1` | `2.2.2.2` | `10,204` | `1` | `49` |
+
+
+## Learn More
+
+See the following topics for more information:
+
+* [SQL-based ingestion query examples](https://druid.apache.org/docs/latest/multi-stage-query/examples/#insert-with-rollup) for another example of data rollup during ingestion.
+
+* [SQL-based ingestion concepts](https://druid.apache.org/docs/latest/multi-stage-query/concepts/#rollup) for more details on the concept of rollup.
+
+* [Data rollup](https://druid.apache.org/docs/latest/ingestion/rollup/) for suggestions and best practices when performing rollup.
+
+
+* [Druid schema model](https://druid.apache.org/docs/latest/ingestion/schema-model/) to go over more details on timestamp, dimensions, and metrics.
 
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -156,7 +156,7 @@ Therefore, no rollup takes place:
 
 See the following topics for more information:
 
-* [SQL-based ingestion query examples](../multi-stage-query/examples.md#insert-with-rollup) for another example of data rollup during ingestion.  
-* [SQL-based ingestion concepts](../multi-stage-query/concepts.md#rollup) for more details on the concept of rollup.  
-* [Data rollup](../ingestion/rollup.md) for suggestions and best practices when performing rollup.  
-* [Druid schema model](../ingestion/schema-model.md) to go over more details on timestamp, dimensions, and metrics.
+* [Data rollup](../ingestion/rollup.md) for suggestions and best practices when performing rollup.
+* [SQL-based ingestion concepts](../multi-stage-query/concepts.md#rollup) for information on rollup using SQL-based ingestion.
+* [SQL-based ingestion query examples](../multi-stage-query/examples.md#insert-with-rollup) for another example of data rollup.  
+* [Druid schema model](../ingestion/schema-model.md) to learn about the primary timestamp, dimensions, and metrics.

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -24,18 +24,18 @@ sidebar_label: Aggregate data with rollup
   -->
 
 
-Apache Druid&circledR; can summarize raw data at ingestion time using a process we refer to as "rollup". Rollup is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
+Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup". Rollup is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
-This tutorial will demonstrate the effects of rollup on an example dataset.
+This tutorial demonstrate the effects of rollup on an example dataset.
 
-For this tutorial, we'll assume you've already downloaded Druid as described in
-the [single-machine quickstart](index.md) and have it running on your local machine. The examples in the tutorial use the [multi-stage query](../multi-stage-query/) (MSQ) task engine to execute SQL statements.
+For this tutorial, you should have Druid downloaded as described in
+the [single-machine quickstart](index.md) and have it running on your local machine. The examples in the tutorial use the [multi-stage query](../multi-stage-query/index.md) (MSQ) task engine to execute SQL statements.
 
-It will also be helpful to have finished [Load a file](../tutorials/tutorial-batch.md) and [Query data](../tutorials/tutorial-query.md) tutorials.
+It is helpful to have finished [Load a file](../tutorials/tutorial-batch.md) and [Query data](../tutorials/tutorial-query.md) tutorials.
 
 ## Example data
 
-For this tutorial, we'll use a small sample of network flow event data, representing packet and byte counts for traffic from a source to a destination IP address that occurred within a particular second.
+For this tutorial, you use a small sample of network flow event data, representing packet and byte counts for traffic from a source to a destination IP address that occurred within a particular second.
 
 ```json
 {"timestamp":"2018-01-01T01:01:35Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":20,"bytes":9024}
@@ -49,11 +49,11 @@ For this tutorial, we'll use a small sample of network flow event data, represen
 {"timestamp":"2018-01-02T21:35:45Z","srcIP":"7.7.7.7", "dstIP":"8.8.8.8","packets":12,"bytes":2818}
 ```
 
-We will see how to ingest this data using rollup.
+The tutorial guides you through how to ingest this data using rollup.
 
 ## Load the example data
 
-Load a sample dataset using INSERT and EXTERN functions. The EXTERN function lets you read external data or write to an external location.
+Load the sample dataset using INSERT and EXTERN functions. The EXTERN function lets you read external data or write to an external location.
 
 In the Druid web console, go to the Query view and run the following query:
 
@@ -79,9 +79,9 @@ GROUP BY 1, 2, 3
 PARTITIONED BY DAY
 ```
 
-Note that the query uses the `FLOOR` function to give the `__time` a granularity of `MINUTE`. The query defines the dimmensions of the rollup by grouping columns 1, 2, and 3, which corresponds to the `timestamp`, `srcIP`, and `dstIP` columns. The query defines the metrics of the rollup by aggregating the `bytes` and `packets` columns.
+Note that the query uses the `FLOOR` function to give the `__time` a granularity of `MINUTE`. The query defines the dimensions of the rollup by grouping columns 1, 2, and 3, which corresponds to the `timestamp`, `srcIP`, and `dstIP` columns. The query defines the metrics of the rollup by aggregating the `bytes` and `packets` columns.
 
-After the script completes, we will query the data.
+After the ingestion completes, you can query the data.
 
 ## Query the example data
 
@@ -110,7 +110,7 @@ Consider the three events in the original input data that occur over the course 
 {"timestamp":"2018-01-01T01:01:59Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":11,"bytes":5780}
 ```
 
-Apache Druid combines the three rows into the following during rollup:
+Druid combines the three rows into the following during rollup:
 
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -24,7 +24,7 @@ sidebar_label: Aggregate data with rollup
   -->
 
 
-Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup". Rollup is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
+Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup." Rollup is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
 This tutorial demonstrates the effects of rollup on an example dataset.
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -117,9 +117,9 @@ Druid combines the three rows into one during rollup:
 | -- | -- | -- | -- | -- | -- |
 | `2018-01-01T01:01:00.000Z` | `1.1.1.1` | `2.2.2.2` | `35,937` | `3` | `286` |
 
-The input rows were grouped by the timestamp and dimension columns `{timestamp, srcIP, dstIP}` with sum aggregations on the metric columns `packets` and `bytes`. The `count` metric shows how many rows in the original input data contributed to the final "rolled up" row.
+Before the grouping occurs, the `FLOOR(TIME_PARSE("timestamp") TO MINUTE)` expression buckets (floors) the timestamp column of the original input by minute.
 
-Before the grouping occurs, the timestamps of the original input data are bucketed (floored) by minute, due to the `FLOOR(TIME_PARSE("timestamp") TO MINUTE)` expression in the query.
+The input rows are then grouped by the timestamp and dimension columns `{timestamp, srcIP, dstIP}` with sum aggregations on the metric columns `packets` and `bytes`. The `count` metric shows how many rows from the original input data contributed to the final "rolled up" row.
 
 Now, consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
 
@@ -128,7 +128,7 @@ Now, consider the two events in the original input data that occur over the cour
 {"timestamp":"2018-01-01T01:02:29Z","srcIP":"1.1.1.1", "dstIP":"2.2.2.2","packets":377,"bytes":359971}
 ```
 
-The rows have been grouped into the following during rollup:
+The rows are grouped into the following during rollup:
 
 | `__time` | `srcIP` | `dstIP` | `bytes` | `count` | `packets` |
 | -- | -- | -- | -- | -- | -- |

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -26,7 +26,7 @@ sidebar_label: Aggregate data with rollup
 
 Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup." [Rollup](../multi-stage-query/concepts.md#rollup) is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
-This tutorial demonstrates how to apply rollup during ingestion and highlights its effects during query execution. The examples in the tutorial use the [multi-stage query (MSQ)](../multi-stage-query/index.md) task engine to executes SQL statements.
+This tutorial demonstrates how to apply rollup during ingestion and highlights its effects during query execution. The examples in the tutorial use the [multi-stage query (MSQ)](../multi-stage-query/index.md) task engine to execute SQL statements.
 
 ## Prerequisites
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -24,20 +24,20 @@ sidebar_label: Aggregate data with rollup
   -->
 
 
-Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup." [Rollup](../ingestion/rollup.md) is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
+Apache Druid&circledR; can summarize raw data at ingestion time using a process known as "rollup." [Rollup](../multi-stage-query/concepts.md#rollup) is a first-level aggregation operation over a selected set of columns that reduces the size of stored data.
 
-The tutorial demonstrates how to apply rollup at ingestion and shows the effect of rollup at query time. See [ingesting with rollup](https://druid.apache.org/docs/latest/multi-stage-query/concepts/#rollup) to learn more. 
+This tutorial demonstrates how to apply rollup during ingestion and highlights its effects during query execution. The examples in the tutorial use the [multi-stage query (MSQ)](../multi-stage-query/index.md) task engine to executes SQL statements.
 
 ## Prerequisites
 
 Before proceeding, download Druid as described in [Quickstart (local)](index.md) and have it running on your local machine. You don't need to load any data into the Druid cluster.
 
-You should be familiar with data querying in Druid. If you haven't already, go through the [Query data](../tutorials/tutorial-query.md) tutorial first.
+You should be familiar with data querying in Druid. If you haven't already, go through the [Query data](../tutorials/tutorial-query.md) tutorial first. 
 
 
 ## Load the example data
 
-For this tutorial, you use a small sample of network flow event data, representing IP traffic.
+For this tutorial, you use a small sample of network flow event data representing IP traffic.
 The data contains packet and byte counts from a source IP address to a destination IP address.
 
 ```json
@@ -77,7 +77,7 @@ PARTITIONED BY DAY
 ```
 
 In the query, you group by dimensions, `timestamp`, `srcIP`, and `dstIP`. Note that the query uses the `FLOOR` function to bucket rows based on MINUTE granularity.
-For the metrics, you apply aggregations to sum the `bytes` and `packets` columns and add a column that counts the number of rows that get rolled up.
+For the metrics, you apply aggregations to sum the `bytes` and `packets` columns and add a column that counts the number of rows that get rolled-up.
 
 After the ingestion completes, you can query the data.
 
@@ -119,7 +119,7 @@ Druid combines the three rows into one during rollup:
 
 Before the grouping occurs, the `FLOOR(TIME_PARSE("timestamp") TO MINUTE)` expression buckets (floors) the timestamp column of the original input by minute.
 
-The input rows are grouped because they have the same values for their dimension columns `{timestamp, srcIP, dstIP}`. The metric columns calculate the sum aggregation of the grouped rows for `packets` and `bytes`. The `count` metric shows how many rows from the original input data contributed to the final "rolled up" row.
+The input rows are grouped because they have the same values for their dimension columns `{timestamp, srcIP, dstIP}`. The metric columns calculate the sum aggregation of the grouped rows for `packets` and `bytes`. The `count` metric shows how many rows from the original input data contributed to the final rolled-up row.
 
 Now, consider the two events in the original input data that occur over the course of minute `2018-01-01T01:02`:
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -156,13 +156,13 @@ Therefore, no rollup takes place:
 
 See the following topics for more information:
 
-* [SQL-based ingestion query examples](https://druid.apache.org/docs/latest/multi-stage-query/examples/#insert-with-rollup) for another example of data rollup during ingestion.
+* [SQL-based ingestion query examples](../multi-stage-query/examples.md/#insert-with-rollup) for another example of data rollup during ingestion.
 
-* [SQL-based ingestion concepts](https://druid.apache.org/docs/latest/multi-stage-query/concepts/#rollup) for more details on the concept of rollup.
+* [SQL-based ingestion concepts](../multi-stage-query/concepts/#rollup) for more details on the concept of rollup.
 
-* [Data rollup](https://druid.apache.org/docs/latest/ingestion/rollup/) for suggestions and best practices when performing rollup.
+* [Data rollup](../ingestion/rollup/) for suggestions and best practices when performing rollup.
 
 
-* [Druid schema model](https://druid.apache.org/docs/latest/ingestion/schema-model/) to go over more details on timestamp, dimensions, and metrics.
+* [Druid schema model](../ingestion/schema-model.md) to go over more details on timestamp, dimensions, and metrics.
 
 

--- a/docs/tutorials/tutorial-rollup.md
+++ b/docs/tutorials/tutorial-rollup.md
@@ -31,7 +31,7 @@ This tutorial demonstrates the effects of rollup on an example dataset.
 For this tutorial, you should have Druid downloaded as described in
 the [single-machine quickstart](index.md) and have it running on your local machine. The examples in the tutorial use the [multi-stage query](../multi-stage-query/index.md) (MSQ) task engine to execute SQL statements.
 
-It is helpful to have finished [Load a file](../tutorials/tutorial-batch.md) and [Query data](../tutorials/tutorial-query.md) tutorials.
+Before proceeding, it's recommended to complete the tutorials to [Load a file](../tutorials/tutorial-batch.md) and [Query data](../tutorials/tutorial-query.md).
 
 ## Example data
 


### PR DESCRIPTION
### Description

Updating `tutorial-rollup.md` to to use MSQ inline ingestion. Replaces file segments associated with the defunct instructions.  

This PR has:

- [X] been self-reviewed.
