### PR TITLE
Add annotation for pod template

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -43,6 +43,7 @@ public class DruidK8sConstants
   public static final String DRUID_HOSTNAME_ENV = "HOSTNAME";
   public static final String LABEL_KEY = "druid.k8s.peons";
   public static final String DRUID_LABEL_PREFIX = "druid.";
+  public static final String BASE_TEMPLATE_NAME = "base";
   public static final long MAX_ENV_VARIABLE_KBS = 130048; // 127 KB
   static final Predicate<Throwable> IS_TRANSIENT = e -> e instanceof KubernetesResourceNotFoundException;
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -28,6 +28,7 @@ public class DruidK8sConstants
   public static final String TASK_TYPE = "task.type";
   public static final String TASK_GROUP_ID = "task.group.id";
   public static final String TASK_DATASOURCE = "task.datasource";
+  public static final String TASK_JOB_TEMPLATE = "task.jobTemplate";
   public static final int PORT = 8100;
   public static final int TLS_PORT = 8091;
   public static final int DEFAULT_CPU_MILLICORES = 1000;

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
-import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
 
 import javax.validation.constraints.NotNull;
 import java.util.Map;
@@ -43,7 +43,7 @@ public interface PodTemplateSelectStrategy
    * allows for customized resource allocation and management tailored to the task's specific requirements.
    *
    * @param task The task for which the Pod template is determined.
-   * @return The pod template that should be used to run the task.
+   * @return The PodTemplateWithName POJO that contains the name of the template selected and the template itself.
    */
-  @NotNull Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates);
+  @NotNull PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates);
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.Pair;
 
 import javax.validation.constraints.NotNull;
 import java.util.Map;
@@ -44,5 +45,5 @@ public interface PodTemplateSelectStrategy
    * @param task The task for which the Pod template is determined.
    * @return The pod template that should be used to run the task.
    */
-  @NotNull PodTemplate getPodTemplateForTask(Task task, Map<String, PodTemplate> templates);
+  @NotNull Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates);
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.Pair;
 
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ public class SelectorBasedPodTemplateSelectStrategy implements PodTemplateSelect
    * @return the template if a selector matches, otherwise fallback to base template
    */
   @Override
-  public PodTemplate getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
   {
     String templateKey = selectors.stream()
                                   .filter(selector -> selector.evaluate(task))
@@ -61,7 +62,10 @@ public class SelectorBasedPodTemplateSelectStrategy implements PodTemplateSelect
                                   .map(Selector::getSelectionKey)
                                   .orElse("base");
 
-    return templates.getOrDefault(templateKey, templates.get("base"));
+    if (!templates.containsKey(templateKey)) {
+      templateKey = "base";
+    }
+    return Pair.of(templateKey, templates.get(templateKey));
   }
 
   @JsonProperty

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
@@ -24,7 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
-import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
 
 import java.util.List;
 import java.util.Map;
@@ -54,18 +55,18 @@ public class SelectorBasedPodTemplateSelectStrategy implements PodTemplateSelect
    * @return the template if a selector matches, otherwise fallback to base template
    */
   @Override
-  public Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
   {
     String templateKey = selectors.stream()
                                   .filter(selector -> selector.evaluate(task))
                                   .findFirst()
                                   .map(Selector::getSelectionKey)
-                                  .orElse("base");
+                                  .orElse(DruidK8sConstants.BASE_TEMPLATE_NAME);
 
     if (!templates.containsKey(templateKey)) {
-      templateKey = "base";
+      templateKey = DruidK8sConstants.BASE_TEMPLATE_NAME;
     }
-    return Pair.of(templateKey, templates.get(templateKey));
+    return new PodTemplateWithName(templateKey, templates.get(templateKey));
   }
 
   @JsonProperty

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
@@ -22,7 +22,8 @@ package org.apache.druid.k8s.overlord.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
-import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
 
 import java.util.Map;
 
@@ -41,10 +42,10 @@ public class TaskTypePodTemplateSelectStrategy implements PodTemplateSelectStrat
   }
 
   @Override
-  public Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
   {
-    String templateKey = templates.containsKey(task.getType()) ? task.getType() : "base";
-    return Pair.of(templateKey, templates.get(templateKey));
+    String templateKey = templates.containsKey(task.getType()) ? task.getType() : DruidK8sConstants.BASE_TEMPLATE_NAME;
+    return new PodTemplateWithName(templateKey, templates.get(templateKey));
   }
 
   @Override

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
@@ -22,6 +22,7 @@ package org.apache.druid.k8s.overlord.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.Pair;
 
 import java.util.Map;
 
@@ -40,9 +41,10 @@ public class TaskTypePodTemplateSelectStrategy implements PodTemplateSelectStrat
   }
 
   @Override
-  public PodTemplate getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public Pair<String, PodTemplate> getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
   {
-    return templates.getOrDefault(task.getType(), templates.get("base"));
+    String templateKey = templates.containsKey(task.getType()) ? task.getType() : "base";
+    return Pair.of(templateKey, templates.get(templateKey));
   }
 
   @Override

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -39,7 +39,6 @@ import org.apache.druid.guice.IndexingServiceModuleHelper;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.common.IAE;
-import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.k8s.overlord.KubernetesTaskRunnerConfig;
@@ -139,22 +138,21 @@ public class PodTemplateTaskAdapter implements TaskAdapter
       podTemplateSelectStrategy = dynamicConfig.getPodTemplateSelectStrategy();
     }
 
-    Pair<String, PodTemplate> podTemplatePair = podTemplateSelectStrategy.getPodTemplateForTask(task, templates);
-    assert podTemplatePair.lhs != null && podTemplatePair.rhs != null;
+    PodTemplateWithName podTemplateWithName = podTemplateSelectStrategy.getPodTemplateForTask(task, templates);
 
     return new JobBuilder()
         .withNewMetadata()
         .withName(new K8sTaskId(task).getK8sJobName())
         .addToLabels(getJobLabels(taskRunnerConfig, task))
         .addToAnnotations(getJobAnnotations(taskRunnerConfig, task))
-        .addToAnnotations(DruidK8sConstants.TASK_JOB_TEMPLATE, podTemplatePair.lhs)
+        .addToAnnotations(DruidK8sConstants.TASK_JOB_TEMPLATE, podTemplateWithName.getName())
         .endMetadata()
         .withNewSpec()
-        .withTemplate(podTemplatePair.rhs.getTemplate())
+        .withTemplate(podTemplateWithName.getPodTemplate().getTemplate())
         .editTemplate()
         .editOrNewMetadata()
         .addToAnnotations(getPodTemplateAnnotations(task))
-        .addToAnnotations(DruidK8sConstants.TASK_JOB_TEMPLATE, podTemplatePair.lhs)
+        .addToAnnotations(DruidK8sConstants.TASK_JOB_TEMPLATE, podTemplateWithName.getName())
         .addToLabels(getPodLabels(taskRunnerConfig, task))
         .endMetadata()
         .editSpec()

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateWithName.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateWithName.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.taskadapter;
+
+import io.fabric8.kubernetes.api.model.PodTemplate;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public class PodTemplateWithName
+{
+  private final String name;
+  private final PodTemplate podTemplate;
+
+  public PodTemplateWithName(String name, PodTemplate podTemplate)
+  {
+    this.name = name;
+    this.podTemplate = podTemplate;
+  }
+
+  @Nonnull
+  public String getName()
+  {
+    return name;
+  }
+
+  @Nonnull
+  public PodTemplate getPodTemplate()
+  {
+    return podTemplate;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PodTemplateWithName that = (PodTemplateWithName) o;
+    return Objects.equals(name, that.name) &&
+        Objects.equals(podTemplate, that.podTemplate);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(name, podTemplate);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "PodTemplateWithName{" +
+        "name='" + name + '\'' +
+        ", podTemplate=" + podTemplate +
+        '}';
+  }
+}

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateWithNameTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/PodTemplateWithNameTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common;
+
+import io.fabric8.kubernetes.api.model.PodTemplate;
+import io.fabric8.kubernetes.api.model.PodTemplateBuilder;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class PodTemplateWithNameTest
+{
+  @Test
+  void testEqualityToMakeCoverageHappy()
+  {
+    PodTemplateWithName podTemplateWithName = new PodTemplateWithName(
+        "name",
+        new PodTemplateBuilder().build()
+    );
+    PodTemplateWithName podTemplateWithName2 = podTemplateWithName;
+
+    assertEquals(podTemplateWithName, podTemplateWithName2);
+    assertNotEquals(podTemplateWithName, null);
+    assertNotEquals(podTemplateWithName, "string");
+    assertEquals(podTemplateWithName.hashCode(), podTemplateWithName2.hashCode());
+  }
+
+  @Test
+  void testGettersToMakeCoverageHappy()
+  {
+    String name = "name";
+    PodTemplate podTemplate = new PodTemplateBuilder().build();
+    PodTemplateWithName podTemplateWithName = new PodTemplateWithName(
+        name,
+        podTemplate
+    );
+
+    assertEquals(name, podTemplateWithName.getName());
+    assertEquals(podTemplate, podTemplateWithName.getPodTemplate());
+  }
+}

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
 import org.apache.druid.segment.TestHelper;
 import org.junit.Assert;
 import org.junit.Before;
@@ -97,7 +98,10 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> emptySelectors = Collections.emptyList();
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(emptySelectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getName());
+    PodTemplateWithName podTemplateWithName = strategy.getPodTemplateForTask(task, templates);
+    Assert.assertEquals("base", podTemplateWithName.getName());
+    Assert.assertEquals("base", podTemplateWithName.getPodTemplate().getMetadata().getName());
+
   }
 
   @Test
@@ -107,7 +111,9 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> selectors = Collections.singletonList(noMatchSelector);
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getName());
+    PodTemplateWithName podTemplateWithName = strategy.getPodTemplateForTask(task, templates);
+    Assert.assertEquals("base", podTemplateWithName.getName());
+    Assert.assertEquals("base", podTemplateWithName.getPodTemplate().getMetadata().getName());
   }
 
   @Test
@@ -124,7 +130,9 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     );
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("match", strategy.getPodTemplateForTask(task, templates).getName());
+    PodTemplateWithName podTemplateWithName = strategy.getPodTemplateForTask(task, templates);
+    Assert.assertEquals("match", podTemplateWithName.getName());
+    Assert.assertEquals("match", podTemplateWithName.getPodTemplate().getMetadata().getName());
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
@@ -97,7 +97,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> emptySelectors = Collections.emptyList();
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(emptySelectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getMetadata().getName());
+    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> selectors = Collections.singletonList(noMatchSelector);
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getMetadata().getName());
+    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     );
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("match", strategy.getPodTemplateForTask(task, templates).getMetadata().getName());
+    Assert.assertEquals("match", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
@@ -97,7 +97,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> emptySelectors = Collections.emptyList();
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(emptySelectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
+    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getName());
   }
 
   @Test
@@ -107,7 +107,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     List<Selector> selectors = Collections.singletonList(noMatchSelector);
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
+    Assert.assertEquals("base", strategy.getPodTemplateForTask(task, templates).getName());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
     );
     SelectorBasedPodTemplateSelectStrategy strategy = new SelectorBasedPodTemplateSelectStrategy(selectors);
     Task task = NoopTask.create();
-    Assert.assertEquals("match", strategy.getPodTemplateForTask(task, templates).rhs.getMetadata().getName());
+    Assert.assertEquals("match", strategy.getPodTemplateForTask(task, templates).getName());
   }
 
   @Test

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
@@ -163,7 +163,7 @@ public class PodTemplateTaskAdapterTest
 
     Task task = new NoopTask("id", "id", "datasource", 0, 0, null);
     Job actual = adapter.fromTask(task);
-    Job expected = K8sTestUtils.fileToResource("expectedNoopJob.yaml", Job.class);
+    Job expected = K8sTestUtils.fileToResource("expectedNoopJobBase.yaml", Job.class);
 
     assertJobSpecsEqual(actual, expected);
   }
@@ -197,7 +197,7 @@ public class PodTemplateTaskAdapterTest
 
     Task task = new NoopTask("id", "id", "datasource", 0, 0, null);
     Job actual = adapter.fromTask(task);
-    Job expected = K8sTestUtils.fileToResource("expectedNoopJobTlsEnabled.yaml", Job.class);
+    Job expected = K8sTestUtils.fileToResource("expectedNoopJobTlsEnabledBase.yaml", Job.class);
 
     assertJobSpecsEqual(actual, expected);
   }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJob.yaml
@@ -8,11 +8,13 @@ metadata:
     druid.task.type: "noop"
     druid.task.group.id: "id"
     druid.task.datasource: "datasource"
+
   annotations:
     task.id: "id"
     task.type: "noop"
     task.group.id: "id"
     task.datasource: "datasource"
+    task.jobTemplate: noop
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -32,6 +34,7 @@ spec:
         task.type: "noop"
         task.group.id: "id"
         task.datasource: "datasource"
+        task.jobTemplate: noop
     spec:
       containers:
         - command:

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobBase.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobBase.yaml
@@ -8,12 +8,13 @@ metadata:
     druid.task.type: "noop"
     druid.task.group.id: "id"
     druid.task.datasource: "datasource"
+
   annotations:
     task.id: "id"
     task.type: "noop"
     task.group.id: "id"
     task.datasource: "datasource"
-    task.jobTemplate: noop
+    task.jobTemplate: base
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -28,12 +29,12 @@ spec:
         druid.task.datasource: "datasource"
       annotations:
         task: "H4sIAAAAAAAAAD2MvQ4CIRCE32VqijsTG1qLi7W+wArEbHICrmC8EN7dJf40k/lmJtNQthxgEVPKMGCvXsXgKqnm4x89FTqlKm6MBzw+YCA1nvmm8W4/TQYuxRJeBbZ17cJ3ZhvoSbzShVcu2zLOf9cS7pUl+ANlclrCzr2/AQUK0FqZAAAA"
-        tls.enabled: "true"
+        tls.enabled: "false"
         task.id: "id"
         task.type: "noop"
         task.group.id: "id"
         task.datasource: "datasource"
-        task.jobTemplate: noop
+        task.jobTemplate: base
     spec:
       containers:
         - command:

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
@@ -13,6 +13,7 @@ metadata:
     task.type: "noop"
     task.group.id: "api-issued_kill_wikipedia3_omjobnbc_1000-01-01T00:00:00.000Z_2023-05-14T00:00:00.000Z_2023-05-15T17:03:01.220Z"
     task.datasource: "data_source"
+    task.jobTemplate: noop
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -32,6 +33,7 @@ spec:
         task.type: "noop"
         task.group.id: "api-issued_kill_wikipedia3_omjobnbc_1000-01-01T00:00:00.000Z_2023-05-14T00:00:00.000Z_2023-05-15T17:03:01.220Z"
         task.datasource: "data_source"
+        task.jobTemplate: noop
     spec:
       containers:
         - command:

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
@@ -13,6 +13,7 @@ metadata:
     task.type: "noop"
     task.group.id: "id"
     task.datasource: "datasource"
+    task.jobTemplate: noop
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -31,6 +32,7 @@ spec:
         task.type: "noop"
         task.group.id: "id"
         task.datasource: "datasource"
+        task.jobTemplate: noop
     spec:
       containers:
         - command:

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
@@ -13,7 +13,7 @@ metadata:
     task.type: "noop"
     task.group.id: "id"
     task.datasource: "datasource"
-    task.jobTemplate: noop
+    task.jobTemplate: base
 spec:
   activeDeadlineSeconds: 14400
   backoffLimit: 0
@@ -33,7 +33,7 @@ spec:
         task.type: "noop"
         task.group.id: "id"
         task.datasource: "datasource"
-        task.jobTemplate: noop
+        task.jobTemplate: base
     spec:
       containers:
         - command:


### PR DESCRIPTION
Add the template name as a annotation on the pod spec to tell which pods are running which templates in metrics.

### Description
It can be useful to group k8s pods launched by mmless ingestion based on the template they used for metrics, logs, etc. To do this we can add the template name as a annotation.

#### Release note
- In mmless ingestion, add the pod template name as a annotation to the created job/pod.

##### Key changed/added classes in this PR
 * `PodTemplateTaskAdapter`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
