### PR TITLE
SuperSorter: direct merging, increased parallelism.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameChannelMerger.java
@@ -30,11 +30,11 @@ import org.apache.druid.frame.key.FrameComparisonWidget;
 import org.apache.druid.frame.key.KeyColumn;
 import org.apache.druid.frame.key.RowKey;
 import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.frame.segment.FrameCursor;
 import org.apache.druid.frame.write.FrameWriter;
 import org.apache.druid.frame.write.FrameWriterFactory;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.segment.ColumnSelectorFactory;
-import org.apache.druid.segment.Cursor;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -73,6 +73,17 @@ public class FrameChannelMerger implements FrameProcessor<Long>
   // ColumnSelectorFactory that always reads from the current row in the merged sequence.
   final MultiColumnSelectorFactory mergedColumnSelectorFactory;
 
+  /**
+   * @param inputChannels      readable frame channels. Each channel must be sorted (i.e., if all frames in the channel
+   *                           are concatenated, the concatenated result must be fully sorted).
+   * @param frameReader        reader for frames
+   * @param outputChannel      writable channel to receive the merge-sorted data
+   * @param frameWriterFactory writer for frames
+   * @param sortKey            sort key for input and output frames
+   * @param partitions         partitions for output frames. If non-null, output frames are written with
+   *                           {@link FrameWithPartition#partition()} set according to this parameter
+   * @param rowLimit           maximum number of rows to write to the output channel
+   */
   public FrameChannelMerger(
       final List<ReadableFrameChannel> inputChannels,
       final FrameReader frameReader,
@@ -91,9 +102,8 @@ public class FrameChannelMerger implements FrameProcessor<Long>
         partitions == null ? ClusterByPartitions.oneUniversalPartition() : partitions;
 
     if (!partitionsToUse.allAbutting()) {
-      // Sanity check: we lack logic in FrameMergeIterator for not returning every row in the provided frames, so make
-      // sure there are no holes in partitionsToUse. Note that this check isn't perfect, because rows outside the
-      // min / max value of partitionsToUse can still appear. But it's a cheap check, and it doesn't hurt to do it.
+      // To simplify merging logic, when frames we only look at the earliest and latest key in "partitions". To ensure
+      // correctness, we need to verify that there are no gaps.
       throw new IAE("Partitions must all abut each other");
     }
 
@@ -124,9 +134,9 @@ public class FrameChannelMerger implements FrameProcessor<Long>
             return -1;
           } else {
             return currentFrames[k1].comparisonWidget.compare(
-                currentFrames[k1].rowNumber,
+                currentFrames[k1].rowNumber(),
                 currentFrames[k2].comparisonWidget,
-                currentFrames[k2].rowNumber
+                currentFrames[k2].rowNumber()
             );
           }
         }
@@ -193,13 +203,13 @@ public class FrameChannelMerger implements FrameProcessor<Long>
 
         if (currentPartitionEnd != null) {
           final FramePlus currentFrame = currentFrames[currentChannel];
-          if (currentFrame.comparisonWidget.compare(currentFrame.rowNumber, currentPartitionEnd) >= 0) {
+          if (currentFrame.comparisonWidget.compare(currentFrame.rowNumber(), currentPartitionEnd) >= 0) {
             // Current key is past the end of the partition. Advance currentPartition til it matches the current key.
             do {
               currentPartition++;
               currentPartitionEnd = partitions.get(currentPartition).getEnd();
             } while (currentPartitionEnd != null
-                     && currentFrame.comparisonWidget.compare(currentFrame.rowNumber, currentPartitionEnd) >= 0);
+                     && currentFrame.comparisonWidget.compare(currentFrame.rowNumber(), currentPartitionEnd) >= 0);
 
             if (mergedFrameWriter.getNumRows() == 0) {
               // Fall through: keep reading into the new partition.
@@ -229,9 +239,9 @@ public class FrameChannelMerger implements FrameProcessor<Long>
         } else {
           // Continue reading the currentChannel.
           final FramePlus channelFramePlus = currentFrames[currentChannel];
-          channelFramePlus.advance();
+          channelFramePlus.cursor.advance();
 
-          if (channelFramePlus.cursor.isDone()) {
+          if (channelFramePlus.isDone()) {
             // Done reading current frame from "channel".
             // Clear it and see if there is another one available for immediate loading.
             currentFrames[currentChannel] = null;
@@ -242,8 +252,15 @@ public class FrameChannelMerger implements FrameProcessor<Long>
             if (channel.canRead()) {
               // Read next frame from this channel.
               final Frame frame = channel.read();
-              currentFrames[currentChannel] = new FramePlus(frame, frameReader, sortKey);
-              remainingChannels++;
+              final FramePlus framePlus = makeFramePlus(frame, frameReader);
+              if (framePlus.isDone()) {
+                // Nothing to read in this frame. Not finished; we can't continue.
+                // Finish up the current frame and return it.
+                break;
+              } else {
+                currentFrames[currentChannel] = framePlus;
+                remainingChannels++;
+              }
             } else if (channel.isFinished()) {
               // Done reading this channel. Fall through and continue with other channels.
             } else {
@@ -284,8 +301,13 @@ public class FrameChannelMerger implements FrameProcessor<Long>
 
         if (channel.canRead()) {
           final Frame frame = channel.read();
-          currentFrames[i] = new FramePlus(frame, frameReader, sortKey);
-          remainingChannels++;
+          final FramePlus framePlus = makeFramePlus(frame, frameReader);
+          if (framePlus.isDone()) {
+            await.add(i);
+          } else {
+            currentFrames[i] = framePlus;
+            remainingChannels++;
+          }
         } else if (!channel.isFinished()) {
           await.add(i);
         }
@@ -296,25 +318,88 @@ public class FrameChannelMerger implements FrameProcessor<Long>
   }
 
   /**
+   * Creates a {@link FramePlus} with start and end row set to match {@link #partitions}.
+   */
+  private FramePlus makeFramePlus(
+      final Frame frame,
+      final FrameReader frameReader
+  )
+  {
+    final FrameCursor cursor = FrameProcessors.makeCursor(frame, frameReader);
+    final FrameComparisonWidget comparisonWidget = frameReader.makeComparisonWidget(frame, sortKey);
+    cursor.setCurrentRow(findRow(frame, comparisonWidget, partitions.get(0).getStart()));
+
+    final RowKey endRowKey = partitions.get(partitions.size() - 1).getEnd();
+    final int endRow;
+
+    if (endRowKey == null) {
+      endRow = frame.numRows();
+    } else {
+      endRow = findRow(frame, comparisonWidget, endRowKey);
+    }
+
+    return new FramePlus(cursor, comparisonWidget, endRow);
+  }
+
+  /**
+   * Find the first row in a frame with a key equal to, or greater than, the provided key. Returns 0 if the input
+   * key is null.
+   */
+  static int findRow(
+      final Frame frame,
+      final FrameComparisonWidget comparisonWidget,
+      @Nullable final RowKey key
+  )
+  {
+    if (key == null) {
+      return 0;
+    }
+
+    int minIndex = 0;
+    int maxIndex = frame.numRows();
+
+    while (minIndex < maxIndex) {
+      final int currIndex = (minIndex + maxIndex) / 2;
+      final int cmp = comparisonWidget.compare(currIndex, key);
+
+      if (cmp < 0) {
+        minIndex = currIndex + 1;
+      } else {
+        maxIndex = currIndex;
+      }
+    }
+
+    return minIndex;
+  }
+
+  /**
    * Class that encapsulates the apparatus necessary for reading a {@link Frame}.
    */
   private static class FramePlus
   {
-    private final Cursor cursor;
+    private final FrameCursor cursor;
     private final FrameComparisonWidget comparisonWidget;
-    private int rowNumber;
+    private final int endRow;
 
-    private FramePlus(Frame frame, FrameReader frameReader, List<KeyColumn> sortKey)
+    public FramePlus(
+        final FrameCursor cursor,
+        final FrameComparisonWidget comparisonWidget,
+        final int endRow
+    )
     {
-      this.cursor = FrameProcessors.makeCursor(frame, frameReader);
-      this.comparisonWidget = frameReader.makeComparisonWidget(frame, sortKey);
-      this.rowNumber = 0;
+      this.cursor = cursor;
+      this.comparisonWidget = comparisonWidget;
+      this.endRow = endRow;
     }
 
-    private void advance()
+    public int rowNumber()
     {
-      cursor.advance();
-      rowNumber++;
+      return cursor.getCurrentRow();
+    }
+
+    public boolean isDone()
+    {
+      return cursor.getCurrentRow() >= endRow;
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -36,6 +36,7 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongRBTreeSet;
 import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import org.apache.druid.common.guava.FutureUtils;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.allocation.MemoryAllocatorFactory;
 import org.apache.druid.frame.allocation.SingleMemoryAllocatorFactory;
@@ -68,29 +69,38 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import java.util.stream.IntStream;
 
 /**
- * Sorts and partitions a dataset using parallel external merge sort.
+ * Sorts and partitions a dataset using parallel, possibly-external merge sort.
  *
  * Input is provided as a set of {@link ReadableFrameChannel} and output is provided as {@link OutputChannels}.
  * Work is performed on a provided {@link FrameProcessorExecutor}.
  *
  * The most central point for SuperSorter logic is the {@link #runWorkersIfPossible} method, which determines what
- * needs to be done next based on the current state of the SuperSorter. The logic is:
+ * needs to be done next based on the current state of the SuperSorter.
  *
- * 1) Read input channels into {@link #inputBuffer} using {@link FrameChannelBatcher}, launched via
- * {@link #runNextBatcher()}, up to a limit of {@link #maxChannelsPerProcessor} per batcher.
+ * First, input channels are read into {@link #inputBuffer} using {@link FrameChannelBatcher}, launched via
+ * {@link #runNextBatcher()}.
+ *
+ * If the sorter finishes reading its input before reaching {@link #getMaxInputBufferFramesForDirectMerging()} number of
+ * frames in the {@link #inputBuffer}, the sorter operates in "direct mode". In this mode, {@link #totalMergingLevels}
+ * is 1. Mergers launched by {@link #runNextDirectMerger()} directly merge input frames into output channels, fully
+ * in-memory. No temporary files are used. Each direct merger reads *all* frames, but only rows corresponding to a
+ * single output partition.
+ *
+ * Otherwise, the sorter operates in "external mode". In this mode, {@link #totalMergingLevels} is 2 or more. Logic
+ * for external mode is:
+ *
+ * 1) Read inputs into {@link #inputBuffer} using {@link FrameChannelBatcher} (same as direct mode).
  *
  * 2) Merge and write frames from {@link #inputBuffer} into {@link FrameFile} scratch files using
  * {@link FrameChannelMerger} launched via {@link #runNextLevelZeroMerger()}.
  *
  * 3a) Merge level 0 scratch files into level 1 scratch files using {@link FrameChannelMerger} launched from
- * {@link #runNextMiddleMerger()}, processing up to {@link #maxChannelsPerProcessor} files per merger.
+ * {@link #runNextMiddleMerger()}, processing up to {@link #maxChannelsPerMerger} files per merger.
  * Continue this process through increasing level numbers, with the size of scratch files increasing by a factor
- * of {@link #maxChannelsPerProcessor} each level.
+ * of {@link #maxChannelsPerMerger} each level.
  *
  * 3b) For the penultimate level, the {@link FrameChannelMerger} launched by {@link #runNextMiddleMerger()} writes
  * partitioned {@link FrameFile} scratch files. The penultimate level cannot be written until
@@ -106,8 +116,7 @@ import java.util.stream.IntStream;
  *
  * Potential future work (things we could optimize if necessary):
  *
- * - Collapse merging to a single level if level zero has one merger, and we want to write one output partition.
- * - Skip batching, and inject directly into level 0, if input channels are already individually fully-sorted.
+ * - Identify sorted runs of frames in the {@link #inputBuffer}, group them into smaller sets of channels.
  * - Combine (for example: aggregate) while merging.
  */
 public class SuperSorter
@@ -124,7 +133,7 @@ public class SuperSorter
   private final FrameProcessorExecutor exec;
   private final OutputChannelFactory outputChannelFactory;
   private final OutputChannelFactory intermediateOutputChannelFactory;
-  private final int maxChannelsPerProcessor;
+  private final int maxChannelsPerMerger;
   private final int maxActiveProcessors;
   private final long rowLimit;
   private final String cancellationId;
@@ -199,7 +208,9 @@ public class SuperSorter
    * @param intermediateOutputChannelFactory factory for intermediate data produced by sorting levels
    * @param maxActiveProcessors              maximum number of merging processors to execute at once in the provided
    *                                         {@link FrameProcessorExecutor}
-   * @param maxChannelsPerProcessor          maximum number of channels to merge at once per merging processor
+   * @param maxChannelsPerMerger             maximum number of channels to merge at once, for regular mergers
+   *                                         (does not apply to direct mergers; see
+   *                                         {@link #getMaxInputBufferFramesForDirectMerging()})
    * @param rowLimit                         limit to apply during sorting. The limit is merely advisory: the actual number
    *                                         of rows returned may be larger than the limit. The limit is applied across
    *                                         all partitions, not to each partition individually.
@@ -216,7 +227,7 @@ public class SuperSorter
       final OutputChannelFactory outputChannelFactory,
       final OutputChannelFactory intermediateOutputChannelFactory,
       final int maxActiveProcessors,
-      final int maxChannelsPerProcessor,
+      final int maxChannelsPerMerger,
       final long rowLimit,
       @Nullable final String cancellationId,
       final SuperSorterProgressTracker superSorterProgressTracker,
@@ -230,7 +241,7 @@ public class SuperSorter
     this.exec = exec;
     this.outputChannelFactory = outputChannelFactory;
     this.intermediateOutputChannelFactory = intermediateOutputChannelFactory;
-    this.maxChannelsPerProcessor = maxChannelsPerProcessor;
+    this.maxChannelsPerMerger = maxChannelsPerMerger;
     this.maxActiveProcessors = maxActiveProcessors;
     this.rowLimit = rowLimit;
     this.cancellationId = cancellationId;
@@ -245,8 +256,8 @@ public class SuperSorter
       throw new IAE("maxActiveProcessors[%d] < 1", maxActiveProcessors);
     }
 
-    if (maxChannelsPerProcessor < 2) {
-      throw new IAE("maxChannelsPerProcessor[%d] < 2", maxChannelsPerProcessor);
+    if (maxChannelsPerMerger < 2) {
+      throw new IAE("maxChannelsPerMerger[%d] < 2", maxChannelsPerMerger);
     }
   }
 
@@ -339,9 +350,16 @@ public class SuperSorter
       return;
     }
 
+    setTotalMergingLevelsIfPossible();
+
     try {
-      while (activeProcessors < maxActiveProcessors &&
-             (runNextUltimateMerger() || runNextMiddleMerger() || runNextLevelZeroMerger() || runNextBatcher())) {
+      // Attempt to run mergers in reverse order, so we merge later layers first.
+      while (activeProcessors < maxActiveProcessors
+             && (runNextDirectMerger()
+                 || runNextUltimateMerger()
+                 || runNextMiddleMerger()
+                 || runNextLevelZeroMerger()
+                 || runNextBatcher())) {
         activeProcessors += 1;
 
         if (log.isDebugEnabled()) {
@@ -377,7 +395,8 @@ public class SuperSorter
       allDone.set(OutputChannels.wrap(channels));
     } else if (totalMergingLevels != UNKNOWN_LEVEL
                && outputsReadyByLevel.containsKey(totalMergingLevels - 1)
-               && outputsReadyByLevel.get(totalMergingLevels - 1).size() == getOutputPartitions().size()) {
+               && (outputsReadyByLevel.get(totalMergingLevels - 1).size() ==
+                   getTotalMergersInLevel(totalMergingLevels - 1))) {
       // We're done!!
       try {
         // OK to use wrap, not wrapReadOnly, because all channels in this list are already read-only.
@@ -398,7 +417,7 @@ public class SuperSorter
       batcherIsRunning = true;
 
       runWorker(
-          new FrameChannelBatcher(inputChannels, maxChannelsPerProcessor),
+          new FrameChannelBatcher(inputChannels, maxChannelsPerMerger),
           result -> {
             final List<Frame> batch = result.lhs;
             final IntSet keepReading = result.rhs;
@@ -411,8 +430,9 @@ public class SuperSorter
               if (inputChannelsToRead.isEmpty()) {
                 inputChannels.forEach(ReadableFrameChannel::close);
                 setTotalInputFrames(inputFramesReadSoFar);
+                setTotalMergingLevelsIfPossible();
                 runWorkersIfPossible();
-              } else if (inputBuffer.size() >= maxChannelsPerProcessor) {
+              } else if (inputBuffer.size() >= maxChannelsPerMerger) {
                 runWorkersIfPossible();
               }
 
@@ -426,19 +446,55 @@ public class SuperSorter
   }
 
   /**
+   * Launch a merger that reads from {@link #inputBuffer} and directly writes an output channel. This method only
+   * does anything when the sorter is in "direct mode", i.e. when all input fits in memory. See class-level javadoc
+   * for more details.
+   */
+  @GuardedBy("runWorkersLock")
+  private boolean runNextDirectMerger()
+  {
+    // Direct merging is a single-level merge (totalMergingLevels == 1).
+    if (!(totalMergingLevels == 1
+          && allInputRead()
+          && ultimateMergersRunSoFar < getTotalMergersInLevel(0))) {
+      return false;
+    }
+
+    final List<ReadableFrameChannel> in = new ArrayList<>();
+
+    for (final Frame frame : inputBuffer) {
+      in.add(singleReadableFrameChannel(new FrameWithPartition(frame, FrameWithPartition.NO_PARTITION)));
+    }
+
+    runMerger(0, ultimateMergersRunSoFar++, in, Collections.emptyList());
+    return true;
+  }
+
+  /**
    * Level zero mergers read batches of frames from the "inputBuffer". These frames are individually sorted, but there
    * is no ordering between the frames. Their output is a sorted sequence of frames.
    */
   @GuardedBy("runWorkersLock")
   private boolean runNextLevelZeroMerger()
   {
-    if (inputBuffer.isEmpty() || (inputBuffer.size() < maxChannelsPerProcessor && !allInputRead())) {
+    if (totalMergingLevels == 1) {
+      // When there's just one merging level, the inputBuffer is merged by runNextDirectMerger, not this method.
+      return false;
+    }
+
+    if (inputBuffer.isEmpty()) {
+      // Nothing to merge.
+      return false;
+    }
+
+    if (totalMergingLevels == UNKNOWN_LEVEL && inputBuffer.size() < getMaxInputBufferFramesForDirectMerging()) {
+      // Buffer up as much as possible until we've determined the merging structure, or until the buffer is full.
       return false;
     }
 
     final List<ReadableFrameChannel> in = new ArrayList<>();
 
-    while (in.size() < maxChannelsPerProcessor) {
+    while (in.size() < maxChannelsPerMerger) {
       final Frame frame = inputBuffer.poll();
 
       if (frame == null) {
@@ -448,7 +504,7 @@ public class SuperSorter
       in.add(singleReadableFrameChannel(new FrameWithPartition(frame, FrameWithPartition.NO_PARTITION)));
     }
 
-    runMerger(0, levelZeroMergersRunSoFar++, in, null, ImmutableList.of());
+    runMerger(0, levelZeroMergersRunSoFar++, in, ImmutableList.of());
     return true;
   }
 
@@ -461,30 +517,36 @@ public class SuperSorter
       final LongSortedSet inputsReady = outputsReadyByLevel.get(inLevel);
 
       if (totalMergingLevels != UNKNOWN_LEVEL && outLevel >= totalMergingLevels - 1) {
-        // This is the ultimate level. Skip it, since it will be launched by runNextUltimateMerger.
+        // This is the ultimate level. Skip it, since it will be launched by either runNextDirectMerger (if one
+        // merging level) or runNextUltimateMerger (if more than one merging level).
         continue;
       }
 
       if (totalMergingLevels == UNKNOWN_LEVEL
-          && LongMath.divide(inputsReady.size(), maxChannelsPerProcessor, RoundingMode.CEILING)
-             <= maxChannelsPerProcessor) {
+          && LongMath.divide(inputsReady.size(), maxChannelsPerMerger, RoundingMode.CEILING) <= maxChannelsPerMerger) {
         // This *might* be the penultimate level. Skip until we know for sure. (i.e., until all input frames have
         // been read.)
         continue;
       }
 
-      final ClusterByPartitions outPartitions;
+      final int channelsPerMerger;
 
       if (totalMergingLevels != UNKNOWN_LEVEL && outLevel == totalMergingLevels - 2) {
-        // This is the penultimate level.
-        if (!outputPartitionsFuture.isDone()) {
-          // Can't launch penultimate level until output partitions are known.
+        // Definitely the penultimate level. Channels per merger may be less than maxChannelsPerMerger.
+        if (outputPartitionsFuture.isDone()) {
+          channelsPerMerger = Ints.checkedCast(
+              LongMath.divide(
+                  totalInputs,
+                  getTotalMergersInLevel(outLevel),
+                  RoundingMode.CEILING
+              )
+          );
+        } else {
+          // Can't run penultimate level until output partitions are known.
           continue;
         }
-
-        outPartitions = getOutputPartitions();
       } else {
-        outPartitions = null;
+        channelsPerMerger = maxChannelsPerMerger;
       }
 
       // See if there's work to do.
@@ -494,7 +556,7 @@ public class SuperSorter
       long currentSetStart = -1, currentSetIndex = -1;
       while (iter.hasNext()) {
         final long w = iter.nextLong();
-        if (w % maxChannelsPerProcessor == 0) {
+        if (w % channelsPerMerger == 0) {
           // w is the start of a set
           currentSetStart = w;
           currentSetIndex = -1;
@@ -505,11 +567,11 @@ public class SuperSorter
           long pos = w - currentSetStart;
 
           if (pos == currentSetIndex + 1 &&
-              (pos == maxChannelsPerProcessor - 1 || (totalInputs != UNKNOWN_TOTAL && w == totalInputs - 1))) {
+              (pos == channelsPerMerger - 1 || (totalInputs != UNKNOWN_TOTAL && w == totalInputs - 1))) {
             // We found a set to merge. Let's collect the input channels and launch the merger.
             final List<ReadableFrameChannel> in = new ArrayList<>();
             final List<PartitionedReadableFrameChannel> partitionedReadableFrameChannels = new ArrayList<>();
-            for (long i = currentSetStart; i < currentSetStart + maxChannelsPerProcessor; i++) {
+            for (long i = currentSetStart; i < currentSetStart + channelsPerMerger; i++) {
               if (inputsReady.remove(i)) {
                 String levelAndRankKey = mergerOutputFileName(inLevel, i);
                 PartitionedReadableFrameChannel partitionedReadableFrameChannel =
@@ -523,9 +585,8 @@ public class SuperSorter
 
             runMerger(
                 outLevel,
-                currentSetStart / maxChannelsPerProcessor,
+                currentSetStart / channelsPerMerger,
                 in,
-                outPartitions,
                 partitionedReadableFrameChannels
             );
             return true;
@@ -546,9 +607,10 @@ public class SuperSorter
   @GuardedBy("runWorkersLock")
   private boolean runNextUltimateMerger()
   {
-    if (totalMergingLevels == UNKNOWN_LEVEL
-        || !outputPartitionsFuture.isDone()
-        || ultimateMergersRunSoFar >= getOutputPartitions().size()) {
+    if (!(totalMergingLevels != UNKNOWN_LEVEL
+          && totalMergingLevels >= 2
+          && outputPartitionsFuture.isDone()
+          && ultimateMergersRunSoFar < getOutputPartitions().size())) {
       return false;
     }
 
@@ -577,12 +639,7 @@ public class SuperSorter
       );
     }
 
-    if (outputChannels == null) {
-      outputChannels = Arrays.asList(new OutputChannel[getOutputPartitions().size()]);
-    }
-
-    runMerger(outLevel, ultimateMergersRunSoFar, in, null, ImmutableList.of());
-    ultimateMergersRunSoFar++;
+    runMerger(outLevel, ultimateMergersRunSoFar++, in, ImmutableList.of());
     return true;
   }
 
@@ -591,28 +648,49 @@ public class SuperSorter
       final int level,
       final long rank,
       final List<ReadableFrameChannel> in,
-      @Nullable final ClusterByPartitions partitions,
       final List<PartitionedReadableFrameChannel> partitionedReadableChannelsToClose
   )
   {
     try {
       final WritableFrameChannel writableChannel;
       final MemoryAllocatorFactory frameAllocatorFactory;
-      String levelAndRankKey = mergerOutputFileName(level, rank);
+      final ClusterByPartitions outPartitions;
+      final String levelAndRankKey = mergerOutputFileName(level, rank);
+      final boolean isFinalOutput = totalMergingLevels != UNKNOWN_LEVEL && level == totalMergingLevels - 1;
 
-      if (totalMergingLevels != UNKNOWN_LEVEL && level == totalMergingLevels - 1) {
+      if (isFinalOutput) {
+        // Writing final partitioned output.
+        final int outputPartitionCount = getOutputPartitions().size();
         final int intRank = Ints.checkedCast(rank);
+
+        if (outputChannels == null) {
+          outputChannels = Arrays.asList(new OutputChannel[outputPartitionCount]);
+        }
+
         final OutputChannel outputChannel = outputChannelFactory.openChannel(intRank);
-        outputChannels.set(intRank, outputChannel.readOnly());
-        frameAllocatorFactory = new SingleMemoryAllocatorFactory(outputChannel.getFrameMemoryAllocator());
         writableChannel = outputChannel.getWritableChannel();
+        frameAllocatorFactory = new SingleMemoryAllocatorFactory(outputChannel.getFrameMemoryAllocator());
+        outputChannels.set(intRank, outputChannel);
+
+        if (totalMergingLevels == 1) {
+          // Reading from the inputBuffer. (i.e. "direct mode"; see class-level javadoc for more details.)
+          outPartitions = new ClusterByPartitions(Collections.singletonList(getOutputPartitions().get(intRank)));
+        } else {
+          // Reading from intermediate partitioned channels.
+          outPartitions = null;
+        }
       } else {
-        PartitionedOutputChannel partitionedOutputChannel = intermediateOutputChannelFactory.openPartitionedChannel(
-            levelAndRankKey,
-            true
-        );
+        // Writing some intermediate layer.
+        PartitionedOutputChannel partitionedOutputChannel =
+            intermediateOutputChannelFactory.openPartitionedChannel(levelAndRankKey, true);
         writableChannel = partitionedOutputChannel.getWritableChannel();
         frameAllocatorFactory = new SingleMemoryAllocatorFactory(partitionedOutputChannel.getFrameMemoryAllocator());
+
+        if (level == totalMergingLevels - 2) {
+          outPartitions = getOutputPartitions();
+        } else {
+          outPartitions = null;
+        }
 
         // We add the readOnly() channel even though we require the writableChannel and the frame allocator because
         // the original partitionedOutputChannel would contain the reference to those, which would get cleaned up
@@ -634,7 +712,7 @@ public class SuperSorter
                   removeNullBytes
               ),
               sortKey,
-              partitions,
+              outPartitions,
               rowLimit
           );
 
@@ -704,33 +782,68 @@ public class SuperSorter
   @GuardedBy("runWorkersLock")
   private void setTotalInputFrames(final long totalInputFrames)
   {
+    if (this.totalInputFrames != UNKNOWN_TOTAL) {
+      throw DruidException.defensive(
+          "Cannot set totalInputFrames twice (first[%s], second[%s])",
+          this.totalInputFrames,
+          totalInputFrames
+      );
+    }
+
     this.totalInputFrames = totalInputFrames;
 
     // Mark the progress tracker as trivially complete, if there is nothing to sort.
     if (totalInputFrames == 0) {
       superSorterProgressTracker.markTriviallyComplete();
     }
+  }
 
-    // Set totalMergingLevels too
-    long totalMergersInLevel = totalInputFrames;
-    int level = 0;
-
-    while (totalMergersInLevel > maxChannelsPerProcessor) {
-      totalMergersInLevel = LongMath.divide(totalMergersInLevel, maxChannelsPerProcessor, RoundingMode.CEILING);
-      superSorterProgressTracker.setTotalMergersForLevel(level, totalMergersInLevel);
-      level++;
+  @GuardedBy("runWorkersLock")
+  private void setTotalMergingLevelsIfPossible()
+  {
+    if (totalMergingLevels != UNKNOWN_LEVEL
+        || totalInputFrames == UNKNOWN_TOTAL
+        || !outputPartitionsFuture.isDone()) {
+      return;
     }
 
-    // Must have at least three levels. (Zero, penultimate, ultimate.)
-    totalMergingLevels = Math.max(level + 1, 3);
+    if (levelZeroMergersRunSoFar == 0) {
+      // All frames fit in memory.
+      totalMergingLevels = 1;
+      superSorterProgressTracker.setTotalMergingLevels(1);
+      superSorterProgressTracker.setTotalMergersForLevel(0, getOutputPartitions().size());
+      return;
+    }
 
-    // Add remaining levels to the tracker, if required
-    IntStream.range(level, totalMergingLevels)
-             .forEach(curLevel -> {
-               synchronized (runWorkersLock) {
-                 superSorterProgressTracker.setTotalMergersForLevel(curLevel, 1);
-               }
-             });
+    // Need to do a multi-level merge. Figure out how many levels.
+    int level = 0;
+    long inputsForLevel = totalInputFrames;
+
+    while (inputsForLevel > maxChannelsPerMerger) {
+      final long totalMergersInLevel =
+          LongMath.divide(inputsForLevel, maxChannelsPerMerger, RoundingMode.CEILING);
+      superSorterProgressTracker.setTotalMergersForLevel(level, totalMergersInLevel);
+
+      level++;
+      inputsForLevel = totalMergersInLevel;
+    }
+
+    if (level <= 1) {
+      if (getOutputPartitions().size() > 1) {
+        // Use three levels so the final merge layer (which writes the final output channels) can read from
+        // a cleanly partitioned penultimate layer.
+        totalMergingLevels = 3;
+      } else {
+        // Use two levels: no need to have a partitioned penultimate layer.
+        totalMergingLevels = 2;
+      }
+    } else {
+      totalMergingLevels = level + 1;
+    }
+
+    for (int i = level; i < totalMergingLevels; i++) {
+      superSorterProgressTracker.setTotalMergersForLevel(i, 1);
+    }
 
     superSorterProgressTracker.setTotalMergingLevels(totalMergingLevels);
   }
@@ -741,16 +854,7 @@ public class SuperSorter
       throw new ISE("Output partitions are not ready yet");
     }
 
-    try {
-      return outputPartitionsFuture.get();
-    }
-    catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
-    }
-    catch (ExecutionException e) {
-      throw new RuntimeException(e);
-    }
+    return FutureUtils.getUnchecked(outputPartitionsFuture, true);
   }
 
   @GuardedBy("runWorkersLock")
@@ -761,12 +865,42 @@ public class SuperSorter
     } else if (level >= totalMergingLevels) {
       throw new ISE("Invalid level %d", level);
     } else if (level == totalMergingLevels - 1) {
-      return outputPartitionsFuture.isDone() ? getOutputPartitions().size() : UNKNOWN_TOTAL;
+      if (outputPartitionsFuture.isDone()) {
+        return totalInputFrames == 0 ? 0 : getOutputPartitions().size();
+      } else {
+        return UNKNOWN_TOTAL;
+      }
+    } else if (level > 0 && level == totalMergingLevels - 2) {
+      if (outputPartitionsFuture.isDone()) {
+        // Smallest number of mergers we can possibly use in the penultimate level.
+        final long totalInputs = getTotalMergersInLevel(level - 1);
+        final long minMergers =
+            LongMath.divide(totalInputs, maxChannelsPerMerger, RoundingMode.CEILING);
+
+        // Ensure we have a maximal degree of parallelism: possibly use more mergers than minMergers.
+        long targetNumMergers = Math.max(
+            minMergers,
+            Math.min(
+                maxActiveProcessors,
+                getOutputPartitions().size()
+            )
+        );
+
+        // Lower targetNumMergers if runNextMiddleManager would not actually be able to launch this many.
+        return LongMath.divide(
+            totalInputs,
+            LongMath.divide(totalInputs, targetNumMergers, RoundingMode.CEILING),
+            RoundingMode.CEILING
+        );
+      } else {
+        return UNKNOWN_TOTAL;
+      }
     } else {
       long totalMergersInLevel = totalInputFrames;
 
       for (int i = 0; i <= level; i++) {
-        totalMergersInLevel = LongMath.divide(totalMergersInLevel, maxChannelsPerProcessor, RoundingMode.CEILING);
+        totalMergersInLevel =
+            LongMath.divide(totalMergersInLevel, maxChannelsPerMerger, RoundingMode.CEILING);
       }
 
       return totalMergersInLevel;
@@ -837,6 +971,14 @@ public class SuperSorter
   private String mergerOutputFileName(final int level, final long rank)
   {
     return StringUtils.format("merged.%d.%d", level, rank);
+  }
+
+  /**
+   * Maximum number of frames permissible in the {@link #inputBuffer} for "direct mode" (see class-level javadoc).
+   */
+  private int getMaxInputBufferFramesForDirectMerging()
+  {
+    return maxChannelsPerMerger * maxActiveProcessors;
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.frame.processor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.frame.Frame;
@@ -83,7 +84,7 @@ public class SuperSorterTest
   private static final Logger log = new Logger(SuperSorterTest.class);
 
   /**
-   * Non-parameterized test cases that
+   * Non-parameterized test cases for specific scenarios.
    */
   public static class NonParameterizedCasesTest extends InitializedNullHandlingTest
   {
@@ -144,6 +145,40 @@ public class SuperSorterTest
       Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
       channel.close();
     }
+
+    @Test
+    public void testSingleEmptyInputChannel_immediately_fileStorage() throws Exception
+    {
+      final BlockingQueueFrameChannel inputChannel = BlockingQueueFrameChannel.minimal();
+      inputChannel.writable().close();
+
+      final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
+
+      final File tempFolder = temporaryFolder.newFolder();
+      final SuperSorter superSorter = new SuperSorter(
+          Collections.singletonList(inputChannel.readable()),
+          FrameReader.create(RowSignature.empty()),
+          Collections.emptyList(),
+          Futures.immediateFuture(ClusterByPartitions.oneUniversalPartition()),
+          exec,
+          new FileOutputChannelFactory(tempFolder, FRAME_SIZE, null),
+          new FileOutputChannelFactory(tempFolder, FRAME_SIZE, null),
+          2,
+          2,
+          -1,
+          null,
+          superSorterProgressTracker,
+          false
+      );
+
+      final OutputChannels channels = superSorter.run().get();
+      Assert.assertEquals(1, channels.getAllChannels().size());
+
+      final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
+      Assert.assertTrue(channel.isFinished());
+      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      channel.close();
+    }
   }
 
   /**
@@ -163,6 +198,7 @@ public class SuperSorterTest
     private final int maxChannelsPerProcessor;
     private final int numThreads;
     private final boolean isComposedStorage;
+    private final boolean partitionsDeferred;
 
     private StorageAdapter adapter;
     private RowSignature signature;
@@ -177,7 +213,8 @@ public class SuperSorterTest
         int maxActiveProcessors,
         int maxChannelsPerProcessor,
         int numThreads,
-        boolean isComposedStorage
+        boolean isComposedStorage,
+        boolean partitionsDeferred
     )
     {
       this.maxRowsPerFrame = maxRowsPerFrame;
@@ -187,6 +224,7 @@ public class SuperSorterTest
       this.maxChannelsPerProcessor = maxChannelsPerProcessor;
       this.numThreads = numThreads;
       this.isComposedStorage = isComposedStorage;
+      this.partitionsDeferred = partitionsDeferred;
     }
 
     @Parameterized.Parameters(
@@ -194,22 +232,23 @@ public class SuperSorterTest
                + "maxBytesPerFrame = {1}, "
                + "numChannels = {2}, "
                + "maxActiveProcessors = {3}, "
-               + "maxChannelsPerProcessor = {4}, "
+               + "maxChannelsPerProcessor= {4}, "
                + "numThreads = {5}, "
-               + "isComposedStorage = {6}"
+               + "isComposedStorage = {6}, "
+               + "partitionsDeferred = {7}"
     )
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
 
       for (int maxRowsPerFrame : new int[]{Integer.MAX_VALUE, 50, 1}) {
-        for (int maxBytesPerFrame : new int[]{20000, 200000}) {
+        for (int maxBytesPerFrame : new int[]{20_000, 2_000_000}) {
           for (int numChannels : new int[]{1, 3}) {
             for (int maxActiveProcessors : new int[]{1, 2, 4}) {
               for (int maxChannelsPerProcessor : new int[]{2, 3, 8}) {
                 for (int numThreads : new int[]{1, 3}) {
                   for (boolean isComposedStorage : new boolean[]{true, false}) {
-                    if (maxActiveProcessors >= maxChannelsPerProcessor) {
+                    for (boolean partitionsDeferred : new boolean[]{true, false}) {
                       constructors.add(
                           new Object[]{
                               maxRowsPerFrame,
@@ -218,7 +257,8 @@ public class SuperSorterTest
                               maxActiveProcessors,
                               maxChannelsPerProcessor,
                               numThreads,
-                              isComposedStorage
+                              isComposedStorage,
+                              partitionsDeferred
                           }
                       );
                     }
@@ -277,7 +317,7 @@ public class SuperSorterTest
       frameReader = FrameReader.create(signature);
     }
 
-    private OutputChannels verifySuperSorter(
+    private void verifySuperSorter(
         final ClusterBy clusterBy,
         final ClusterByPartitions clusterByPartitions
     ) throws Exception
@@ -295,6 +335,10 @@ public class SuperSorterTest
       final SettableFuture<ClusterByPartitions> clusterByPartitionsFuture = SettableFuture.create();
       final SuperSorterProgressTracker superSorterProgressTracker = new SuperSorterProgressTracker();
 
+      if (!partitionsDeferred) {
+        clusterByPartitionsFuture.set(clusterByPartitions);
+      }
+
       final SuperSorter superSorter = new SuperSorter(
           inputChannels,
           frameReader,
@@ -311,16 +355,19 @@ public class SuperSorterTest
           false
       );
 
-      superSorter.setNoWorkRunnable(() -> clusterByPartitionsFuture.set(clusterByPartitions));
+      if (partitionsDeferred) {
+        superSorter.setNoWorkRunnable(() -> clusterByPartitionsFuture.set(clusterByPartitions));
+      }
+
       final OutputChannels outputChannels = superSorter.run().get();
       Assert.assertEquals(clusterByPartitions.size(), outputChannels.getAllChannels().size());
-      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      Assert.assertEquals(Double.valueOf(1.0), superSorterProgressTracker.snapshot().getProgressDigest());
 
       final int[] clusterByPartColumns = clusterBy.getColumns().stream().mapToInt(
           part -> signature.indexOf(part.columnName())
       ).toArray();
 
-      final List<Sequence<List<Object>>> outputSequences = new ArrayList<>();
+      final List<List<Object>> readRows = new ArrayList<>();
       for (int partitionNumber : outputChannels.getPartitionNumbers()) {
         final ClusterByPartition partition = clusterByPartitions.get(partitionNumber);
         final ReadableFrameChannel outputChannel =
@@ -328,7 +375,7 @@ public class SuperSorterTest
 
         // Validate that everything in this channel is in the correct key range.
         FrameTestUtil.readRowsFromFrameChannel(
-            duplicateOutputChannel(outputChannel),
+            outputChannel,
             frameReader
         ).forEach(
             row -> {
@@ -359,14 +406,9 @@ public class SuperSorterTest
                   ),
                   partition.getEnd() == null || keyComparator.compare(key, partition.getEnd()) < 0
               );
-            }
-        );
 
-        outputSequences.add(
-            FrameTestUtil.readRowsFromFrameChannel(
-                duplicateOutputChannel(outputChannel),
-                frameReader
-            )
+              readRows.add(row);
+            }
         );
       }
 
@@ -386,9 +428,7 @@ public class SuperSorterTest
           )
       );
 
-      FrameTestUtil.assertRowsEqual(expectedRows, Sequences.concat(outputSequences));
-
-      return outputChannels;
+      FrameTestUtil.assertRowsEqual(expectedRows, Sequences.simple(readRows));
     }
 
     @Test
@@ -420,34 +460,12 @@ public class SuperSorterTest
       setUpInputChannels(clusterBy);
 
       final RowKey zeroZero = createKey(clusterBy, 0L, 0L);
-      final OutputChannels outputChannels = verifySuperSorter(
+      verifySuperSorter(
           clusterBy,
           new ClusterByPartitions(
               ImmutableList.of(
                   new ClusterByPartition(null, zeroZero), // empty partition
                   new ClusterByPartition(zeroZero, null) // all data goes in here
-              )
-          )
-      );
-
-      // Verify that one of the partitions is actually empty.
-      Assert.assertEquals(
-          0,
-          countSequence(
-              FrameTestUtil.readRowsFromFrameChannel(
-                  Iterables.getOnlyElement(outputChannels.getChannelsForPartition(0)).getReadableChannel(),
-                  frameReader
-              )
-          )
-      );
-
-      // Verify that the other partition has all data in it.
-      Assert.assertEquals(
-          adapter.getNumRows(),
-          countSequence(
-              FrameTestUtil.readRowsFromFrameChannel(
-                  Iterables.getOnlyElement(outputChannels.getChannelsForPartition(1)).getReadableChannel(),
-                  frameReader
               )
           )
       );
@@ -708,11 +726,6 @@ public class SuperSorterTest
     }
 
     return retVal;
-  }
-
-  private static ReadableFrameChannel duplicateOutputChannel(final ReadableFrameChannel channel)
-  {
-    return new ReadableFileFrameChannel(((ReadableFileFrameChannel) channel).newFrameFileReference());
   }
 
   private static <T> long countSequence(final Sequence<T> sequence)


### PR DESCRIPTION
Two performance enhancements:

1) Direct merging of input frames to output channels, without any
   temporary files, if all input frames fit in memory.

2) When doing multi-level merging (now called "external mode"),
   improve parallelism by boosting up the number of mergers in the
   penultimate level.

To support direct merging, FrameChannelMerger is enhanced such that the output partition min/max values are used to filter input frames. This is necessary because all direct mergers read all input frames, but only rows corresponding to a single output partition.