### PR TITLE
MSQ window functions: Fix partition boundary issues for arrays

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -87,7 +87,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
 
   // List of type strategies to compare the partition columns across rows.
   // Type strategies are pushed in the same order as column types in frameReader.signature()
-  private final List<NullableTypeStrategy<Object>> typeStrategies = new ArrayList<>();
+  private final NullableTypeStrategy[] typeStrategies;
 
   public WindowOperatorQueryFrameProcessor(
       WindowOperatorQuery query,
@@ -115,8 +115,9 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     this.partitionColumnNames = partitionColumnNames;
 
     this.frameReader = frameReader;
+    this.typeStrategies = new NullableTypeStrategy[frameReader.signature().size()];
     for (int i = 0; i < frameReader.signature().size(); i++) {
-      typeStrategies.add(frameReader.signature().getColumnType(i).get().getNullableStrategy());
+      typeStrategies[i] = frameReader.signature().getColumnType(i).get().getNullableStrategy();
     }
   }
 
@@ -507,7 +508,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     int match = 0;
     for (String columnName : partitionColumnNames) {
       int i = frameReader.signature().indexOf(columnName);
-      if (typeStrategies.get(i).compare(row1.get(i), row2.get(i)) == 0) {
+      if (typeStrategies[i].compare(row1.get(i), row2.get(i)) == 0) {
         match++;
       }
     }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -51,6 +51,7 @@ import org.apache.druid.query.rowsandcols.semantic.ColumnSelectorFactoryMaker;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
+import org.apache.druid.segment.column.NullableTypeStrategy;
 import org.apache.druid.segment.column.RowSignature;
 
 import javax.annotation.Nullable;
@@ -59,7 +60,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -499,7 +499,8 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     int match = 0;
     for (String columnName : partitionColumnNames) {
       int i = frameReader.signature().indexOf(columnName);
-      if (Objects.equals(row1.get(i), row2.get(i))) {
+      NullableTypeStrategy<Object> nullableTypeStrategy = frameReader.signature().getColumnType(columnName).get().getNullableStrategy();
+      if (nullableTypeStrategy.compare(row1.get(i), row2.get(i)) == 0) {
         match++;
       }
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -7750,4 +7750,18 @@ public class DrillWindowQueryTest extends BaseCalciteQueryTest
   {
     windowQueryTest();
   }
+
+  @DrillTest("druid_queries/partition_by_array/wikipedia_query_1")
+  @Test
+  public void test_partition_by_array_wikipedia_query_1()
+  {
+    windowQueryTest();
+  }
+
+  @DrillTest("druid_queries/partition_by_array/wikipedia_query_2")
+  @Test
+  public void test_partition_by_array_wikipedia_query_2()
+  {
+    windowQueryTest();
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -7764,4 +7764,11 @@ public class DrillWindowQueryTest extends BaseCalciteQueryTest
   {
     windowQueryTest();
   }
+
+  @DrillTest("druid_queries/partition_by_array/wikipedia_query_3")
+  @Test
+  public void test_partition_by_array_wikipedia_query_3()
+  {
+    windowQueryTest();
+  }
 }

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_1.e
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_1.e
@@ -1,0 +1,13 @@
+Austria	null	#de.wikipedia	1
+Republic of Korea	null	#en.wikipedia	2
+Republic of Korea	null	#ja.wikipedia	3
+Republic of Korea	null	#ko.wikipedia	4
+Republic of Korea	Seoul	#ko.wikipedia	1
+Austria	Vienna	#de.wikipedia	1
+Austria	Vienna	#es.wikipedia	2
+Austria	Vienna	#tr.wikipedia	3
+Republic of Korea	Jeonju	#ko.wikipedia	4
+Republic of Korea	Suwon-si	#ko.wikipedia	1
+Austria	Horsching	#de.wikipedia	1
+Republic of Korea	Seongnam-si	#ko.wikipedia	1
+Republic of Korea	Yongsan-dong	#ko.wikipedia	1

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_1.q
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_1.q
@@ -1,0 +1,6 @@
+select
+countryName, cityName, channel,
+row_number() over (partition by array[1,2,length(cityName)] order by countryName) as c
+from wikipedia
+where countryName in ('Austria', 'Republic of Korea')
+group by countryName, cityName, channel

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_2.e
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_2.e
@@ -1,0 +1,13 @@
+Austria	null	#de.wikipedia	1
+Austria	Horsching	#de.wikipedia	2
+Austria	Vienna	#de.wikipedia	3
+Austria	Vienna	#es.wikipedia	4
+Austria	Vienna	#tr.wikipedia	5
+Republic of Korea	null	#en.wikipedia	6
+Republic of Korea	null	#ja.wikipedia	7
+Republic of Korea	null	#ko.wikipedia	8
+Republic of Korea	Jeonju	#ko.wikipedia	9
+Republic of Korea	Seongnam-si	#ko.wikipedia	10
+Republic of Korea	Seoul	#ko.wikipedia	11
+Republic of Korea	Suwon-si	#ko.wikipedia	12
+Republic of Korea	Yongsan-dong	#ko.wikipedia	13

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_2.q
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_2.q
@@ -1,0 +1,6 @@
+select
+countryName, cityName, channel,
+row_number() over (partition by array[1,2,3] order by countryName) as c
+from wikipedia
+where countryName in ('Austria', 'Republic of Korea')
+group by countryName, cityName, channel

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_3.e
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_3.e
@@ -1,0 +1,13 @@
+Austria	null	#de.wikipedia	1
+Austria	Vienna	#de.wikipedia	1
+Austria	Vienna	#es.wikipedia	2
+Austria	Vienna	#tr.wikipedia	3
+Austria	Horsching	#de.wikipedia	1
+Republic of Korea	null	#en.wikipedia	1
+Republic of Korea	null	#ja.wikipedia	2
+Republic of Korea	null	#ko.wikipedia	3
+Republic of Korea	Seoul	#ko.wikipedia	1
+Republic of Korea	Jeonju	#ko.wikipedia	1
+Republic of Korea	Suwon-si	#ko.wikipedia	1
+Republic of Korea	Seongnam-si	#ko.wikipedia	1
+Republic of Korea	Yongsan-dong	#ko.wikipedia	1

--- a/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_3.q
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/partition_by_array/wikipedia_query_3.q
@@ -1,0 +1,6 @@
+select
+countryName, cityName, channel,
+row_number() over (partition by array[1,length(countryName),length(cityName)] order by countryName) as c
+from wikipedia
+where countryName in ('Austria', 'Republic of Korea')
+group by countryName, cityName, channel


### PR DESCRIPTION
### Description

Currently, queries like the following give incorrect results:
```sql
select countryName, cityName, channel, 
row_number() over (partition by array[1,2,length(cityName)] order by countryName) as c
from wikipedia
where countryName in ('Austria', 'Republic of Korea')
group by countryName, cityName, channel
```

This is because while calculating the partitioning boundaries, we use Objects.equals() to check the value for partition column. But it returns false when trying to compare [1,2,null] against [1,2,null] because of the presence of null value.

This PR changes the comparison logic to use NullableTypeStrategy for the column type.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
