### PR TITLE
Added an option to hide the workbench-view toolbar

### DIFF
--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -104,6 +104,7 @@ export interface WorkbenchViewProps {
   maxTaskMenuHeader?: JSX.Element;
   enginesLabelFn?: ComponentProps<typeof QueryTab>['enginesLabelFn'];
   maxTaskLabelFn?: ComponentProps<typeof QueryTab>['maxTaskLabelFn'];
+  hideToolbar?: boolean;
 }
 
 export interface WorkbenchViewState {
@@ -613,8 +614,9 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
   }
 
   private renderToolbar() {
-    const { queryEngines } = this.props;
+    const { queryEngines, hideToolbar } = this.props;
     if (!queryEngines.includes('sql-msq-task')) return;
+    if (hideToolbar) return;
 
     const { showRecentQueryTaskPanel } = this.state;
     return (


### PR DESCRIPTION
In the continuity of #16749, this makes it possible to hide those two buttons:
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/5c43bf32-8e6f-48d5-9892-5de83e3d4b35">
