### PR TITLE
ignore dependencies for github stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -52,7 +52,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: 'Evergreen,Security,Bug,Proposal,Design Review,Improvement,Performance,Refactoring,Apache,Area - Automation/Static Analysis,Area - Batch Indexing,Area - Cache,Area - Deep Storage,Area - Dependencies,Area - Dependency Injection,Area - Dev,Area - Documentation,Area - Extension,Area - Kafka/Kinesis Indexing,Area - Lookups,Area - Metadata,Area - Metrics/Event Emitting,Area - Null Handling,Area - Operations,Area - Query UI,Area - Querying,Area - Router,Area - Segment Balancing/Coordination,Area - Segment Format and Ser/De,Area - SQL,Area - Testing,Area - Web Console,Area - Zookeeper/Curator,Compatibility,Contributions Welcome,Development Blocker,Ease of Use,Error handling,HTTP,Incompatible,Stable API'
-          exempt-pr-labels: 'Evergreen'
+          exempt-pr-labels: 'Evergreen,Area - Dependencies'
           exempt-milestones: true
           exempt-assignees: true
           ascending: true


### PR DESCRIPTION
Modifies the stale action so that it ignores PRs with the 'Area -Dependencies' label which are typically opened by dependabot these days. We could certainly be better about getting these things merged, but right now when the stale action closes a dependabot PR, it does something like https://github.com/apache/druid/pull/16200#issuecomment-2246618957, which is kind of sad.