### PR TITLE
[Docs} Remove avro_ocf support from Kafka & Kinesis streaming sources (Revert changes from #11865)

### DIFF
--- a/docs/ingestion/kafka-ingestion.md
+++ b/docs/ingestion/kafka-ingestion.md
@@ -254,7 +254,6 @@ The Kinesis indexing service supports the following values for `inputFormat`:
 * `json`
 * `kafka`
 * `avro_stream`
-* `avro_ocf`
 * `protobuf`
 
 You can use `parser` to read [`thrift`](../development/extensions-contrib/thrift.md) formats.

--- a/docs/ingestion/kinesis-ingestion.md
+++ b/docs/ingestion/kinesis-ingestion.md
@@ -143,7 +143,6 @@ The Kinesis indexing service supports the following values for `inputFormat`:
 * `tvs`
 * `json`
 * `avro_stream`
-* `avro_ocf`
 * `protobuf`
 
 You can use `parser` to read [`thrift`](../development/extensions-contrib/thrift.md) formats.


### PR DESCRIPTION
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

Reverts changes to Kafka and Kinesis streaming ingestion docs that indicate Avro OCF streaming support.

This PR has:

- [ x] been self-reviewed.