### PR TITLE
Add task report fields in response of SQL statements endpoint

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -629,9 +629,20 @@ Retrieves information about the query associated with the given query ID. The re
   - `sizeInBytes`: the size of the page.
   - `id`: the page number that you can use to reference a specific page when you get query results.
 
+If the optional query parameter `detail` is supplied, then the response also includes the following:
+- A `stages` object that summarizes information about the different stages being used for query execution, such as stage number, phase, start time, duration, input and output information, processing methods, and partitioning.
+- A `counters` object that provides details on the rows, bytes, and files processed at various stages for each worker across different channels, along with sort progress.
+- A `warnings` object that provides details about any warnings.
+
 #### URL
 
 `GET` `/druid/v2/sql/statements/{queryId}`
+
+#### Query parameters
+* `detail` (optional)
+    * Type: Boolean
+    * Default: false
+    * Fetch additional details about the query, which includes the information about different stages, counters for each stage, and any warnings.
 
 #### Responses
 
@@ -672,7 +683,7 @@ The following example retrieves the status of a query with specified ID `query-9
 
 
 ```shell
-curl "http://ROUTER_IP:ROUTER_PORT/druid/v2/sql/statements/query-9b93f6f7-ab0e-48f5-986a-3520f84f0804"
+curl "http://ROUTER_IP:ROUTER_PORT/druid/v2/sql/statements/query-9b93f6f7-ab0e-48f5-986a-3520f84f0804?detail=true"
 ```
 
 </TabItem>
@@ -680,7 +691,7 @@ curl "http://ROUTER_IP:ROUTER_PORT/druid/v2/sql/statements/query-9b93f6f7-ab0e-4
 
 
 ```HTTP
-GET /druid/v2/sql/statements/query-9b93f6f7-ab0e-48f5-986a-3520f84f0804 HTTP/1.1
+GET /druid/v2/sql/statements/query-9b93f6f7-ab0e-48f5-986a-3520f84f0804?detail=true HTTP/1.1
 Host: http://ROUTER_IP:ROUTER_PORT
 ```
 
@@ -835,7 +846,422 @@ Host: http://ROUTER_IP:ROUTER_PORT
                 "sizeInBytes": 375
             }
         ]
-    }
+    },
+    "stages": [
+        {
+            "stageNumber": 0,
+            "definition": {
+                "id": "query-9b93f6f7-ab0e-48f5-986a-3520f84f0804_0",
+                "input": [
+                    {
+                        "type": "table",
+                        "dataSource": "wikipedia",
+                        "intervals": [
+                            "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
+                        ],
+                        "filter": {
+                            "type": "equals",
+                            "column": "user",
+                            "matchValueType": "STRING",
+                            "matchValue": "BlueMoon2662"
+                        },
+                        "filterFields": [
+                            "user"
+                        ]
+                    }
+                ],
+                "processor": {
+                    "type": "scan",
+                    "query": {
+                        "queryType": "scan",
+                        "dataSource": {
+                            "type": "inputNumber",
+                            "inputNumber": 0
+                        },
+                        "intervals": {
+                            "type": "intervals",
+                            "intervals": [
+                                "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
+                            ]
+                        },
+                        "virtualColumns": [
+                            {
+                                "type": "expression",
+                                "name": "v0",
+                                "expression": "'BlueMoon2662'",
+                                "outputType": "STRING"
+                            }
+                        ],
+                        "resultFormat": "compactedList",
+                        "limit": 1001,
+                        "filter": {
+                            "type": "equals",
+                            "column": "user",
+                            "matchValueType": "STRING",
+                            "matchValue": "BlueMoon2662"
+                        },
+                        "columns": [
+                            "__time",
+                            "added",
+                            "channel",
+                            "cityName",
+                            "comment",
+                            "commentLength",
+                            "countryIsoCode",
+                            "countryName",
+                            "deleted",
+                            "delta",
+                            "deltaBucket",
+                            "diffUrl",
+                            "flags",
+                            "isAnonymous",
+                            "isMinor",
+                            "isNew",
+                            "isRobot",
+                            "isUnpatrolled",
+                            "metroCode",
+                            "namespace",
+                            "page",
+                            "regionIsoCode",
+                            "regionName",
+                            "v0"
+                        ],
+                        "context": {
+                            "__resultFormat": "array",
+                            "__user": "allowAll",
+                            "enableWindowing": true,
+                            "executionMode": "async",
+                            "finalize": true,
+                            "maxNumTasks": 2,
+                            "maxParseExceptions": 0,
+                            "queryId": "33b53acb-7533-4880-a81b-51c16c489eab",
+                            "scanSignature": "[{\"name\":\"__time\",\"type\":\"LONG\"},{\"name\":\"added\",\"type\":\"LONG\"},{\"name\":\"channel\",\"type\":\"STRING\"},{\"name\":\"cityName\",\"type\":\"STRING\"},{\"name\":\"comment\",\"type\":\"STRING\"},{\"name\":\"commentLength\",\"type\":\"LONG\"},{\"name\":\"countryIsoCode\",\"type\":\"STRING\"},{\"name\":\"countryName\",\"type\":\"STRING\"},{\"name\":\"deleted\",\"type\":\"LONG\"},{\"name\":\"delta\",\"type\":\"LONG\"},{\"name\":\"deltaBucket\",\"type\":\"LONG\"},{\"name\":\"diffUrl\",\"type\":\"STRING\"},{\"name\":\"flags\",\"type\":\"STRING\"},{\"name\":\"isAnonymous\",\"type\":\"STRING\"},{\"name\":\"isMinor\",\"type\":\"STRING\"},{\"name\":\"isNew\",\"type\":\"STRING\"},{\"name\":\"isRobot\",\"type\":\"STRING\"},{\"name\":\"isUnpatrolled\",\"type\":\"STRING\"},{\"name\":\"metroCode\",\"type\":\"STRING\"},{\"name\":\"namespace\",\"type\":\"STRING\"},{\"name\":\"page\",\"type\":\"STRING\"},{\"name\":\"regionIsoCode\",\"type\":\"STRING\"},{\"name\":\"regionName\",\"type\":\"STRING\"},{\"name\":\"v0\",\"type\":\"STRING\"}]",
+                            "sqlOuterLimit": 1001,
+                            "sqlQueryId": "33b53acb-7533-4880-a81b-51c16c489eab",
+                            "sqlStringifyArrays": false
+                        },
+                        "columnTypes": [
+                            "LONG",
+                            "LONG",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "LONG",
+                            "STRING",
+                            "STRING",
+                            "LONG",
+                            "LONG",
+                            "LONG",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING",
+                            "STRING"
+                        ],
+                        "granularity": {
+                            "type": "all"
+                        },
+                        "legacy": false
+                    }
+                },
+                "signature": [
+                    {
+                        "name": "__boost",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "__time",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "added",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "channel",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "cityName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "commentLength",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "countryIsoCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "countryName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "deleted",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "delta",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "deltaBucket",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "diffUrl",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "flags",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isAnonymous",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isMinor",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isNew",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isRobot",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isUnpatrolled",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "metroCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "page",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "regionIsoCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "regionName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "v0",
+                        "type": "STRING"
+                    }
+                ],
+                "shuffleSpec": {
+                    "type": "mix"
+                },
+                "maxWorkerCount": 1
+            },
+            "phase": "FINISHED",
+            "workerCount": 1,
+            "partitionCount": 1,
+            "shuffle": "mix",
+            "output": "localStorage",
+            "startTime": "2024-07-31T15:20:21.255Z",
+            "duration": 103
+        },
+        {
+            "stageNumber": 1,
+            "definition": {
+                "id": "query-9b93f6f7-ab0e-48f5-986a-3520f84f0804_1",
+                "input": [
+                    {
+                        "type": "stage",
+                        "stage": 0
+                    }
+                ],
+                "processor": {
+                    "type": "limit",
+                    "limit": 1001
+                },
+                "signature": [
+                    {
+                        "name": "__boost",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "__time",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "added",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "channel",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "cityName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "comment",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "commentLength",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "countryIsoCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "countryName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "deleted",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "delta",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "deltaBucket",
+                        "type": "LONG"
+                    },
+                    {
+                        "name": "diffUrl",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "flags",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isAnonymous",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isMinor",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isNew",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isRobot",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "isUnpatrolled",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "metroCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "page",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "regionIsoCode",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "regionName",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "v0",
+                        "type": "STRING"
+                    }
+                ],
+                "shuffleSpec": {
+                    "type": "maxCount",
+                    "clusterBy": {
+                        "columns": [
+                            {
+                                "columnName": "__boost",
+                                "order": "ASCENDING"
+                            }
+                        ]
+                    },
+                    "partitions": 1
+                },
+                "maxWorkerCount": 1
+            },
+            "phase": "FINISHED",
+            "workerCount": 1,
+            "partitionCount": 1,
+            "shuffle": "globalSort",
+            "output": "localStorage",
+            "startTime": "2024-07-31T15:20:21.355Z",
+            "duration": 10,
+            "sort": true
+        }
+    ],
+    "counters": {
+        "0": {
+            "0": {
+                "input0": {
+                    "type": "channel",
+                    "rows": [
+                        24433
+                    ],
+                    "bytes": [
+                        7393933
+                    ],
+                    "files": [
+                        22
+                    ],
+                    "totalFiles": [
+                        22
+                    ]
+                }
+            }
+        },
+        "1": {
+            "0": {
+                "sortProgress": {
+                    "type": "sortProgress",
+                    "totalMergingLevels": -1,
+                    "levelToTotalBatches": {},
+                    "levelToMergedBatches": {},
+                    "totalMergersForUltimateLevel": -1,
+                    "triviallyComplete": true,
+                    "progressDigest": 1
+                }
+            }
+        }
+    },
+    "warnings": []
 }
   ```
 </details>

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
@@ -121,7 +121,9 @@ public class CounterSnapshotsTree
     }
     CounterSnapshotsTree that = (CounterSnapshotsTree) o;
     synchronized (snapshotsMap) {
-      return Objects.equals(snapshotsMap, that.snapshotsMap);
+      synchronized (that.snapshotsMap) {
+        return Objects.equals(snapshotsMap, that.snapshotsMap);
+      }
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
@@ -28,6 +28,7 @@ import org.apache.druid.msq.exec.ControllerClient;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Tree of {@link CounterSnapshots} (named counter snapshots) organized by stage and worker.
@@ -106,6 +107,39 @@ public class CounterSnapshotsTree
           put(stageEntry.getKey(), workerEntry.getKey(), workerEntry.getValue());
         }
       }
+    }
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CounterSnapshotsTree that = (CounterSnapshotsTree) o;
+    synchronized (snapshotsMap) {
+      return Objects.equals(snapshotsMap, that.snapshotsMap);
+    }
+  }
+
+  @Override
+  public int hashCode()
+  {
+    synchronized (snapshotsMap) {
+      return Objects.hashCode(snapshotsMap);
+    }
+  }
+
+  @Override
+  public String toString()
+  {
+    synchronized (snapshotsMap) {
+      return "CounterSnapshotsTree{" +
+             "snapshotsMap=" + snapshotsMap +
+             '}';
     }
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/counters/CounterSnapshotsTree.java
@@ -28,7 +28,6 @@ import org.apache.druid.msq.exec.ControllerClient;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Tree of {@link CounterSnapshots} (named counter snapshots) organized by stage and worker.
@@ -107,31 +106,6 @@ public class CounterSnapshotsTree
           put(stageEntry.getKey(), workerEntry.getKey(), workerEntry.getValue());
         }
       }
-    }
-  }
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    CounterSnapshotsTree that = (CounterSnapshotsTree) o;
-    synchronized (snapshotsMap) {
-      synchronized (that.snapshotsMap) {
-        return Objects.equals(snapshotsMap, that.snapshotsMap);
-      }
-    }
-  }
-
-  @Override
-  public int hashCode()
-  {
-    synchronized (snapshotsMap) {
-      return Objects.hashCode(snapshotsMap);
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.error.ErrorResponse;
 import org.apache.druid.msq.counters.CounterSnapshotsTree;
+import org.apache.druid.msq.indexing.error.MSQErrorReport;
 import org.apache.druid.msq.indexing.report.MSQStagesReport;
 import org.apache.druid.msq.sql.SqlStatementState;
 import org.joda.time.DateTime;
@@ -59,6 +60,9 @@ public class SqlStatementResult
   @Nullable
   private final CounterSnapshotsTree counters;
 
+  @Nullable
+  private final List<MSQErrorReport> warnings;
+
   public SqlStatementResult(
       String queryId,
       SqlStatementState state,
@@ -69,7 +73,7 @@ public class SqlStatementResult
       ErrorResponse errorResponse
   )
   {
-    this(queryId, state, createdAt, sqlRowSignature, durationMs, resultSetInformation, errorResponse, null, null);
+    this(queryId, state, createdAt, sqlRowSignature, durationMs, resultSetInformation, errorResponse, null, null, null);
   }
 
   @JsonCreator
@@ -91,7 +95,9 @@ public class SqlStatementResult
       @Nullable @JsonProperty("stages")
       MSQStagesReport stages,
       @Nullable @JsonProperty("counters")
-      CounterSnapshotsTree counters
+      CounterSnapshotsTree counters,
+      @Nullable @JsonProperty("warnings")
+      List<MSQErrorReport> warnings
   )
   {
     this.queryId = queryId;
@@ -103,6 +109,7 @@ public class SqlStatementResult
     this.errorResponse = errorResponse;
     this.stages = stages;
     this.counters = counters;
+    this.warnings = warnings;
   }
 
   @JsonProperty
@@ -171,6 +178,13 @@ public class SqlStatementResult
     return counters;
   }
 
+  @JsonProperty("warnings")
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public List<MSQErrorReport> getWarnings()
+  {
+    return warnings;
+  }
 
   @Override
   public boolean equals(Object o)
@@ -191,7 +205,10 @@ public class SqlStatementResult
     ) && Objects.equals(resultSetInformation, that.resultSetInformation) && Objects.equals(
         errorResponse == null ? null : errorResponse.getAsMap(),
         that.errorResponse == null ? null : that.errorResponse.getAsMap()
-    ) && Objects.equals(stages, that.stages) && Objects.equals(counters, that.counters);
+    ) && Objects.equals(stages, that.stages) && Objects.equals(counters, that.counters) && Objects.equals(
+        warnings,
+        that.warnings
+    );
   }
 
   @Override
@@ -206,7 +223,8 @@ public class SqlStatementResult
         resultSetInformation,
         errorResponse == null ? null : errorResponse.getAsMap(),
         stages,
-        counters
+        counters,
+        warnings
     );
   }
 
@@ -225,6 +243,7 @@ public class SqlStatementResult
                                  : errorResponse.getAsMap().toString()) +
            ", stages=" + stages +
            ", counters=" + counters +
+           ", warnings=" + warnings +
            '}';
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
@@ -31,6 +31,7 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Objects;
 
 public class SqlStatementResult
 {
@@ -183,6 +184,51 @@ public class SqlStatementResult
   public List<MSQErrorReport> getWarnings()
   {
     return warnings;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SqlStatementResult that = (SqlStatementResult) o;
+    return Objects.equals(queryId, that.queryId) && state == that.state && Objects.equals(
+        createdAt,
+        that.createdAt
+    ) && Objects.equals(sqlRowSignature, that.sqlRowSignature) && Objects.equals(
+        durationMs,
+        that.durationMs
+    ) && Objects.equals(resultSetInformation, that.resultSetInformation) && Objects.equals(
+        errorResponse == null ? null : errorResponse.getAsMap(),
+        that.errorResponse == null ? null : that.errorResponse.getAsMap()
+    ) && Objects.equals(stages, that.stages) && Objects.equals(
+        counters == null ? null : counters.toString(),
+        that.counters == null ? null : that.counters.toString()
+    ) && Objects.equals(
+        warnings,
+        that.warnings
+    );
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(
+        queryId,
+        state,
+        createdAt,
+        sqlRowSignature,
+        durationMs,
+        resultSetInformation,
+        errorResponse == null ? null : errorResponse.getAsMap(),
+        stages,
+        counters == null ? null : counters.toString(),
+        warnings
+    );
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
@@ -31,7 +31,6 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 public class SqlStatementResult
 {
@@ -184,51 +183,6 @@ public class SqlStatementResult
   public List<MSQErrorReport> getWarnings()
   {
     return warnings;
-  }
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    SqlStatementResult that = (SqlStatementResult) o;
-    return Objects.equals(queryId, that.queryId) && state == that.state && Objects.equals(
-        createdAt,
-        that.createdAt
-    ) && Objects.equals(sqlRowSignature, that.sqlRowSignature) && Objects.equals(
-        durationMs,
-        that.durationMs
-    ) && Objects.equals(resultSetInformation, that.resultSetInformation) && Objects.equals(
-        errorResponse == null ? null : errorResponse.getAsMap(),
-        that.errorResponse == null ? null : that.errorResponse.getAsMap()
-    ) && Objects.equals(stages, that.stages) && Objects.equals(
-        counters == null ? null : counters.toString(),
-        that.counters == null ? null : that.counters.toString()
-    ) && Objects.equals(
-        warnings,
-        that.warnings
-    );
-  }
-
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(
-        queryId,
-        state,
-        createdAt,
-        sqlRowSignature,
-        durationMs,
-        resultSetInformation,
-        errorResponse == null ? null : errorResponse.getAsMap(),
-        stages,
-        counters == null ? null : counters.toString(),
-        warnings
-    );
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.error.ErrorResponse;
+import org.apache.druid.msq.counters.CounterSnapshotsTree;
+import org.apache.druid.msq.indexing.report.MSQStagesReport;
 import org.apache.druid.msq.sql.SqlStatementState;
 import org.joda.time.DateTime;
 
@@ -51,6 +53,24 @@ public class SqlStatementResult
   @Nullable
   private final ErrorResponse errorResponse;
 
+  @Nullable
+  private final MSQStagesReport stages;
+
+  @Nullable
+  private final CounterSnapshotsTree counters;
+
+  public SqlStatementResult(
+      String queryId,
+      SqlStatementState state,
+      DateTime createdAt,
+      List<ColumnNameAndTypes> sqlRowSignature,
+      Long durationMs,
+      ResultSetInformation resultSetInformation,
+      ErrorResponse errorResponse
+  )
+  {
+    this(queryId, state, createdAt, sqlRowSignature, durationMs, resultSetInformation, errorResponse, null, null);
+  }
 
   @JsonCreator
   public SqlStatementResult(
@@ -67,8 +87,11 @@ public class SqlStatementResult
       @Nullable @JsonProperty("result")
       ResultSetInformation resultSetInformation,
       @Nullable @JsonProperty("errorDetails")
-      ErrorResponse errorResponse
-
+      ErrorResponse errorResponse,
+      @Nullable @JsonProperty("stages")
+      MSQStagesReport stages,
+      @Nullable @JsonProperty("counters")
+      CounterSnapshotsTree counters
   )
   {
     this.queryId = queryId;
@@ -78,6 +101,8 @@ public class SqlStatementResult
     this.durationMs = durationMs;
     this.resultSetInformation = resultSetInformation;
     this.errorResponse = errorResponse;
+    this.stages = stages;
+    this.counters = counters;
   }
 
   @JsonProperty
@@ -130,6 +155,22 @@ public class SqlStatementResult
     return errorResponse;
   }
 
+  @JsonProperty("stages")
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public MSQStagesReport getStages()
+  {
+    return stages;
+  }
+
+  @JsonProperty("counters")
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public CounterSnapshotsTree getCounters()
+  {
+    return counters;
+  }
+
 
   @Override
   public boolean equals(Object o)
@@ -150,7 +191,7 @@ public class SqlStatementResult
     ) && Objects.equals(resultSetInformation, that.resultSetInformation) && Objects.equals(
         errorResponse == null ? null : errorResponse.getAsMap(),
         that.errorResponse == null ? null : that.errorResponse.getAsMap()
-    );
+    ) && Objects.equals(stages, that.stages) && Objects.equals(counters, that.counters);
   }
 
   @Override
@@ -163,7 +204,9 @@ public class SqlStatementResult
         sqlRowSignature,
         durationMs,
         resultSetInformation,
-        errorResponse == null ? null : errorResponse.getAsMap()
+        errorResponse == null ? null : errorResponse.getAsMap(),
+        stages,
+        counters
     );
   }
 
@@ -180,6 +223,8 @@ public class SqlStatementResult
            ", errorResponse=" + (errorResponse == null
                                  ? "{}"
                                  : errorResponse.getAsMap().toString()) +
+           ", stages=" + stages +
+           ", counters=" + counters +
            '}';
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/entity/SqlStatementResult.java
@@ -31,7 +31,6 @@ import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 
 public class SqlStatementResult
 {
@@ -184,48 +183,6 @@ public class SqlStatementResult
   public List<MSQErrorReport> getWarnings()
   {
     return warnings;
-  }
-
-  @Override
-  public boolean equals(Object o)
-  {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    SqlStatementResult that = (SqlStatementResult) o;
-    return Objects.equals(queryId, that.queryId) && state == that.state && Objects.equals(
-        createdAt,
-        that.createdAt
-    ) && Objects.equals(sqlRowSignature, that.sqlRowSignature) && Objects.equals(
-        durationMs,
-        that.durationMs
-    ) && Objects.equals(resultSetInformation, that.resultSetInformation) && Objects.equals(
-        errorResponse == null ? null : errorResponse.getAsMap(),
-        that.errorResponse == null ? null : that.errorResponse.getAsMap()
-    ) && Objects.equals(stages, that.stages) && Objects.equals(counters, that.counters) && Objects.equals(
-        warnings,
-        that.warnings
-    );
-  }
-
-  @Override
-  public int hashCode()
-  {
-    return Objects.hash(
-        queryId,
-        state,
-        createdAt,
-        sqlRowSignature,
-        durationMs,
-        resultSetInformation,
-        errorResponse == null ? null : errorResponse.getAsMap(),
-        stages,
-        counters,
-        warnings
-    );
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -587,9 +587,9 @@ public class SqlStatementResource
     MSQControllerTask msqControllerTask = getMSQControllerTaskAndCheckPermission(queryId, authenticationResult, forAction);
     SqlStatementState sqlStatementState = SqlStatementResourceHelper.getSqlStatementState(statusPlus);
 
-    MSQTaskReportPayload msqTaskReportPayload = null;
+    Optional<MSQTaskReportPayload> msqTaskReportPayload = Optional.empty();
     try {
-      msqTaskReportPayload = SqlStatementResourceHelper.getPayload(contactOverlord(overlordClient.taskReportAsMap(queryId), queryId));
+      msqTaskReportPayload = Optional.ofNullable(SqlStatementResourceHelper.getPayload(contactOverlord(overlordClient.taskReportAsMap(queryId), queryId)));
     }
     catch (DruidException e) {
       if (!e.getErrorCode().equals("notFound")) {
@@ -603,7 +603,7 @@ public class SqlStatementResource
           taskResponse,
           statusPlus,
           sqlStatementState,
-          msqTaskReportPayload,
+          msqTaskReportPayload.orElse(null),
           jsonMapper,
           detail
       );
@@ -622,9 +622,9 @@ public class SqlStatementResource
               msqControllerTask.getQuerySpec().getDestination()
           ).orElse(null) : null,
           null,
-          detail ? SqlStatementResourceHelper.getQueryStagesReport(msqTaskReportPayload) : null,
-          detail ? SqlStatementResourceHelper.getQueryCounters(msqTaskReportPayload) : null,
-          detail ? SqlStatementResourceHelper.getQueryWarningDetails(msqTaskReportPayload) : null
+          detail ? SqlStatementResourceHelper.getQueryStagesReport(msqTaskReportPayload.orElse(null)) : null,
+          detail ? SqlStatementResourceHelper.getQueryCounters(msqTaskReportPayload.orElse(null)) : null,
+          detail ? SqlStatementResourceHelper.getQueryWarningDetails(msqTaskReportPayload.orElse(null)) : null
       ));
     }
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/SqlStatementResourceHelper.java
@@ -360,7 +360,7 @@ public class SqlStatementResourceHelper
   }
 
   @Nullable
-  public static MSQStagesReport.Stage getFinalStage(MSQTaskReportPayload msqTaskReportPayload)
+  public static MSQStagesReport.Stage getFinalStage(@Nullable MSQTaskReportPayload msqTaskReportPayload)
   {
     if (msqTaskReportPayload == null || msqTaskReportPayload.getStages().getStages() == null) {
       return null;
@@ -376,25 +376,25 @@ public class SqlStatementResourceHelper
   }
 
   @Nullable
-  private static MSQErrorReport getQueryExceptionDetails(MSQTaskReportPayload payload)
+  private static MSQErrorReport getQueryExceptionDetails(@Nullable MSQTaskReportPayload payload)
   {
     return payload == null ? null : payload.getStatus().getErrorReport();
   }
 
   @Nullable
-  public static List<MSQErrorReport> getQueryWarningDetails(MSQTaskReportPayload payload)
+  public static List<MSQErrorReport> getQueryWarningDetails(@Nullable MSQTaskReportPayload payload)
   {
     return payload == null ? null : new ArrayList<>(payload.getStatus().getWarningReports());
   }
 
   @Nullable
-  public static MSQStagesReport getQueryStagesReport(MSQTaskReportPayload payload)
+  public static MSQStagesReport getQueryStagesReport(@Nullable MSQTaskReportPayload payload)
   {
     return payload == null ? null : payload.getStages();
   }
 
   @Nullable
-  public static CounterSnapshotsTree getQueryCounters(MSQTaskReportPayload payload)
+  public static CounterSnapshotsTree getQueryCounters(@Nullable MSQTaskReportPayload payload)
   {
     return payload == null ? null : payload.getCounters();
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
@@ -87,7 +87,9 @@ public class SqlStatementResultTest
         + " sqlRowSignature=[ColumnNameAndTypes{colName='_time', sqlTypeName='TIMESTAMP', nativeTypeName='LONG'}, ColumnNameAndTypes{colName='alias', sqlTypeName='VARCHAR', nativeTypeName='STRING'}, ColumnNameAndTypes{colName='market', sqlTypeName='VARCHAR', nativeTypeName='STRING'}],"
         + " durationInMs=100,"
         + " resultSetInformation=ResultSetInformation{numTotalRows=1, totalSizeInBytes=1, resultFormat=object, records=null, dataSource='ds', pages=[PageInformation{id=0, numRows=null, sizeInBytes=1, worker=null, partition=null}]},"
-        + " errorResponse={error=druidException, errorCode=QueryNotSupported, persona=USER, category=UNCATEGORIZED, errorMessage=QueryNotSupported, context={}}}",
+        + " errorResponse={error=druidException, errorCode=QueryNotSupported, persona=USER, category=UNCATEGORIZED, errorMessage=QueryNotSupported, context={}},"
+        + " stages=null,"
+        + " counters=null}",
         SQL_STATEMENT_RESULT.toString()
     );
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
@@ -89,7 +89,8 @@ public class SqlStatementResultTest
         + " resultSetInformation=ResultSetInformation{numTotalRows=1, totalSizeInBytes=1, resultFormat=object, records=null, dataSource='ds', pages=[PageInformation{id=0, numRows=null, sizeInBytes=1, worker=null, partition=null}]},"
         + " errorResponse={error=druidException, errorCode=QueryNotSupported, persona=USER, category=UNCATEGORIZED, errorMessage=QueryNotSupported, context={}},"
         + " stages=null,"
-        + " counters=null}",
+        + " counters=null,"
+        + " warnings=null}",
         SQL_STATEMENT_RESULT.toString()
     );
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
@@ -72,14 +72,6 @@ public class SqlStatementResultTest
 
     Assert.assertEquals(JSON_STRING, MAPPER.writeValueAsString(SQL_STATEMENT_RESULT));
     Assert.assertEquals(
-        SQL_STATEMENT_RESULT,
-        MAPPER.readValue(MAPPER.writeValueAsString(SQL_STATEMENT_RESULT), SqlStatementResult.class)
-    );
-    Assert.assertEquals(
-        SQL_STATEMENT_RESULT.hashCode(),
-        MAPPER.readValue(MAPPER.writeValueAsString(SQL_STATEMENT_RESULT), SqlStatementResult.class).hashCode()
-    );
-    Assert.assertEquals(
         "SqlStatementResult{"
         + "queryId='q1',"
         + " state=RUNNING,"

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/entity/SqlStatementResultTest.java
@@ -72,6 +72,14 @@ public class SqlStatementResultTest
 
     Assert.assertEquals(JSON_STRING, MAPPER.writeValueAsString(SQL_STATEMENT_RESULT));
     Assert.assertEquals(
+        SQL_STATEMENT_RESULT,
+        MAPPER.readValue(MAPPER.writeValueAsString(SQL_STATEMENT_RESULT), SqlStatementResult.class)
+    );
+    Assert.assertEquals(
+        SQL_STATEMENT_RESULT.hashCode(),
+        MAPPER.readValue(MAPPER.writeValueAsString(SQL_STATEMENT_RESULT), SqlStatementResult.class).hashCode()
+    );
+    Assert.assertEquals(
         "SqlStatementResult{"
         + "queryId='q1',"
         + " state=RUNNING,"

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -689,7 +689,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     );
     Assert.assertEquals(expected, actual);
 
-    Response getResponse = resource.doGetStatus(actual.getQueryId(), SqlStatementResourceTest.makeOkRequest());
+    Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
     Assert.assertEquals(expected, getResponse.getEntity());
 
@@ -732,7 +732,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     );
     Assert.assertEquals(expected, actual);
 
-    Response getResponse = resource.doGetStatus(actual.getQueryId(), SqlStatementResourceTest.makeOkRequest());
+    Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
     Assert.assertEquals(expected, getResponse.getEntity());
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -206,7 +206,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(0L, 0L, null, "foo1", null, null),
         null
     );
-    assertSqlStatementResult(expected, actual);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test
@@ -236,7 +236,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(0L, 0L, null, "foo1", null, null),
         null
     );
-    assertSqlStatementResult(expected, actual);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test
@@ -282,7 +282,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
           }
         }).toErrorResponse()
     );
-    assertSqlStatementResult(expected, actual);
+    Assert.assertEquals(expected, actual);
   }
 
   @Test
@@ -687,11 +687,11 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(NullHandling.sqlCompatible() ? 6L : 5L, 0L, null, "foo1", null, null),
         null
     );
-    assertSqlStatementResult(expected, actual);
+    Assert.assertEquals(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
-    assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
+    Assert.assertEquals(expected, getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
@@ -730,11 +730,11 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(NullHandling.sqlCompatible() ? 6L : 5L, 0L, null, "foo1", null, null),
         null
     );
-    assertSqlStatementResult(expected, actual);
+    Assert.assertEquals(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
-    assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
+    Assert.assertEquals(expected, getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
@@ -754,27 +754,4 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     return context;
   }
 
-  private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
-  {
-    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
-    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
-    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
-    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
-    Assert.assertEquals(expected.getStages(), actual.getStages());
-    Assert.assertEquals(expected.getState(), actual.getState());
-    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
-    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
-
-    if (actual.getCounters() == null || expected.getCounters() == null) {
-      Assert.assertEquals(expected.getCounters(), actual.getCounters());
-    } else {
-      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
-    }
-
-    if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
-      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
-    } else {
-      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
-    }
-  }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -206,7 +206,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(0L, 0L, null, "foo1", null, null),
         null
     );
-    Assert.assertEquals(expected, actual);
+    assertSqlStatementResult(expected, actual);
   }
 
   @Test
@@ -236,7 +236,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(0L, 0L, null, "foo1", null, null),
         null
     );
-    Assert.assertEquals(expected, actual);
+    assertSqlStatementResult(expected, actual);
   }
 
   @Test
@@ -282,7 +282,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
           }
         }).toErrorResponse()
     );
-    Assert.assertEquals(expected, actual);
+    assertSqlStatementResult(expected, actual);
   }
 
   @Test
@@ -687,11 +687,11 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(NullHandling.sqlCompatible() ? 6L : 5L, 0L, null, "foo1", null, null),
         null
     );
-    Assert.assertEquals(expected, actual);
+    assertSqlStatementResult(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
-    Assert.assertEquals(expected, getResponse.getEntity());
+    assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
@@ -730,11 +730,11 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         new ResultSetInformation(NullHandling.sqlCompatible() ? 6L : 5L, 0L, null, "foo1", null, null),
         null
     );
-    Assert.assertEquals(expected, actual);
+    assertSqlStatementResult(expected, actual);
 
     Response getResponse = resource.doGetStatus(actual.getQueryId(), false, SqlStatementResourceTest.makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), getResponse.getStatus());
-    Assert.assertEquals(expected, getResponse.getEntity());
+    assertSqlStatementResult(expected, (SqlStatementResult) getResponse.getEntity());
 
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
@@ -754,4 +754,27 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     return context;
   }
 
+  private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
+  {
+    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
+    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
+    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
+    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
+    Assert.assertEquals(expected.getStages(), actual.getStages());
+    Assert.assertEquals(expected.getState(), actual.getState());
+    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
+    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
+
+    if (actual.getCounters() == null || expected.getCounters() == null) {
+      Assert.assertEquals(expected.getCounters(), actual.getCounters());
+    } else {
+      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
+    }
+
+    if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
+      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
+    } else {
+      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
+    }
+  }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -701,7 +701,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(ACCEPTED_SELECT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertSqlStatementResult(
+    Assert.assertEquals(
         new SqlStatementResult(
             ACCEPTED_SELECT_MSQ_QUERY,
             SqlStatementState.ACCEPTED,
@@ -711,7 +711,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        (SqlStatementResult) response.getEntity()
+        response.getEntity()
     );
 
     assertExceptionMessage(
@@ -735,7 +735,7 @@ public class SqlStatementResourceTest extends MSQTestBase
 
     Response response = resource.doGetStatus(RUNNING_SELECT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertSqlStatementResult(
+    Assert.assertEquals(
         new SqlStatementResult(
             RUNNING_SELECT_MSQ_QUERY,
             SqlStatementState.RUNNING,
@@ -745,7 +745,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        (SqlStatementResult) response.getEntity()
+        response.getEntity()
     );
 
     assertExceptionMessage(
@@ -782,9 +782,9 @@ public class SqlStatementResourceTest extends MSQTestBase
         new ArrayList<>(selectTaskReport.get().getPayload().getStatus().getWarningReports())
     );
 
-    assertSqlStatementResult(
+    Assert.assertEquals(
         expectedSqlStatementResult,
-        (SqlStatementResult) response.getEntity()
+        response.getEntity()
     );
 
     Assert.assertEquals(
@@ -886,7 +886,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(FINISHED_INSERT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertSqlStatementResult(new SqlStatementResult(
+    Assert.assertEquals(new SqlStatementResult(
         FINISHED_INSERT_MSQ_QUERY,
         SqlStatementState.SUCCESS,
         CREATED_TIME,
@@ -894,7 +894,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         100L,
         new ResultSetInformation(null, null, null, "test", null, null),
         null
-    ), (SqlStatementResult) response.getEntity());
+    ), response.getEntity());
 
     Assert.assertEquals(
         Response.Status.OK.getStatusCode(),
@@ -926,7 +926,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(ACCEPTED_INSERT_MSQ_TASK, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertSqlStatementResult(
+    Assert.assertEquals(
         new SqlStatementResult(
             ACCEPTED_INSERT_MSQ_TASK,
             SqlStatementState.ACCEPTED,
@@ -936,7 +936,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        (SqlStatementResult) response.getEntity()
+        response.getEntity()
     );
 
     assertExceptionMessage(
@@ -959,7 +959,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(RUNNING_INSERT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    assertSqlStatementResult(
+    Assert.assertEquals(
         new SqlStatementResult(
             RUNNING_INSERT_MSQ_QUERY,
             SqlStatementState.RUNNING,
@@ -969,7 +969,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        (SqlStatementResult) response.getEntity()
+        response.getEntity()
     );
 
     assertExceptionMessage(
@@ -1167,29 +1167,5 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testIsEnabled()
   {
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resource.isEnabled(makeOkRequest()).getStatus());
-  }
-
-  private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
-  {
-    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
-    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
-    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
-    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
-    Assert.assertEquals(expected.getStages(), actual.getStages());
-    Assert.assertEquals(expected.getState(), actual.getState());
-    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
-    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
-
-    if (actual.getCounters() == null || expected.getCounters() == null) {
-      Assert.assertEquals(expected.getCounters(), actual.getCounters());
-    } else {
-      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
-    }
-
-    if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
-      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
-    } else {
-      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
-    }
   }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -701,7 +701,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(ACCEPTED_SELECT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(
+    assertSqlStatementResult(
         new SqlStatementResult(
             ACCEPTED_SELECT_MSQ_QUERY,
             SqlStatementState.ACCEPTED,
@@ -711,7 +711,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        response.getEntity()
+        (SqlStatementResult) response.getEntity()
     );
 
     assertExceptionMessage(
@@ -735,7 +735,7 @@ public class SqlStatementResourceTest extends MSQTestBase
 
     Response response = resource.doGetStatus(RUNNING_SELECT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(
+    assertSqlStatementResult(
         new SqlStatementResult(
             RUNNING_SELECT_MSQ_QUERY,
             SqlStatementState.RUNNING,
@@ -745,7 +745,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        response.getEntity()
+        (SqlStatementResult) response.getEntity()
     );
 
     assertExceptionMessage(
@@ -782,9 +782,9 @@ public class SqlStatementResourceTest extends MSQTestBase
         new ArrayList<>(selectTaskReport.get().getPayload().getStatus().getWarningReports())
     );
 
-    Assert.assertEquals(
+    assertSqlStatementResult(
         expectedSqlStatementResult,
-        response.getEntity()
+        (SqlStatementResult) response.getEntity()
     );
 
     Assert.assertEquals(
@@ -886,7 +886,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(FINISHED_INSERT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(new SqlStatementResult(
+    assertSqlStatementResult(new SqlStatementResult(
         FINISHED_INSERT_MSQ_QUERY,
         SqlStatementState.SUCCESS,
         CREATED_TIME,
@@ -894,7 +894,7 @@ public class SqlStatementResourceTest extends MSQTestBase
         100L,
         new ResultSetInformation(null, null, null, "test", null, null),
         null
-    ), response.getEntity());
+    ), (SqlStatementResult) response.getEntity());
 
     Assert.assertEquals(
         Response.Status.OK.getStatusCode(),
@@ -926,7 +926,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(ACCEPTED_INSERT_MSQ_TASK, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(
+    assertSqlStatementResult(
         new SqlStatementResult(
             ACCEPTED_INSERT_MSQ_TASK,
             SqlStatementState.ACCEPTED,
@@ -936,7 +936,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        response.getEntity()
+        (SqlStatementResult) response.getEntity()
     );
 
     assertExceptionMessage(
@@ -959,7 +959,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   {
     Response response = resource.doGetStatus(RUNNING_INSERT_MSQ_QUERY, false, makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(
+    assertSqlStatementResult(
         new SqlStatementResult(
             RUNNING_INSERT_MSQ_QUERY,
             SqlStatementState.RUNNING,
@@ -969,7 +969,7 @@ public class SqlStatementResourceTest extends MSQTestBase
             null,
             null
         ),
-        response.getEntity()
+        (SqlStatementResult) response.getEntity()
     );
 
     assertExceptionMessage(
@@ -1167,5 +1167,29 @@ public class SqlStatementResourceTest extends MSQTestBase
   public void testIsEnabled()
   {
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resource.isEnabled(makeOkRequest()).getStatus());
+  }
+
+  private void assertSqlStatementResult(SqlStatementResult expected, SqlStatementResult actual)
+  {
+    Assert.assertEquals(expected.getQueryId(), actual.getQueryId());
+    Assert.assertEquals(expected.getCreatedAt(), actual.getCreatedAt());
+    Assert.assertEquals(expected.getSqlRowSignature(), actual.getSqlRowSignature());
+    Assert.assertEquals(expected.getDurationMs(), actual.getDurationMs());
+    Assert.assertEquals(expected.getStages(), actual.getStages());
+    Assert.assertEquals(expected.getState(), actual.getState());
+    Assert.assertEquals(expected.getWarnings(), actual.getWarnings());
+    Assert.assertEquals(expected.getResultSetInformation(), actual.getResultSetInformation());
+
+    if (actual.getCounters() == null || expected.getCounters() == null) {
+      Assert.assertEquals(expected.getCounters(), actual.getCounters());
+    } else {
+      Assert.assertEquals(expected.getCounters().toString(), actual.getCounters().toString());
+    }
+
+    if (actual.getErrorResponse() == null || expected.getErrorResponse() == null) {
+      Assert.assertEquals(expected.getErrorResponse(), actual.getErrorResponse());
+    } else {
+      Assert.assertEquals(expected.getErrorResponse().getAsMap(), actual.getErrorResponse().getAsMap());
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR adds an optional query param `detail` to `/v2/sql/statements/query-id` endpoint.

As per offline discussion with @vogievetsky, the PR adds 3 additional fields to the API response when `detail=true` is passed:
1. `stages`: Stages for the query from MSQ task report
2. `counters`: Stage counters for the query from MSQ task report
3. `warnings`: Warning reports for the query from MSQ task report

This is to allow us to have a single API that returns the status and task report for MSQ queries.

<details>
<summary>Sample API response when detail=true is passed</summary>
<br>

```json
{
  "queryId": "query-db88b7ba-7c1e-4eb1-b553-3076b0284365",
  "state": "SUCCESS",
  "createdAt": "2024-07-26T18:38:22.855Z",
  "schema": [
    {
      "name": "__time",
      "type": "TIMESTAMP",
      "nativeType": "LONG"
    },
    {
      "name": "name",
      "type": "VARCHAR",
      "nativeType": "STRING"
    },
    {
      "name": "rollNumber",
      "type": "BIGINT",
      "nativeType": "LONG"
    },
    {
      "name": "country",
      "type": "VARCHAR",
      "nativeType": "STRING"
    },
    {
      "name": "age",
      "type": "BIGINT",
      "nativeType": "LONG"
    },
    {
      "name": "grade",
      "type": "VARCHAR",
      "nativeType": "STRING"
    }
  ],
  "durationMs": 1656,
  "result": {
    "numTotalRows": 6,
    "totalSizeInBytes": 701,
    "dataSource": "__query_select",
    "sampleRecords": [
      [
        1442278018771,
        "Ankit Singh",
        6,
        "India",
        26,
        "E"
      ],
      [
        1442018818771,
        "Adarsh",
        1,
        "India",
        20,
        "A"
      ],
      [
        1442191618771,
        "Amit",
        4,
        "India",
        26,
        "C"
      ],
      [
        1442105218771,
        "Akshat",
        3,
        "India",
        24,
        "A"
      ],
      [
        1442191618771,
        "Ankit Kumar",
        5,
        "India",
        26,
        "D"
      ],
      [
        1442018818771,
        "Ajith",
        2,
        "India",
        22,
        "B"
      ]
    ],
    "pages": [
      {
        "id": 0,
        "numRows": 6,
        "sizeInBytes": 701
      }
    ]
  },
  "stages": [
    {
      "stageNumber": 0,
      "definition": {
        "id": "query-db88b7ba-7c1e-4eb1-b553-3076b0284365_0",
        "input": [
          {
            "type": "table",
            "dataSource": "roll_number_datasource",
            "intervals": [
              "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
            ]
          }
        ],
        "processor": {
          "type": "scan",
          "query": {
            "queryType": "scan",
            "dataSource": {
              "type": "inputNumber",
              "inputNumber": 0
            },
            "intervals": {
              "type": "intervals",
              "intervals": [
                "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z"
              ]
            },
            "resultFormat": "compactedList",
            "limit": 1001,
            "columns": [
              "__time",
              "age",
              "country",
              "grade",
              "name",
              "rollNumber"
            ],
            "context": {
              "__resultFormat": "array",
              "__user": "allowAll",
              "enableWindowing": true,
              "executionMode": "async",
              "finalize": true,
              "maxNumTasks": 3,
              "maxParseExceptions": 0,
              "queryId": "db88b7ba-7c1e-4eb1-b553-3076b0284365",
              "scanSignature": "[{\"name\":\"__time\",\"type\":\"LONG\"},{\"name\":\"age\",\"type\":\"LONG\"},{\"name\":\"country\",\"type\":\"STRING\"},{\"name\":\"grade\",\"type\":\"STRING\"},{\"name\":\"name\",\"type\":\"STRING\"},{\"name\":\"rollNumber\",\"type\":\"LONG\"}]",
              "sqlOuterLimit": 1001,
              "sqlQueryId": "db88b7ba-7c1e-4eb1-b553-3076b0284365",
              "sqlStringifyArrays": false
            },
            "columnTypes": [
              "LONG",
              "LONG",
              "STRING",
              "STRING",
              "STRING",
              "LONG"
            ],
            "granularity": {
              "type": "all"
            },
            "legacy": false
          }
        },
        "signature": [
          {
            "name": "__boost",
            "type": "LONG"
          },
          {
            "name": "__time",
            "type": "LONG"
          },
          {
            "name": "age",
            "type": "LONG"
          },
          {
            "name": "country",
            "type": "STRING"
          },
          {
            "name": "grade",
            "type": "STRING"
          },
          {
            "name": "name",
            "type": "STRING"
          },
          {
            "name": "rollNumber",
            "type": "LONG"
          }
        ],
        "shuffleSpec": {
          "type": "mix"
        },
        "maxWorkerCount": 2
      },
      "phase": "FINISHED",
      "workerCount": 2,
      "partitionCount": 1,
      "shuffle": "mix",
      "output": "localStorage",
      "startTime": "2024-07-26T18:38:23.102Z",
      "duration": 1202
    },
    {
      "stageNumber": 1,
      "definition": {
        "id": "query-db88b7ba-7c1e-4eb1-b553-3076b0284365_1",
        "input": [
          {
            "type": "stage",
            "stage": 0
          }
        ],
        "processor": {
          "type": "limit",
          "limit": 1001
        },
        "signature": [
          {
            "name": "__boost",
            "type": "LONG"
          },
          {
            "name": "__time",
            "type": "LONG"
          },
          {
            "name": "age",
            "type": "LONG"
          },
          {
            "name": "country",
            "type": "STRING"
          },
          {
            "name": "grade",
            "type": "STRING"
          },
          {
            "name": "name",
            "type": "STRING"
          },
          {
            "name": "rollNumber",
            "type": "LONG"
          }
        ],
        "shuffleSpec": {
          "type": "maxCount",
          "clusterBy": {
            "columns": [
              {
                "columnName": "__boost",
                "order": "ASCENDING"
              }
            ]
          },
          "partitions": 1
        },
        "maxWorkerCount": 1
      },
      "phase": "FINISHED",
      "workerCount": 1,
      "partitionCount": 1,
      "shuffle": "globalSort",
      "output": "localStorage",
      "startTime": "2024-07-26T18:38:24.303Z",
      "duration": 14,
      "sort": true
    }
  ],
  "counters": {
    "0": {
      "0": {
        "input0": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            4039
          ],
          "files": [
            2
          ],
          "totalFiles": [
            2
          ]
        },
        "output": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            351
          ],
          "frames": [
            2
          ]
        },
        "shuffle": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            351
          ],
          "frames": [
            2
          ]
        }
      },
      "1": {
        "input0": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            4038
          ],
          "files": [
            2
          ],
          "totalFiles": [
            2
          ]
        },
        "output": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            350
          ],
          "frames": [
            2
          ]
        },
        "shuffle": {
          "type": "channel",
          "rows": [
            3
          ],
          "bytes": [
            350
          ],
          "frames": [
            2
          ]
        }
      }
    },
    "1": {
      "0": {
        "input0": {
          "type": "channel",
          "rows": [
            6
          ],
          "bytes": [
            701
          ],
          "frames": [
            4
          ]
        },
        "output": {
          "type": "channel",
          "rows": [
            6
          ],
          "bytes": [
            701
          ],
          "frames": [
            4
          ]
        },
        "shuffle": {
          "type": "channel",
          "rows": [
            6
          ],
          "bytes": [
            599
          ],
          "frames": [
            1
          ]
        },
        "sortProgress": {
          "type": "sortProgress",
          "totalMergingLevels": 3,
          "levelToTotalBatches": {
            "0": 2,
            "1": 1,
            "2": 1
          },
          "levelToMergedBatches": {
            "0": 2,
            "1": 1,
            "2": 1
          },
          "totalMergersForUltimateLevel": 1,
          "progressDigest": 1.0
        }
      }
    }
  },
  "warnings": []
}
```

</details>

### Release Notes

Add optional boolean query parameter `detail` for the API to get query status.

Path: `/v2/sql/statements/query-id?detail=true`
Method: `GET`

If the optional query parameter `detail` is supplied, then the response also includes the following:
- A `stages` object that summarizes information about the different stages being used for query execution, such as stage number, phase, start time, duration, input and output information, processing methods, and partitioning.
- A `counters` object that provides details on the rows, bytes, and files processed at various stages for each worker across different channels, along with sort progress.
- A `warnings` object that provides details about any warnings.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
