### PR TITLE
Remove deprecated maxRowsPerSegment from batch task tuning configs

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTestUtils.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTestUtils.java
@@ -86,8 +86,6 @@ public class K8sTestUtils
             ),
             new IndexTask.IndexTuningConfig(
                 null,
-                null,
-                null,
                 10,
                 null,
                 null,

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -402,7 +402,6 @@ public class MSQCompactionRunnerTest
         .forCompactionTask()
         .withMaxRowsInMemory(500000)
         .withMaxBytesInMemory(1000000L)
-        .withMaxTotalRows(Long.MAX_VALUE)
         .withPartitionsSpec(partitionsSpec)
         .withIndexSpec(indexSpec)
         .withForceGuaranteedRollup(!(partitionsSpec instanceof DynamicPartitionsSpec))

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -252,14 +252,10 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     } else if (tuningConfig instanceof ParallelIndexTuningConfig) {
       final ParallelIndexTuningConfig parallelIndexTuningConfig = (ParallelIndexTuningConfig) tuningConfig;
       return new CompactionTuningConfig(
-          null,
-          parallelIndexTuningConfig.getMaxRowsPerSegment(),
           parallelIndexTuningConfig.getAppendableIndexSpec(),
           parallelIndexTuningConfig.getMaxRowsInMemory(),
           parallelIndexTuningConfig.getMaxBytesInMemory(),
           parallelIndexTuningConfig.isSkipBytesInMemoryOverheadCheck(),
-          parallelIndexTuningConfig.getMaxTotalRows(),
-          parallelIndexTuningConfig.getNumShards(),
           parallelIndexTuningConfig.getSplitHintSpec(),
           parallelIndexTuningConfig.getPartitionsSpec(),
           parallelIndexTuningConfig.getIndexSpec(),
@@ -287,14 +283,10 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     } else if (tuningConfig instanceof IndexTuningConfig) {
       final IndexTuningConfig indexTuningConfig = (IndexTuningConfig) tuningConfig;
       return new CompactionTuningConfig(
-          null,
-          indexTuningConfig.getMaxRowsPerSegment(),
           indexTuningConfig.getAppendableIndexSpec(),
           indexTuningConfig.getMaxRowsInMemory(),
           indexTuningConfig.getMaxBytesInMemory(),
           indexTuningConfig.isSkipBytesInMemoryOverheadCheck(),
-          indexTuningConfig.getMaxTotalRows(),
-          indexTuningConfig.getNumShards(),
           null,
           indexTuningConfig.getPartitionsSpec(),
           indexTuningConfig.getIndexSpec(),
@@ -1184,10 +1176,6 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
           null,
           null,
           null,
-          null,
-          null,
-          null,
-          null,
           0L,
           null
       );
@@ -1195,14 +1183,10 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
 
     @JsonCreator
     public CompactionTuningConfig(
-        @JsonProperty("targetPartitionSize") @Deprecated @Nullable Integer targetPartitionSize,
-        @JsonProperty("maxRowsPerSegment") @Deprecated @Nullable Integer maxRowsPerSegment,
         @JsonProperty("appendableIndexSpec") @Nullable AppendableIndexSpec appendableIndexSpec,
         @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
         @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
         @JsonProperty("skipBytesInMemoryOverheadCheck") @Nullable Boolean skipBytesInMemoryOverheadCheck,
-        @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
-        @JsonProperty("numShards") @Deprecated @Nullable Integer numShards,
         @JsonProperty("splitHintSpec") @Nullable SplitHintSpec splitHintSpec,
         @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
         @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
@@ -1230,14 +1214,10 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     )
     {
       super(
-          targetPartitionSize,
-          maxRowsPerSegment,
           appendableIndexSpec,
           maxRowsInMemory,
           maxBytesInMemory,
           skipBytesInMemoryOverheadCheck,
-          maxTotalRows,
-          numShards,
           splitHintSpec,
           partitionsSpec,
           indexSpec,
@@ -1276,14 +1256,10 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
     public CompactionTuningConfig withPartitionsSpec(PartitionsSpec partitionsSpec)
     {
       return new CompactionTuningConfig(
-          null,
-          null,
           getAppendableIndexSpec(),
           getMaxRowsInMemory(),
           getMaxBytesInMemory(),
           isSkipBytesInMemoryOverheadCheck(),
-          null,
-          null,
           getSplitHintSpec(),
           partitionsSpec,
           getIndexSpec(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1287,23 +1287,16 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   private static IndexTuningConfig convertToIndexTuningConfig(ParallelIndexTuningConfig tuningConfig)
   {
     return new IndexTuningConfig(
-        null,
-        null,
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemory(),
         tuningConfig.isSkipBytesInMemoryOverheadCheck(),
-        null,
-        null,
-        null,
-        null,
         tuningConfig.getPartitionsSpec(),
         tuningConfig.getIndexSpec(),
         tuningConfig.getIndexSpecForIntermediatePersists(),
         tuningConfig.getMaxPendingPersists(),
         tuningConfig.isForceGuaranteedRollup(),
         tuningConfig.isReportParseExceptions(),
-        null,
         tuningConfig.getPushTimeout(),
         tuningConfig.getSegmentWriteOutMediumFactory(),
         tuningConfig.isLogParseExceptions(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfig.java
@@ -104,24 +104,16 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
         null,
         null,
         null,
-        null,
-        null,
-        null,
-        null,
         null
     );
   }
 
   @JsonCreator
   public ParallelIndexTuningConfig(
-      @JsonProperty("targetPartitionSize") @Deprecated @Nullable Integer targetPartitionSize,
-      @JsonProperty("maxRowsPerSegment") @Deprecated @Nullable Integer maxRowsPerSegment,
       @JsonProperty("appendableIndexSpec") @Nullable AppendableIndexSpec appendableIndexSpec,
       @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
       @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
       @JsonProperty("skipBytesInMemoryOverheadCheck") @Nullable Boolean skipBytesInMemoryOverheadCheck,
-      @JsonProperty("maxTotalRows") @Deprecated @Nullable Long maxTotalRows,
-      @JsonProperty("numShards") @Deprecated @Nullable Integer numShards,
       @JsonProperty("splitHintSpec") @Nullable SplitHintSpec splitHintSpec,
       @JsonProperty("partitionsSpec") @Nullable PartitionsSpec partitionsSpec,
       @JsonProperty("indexSpec") @Nullable IndexSpec indexSpec,
@@ -149,23 +141,16 @@ public class ParallelIndexTuningConfig extends IndexTuningConfig
   )
   {
     super(
-        targetPartitionSize,
-        maxRowsPerSegment,
         appendableIndexSpec,
         maxRowsInMemory,
         maxBytesInMemory,
         skipBytesInMemoryOverheadCheck,
-        maxTotalRows,
-        null,
-        numShards,
-        null,
         partitionsSpec,
         indexSpec,
         indexSpecForIntermediatePersists,
         maxPendingPersists,
         forceGuaranteedRollup,
         reportParseExceptions,
-        null,
         pushTimeout,
         segmentWriteOutMediumFactory,
         logParseExceptions,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTuningConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTuningConfig.java
@@ -169,7 +169,6 @@ public abstract class SeekableStreamIndexTaskTuningConfig implements Appenderato
     return skipBytesInMemoryOverheadCheck;
   }
 
-  @Override
   @JsonProperty
   public Integer getMaxRowsPerSegment()
   {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -545,7 +545,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
                 Granularities.MINUTE,
                 null
             ),
-            IndexTaskTest.createTuningConfig(2, 2, 2L, null, false, true),
+            IndexTaskTest.createTuningConfig(2, 2, 2L, false, true),
             false,
             false
         ),
@@ -1918,7 +1918,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
                 Granularities.MINUTE,
                 null
             ),
-            IndexTaskTest.createTuningConfig(2, 2, 2L, null, false, true),
+            IndexTaskTest.createTuningConfig(2, 2, 2L, false, true),
             appendToExisting,
             false
         ),
@@ -1958,7 +1958,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
                 Granularities.MINUTE,
                 null
             ),
-            IndexTaskTest.createTuningConfig(2, 2, 2L, null, false, true),
+            IndexTaskTest.createTuningConfig(2, 2, 2L, false, true),
             appendToExisting,
             false
         ),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -79,8 +79,8 @@ public class TaskSerdeTest
         IndexTask.IndexIOConfig.class
     );
 
-    Assert.assertEquals(false, ioConfig.isAppendToExisting());
-    Assert.assertEquals(false, ioConfig.isDropExisting());
+    Assert.assertFalse(ioConfig.isAppendToExisting());
+    Assert.assertFalse(ioConfig.isDropExisting());
   }
 
   @Test
@@ -96,8 +96,8 @@ public class TaskSerdeTest
     Assert.assertEquals(new Period(Integer.MAX_VALUE), tuningConfig.getIntermediatePersistPeriod());
     Assert.assertEquals(0, tuningConfig.getMaxPendingPersists());
     Assert.assertEquals(1000000, tuningConfig.getMaxRowsInMemory());
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
+    // TODO: Assert.assertNull(tuningConfig.getNumShards());
+    Assert.assertNull(tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
   }
 
   @Test
@@ -108,56 +108,59 @@ public class TaskSerdeTest
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assert.assertNull(tuningConfig.getNumShards());
+    Assert.assertEquals(10, (int) tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
+    // Assert.assertNull(tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\"}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assert.assertNull(tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"maxRowsPerSegment\":10}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assert.assertNull(tuningConfig.getNumShards());
+    Assert.assertEquals(10, (int) tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
+    // Assert.assertNull(tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assert.assertNull(tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
+    // Assert.assertEquals(10, (int) tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assert.assertNull(tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
+    // Assert.assertEquals(10, (int) tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":10, \"numShards\":-1}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
+    // Assert.assertNull(tuningConfig.getNumShards());
+    Assert.assertEquals(10, (int) tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":-1, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertNotNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, tuningConfig.getMaxRowsPerSegment().intValue());
+    // Assert.assertNull(tuningConfig.getNumShards());
+    Assert.assertNotNull(tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment());
+    Assert.assertEquals(
+        PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT,
+        tuningConfig.getGivenOrDefaultPartitionsSpec().getMaxRowsPerSegment().intValue()
+    );
   }
 
   @Test
@@ -275,8 +278,11 @@ public class TaskSerdeTest
     );
     Assert.assertEquals(taskTuningConfig.getMaxPendingPersists(), task2TuningConfig.getMaxPendingPersists());
     Assert.assertEquals(taskTuningConfig.getMaxRowsInMemory(), task2TuningConfig.getMaxRowsInMemory());
-    Assert.assertEquals(taskTuningConfig.getNumShards(), task2TuningConfig.getNumShards());
-    Assert.assertEquals(taskTuningConfig.getMaxRowsPerSegment(), task2TuningConfig.getMaxRowsPerSegment());
+    // Assert.assertEquals(taskTuningConfig.getNumShards(), task2TuningConfig.getNumShards());
+    Assert.assertEquals(
+        taskTuningConfig.getGivenOrDefaultPartitionsSpec(),
+        task2TuningConfig.getGivenOrDefaultPartitionsSpec()
+    );
     Assert.assertEquals(taskTuningConfig.isReportParseExceptions(), task2TuningConfig.isReportParseExceptions());
     Assert.assertEquals(taskTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(), task2TuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TuningConfigBuilder.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TuningConfigBuilder.java
@@ -37,14 +37,10 @@ import org.joda.time.Duration;
  */
 public abstract class TuningConfigBuilder<C>
 {
-  protected Integer targetPartitionSize;
-  protected Integer maxRowsPerSegment;
   protected AppendableIndexSpec appendableIndexSpec;
   protected Integer maxRowsInMemory;
   protected Long maxBytesInMemory;
   protected Boolean skipBytesInMemoryOverheadCheck;
-  protected Long maxTotalRows;
-  protected Integer numShards;
   protected SplitHintSpec splitHintSpec;
   protected PartitionsSpec partitionsSpec;
   protected IndexSpec indexSpec;
@@ -52,7 +48,6 @@ public abstract class TuningConfigBuilder<C>
   protected Integer maxPendingPersists;
   protected Boolean forceGuaranteedRollup;
   protected Boolean reportParseExceptions;
-  protected Long publishTimeout;
   protected Long pushTimeout;
   protected SegmentWriteOutMediumFactory segmentWriteOutMediumFactory;
   protected Integer maxNumSubTasks;
@@ -70,18 +65,6 @@ public abstract class TuningConfigBuilder<C>
   protected Long awaitSegmentAvailabilityTimeoutMillis;
   protected Integer maxAllowedLockCount;
   protected Integer numPersistThreads;
-
-  public TuningConfigBuilder<C> withTargetPartitionSize(Integer targetPartitionSize)
-  {
-    this.targetPartitionSize = targetPartitionSize;
-    return this;
-  }
-
-  public TuningConfigBuilder<C> withMaxRowsPerSegment(Integer maxRowsPerSegment)
-  {
-    this.maxRowsPerSegment = maxRowsPerSegment;
-    return this;
-  }
 
   public TuningConfigBuilder<C> withAppendableIndexSpec(AppendableIndexSpec appendableIndexSpec)
   {
@@ -104,18 +87,6 @@ public abstract class TuningConfigBuilder<C>
   public TuningConfigBuilder<C> withSkipBytesInMemoryOverheadCheck(Boolean skipBytesInMemoryOverheadCheck)
   {
     this.skipBytesInMemoryOverheadCheck = skipBytesInMemoryOverheadCheck;
-    return this;
-  }
-
-  public TuningConfigBuilder<C> withMaxTotalRows(Long maxTotalRows)
-  {
-    this.maxTotalRows = maxTotalRows;
-    return this;
-  }
-
-  public TuningConfigBuilder<C> withNumShards(Integer numShards)
-  {
-    this.numShards = numShards;
     return this;
   }
 
@@ -164,12 +135,6 @@ public abstract class TuningConfigBuilder<C>
   public TuningConfigBuilder<C> withPushTimeout(Long pushTimeout)
   {
     this.pushTimeout = pushTimeout;
-    return this;
-  }
-
-  public TuningConfigBuilder<C> withPublishTimeout(Long publishTimeout)
-  {
-    this.publishTimeout = publishTimeout;
     return this;
   }
 
@@ -301,23 +266,16 @@ public abstract class TuningConfigBuilder<C>
     public IndexTask.IndexTuningConfig build()
     {
       return new IndexTask.IndexTuningConfig(
-          targetPartitionSize,
-          maxRowsPerSegment,
           appendableIndexSpec,
           maxRowsInMemory,
           maxBytesInMemory,
           skipBytesInMemoryOverheadCheck,
-          maxTotalRows,
-          null,
-          numShards,
-          null,
           partitionsSpec,
           indexSpec,
           indexSpecForIntermediatePersists,
           maxPendingPersists,
           forceGuaranteedRollup,
           reportParseExceptions,
-          publishTimeout,
           pushTimeout,
           segmentWriteOutMediumFactory,
           logParseExceptions,
@@ -336,14 +294,10 @@ public abstract class TuningConfigBuilder<C>
     public ParallelIndexTuningConfig build()
     {
       return new ParallelIndexTuningConfig(
-          targetPartitionSize,
-          maxRowsPerSegment,
           appendableIndexSpec,
           maxRowsInMemory,
           maxBytesInMemory,
           skipBytesInMemoryOverheadCheck,
-          maxTotalRows,
-          numShards,
           splitHintSpec,
           partitionsSpec,
           indexSpec,
@@ -378,14 +332,10 @@ public abstract class TuningConfigBuilder<C>
     public CompactionTask.CompactionTuningConfig build()
     {
       return new CompactionTask.CompactionTuningConfig(
-          targetPartitionSize,
-          maxRowsPerSegment,
           appendableIndexSpec,
           maxRowsInMemory,
           maxBytesInMemory,
           skipBytesInMemoryOverheadCheck,
-          maxTotalRows,
-          numShards,
           splitHintSpec,
           partitionsSpec,
           indexSpec,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -329,16 +329,19 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
       // will break requiring messing with the logic below).
       // For the other two subsequent failures we need to have numShards non-null, so it bypasses
       // the first failure, so the conditions for failure in the different phase are given below:
+      final HashedPartitionsSpec partitionsSpec
+          = (HashedPartitionsSpec) getIngestionSchema().getTuningConfig().getPartitionsSpec();
+
       ParallelIndexTaskRunner<T, R> retVal;
       if (succeedsBeforeFailing == 0
-          && this.getIngestionSchema().getTuningConfig().getNumShards() == null) {
+          && partitionsSpec == null || partitionsSpec.getNumShards() == null) {
         retVal = (ParallelIndexTaskRunner<T, R>) new TestRunner(false, "PHASE-1");
       } else if (succeedsBeforeFailing == 0
-                 && this.getIngestionSchema().getTuningConfig().getNumShards() != null) {
+                 && partitionsSpec.getNumShards() != null) {
         retVal = (ParallelIndexTaskRunner<T, R>) new TestRunner(false, "PHASE-2");
       } else if (succeedsBeforeFailing == 1
                  && numRuns == 1
-                 && this.getIngestionSchema().getTuningConfig().getNumShards() != null) {
+                 && partitionsSpec == null || partitionsSpec.getNumShards() != null) {
         retVal = (ParallelIndexTaskRunner<T, R>) new TestRunner(false, "PHASE-3");
       } else {
         numRuns++;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -52,6 +52,7 @@ import org.apache.druid.discovery.LookupNodeService;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
 import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskLockType;
@@ -120,7 +121,6 @@ import org.apache.druid.segment.handoff.SegmentHandoffNotifier;
 import org.apache.druid.segment.handoff.SegmentHandoffNotifierFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
-import org.apache.druid.segment.join.JoinableFactoryWrapperTest;
 import org.apache.druid.segment.join.NoopJoinableFactory;
 import org.apache.druid.segment.loading.DataSegmentPusher;
 import org.apache.druid.segment.loading.LocalDataSegmentKiller;
@@ -686,7 +686,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
             ),
             new IndexIOConfig(new MockInputSource(), new NoopInputFormat(), false, false),
             TuningConfigBuilder.forIndexTask()
-                               .withMaxRowsPerSegment(10000)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
                                .withMaxRowsInMemory(100)
                                .withIndexSpec(indexSpec)
                                .withMaxPendingPersists(3)
@@ -749,7 +749,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
             ),
             new IndexIOConfig(new MockExceptionInputSource(), new NoopInputFormat(), false, false),
             TuningConfigBuilder.forIndexTask()
-                               .withMaxRowsPerSegment(10000)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
                                .withMaxRowsInMemory(10)
                                .withIndexSpec(indexSpec)
                                .withMaxPendingPersists(3)
@@ -1179,7 +1179,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
             ),
             new IndexIOConfig(new MockInputSource(), new NoopInputFormat(), false, false),
             TuningConfigBuilder.forIndexTask()
-                               .withMaxRowsPerSegment(10000)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
                                .withMaxRowsInMemory(10)
                                .withIndexSpec(indexSpec)
                                .build()
@@ -1235,7 +1235,6 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
 
     UnifiedIndexerAppenderatorsManager unifiedIndexerAppenderatorsManager = new UnifiedIndexerAppenderatorsManager(
         new ForwardingQueryProcessingPool(exec),
-        JoinableFactoryWrapperTest.NOOP_JOINABLE_FACTORY_WRAPPER,
         new WorkerConfig(),
         MapCache.create(2048),
         new CacheConfig(),
@@ -1267,7 +1266,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
             ),
             new IndexIOConfig(new MockInputSource(), new NoopInputFormat(), false, false),
             TuningConfigBuilder.forIndexTask()
-                               .withMaxRowsPerSegment(10000)
+                               .withPartitionsSpec(new DynamicPartitionsSpec(10000, null))
                                .withMaxRowsInMemory(10)
                                .withIndexSpec(indexSpec)
                                .withMaxPendingPersists(3)

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorConfig.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorConfig.java
@@ -43,15 +43,6 @@ public interface AppenderatorConfig extends TuningConfig
   }
 
   /**
-   * Maximum number of rows in a single segment before pushing to deep storage
-   */
-  @Nullable
-  default Integer getMaxRowsPerSegment()
-  {
-    return Integer.MAX_VALUE;
-  }
-
-  /**
    * Maximum number of rows across all segments before pushing to deep storage
    */
   @Nullable

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -60,7 +60,6 @@ import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.join.JoinableFactory;
-import org.apache.druid.segment.join.JoinableFactoryWrapper;
 import org.apache.druid.segment.loading.DataSegmentPusher;
 import org.apache.druid.segment.loading.SegmentLoaderConfig;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
@@ -110,7 +109,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
   private final Map<String, DatasourceBundle> datasourceBundles = new HashMap<>();
 
   private final QueryProcessingPool queryProcessingPool;
-  private final JoinableFactoryWrapper joinableFactoryWrapper;
   private final WorkerConfig workerConfig;
   private final Cache cache;
   private final CacheConfig cacheConfig;
@@ -124,7 +122,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
   @Inject
   public UnifiedIndexerAppenderatorsManager(
       QueryProcessingPool queryProcessingPool,
-      JoinableFactoryWrapper joinableFactoryWrapper,
       WorkerConfig workerConfig,
       Cache cache,
       CacheConfig cacheConfig,
@@ -135,7 +132,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
   )
   {
     this.queryProcessingPool = queryProcessingPool;
-    this.joinableFactoryWrapper = joinableFactoryWrapper;
     this.workerConfig = workerConfig;
     this.cache = cache;
     this.cacheConfig = cacheConfig;
@@ -438,13 +434,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
     public int getMaxPendingPersists()
     {
       return baseConfig.getMaxPendingPersists();
-    }
-
-    @Nullable
-    @Override
-    public Integer getMaxRowsPerSegment()
-    {
-      return baseConfig.getMaxRowsPerSegment();
     }
 
     @Nullable

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManagerTest.java
@@ -46,7 +46,6 @@ import org.apache.druid.segment.incremental.NoopRowIngestionMeters;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.granularity.UniformGranularitySpec;
-import org.apache.druid.segment.join.JoinableFactoryWrapperTest;
 import org.apache.druid.segment.loading.NoopDataSegmentPusher;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.segment.realtime.SegmentGenerationMetrics;
@@ -76,7 +75,6 @@ public class UnifiedIndexerAppenderatorsManagerTest extends InitializedNullHandl
   private final WorkerConfig workerConfig = new WorkerConfig();
   private final UnifiedIndexerAppenderatorsManager manager = new UnifiedIndexerAppenderatorsManager(
       DirectQueryProcessingPool.INSTANCE,
-      JoinableFactoryWrapperTest.NOOP_JOINABLE_FACTORY_WRAPPER,
       workerConfig,
       MapCache.create(10),
       new CacheConfig(),

--- a/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
+++ b/services/src/test/java/org/apache/druid/cli/validate/DruidJsonValidatorTest.java
@@ -150,13 +150,7 @@ public class DruidJsonValidatorTest
 
             new IndexTask.IndexTuningConfig(
                 null,
-                null,
-                null,
                 10,
-                null,
-                null,
-                null,
-                null,
                 null,
                 null,
                 new DynamicPartitionsSpec(10000, null),
@@ -164,7 +158,6 @@ public class DruidJsonValidatorTest
                 null,
                 3,
                 false,
-                null,
                 null,
                 null,
                 null,


### PR DESCRIPTION
### Description

The following fields have been deprecated since #8141 , Druid 0.16.0.
- `maxRowsPerSegment`
- `numShards`
- `maxTotalRows`

Instead of these fields, users can explicitly specify the desired `partitionsSpec`.

### Changes
- Remove deprecated fields from batch task tuning configs.
- Streaming tasks tuning configs need not change as they always use `dynamic` partitioning
and it suffices to just specify the `maxRowsPerSegment`.
- Remove `publishTimeout` as it is just an alias for `pushTimeout`

### Release notes

The following deprecated fields are being removed from all batch task tuning configs:
- `maxRowsPerSegment`
- `numShards`
- `maxTotalRows`
- `publishTimeout`

Instead of these fields, users can explicitly specify the desired `partitionsSpec` in the `tuningConfig`.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
