### PR TITLE
Made selectDestination default customizable

### DIFF
--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -44,12 +44,16 @@ const DEFAULT_MAX_NUM_LABEL_FN = (maxNum: number) => {
   return { text: formatInteger(maxNum), label: `(1 controller + max ${maxNum - 1} workers)` };
 };
 
+const DEFAULT_FULL_CLUSTER_CAPACITY_LABEL_FN = (clusterCapacity: number) =>
+  `${formatInteger(clusterCapacity)} (full cluster capacity)`;
+
 export interface MaxTasksButtonProps extends Omit<ButtonProps, 'text' | 'rightIcon'> {
   clusterCapacity: number | undefined;
   queryContext: QueryContext;
   changeQueryContext(queryContext: QueryContext): void;
   menuHeader?: JSX.Element;
   maxNumLabelFn?: (maxNum: number) => { text: string; label?: string };
+  fullClusterCapacityLabelFn?: (clusterCapacity: number) => string;
 }
 
 export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps) {
@@ -59,6 +63,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     changeQueryContext,
     menuHeader,
     maxNumLabelFn = DEFAULT_MAX_NUM_LABEL_FN,
+    fullClusterCapacityLabelFn = DEFAULT_FULL_CLUSTER_CAPACITY_LABEL_FN,
     ...rest
   } = props;
   const [customMaxNumTasksDialogOpen, setCustomMaxNumTasksDialogOpen] = useState(false);
@@ -67,9 +72,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
   const taskAssigment = getTaskAssigment(queryContext);
 
   const fullClusterCapacity =
-    typeof clusterCapacity === 'number'
-      ? `${formatInteger(clusterCapacity)} (full cluster capacity)`
-      : undefined;
+    typeof clusterCapacity === 'number' ? fullClusterCapacityLabelFn(clusterCapacity) : undefined;
 
   const shownMaxNumTaskOptions = clusterCapacity
     ? MAX_NUM_TASK_OPTIONS.filter(_ => _ <= clusterCapacity)

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -72,7 +72,10 @@ const queryRunner = new QueryRunner({
 export interface QueryTabProps
   extends Pick<
     ComponentProps<typeof RunPanel>,
-    'enginesLabelFn' | 'maxTaskLabelFn' | 'defaultSelectDestinationFn'
+    | 'enginesLabelFn'
+    | 'maxTaskLabelFn'
+    | 'defaultSelectDestinationFn'
+    | 'maxTaskFullClusterCapacityLabelFn'
   > {
   query: WorkbenchQuery;
   id: string;
@@ -106,6 +109,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
     maxTaskMenuHeader,
     enginesLabelFn,
     maxTaskLabelFn,
+    maxTaskFullClusterCapacityLabelFn,
     defaultSelectDestinationFn = DEFAULT_SELECT_DESTINATION_FN,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
@@ -419,6 +423,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               enginesLabelFn={enginesLabelFn}
               maxTaskLabelFn={maxTaskLabelFn}
               defaultSelectDestinationFn={defaultSelectDestinationFn}
+              maxTaskFullClusterCapacityLabelFn={maxTaskFullClusterCapacityLabelFn}
             />
             {executionState.isLoading() && (
               <ExecutionTimerPanel

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -135,6 +135,9 @@ export interface RunPanelProps {
   maxTaskMenuHeader?: JSX.Element;
   enginesLabelFn?: (engine: DruidEngine | undefined) => { text: string; label?: string };
   maxTaskLabelFn?: ComponentProps<typeof MaxTasksButton>['maxNumLabelFn'];
+  maxTaskFullClusterCapacityLabelFn?: ComponentProps<
+    typeof MaxTasksButton
+  >['fullClusterCapacityLabelFn'];
   defaultSelectDestinationFn?: (engine: DruidEngine | undefined) => 'taskReport' | 'durableStorage';
 }
 
@@ -150,6 +153,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     clusterCapacity,
     maxTaskMenuHeader,
     maxTaskLabelFn,
+    maxTaskFullClusterCapacityLabelFn,
     enginesLabelFn = DEFAULT_ENGINES_LABEL_FN,
     defaultSelectDestinationFn = DEFAULT_SELECT_DESTINATION_FN,
   } = props;
@@ -540,6 +544,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
               changeQueryContext={changeQueryContext}
               menuHeader={maxTaskMenuHeader}
               maxNumLabelFn={maxTaskLabelFn}
+              fullClusterCapacityLabelFn={maxTaskFullClusterCapacityLabelFn}
             />
           )}
           {ingestMode && (

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -119,6 +119,10 @@ const DEFAULT_ENGINES_LABEL_FN = (engine: DruidEngine | undefined) => {
   };
 };
 
+export const DEFAULT_SELECT_DESTINATION_FN = (_engine: DruidEngine | undefined) => {
+  return 'taskReport' as const;
+};
+
 export interface RunPanelProps {
   query: WorkbenchQuery;
   onQueryChange(query: WorkbenchQuery): void;
@@ -131,6 +135,7 @@ export interface RunPanelProps {
   maxTaskMenuHeader?: JSX.Element;
   enginesLabelFn?: (engine: DruidEngine | undefined) => { text: string; label?: string };
   maxTaskLabelFn?: ComponentProps<typeof MaxTasksButton>['maxNumLabelFn'];
+  defaultSelectDestinationFn?: (engine: DruidEngine | undefined) => 'taskReport' | 'durableStorage';
 }
 
 export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
@@ -146,6 +151,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     maxTaskMenuHeader,
     maxTaskLabelFn,
     enginesLabelFn = DEFAULT_ENGINES_LABEL_FN,
+    defaultSelectDestinationFn = DEFAULT_SELECT_DESTINATION_FN,
   } = props;
   const [editContextDialogOpen, setEditContextDialogOpen] = useState(false);
   const [editParametersDialogOpen, setEditParametersDialogOpen] = useState(false);
@@ -165,7 +171,8 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
   const waitUntilSegmentsLoad = getWaitUntilSegmentsLoad(queryContext);
   const groupByEnableMultiValueUnnesting = getGroupByEnableMultiValueUnnesting(queryContext);
   const sqlJoinAlgorithm = queryContext.sqlJoinAlgorithm ?? 'broadcast';
-  const selectDestination = queryContext.selectDestination ?? 'taskReport';
+  const selectDestination =
+    queryContext.selectDestination ?? defaultSelectDestinationFn(query.engine);
   const durableShuffleStorage = getDurableShuffleStorage(queryContext);
   const indexSpec: IndexSpec | undefined = deepGet(queryContext, 'indexSpec');
   const useApproximateCountDistinct = getUseApproximateCountDistinct(queryContext);

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -90,7 +90,11 @@ function externalDataTabId(tabId: string | undefined): boolean {
   return String(tabId).startsWith('connect-external-data');
 }
 
-export interface WorkbenchViewProps {
+export interface WorkbenchViewProps
+  extends Pick<
+    ComponentProps<typeof QueryTab>,
+    'enginesLabelFn' | 'maxTaskLabelFn' | 'defaultSelectDestinationFn'
+  > {
   capabilities: Capabilities;
   tabId: string | undefined;
   onTabChange(newTabId: string): void;
@@ -102,8 +106,6 @@ export interface WorkbenchViewProps {
   goToTask(taskId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
   maxTaskMenuHeader?: JSX.Element;
-  enginesLabelFn?: ComponentProps<typeof QueryTab>['enginesLabelFn'];
-  maxTaskLabelFn?: ComponentProps<typeof QueryTab>['maxTaskLabelFn'];
   hideToolbar?: boolean;
 }
 
@@ -657,6 +659,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTaskMenuHeader,
       enginesLabelFn,
       maxTaskLabelFn,
+      defaultSelectDestinationFn,
     } = this.props;
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
@@ -684,6 +687,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTaskMenuHeader={maxTaskMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTaskLabelFn={maxTaskLabelFn}
+          defaultSelectDestinationFn={defaultSelectDestinationFn}
           runMoreMenu={
             <Menu>
               {allowExplain &&

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -93,7 +93,10 @@ function externalDataTabId(tabId: string | undefined): boolean {
 export interface WorkbenchViewProps
   extends Pick<
     ComponentProps<typeof QueryTab>,
-    'enginesLabelFn' | 'maxTaskLabelFn' | 'defaultSelectDestinationFn'
+    | 'enginesLabelFn'
+    | 'maxTaskLabelFn'
+    | 'defaultSelectDestinationFn'
+    | 'maxTaskFullClusterCapacityLabelFn'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -660,6 +663,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       enginesLabelFn,
       maxTaskLabelFn,
       defaultSelectDestinationFn,
+      maxTaskFullClusterCapacityLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
@@ -688,6 +692,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           enginesLabelFn={enginesLabelFn}
           maxTaskLabelFn={maxTaskLabelFn}
           defaultSelectDestinationFn={defaultSelectDestinationFn}
+          maxTaskFullClusterCapacityLabelFn={maxTaskFullClusterCapacityLabelFn}
           runMoreMenu={
             <Menu>
               {allowExplain &&


### PR DESCRIPTION
Made it possible to define the `selectDestination` context value per engine, from the outside.