### PR TITLE
Don't use ComplexMetricExtractor to fetch the class of the object in field readers 

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
@@ -22,11 +22,13 @@ package org.apache.druid.msq.exec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.LocalInputSource;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.guice.NestedDataModule;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.msq.indexing.MSQSpec;
 import org.apache.druid.msq.indexing.MSQTuningConfig;
 import org.apache.druid.msq.indexing.destination.TaskReportMSQDestination;
@@ -34,8 +36,20 @@ import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.query.QueryDataSource;
+import org.apache.druid.query.aggregation.CountAggregatorFactory;
+import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
+import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.filter.DimFilter;
+import org.apache.druid.query.filter.NotDimFilter;
+import org.apache.druid.query.filter.NullFilter;
+import org.apache.druid.query.filter.SelectorDimFilter;
+import org.apache.druid.query.groupby.GroupByQuery;
 import org.apache.druid.query.groupby.GroupByQueryConfig;
+import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
+import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
+import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.query.scan.ScanQuery;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -44,6 +58,7 @@ import org.apache.druid.sql.calcite.external.ExternalDataSource;
 import org.apache.druid.sql.calcite.filtration.Filtration;
 import org.apache.druid.sql.calcite.planner.ColumnMapping;
 import org.apache.druid.sql.calcite.planner.ColumnMappings;
+import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CompressionUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +102,7 @@ public class MSQComplexGroupByTest extends MSQTestBase
   {
     File dataFile = newTempFile("dataFile");
     final InputStream resourceStream = this.getClass().getClassLoader()
-                                                                .getResourceAsStream(NestedDataTestUtils.ALL_TYPES_TEST_DATA_FILE);
+                                           .getResourceAsStream(NestedDataTestUtils.ALL_TYPES_TEST_DATA_FILE);
     final InputStream decompressing = CompressionUtils.decompress(
         resourceStream,
         "nested-all-types-test-data.json"
@@ -413,6 +428,92 @@ public class MSQComplexGroupByTest extends MSQTestBase
                          new Object[]{"{\"a\":600,\"b\":{\"x\":\"f\",\"y\":1.1,\"z\":[6,7,8,9]},\"v\":\"b\"}"},
                          new Object[]{"{\"a\":400,\"b\":{\"x\":\"d\",\"y\":1.1,\"z\":[3,4]},\"v\":[]}"},
                          new Object[]{"{\"a\":300}"}
+                     ))
+                     .verifyResults();
+  }
+
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}:with context {0}")
+  public void testCountDistinctOnNestedData(String contextName, Map<String, Object> context)
+  {
+    RowSignature rowSignature = RowSignature.builder()
+                                            .add("distinct_obj", ColumnType.LONG)
+                                            .build();
+
+    Map<String, Object> modifiedContext = ImmutableMap.<String, Object>builder()
+                                                      .putAll(context)
+                                                      .put(PlannerConfig.CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT, false)
+                                                      .build();
+
+    DimFilter innerFilter = NullHandling.replaceWithDefault()
+                            ? new SelectorDimFilter("d0", null, null)
+                            : new NullFilter("d0", null);
+
+    testSelectQuery().setSql("SELECT\n"
+                             + " COUNT(DISTINCT obj) AS distinct_obj\n"
+                             + "FROM TABLE(\n"
+                             + "  EXTERN(\n"
+                             + "    '{ \"files\": [" + dataFileNameJsonString + "],\"type\":\"local\"}',\n"
+                             + "    '{\"type\": \"json\"}',\n"
+                             + "    '[{\"name\": \"timestamp\", \"type\": \"STRING\"}, {\"name\": \"obj\", \"type\": \"COMPLEX<json>\"}]'\n"
+
+                             + "   )\n"
+                             + " )\n"
+                             + " ORDER BY 1")
+                     .setQueryContext(ImmutableMap.of(PlannerConfig.CTX_KEY_USE_APPROXIMATE_COUNT_DISTINCT, false))
+                     .setExpectedMSQSpec(
+                         MSQSpec
+                             .builder()
+                             .query(
+                                 GroupByQuery
+                                     .builder()
+                                     .setDataSource(
+                                         new QueryDataSource(
+                                             GroupByQuery
+                                                 .builder()
+                                                 .setDataSource(dataFileExternalDataSource)
+                                                 .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                                 .setDimensions(
+                                                     new DefaultDimensionSpec("obj", "d0", ColumnType.NESTED_DATA)
+                                                 )
+                                                 .setGranularity(Granularities.ALL)
+                                                 .setContext(modifiedContext)
+                                                 .build()
+                                         )
+                                     )
+                                     .setAggregatorSpecs(
+                                         new FilteredAggregatorFactory(
+                                             new CountAggregatorFactory("a0"),
+                                             new NotDimFilter(innerFilter),
+                                             "a0"
+                                         )
+                                     )
+                                     .setQuerySegmentSpec(querySegmentSpec(Intervals.ETERNITY))
+                                     .setGranularity(Granularities.ALL)
+                                     .setLimitSpec(new DefaultLimitSpec(
+                                         ImmutableList.of(
+                                             new OrderByColumnSpec(
+                                                 "a0",
+                                                 OrderByColumnSpec.Direction.ASCENDING,
+                                                 StringComparators.NUMERIC
+                                             )
+                                         ),
+                                         Integer.MAX_VALUE
+                                     ))
+                                     .setContext(modifiedContext)
+                                     .build()
+                             )
+                             .columnMappings(new ColumnMappings(ImmutableList.of(
+                                 new ColumnMapping("a0", "distinct_obj")
+                             )))
+                             .tuningConfig(MSQTuningConfig.defaultConfig())
+                             .destination(TaskReportMSQDestination.INSTANCE)
+                             .build()
+                     )
+                     .setExpectedRowSignature(rowSignature)
+                     .setQueryContext(modifiedContext)
+                     .setExpectedResultRows(ImmutableList.of(
+                         new Object[]{7L}
                      ))
                      .verifyResults();
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQComplexGroupByTest.java
@@ -61,6 +61,7 @@ import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CompressionUtils;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -436,6 +437,7 @@ public class MSQComplexGroupByTest extends MSQTestBase
   @ParameterizedTest(name = "{index}:with context {0}")
   public void testCountDistinctOnNestedData(String contextName, Map<String, Object> context)
   {
+    Assumptions.assumeTrue(NullHandling.sqlCompatible());
     RowSignature rowSignature = RowSignature.builder()
                                             .add("distinct_obj", ColumnType.LONG)
                                             .build();

--- a/processing/src/main/java/org/apache/druid/frame/field/ComplexFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/ComplexFieldReader.java
@@ -150,12 +150,16 @@ public class ComplexFieldReader implements FieldReader
     private final Memory memory;
     private final ReadableFieldPointer fieldPointer;
     private final ComplexMetricSerde serde;
+    @SuppressWarnings("rawtypes")
+    private final Class clazz;
 
     private Selector(Memory memory, ReadableFieldPointer fieldPointer, ComplexMetricSerde serde)
     {
       this.memory = memory;
       this.fieldPointer = fieldPointer;
       this.serde = serde;
+      //noinspection deprecation
+      this.clazz = serde.getObjectStrategy().getClazz();
     }
 
     @Nullable
@@ -169,7 +173,8 @@ public class ComplexFieldReader implements FieldReader
     @Override
     public Class<T> classOfObject()
     {
-      return serde.getExtractor().extractedClass();
+      //noinspection unchecked
+      return clazz;
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/frame/read/columnar/ComplexFrameColumnReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/columnar/ComplexFrameColumnReader.java
@@ -124,6 +124,7 @@ public class ComplexFrameColumnReader implements FrameColumnReader
   {
     private final Frame frame;
     private final ComplexMetricSerde serde;
+    private final Class<?> clazz;
     private final Memory memory;
     private final long startOfOffsetSection;
     private final long startOfDataSection;
@@ -138,6 +139,8 @@ public class ComplexFrameColumnReader implements FrameColumnReader
     {
       this.frame = frame;
       this.serde = serde;
+      //noinspection deprecation
+      this.clazz = serde.getObjectStrategy().getClazz();
       this.memory = memory;
       this.startOfOffsetSection = startOfOffsetSection;
       this.startOfDataSection = startOfDataSection;
@@ -158,7 +161,7 @@ public class ComplexFrameColumnReader implements FrameColumnReader
         @Override
         public Class<?> classOfObject()
         {
-          return serde.getExtractor().extractedClass();
+          return clazz;
         }
 
         @Override

--- a/processing/src/main/java/org/apache/druid/query/filter/SelectorPredicateFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/SelectorPredicateFactory.java
@@ -74,6 +74,15 @@ public class SelectorPredicateFactory implements DruidPredicateFactory
     return doublePredicate;
   }
 
+  @Override
+  public DruidObjectPredicate<Object> makeObjectPredicate()
+  {
+    if (value == null) {
+      return DruidObjectPredicate.isNull();
+    }
+    return DruidObjectPredicate.equalTo(value);
+  }
+
   private void initLongPredicate()
   {
     if (longPredicate != null) {

--- a/processing/src/main/java/org/apache/druid/query/filter/SelectorPredicateFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/SelectorPredicateFactory.java
@@ -74,15 +74,6 @@ public class SelectorPredicateFactory implements DruidPredicateFactory
     return doublePredicate;
   }
 
-  @Override
-  public DruidObjectPredicate<Object> makeObjectPredicate()
-  {
-    if (value == null) {
-      return DruidObjectPredicate.isNull();
-    }
-    return DruidObjectPredicate.equalTo(value);
-  }
-
   private void initLongPredicate()
   {
     if (longPredicate != null) {


### PR DESCRIPTION
### Description

This PR fixes queries like 
```sql
SELECT COUNT(DISTINCT json_col) FROM foo
```
when run using MSQ.

The frames delegate the `classOfObject` to `ComplexMetricSerde.getExtractor()` which isn't implemented for JSON columns and is probably not the right way to fetch the class of the complex type. A better alternative is to use the object type strategy to fetch the class, which is implemented for every complex serde. This PR modifies the field reader and the column readers to use the latter method. 

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
