### PR TITLE
Fix issues with fetching task reports in SQL statements endpoint for MiddleManager setups

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -595,7 +595,7 @@ public class SqlStatementResource
         ));
       }
       catch (DruidException e) {
-        if (e.getErrorCode().equals("notFound")) {
+        if (e.getErrorCode().equals("notFound") || e.getMessage().contains("Unable to contact overlord")) {
           return Optional.empty();
         }
         throw e;


### PR DESCRIPTION
### Description

This PR fixes the issues with fetching task reports in SQL statements endpoint for middlemanager setups.

With https://github.com/apache/druid/pull/16808, we started fetching task report using indexer API, but in the case of MiddleManager setups - the overlord API initially ends up throwing "Unable to contact overlord" until the peons are ready.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
