### PR TITLE
[Docs] Batch06: starting string functions

### DIFF
--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -476,7 +476,7 @@ Returns the following:
 
 Alias for [`LENGTH`](#length).
 
-* **Syntax:**`CHAR_LENGTH(expr)`
+* **Syntax:** `CHAR_LENGTH(expr)`
 * **Function type:** Scalar, string 
 
 [Learn more](sql-scalar.md#string-functions)
@@ -485,7 +485,7 @@ Alias for [`LENGTH`](#length).
 
 Alias for [`LENGTH`](#length).
 
-* **Syntax:**`CHARACTER_LENGTH(expr)`
+* **Syntax:** `CHARACTER_LENGTH(expr)`
 * **Function type:** Scalar, string 
 
 [Learn more](sql-scalar.md#string-functions)
@@ -503,7 +503,7 @@ Returns the first non-null value.
 
 Concatenates a list of expressions.
 
-* **Syntax:**`CONCAT(expr[, expr,...])`
+* **Syntax:** `CONCAT(expr[, expr,...])`
 * **Function type:** Scalar, string
 
 <details><summary>Example</summary>
@@ -533,7 +533,7 @@ Returns the following:
 
 Returns `true` if `str` is a substring of `expr`, case-sensitive. Otherwise returns `false`.
 
-* **Syntax:**`CONTAINS_STRING(expr, str)`
+* **Syntax:** `CONTAINS_STRING(expr, str)`
 * **Function type:** Scalar, string
 
 <details><summary>Example</summary>
@@ -630,7 +630,7 @@ Decodes a Base64-encoded string into a complex data type, where `dataType` is th
 
 Decodes a Base64-encoded string into a UTF-8 encoded string.
 
-* **Syntax:**`DECODE_BASE64_UTF8(expr)`
+* **Syntax:** `DECODE_BASE64_UTF8(expr)`
 * **Function type:** Scalar, string
 
 <details><summary>Example</summary>
@@ -1143,7 +1143,7 @@ Returns the `N` leftmost characters of an expression, where `N` is an integer va
 
 Returns the length of the expression in UTF-16 code units.
 
-* **Syntax:**`LENGTH(expr)`
+* **Syntax:** `LENGTH(expr)`
 * **Function type:** Scalar, string
 
 <details><summary>Example</summary>
@@ -1660,7 +1660,7 @@ Splits `str1` into an multi-value string on the delimiter specified by `str2`, w
 
 Alias for [`LENGTH`](#length).
 
-* **Syntax:**`STRLEN(expr)`
+* **Syntax:** `STRLEN(expr)`
 * **Function type:** Scalar, string 
 
 [Learn more](sql-scalar.md#string-functions)
@@ -1725,7 +1725,7 @@ Returns the quantile for the specified fraction from a T-Digest sketch construct
 
 Concatenates two string expressions.
 
-* **Syntax:**`TEXTCAT(expr, expr)`
+* **Syntax:** `TEXTCAT(expr, expr)`
 * **Function type:** Scalar, string
   
 <details><summary>Example</summary>

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -474,19 +474,22 @@ Returns the following:
 
 ## CHAR_LENGTH
 
-`CHAR_LENGTH(expr)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
 Alias for [`LENGTH`](#length).
+
+* **Syntax:**`CHAR_LENGTH(expr)`
+* **Function type:** Scalar, string 
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## CHARACTER_LENGTH
 
-`CHARACTER_LENGTH(expr)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
 Alias for [`LENGTH`](#length).
+
+* **Syntax:**`CHARACTER_LENGTH(expr)`
+* **Function type:** Scalar, string 
+
+[Learn more](sql-scalar.md#string-functions)
+
 
 ## COALESCE
 
@@ -498,19 +501,64 @@ Returns the first non-null value.
 
 ## CONCAT
 
-`CONCAT(expr, expr...)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
 Concatenates a list of expressions.
+
+* **Syntax:**`CONCAT(expr[, expr,...])`
+* **Function type:** Scalar, string
+
+<details><summary>Example</summary>
+
+The following example concatenates the `OriginCityName` column, the word ` to `, and the `DestCityName` column. The `OriginCityName` and `DestCityName` are both from the `flight-carriers` datasource. 
+
+```sql
+SELECT
+  "OriginCityName" AS "origin_city",
+  "DestCityName" AS "destination_city",
+  CONCAT("OriginCityName", ' to ', "DestCityName") AS "concatenate_flight_details"
+FROM "flight-carriers"
+LIMIT 1
+```
+
+Returns the following:
+
+| `origin_city` | `destination_city` | `concatenate_flight_details` |
+| -- | -- | -- |
+| `San Juan, PR` | `Washington, DC` | `San Juan, PR to Washington, DC` | 
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## CONTAINS_STRING
 
-`CONTAINS_STRING(<CHARACTER>, <CHARACTER>)`
+Returns `true` if `str` is a substring of `expr`, case-sensitive. Otherwise returns `false`.
 
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
+* **Syntax:**`CONTAINS_STRING(expr, str)`
+* **Function type:** Scalar, string
 
-Finds whether a string is in a given expression, case-sensitive.
+<details><summary>Example</summary>
+
+The following example returns `true` if the `OriginCityName` column from the `flight-carriers` datasource contains the substring `San`. 
+
+```sql
+SELECT
+  "OriginCityName" AS "origin_city",
+  CONTAINS_STRING("OriginCityName", 'San') AS "contains_string"
+FROM "flight-carriers"
+LIMIT 2
+```
+
+Returns the following:
+
+| `origin_city` | `contains_string` | 
+| -- | -- |
+| `San Juan, PR` | `true` |
+| `Boston, MA` | `false` |
+
+</details>
+
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## COS
 
@@ -580,12 +628,30 @@ Decodes a Base64-encoded string into a complex data type, where `dataType` is th
 
 ## DECODE_BASE64_UTF8
 
-`DECODE_BASE64_UTF8(expr)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
-
 Decodes a Base64-encoded string into a UTF-8 encoded string.
+
+* **Syntax:**`DECODE_BASE64_UTF8(expr)`
+* **Function type:** Scalar, string
+
+<details><summary>Example</summary>
+
+The following example converts the base64 encoded string `SGVsbG8gV29ybGQhCg==` into an UTF-8 encoded string.
+
+```sql
+SELECT
+  'SGVsbG8gV29ybGQhCg==' AS "base64_encoding",
+  DECODE_BASE64_UTF8('SGVsbG8gV29ybGQhCg==') AS "convert_to_UTF8_encoding"
+```
+
+Returns the following:
+
+| `base64_encoding` | `convert_to_UTF8_encoding` |
+| -- | -- |
+| `SGVsbG8gV29ybGQhCg==` | `Hello World!` |
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## DEGREES
 
@@ -890,11 +956,33 @@ Converts a byte size into human-readable SI format with single-character units.
 
 ## ICONTAINS_STRING
 
-`ICONTAINS_STRING(<expr>, str)`
+Returns `true` if `str` is a substring of `expr`, case-insensitive. Otherwise returns `false`.
 
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
+* **Syntax:** `ICONTAINS_STRING(expr, str)`
+* **Function type:** Scalar, string
 
-Finds whether a string is in a given expression, case-insensitive.
+<details><summary>Example</summary>
+
+The following example returns `true` if the `OriginCityName` column from the `flight-carriers` datasource contains the case-insensitive substring `san`.  
+
+```sql
+SELECT
+  "OriginCityName" AS "origin_city",
+  ICONTAINS_STRING("OriginCityName", 'san') AS "contains_case_insensitive_string"
+FROM "flight-carriers"
+LIMIT 2
+```
+
+Returns the following:
+
+| `origin_city` | `contains_case_insensitive_string` |
+| -- | -- |
+| `San Juan, PR` | `true` |
+| `Boston, MA` | `false` |
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## IPV4_MATCH
 
@@ -1026,19 +1114,59 @@ Returns the minimum value from the provided arguments.
 
 ## LEFT
 
-`LEFT(expr, [length])`
+Returns the `N` leftmost characters of an expression, where `N` is an integer value.
 
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
+* **Syntax:** `LEFT(expr, N)`
+* **Function type:** Scalar, string 
 
-Returns the leftmost number of characters from an expression.
+<details><summary>Example</summary>
+
+  The following example returns the `3` leftmost characters of the expresion `ABCDEFG`.
+
+  ```sql
+  SELECT
+    'ABCDEFG' AS "expression",
+    LEFT('ABCDEFG', 3) AS "leftmost_characters"
+  ```
+
+  Returns the following:
+
+  | `expression` | `leftmost_characters` |
+  | -- | -- |
+  | `ABCDEFG` | `ABC` |
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## LENGTH
 
-`LENGTH(expr)`
+Returns the length of the expression in UTF-16 code units.
 
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
+* **Syntax:**`LENGTH(expr)`
+* **Function type:** Scalar, string
 
-Returns the length of the expression in UTF-16 encoding.
+<details><summary>Example</summary>
+
+  The following example returns the character length of the `OriginCityName` column from the `flight-carriers` datasource.
+
+  ```sql
+  SELECT 
+    "OriginCityName" AS "origin_city_name",
+    LENGTH("OriginCityName") AS "city_name_length"
+  FROM "flight-carriers"
+  LIMIT 1
+  ```
+
+Returns the following:
+
+| `origin_city_name` | `city_name_length` | 
+| -- | -- |
+| `San Juan, PR` | `12` |
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## LN
 
@@ -1390,11 +1518,30 @@ Reverses the given expression.
 
 ## RIGHT
 
-`RIGHT(expr, [length])`
+Returns the `N` rightmost characters of an expression, where `N` is an integer value.
 
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
+* **Syntax:** `RIGHT(expr, N)`
+* **Function type:** Scalar, string 
 
-Returns the rightmost number of characters from an expression.
+<details><summary>Example</summary>
+
+  The following example returns the `3` rightmost characters of the expresion `ABCDEFG`.
+
+  ```sql
+  SELECT
+    'ABCDEFG' AS "expression",
+    RIGHT('ABCDEFG', 3) AS "rightmost_characters"
+  ```
+
+  Returns the following:
+
+  | `expression` | `rightmost_characters` |
+  | -- | -- |
+  | `ABCDEFG` | `EFG` |
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## ROUND
 
@@ -1511,11 +1658,12 @@ Splits `str1` into an multi-value string on the delimiter specified by `str2`, w
 
 ## STRLEN
 
-`STRLEN(expr)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
 Alias for [`LENGTH`](#length).
+
+* **Syntax:**`STRLEN(expr)`
+* **Function type:** Scalar, string 
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## STRPOS
 
@@ -1575,11 +1723,32 @@ Returns the quantile for the specified fraction from a T-Digest sketch construct
 
 ## TEXTCAT
 
-`TEXTCAT(<CHARACTER>, <CHARACTER>)`
-
-**Function type:** [Scalar, string](sql-scalar.md#string-functions)
-
 Concatenates two string expressions.
+
+* **Syntax:**`TEXTCAT(expr, expr)`
+* **Function type:** Scalar, string
+  
+<details><summary>Example</summary>
+
+  The following example concatenates `OriginState` column from the `flight-carriers` datasource to `, USA`,
+
+  ```sql
+SELECT
+  "OriginState" AS "origin_state",
+  TEXTCAT("OriginState", ', USA') AS "concatenate_state_with_USA"
+FROM "flight-carriers"
+LIMIT 1
+  ```
+
+Returns the following:
+
+| `origin_state` | `concatenate_state_with_USA` | 
+| -- | -- | 
+| `PR` | `PR, USA` | 
+
+</details>
+
+[Learn more](sql-scalar.md#string-functions)
 
 ## THETA_SKETCH_ESTIMATE
 


### PR DESCRIPTION
### Description

Add examples to the sql-functions.md page

Updates the `CONCAT`, `TEXTCAT`, `CONTAINS_STRING`, `ICONTAINS_STRING`, `DECODE_BASE64_UTF8 `, `LEFT`, `RIGHT`, `LENGTH`, `CHAR_LENGTH`, `CHARACTER_LENGTH`, and `STRLEN`.

This PR has:

- [X] been self-reviewed.