### PR TITLE
Suppress CVE-2024-25638

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -692,4 +692,11 @@
     <cve>CVE-2023-50386</cve>
     <cve>CVE-2023-50292</cve>
   </suppress>
+  <suppress>
+    <!-- Transitive dependency from Apache Hadoop Common, which does not have a fix that can be upgraded to yet -->
+    <notes><![CDATA[
+    file name: dnsjava-2.1.7.jar
+    ]]></notes>
+    <vulnerabilityName>CVE-2024-25638</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Suppresses CVE-2024-25638, which is present in dnsjava versions prior to 3.6.0. Druid does not use dnsjava directly, it is introduced as a dependency of Apache Hadoop Common, which does not have a release which uses >= dnsjava 3.6.0 yet.