### PR TITLE
Reduce logging in RetryableS3OutputStream

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -212,11 +212,10 @@ public class RetryableS3OutputStream extends OutputStream
     // Closeables are closed in LIFO order
     closer.register(() -> {
       org.apache.commons.io.FileUtils.forceDelete(chunkStorePath);
-      LOG.info("Deleted chunkStorePath[%s]", chunkStorePath);
 
       final long totalBytesUploaded = (currentChunk.id - 1) * chunkSize + currentChunk.length();
       final long totalUploadTimeMillis = pushStopwatch.elapsed(TimeUnit.MILLISECONDS);
-      LOG.info(
+      LOG.debug(
           "Pushed total [%d] parts containing [%d] bytes in [%d]ms for s3Key[%s], uploadId[%s].",
           futures.size(),
           totalBytesUploaded,

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -215,16 +215,14 @@ public class RetryableS3OutputStream extends OutputStream
 
       final long totalBytesUploaded = (currentChunk.id - 1) * chunkSize + currentChunk.length();
       final long totalUploadTimeMillis = pushStopwatch.elapsed(TimeUnit.MILLISECONDS);
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(
-            "Pushed total [%d] parts containing [%d] bytes in [%d]ms for s3Key[%s], uploadId[%s].",
-            futures.size(),
-            totalBytesUploaded,
-            totalUploadTimeMillis,
-            s3Key,
-            uploadId
-        );
-      }
+      LOG.debug(
+          "Pushed total [%d] parts containing [%d] bytes in [%d]ms for s3Key[%s], uploadId[%s].",
+          futures.size(),
+          totalBytesUploaded,
+          totalUploadTimeMillis,
+          s3Key,
+          uploadId
+      );
 
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder().setDimension("uploadId", uploadId);
       uploadManager.emitMetric(builder.setMetric(METRIC_TOTAL_UPLOAD_TIME, totalUploadTimeMillis));

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -215,14 +215,16 @@ public class RetryableS3OutputStream extends OutputStream
 
       final long totalBytesUploaded = (currentChunk.id - 1) * chunkSize + currentChunk.length();
       final long totalUploadTimeMillis = pushStopwatch.elapsed(TimeUnit.MILLISECONDS);
-      LOG.debug(
-          "Pushed total [%d] parts containing [%d] bytes in [%d]ms for s3Key[%s], uploadId[%s].",
-          futures.size(),
-          totalBytesUploaded,
-          totalUploadTimeMillis,
-          s3Key,
-          uploadId
-      );
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Pushed total [%d] parts containing [%d] bytes in [%d]ms for s3Key[%s], uploadId[%s].",
+            futures.size(),
+            totalBytesUploaded,
+            totalUploadTimeMillis,
+            s3Key,
+            uploadId
+        );
+      }
 
       final ServiceMetricEvent.Builder builder = new ServiceMetricEvent.Builder().setDimension("uploadId", uploadId);
       uploadManager.emitMetric(builder.setMetric(METRIC_TOTAL_UPLOAD_TIME, totalUploadTimeMillis));


### PR DESCRIPTION
### Description

This PR reduces logging in RetryableS3OutputStream.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
