### PR TITLE
Fix IndexOutOfBoundsException for MSQ window function queries with empty RAC

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -203,9 +203,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
         final Frame frame = inputChannel.read();
         convertRowFrameToRowsAndColumns(frame);
       } else if (inputChannel.isFinished()) {
-        if (!frameRowsAndCols.isEmpty()) {
-          runAllOpsOnMultipleRac(frameRowsAndCols);
-        }
+        runAllOpsOnMultipleRac(frameRowsAndCols);
         return ReturnOrAwait.returnObject(Unit.instance());
       } else {
         return ReturnOrAwait.awaitAll(inputChannels().size());
@@ -328,6 +326,9 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
    */
   private void runAllOpsOnMultipleRac(ArrayList<RowsAndColumns> listOfRacs)
   {
+    if (listOfRacs.isEmpty()) {
+      return;
+    }
     Operator op = new Operator()
     {
       @Nullable

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -203,7 +203,9 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
         final Frame frame = inputChannel.read();
         convertRowFrameToRowsAndColumns(frame);
       } else if (inputChannel.isFinished()) {
-        runAllOpsOnMultipleRac(frameRowsAndCols);
+        if (!frameRowsAndCols.isEmpty()) {
+          runAllOpsOnMultipleRac(frameRowsAndCols);
+        }
         return ReturnOrAwait.returnObject(Unit.instance());
       } else {
         return ReturnOrAwait.awaitAll(inputChannels().size());

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -326,9 +326,6 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
    */
   private void runAllOpsOnMultipleRac(ArrayList<RowsAndColumns> listOfRacs)
   {
-    if (listOfRacs.isEmpty()) {
-      return;
-    }
     Operator op = new Operator()
     {
       @Nullable

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.rowsandcols;
 
+import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
@@ -30,6 +31,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -53,6 +55,7 @@ public class ConcatRowsAndColumns implements RowsAndColumns
       ArrayList<RowsAndColumns> racBuffer
   )
   {
+    Preconditions.checkNotNull(racBuffer, "racBuffer cannot be null");
     this.racBuffer = racBuffer;
 
     int numRows = 0;
@@ -76,6 +79,9 @@ public class ConcatRowsAndColumns implements RowsAndColumns
   @Override
   public Collection<String> getColumnNames()
   {
+    if (racBuffer.isEmpty()) {
+      return Collections.emptySet();
+    }
     return racBuffer.get(0).getColumnNames();
   }
 

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
@@ -92,6 +92,9 @@ public class ConcatRowsAndColumns implements RowsAndColumns
     if (columnCache.containsKey(name)) {
       return columnCache.get(name);
     } else {
+      if (racBuffer.isEmpty()) {
+        return null;
+      }
       final Column firstCol = racBuffer.get(0).findColumn(name);
       if (firstCol == null) {
         for (int i = 1; i < racBuffer.size(); ++i) {

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumnsTest.java
@@ -19,10 +19,13 @@
 
 package org.apache.druid.query.rowsandcols;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.query.rowsandcols.column.IntArrayColumn;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.function.Function;
 
 public class ConcatRowsAndColumnsTest extends RowsAndColumnsTestBase
@@ -47,9 +50,53 @@ public class ConcatRowsAndColumnsTest extends RowsAndColumnsTestBase
   };
 
   @Test
+  public void testConstructorWithNullRacBuffer()
+  {
+    final NullPointerException e = Assert.assertThrows(
+        NullPointerException.class,
+        () -> new ConcatRowsAndColumns(null)
+    );
+    Assert.assertEquals("racBuffer cannot be null", e.getMessage());
+  }
+
+  @Test
+  public void testFindColumn()
+  {
+    MapOfColumnsRowsAndColumns rac = MapOfColumnsRowsAndColumns.fromMap(
+        ImmutableMap.of(
+            "column1", new IntArrayColumn(new int[]{1, 2, 3, 4, 5, 6}),
+            "column2", new IntArrayColumn(new int[]{6, 5, 4, 3, 2, 1})
+        )
+    );
+    ConcatRowsAndColumns apply = MAKER.apply(rac);
+    Assert.assertEquals(1, apply.findColumn("column1").toAccessor().getInt(0));
+    Assert.assertEquals(6, apply.findColumn("column2").toAccessor().getInt(0));
+  }
+
+  @Test
   public void testFindColumnWithEmptyRacBuffer()
   {
     ConcatRowsAndColumns concatRowsAndColumns = new ConcatRowsAndColumns(new ArrayList<>());
     Assert.assertNull(concatRowsAndColumns.findColumn("columnName"));
+  }
+
+  @Test
+  public void testGetColumns()
+  {
+    MapOfColumnsRowsAndColumns rac = MapOfColumnsRowsAndColumns.fromMap(
+        ImmutableMap.of(
+            "column1", new IntArrayColumn(new int[]{0, 0, 0, 1, 1, 2, 4, 4, 4}),
+            "column2", new IntArrayColumn(new int[]{3, 54, 21, 1, 5, 54, 2, 3, 92})
+        )
+    );
+    ConcatRowsAndColumns apply = MAKER.apply(rac);
+    Assert.assertEquals(Arrays.asList("column1", "column2"), new ArrayList<>(apply.getColumnNames()));
+  }
+
+  @Test
+  public void testGetColumnsWithEmptyRacBuffer()
+  {
+    ConcatRowsAndColumns concatRowsAndColumns = new ConcatRowsAndColumns(new ArrayList<>());
+    Assert.assertTrue(concatRowsAndColumns.getColumnNames().isEmpty());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumnsTest.java
@@ -19,6 +19,9 @@
 
 package org.apache.druid.query.rowsandcols;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.function.Function;
 
@@ -42,4 +45,11 @@ public class ConcatRowsAndColumnsTest extends RowsAndColumnsTestBase
 
     return new ConcatRowsAndColumns(theRac);
   };
+
+  @Test
+  public void testFindColumnWithEmptyRacBuffer()
+  {
+    ConcatRowsAndColumns concatRowsAndColumns = new ConcatRowsAndColumns(new ArrayList<>());
+    Assert.assertNull(concatRowsAndColumns.findColumn("columnName"));
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -7622,6 +7622,13 @@ public class DrillWindowQueryTest extends BaseCalciteQueryTest
     windowQueryTest();
   }
 
+  @DrillTest("druid_queries/empty_over_clause/single_empty_over_3")
+  @Test
+  public void test_empty_over_single_empty_over_3()
+  {
+    windowQueryTest();
+  }
+
   @DrillTest("druid_queries/empty_over_clause/multiple_empty_over_1")
   @Test
   public void test_empty_over_multiple_empty_over_1()

--- a/sql/src/test/resources/drill/window/queries/druid_queries/empty_over_clause/single_empty_over_3.q
+++ b/sql/src/test/resources/drill/window/queries/druid_queries/empty_over_clause/single_empty_over_3.q
@@ -1,0 +1,4 @@
+select countryName, row_number() over () as c1
+from wikipedia
+where countryName in ('non-existent-country')
+group by countryName, cityName, channel


### PR DESCRIPTION
### Description

Currently, queries like the following give IndexOutOfBoundsException error because we attempt to create a frame writer for empty RAC.

```sql
select countryName, row_number() over () as c1
from wikipedia
where countryName in ('non-existent-country')
group by countryName, cityName, channel
```

The above query gives:

```java
 Caused by: java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:374)
	at java.base/java.util.ArrayList.get(ArrayList.java:459)
	at org.apache.druid.query.rowsandcols.ConcatRowsAndColumns.findColumn(ConcatRowsAndColumns.java:95)
	at org.apache.druid.query.rowsandcols.semantic.DefaultColumnSelectorFactoryMaker$ColumnAccessorBasedColumnSelectorFactory.withColumnAccessor(DefaultColumnSelectorFactoryMaker.java:183)
	at org.apache.druid.query.rowsandcols.semantic.DefaultColumnSelectorFactoryMaker$ColumnAccessorBasedColumnSelectorFactory.makeDimensionSelector(DefaultColumnSelectorFactoryMaker.java:83)
	at org.apache.druid.frame.field.FieldWriters.makeStringWriter(FieldWriters.java:132)
	at org.apache.druid.frame.field.FieldWriters.create(FieldWriters.java:78)
	at org.apache.druid.frame.write.RowBasedFrameWriterFactory.makeFieldWriters(RowBasedFrameWriterFactory.java:117)
	at org.apache.druid.frame.write.RowBasedFrameWriterFactory.newFrameWriter(RowBasedFrameWriterFactory.java:76)
	at org.apache.druid.msq.querykit.WindowOperatorQueryFrameProcessor.createFrameWriterIfNeeded(WindowOperatorQueryFrameProcessor.java:407)
	at org.apache.druid.msq.querykit.WindowOperatorQueryFrameProcessor.flushAllRowsAndCols(WindowOperatorQueryFrameProcessor.java:394)
```

This PR fixes it and adds a test that fails with the above stacktrace without this PR's change.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
