### PR TITLE
Web console: Server context defaults

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5085,7 +5085,7 @@ license_category: binary
 module: web-console
 license_name: Apache License version 2.0
 copyright: Imply Data
-version: 0.22.20
+version: 0.22.21
 
 ---
 

--- a/web-console/console-config.js
+++ b/web-console/console-config.js
@@ -17,6 +17,5 @@
  */
 
 window.consoleConfig = {
-  exampleManifestsUrl: 'https://druid.apache.org/data/example-manifests-v2.tsv',
-  /* future configs may go here */
+  /* configs go here */
 };

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -14,7 +14,7 @@
         "@blueprintjs/datetime2": "^2.3.7",
         "@blueprintjs/icons": "^5.10.0",
         "@blueprintjs/select": "^5.2.1",
-        "@druid-toolkit/query": "^0.22.20",
+        "@druid-toolkit/query": "^0.22.21",
         "@druid-toolkit/visuals-core": "^0.3.3",
         "@druid-toolkit/visuals-react": "^0.3.3",
         "@fontsource/open-sans": "^5.0.28",
@@ -989,9 +989,9 @@
       }
     },
     "node_modules/@druid-toolkit/query": {
-      "version": "0.22.20",
-      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.22.20.tgz",
-      "integrity": "sha512-GmmSd27y7zLVTjgTBQy+XoGeSSGhSDNmwyiwWtSua7I5LX8XqHV7Chi8HIH25YQoVgTK1pLK4RS8eRXxthRAzg==",
+      "version": "0.22.21",
+      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.22.21.tgz",
+      "integrity": "sha512-4k0NGO2Ay90naSO8nyivPPvvhz73D/OkCo6So3frmPDLFfw5CYKSvAhy4RadtnLMZPwsnlVREjAmqbvBsHqgjQ==",
       "dependencies": {
         "tslib": "^2.5.2"
       }
@@ -19093,9 +19093,9 @@
       "dev": true
     },
     "@druid-toolkit/query": {
-      "version": "0.22.20",
-      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.22.20.tgz",
-      "integrity": "sha512-GmmSd27y7zLVTjgTBQy+XoGeSSGhSDNmwyiwWtSua7I5LX8XqHV7Chi8HIH25YQoVgTK1pLK4RS8eRXxthRAzg==",
+      "version": "0.22.21",
+      "resolved": "https://registry.npmjs.org/@druid-toolkit/query/-/query-0.22.21.tgz",
+      "integrity": "sha512-4k0NGO2Ay90naSO8nyivPPvvhz73D/OkCo6So3frmPDLFfw5CYKSvAhy4RadtnLMZPwsnlVREjAmqbvBsHqgjQ==",
       "requires": {
         "tslib": "^2.5.2"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -68,7 +68,7 @@
     "@blueprintjs/datetime2": "^2.3.7",
     "@blueprintjs/icons": "^5.10.0",
     "@blueprintjs/select": "^5.2.1",
-    "@druid-toolkit/query": "^0.22.20",
+    "@druid-toolkit/query": "^0.22.21",
     "@druid-toolkit/visuals-core": "^0.3.3",
     "@druid-toolkit/visuals-react": "^0.3.3",
     "@fontsource/open-sans": "^5.0.28",

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -59,7 +59,6 @@ import './header-bar.scss';
 const capabilitiesOverride = localStorageGetJson(LocalStorageKeys.CAPABILITIES_OVERRIDE);
 
 export type HeaderActiveTab =
-  | null
   | 'data-loader'
   | 'streaming-data-loader'
   | 'classic-batch-data-loader'
@@ -93,7 +92,7 @@ const DruidLogo = React.memo(function DruidLogo() {
 });
 
 export interface HeaderBarProps {
-  active: HeaderActiveTab;
+  active: HeaderActiveTab | null;
   capabilities: Capabilities;
   onUnrestrict(capabilities: Capabilities): void;
 }

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -68,7 +68,7 @@ function switchTab(tab: HeaderActiveTab) {
   location.hash = tab;
 }
 
-function switchWorkspeaceTab(tabId: string) {
+function switchToWorkbenchTab(tabId: string) {
   location.hash = `workbench/${tabId}`;
 }
 
@@ -320,7 +320,7 @@ export class ConsoleApplication extends React.PureComponent<
       <WorkbenchView
         capabilities={capabilities}
         tabId={p.match.params.tabId}
-        onTabChange={switchWorkspeaceTab}
+        onTabChange={switchToWorkbenchTab}
         initQueryWithContext={this.queryWithContext}
         defaultQueryContext={defaultQueryContext}
         mandatoryQueryContext={mandatoryQueryContext}

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -28,7 +28,7 @@ import type { Filter } from 'react-table';
 
 import type { HeaderActiveTab } from './components';
 import { HeaderBar, Loader } from './components';
-import type { DruidEngine, QueryWithContext } from './druid-models';
+import type { DruidEngine, QueryContext, QueryWithContext } from './druid-models';
 import { Capabilities, maybeGetClusterCapacity } from './helpers';
 import { stringToTableFilters, tableFiltersToString } from './react-table';
 import { AppToaster } from './singletons';
@@ -51,22 +51,32 @@ import './console-application.scss';
 
 type FiltersRouteMatch = RouteComponentProps<{ filters?: string }>;
 
-function changeHashWithFilter(slug: string, filters: Filter[]) {
+function changeTabWithFilter(tab: HeaderActiveTab, filters: Filter[]) {
   const filterString = tableFiltersToString(filters);
-  location.hash = slug + (filterString ? `/${filterString}` : '');
+  location.hash = tab + (filterString ? `/${filterString}` : '');
 }
 
-function viewFilterChange(slug: string) {
-  return (filters: Filter[]) => changeHashWithFilter(slug, filters);
+function viewFilterChange(tab: HeaderActiveTab) {
+  return (filters: Filter[]) => changeTabWithFilter(tab, filters);
 }
 
-function pathWithFilter(slug: string) {
-  return [`/${slug}/:filters`, `/${slug}`];
+function pathWithFilter(tab: HeaderActiveTab) {
+  return [`/${tab}/:filters`, `/${tab}`];
+}
+
+function switchTab(tab: HeaderActiveTab) {
+  location.hash = tab;
+}
+
+function switchWorkspeaceTab(tabId: string) {
+  location.hash = `workbench/${tabId}`;
 }
 
 export interface ConsoleApplicationProps {
-  defaultQueryContext?: Record<string, any>;
-  mandatoryQueryContext?: Record<string, any>;
+  baseQueryContext?: QueryContext;
+  defaultQueryContext?: QueryContext;
+  mandatoryQueryContext?: QueryContext;
+  serverQueryContext?: QueryContext;
 }
 
 export interface ConsoleApplicationState {
@@ -158,22 +168,22 @@ export class ConsoleApplication extends React.PureComponent<
 
   private readonly goToStreamingDataLoader = (supervisorId?: string) => {
     if (supervisorId) this.supervisorId = supervisorId;
-    location.hash = 'streaming-data-loader';
+    switchTab('streaming-data-loader');
     this.resetInitialsWithDelay();
   };
 
   private readonly goToClassicBatchDataLoader = (taskId?: string) => {
     if (taskId) this.taskId = taskId;
-    location.hash = 'classic-batch-data-loader';
+    switchTab('classic-batch-data-loader');
     this.resetInitialsWithDelay();
   };
 
   private readonly goToDatasources = (datasource: string) => {
-    changeHashWithFilter('datasources', [{ id: 'datasource', value: `=${datasource}` }]);
+    changeTabWithFilter('datasources', [{ id: 'datasource', value: `=${datasource}` }]);
   };
 
   private readonly goToSegments = (datasource: string, onlyUnavailable = false) => {
-    changeHashWithFilter(
+    changeTabWithFilter(
       'segments',
       compact([
         { id: 'datasource', value: `=${datasource}` },
@@ -183,19 +193,19 @@ export class ConsoleApplication extends React.PureComponent<
   };
 
   private readonly goToSupervisor = (supervisorId: string) => {
-    changeHashWithFilter('supervisors', [{ id: 'supervisor_id', value: `=${supervisorId}` }]);
+    changeTabWithFilter('supervisors', [{ id: 'supervisor_id', value: `=${supervisorId}` }]);
   };
 
   private readonly goToTasksWithTaskId = (taskId: string) => {
-    changeHashWithFilter('tasks', [{ id: 'task_id', value: `=${taskId}` }]);
+    changeTabWithFilter('tasks', [{ id: 'task_id', value: `=${taskId}` }]);
   };
 
   private readonly goToTasksWithTaskGroupId = (taskGroupId: string) => {
-    changeHashWithFilter('tasks', [{ id: 'group_id', value: `=${taskGroupId}` }]);
+    changeTabWithFilter('tasks', [{ id: 'group_id', value: `=${taskGroupId}` }]);
   };
 
   private readonly goToTasksWithDatasource = (datasource: string, type?: string) => {
-    changeHashWithFilter(
+    changeTabWithFilter(
       'tasks',
       compact([
         { id: 'datasource', value: `=${datasource}` },
@@ -206,24 +216,24 @@ export class ConsoleApplication extends React.PureComponent<
 
   private readonly openSupervisorSubmit = () => {
     this.openSupervisorDialog = true;
-    location.hash = 'supervisors';
+    switchTab('supervisors');
     this.resetInitialsWithDelay();
   };
 
   private readonly openTaskSubmit = () => {
     this.openTaskDialog = true;
-    location.hash = 'tasks';
+    switchTab('tasks');
     this.resetInitialsWithDelay();
   };
 
   private readonly goToQuery = (queryWithContext: QueryWithContext) => {
     this.queryWithContext = queryWithContext;
-    location.hash = 'workbench';
+    switchTab('workbench');
     this.resetInitialsWithDelay();
   };
 
   private readonly wrapInViewContainer = (
-    active: HeaderActiveTab,
+    active: HeaderActiveTab | null,
     el: JSX.Element,
     classType: 'normal' | 'narrow-pad' | 'thin' | 'thinner' = 'normal',
   ) => {
@@ -293,7 +303,8 @@ export class ConsoleApplication extends React.PureComponent<
   };
 
   private readonly wrappedWorkbenchView = (p: RouteComponentProps<{ tabId?: string }>) => {
-    const { defaultQueryContext, mandatoryQueryContext } = this.props;
+    const { defaultQueryContext, mandatoryQueryContext, baseQueryContext, serverQueryContext } =
+      this.props;
     const { capabilities } = this.state;
 
     const queryEngines: DruidEngine[] = ['native'];
@@ -309,12 +320,12 @@ export class ConsoleApplication extends React.PureComponent<
       <WorkbenchView
         capabilities={capabilities}
         tabId={p.match.params.tabId}
-        onTabChange={newTabId => {
-          location.hash = `workbench/${newTabId}`;
-        }}
+        onTabChange={switchWorkspeaceTab}
         initQueryWithContext={this.queryWithContext}
         defaultQueryContext={defaultQueryContext}
         mandatoryQueryContext={mandatoryQueryContext}
+        baseQueryContext={baseQueryContext}
+        serverQueryContext={serverQueryContext}
         queryEngines={queryEngines}
         allowExplain
         goToTask={this.goToTasksWithTaskId}
@@ -325,6 +336,7 @@ export class ConsoleApplication extends React.PureComponent<
   };
 
   private readonly wrappedSqlDataLoaderView = () => {
+    const { serverQueryContext } = this.props;
     const { capabilities } = this.state;
     return this.wrapInViewContainer(
       'sql-data-loader',
@@ -334,6 +346,7 @@ export class ConsoleApplication extends React.PureComponent<
         goToTask={this.goToTasksWithTaskId}
         goToTaskGroup={this.goToTasksWithTaskGroupId}
         getClusterCapacity={maybeGetClusterCapacity}
+        serverQueryContext={serverQueryContext}
       />,
     );
   };

--- a/web-console/src/druid-models/query-context/query-context.tsx
+++ b/web-console/src/druid-models/query-context/query-context.tsx
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-import { deepDelete, deepSet } from '../../utils';
-
+export type SelectDestination = 'taskReport' | 'durableStorage';
 export type ArrayIngestMode = 'array' | 'mvd';
+export type TaskAssignment = 'auto' | 'max';
+export type SqlJoinAlgorithm = 'broadcast' | 'sortMerge';
 
 export interface QueryContext {
   useCache?: boolean;
@@ -30,14 +31,37 @@ export interface QueryContext {
   // Multi-stage query
   maxNumTasks?: number;
   finalizeAggregations?: boolean;
-  selectDestination?: string;
+  selectDestination?: SelectDestination;
   durableShuffleStorage?: boolean;
   maxParseExceptions?: number;
   groupByEnableMultiValueUnnesting?: boolean;
   arrayIngestMode?: ArrayIngestMode;
+  taskAssignment?: TaskAssignment;
+  sqlJoinAlgorithm?: SqlJoinAlgorithm;
+  failOnEmptyInsert?: boolean;
+  waitUntilSegmentsLoad?: boolean;
 
   [key: string]: any;
 }
+
+export const DEFAULT_SERVER_QUERY_CONTEXT: QueryContext = {
+  useCache: true,
+  populateCache: true,
+  useApproximateCountDistinct: true,
+  useApproximateTopN: true,
+  sqlTimeZone: 'Etc/UTC',
+
+  // Multi-stage query
+  finalizeAggregations: true,
+  selectDestination: 'taskReport',
+  durableShuffleStorage: false,
+  maxParseExceptions: 0,
+  groupByEnableMultiValueUnnesting: true,
+  taskAssignment: 'max',
+  sqlJoinAlgorithm: 'broadcast',
+  failOnEmptyInsert: false,
+  waitUntilSegmentsLoad: false,
+};
 
 export interface QueryWithContext {
   queryString: string;
@@ -49,221 +73,10 @@ export function isEmptyContext(context: QueryContext | undefined): boolean {
   return !context || Object.keys(context).length === 0;
 }
 
-// -----------------------------
-
-export function getUseCache(context: QueryContext): boolean {
-  const { useCache } = context;
-  return typeof useCache === 'boolean' ? useCache : true;
-}
-
-export function changeUseCache(context: QueryContext, useCache: boolean): QueryContext {
-  let newContext = context;
-  if (useCache) {
-    newContext = deepDelete(newContext, 'useCache');
-    newContext = deepDelete(newContext, 'populateCache');
-  } else {
-    newContext = deepSet(newContext, 'useCache', false);
-    newContext = deepSet(newContext, 'populateCache', false);
-  }
-  return newContext;
-}
-
-// -----------------------------
-
-export function getUseApproximateCountDistinct(context: QueryContext): boolean {
-  const { useApproximateCountDistinct } = context;
-  return typeof useApproximateCountDistinct === 'boolean' ? useApproximateCountDistinct : true;
-}
-
-export function changeUseApproximateCountDistinct(
+export function getQueryContextKey(
+  key: keyof QueryContext,
   context: QueryContext,
-  useApproximateCountDistinct: boolean,
-): QueryContext {
-  if (useApproximateCountDistinct) {
-    return deepDelete(context, 'useApproximateCountDistinct');
-  } else {
-    return deepSet(context, 'useApproximateCountDistinct', false);
-  }
-}
-
-// -----------------------------
-
-export function getUseApproximateTopN(context: QueryContext): boolean {
-  const { useApproximateTopN } = context;
-  return typeof useApproximateTopN === 'boolean' ? useApproximateTopN : true;
-}
-
-export function changeUseApproximateTopN(
-  context: QueryContext,
-  useApproximateTopN: boolean,
-): QueryContext {
-  if (useApproximateTopN) {
-    return deepDelete(context, 'useApproximateTopN');
-  } else {
-    return deepSet(context, 'useApproximateTopN', false);
-  }
-}
-
-// sqlTimeZone
-
-export function getTimezone(context: QueryContext): string | undefined {
-  return context.sqlTimeZone;
-}
-
-export function changeTimezone(context: QueryContext, timezone: string | undefined): QueryContext {
-  if (timezone) {
-    return deepSet(context, 'sqlTimeZone', timezone);
-  } else {
-    return deepDelete(context, 'sqlTimeZone');
-  }
-}
-
-// maxNumTasks
-
-export function getMaxNumTasks(context: QueryContext): number | undefined {
-  return context.maxNumTasks;
-}
-
-export function changeMaxNumTasks(
-  context: QueryContext,
-  maxNumTasks: number | undefined,
-): QueryContext {
-  return typeof maxNumTasks === 'number'
-    ? deepSet(context, 'maxNumTasks', maxNumTasks)
-    : deepDelete(context, 'maxNumTasks');
-}
-
-// taskAssignment
-
-export function getTaskAssigment(context: QueryContext): string {
-  const { taskAssignment } = context;
-  return taskAssignment ?? 'max';
-}
-
-export function changeTaskAssigment(
-  context: QueryContext,
-  taskAssignment: string | undefined,
-): QueryContext {
-  return typeof taskAssignment === 'string'
-    ? deepSet(context, 'taskAssignment', taskAssignment)
-    : deepDelete(context, 'taskAssignment');
-}
-
-// failOnEmptyInsert
-
-export function getFailOnEmptyInsert(context: QueryContext): boolean | undefined {
-  const { failOnEmptyInsert } = context;
-  return typeof failOnEmptyInsert === 'boolean' ? failOnEmptyInsert : undefined;
-}
-
-export function changeFailOnEmptyInsert(
-  context: QueryContext,
-  failOnEmptyInsert: boolean | undefined,
-): QueryContext {
-  return typeof failOnEmptyInsert === 'boolean'
-    ? deepSet(context, 'failOnEmptyInsert', failOnEmptyInsert)
-    : deepDelete(context, 'failOnEmptyInsert');
-}
-
-// finalizeAggregations
-
-export function getFinalizeAggregations(context: QueryContext): boolean | undefined {
-  const { finalizeAggregations } = context;
-  return typeof finalizeAggregations === 'boolean' ? finalizeAggregations : undefined;
-}
-
-export function changeFinalizeAggregations(
-  context: QueryContext,
-  finalizeAggregations: boolean | undefined,
-): QueryContext {
-  return typeof finalizeAggregations === 'boolean'
-    ? deepSet(context, 'finalizeAggregations', finalizeAggregations)
-    : deepDelete(context, 'finalizeAggregations');
-}
-
-// waitUntilSegmentsLoad
-
-export function getWaitUntilSegmentsLoad(context: QueryContext): boolean | undefined {
-  const { waitUntilSegmentsLoad } = context;
-  return typeof waitUntilSegmentsLoad === 'boolean' ? waitUntilSegmentsLoad : undefined;
-}
-
-export function changeWaitUntilSegmentsLoad(
-  context: QueryContext,
-  waitUntilSegmentsLoad: boolean | undefined,
-): QueryContext {
-  return typeof waitUntilSegmentsLoad === 'boolean'
-    ? deepSet(context, 'waitUntilSegmentsLoad', waitUntilSegmentsLoad)
-    : deepDelete(context, 'waitUntilSegmentsLoad');
-}
-
-// groupByEnableMultiValueUnnesting
-
-export function getGroupByEnableMultiValueUnnesting(context: QueryContext): boolean | undefined {
-  const { groupByEnableMultiValueUnnesting } = context;
-  return typeof groupByEnableMultiValueUnnesting === 'boolean'
-    ? groupByEnableMultiValueUnnesting
-    : undefined;
-}
-
-export function changeGroupByEnableMultiValueUnnesting(
-  context: QueryContext,
-  groupByEnableMultiValueUnnesting: boolean | undefined,
-): QueryContext {
-  return typeof groupByEnableMultiValueUnnesting === 'boolean'
-    ? deepSet(context, 'groupByEnableMultiValueUnnesting', groupByEnableMultiValueUnnesting)
-    : deepDelete(context, 'groupByEnableMultiValueUnnesting');
-}
-
-// durableShuffleStorage
-
-export function getDurableShuffleStorage(context: QueryContext): boolean {
-  const { durableShuffleStorage } = context;
-  return Boolean(durableShuffleStorage);
-}
-
-export function changeDurableShuffleStorage(
-  context: QueryContext,
-  durableShuffleStorage: boolean,
-): QueryContext {
-  if (durableShuffleStorage) {
-    return deepSet(context, 'durableShuffleStorage', true);
-  } else {
-    return deepDelete(context, 'durableShuffleStorage');
-  }
-}
-
-// maxParseExceptions
-
-export function getMaxParseExceptions(context: QueryContext): number {
-  const { maxParseExceptions } = context;
-  return Number(maxParseExceptions) || 0;
-}
-
-export function changeMaxParseExceptions(
-  context: QueryContext,
-  maxParseExceptions: number,
-): QueryContext {
-  if (maxParseExceptions !== 0) {
-    return deepSet(context, 'maxParseExceptions', maxParseExceptions);
-  } else {
-    return deepDelete(context, 'maxParseExceptions');
-  }
-}
-
-// arrayIngestMode
-
-export function getArrayIngestMode(context: QueryContext): ArrayIngestMode | undefined {
-  return context.arrayIngestMode;
-}
-
-export function changeArrayIngestMode(
-  context: QueryContext,
-  arrayIngestMode: ArrayIngestMode | undefined,
-): QueryContext {
-  if (arrayIngestMode) {
-    return deepSet(context, 'arrayIngestMode', arrayIngestMode);
-  } else {
-    return deepDelete(context, 'arrayIngestMode');
-  }
+  defaultContext: QueryContext,
+): any {
+  return typeof context[key] !== 'undefined' ? context[key] : defaultContext[key];
 }

--- a/web-console/src/entry.tsx
+++ b/web-console/src/entry.tsx
@@ -28,6 +28,7 @@ import { createRoot } from 'react-dom/client';
 import { bootstrapJsonParse } from './bootstrap/json-parser';
 import { bootstrapReactTable } from './bootstrap/react-table-defaults';
 import { ConsoleApplication } from './console-application';
+import type { QueryContext } from './druid-models';
 import type { Links } from './links';
 import { setLinkOverrides } from './links';
 import { Api, UrlBaser } from './singletons';
@@ -55,11 +56,16 @@ interface ConsoleConfig {
   // A set of custom headers name/value to set on every AJAX request
   customHeaders?: Record<string, string>;
 
-  // The query context to set if the user does not have one saved in local storage, defaults to {}
-  defaultQueryContext?: Record<string, any>;
+  baseQueryContext?: QueryContext;
+
+  // The query context to set one new query tabs
+  defaultQueryContext?: QueryContext;
 
   // Extra context properties that will be added to all query requests
-  mandatoryQueryContext?: Record<string, any>;
+  mandatoryQueryContext?: QueryContext;
+
+  // The default context that is set by the server
+  serverQueryContext?: QueryContext;
 
   // Allow for link overriding to different docs
   linkOverrides?: Links;
@@ -104,8 +110,10 @@ QueryRunner.defaultQueryExecutor = (payload, isSql, cancelToken) => {
 createRoot(container).render(
   <OverlaysProvider>
     <ConsoleApplication
+      baseQueryContext={consoleConfig.baseQueryContext}
       defaultQueryContext={consoleConfig.defaultQueryContext}
       mandatoryQueryContext={consoleConfig.mandatoryQueryContext}
+      serverQueryContext={consoleConfig.serverQueryContext}
     />
   </OverlaysProvider>,
 );

--- a/web-console/src/helpers/execution/sql-task-execution.ts
+++ b/web-console/src/helpers/execution/sql-task-execution.ts
@@ -36,6 +36,7 @@ function ensureExecutionModeIsSet(context: QueryContext | undefined): QueryConte
 export interface SubmitTaskQueryOptions {
   query: string | Record<string, any>;
   context?: QueryContext;
+  baseQueryContext?: QueryContext;
   prefixLines?: number;
   cancelToken?: CancelToken;
   preserveOnTermination?: boolean;
@@ -45,7 +46,15 @@ export interface SubmitTaskQueryOptions {
 export async function submitTaskQuery(
   options: SubmitTaskQueryOptions,
 ): Promise<Execution | IntermediateQueryState<Execution>> {
-  const { query, context, prefixLines, cancelToken, preserveOnTermination, onSubmitted } = options;
+  const {
+    query,
+    context,
+    baseQueryContext,
+    prefixLines,
+    cancelToken,
+    preserveOnTermination,
+    onSubmitted,
+  } = options;
 
   let sqlQuery: string;
   let jsonQuery: Record<string, any>;
@@ -53,7 +62,7 @@ export async function submitTaskQuery(
     sqlQuery = query;
     jsonQuery = {
       query: sqlQuery,
-      context: ensureExecutionModeIsSet(context),
+      context: ensureExecutionModeIsSet({ ...baseQueryContext, ...context }),
       resultFormat: 'array',
       header: true,
       typesHeader: true,
@@ -65,6 +74,7 @@ export async function submitTaskQuery(
     jsonQuery = {
       ...query,
       context: ensureExecutionModeIsSet({
+        ...baseQueryContext,
         ...query.context,
         ...context,
       }),
@@ -96,7 +106,7 @@ export async function submitTaskQuery(
     );
   }
 
-  const execution = Execution.fromAsyncStatus(sqlAsyncStatus, sqlQuery, context);
+  const execution = Execution.fromAsyncStatus(sqlAsyncStatus, sqlQuery, jsonQuery.context);
 
   if (onSubmitted) {
     onSubmitted(execution.id);

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -389,6 +389,12 @@ export function assemble<T>(...xs: (T | undefined | false | null | '')[]): T[] {
   return compact(xs);
 }
 
+export function removeUndefinedValues<T extends Record<string, any>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([_, value]) => value !== undefined),
+  ) as Partial<T>;
+}
+
 export function moveToEnd<T>(
   xs: T[],
   predicate: (value: T, index: number, array: T[]) => unknown,

--- a/web-console/src/utils/values-query.spec.tsx
+++ b/web-console/src/utils/values-query.spec.tsx
@@ -45,6 +45,7 @@ describe('queryResultToValuesQuery', () => {
           [2, 3],
           null,
         ],
+        [null, null, null, null, null, null, null],
       ],
       false,
       true,
@@ -64,7 +65,8 @@ describe('queryResultToValuesQuery', () => {
       FROM (
         VALUES
         ('2022-02-01T00:00:00.000Z', 'brokerA.internal', 'broker', '{"type":"sys","swap/free":1223334,"swap/max":3223334}', 'es<#>es-419', '1', NULL),
-        ('2022-02-01T00:00:00.000Z', 'brokerA.internal', 'broker', '{"type":"query","time":1223,"bytes":2434234}', 'en<#>es<#>es-419', '2<#>3', NULL)
+        ('2022-02-01T00:00:00.000Z', 'brokerA.internal', 'broker', '{"type":"query","time":1223,"bytes":2434234}', 'en<#>es<#>es-419', '2<#>3', NULL),
+        (NULL, NULL, NULL, NULL, NULL, NULL, NULL)
       ) AS "t" ("c1", "c2", "c3", "c4", "c5", "c6", "c7")
     `);
   });

--- a/web-console/src/utils/values-query.tsx
+++ b/web-console/src/utils/values-query.tsx
@@ -65,29 +65,29 @@ export function queryResultToValuesQuery(sample: QueryResult): SqlQuery {
       expression: SqlValues.create(
         rows.map(row =>
           SqlRecord.create(
-            row.map((r, i) => {
-              if (r == null) return L.NULL;
+            row.map((d, i) => {
+              if (d == null) return L.NULL;
               const column = header[i];
               const { nativeType } = column;
               const sqlType = getEffectiveSqlType(column);
               if (nativeType === 'COMPLEX<json>') {
-                return L(isJsonString(r) ? r : JSONBig.stringify(r));
+                return L(isJsonString(d) ? d : JSONBig.stringify(d));
               } else if (String(sqlType).endsWith(' ARRAY')) {
-                return L(r.join(SAMPLE_ARRAY_SEPARATOR));
+                return L(d.join(SAMPLE_ARRAY_SEPARATOR));
               } else if (
                 sqlType === 'OTHER' &&
                 String(nativeType).startsWith('COMPLEX<') &&
-                typeof r === 'string' &&
-                r.startsWith('"') &&
-                r.endsWith('"')
+                typeof d === 'string' &&
+                d.startsWith('"') &&
+                d.endsWith('"')
               ) {
-                // r is a JSON encoded base64 string
-                return L(r.slice(1, -1));
-              } else if (typeof r === 'object') {
+                // d is a JSON encoded base64 string
+                return L(d.slice(1, -1));
+              } else if (typeof d === 'object') {
                 // Cleanup array if it happens to get here, it shouldn't.
                 return L.NULL;
               } else {
-                return L(r);
+                return L(d);
               }
             }),
           ),

--- a/web-console/src/utils/values-query.tsx
+++ b/web-console/src/utils/values-query.tsx
@@ -66,6 +66,7 @@ export function queryResultToValuesQuery(sample: QueryResult): SqlQuery {
         rows.map(row =>
           SqlRecord.create(
             row.map((r, i) => {
+              if (r == null) return L.NULL;
               const column = header[i];
               const { nativeType } = column;
               const sqlType = getEffectiveSqlType(column);

--- a/web-console/src/views/sql-data-loader-view/sql-data-loader-view.tsx
+++ b/web-console/src/views/sql-data-loader-view/sql-data-loader-view.tsx
@@ -30,6 +30,7 @@ import type {
   QueryWithContext,
 } from '../../druid-models';
 import {
+  DEFAULT_SERVER_QUERY_CONTEXT,
   Execution,
   externalConfigToIngestQueryPattern,
   ingestQueryPatternToQuery,
@@ -65,12 +66,20 @@ export interface SqlDataLoaderViewProps {
   goToTask(taskId: string): void;
   goToTaskGroup(taskGroupId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
+  serverQueryContext?: QueryContext;
 }
 
 export const SqlDataLoaderView = React.memo(function SqlDataLoaderView(
   props: SqlDataLoaderViewProps,
 ) {
-  const { capabilities, goToQuery, goToTask, goToTaskGroup, getClusterCapacity } = props;
+  const {
+    capabilities,
+    goToQuery,
+    goToTask,
+    goToTaskGroup,
+    getClusterCapacity,
+    serverQueryContext = DEFAULT_SERVER_QUERY_CONTEXT,
+  } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
   const [externalConfigStep, setExternalConfigStep] = useState<Partial<ExternalConfig>>({});
   const [content, setContent] = useLocalStorageState<LoaderContent | undefined>(
@@ -187,6 +196,7 @@ export const SqlDataLoaderView = React.memo(function SqlDataLoaderView(
               clusterCapacity={capabilities.getMaxTaskSlots()}
               queryContext={content.queryContext || {}}
               changeQueryContext={queryContext => setContent({ ...content, queryContext })}
+              defaultQueryContext={serverQueryContext}
               minimal
             />
           }

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.spec.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.spec.tsx
@@ -18,6 +18,7 @@
 
 import React from 'react';
 
+import { DEFAULT_SERVER_QUERY_CONTEXT } from '../../../druid-models';
 import { shallow } from '../../../utils/shallow-renderer';
 
 import { MaxTasksButton } from './max-tasks-button';
@@ -25,7 +26,12 @@ import { MaxTasksButton } from './max-tasks-button';
 describe('MaxTasksButton', () => {
   it('matches snapshot', () => {
     const comp = shallow(
-      <MaxTasksButton clusterCapacity={6} queryContext={{}} changeQueryContext={() => {}} />,
+      <MaxTasksButton
+        clusterCapacity={6}
+        queryContext={{}}
+        changeQueryContext={() => {}}
+        defaultQueryContext={DEFAULT_SERVER_QUERY_CONTEXT}
+      />,
     );
 
     expect(comp).toMatchSnapshot();

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -97,7 +97,10 @@ function externalDataTabId(tabId: string | undefined): boolean {
 }
 
 export interface WorkbenchViewProps
-  extends Pick<QueryTabProps, 'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn'> {
+  extends Pick<
+    QueryTabProps,
+    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
+  > {
   capabilities: Capabilities;
   tabId: string | undefined;
   onTabChange(newTabId: string): void;
@@ -669,6 +672,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTasksMenuHeader,
       enginesLabelFn,
       maxTasksLabelFn,
+      fullClusterCapacityLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
@@ -698,6 +702,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTasksLabelFn={maxTasksLabelFn}
+          fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
           runMoreMenu={
             <Menu>
               {allowExplain &&

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -30,7 +30,6 @@ import type { SqlQuery } from '@druid-toolkit/query';
 import { SqlExpression } from '@druid-toolkit/query';
 import classNames from 'classnames';
 import copy from 'copy-to-clipboard';
-import type { ComponentProps } from 'react';
 import React from 'react';
 
 import { SpecDialog, StringInputDialog } from '../../dialogs';
@@ -38,10 +37,15 @@ import type {
   CapacityInfo,
   DruidEngine,
   Execution,
+  QueryContext,
   QueryWithContext,
   TabEntry,
 } from '../../druid-models';
-import { guessDataSourceNameFromInputSource, WorkbenchQuery } from '../../druid-models';
+import {
+  DEFAULT_SERVER_QUERY_CONTEXT,
+  guessDataSourceNameFromInputSource,
+  WorkbenchQuery,
+} from '../../druid-models';
 import type { Capabilities } from '../../helpers';
 import { convertSpecToSql, getSpecDatasourceName, getTaskExecution } from '../../helpers';
 import { getLink } from '../../links';
@@ -71,6 +75,7 @@ import type { ExecutionDetailsTab } from './execution-details-pane/execution-det
 import { ExecutionSubmitDialog } from './execution-submit-dialog/execution-submit-dialog';
 import { ExplainDialog } from './explain-dialog/explain-dialog';
 import { MetadataChangeDetector } from './metadata-change-detector';
+import type { QueryTabProps } from './query-tab/query-tab';
 import { QueryTab } from './query-tab/query-tab';
 import { RecentQueryTaskPanel } from './recent-query-task-panel/recent-query-task-panel';
 import { TabRenameDialog } from './tab-rename-dialog/tab-rename-dialog';
@@ -91,20 +96,20 @@ function externalDataTabId(tabId: string | undefined): boolean {
   return String(tabId).startsWith('connect-external-data');
 }
 
-export interface WorkbenchViewProps {
+export interface WorkbenchViewProps
+  extends Pick<QueryTabProps, 'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn'> {
   capabilities: Capabilities;
   tabId: string | undefined;
   onTabChange(newTabId: string): void;
   initQueryWithContext: QueryWithContext | undefined;
-  defaultQueryContext?: Record<string, any>;
-  mandatoryQueryContext?: Record<string, any>;
+  baseQueryContext?: QueryContext;
+  defaultQueryContext?: QueryContext;
+  mandatoryQueryContext?: QueryContext;
+  serverQueryContext?: QueryContext;
   queryEngines: DruidEngine[];
   allowExplain: boolean;
   goToTask(taskId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
-  maxTaskMenuHeader?: JSX.Element;
-  enginesLabelFn?: ComponentProps<typeof QueryTab>['enginesLabelFn'];
-  maxTaskLabelFn?: ComponentProps<typeof QueryTab>['maxTaskLabelFn'];
   hideToolbar?: boolean;
 }
 
@@ -249,11 +254,15 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
     });
   };
 
+  private getInitWorkbenchQuery(): WorkbenchQuery {
+    return WorkbenchQuery.blank().changeQueryContext(this.props.defaultQueryContext || {});
+  }
+
   private getInitTab(): TabEntry {
     return {
       id: generate8HexId(),
       tabName: 'Tab 1',
-      query: WorkbenchQuery.blank().changeQueryContext(this.props.defaultQueryContext || {}),
+      query: this.getInitWorkbenchQuery(),
     };
   }
 
@@ -607,7 +616,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           icon={IconNames.PLUS}
           minimal
           onClick={() => {
-            this.handleNewTab(WorkbenchQuery.blank());
+            this.handleNewTab(this.getInitWorkbenchQuery());
           }}
         />
       </div>
@@ -651,13 +660,15 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
     const {
       capabilities,
       mandatoryQueryContext,
+      baseQueryContext,
+      serverQueryContext = DEFAULT_SERVER_QUERY_CONTEXT,
       queryEngines,
       allowExplain,
       goToTask,
       getClusterCapacity,
-      maxTaskMenuHeader,
+      maxTasksMenuHeader,
       enginesLabelFn,
-      maxTaskLabelFn,
+      maxTasksLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
@@ -674,6 +685,8 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           query={currentTabEntry.query}
           id={currentTabEntry.id}
           mandatoryQueryContext={mandatoryQueryContext}
+          baseQueryContext={baseQueryContext}
+          serverQueryContext={serverQueryContext}
           columnMetadata={columnMetadataState.getSomeData()}
           onQueryChange={this.handleQueryChange}
           onQueryTab={this.handleNewTab}
@@ -682,9 +695,9 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           clusterCapacity={capabilities.getMaxTaskSlots()}
           goToTask={goToTask}
           getClusterCapacity={getClusterCapacity}
-          maxTaskMenuHeader={maxTaskMenuHeader}
+          maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
-          maxTaskLabelFn={maxTaskLabelFn}
+          maxTasksLabelFn={maxTasksLabelFn}
           runMoreMenu={
             <Menu>
               {allowExplain &&


### PR DESCRIPTION
This PR is inspired by my comment in another PR https://github.com/apache/druid/pull/16819#pullrequestreview-2213300179 . Basically I made that comment and I realized it is not 100% true that `mandatoryQueryContext` does that @lorem--ipsum tried to do. I instead added `baseQueryContext` that I believe works as expected and also added a configurable `serverQueryContext` which is my implementation of the `clusterDefaultContext` I suggested in the comment.

I believe this PR fully obviates the need for 16819

Also fixes a bug where SQL data loader crashes on https://github.com/apache/druid/blob/master/processing/src/test/resources/nested-array-test-data.json