### PR TITLE
Fix issue with returning non-matching null rows in broadcast joins due to join rewrite

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/RhsRewriteCandidates.java
+++ b/processing/src/main/java/org/apache/druid/segment/join/filter/rewrite/RhsRewriteCandidates.java
@@ -23,6 +23,7 @@ import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.filter.Filters;
 import org.apache.druid.segment.filter.OrFilter;
 import org.apache.druid.segment.filter.SelectorFilter;
+import org.apache.druid.segment.join.JoinType;
 import org.apache.druid.segment.join.JoinableClause;
 import org.apache.druid.segment.join.filter.Equiconditions;
 import org.apache.druid.segment.join.filter.JoinableClauses;
@@ -106,7 +107,7 @@ public class RhsRewriteCandidates
     if (equiconditions.doesFilterSupportDirectJoinFilterRewrite(orClause)) {
       String reqColumn = orClause.getRequiredColumns().iterator().next();
       JoinableClause joinableClause = joinableClauses.getColumnFromJoinIfExists(reqColumn);
-      if (joinableClause != null) {
+      if (joinableClause != null && joinableClause.getJoinType() == JoinType.INNER) {
         return Optional.of(
             new RhsRewriteCandidate(
                 joinableClause,
@@ -121,7 +122,7 @@ public class RhsRewriteCandidates
       String reqColumn = ((SelectorFilter) orClause).getDimension();
       String reqValue = ((SelectorFilter) orClause).getValue();
       JoinableClause joinableClause = joinableClauses.getColumnFromJoinIfExists(reqColumn);
-      if (joinableClause != null) {
+      if (joinableClause != null && joinableClause.getJoinType() == JoinType.INNER) {
         return Optional.of(
             new RhsRewriteCandidate(
                 joinableClause,


### PR DESCRIPTION
### Description

Consider the following query
```sql
select
  t1.countryName, 
  t2.countryName,
  t1.code, 
  t2.code

from wikiticker t1 left join wikiticker t2
on t1.countryName = t2.countryName and t1.code = t2.code
where
  t1.countryName in ('Japan', 'Peru')
  and (t1.code in ('J', 'P') or t1.code is null)
  and t2.countryName in ('Japan', 'Peru')
  and (t2.code in ('J', 'P') or t2.code is null)
```

on the table
| countryName | code |
|--------|--------|
| Japan | J |
| Peru | null | 

The query returns the following answer

| t1.countryName | t1.code | t2.countryName | t2.code |
|--------|--------|--------|--------|
| Japan | J | Japan | null |
| Peru | null | null | null | 

However the filter `t2.countryName in ('Japan', 'Peru')` doesn't hold true for the second row that is returned. This happens because the filter on the RHS is rewritten to a filter on the LHS, which matches for both rows. The join returns `(Peru, null, null, null)` for the second row since that row doesn't join because of `(t1.code = t2.code)`. However, the rewritten filter is lost and we return an answer for which the filter doesn't hold.

<hr>


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
