### PR TITLE
Fix Parquet Reader when ingestion need to read columns in filter

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/indexing/ReaderUtils.java
+++ b/server/src/main/java/org/apache/druid/segment/indexing/ReaderUtils.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.segment.transform.Transform;
 import org.apache.druid.segment.transform.TransformSpec;
 
@@ -130,10 +131,16 @@ public class ReaderUtils
       }
     }
 
-    // Determine any fields we need to read from input file that is used in the transformSpec
+    // Determine any fields we need to read from input file that is used in the transform of the transformSpec
     List<Transform> transforms = transformSpec.getTransforms();
     for (Transform transform : transforms) {
       fieldsRequired.addAll(transform.getRequiredColumns());
+    }
+
+    // Determine any fields we need to read from input file that is used in the filter of the transformSpec
+    DimFilter filter = transformSpec.getFilter();
+    if (filter != null) {
+      fieldsRequired.addAll(filter.getRequiredColumns());
     }
 
     // Determine any fields we need to read from input file that is used in the dimensionsSpec


### PR DESCRIPTION
Fix Parquet Reader when ingestion need to read columns in filter

### Description

When columns are required in the filter (of the TransformSpec) but are not specified in any of the metricSpec, dimensionSpec, transform (of the TransformSpec), flattenSpec, timestampSpec, then it will not be read for Parquet data files. Since the columns are not read, the filter will end up not matching any rows. This fix makes sure that required columns for the filter are read from the Parquet data files (so that filters can work as expected!).

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
