### PR TITLE
Remove Query ID verification check from MSQ workers

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -1100,7 +1100,7 @@ public class WorkerImpl implements Worker
      */
     public void addKernel(final WorkerStageKernel kernel)
     {
-      final StageId stageId = verifyQueryId(kernel.getWorkOrder().getStageDefinition().getId());
+      final StageId stageId = kernel.getWorkOrder().getStageDefinition().getId();
 
       if (holderMap.putIfAbsent(stageId.getStageNumber(), new KernelHolder(kernel)) != null) {
         // Already added. Do nothing.
@@ -1116,7 +1116,7 @@ public class WorkerImpl implements Worker
      */
     public void finishProcessing(final StageId stageId)
     {
-      final KernelHolder kernel = holderMap.get(verifyQueryId(stageId).getStageNumber());
+      final KernelHolder kernel = holderMap.get(stageId.getStageNumber());
 
       if (kernel != null) {
         try {
@@ -1137,7 +1137,7 @@ public class WorkerImpl implements Worker
      */
     public void removeKernel(final StageId stageId)
     {
-      final KernelHolder removed = holderMap.remove(verifyQueryId(stageId).getStageNumber());
+      final KernelHolder removed = holderMap.remove(stageId.getStageNumber());
 
       if (removed == null) {
         throw new ISE("No kernel for stage[%s]", stageId);
@@ -1191,7 +1191,7 @@ public class WorkerImpl implements Worker
     @Nullable
     public WorkerStageKernel getKernelFor(final StageId stageId)
     {
-      final KernelHolder holder = holderMap.get(verifyQueryId(stageId).getStageNumber());
+      final KernelHolder holder = holderMap.get(stageId.getStageNumber());
       if (holder != null) {
         return holder.kernel;
       } else {
@@ -1239,15 +1239,6 @@ public class WorkerImpl implements Worker
     public void setDone()
     {
       this.done = true;
-    }
-
-    private StageId verifyQueryId(final StageId stageId)
-    {
-      if (!stageId.getQueryId().equals(workerContext.queryId())) {
-        throw new ISE("Unexpected queryId[%s], expected queryId[%s]", stageId.getQueryId(), workerContext.queryId());
-      }
-
-      return stageId;
     }
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/StageId.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/kernel/StageId.java
@@ -31,6 +31,9 @@ import java.util.Objects;
 
 /**
  * Globally unique stage identifier: query ID plus stage number.
+ *
+ * Note: Versions till Druid 30 had a bug in the QueryKits which populated the {@link #queryId} field with random
+ * UUIDs. Therefore, all usage of the field must be vetted instead of assuming that it will be the expected query id
  */
 public class StageId implements Comparable<StageId>
 {


### PR DESCRIPTION
### Description

Recent refactors to MSQ introduced a sanity check to verify that the query ID received by the worker during its communication with the controller is correct. However, there was a pre-existing bug in Druid where the query ids for each individual stage can be populated with random UUIDs instead of the correct value. Upgrade/Downgrade between any version till or before Druid 30 where the newer version runs a worker task, while the older version runs a controller task can fail. This PR removes that verification check till its safe to add it back.


<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
