### PR TITLE
Web console: bump axios to 1.7.4 to resolve CVE-2024-39338

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5301,7 +5301,7 @@ license_category: binary
 module: web-console
 license_name: MIT License
 copyright: Matt Zabriskie
-version: 1.6.7
+version: 1.7.4
 license_file_path: licenses/bin/axios.MIT
 
 ---

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -19,7 +19,7 @@
         "@druid-toolkit/visuals-react": "^0.3.3",
         "@fontsource/open-sans": "^5.0.28",
         "ace-builds": "~1.4.14",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "chronoshift": "^0.10.0",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
@@ -3968,11 +3968,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -21489,11 +21489,11 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "requires": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -73,7 +73,7 @@
     "@druid-toolkit/visuals-react": "^0.3.3",
     "@fontsource/open-sans": "^5.0.28",
     "ace-builds": "~1.4.14",
-    "axios": "^1.6.7",
+    "axios": "^1.7.4",
     "chronoshift": "^0.10.0",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.2.0",


### PR DESCRIPTION
Bumping axios version to resolve [https://github.com/advisories/GHSA-8hc4-vh64-cxmj](CVE-2024-39338) see https://github.com/axios/axios/releases/tag/v1.7.4