### PR TITLE
[docs] Batch11 date and time functions

### DIFF
--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1124,7 +1124,7 @@ Returns the following:
 
 ## EXTRACT
 
-Extracts the value of some unit of the timestamp. 
+Extracts the value of some unit from the timestamp.
 
 * **Syntax:** `EXTRACT(unit FROM timestamp_expr)`
 * **Function type:** Scalar, date and time
@@ -2536,7 +2536,7 @@ Returns whether a timestamp is contained within a particular interval. Intervals
 
 <details><summary>Example</summary>
 
-The following example returns `true` when a timestamp in the `__time` column from the `taxi-trips` datasource is in an one hour interval starting from `2013-08-01T08:00:00`. 
+The following example returns `true` when a timestamp in the `__time` column of the `taxi-trips` datasource is within a hour interval starting from `2013-08-01T08:00:00`.
 
 ```sql
 SELECT 
@@ -2600,13 +2600,11 @@ Returns the following:
 
 </details>
 
-
 [Learn more](sql-scalar.md#date-and-time-functions)
-
 
 ## TIMESTAMPADD
 
-Adds `count` number of a `unit` to a given timestamp.
+Adds a `unit` of time to `timestamp` a total of `count` times.
 
 * **Syntax:** `TIMESTAMPADD(unit, count, timestamp)`
 * **Function type:** Scalar, date and time

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -640,7 +640,7 @@ Converts a value into the specified data type.
 
 ## CEIL (date and time)
 
-Rounds up a timestamp by a given time unit. Units must be provided unquoted.
+Rounds up a timestamp by a given time unit.
 
 * **Syntax:** `CEIL(timestamp_expr TO unit>)`
 * **Function type:** Scalar, date and time
@@ -1124,7 +1124,7 @@ Returns the following:
 
 ## EXTRACT
 
-Extracts the value of some unit of the timestamp. Units must be provided unquoted. 
+Extracts the value of some unit of the timestamp. 
 
 * **Syntax:** `EXTRACT(unit FROM timestamp_expr)`
 * **Function type:** Scalar, date and time
@@ -1161,7 +1161,7 @@ Returns the value evaluated for the expression for the first row within the wind
 
 ## FLOOR (date and time)
 
-Rounds down a timestamp by a given time unit. Units must be provided unquoted.
+Rounds down a timestamp by a given time unit. 
 
 * **Syntax:** `FLOOR(timestamp_expr TO unit>)`
 * **Function type:** Scalar, date and time
@@ -1676,12 +1676,12 @@ Converts a number of milliseconds since epoch into a timestamp.
 The following example converts `1375344877000` milliseconds from epoch into a timestamp. 
 
 ```sql
-SELECT MILLIS_TO_TIMESTAMP(1375344877000) AS "millis_to_time"
+SELECT MILLIS_TO_TIMESTAMP(1375344877000) AS "timestamp"
 ```
 
 Returns the following:
 
-| `millis_to_time` |
+| `timestamp` |
 | -- |
 | `2013-08-01T08:14:37.000Z` |
 
@@ -2536,7 +2536,7 @@ Returns whether a timestamp is contained within a particular interval. Intervals
 
 <details><summary>Example</summary>
 
-The following example returns `true` when a timestamp in the `__time` column from the `taxi-trips` datasource is in a one hour interval starting from `2013-08-01T08:00:00`. 
+The following example returns `true` when a timestamp in the `__time` column from the `taxi-trips` datasource is in an one hour interval starting from `2013-08-01T08:00:00`. 
 ```sql
 SELECT 
   "__time" AS "original_time",
@@ -2605,14 +2605,14 @@ Returns the following:
 
 ## TIMESTAMPADD
 
-Adds `count` number of `unit` to a given timestamp.
+Adds `count` number of a `unit` to a given timestamp.
 
 * **Syntax:** `TIMESTAMPADD(unit, count, timestamp)`
 * **Function type:** Scalar, date and time
 
 <details><summary>Example</summary>
 
-The following example adds five months to the timestamp `000-01-01 00:00:00`
+The following example adds five months to the timestamp `2000-01-01 00:00:00`
 
 ```sql
 SELECT

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -2604,7 +2604,7 @@ Returns the following:
 
 ## TIMESTAMPADD
 
-Adds a `unit` of time to `timestamp` a total of `count` times.
+Add a `unit` of time multiplied by `count` to `timestamp`.
 
 * **Syntax:** `TIMESTAMPADD(unit, count, timestamp)`
 * **Function type:** Scalar, date and time

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1673,7 +1673,7 @@ Converts a number of milliseconds since epoch into a timestamp.
 
 <details><summary>Example</summary>
 
-The following example converts `1375344877000` milliseconds from epoch into a timestamp. 
+The following example converts 1375344877000 milliseconds from epoch into a timestamp. 
 
 ```sql
 SELECT MILLIS_TO_TIMESTAMP(1375344877000) AS "timestamp"

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -2644,7 +2644,7 @@ The following example calculates the taxi trip length in minutes by subtracting 
 SELECT
   "__time" AS "pickup_time",
   "dropoff_datetime" AS "dropoff_time",
-  TIMESTAMPDIFF (MINUTE, "__time", TIME_PARSE("dropoff_datetime"))
+  TIMESTAMPDIFF (MINUTE, "__time", TIME_PARSE("dropoff_datetime")) AS "trip_length"
 FROM "taxi-trips"
 LIMIT 1
 ```

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -640,11 +640,32 @@ Converts a value into the specified data type.
 
 ## CEIL (date and time)
 
-`CEIL(<TIMESTAMP> TO <TIME_UNIT>)`
+Rounds up a timestamp by a given time unit. Units must be provided unquoted.
 
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
+* **Syntax:** `CEIL(timestamp_expr TO unit>)`
+* **Function type:** Scalar, date and time
 
-Rounds up a timestamp by a given time unit.
+<details><summary>Example</summary>
+
+The following example rounds up the `__time` column from the `taxi-trips` datasource to the nearest year.
+
+```sql
+SELECT
+  "__time" AS "original_time",
+  CEIL("__time" TO YEAR) AS "ceiling"
+FROM "taxi-trips"
+LIMIT 1
+```
+
+Returns the following:
+
+| `original_time` | `ceiling` |
+| -- | -- |
+| `2013-08-01T08:14:37.000Z` | `2014-01-01T00:00:00.000Z` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## CEIL (numeric)
 
@@ -1103,11 +1124,32 @@ Returns the following:
 
 ## EXTRACT
 
-`EXTRACT(<TIME_UNIT> FROM <TIMESTAMP>)`
+Extracts the value of some unit of the timestamp. Units must be provided unquoted. 
 
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
+* **Syntax:** `EXTRACT(unit FROM timestamp_expr)`
+* **Function type:** Scalar, date and time
 
-Extracts the value of some unit of the timestamp, optionally from a certain time zone, and returns the number.
+<details><summary>Example</summary>
+
+The following example extracts the year from the `__time` column from the `taxi-trips` datasource.
+
+```sql
+SELECT 
+  "__time" AS "original_time",
+  EXTRACT(YEAR FROM "__time" ) AS "year"
+FROM "taxi-trips"
+LIMIT 1
+```
+
+Returns the following:
+
+| `original_time` | `year` |
+| -- | -- |
+| `2013-08-01T08:14:37.000Z` | `2013` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## FIRST_VALUE
 
@@ -1119,11 +1161,32 @@ Returns the value evaluated for the expression for the first row within the wind
 
 ## FLOOR (date and time)
 
-`FLOOR(<TIMESTAMP> TO <TIME_UNIT>)`
+Rounds down a timestamp by a given time unit. Units must be provided unquoted.
 
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
+* **Syntax:** `FLOOR(timestamp_expr TO unit>)`
+* **Function type:** Scalar, date and time
 
-Rounds down a timestamp by a given time unit.
+<details><summary>Example</summary>
+
+The following example rounds down the `__time` column from the `taxi-trips` datasource to the nearest year.
+
+```sql
+SELECT
+  "__time" AS "original_time",
+  FLOOR("__time" TO YEAR) AS "floor"
+FROM "taxi-trips"
+LIMIT 1
+```
+
+Returns the following:
+
+| `original_time` | `floor` |
+| -- | -- |
+| `2013-08-01T08:14:37.000Z` | `2013-01-01T00:00:00.000Z` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## FLOOR (numeric)
 
@@ -1603,11 +1666,28 @@ Returns the maximum value of a set of values.
 
 ## MILLIS_TO_TIMESTAMP
 
-`MILLIS_TO_TIMESTAMP(millis_expr)`
-
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
-
 Converts a number of milliseconds since epoch into a timestamp.
+
+* **Syntax:** `MILLIS_TO_TIMESTAMP(millis_expr)`
+* **Function type:** Scalar, date and time
+
+<details><summary>Example</summary>
+
+The following example converts `1375344877000` milliseconds from epoch into a timestamp. 
+
+```sql
+SELECT MILLIS_TO_TIMESTAMP(1375344877000) AS "millis_to_time"
+```
+
+Returns the following:
+
+| `millis_to_time` |
+| -- |
+| `2013-08-01T08:14:37.000Z` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## MIN
 
@@ -2449,11 +2529,32 @@ Formats a timestamp as a string.
 
 ## TIME_IN_INTERVAL
 
-`TIME_IN_INTERVAL(<TIMESTAMP>, <CHARACTER>)`
+Returns whether a timestamp is contained within a particular interval. Intervals must be formatted as a string literal containing any ISO 8601 interval. The start instant of an interval is inclusive, and the end instant is exclusive.
 
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
+* **Syntax:** `TIME_IN_INTERVAL(timestamp_expr, interval)`
+* **Function type:** Scalar, date and time
 
-Returns whether a timestamp is contained within a particular interval, formatted as a string.
+<details><summary>Example</summary>
+
+The following example returns `true` when a timestamp in the `__time` column from the `taxi-trips` datasource is in a one hour interval starting from `2013-08-01T08:00:00`. 
+```sql
+SELECT 
+  "__time" AS "original_time",
+  TIME_IN_INTERVAL("__time", '2013-08-01T08:00:00/PT1H') AS "in_interval"
+FROM "taxi-trips"
+LIMIT 2
+```
+
+Returns the following:
+
+| `original_time` | `in_interval` |
+| -- | -- |
+| `2013-08-01T08:14:37.000Z` | `true` | 
+| `2013-08-01T09:13:00.000Z` | `false` | 
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## TIME_PARSE
 
@@ -2473,27 +2574,91 @@ Shifts a timestamp forwards or backwards by a given number of time units.
 
 ## TIMESTAMP_TO_MILLIS
 
-`TIMESTAMP_TO_MILLIS(<TIMESTAMP>)`
-
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
-
 Returns the number of milliseconds since epoch for the given timestamp.
+
+* **Syntax:** `TIMESTAMP_TO_MILLIS(timestamp_expr)`
+* **Function type:** Scalar, date and time
+
+<details><summary>Example</summary>
+
+The following example converts the `__time` timestamp column from the `taxi-trips` datasource into milliseconds since epoch.
+
+```sql
+SELECT 
+  "__time" AS "original_time",
+  TIMESTAMP_TO_MILLIS("__time") AS "miliseconds"
+FROM "taxi-trips"
+LIMIT 1
+```
+
+Returns the following:
+
+| `original_time` | `miliseconds` |
+| -- | -- |
+| `2013-08-01T08:14:37.000Z` | `1375344877000` |
+
+</details>
+
+
+[Learn more](sql-scalar.md#date-and-time-functions)
+
 
 ## TIMESTAMPADD
 
-`TIMESTAMPADD(<unit>, <count>, <TIMESTAMP>)`
+Adds `count` number of `unit` to a given timestamp.
 
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
+* **Syntax:** `TIMESTAMPADD(unit, count, timestamp)`
+* **Function type:** Scalar, date and time
 
-Adds a certain amount of time to a given timestamp.
+<details><summary>Example</summary>
+
+The following example adds five months to the timestamp `000-01-01 00:00:00`
+
+```sql
+SELECT
+  TIMESTAMP '2000-01-01 00:00:00' AS "original_time",
+  TIMESTAMPADD (MONTH, 5, TIMESTAMP '2000-01-01 00:00:00') AS "new_time"
+```
+
+Returns the following:
+
+| `original_time` | `new_time` |
+| -- | -- |
+| `2000-01-01T00:00:00.000Z` | `2000-06-01T00:00:00.000Z` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## TIMESTAMPDIFF
 
-`TIMESTAMPDIFF(<unit>, <TIMESTAMP>, <TIMESTAMP>)`
-
-**Function type:** [Scalar, date and time](sql-scalar.md#date-and-time-functions)
-
 Takes the difference between two timestamps, returning the results in the given units.
+
+* **Syntax:** `TIMESTAMPDIFF(unit, timestamp1, timestamp2)`
+* **Function type:** Scalar, date and time
+
+<details><summary>Example</summary>
+
+The following example takes the difference between the `__time` and `dropoff_datetime` columns from the `taxi-trips` datasource to find the length of the taxi trip in minutes.
+
+```sql
+SELECT
+  "__time" AS "pickup_time",
+  "dropoff_datetime" AS "dropoff_time",
+  TIMESTAMPDIFF (MINUTE, "__time", TIME_PARSE("dropoff_datetime"))
+FROM "taxi-trips"
+LIMIT 1
+```
+
+Returns the following: 
+
+| `pickup_time` | `dropoff_time` | `trip_length` |
+| -- | -- | -- |
+| `2013-08-01T08:14:37.000Z` | `2013-08-01 09:09:06` | `54` |
+
+</details>
+
+[Learn more](sql-scalar.md#date-and-time-functions)
 
 ## TO_JSON_STRING
 

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -2582,7 +2582,7 @@ Returns the number of milliseconds since epoch for the given timestamp.
 
 <details><summary>Example</summary>
 
-The following example converts the `__time` timestamp column from the `taxi-trips` datasource into milliseconds since epoch.
+The following example converts the `__time` column from the `taxi-trips` datasource into milliseconds since epoch.
 
 ```sql
 SELECT 
@@ -2613,7 +2613,7 @@ Adds `count` number of a `unit` to a given timestamp.
 
 <details><summary>Example</summary>
 
-The following example adds five months to the timestamp `2000-01-01 00:00:00`
+The following example adds five months to the timestamp `2000-01-01 00:00:00`.
 
 ```sql
 SELECT
@@ -2633,14 +2633,14 @@ Returns the following:
 
 ## TIMESTAMPDIFF
 
-Takes the difference between two timestamps, returning the results in the given units.
+Returns the difference between two timestamps in the given `unit`.
 
 * **Syntax:** `TIMESTAMPDIFF(unit, timestamp1, timestamp2)`
 * **Function type:** Scalar, date and time
 
 <details><summary>Example</summary>
 
-The following example takes the difference between the `__time` and `dropoff_datetime` columns from the `taxi-trips` datasource to find the length of the taxi trip in minutes.
+The following example calculates the taxi trip length in minutes by subtracting the `__time` column from the `dropoff_datetime` column in the `taxi-trips` datasource.
 
 ```sql
 SELECT

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -2537,6 +2537,7 @@ Returns whether a timestamp is contained within a particular interval. Intervals
 <details><summary>Example</summary>
 
 The following example returns `true` when a timestamp in the `__time` column from the `taxi-trips` datasource is in an one hour interval starting from `2013-08-01T08:00:00`. 
+
 ```sql
 SELECT 
   "__time" AS "original_time",

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -2529,14 +2529,14 @@ Formats a timestamp as a string.
 
 ## TIME_IN_INTERVAL
 
-Returns whether a timestamp is contained within a particular interval. Intervals must be formatted as a string literal containing any ISO 8601 interval. The start instant of an interval is inclusive, and the end instant is exclusive.
+Returns true if a timestamp is contained within a particular interval. Intervals must be formatted as a string literal containing any ISO 8601 interval. The start instant of an interval is inclusive, and the end instant is exclusive.
 
 * **Syntax:** `TIME_IN_INTERVAL(timestamp_expr, interval)`
 * **Function type:** Scalar, date and time
 
 <details><summary>Example</summary>
 
-The following example returns `true` when a timestamp in the `__time` column of the `taxi-trips` datasource is within a hour interval starting from `2013-08-01T08:00:00`.
+The following example returns true when a timestamp in the `__time` column of the `taxi-trips` datasource is within a hour interval starting from `2013-08-01T08:00:00`.
 
 ```sql
 SELECT 
@@ -2631,7 +2631,7 @@ Returns the following:
 
 ## TIMESTAMPDIFF
 
-Returns the difference between two timestamps in the given `unit`.
+Returns the difference between two timestamps in a given unit.
 
 * **Syntax:** `TIMESTAMPDIFF(unit, timestamp1, timestamp2)`
 * **Function type:** Scalar, date and time

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -175,8 +175,8 @@ overhead.
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
 |`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`TIMESTAMPADD(unit, count, timestamp)`|Adds `count` number of `unit` to timestamp, equivalent to `timestamp + count * UNIT`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns the (signed) number of `unit` between `timestamp1` and `timestamp2`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPADD(unit, count, timestamp)`|Adds a `count` number of time `unit` to timestamp, equivalent to `timestamp + count * UNIT`. Unit must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns a signed number of `unit` between `timestamp1` and `timestamp2`. Unit must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 
 
 ## Reduction functions

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -175,8 +175,8 @@ overhead.
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
 |`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`TIMESTAMPADD(unit, count, timestamp)`|Adds a `count` number of time `unit` to timestamp, equivalent to `timestamp + count * UNIT`. Unit must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns a signed number of `unit` between `timestamp1` and `timestamp2`. Unit must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPADD(unit, count, timestamp)`|Adds a `count` number of time `unit` to timestamp, equivalent to `timestamp + count * unit`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns a signed number of `unit` between `timestamp1` and `timestamp2`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 
 
 ## Reduction functions

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -173,10 +173,10 @@ overhead.
 |`MILLIS_TO_TIMESTAMP(millis_expr)`|Converts a number of milliseconds since the epoch (1970-01-01 00:00:00 UTC) into a timestamp.|
 |`TIMESTAMP_TO_MILLIS(timestamp_expr)`|Converts a timestamp into a number of milliseconds since the epoch.|
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
-|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Unit can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Unit can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`TIMESTAMPADD(unit, count, timestamp)`|Equivalent to `timestamp + count * INTERVAL '1' UNIT`.|
-|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns the (signed) number of `unit` between `timestamp1` and `timestamp2`. Unit can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPADD(unit, count, timestamp)`|Adds `count` number of `unit` to timestamp, equivalent to `timestamp + count * UNIT`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns the (signed) number of `unit` between `timestamp1` and `timestamp2`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 
 
 ## Reduction functions

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -173,8 +173,8 @@ overhead.
 |`MILLIS_TO_TIMESTAMP(millis_expr)`|Converts a number of milliseconds since the epoch (1970-01-01 00:00:00 UTC) into a timestamp.|
 |`TIMESTAMP_TO_MILLIS(timestamp_expr)`|Converts a timestamp into a number of milliseconds since the epoch.|
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
-|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. The `unit` parameter must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. The `unit` parameter must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPADD(unit, count, timestamp)`|Adds a `count` number of time `unit` to timestamp, equivalent to `timestamp + count * unit`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns a signed number of `unit` between `timestamp1` and `timestamp2`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -174,7 +174,7 @@ overhead.
 |`TIMESTAMP_TO_MILLIS(timestamp_expr)`|Converts a timestamp into a number of milliseconds since the epoch.|
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
 |`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. Units must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPADD(unit, count, timestamp)`|Adds `count` number of `unit` to timestamp, equivalent to `timestamp + count * UNIT`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns the (signed) number of `unit` between `timestamp1` and `timestamp2`. Unit must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 

--- a/docs/querying/sql-scalar.md
+++ b/docs/querying/sql-scalar.md
@@ -173,8 +173,8 @@ overhead.
 |`MILLIS_TO_TIMESTAMP(millis_expr)`|Converts a number of milliseconds since the epoch (1970-01-01 00:00:00 UTC) into a timestamp.|
 |`TIMESTAMP_TO_MILLIS(timestamp_expr)`|Converts a timestamp into a number of milliseconds since the epoch.|
 |`EXTRACT(unit FROM timestamp_expr)`|Extracts a time part from `expr`, returning it as a number. Unit can be EPOCH, MICROSECOND, MILLISECOND, SECOND, MINUTE, HOUR, DAY (day of month), DOW (day of week), ISODOW (ISO day of week), DOY (day of year), WEEK (week of year), MONTH, QUARTER, YEAR, ISOYEAR, DECADE, CENTURY or MILLENNIUM. Units must be provided unquoted, like `EXTRACT(HOUR FROM __time)`.|
-|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. The `unit` parameter must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
-|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. The `unit` parameter must be provided unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`FLOOR(timestamp_expr TO unit)`|Rounds down a timestamp, returning it as a new timestamp. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
+|`CEIL(timestamp_expr TO unit)`|Rounds up a timestamp, returning it as a new timestamp. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPADD(unit, count, timestamp)`|Adds a `count` number of time `unit` to timestamp, equivalent to `timestamp + count * unit`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 |`TIMESTAMPDIFF(unit, timestamp1, timestamp2)`|Returns a signed number of `unit` between `timestamp1` and `timestamp2`. The `unit` parameter must be unquoted and can be SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, or YEAR.|
 


### PR DESCRIPTION
### Description

Add examples to the sql-functions.md page

Updates the `TIME_IN_INTERVAL `, `MILLIS_TO_TIMESTAMP `, `TIMESTAMP_TO_MILLIS `, `EXTRACT `, `FLOOR `, `CEIL `, `TIMESTAMPADD `,  and `TIMESTAMPDIFF ` functions.

This PR has:

- [X] been self-reviewed.