### PR TITLE
Add docs for log audit manager

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -363,6 +363,8 @@ Coordinator and Overlord log changes to lookups, segment load/drop rules, and dy
 
 |Property|Description|Default|
 |--------|-----------|-------|
+|`druid.audit.manager.type`|Allows audited events to either be logged when set to `log` or persisted in metadata store when set to `sql`.|sql|
+|`druid.audit.manager.logLevel`|Set the log level of audit events and can take values DEBUG, INFO, WARN. This gets activated only if type is `log`.|INFO|
 |`druid.audit.manager.auditHistoryMillis`|Default duration for querying audit history.|1 week|
 |`druid.audit.manager.includePayloadAsDimensionInMetric`|Boolean flag on whether to add `payload` column in service metric.|false|
 |`druid.audit.manager.maxPayloadSizeBytes`|The maximum size of audit payload to store in Druid's metadata store audit table. If the size of audit payload exceeds this value, the audit log would be stored with a message indicating that the payload was omitted instead. Setting `maxPayloadSizeBytes` to -1 (default value) disables this check, meaning Druid will always store audit payload regardless of it's size. Setting to any negative number other than `-1` is invalid. Human-readable format is supported, see [here](human-readable-byte.md).  |-1|

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -363,8 +363,8 @@ Coordinator and Overlord log changes to lookups, segment load/drop rules, and dy
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`druid.audit.manager.type`|Allows audited events to either be logged when set to `log` or persisted in metadata store when set to `sql`.|sql|
-|`druid.audit.manager.logLevel`|Set the log level of audit events and can take values DEBUG, INFO, WARN. This gets activated only if type is `log`.|INFO|
+|`druid.audit.manager.type`|Type of audit manager used for handling audited events. Audited events are logged when set to `log` or persisted in metadata store when set to `sql`.|sql|
+|`druid.audit.manager.logLevel`|Log level of audit events with possible values DEBUG, INFO, WARN. This property is used only when `druid.audit.manager.type` is set to `log`.|INFO|
 |`druid.audit.manager.auditHistoryMillis`|Default duration for querying audit history.|1 week|
 |`druid.audit.manager.includePayloadAsDimensionInMetric`|Boolean flag on whether to add `payload` column in service metric.|false|
 |`druid.audit.manager.maxPayloadSizeBytes`|The maximum size of audit payload to store in Druid's metadata store audit table. If the size of audit payload exceeds this value, the audit log would be stored with a message indicating that the payload was omitted instead. Setting `maxPayloadSizeBytes` to -1 (default value) disables this check, meaning Druid will always store audit payload regardless of it's size. Setting to any negative number other than `-1` is invalid. Human-readable format is supported, see [here](human-readable-byte.md).  |-1|


### PR DESCRIPTION
### Description

Add docs on `druid.audit.manager.type=log` implemented in Druid 29.0.0 https://github.com/apache/druid/pull/15480

- [x] added documentation for new or modified features or behaviors.
