### PR TITLE
SuperSorter: Store readOnly output channels.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -670,7 +670,7 @@ public class SuperSorter
         final OutputChannel outputChannel = outputChannelFactory.openChannel(intRank);
         writableChannel = outputChannel.getWritableChannel();
         frameAllocatorFactory = new SingleMemoryAllocatorFactory(outputChannel.getFrameMemoryAllocator());
-        outputChannels.set(intRank, outputChannel);
+        outputChannels.set(intRank, outputChannel.readOnly());
 
         if (totalMergingLevels == 1) {
           // Reading from the inputBuffer. (i.e. "direct mode"; see class-level javadoc for more details.)


### PR DESCRIPTION
Without the call to readOnly, each output channel retains a 1 MB allocator, leading to excessive memory use. Fixes regression from #16775.