### PR TITLE
Fix buffer capacity race condition in spatial

### DIFF
--- a/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
@@ -21,8 +21,10 @@ package org.apache.druid.collections.spatial;
 
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
+import org.apache.druid.java.util.common.logger.Logger;
 
 import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.Iterator;
 
 /**
@@ -34,23 +36,20 @@ import java.util.Iterator;
  * 2 + numDims * Float.BYTES to 2 + 2 * numDims * Float.BYTES : maxCoordinates
  * concise set
  * rest (children) : Every 4 bytes is storing an offset representing the position of a child.
- *
+ * <p>
  * The child offset is an offset from the initialOffset
  */
 public class ImmutableFloatNode implements ImmutableNode<float[]>
 {
   public static final int HEADER_NUM_BYTES = 2;
-
+  private static final Logger log = new Logger(ImmutableFloatNode.class);
   private final int numDims;
   private final int initialOffset;
   private final int offsetFromInitial;
-
   private final short numChildren;
   private final boolean isLeaf;
   private final int childrenOffset;
-
   private final ByteBuffer data;
-
   private final BitmapFactory bitmapFactory;
 
   public ImmutableFloatNode(
@@ -150,9 +149,23 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
     final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int numBytes = data.getInt(sizePosition);
     final ByteBuffer readOnlyBuffer = data.asReadOnlyBuffer();
-    readOnlyBuffer.position(sizePosition + Integer.BYTES);
-    readOnlyBuffer.limit(readOnlyBuffer.position() + numBytes);
-    return bitmapFactory.mapImmutableBitmap(readOnlyBuffer);
+    int newPosition = sizePosition + Integer.BYTES;
+    readOnlyBuffer.position(newPosition);
+    int newLimit = readOnlyBuffer.position() + numBytes;
+    readOnlyBuffer.limit(newLimit);
+    try {
+      return bitmapFactory.mapImmutableBitmap(readOnlyBuffer);
+    }
+    catch (Exception e) {
+      log.error(e, "Failed to read bitmap from buffer '%s',"
+                   + "current pos: %d, set pos: %d, set limit: %d",
+                Base64.getEncoder().encodeToString(readOnlyBuffer.array()),
+                readOnlyBuffer.position(),
+                newPosition,
+                newLimit
+      );
+      throw e;
+    }
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
@@ -149,10 +149,10 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
   {
     final int sizePosition = initialOffset + offsetFromInitial + HEADER_NUM_BYTES + 2 * numDims * Float.BYTES;
     int numBytes = data.getInt(sizePosition);
-    data.position(sizePosition + Integer.BYTES);
-    ByteBuffer tmpBuffer = data.slice();
-    tmpBuffer.limit(numBytes);
-    return bitmapFactory.mapImmutableBitmap(tmpBuffer.asReadOnlyBuffer());
+    final ByteBuffer readOnlyBuffer = data.asReadOnlyBuffer();
+    readOnlyBuffer.position(sizePosition + Integer.BYTES);
+    readOnlyBuffer.limit(readOnlyBuffer.position() + numBytes);
+    return bitmapFactory.mapImmutableBitmap(readOnlyBuffer);
   }
 
   @Override
@@ -182,7 +182,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
                   numDims,
                   initialOffset,
                   data.getInt(childrenOffset + (count++) * Integer.BYTES),
-                  data.duplicate(),
+                  data,
                   bitmapFactory
               );
             }
@@ -190,7 +190,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
                 numDims,
                 initialOffset,
                 data.getInt(childrenOffset + (count++) * Integer.BYTES),
-                data.duplicate(),
+                data,
                 bitmapFactory
             );
           }

--- a/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
+++ b/processing/src/main/java/org/apache/druid/collections/spatial/ImmutableFloatNode.java
@@ -182,7 +182,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
                   numDims,
                   initialOffset,
                   data.getInt(childrenOffset + (count++) * Integer.BYTES),
-                  data,
+                  data.duplicate(),
                   bitmapFactory
               );
             }
@@ -190,7 +190,7 @@ public class ImmutableFloatNode implements ImmutableNode<float[]>
                 numDims,
                 initialOffset,
                 data.getInt(childrenOffset + (count++) * Integer.BYTES),
-                data,
+                data.duplicate(),
                 bitmapFactory
             );
           }


### PR DESCRIPTION
### Description

This PR has potential fix for the following exception, found that we are creating immutable node and passing the mutable data buffer to immutable node. 

```
java.lang.IllegalArgumentException: newLimit > capacity: (20 > 18)
	at java.base/java.nio.Buffer.createLimitException(Buffer.java:372) ~[?:?]
	at java.base/java.nio.Buffer.limit(Buffer.java:346) ~[?:?]
	at java.base/java.nio.ByteBuffer.limit(ByteBuffer.java:1107) ~[?:?]
	at java.base/java.nio.MappedByteBuffer.limit(MappedByteBuffer.java:235) ~[?:?]
	at java.base/java.nio.MappedByteBuffer.limit(MappedByteBuffer.java:67) ~[?:?]
	at org.roaringbitmap.buffer.ImmutableRoaringArray.<init>(ImmutableRoaringArray.java:52) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.ImmutableRoaringBitmap.<init>(ImmutableRoaringBitmap.java:1057) ~[RoaringBitmap-0.9.49.jar:?]
	at org.apache.druid.collections.bitmap.WrappedImmutableRoaringBitmap.<init>(WrappedImmutableRoaringBitmap.java:38) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.collections.bitmap.RoaringBitmapFactory.mapImmutableBitmap(RoaringBitmapFactory.java:126) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.collections.spatial.ImmutableFloatNode.getImmutableBitmap(ImmutableFloatNode.java:155) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.collections.spatial.search.GutmanSearchStrategy$2.apply(GutmanSearchStrategy.java:57) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.collections.spatial.search.GutmanSearchStrategy$2.apply(GutmanSearchStrategy.java:53) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at com.google.common.collect.Iterators$6.transform(Iterators.java:828) ~[guava-32.0.1-jre.jar:?]
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52) ~[guava-32.0.1-jre.jar:?]
	at org.apache.druid.collections.bitmap.RoaringBitmapFactory$1$1.next(RoaringBitmapFactory.java:84) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.collections.bitmap.RoaringBitmapFactory$1$1.next(RoaringBitmapFactory.java:68) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.roaringbitmap.buffer.BufferFastAggregation.naive_or(BufferFastAggregation.java:782) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.BufferFastAggregation.or(BufferFastAggregation.java:875) ~[RoaringBitmap-0.9.49.jar:?]
	at org.roaringbitmap.buffer.ImmutableRoaringBitmap.or(ImmutableRoaringBitmap.java:875) ~[RoaringBitmap-0.9.49.jar:?]
	at org.apache.druid.collections.bitmap.RoaringBitmapFactory.union(RoaringBitmapFactory.java:142) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.query.DefaultBitmapResultFactory.unionDimensionValueBitmaps(DefaultBitmapResultFactory.java:73) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]
	at org.apache.druid.query.DefaultBitmapResultFactory.unionDimensionValueBitmaps(DefaultBitmapResultFactory.java:25) ~[druid-processing-2024.07.0-iap.jar:2024.07.0-iap]


```
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
