### PR TITLE
Loosen case in FrameFileWriterTest.

### DIFF
--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
@@ -76,7 +76,7 @@ public class FrameFileWriterTest extends InitializedNullHandlingTest
     MatcherAssert.assertThat(
         e,
         ThrowableMessageMatcher.hasMessage(
-            CoreMatchers.containsString("Negative-size footer. Corrupt or truncated file[")
+            CoreMatchers.containsString("Corrupt or truncated file[")
         )
     );
   }


### PR DESCRIPTION
The specific error on a truncated file can vary based on how the final frame of the truncated file is written. This patch loosens the check so it passes regardless of how the truncated file is written.