### PR TITLE
fix ipv4_parse function return type in SQL to be bigint instead of integer

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressParseOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/IPv4AddressParseOperatorConversion.java
@@ -39,7 +39,7 @@ public class IPv4AddressParseOperatorConversion extends DirectOperatorConversion
               OperandTypes.family(SqlTypeFamily.STRING),
               OperandTypes.family(SqlTypeFamily.INTEGER)
           ))
-      .returnTypeNullable(SqlTypeName.INTEGER)
+      .returnTypeNullable(SqlTypeName.BIGINT)
       .functionCategory(SqlFunctionCategory.USER_DEFINED_FUNCTION)
       .build();
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -16128,7 +16128,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
                   .resultFormat(ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
                   .build()
         ),
-        ImmutableList.of(NullHandling.sqlCompatible() ? new Object[]{null} : new Object[]{0})
+        ImmutableList.of(NullHandling.sqlCompatible() ? new Object[]{null} : new Object[]{0L})
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -16133,6 +16133,30 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
   }
 
   @Test
+  public void testIpv4ParseWithBigintOutput()
+  {
+    testQuery(
+        "select ipv4_parse('192.168.0.1') from (values(1)) as t(col)",
+        ImmutableList.of(
+            Druids.newScanQueryBuilder()
+                  .dataSource(InlineDataSource.fromIterable(
+                      ImmutableList.of(new Object[]{1L}),
+                      RowSignature.builder()
+                                  .add("col", ColumnType.LONG)
+                                  .build()
+                  ))
+                  .intervals(querySegmentSpec(Filtration.eternity()))
+                  .columns("v0")
+                  .virtualColumns(expressionVirtualColumn("v0", "3232235521", ColumnType.LONG))
+                  .context(QUERY_CONTEXT_DEFAULT)
+                  .resultFormat(ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                  .build()
+        ),
+        ImmutableList.of(new Object[]{3232235521L})
+    );
+  }
+
+  @Test
   public void testBitwiseXor()
   {
     cannotVectorize();


### PR DESCRIPTION
Fixes inconsistency in `IPV4_PARSE` function SQL return type, which prior to this PR was specified as `INTEGER` while the native layer uses `LONG`. Because of this, something like `ipv4_parse('192.168.0.1')` would return -1062731775 since java only has signed integers, while the long number of the native layer is 3232235521.

We could probably consider casting the negative arguments in the native layer into an int and then the bits back into a long to try to turn something like -1062731775 into 3232235521 so it isn't discarded as a null, but I didn't make that change at this time since there would be some performance cost to it, and I'm not sure if it should work anyway...