### PR TITLE
Use controller ID while reading from durable storage

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
@@ -110,6 +110,7 @@ import java.util.stream.Collectors;
  */
 public class RunWorkOrder
 {
+  private final String controllerTaskId;
   private final WorkOrder workOrder;
   private final InputChannelFactory inputChannelFactory;
   private final CounterTracker counterTracker;
@@ -138,6 +139,7 @@ public class RunWorkOrder
   private ListenableFuture<OutputChannels> stageOutputChannelsFuture;
 
   public RunWorkOrder(
+      final String controllerTaskId,
       final WorkOrder workOrder,
       final InputChannelFactory inputChannelFactory,
       final CounterTracker counterTracker,
@@ -150,6 +152,7 @@ public class RunWorkOrder
       final boolean removeNullBytes
   )
   {
+    this.controllerTaskId = controllerTaskId;
     this.workOrder = workOrder;
     this.inputChannelFactory = inputChannelFactory;
     this.counterTracker = counterTracker;
@@ -565,7 +568,7 @@ public class RunWorkOrder
   )
   {
     return DurableStorageOutputChannelFactory.createStandardImplementation(
-        workOrder.getQueryDefinition().getQueryId(),
+        controllerTaskId,
         workOrder.getWorkerNumber(),
         workOrder.getStageNumber(),
         workerContext.workerId(),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -408,6 +408,7 @@ public class WorkerImpl implements Worker
 
     final QueryContext queryContext = task != null ? QueryContext.of(task.getContext()) : QueryContext.empty();
     final RunWorkOrder runWorkOrder = new RunWorkOrder(
+        task.getControllerTaskId(),
         workOrder,
         inputChannelFactory,
         stageCounters.computeIfAbsent(


### PR DESCRIPTION
There is currently a bug when upgrading from previous versions when running MSQ queries with durable storage.

With https://github.com/apache/druid/pull/16790, the worker was changed to use the stage ID when writing files from durable storage. However, when reading files, the controller ID is still used (https://github.com/apache/druid/blob/5d1950d4512ff464975773d8c3eead44bd6b8930/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/shuffle/input/DurableStorageInputChannelFactory.java#L90)

Generally, this is not a problem, since these are the same since https://github.com/apache/druid/pull/16168. However, when upgrading from previous versions, there is a bug where the stage id would be different. This causes tasks to fail with an exception 
```
org.apache.druid.java.util.common.IOE: Encountered error while reading the output of stage [0], partition [0] for worker [0]
```
This fixes the bug during upgrades by using the controller task id to write results to durable storage as well.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
