### PR TITLE
Planning could have failed if UNION ALL operator was completely removed

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
@@ -73,7 +73,7 @@ public class QueryableIndexCursorHolder implements CursorHolder
   @Nullable
   private final Filter filter;
   @Nullable
-  private final QueryMetrics<? extends Query> metrics;
+  private final QueryMetrics<? extends Query<?>> metrics;
   private final List<OrderBy> ordering;
   private final boolean descending;
   private final QueryContext queryContext;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/builtin/CastOperatorConversion.java
@@ -92,9 +92,12 @@ public class CastOperatorConversion implements SqlOperatorConversion
                                               ? ExpressionType.fromColumnType(fromDruidType)
                                               : ExpressionType.fromColumnType(toDruidType);
 
-      if (fromExpressionType == null || toExpressionType == null) {
+      if (toExpressionType == null) {
         // We have no runtime type for these SQL types.
         return null;
+      }
+      if (fromExpressionType == null) {
+        return DruidExpression.ofLiteral(toDruidType, DruidExpression.nullLiteral());
       }
 
       final DruidExpression typeCastExpression;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -115,7 +115,6 @@ public class ExpressionsTest extends CalciteTestBase
       .add("tstr", ColumnType.STRING)
       .add("dstr", ColumnType.STRING)
       .add("timezone", ColumnType.STRING)
-      .add("unknown", null)
       .build();
 
   private static final Map<String, Object> BINDINGS = ImmutableMap.<String, Object>builder()
@@ -2048,23 +2047,6 @@ public class ExpressionsTest extends CalciteTestBase
         ),
         makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'DAY','UTC')"),
         3L
-    );
-  }
-
-  @Test
-  public void testCastUnknown()
-  {
-    testHelper.testExpression(
-        testHelper.makeAbstractCast(
-            testHelper.createSqlType(SqlTypeName.TIMESTAMP),
-            testHelper.makeInputRef("t")
-        ),
-        DruidExpression.ofColumn(
-            ColumnType.LONG,
-            "t",
-            SimpleExtraction.of("t", null)
-        ),
-        DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionsTest.java
@@ -115,6 +115,7 @@ public class ExpressionsTest extends CalciteTestBase
       .add("tstr", ColumnType.STRING)
       .add("dstr", ColumnType.STRING)
       .add("timezone", ColumnType.STRING)
+      .add("unknown", null)
       .build();
 
   private static final Map<String, Object> BINDINGS = ImmutableMap.<String, Object>builder()
@@ -2047,6 +2048,23 @@ public class ExpressionsTest extends CalciteTestBase
         ),
         makeExpression(ColumnType.LONG, "timestamp_extract(\"t\",'DAY','UTC')"),
         3L
+    );
+  }
+
+  @Test
+  public void testCastUnknown()
+  {
+    testHelper.testExpression(
+        testHelper.makeAbstractCast(
+            testHelper.createSqlType(SqlTypeName.TIMESTAMP),
+            testHelper.makeInputRef("t")
+        ),
+        DruidExpression.ofColumn(
+            ColumnType.LONG,
+            "t",
+            SimpleExtraction.of("t", null)
+        ),
+        DateTimes.of("2000-02-03T04:05:06Z").getMillis()
     );
   }
 

--- a/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/union_removed_branch_union_nulls.iq
+++ b/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/union_removed_branch_union_nulls.iq
@@ -1,0 +1,66 @@
+!set plannerStrategy DECOUPLED
+!set debug true
+!use druidtest://?numMergeBuffers=3
+!set outputformat mysql
+
+(SELECT COUNT(*), "channel" FROM "wikipedia" WHERE
+ added = '31'
+AND __time >= '2024-08-17T00:00:00+00:00' AND 'timestamp' > 1723856628000
+AND __time <= '2024-08-17T00:00:00+00:00' AND 'timestamp' <= 1723855690000
+GROUP BY "channel")
+UNION ALL
+(SELECT null,null)
+;
++--------+---------+
+| EXPR$0 | channel |
++--------+---------+
+|        |         |
++--------+---------+
+(1 row)
+
+!ok
+LogicalUnion(all=[true])
+  LogicalProject(EXPR$0=[$1], channel=[$0])
+    LogicalAggregate(group=[{0}], EXPR$0=[COUNT()])
+      LogicalProject(channel=[$1])
+        LogicalFilter(condition=[AND(=($18, CAST('31'):BIGINT NOT NULL), >=($0, CAST('2024-08-17T00:00:00+00:00'):TIMESTAMP(3) NOT NULL), >(CAST('timestamp'):BIGINT NOT NULL, 1723856628000), <=($0, CAST('2024-08-17T00:00:00+00:00'):TIMESTAMP(3) NOT NULL), <=(CAST('timestamp'):BIGINT NOT NULL, 1723855690000))])
+          LogicalTableScan(table=[[druid, wikipedia]])
+  LogicalValues(tuples=[[{ null, null }]])
+
+!convertedPlan
+LogicalProject(EXPR$0=[CAST($0):BIGINT], channel=[CAST($1):VARCHAR])
+  LogicalValues(tuples=[[{ null, null }]])
+
+!druidPlan
+{
+  "queryType" : "scan",
+  "dataSource" : {
+    "type" : "inline",
+    "columnNames" : [ "EXPR$0", "EXPR$1" ],
+    "rows" : [ [ null, null ] ]
+  },
+  "intervals" : {
+    "type" : "intervals",
+    "intervals" : [ "-146136543-09-08T08:23:32.096Z/146140482-04-24T15:36:27.903Z" ]
+  },
+  "virtualColumns" : [ {
+    "type" : "expression",
+    "name" : "v0",
+    "expression" : "null",
+    "outputType" : "LONG"
+  }, {
+    "type" : "expression",
+    "name" : "v1",
+    "expression" : "null",
+    "outputType" : "STRING"
+  } ],
+  "resultFormat" : "compactedList",
+  "columns" : [ "v0", "v1" ],
+  "columnTypes" : [ "LONG", "STRING" ],
+  "granularity" : {
+    "type" : "all"
+  },
+  "legacy" : false
+}
+!nativePlan
+

--- a/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/union_removed_branch_union_nulls.iq
+++ b/sql/src/test/quidem/org.apache.druid.quidem.SqlQuidemTest/union_removed_branch_union_nulls.iq
@@ -28,8 +28,8 @@ LogicalUnion(all=[true])
   LogicalValues(tuples=[[{ null, null }]])
 
 !convertedPlan
-LogicalProject(EXPR$0=[CAST($0):BIGINT], channel=[CAST($1):VARCHAR])
-  LogicalValues(tuples=[[{ null, null }]])
+DruidProject(EXPR$0=[CAST($0):BIGINT], channel=[CAST($1):VARCHAR], druid=[logical])
+  DruidValues(tuples=[[{ null, null }]])
 
 !druidPlan
 {


### PR DESCRIPTION
For a query in which the *UNION* could be removed; the planning may lead to an exception - because after the removal of the union to retain the rowType of the union; a `Project` is added - which just casts the columns to the right types.
If the remaining branch of the union selects some `null`-s the incoming type will be undefined.

```sql
SELECT COUNT(*), "channel" FROM "wikipedia"
	WHERE false
	GROUP BY "channel"
UNION ALL
SELECT null,null;
```

After optimization
```
DruidProject(EXPR$0=[CAST($0):BIGINT], channel=[CAST($1):VARCHAR], druid=[logical]): rowcount = 1.0, cumulative cost = {1.0 rows, 1.0E-6 cpu, 0.0 io}, id = 355
  DruidValues(tuples=[[{ null, null }]]): rowcount = 1.0, cumulative cost = {1.0 rows, 0.0 cpu, 0.0 io}, id = 352
```

<details>
<summary>Exception</summary>

```
2024-08-22T10:43:09,169 ERROR [qtp533769848-25] org.apache.druid.sql.avatica.DruidMeta - Cannot translate reference[CAST($0):BIGINT] from rel[rel#2315:DruidProject.DRUID_LOGICAL.[](input=DruidValues#2312,exprs=[CAST($0):BIGINT, CAST($1):VARCHAR],druid=logical)]
org.apache.druid.error.DruidException: Cannot translate reference[CAST($0):BIGINT] from rel[rel#2315:DruidProject.DRUID_LOGICAL.[](input=DruidValues#2312,exprs=[CAST($0):BIGINT, CAST($1):VARCHAR],druid=logical)]
	at org.apache.druid.sql.calcite.planner.DruidPlanner.translateException(DruidPlanner.java:395) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.QueryHandler.plan(QueryHandler.java:258) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.DruidPlanner.plan(DruidPlanner.java:245) ~[classes/:?]
	at org.apache.druid.sql.DirectStatement.createPlan(DirectStatement.java:255) ~[classes/:?]
	at org.apache.druid.sql.DirectStatement.plan(DirectStatement.java:223) ~[classes/:?]
	at org.apache.druid.sql.DirectStatement.execute(DirectStatement.java:184) ~[classes/:?]
	at org.apache.druid.sql.avatica.DruidJdbcResultSet.lambda$0(DruidJdbcResultSet.java:239) ~[classes/:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.apache.druid.sql.calcite.rel.CannotBuildQueryException: Cannot translate reference[CAST($0):BIGINT] from rel[rel#2315:DruidProject.DRUID_LOGICAL.[](input=DruidValues#2312,exprs=[CAST($0):BIGINT, CAST($1):VARCHAR],druid=logical)]
	at org.apache.druid.sql.calcite.rel.Projection.preAggregation(Projection.java:243) ~[classes/:?]
	at org.apache.druid.sql.calcite.rel.DruidQuery.computeSelectProjection(DruidQuery.java:382) ~[classes/:?]
	at org.apache.druid.sql.calcite.rel.DruidQuery.fromPartialQuery(DruidQuery.java:246) ~[classes/:?]
	at org.apache.druid.sql.calcite.rel.PartialDruidQuery.build(PartialDruidQuery.java:525) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.querygen.DruidQueryGenerator$PDQVertexFactory$PDQVertex.buildQuery(DruidQueryGenerator.java:170) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.querygen.DruidQueryGenerator.buildQuery(DruidQueryGenerator.java:66) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.QueryHandler.planWithDruidConvention(QueryHandler.java:572) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.QueryHandler$SelectHandler.planForDruid(QueryHandler.java:746) ~[classes/:?]
	at org.apache.druid.sql.calcite.planner.QueryHandler.plan(QueryHandler.java:225) ~[classes/:?]
	... 9 more
```
</details>