### PR TITLE
Add supervisor log when task count is greater than partitions

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2735,7 +2735,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
     Integer taskCount = spec.getIoConfig().getTaskCount();
     if (spec.getIoConfig().getTaskCount() > partitionIdsFromSupplier.size()) {
-      log.warn("Configured task count [%s] is greater than the [%d] of partitions for [%s].", taskCount, partitionIdsFromSupplier.size(), supervisorId);
+      log.warn("Configured task count[%s] for supervisor[%s] is greater than the number of partitions[%d].", configuredTaskCount, supervisorId, partitionIdsFromSupplier.size());
     }
     Map<PartitionIdType, SequenceOffsetType> storedMetadata = getOffsetsFromMetadataStorage();
     Set<PartitionIdType> storedPartitions = storedMetadata.keySet();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2734,7 +2734,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     log.debug("Found [%d] partitions for stream [%s]", partitionIdsFromSupplier.size(), ioConfig.getStream());
 
     final int configuredTaskCount = spec.getIoConfig().getTaskCount();
-    if (spec.getIoConfig().getTaskCount() > partitionIdsFromSupplier.size()) {
+    if (configuredTaskCount > partitionIdsFromSupplier.size()) {
       log.warn("Configured task count[%s] for supervisor[%s] is greater than the number of partitions[%d].", configuredTaskCount, supervisorId, partitionIdsFromSupplier.size());
     }
     Map<PartitionIdType, SequenceOffsetType> storedMetadata = getOffsetsFromMetadataStorage();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2733,7 +2733,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
     log.debug("Found [%d] partitions for stream [%s]", partitionIdsFromSupplier.size(), ioConfig.getStream());
 
-    Integer taskCount = spec.getIoConfig().getTaskCount();
+    final int configuredTaskCount = spec.getIoConfig().getTaskCount();
     if (spec.getIoConfig().getTaskCount() > partitionIdsFromSupplier.size()) {
       log.warn("Configured task count[%s] for supervisor[%s] is greater than the number of partitions[%d].", configuredTaskCount, supervisorId, partitionIdsFromSupplier.size());
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1295,6 +1295,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   {
     int numPartitions = partitionGroups.values().stream().mapToInt(Set::size).sum();
 
+
     final SeekableStreamSupervisorReportPayload<PartitionIdType, SequenceOffsetType> payload = createReportPayload(
         numPartitions,
         includeOffsets
@@ -2733,6 +2734,10 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
     log.debug("Found [%d] partitions for stream [%s]", partitionIdsFromSupplier.size(), ioConfig.getStream());
 
+    Integer taskCount = spec.getIoConfig().getTaskCount();
+    if (partitionIdsFromSupplier.size() > spec.getIoConfig().getTaskCount()) {
+      log.warn("Configured task count [%s] is greater than the [%d] of partitions.", taskCount, partitionIdsFromSupplier.size());
+    }
     Map<PartitionIdType, SequenceOffsetType> storedMetadata = getOffsetsFromMetadataStorage();
     Set<PartitionIdType> storedPartitions = storedMetadata.keySet();
     Set<PartitionIdType> closedPartitions = storedMetadata

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2734,7 +2734,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     log.debug("Found [%d] partitions for stream [%s]", partitionIdsFromSupplier.size(), ioConfig.getStream());
 
     Integer taskCount = spec.getIoConfig().getTaskCount();
-    if (partitionIdsFromSupplier.size() > spec.getIoConfig().getTaskCount()) {
+    if (spec.getIoConfig().getTaskCount() > partitionIdsFromSupplier.size()) {
       log.warn("Configured task count [%s] is greater than the [%d] of partitions.", taskCount, partitionIdsFromSupplier.size());
     }
     Map<PartitionIdType, SequenceOffsetType> storedMetadata = getOffsetsFromMetadataStorage();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1295,7 +1295,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   {
     int numPartitions = partitionGroups.values().stream().mapToInt(Set::size).sum();
 
-
     final SeekableStreamSupervisorReportPayload<PartitionIdType, SequenceOffsetType> payload = createReportPayload(
         numPartitions,
         includeOffsets

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -2735,7 +2735,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
     Integer taskCount = spec.getIoConfig().getTaskCount();
     if (spec.getIoConfig().getTaskCount() > partitionIdsFromSupplier.size()) {
-      log.warn("Configured task count [%s] is greater than the [%d] of partitions.", taskCount, partitionIdsFromSupplier.size());
+      log.warn("Configured task count [%s] is greater than the [%d] of partitions for [%s].", taskCount, partitionIdsFromSupplier.size(), supervisorId);
     }
     Map<PartitionIdType, SequenceOffsetType> storedMetadata = getOffsetsFromMetadataStorage();
     Set<PartitionIdType> storedPartitions = storedMetadata.keySet();


### PR DESCRIPTION
Currently streaming supervisors will handle the case where the # of task groups is greater than the # of partitions available by truncating the # of task groups to the # of partitions (see KafkaSupervisor.getTaskGroupIdForPartition). This is okay behavior but its nice to know when this situation occurs (because it indicates the kafka topic should be scaled up).

### Description
Add a warn log when discovering partitions from streams if the # of discovered partitions is less than the number of task groups configured. This seemed like the best place to do this.

The other place i considered was in generateReport, but thats only called when the supervisor /status endpoint is called or if debug logging is enabled.

#### Release note
- add a informational log when task groups > partition count.

<hr>

##### Key changed/added classes in this PR
 * `SeekableStreamSupervisor`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
