### PR TITLE
Allow druid.azure.account to be nullable

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureAccountConfig.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 
 /**
  * Stores the configuration for an Azure account.
@@ -31,7 +30,7 @@ import javax.validation.constraints.NotNull;
 public class AzureAccountConfig
 {
   @JsonProperty
-  @NotNull
+  @Nullable
   private String account;
 
   /**


### PR DESCRIPTION
This PR allows the `druid.azure.account` property to be nullable.

`AzureStorageAccountInputSource` uses an injected `AzureAccountConfig` (used for configuring Azure deep storage) as a fallback configuration if the explicit input source configuration is not set.

The non-nullable annotation on `account` causes problems when using `AzureStorageAccountInputSource` in a Druid cluster that does not use Azure deep storage and does not have that property set. 

The user should not have to set this property in that case.

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
