### PR TITLE
Add dynamic query params example

### DIFF
--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -398,7 +398,8 @@ at execution time. To use dynamic parameters, replace any literal in the query w
 corresponding parameter value when you execute the query. Parameters are bound to the placeholders in the order in
 which they are passed. Parameters are supported in both the [HTTP POST](../api-reference/sql-api.md) and [JDBC](../api-reference/sql-jdbc.md) APIs.
 
-Druid supports double and null values in arrays for dynamic queries. The following example query using the [ARRAY_CONTAINS](./sql-functions.md#array_contains) function returns `doubleArrayColumn` when the reference array `[-25.7, null, 36.85]` contains all elements of the value of `doubleArrayColumn`:
+Druid supports double and null values in arrays for dynamic queries.
+The following example query using the [ARRAY_CONTAINS](./sql-functions.md#array_contains) function returns `doubleArrayColumn` when the reference array `[-25.7, null, 36.85]` contains all elements of the value of `doubleArrayColumn`:
 
 ```sql
 {

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -404,7 +404,10 @@ Druid supports double and null values in arrays for dynamic queries. For example
 {
    "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?,  doubleArrayColumn)",
    "parameters": [
-      {"type":"ARRAY", "value":[-25.7, null, 36.85]}
+      {
+        "type": "ARRAY",
+        "value": [-25.7, null, 36.85]
+      }
    ]
 }
 ```

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -403,7 +403,7 @@ Druid supports double and null values in arrays for dynamic queries. For example
 ```sql
 {
    "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?,  doubleArrayColumn)",
-   "Parameters":[
+   "parameters": [
       {"type":"ARRAY", "value":[-25.7, null, 36.85]}
    ]
 }

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -399,7 +399,7 @@ corresponding parameter value when you execute the query. Parameters are bound t
 which they are passed. Parameters are supported in both the [HTTP POST](../api-reference/sql-api.md) and [JDBC](../api-reference/sql-jdbc.md) APIs.
 
 Druid supports double and null values in arrays for dynamic queries.
-The following example query using the [ARRAY_CONTAINS](./sql-functions.md#array_contains) function returns `doubleArrayColumn` when the reference array `[-25.7, null, 36.85]` contains all elements of the value of `doubleArrayColumn`:
+The following example query uses the [ARRAY_CONTAINS](./sql-functions.md#array_contains) function to return `doubleArrayColumn` when the reference array `[-25.7, null, 36.85]` contains all elements of the value of `doubleArrayColumn`:
 
 ```sql
 {

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -403,7 +403,7 @@ The following example query uses the [ARRAY_CONTAINS](./sql-functions.md#array_c
 
 ```sql
 {
-   "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?,  doubleArrayColumn)",
+   "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?, doubleArrayColumn)",
    "parameters": [
       {
         "type": "ARRAY",

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -398,6 +398,17 @@ at execution time. To use dynamic parameters, replace any literal in the query w
 corresponding parameter value when you execute the query. Parameters are bound to the placeholders in the order in
 which they are passed. Parameters are supported in both the [HTTP POST](../api-reference/sql-api.md) and [JDBC](../api-reference/sql-jdbc.md) APIs.
 
+Druid supports double and null values in arrays for dynamic queries. For example:
+
+```sql
+{
+   "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?,  doubleArrayColumn)",
+   "Parameters":[
+      {"type":"ARRAY", "value":[-25.7, null, 36.85]}
+   ]
+}
+```
+
 In certain cases, using dynamic parameters in expressions can cause type inference issues which cause your query to fail, for example:
 
 ```sql

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -398,7 +398,7 @@ at execution time. To use dynamic parameters, replace any literal in the query w
 corresponding parameter value when you execute the query. Parameters are bound to the placeholders in the order in
 which they are passed. Parameters are supported in both the [HTTP POST](../api-reference/sql-api.md) and [JDBC](../api-reference/sql-jdbc.md) APIs.
 
-Druid supports double and null values in arrays for dynamic queries. For example:
+Druid supports double and null values in arrays for dynamic queries. The following example query using the [ARRAY_CONTAINS](./sql-functions.md#array_contains) function returns `doubleArrayColumn` when the reference array `[-25.7, null, 36.85]` contains all elements of the value of `doubleArrayColumn`:
 
 ```sql
 {


### PR DESCRIPTION
Add an example of dynamic query params to the docs, as a relevant example to point to from the Polaris UI.

Example taken from the Druid 30.0 blog:
https://imply.io/blog/introducing-apache-druid-30-0/

This PR has:
- [x] been self-reviewed.