### PR TITLE
Cosmetic improvements in web-console

### DIFF
--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -50,6 +50,7 @@ export interface MaxTasksButtonProps extends Omit<ButtonProps, 'text' | 'rightIc
   defaultQueryContext: QueryContext;
   menuHeader?: JSX.Element;
   maxTasksLabelFn?: (maxNum: number) => { text: string; label?: string };
+  maxNumTaskOptions?: number[];
   fullClusterCapacityLabelFn?: (clusterCapacity: number) => string;
 }
 
@@ -62,6 +63,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     menuHeader,
     maxTasksLabelFn = DEFAULT_MAX_NUM_TASKS_LABEL_FN,
     fullClusterCapacityLabelFn = DEFAULT_FULL_CLUSTER_CAPACITY_LABEL_FN,
+    maxNumTaskOptions = MAX_NUM_TASK_OPTIONS,
     ...rest
   } = props;
   const [customMaxNumTasksDialogOpen, setCustomMaxNumTasksDialogOpen] = useState(false);
@@ -73,8 +75,8 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     typeof clusterCapacity === 'number' ? fullClusterCapacityLabelFn(clusterCapacity) : undefined;
 
   const shownMaxNumTaskOptions = clusterCapacity
-    ? MAX_NUM_TASK_OPTIONS.filter(_ => _ <= clusterCapacity)
-    : MAX_NUM_TASK_OPTIONS;
+    ? maxNumTaskOptions.filter(_ => _ <= clusterCapacity)
+    : maxNumTaskOptions;
 
   return (
     <>
@@ -90,6 +92,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                 icon={tickIcon(typeof maxNumTasks === 'undefined')}
                 text={fullClusterCapacity}
                 onClick={() => changeQueryContext(deleteKeys(queryContext, ['maxNumTasks']))}
+                shouldDismissPopover
               />
             )}
             {shownMaxNumTaskOptions.map(m => {
@@ -102,6 +105,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                   text={text}
                   label={label}
                   onClick={() => changeQueryContext({ ...queryContext, maxNumTasks: m })}
+                  shouldDismissPopover
                 />
               );
             })}

--- a/web-console/src/views/workbench-view/query-parameters-dialog/query-parameters-dialog.tsx
+++ b/web-console/src/views/workbench-view/query-parameters-dialog/query-parameters-dialog.tsx
@@ -70,8 +70,15 @@ export const QueryParametersDialog = React.memo(function QueryParametersDialog(
     >
       <div className={Classes.DIALOG_BODY}>
         <p>
-          Druid SQL supports dynamic parameters using question mark <Code>?</Code> syntax, where
-          parameters are bound positionally to ? placeholders at execution time.
+          Define up to 2 parameter values to replace question mark <Code>?</Code> placeholders in
+          your query. See the{' '}
+          <a
+            href="https://druid.apache.org/docs/0.20.2/querying/sql.html#dynamic-parameters"
+            target="_blank"
+          >
+            Druid SQL docs
+          </a>{' '}
+          Druid SQL docs for more information and examples.
         </p>
         {currentQueryParameters.map((queryParameter, i) => {
           const { type, value } = queryParameter;

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -73,7 +73,11 @@ const queryRunner = new QueryRunner({
 export interface QueryTabProps
   extends Pick<
     RunPanelProps,
-    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
+    | 'maxTasksMenuHeader'
+    | 'enginesLabelFn'
+    | 'maxTasksLabelFn'
+    | 'fullClusterCapacityLabelFn'
+    | 'maxNumTaskOptions'
   > {
   query: WorkbenchQuery;
   id: string;
@@ -110,6 +114,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
     maxTasksMenuHeader,
     enginesLabelFn,
     maxTasksLabelFn,
+    maxNumTaskOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
@@ -419,6 +424,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               maxTasksMenuHeader={maxTasksMenuHeader}
               enginesLabelFn={enginesLabelFn}
               maxTasksLabelFn={maxTasksLabelFn}
+              maxNumTaskOptions={maxNumTaskOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
             {executionState.isLoading() && (

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -41,7 +41,6 @@ import type {
   DruidEngine,
   IndexSpec,
   QueryContext,
-  SelectDestination,
   SqlJoinAlgorithm,
   WorkbenchQuery,
 } from '../../../druid-models';
@@ -99,7 +98,10 @@ const DEFAULT_ENGINES_LABEL_FN = (engine: DruidEngine | undefined) => {
 };
 
 export interface RunPanelProps
-  extends Pick<MaxTasksButtonProps, 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'> {
+  extends Pick<
+    MaxTasksButtonProps,
+    'maxTasksLabelFn' | 'fullClusterCapacityLabelFn' | 'maxNumTaskOptions'
+  > {
   query: WorkbenchQuery;
   onQueryChange(query: WorkbenchQuery): void;
   running: boolean;
@@ -125,6 +127,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     maxTasksMenuHeader,
     enginesLabelFn = DEFAULT_ENGINES_LABEL_FN,
     maxTasksLabelFn,
+    maxNumTaskOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [editContextDialogOpen, setEditContextDialogOpen] = useState(false);
@@ -170,7 +173,6 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     defaultQueryContext,
   );
   const finalizeAggregations = queryContext.finalizeAggregations;
-  const waitUntilSegmentsLoad = queryContext.waitUntilSegmentsLoad;
   const groupByEnableMultiValueUnnesting = queryContext.groupByEnableMultiValueUnnesting;
   const sqlJoinAlgorithm = getQueryContextKey(
     'sqlJoinAlgorithm',
@@ -384,15 +386,6 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                           changeQueryContext({ ...queryContext, failOnEmptyInsert })
                         }
                       />
-                      <MenuTristate
-                        icon={IconNames.STOPWATCH}
-                        text="Wait until segments have loaded"
-                        value={waitUntilSegmentsLoad}
-                        undefinedEffectiveValue={ingestMode}
-                        onValueChange={waitUntilSegmentsLoad =>
-                          changeQueryContext({ ...queryContext, waitUntilSegmentsLoad })
-                        }
-                      />
                       <MenuItem
                         icon={IconNames.TH_DERIVED}
                         text="Edit index spec"
@@ -454,37 +447,6 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                           }
                         />
                       ))}
-                    </MenuItem>
-                    <MenuItem
-                      icon={IconNames.MANUALLY_ENTERED_DATA}
-                      text="SELECT destination"
-                      label={selectDestination}
-                      intent={intent}
-                    >
-                      {(['taskReport', 'durableStorage'] as SelectDestination[]).map(o => (
-                        <MenuItem
-                          key={o}
-                          icon={tickIcon(selectDestination === o)}
-                          text={o}
-                          shouldDismissPopover={false}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, selectDestination: o })
-                          }
-                        />
-                      ))}
-                      <MenuDivider />
-                      <MenuCheckbox
-                        checked={selectDestination === 'taskReport' ? !query.unlimited : false}
-                        intent={intent}
-                        disabled={selectDestination !== 'taskReport'}
-                        text="Limit SELECT results in taskReport"
-                        labelElement={
-                          query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
-                        }
-                        onChange={() => {
-                          onQueryChange(query.toggleUnlimited());
-                        }}
-                      />
                     </MenuItem>
                     <MenuCheckbox
                       checked={durableShuffleStorage}
@@ -568,6 +530,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
               defaultQueryContext={defaultQueryContext}
               menuHeader={maxTasksMenuHeader}
               maxTasksLabelFn={maxTasksLabelFn}
+              maxNumTaskOptions={maxNumTaskOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
           )}

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -99,7 +99,11 @@ function externalDataTabId(tabId: string | undefined): boolean {
 export interface WorkbenchViewProps
   extends Pick<
     QueryTabProps,
-    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
+    | 'maxTasksMenuHeader'
+    | 'enginesLabelFn'
+    | 'maxTasksLabelFn'
+    | 'fullClusterCapacityLabelFn'
+    | 'maxNumTaskOptions'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -669,6 +673,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTasksMenuHeader,
       enginesLabelFn,
       maxTasksLabelFn,
+      maxNumTaskOptions,
       fullClusterCapacityLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
@@ -699,6 +704,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTasksLabelFn={maxTasksLabelFn}
+          maxNumTaskOptions={maxNumTaskOptions}
           fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
           runMoreMenu={
             <Menu>


### PR DESCRIPTION
This PR contains the following changes in the web-console:
 - made it possible to configure the granularity of max tasks options
 - clicking on a "max task" item dismisses the max tasks menu
 - reworded the explanation text in QueryParametersDialog
 - removed certain options in the engine menu that were useless for the `sql-msq-task` engine