### PR TITLE
OshiSysMonitor: Add ability to skip emitting metrics

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -507,7 +507,7 @@ These metrics are only available if the `OshiSysMonitor` module is included.
 |`sys/tcpv4/out/rsts`|Total "out reset" packets sent to reset the connection||Generally 0|
 |`sys/tcpv4/retrans/segs`|Total segments re-transmitted||Varies|
 
-If you want to enable only some of these metrics categories you could specify `druid.monitoring.oshisys.categories`.
+If you want to enable only some of these metrics categories you could specify `druid.monitoring.sys.categories`.
 Possible values are `mem`, `swap`, `fs`, `disk`, `net`, `cpu`, `sys`, and `tcp`.
 
 ## S3 multi-part upload

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -507,7 +507,7 @@ These metrics are only available if the `OshiSysMonitor` module is included.
 |`sys/tcpv4/out/rsts`|Total "out reset" packets sent to reset the connection||Generally 0|
 |`sys/tcpv4/retrans/segs`|Total segments re-transmitted||Varies|
 
-If you want to skip some of these metrics you could specify `druid.monitoring.oshisys.skipEmitting`.
+If you want to enable only some of these metrics categories you could specify `druid.monitoring.oshisys.categories`.
 Possible values are `mem`, `swap`, `fs`, `disk`, `net`, `cpu`, `sys`, and `tcp`.
 
 ## S3 multi-part upload

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -507,6 +507,8 @@ These metrics are only available if the `OshiSysMonitor` module is included.
 |`sys/tcpv4/out/rsts`|Total "out reset" packets sent to reset the connection||Generally 0|
 |`sys/tcpv4/retrans/segs`|Total segments re-transmitted||Varies|
 
+If you want to skip some of these metrics you could specify `druid.monitoring.oshisys.skipEmitting`.
+Possible values are `mem`, `swap`, `fs`, `disk`, `net`, `cpu`, `sys`, and `tcp`.
 
 ## S3 multi-part upload
 

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/NoopOshiSysMonitor.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/NoopOshiSysMonitor.java
@@ -19,13 +19,15 @@
 
 package org.apache.druid.java.util.metrics;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 public class NoopOshiSysMonitor extends OshiSysMonitor
 {
   public NoopOshiSysMonitor()
   {
-    super();
+    super(ImmutableMap.of(), new OshiSysMonitorConfig(ImmutableList.of()));
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
@@ -20,9 +20,9 @@
 package org.apache.druid.java.util.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,16 +33,11 @@ public class OshiSysMonitorConfig
 
   @JsonProperty("categories")
   @NotNull
-  private List<String> categories;
+  private Set<String> categories;
 
   public OshiSysMonitorConfig(@JsonProperty("categories") List<String> categories)
   {
-    this.categories = categories == null ? new ArrayList<>() : categories;
-  }
-
-  public Set<String> getCategories()
-  {
-    return new HashSet<>(categories);
+    this.categories = categories == null ? new HashSet<>() : ImmutableSet.copyOf(categories);
   }
 
   public boolean shouldEmitMetricCategory(String category)

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class OshiSysMonitorConfig
 {
-  public static final String PREFIX = "druid.monitoring.oshisys";
+  public static final String PREFIX = "druid.monitoring.sys";
 
   @JsonProperty("categories")
   @NotNull

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitorConfig.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.druid.server.metrics;
+package org.apache.druid.java.util.metrics;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -27,21 +27,26 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class OshiSysConfig
+public class OshiSysMonitorConfig
 {
-  static final String PREFIX = "oshisys";
+  public static final String PREFIX = "druid.monitoring.oshisys";
 
-  @JsonProperty("skipEmitting")
+  @JsonProperty("categories")
   @NotNull
-  private List<String> skipEmitting;
+  private List<String> categories;
 
-  public OshiSysConfig(@JsonProperty("skipEmitting") List<String> skipEmitting)
+  public OshiSysMonitorConfig(@JsonProperty("categories") List<String> categories)
   {
-    this.skipEmitting = skipEmitting == null ? new ArrayList<>() : skipEmitting;
+    this.categories = categories == null ? new ArrayList<>() : categories;
   }
 
-  public Set<String> getSkipEmitting()
+  public Set<String> getCategories()
   {
-    return new HashSet<>(skipEmitting);
+    return new HashSet<>(categories);
+  }
+
+  public boolean shouldEmitMetricCategory(String category)
+  {
+    return categories.isEmpty() || categories.contains(category);
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -50,6 +50,7 @@ import org.apache.druid.java.util.metrics.MonitorScheduler;
 import org.apache.druid.java.util.metrics.NoopOshiSysMonitor;
 import org.apache.druid.java.util.metrics.NoopSysMonitor;
 import org.apache.druid.java.util.metrics.OshiSysMonitor;
+import org.apache.druid.java.util.metrics.OshiSysMonitorConfig;
 import org.apache.druid.java.util.metrics.SysMonitor;
 import org.apache.druid.query.ExecutorServiceMonitor;
 
@@ -86,7 +87,7 @@ public class MetricsModule implements Module
   {
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, DruidMonitorSchedulerConfig.class);
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, MonitorsConfig.class);
-    JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX + "." + OshiSysConfig.PREFIX, OshiSysConfig.class);
+    JsonConfigProvider.bind(binder, OshiSysMonitorConfig.PREFIX, OshiSysMonitorConfig.class);
 
     DruidBinders.metricMonitorBinder(binder); // get the binder so that it will inject the empty set at a minimum.
 
@@ -204,7 +205,7 @@ public class MetricsModule implements Module
   public OshiSysMonitor getOshiSysMonitor(
       DataSourceTaskIdHolder dataSourceTaskIdHolder,
       @Self Set<NodeRole> nodeRoles,
-      OshiSysConfig oshiSysConfig
+      OshiSysMonitorConfig oshiSysConfig
   )
   {
     if (nodeRoles.contains(NodeRole.PEON)) {
@@ -214,7 +215,7 @@ public class MetricsModule implements Module
           dataSourceTaskIdHolder.getDataSource(),
           dataSourceTaskIdHolder.getTaskId()
       );
-      return new OshiSysMonitor(dimensions, oshiSysConfig.getSkipEmitting());
+      return new OshiSysMonitor(dimensions, oshiSysConfig);
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -66,7 +66,7 @@ import java.util.stream.Collectors;
  */
 public class MetricsModule implements Module
 {
-  static final String MONITORING_PROPERTY_PREFIX = "druid.monitoring";
+  public static final String MONITORING_PROPERTY_PREFIX = "druid.monitoring";
   private static final Logger log = new Logger(MetricsModule.class);
   private Set<NodeRole> nodeRoles;
 
@@ -86,6 +86,7 @@ public class MetricsModule implements Module
   {
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, DruidMonitorSchedulerConfig.class);
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, MonitorsConfig.class);
+    JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX + "." + OshiSysConfig.PREFIX, OshiSysConfig.class);
 
     DruidBinders.metricMonitorBinder(binder); // get the binder so that it will inject the empty set at a minimum.
 
@@ -200,7 +201,11 @@ public class MetricsModule implements Module
 
   @Provides
   @ManageLifecycle
-  public OshiSysMonitor getOshiSysMonitor(DataSourceTaskIdHolder dataSourceTaskIdHolder, @Self Set<NodeRole> nodeRoles)
+  public OshiSysMonitor getOshiSysMonitor(
+      DataSourceTaskIdHolder dataSourceTaskIdHolder,
+      @Self Set<NodeRole> nodeRoles,
+      OshiSysConfig oshiSysConfig
+  )
   {
     if (nodeRoles.contains(NodeRole.PEON)) {
       return new NoopOshiSysMonitor();
@@ -209,7 +214,7 @@ public class MetricsModule implements Module
           dataSourceTaskIdHolder.getDataSource(),
           dataSourceTaskIdHolder.getTaskId()
       );
-      return new OshiSysMonitor(dimensions);
+      return new OshiSysMonitor(dimensions, oshiSysConfig.getSkipEmitting());
     }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/OshiSysConfig.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/OshiSysConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.metrics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class OshiSysConfig
+{
+  static final String PREFIX = "oshisys";
+
+  @JsonProperty("skipEmitting")
+  @NotNull
+  private List<String> skipEmitting;
+
+  public OshiSysConfig(@JsonProperty("skipEmitting") List<String> skipEmitting)
+  {
+    this.skipEmitting = skipEmitting == null ? new ArrayList<>() : skipEmitting;
+  }
+
+  public Set<String> getSkipEmitting()
+  {
+    return new HashSet<>(skipEmitting);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -47,6 +47,7 @@ import org.apache.druid.java.util.metrics.MonitorScheduler;
 import org.apache.druid.java.util.metrics.NoopOshiSysMonitor;
 import org.apache.druid.java.util.metrics.NoopSysMonitor;
 import org.apache.druid.java.util.metrics.OshiSysMonitor;
+import org.apache.druid.java.util.metrics.OshiSysMonitorConfig;
 import org.apache.druid.java.util.metrics.SysMonitor;
 import org.apache.druid.server.DruidNode;
 import org.hamcrest.CoreMatchers;
@@ -216,38 +217,18 @@ public class MetricsModuleTest
   @Test
   public void testGetOshiSysMonitorViaInjectorBroker()
   {
-    final Injector injector = createInjector(new Properties()
-    {
-      {
-        setProperty("druid.monitoring.oshisys.skipEmitting", "[\"mem\"]");
-      }
-    }, ImmutableSet.of(NodeRole.BROKER));
+    Properties properties = new Properties();
+    properties.setProperty("druid.monitoring.oshisys.categories", "[\"mem\"]");
+    final Injector injector = createInjector(properties, ImmutableSet.of(NodeRole.BROKER));
     final OshiSysMonitor sysMonitor = injector.getInstance(OshiSysMonitor.class);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
     sysMonitor.doMonitor(emitter);
 
     Assert.assertTrue(sysMonitor instanceof OshiSysMonitor);
     Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
-  }
 
-  @Test
-  public void testGetOshiSysMonitorViaInjectorBrokerSkipAll()
-  {
-    final Injector injector = createInjector(new Properties()
-    {
-      {
-        setProperty(
-            "druid.monitoring.oshisys.skipEmitting",
-            "[\"mem\", \"swap\", \"fs\", \"disk\", \"net\", \"cpu\", \"sys\", \"tcp\"]"
-        );
-      }
-    }, ImmutableSet.of(NodeRole.BROKER));
-    final OshiSysMonitor sysMonitor = injector.getInstance(OshiSysMonitor.class);
-    final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
-    sysMonitor.doMonitor(emitter);
-
-    Assert.assertTrue(sysMonitor instanceof OshiSysMonitor);
-    Mockito.verify(emitter, Mockito.never()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
+    Assert.assertTrue(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("mem"));
+    Assert.assertFalse(injector.getInstance(OshiSysMonitorConfig.class).shouldEmitMetricCategory("swap"));
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -218,7 +218,7 @@ public class MetricsModuleTest
   public void testGetOshiSysMonitorViaInjectorBroker()
   {
     Properties properties = new Properties();
-    properties.setProperty("druid.monitoring.oshisys.categories", "[\"mem\"]");
+    properties.setProperty("druid.monitoring.sys.categories", "[\"mem\"]");
     final Injector injector = createInjector(properties, ImmutableSet.of(NodeRole.BROKER));
     final OshiSysMonitor sysMonitor = injector.getInstance(OshiSysMonitor.class);
     final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);

--- a/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/MetricsModuleTest.java
@@ -212,6 +212,44 @@ public class MetricsModuleTest
     Assert.assertTrue(sysMonitor instanceof NoopOshiSysMonitor);
     Mockito.verify(emitter, Mockito.never()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
   }
+
+  @Test
+  public void testGetOshiSysMonitorViaInjectorBroker()
+  {
+    final Injector injector = createInjector(new Properties()
+    {
+      {
+        setProperty("druid.monitoring.oshisys.skipEmitting", "[\"mem\"]");
+      }
+    }, ImmutableSet.of(NodeRole.BROKER));
+    final OshiSysMonitor sysMonitor = injector.getInstance(OshiSysMonitor.class);
+    final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
+    sysMonitor.doMonitor(emitter);
+
+    Assert.assertTrue(sysMonitor instanceof OshiSysMonitor);
+    Mockito.verify(emitter, Mockito.atLeastOnce()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
+  }
+
+  @Test
+  public void testGetOshiSysMonitorViaInjectorBrokerSkipAll()
+  {
+    final Injector injector = createInjector(new Properties()
+    {
+      {
+        setProperty(
+            "druid.monitoring.oshisys.skipEmitting",
+            "[\"mem\", \"swap\", \"fs\", \"disk\", \"net\", \"cpu\", \"sys\", \"tcp\"]"
+        );
+      }
+    }, ImmutableSet.of(NodeRole.BROKER));
+    final OshiSysMonitor sysMonitor = injector.getInstance(OshiSysMonitor.class);
+    final ServiceEmitter emitter = Mockito.mock(ServiceEmitter.class);
+    sysMonitor.doMonitor(emitter);
+
+    Assert.assertTrue(sysMonitor instanceof OshiSysMonitor);
+    Mockito.verify(emitter, Mockito.never()).emit(ArgumentMatchers.any(ServiceEventBuilder.class));
+  }
+
   @Test
   public void testGetOshiSysMonitorWhenNull()
   {


### PR DESCRIPTION
### Description

While running druid in containerized (or any other customized) environments, not all of the metrics emitted by OshiSysMonitor are applicable. This PR adds ability to skip a category of metrics from this monitor so as to reduce computation in calculating/emitting/storing such metrics through specifying `druid.monitoring.oshisys.skipEmitting` config.

#### Release note
Ability to skip emitting metrics by category in OshiSysMonitor.

<hr>

##### Key changed/added classes in this PR
 * `OshiSysMonitor`
 * `MetricsModule`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
