### PR TITLE
Create fewer temporary maps when querying sys.segments.

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -413,11 +414,26 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
    */
   public Map<SegmentId, AvailableSegmentMetadata> getSegmentMetadataSnapshot()
   {
-    final Map<SegmentId, AvailableSegmentMetadata> segmentMetadata = Maps.newHashMapWithExpectedSize(totalSegments);
-    for (ConcurrentSkipListMap<SegmentId, AvailableSegmentMetadata> val : segmentMetadataInfo.values()) {
-      segmentMetadata.putAll(val);
+    final Map<SegmentId, AvailableSegmentMetadata> segmentMetadata = Maps.newHashMapWithExpectedSize(getTotalSegments());
+    final Iterator<AvailableSegmentMetadata> it = iterateSegmentMetadata();
+    while (it.hasNext()) {
+      final AvailableSegmentMetadata availableSegmentMetadata = it.next();
+      segmentMetadata.put(availableSegmentMetadata.getSegment().getId(), availableSegmentMetadata);
     }
     return segmentMetadata;
+  }
+
+  /**
+   * Get metadata for all the cached segments, which includes information like RowSignature, realtime & numRows etc.
+   * This is a lower-overhead method than {@link #getSegmentMetadataSnapshot()}.
+   *
+   * @return iterator of metadata.
+   */
+  public Iterator<AvailableSegmentMetadata> iterateSegmentMetadata()
+  {
+    return FluentIterable.from(segmentMetadataInfo.values())
+                         .transformAndConcat(Map::values)
+                         .iterator();
   }
 
   /**
@@ -431,10 +447,14 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
   @Nullable
   public AvailableSegmentMetadata getAvailableSegmentMetadata(String datasource, SegmentId segmentId)
   {
-    if (!segmentMetadataInfo.containsKey(datasource)) {
+    final ConcurrentSkipListMap<SegmentId, AvailableSegmentMetadata> dataSourceMap =
+        segmentMetadataInfo.get(datasource);
+
+    if (dataSourceMap == null) {
       return null;
+    } else {
+      return dataSourceMap.get(segmentId);
     }
-    return segmentMetadataInfo.get(datasource).get(segmentId);
   }
 
   /**


### PR DESCRIPTION
Eliminates two map creations (`availableSegmentMetadata`, `partialSegmentDataMap`). The `segmentsAlreadySeen` set remains.