### PR TITLE
Fix computed value of maxSegmentsToMove when coordinator period is low

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculator.java
@@ -42,7 +42,7 @@ public class SegmentToMoveCalculator
 {
   /**
    * At least this number of segments must be picked for moving in every cycle
-   * to keep the cluster well balanced.
+   * to keep the cluster well-balanced.
    */
   private static final int MIN_SEGMENTS_TO_MOVE = 100;
 
@@ -150,7 +150,7 @@ public class SegmentToMoveCalculator
     int maxComputationsInThousands = (numBalancerThreads * num30sPeriods) << 20;
     int maxSegmentsToMove = (maxComputationsInThousands / totalSegments) * 1000;
 
-    if (upperBound < lowerBound) {
+    if (upperBound < lowerBound || maxSegmentsToMove < lowerBound) {
       return Math.min(lowerBound, totalSegments);
     } else {
       return Math.min(maxSegmentsToMove, upperBound);

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculatorTest.java
@@ -83,6 +83,10 @@ public class SegmentToMoveCalculatorTest
   @Test
   public void testMaxSegmentsToMoveIncreasesWithCoordinatorPeriod()
   {
+    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(0)));
+    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(10_000)));
+    Assert.assertEquals(100, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(20_000)));
+
     Assert.assertEquals(5_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(30_000)));
     Assert.assertEquals(10_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(60_000)));
     Assert.assertEquals(15_000, computeMaxSegmentsToMoveInPeriod(200_000, Duration.millis(90_000)));


### PR DESCRIPTION
### Description

Bug: When coordinator period is less than 30s, `maxSegmentsToMove` is always computed as 0 irrespective of number of available threads.

### Changes
- Fix lower bound condition and set minimum value to 100.
- Add new test which fails without this fix