### PR TITLE
Revert "[CVE Fixes] Update version of Nimbus.jose.jwt"

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -38,7 +38,7 @@
 
     <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
     <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
-    <nimbus.jose.jwt.version>9.37.2</nimbus.jose.jwt.version>
+    <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
     <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>
   </properties>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -809,7 +809,7 @@ name: com.nimbusds nimbus-jose-jwt
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 9.37.2
+version: 8.22.1
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 


### PR DESCRIPTION
Reverts apache/druid#16320

Updating nimbus to version 9+ is causing `HTTP ERROR 500 java.lang.NoSuchMethodError: 'net.minidev.json.JSONObject com.nimbusds.jwt.JWTClaimsSet.toJSONObject()'`
Refer to https://github.com/SAP/cloud-security-services-integration-library/issues/429#issuecomment-1501601312 for more details.

We would need to upgrade other libraries as well for updating nimbus.jose.jwt
