### PR TITLE
Web console query view improvements

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -327,7 +327,6 @@ export class ConsoleApplication extends React.PureComponent<
         baseQueryContext={baseQueryContext}
         serverQueryContext={serverQueryContext}
         queryEngines={queryEngines}
-        allowExplain
         goToTask={this.goToTasksWithTaskId}
         getClusterCapacity={maybeGetClusterCapacity}
       />,

--- a/web-console/src/views/workbench-view/max-tasks-button/__snapshots__/max-tasks-button.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/max-tasks-button/__snapshots__/max-tasks-button.spec.tsx.snap
@@ -123,15 +123,19 @@ exports[`MaxTasksButton matches snapshot 1`] = `
                 <strong>
                   Auto
                 </strong>
-                : Use the minimum number of tasks while
+                : uses the minimum number of tasks while
                  
-                <a
-                  href="https://druid.apache.org/docs/latest/multi-stage-query/reference#context-parameters"
+                <span
                   onClick={[Function]}
-                  target="_blank"
+                  style={
+                    {
+                      "color": "#3eadf9",
+                      "cursor": "pointer",
+                    }
+                  }
                 >
-                  staying within constrain.
-                </a>
+                  staying within constraints.
+                </span>
               </React.Fragment>
             }
           />

--- a/web-console/src/views/workbench-view/max-tasks-button/__snapshots__/max-tasks-button.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/max-tasks-button/__snapshots__/max-tasks-button.spec.tsx.snap
@@ -100,14 +100,13 @@ exports[`MaxTasksButton matches snapshot 1`] = `
             multiline={true}
             onClick={[Function]}
             popoverProps={{}}
-            shouldDismissPopover={false}
+            shouldDismissPopover={true}
             text={
               <React.Fragment>
                 <strong>
                   Max
                 </strong>
-                : 
-                uses the maximum possible tasks up to the specified limit.
+                : uses the maximum possible tasks up to the specified limit.
               </React.Fragment>
             }
           />
@@ -115,24 +114,24 @@ exports[`MaxTasksButton matches snapshot 1`] = `
             active={false}
             disabled={false}
             icon="blank"
-            labelElement={
-              <Blueprint5.Button
-                icon="help"
-                minimal={true}
-                onClick={[Function]}
-              />
-            }
             multiline={true}
             onClick={[Function]}
             popoverProps={{}}
-            shouldDismissPopover={false}
+            shouldDismissPopover={true}
             text={
               <React.Fragment>
                 <strong>
                   Auto
                 </strong>
-                : 
-                maximizes the number of tasks while staying within 512 MiB or 10,000 files per task, unless more tasks are needed to stay under the max task limit.
+                : Use the minimum number of tasks while
+                 
+                <a
+                  href="https://druid.apache.org/docs/latest/multi-stage-query/reference#context-parameters"
+                  onClick={[Function]}
+                  target="_blank"
+                >
+                  staying within constrain.
+                </a>
               </React.Fragment>
             }
           />

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -126,7 +126,6 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                     <strong>Max</strong>: uses the maximum possible tasks up to the specified limit.
                   </>
                 }
-                shouldDismissPopover
                 multiline
                 onClick={() => changeQueryContext({ ...queryContext, taskAssignment: 'max' })}
               />
@@ -135,17 +134,21 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                 icon={tickIcon(taskAssigment === 'auto')}
                 text={
                   <>
-                    <strong>Auto</strong>: Use the minimum number of tasks while{' '}
-                    <a
-                      href={TASK_DOCUMENTATION_LINK}
-                      target="_blank"
-                      onClick={e => e.stopPropagation()}
+                    <strong>Auto</strong>: uses the minimum number of tasks while{' '}
+                    <span
+                      style={{
+                        color: '#3eadf9',
+                        cursor: 'pointer',
+                      }}
+                      onClick={e => {
+                        window.open(TASK_DOCUMENTATION_LINK, '_blank');
+                        e.stopPropagation();
+                      }}
                     >
-                      staying within constrain.
-                    </a>
+                      staying within constraints.
+                    </span>
                   </>
                 }
-                shouldDismissPopover
                 multiline
                 onClick={() => changeQueryContext({ ...queryContext, taskAssignment: 'auto' })}
               />

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -63,6 +63,7 @@ export interface MaxTasksButtonProps extends Omit<ButtonProps, 'text' | 'rightIc
   defaultQueryContext: QueryContext;
   menuHeader?: JSX.Element;
   maxTasksLabelFn?: (maxNum: number) => { text: string; label?: string };
+  maxNumTaskOptions?: number[];
   fullClusterCapacityLabelFn?: (clusterCapacity: number) => string;
 }
 
@@ -75,6 +76,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     menuHeader,
     maxTasksLabelFn = DEFAULT_MAX_NUM_TASKS_LABEL_FN,
     fullClusterCapacityLabelFn = DEFAULT_FULL_CLUSTER_CAPACITY_LABEL_FN,
+    maxNumTaskOptions = MAX_NUM_TASK_OPTIONS,
     ...rest
   } = props;
   const [customMaxNumTasksDialogOpen, setCustomMaxNumTasksDialogOpen] = useState(false);
@@ -86,8 +88,8 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     typeof clusterCapacity === 'number' ? fullClusterCapacityLabelFn(clusterCapacity) : undefined;
 
   const shownMaxNumTaskOptions = clusterCapacity
-    ? MAX_NUM_TASK_OPTIONS.filter(_ => _ <= clusterCapacity)
-    : MAX_NUM_TASK_OPTIONS;
+    ? maxNumTaskOptions.filter(_ => _ <= clusterCapacity)
+    : maxNumTaskOptions;
 
   return (
     <>
@@ -103,6 +105,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                 icon={tickIcon(typeof maxNumTasks === 'undefined')}
                 text={fullClusterCapacity}
                 onClick={() => changeQueryContext(deleteKeys(queryContext, ['maxNumTasks']))}
+                shouldDismissPopover
               />
             )}
             {shownMaxNumTaskOptions.map(m => {
@@ -115,6 +118,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
                   text={text}
                   label={label}
                   onClick={() => changeQueryContext({ ...queryContext, maxNumTasks: m })}
+                  shouldDismissPopover
                 />
               );
             })}

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -28,7 +28,7 @@ import { getQueryContextKey } from '../../../druid-models';
 import { getLink } from '../../../links';
 import { capitalizeFirst, deleteKeys, formatInteger, tickIcon } from '../../../utils';
 
-const MAX_NUM_TASK_OPTIONS = [2, 3, 4, 5, 7, 9, 11, 17, 33, 65, 129];
+const DEFAULT_MAX_TASKS_OPTIONS = [2, 3, 4, 5, 7, 9, 11, 17, 33, 65, 129];
 const TASK_DOCUMENTATION_LINK = `${getLink('DOCS')}/multi-stage-query/reference#context-parameters`;
 
 const DEFAULT_MAX_NUM_TASKS_LABEL_FN = (maxNum: number) => {
@@ -46,7 +46,7 @@ export interface MaxTasksButtonProps extends Omit<ButtonProps, 'text' | 'rightIc
   defaultQueryContext: QueryContext;
   menuHeader?: JSX.Element;
   maxTasksLabelFn?: (maxNum: number) => { text: string; label?: string };
-  maxNumTaskOptions?: number[];
+  maxTasksOptions?: number[];
   fullClusterCapacityLabelFn?: (clusterCapacity: number) => string;
 }
 
@@ -59,7 +59,7 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     menuHeader,
     maxTasksLabelFn = DEFAULT_MAX_NUM_TASKS_LABEL_FN,
     fullClusterCapacityLabelFn = DEFAULT_FULL_CLUSTER_CAPACITY_LABEL_FN,
-    maxNumTaskOptions = MAX_NUM_TASK_OPTIONS,
+    maxTasksOptions = DEFAULT_MAX_TASKS_OPTIONS,
     ...rest
   } = props;
   const [customMaxNumTasksDialogOpen, setCustomMaxNumTasksDialogOpen] = useState(false);
@@ -71,8 +71,8 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
     typeof clusterCapacity === 'number' ? fullClusterCapacityLabelFn(clusterCapacity) : undefined;
 
   const shownMaxNumTaskOptions = clusterCapacity
-    ? maxNumTaskOptions.filter(_ => _ <= clusterCapacity)
-    : maxNumTaskOptions;
+    ? maxTasksOptions.filter(_ => _ <= clusterCapacity)
+    : maxTasksOptions;
 
   return (
     <>

--- a/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
+++ b/web-console/src/views/workbench-view/max-tasks-button/max-tasks-button.tsx
@@ -19,34 +19,17 @@
 import type { ButtonProps } from '@blueprintjs/core';
 import { Button, Menu, MenuDivider, MenuItem, Popover, Position } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
-import type { JSX, ReactNode } from 'react';
+import type { JSX } from 'react';
 import React, { useState } from 'react';
 
 import { NumericInputDialog } from '../../../dialogs';
-import type { QueryContext, TaskAssignment } from '../../../druid-models';
+import type { QueryContext } from '../../../druid-models';
 import { getQueryContextKey } from '../../../druid-models';
 import { getLink } from '../../../links';
 import { capitalizeFirst, deleteKeys, formatInteger, tickIcon } from '../../../utils';
 
 const MAX_NUM_TASK_OPTIONS = [2, 3, 4, 5, 7, 9, 11, 17, 33, 65, 129];
-const TASK_ASSIGNMENT_OPTIONS: TaskAssignment[] = ['max', 'auto'];
-
-const TASK_ASSIGNMENT_DESCRIPTION: Record<string, string> = {
-  max: 'uses the maximum possible tasks up to the specified limit.',
-  auto: 'maximizes the number of tasks while staying within 512 MiB or 10,000 files per task, unless more tasks are needed to stay under the max task limit.',
-};
-
-const TASK_ASSIGNMENT_LABEL_ELEMENT: Record<string, ReactNode> = {
-  auto: (
-    <Button
-      icon={IconNames.HELP}
-      minimal
-      onClick={() =>
-        window.open(`${getLink('DOCS')}/multi-stage-query/reference#context-parameters`, '_blank')
-      }
-    />
-  ),
-};
+const TASK_DOCUMENTATION_LINK = `${getLink('DOCS')}/multi-stage-query/reference#context-parameters`;
 
 const DEFAULT_MAX_NUM_TASKS_LABEL_FN = (maxNum: number) => {
   if (maxNum === 2) return { text: formatInteger(maxNum), label: '(1 controller + 1 worker)' };
@@ -136,21 +119,36 @@ export const MaxTasksButton = function MaxTasksButton(props: MaxTasksButtonProps
               label={capitalizeFirst(taskAssigment)}
               submenuProps={{ style: { width: 300 } }}
             >
-              {TASK_ASSIGNMENT_OPTIONS.map(t => (
-                <MenuItem
-                  key={String(t)}
-                  icon={tickIcon(t === taskAssigment)}
-                  text={
-                    <>
-                      <strong>{capitalizeFirst(t)}</strong>: {TASK_ASSIGNMENT_DESCRIPTION[t]}
-                    </>
-                  }
-                  labelElement={TASK_ASSIGNMENT_LABEL_ELEMENT[t]}
-                  shouldDismissPopover={false}
-                  multiline
-                  onClick={() => changeQueryContext({ ...queryContext, taskAssignment: t })}
-                />
-              ))}
+              <MenuItem
+                icon={tickIcon(taskAssigment === 'max')}
+                text={
+                  <>
+                    <strong>Max</strong>: uses the maximum possible tasks up to the specified limit.
+                  </>
+                }
+                shouldDismissPopover
+                multiline
+                onClick={() => changeQueryContext({ ...queryContext, taskAssignment: 'max' })}
+              />
+
+              <MenuItem
+                icon={tickIcon(taskAssigment === 'auto')}
+                text={
+                  <>
+                    <strong>Auto</strong>: Use the minimum number of tasks while{' '}
+                    <a
+                      href={TASK_DOCUMENTATION_LINK}
+                      target="_blank"
+                      onClick={e => e.stopPropagation()}
+                    >
+                      staying within constrain.
+                    </a>
+                  </>
+                }
+                shouldDismissPopover
+                multiline
+                onClick={() => changeQueryContext({ ...queryContext, taskAssignment: 'auto' })}
+              />
             </MenuItem>
           </Menu>
         }

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -78,6 +78,7 @@ export interface QueryTabProps
     | 'maxTasksLabelFn'
     | 'fullClusterCapacityLabelFn'
     | 'maxTasksOptions'
+    | 'hiddenOptions'
   > {
   query: WorkbenchQuery;
   id: string;
@@ -116,6 +117,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
     maxTasksLabelFn,
     maxTasksOptions,
     fullClusterCapacityLabelFn,
+    hiddenOptions,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
 
@@ -426,6 +428,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               maxTasksLabelFn={maxTasksLabelFn}
               maxTasksOptions={maxTasksOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
+              hiddenOptions={hiddenOptions}
             />
             {executionState.isLoading() && (
               <ExecutionTimerPanel

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -77,7 +77,7 @@ export interface QueryTabProps
     | 'enginesLabelFn'
     | 'maxTasksLabelFn'
     | 'fullClusterCapacityLabelFn'
-    | 'maxNumTaskOptions'
+    | 'maxTasksOptions'
   > {
   query: WorkbenchQuery;
   id: string;
@@ -114,7 +114,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
     maxTasksMenuHeader,
     enginesLabelFn,
     maxTasksLabelFn,
-    maxNumTaskOptions,
+    maxTasksOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
@@ -424,7 +424,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               maxTasksMenuHeader={maxTasksMenuHeader}
               enginesLabelFn={enginesLabelFn}
               maxTasksLabelFn={maxTasksLabelFn}
-              maxNumTaskOptions={maxNumTaskOptions}
+              maxTasksOptions={maxTasksOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
             {executionState.isLoading() && (

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -73,7 +73,11 @@ const queryRunner = new QueryRunner({
 export interface QueryTabProps
   extends Pick<
     RunPanelProps,
-    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
+    | 'maxTasksMenuHeader'
+    | 'enginesLabelFn'
+    | 'maxTasksLabelFn'
+    | 'fullClusterCapacityLabelFn'
+    | 'maxNumTaskOptions'
   > {
   query: WorkbenchQuery;
   id: string;
@@ -110,6 +114,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
     maxTasksMenuHeader,
     enginesLabelFn,
     maxTasksLabelFn,
+    maxNumTaskOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [alertElement, setAlertElement] = useState<JSX.Element | undefined>();
@@ -419,6 +424,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               maxTasksMenuHeader={maxTasksMenuHeader}
               enginesLabelFn={enginesLabelFn}
               maxTasksLabelFn={maxTasksLabelFn}
+              maxNumTaskOptions={maxNumTaskOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
             {executionState.isLoading() && (

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -122,6 +122,21 @@ const SELECT_DESTINATION_LABEL: Record<SelectDestination, string> = {
 
 const EXPERIMENTAL_ICON = <Icon icon={IconNames.WARNING_SIGN} title="Experimental" />;
 
+type EnginesMenuOption =
+  | 'edit-query-context'
+  | 'define-parameters'
+  | 'timezone'
+  | 'insert-replace-specific-context'
+  | 'max-parse-exceptions'
+  | 'join-algorithm'
+  | 'select-destination'
+  | 'approximate-count-distinct'
+  | 'finalize-aggregations'
+  | 'group-by-enable-multi-value-unnesting'
+  | 'durable-shuffle-storage'
+  | 'use-cache'
+  | 'approximate-top-n'
+  | 'limit-inline-results';
 export interface RunPanelProps
   extends Pick<
     MaxTasksButtonProps,
@@ -137,6 +152,7 @@ export interface RunPanelProps
   moreMenu?: JSX.Element;
   maxTasksMenuHeader?: JSX.Element;
   enginesLabelFn?: (engine: DruidEngine | undefined) => { text: string; label?: string };
+  hiddenOptions?: EnginesMenuOption[];
 }
 
 export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
@@ -154,6 +170,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     maxTasksLabelFn,
     maxTasksOptions,
     fullClusterCapacityLabelFn,
+    hiddenOptions = [],
   } = props;
   const [editContextDialogOpen, setEditContextDialogOpen] = useState(false);
   const [editParametersDialogOpen, setEditParametersDialogOpen] = useState(false);
@@ -344,19 +361,25 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                     <MenuDivider />
                   </>
                 )}
-                <MenuItem
-                  icon={IconNames.PROPERTIES}
-                  text="Edit query context..."
-                  onClick={() => setEditContextDialogOpen(true)}
-                  label={pluralIfNeeded(numContextKeys, 'key')}
-                />
-                <MenuItem
-                  icon={IconNames.HELP}
-                  text="Define parameters..."
-                  onClick={() => setEditParametersDialogOpen(true)}
-                  label={queryParameters ? pluralIfNeeded(queryParameters.length, 'parameter') : ''}
-                />
-                {effectiveEngine !== 'native' && (
+                {!hiddenOptions.includes('edit-query-context') && (
+                  <MenuItem
+                    icon={IconNames.PROPERTIES}
+                    text="Edit query context..."
+                    onClick={() => setEditContextDialogOpen(true)}
+                    label={pluralIfNeeded(numContextKeys, 'key')}
+                  />
+                )}
+                {!hiddenOptions.includes('define-parameters') && (
+                  <MenuItem
+                    icon={IconNames.HELP}
+                    text="Define parameters..."
+                    onClick={() => setEditParametersDialogOpen(true)}
+                    label={
+                      queryParameters ? pluralIfNeeded(queryParameters.length, 'parameter') : ''
+                    }
+                  />
+                )}
+                {effectiveEngine !== 'native' && !hiddenOptions.includes('timezone') && (
                   <MenuItem
                     icon={IconNames.GLOBE_NETWORK}
                     text="Timezone"
@@ -397,133 +420,236 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                 )}
                 {effectiveEngine === 'sql-msq-task' ? (
                   <>
-                    <MenuItem icon={IconNames.BRING_DATA} text="INSERT / REPLACE specific context">
-                      <MenuBoolean
-                        text="Force segment sort by time"
-                        value={forceSegmentSortByTime}
-                        onValueChange={forceSegmentSortByTime =>
-                          changeQueryContext({
-                            ...queryContext,
-                            forceSegmentSortByTime,
-                          })
-                        }
-                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                        optionsLabelElement={{ false: EXPERIMENTAL_ICON }}
-                      />
-                      <MenuBoolean
-                        text="Use concurrent locks"
-                        value={useConcurrentLocks}
-                        onValueChange={useConcurrentLocks =>
-                          changeQueryContext({
-                            ...queryContext,
-                            useConcurrentLocks,
-                          })
-                        }
-                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                        optionsLabelElement={{ true: EXPERIMENTAL_ICON }}
-                      />
-                      <MenuBoolean
-                        text="Fail on empty insert"
-                        value={failOnEmptyInsert}
-                        showUndefined
-                        undefinedEffectiveValue={false}
-                        onValueChange={failOnEmptyInsert =>
-                          changeQueryContext({ ...queryContext, failOnEmptyInsert })
-                        }
-                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                      />
-                      <MenuBoolean
-                        text="Wait until segments have loaded"
-                        value={waitUntilSegmentsLoad}
-                        showUndefined
-                        undefinedEffectiveValue={ingestMode}
-                        onValueChange={waitUntilSegmentsLoad =>
-                          changeQueryContext({ ...queryContext, waitUntilSegmentsLoad })
-                        }
-                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                      />
+                    {!hiddenOptions.includes('insert-replace-specific-context') && (
                       <MenuItem
-                        text="Edit index spec..."
-                        label={summarizeIndexSpec(indexSpec)}
-                        shouldDismissPopover={false}
-                        onClick={() => {
-                          setIndexSpecDialogSpec(indexSpec || {});
-                        }}
-                      />
-                    </MenuItem>
-                    <MenuItem
-                      icon={IconNames.ERROR}
-                      text="Max parse exceptions"
-                      label={String(maxParseExceptions)}
-                    >
-                      {[0, 1, 5, 10, 1000, 10000, -1].map(v => (
-                        <MenuItem
-                          key={String(v)}
-                          icon={tickIcon(v === maxParseExceptions)}
-                          text={v === -1 ? '∞ (-1)' : String(v)}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, maxParseExceptions: v })
+                        icon={IconNames.BRING_DATA}
+                        text="INSERT / REPLACE specific context"
+                      >
+                        <MenuBoolean
+                          text="Force segment sort by time"
+                          value={forceSegmentSortByTime}
+                          onValueChange={forceSegmentSortByTime =>
+                            changeQueryContext({
+                              ...queryContext,
+                              forceSegmentSortByTime,
+                            })
                           }
-                          shouldDismissPopover={false}
+                          optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                          optionsLabelElement={{ false: EXPERIMENTAL_ICON }}
                         />
-                      ))}
-                    </MenuItem>
-                    <MenuItem
-                      icon={IconNames.INNER_JOIN}
-                      text="Join algorithm"
-                      label={
-                        SQL_JOIN_ALGORITHM_LABEL[sqlJoinAlgorithm as SqlJoinAlgorithm] ??
-                        sqlJoinAlgorithm
-                      }
-                    >
-                      {(['broadcast', 'sortMerge'] as SqlJoinAlgorithm[]).map(o => (
-                        <MenuItem
-                          key={o}
-                          icon={tickIcon(sqlJoinAlgorithm === o)}
-                          text={SQL_JOIN_ALGORITHM_LABEL[o]}
-                          shouldDismissPopover={false}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, sqlJoinAlgorithm: o })
+                        <MenuBoolean
+                          text="Use concurrent locks"
+                          value={useConcurrentLocks}
+                          onValueChange={useConcurrentLocks =>
+                            changeQueryContext({
+                              ...queryContext,
+                              useConcurrentLocks,
+                            })
                           }
+                          optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                          optionsLabelElement={{ true: EXPERIMENTAL_ICON }}
                         />
-                      ))}
-                    </MenuItem>
-
-                    <MenuItem
-                      icon={IconNames.MANUALLY_ENTERED_DATA}
-                      text="SELECT destination"
-                      label={
-                        SELECT_DESTINATION_LABEL[selectDestination as SelectDestination] ??
-                        selectDestination
-                      }
-                      intent={intent}
-                    >
-                      {(['taskReport', 'durableStorage'] as SelectDestination[]).map(o => (
-                        <MenuItem
-                          key={o}
-                          icon={tickIcon(selectDestination === o)}
-                          text={SELECT_DESTINATION_LABEL[o]}
-                          shouldDismissPopover={false}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, selectDestination: o })
+                        <MenuBoolean
+                          text="Fail on empty insert"
+                          value={failOnEmptyInsert}
+                          showUndefined
+                          undefinedEffectiveValue={false}
+                          onValueChange={failOnEmptyInsert =>
+                            changeQueryContext({ ...queryContext, failOnEmptyInsert })
                           }
+                          optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
                         />
-                      ))}
-                      <MenuDivider />
-                      <MenuCheckbox
-                        checked={selectDestination === 'taskReport' ? !query.unlimited : false}
-                        intent={intent}
-                        disabled={selectDestination !== 'taskReport'}
-                        text="Limit SELECT results in taskReport"
-                        labelElement={
-                          query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
+                        <MenuBoolean
+                          text="Wait until segments have loaded"
+                          value={waitUntilSegmentsLoad}
+                          showUndefined
+                          undefinedEffectiveValue={ingestMode}
+                          onValueChange={waitUntilSegmentsLoad =>
+                            changeQueryContext({ ...queryContext, waitUntilSegmentsLoad })
+                          }
+                          optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                        />
+                        <MenuItem
+                          text="Edit index spec..."
+                          label={summarizeIndexSpec(indexSpec)}
+                          shouldDismissPopover={false}
+                          onClick={() => {
+                            setIndexSpecDialogSpec(indexSpec || {});
+                          }}
+                        />
+                      </MenuItem>
+                    )}
+                    {!hiddenOptions.includes('max-parse-exceptions') && (
+                      <MenuItem
+                        icon={IconNames.ERROR}
+                        text="Max parse exceptions"
+                        label={String(maxParseExceptions)}
+                      >
+                        {[0, 1, 5, 10, 1000, 10000, -1].map(v => (
+                          <MenuItem
+                            key={String(v)}
+                            icon={tickIcon(v === maxParseExceptions)}
+                            text={v === -1 ? '∞ (-1)' : String(v)}
+                            onClick={() =>
+                              changeQueryContext({ ...queryContext, maxParseExceptions: v })
+                            }
+                            shouldDismissPopover={false}
+                          />
+                        ))}
+                      </MenuItem>
+                    )}
+                    {!hiddenOptions.includes('join-algorithm') && (
+                      <MenuItem
+                        icon={IconNames.INNER_JOIN}
+                        text="Join algorithm"
+                        label={
+                          SQL_JOIN_ALGORITHM_LABEL[sqlJoinAlgorithm as SqlJoinAlgorithm] ??
+                          sqlJoinAlgorithm
                         }
-                        onChange={() => {
-                          onQueryChange(query.toggleUnlimited());
-                        }}
-                      />
-                    </MenuItem>
+                      >
+                        {(['broadcast', 'sortMerge'] as SqlJoinAlgorithm[]).map(o => (
+                          <MenuItem
+                            key={o}
+                            icon={tickIcon(sqlJoinAlgorithm === o)}
+                            text={SQL_JOIN_ALGORITHM_LABEL[o]}
+                            shouldDismissPopover={false}
+                            onClick={() =>
+                              changeQueryContext({ ...queryContext, sqlJoinAlgorithm: o })
+                            }
+                          />
+                        ))}
+                      </MenuItem>
+                    )}
 
+                    {!hiddenOptions.includes('select-destination') && (
+                      <MenuItem
+                        icon={IconNames.MANUALLY_ENTERED_DATA}
+                        text="SELECT destination"
+                        label={
+                          SELECT_DESTINATION_LABEL[selectDestination as SelectDestination] ??
+                          selectDestination
+                        }
+                        intent={intent}
+                      >
+                        {(['taskReport', 'durableStorage'] as SelectDestination[]).map(o => (
+                          <MenuItem
+                            key={o}
+                            icon={tickIcon(selectDestination === o)}
+                            text={SELECT_DESTINATION_LABEL[o]}
+                            shouldDismissPopover={false}
+                            onClick={() =>
+                              changeQueryContext({ ...queryContext, selectDestination: o })
+                            }
+                          />
+                        ))}
+                        <MenuDivider />
+                        <MenuCheckbox
+                          checked={selectDestination === 'taskReport' ? !query.unlimited : false}
+                          intent={intent}
+                          disabled={selectDestination !== 'taskReport'}
+                          text="Limit SELECT results in taskReport"
+                          labelElement={
+                            query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
+                          }
+                          onChange={() => {
+                            onQueryChange(query.toggleUnlimited());
+                          }}
+                        />
+                      </MenuItem>
+                    )}
+
+                    {!hiddenOptions.includes('approximate-count-distinct') && (
+                      <MenuBoolean
+                        icon={IconNames.ROCKET_SLANT}
+                        text="Approximate COUNT(DISTINCT)"
+                        value={useApproximateCountDistinct}
+                        onValueChange={useApproximateCountDistinct =>
+                          changeQueryContext({
+                            ...queryContext,
+                            useApproximateCountDistinct,
+                          })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+
+                    {!hiddenOptions.includes('finalize-aggregations') && (
+                      <MenuBoolean
+                        icon={IconNames.TRANSLATE}
+                        text="Finalize aggregations"
+                        value={finalizeAggregations}
+                        showUndefined
+                        undefinedEffectiveValue={!ingestMode}
+                        onValueChange={finalizeAggregations =>
+                          changeQueryContext({ ...queryContext, finalizeAggregations })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+                    {!hiddenOptions.includes('group-by-enable-multi-value-unnesting') && (
+                      <MenuBoolean
+                        icon={IconNames.FORK}
+                        text="GROUP BY multi-value unnesting"
+                        value={groupByEnableMultiValueUnnesting}
+                        showUndefined
+                        undefinedEffectiveValue={!ingestMode}
+                        onValueChange={groupByEnableMultiValueUnnesting =>
+                          changeQueryContext({ ...queryContext, groupByEnableMultiValueUnnesting })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+                    {!hiddenOptions.includes('durable-shuffle-storage') && (
+                      <MenuBoolean
+                        icon={IconNames.CLOUD_TICK}
+                        text="Durable shuffle storage"
+                        value={durableShuffleStorage}
+                        onValueChange={durableShuffleStorage =>
+                          changeQueryContext({
+                            ...queryContext,
+                            durableShuffleStorage,
+                          })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {!hiddenOptions.includes('use-cache') && (
+                      <MenuBoolean
+                        icon={IconNames.DATA_CONNECTION}
+                        text="Use cache"
+                        value={useCache}
+                        onValueChange={useCache =>
+                          changeQueryContext({
+                            ...queryContext,
+                            useCache,
+                            populateCache: useCache,
+                          })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+                    {!hiddenOptions.includes('approximate-top-n') && (
+                      <MenuBoolean
+                        icon={IconNames.HORIZONTAL_BAR_CHART_DESC}
+                        text="Approximate TopN"
+                        value={useApproximateTopN}
+                        onValueChange={useApproximateTopN =>
+                          changeQueryContext({
+                            ...queryContext,
+                            useApproximateTopN,
+                          })
+                        }
+                        optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      />
+                    )}
+                  </>
+                )}
+                {effectiveEngine !== 'native' &&
+                  effectiveEngine !== 'sql-msq-task' &&
+                  !hiddenOptions.includes('approximate-count-distinct') && (
                     <MenuBoolean
                       icon={IconNames.ROCKET_SLANT}
                       text="Approximate COUNT(DISTINCT)"
@@ -536,98 +662,21 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                       }
                       optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
                     />
-
-                    <MenuBoolean
-                      icon={IconNames.TRANSLATE}
-                      text="Finalize aggregations"
-                      value={finalizeAggregations}
-                      showUndefined
-                      undefinedEffectiveValue={!ingestMode}
-                      onValueChange={finalizeAggregations =>
-                        changeQueryContext({ ...queryContext, finalizeAggregations })
+                  )}
+                {effectiveEngine === 'sql-native' &&
+                  !hiddenOptions.includes('limit-inline-results') && (
+                    <MenuCheckbox
+                      checked={!query.unlimited}
+                      intent={query.unlimited ? Intent.WARNING : undefined}
+                      text="Limit inline results"
+                      labelElement={
+                        query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
                       }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      onChange={() => {
+                        onQueryChange(query.toggleUnlimited());
+                      }}
                     />
-                    <MenuBoolean
-                      icon={IconNames.FORK}
-                      text="GROUP BY multi-value unnesting"
-                      value={groupByEnableMultiValueUnnesting}
-                      showUndefined
-                      undefinedEffectiveValue={!ingestMode}
-                      onValueChange={groupByEnableMultiValueUnnesting =>
-                        changeQueryContext({ ...queryContext, groupByEnableMultiValueUnnesting })
-                      }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                    />
-                    <MenuBoolean
-                      icon={IconNames.CLOUD_TICK}
-                      text="Durable shuffle storage"
-                      value={durableShuffleStorage}
-                      onValueChange={durableShuffleStorage =>
-                        changeQueryContext({
-                          ...queryContext,
-                          durableShuffleStorage,
-                        })
-                      }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <MenuBoolean
-                      icon={IconNames.DATA_CONNECTION}
-                      text="Use cache"
-                      value={useCache}
-                      onValueChange={useCache =>
-                        changeQueryContext({
-                          ...queryContext,
-                          useCache,
-                          populateCache: useCache,
-                        })
-                      }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                    />
-                    <MenuBoolean
-                      icon={IconNames.HORIZONTAL_BAR_CHART_DESC}
-                      text="Approximate TopN"
-                      value={useApproximateTopN}
-                      onValueChange={useApproximateTopN =>
-                        changeQueryContext({
-                          ...queryContext,
-                          useApproximateTopN,
-                        })
-                      }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                    />
-                  </>
-                )}
-                {effectiveEngine !== 'native' && effectiveEngine !== 'sql-msq-task' && (
-                  <MenuBoolean
-                    icon={IconNames.ROCKET_SLANT}
-                    text="Approximate COUNT(DISTINCT)"
-                    value={useApproximateCountDistinct}
-                    onValueChange={useApproximateCountDistinct =>
-                      changeQueryContext({
-                        ...queryContext,
-                        useApproximateCountDistinct,
-                      })
-                    }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
-                  />
-                )}
-                {effectiveEngine === 'sql-native' && (
-                  <MenuCheckbox
-                    checked={!query.unlimited}
-                    intent={query.unlimited ? Intent.WARNING : undefined}
-                    text="Limit inline results"
-                    labelElement={
-                      query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
-                    }
-                    onChange={() => {
-                      onQueryChange(query.toggleUnlimited());
-                    }}
-                  />
-                )}
+                  )}
               </Menu>
             }
           >

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -601,7 +601,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                     />
                   </>
                 )}
-                {effectiveEngine !== 'native' && (
+                {effectiveEngine !== 'native' && effectiveEngine !== 'sql-msq-task' && (
                   <MenuBoolean
                     icon={IconNames.ROCKET_SLANT}
                     text="Approximate COUNT(DISTINCT)"

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -41,6 +41,7 @@ import type {
   DruidEngine,
   IndexSpec,
   QueryContext,
+  SelectDestination,
   SqlJoinAlgorithm,
   WorkbenchQuery,
 } from '../../../druid-models';
@@ -112,6 +113,11 @@ const DEFAULT_ENGINES_LABEL_FN = (engine: DruidEngine | undefined) => {
     default:
       return { text: 'Auto' };
   }
+};
+
+const SELECT_DESTINATION_LABEL: Record<SelectDestination, string> = {
+  taskReport: 'Task report',
+  durableStorage: 'Durable storage',
 };
 
 const EXPERIMENTAL_ICON = <Icon icon={IconNames.WARNING_SIGN} title="Experimental" />;
@@ -481,6 +487,41 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                           }
                         />
                       ))}
+                    </MenuItem>
+
+                    <MenuItem
+                      icon={IconNames.MANUALLY_ENTERED_DATA}
+                      text="SELECT destination"
+                      label={
+                        SELECT_DESTINATION_LABEL[selectDestination as SelectDestination] ??
+                        selectDestination
+                      }
+                      intent={intent}
+                    >
+                      {(['taskReport', 'durableStorage'] as SelectDestination[]).map(o => (
+                        <MenuItem
+                          key={o}
+                          icon={tickIcon(selectDestination === o)}
+                          text={SELECT_DESTINATION_LABEL[o]}
+                          shouldDismissPopover={false}
+                          onClick={() =>
+                            changeQueryContext({ ...queryContext, selectDestination: o })
+                          }
+                        />
+                      ))}
+                      <MenuDivider />
+                      <MenuCheckbox
+                        checked={selectDestination === 'taskReport' ? !query.unlimited : false}
+                        intent={intent}
+                        disabled={selectDestination !== 'taskReport'}
+                        text="Limit SELECT results in taskReport"
+                        labelElement={
+                          query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
+                        }
+                        onChange={() => {
+                          onQueryChange(query.toggleUnlimited());
+                        }}
+                      />
                     </MenuItem>
 
                     <MenuBoolean

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -123,7 +123,10 @@ const DEFAULT_ENGINES_LABEL_FN = (engine: DruidEngine | undefined) => {
 const EXPERIMENTAL_ICON = <Icon icon={IconNames.WARNING_SIGN} title="Experimental" />;
 
 export interface RunPanelProps
-  extends Pick<MaxTasksButtonProps, 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'> {
+  extends Pick<
+    MaxTasksButtonProps,
+    'maxTasksLabelFn' | 'fullClusterCapacityLabelFn' | 'maxNumTaskOptions'
+  > {
   query: WorkbenchQuery;
   onQueryChange(query: WorkbenchQuery): void;
   running: boolean;
@@ -149,6 +152,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     maxTasksMenuHeader,
     enginesLabelFn = DEFAULT_ENGINES_LABEL_FN,
     maxTasksLabelFn,
+    maxNumTaskOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [editContextDialogOpen, setEditContextDialogOpen] = useState(false);
@@ -630,6 +634,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
               defaultQueryContext={defaultQueryContext}
               menuHeader={maxTasksMenuHeader}
               maxTasksLabelFn={maxTasksLabelFn}
+              maxNumTaskOptions={maxNumTaskOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
           )}

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -119,7 +119,7 @@ const EXPERIMENTAL_ICON = <Icon icon={IconNames.WARNING_SIGN} title="Experimenta
 export interface RunPanelProps
   extends Pick<
     MaxTasksButtonProps,
-    'maxTasksLabelFn' | 'fullClusterCapacityLabelFn' | 'maxNumTaskOptions'
+    'maxTasksLabelFn' | 'fullClusterCapacityLabelFn' | 'maxTasksOptions'
   > {
   query: WorkbenchQuery;
   onQueryChange(query: WorkbenchQuery): void;
@@ -146,7 +146,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
     maxTasksMenuHeader,
     enginesLabelFn = DEFAULT_ENGINES_LABEL_FN,
     maxTasksLabelFn,
-    maxNumTaskOptions,
+    maxTasksOptions,
     fullClusterCapacityLabelFn,
   } = props;
   const [editContextDialogOpen, setEditContextDialogOpen] = useState(false);
@@ -608,7 +608,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
               defaultQueryContext={defaultQueryContext}
               menuHeader={maxTasksMenuHeader}
               maxTasksLabelFn={maxTasksLabelFn}
-              maxNumTaskOptions={maxNumTaskOptions}
+              maxTasksOptions={maxTasksOptions}
               fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
             />
           )}

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -41,7 +41,6 @@ import type {
   DruidEngine,
   IndexSpec,
   QueryContext,
-  SelectDestination,
   SqlJoinAlgorithm,
   WorkbenchQuery,
 } from '../../../druid-models';
@@ -97,11 +96,6 @@ const ARRAY_INGEST_MODE_DESCRIPTION: Record<ArrayIngestMode, JSX.Element> = {
 const SQL_JOIN_ALGORITHM_LABEL: Record<SqlJoinAlgorithm, string> = {
   broadcast: 'Broadcast',
   sortMerge: 'Sort merge',
-};
-
-const SELECT_DESTINATION_LABEL: Record<SelectDestination, string> = {
-  taskReport: 'Task report',
-  durableStorage: 'Durable storage',
 };
 
 const DEFAULT_ENGINES_LABEL_FN = (engine: DruidEngine | undefined) => {
@@ -468,6 +462,40 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         />
                       ))}
                     </MenuItem>
+                    <MenuItem
+                      icon={IconNames.INNER_JOIN}
+                      text="Join algorithm"
+                      label={
+                        SQL_JOIN_ALGORITHM_LABEL[sqlJoinAlgorithm as SqlJoinAlgorithm] ??
+                        sqlJoinAlgorithm
+                      }
+                    >
+                      {(['broadcast', 'sortMerge'] as SqlJoinAlgorithm[]).map(o => (
+                        <MenuItem
+                          key={o}
+                          icon={tickIcon(sqlJoinAlgorithm === o)}
+                          text={SQL_JOIN_ALGORITHM_LABEL[o]}
+                          shouldDismissPopover={false}
+                          onClick={() =>
+                            changeQueryContext({ ...queryContext, sqlJoinAlgorithm: o })
+                          }
+                        />
+                      ))}
+                    </MenuItem>
+
+                    <MenuBoolean
+                      icon={IconNames.ROCKET_SLANT}
+                      text="Approximate COUNT(DISTINCT)"
+                      value={useApproximateCountDistinct}
+                      onValueChange={useApproximateCountDistinct =>
+                        changeQueryContext({
+                          ...queryContext,
+                          useApproximateCountDistinct,
+                        })
+                      }
+                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    />
+
                     <MenuBoolean
                       icon={IconNames.TRANSLATE}
                       text="Finalize aggregations"
@@ -490,60 +518,6 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                       }
                       optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
                     />
-                    <MenuItem
-                      icon={IconNames.INNER_JOIN}
-                      text="Join algorithm"
-                      label={
-                        SQL_JOIN_ALGORITHM_LABEL[sqlJoinAlgorithm as SqlJoinAlgorithm] ??
-                        sqlJoinAlgorithm
-                      }
-                    >
-                      {(['broadcast', 'sortMerge'] as SqlJoinAlgorithm[]).map(o => (
-                        <MenuItem
-                          key={o}
-                          icon={tickIcon(sqlJoinAlgorithm === o)}
-                          text={SQL_JOIN_ALGORITHM_LABEL[o]}
-                          shouldDismissPopover={false}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, sqlJoinAlgorithm: o })
-                          }
-                        />
-                      ))}
-                    </MenuItem>
-                    <MenuItem
-                      icon={IconNames.MANUALLY_ENTERED_DATA}
-                      text="SELECT destination"
-                      label={
-                        SELECT_DESTINATION_LABEL[selectDestination as SelectDestination] ??
-                        selectDestination
-                      }
-                      intent={intent}
-                    >
-                      {(['taskReport', 'durableStorage'] as SelectDestination[]).map(o => (
-                        <MenuItem
-                          key={o}
-                          icon={tickIcon(selectDestination === o)}
-                          text={SELECT_DESTINATION_LABEL[o]}
-                          shouldDismissPopover={false}
-                          onClick={() =>
-                            changeQueryContext({ ...queryContext, selectDestination: o })
-                          }
-                        />
-                      ))}
-                      <MenuDivider />
-                      <MenuCheckbox
-                        checked={selectDestination === 'taskReport' ? !query.unlimited : false}
-                        intent={intent}
-                        disabled={selectDestination !== 'taskReport'}
-                        text="Limit SELECT results in taskReport"
-                        labelElement={
-                          query.unlimited ? <Icon icon={IconNames.WARNING_SIGN} /> : undefined
-                        }
-                        onChange={() => {
-                          onQueryChange(query.toggleUnlimited());
-                        }}
-                      />
-                    </MenuItem>
                     <MenuBoolean
                       icon={IconNames.CLOUD_TICK}
                       text="Durable shuffle storage"

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -104,6 +104,7 @@ export interface WorkbenchViewProps
     | 'maxTasksLabelFn'
     | 'fullClusterCapacityLabelFn'
     | 'maxTasksOptions'
+    | 'hiddenOptions'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -675,6 +676,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTasksLabelFn,
       maxTasksOptions,
       fullClusterCapacityLabelFn,
+      hiddenOptions,
     } = this.props;
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
@@ -706,6 +708,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksLabelFn={maxTasksLabelFn}
           maxTasksOptions={maxTasksOptions}
           fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
+          hiddenOptions={hiddenOptions}
           runMoreMenu={
             <Menu>
               {allowExplain &&

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -109,12 +109,7 @@ type MoreMenuItem =
 export interface WorkbenchViewProps
   extends Pick<
     QueryTabProps,
-    | 'maxTasksMenuHeader'
-    | 'enginesLabelFn'
-    | 'maxTasksLabelFn'
-    | 'fullClusterCapacityLabelFn'
-    | 'maxTasksOptions'
-    | 'hiddenOptions'
+    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -129,6 +124,12 @@ export interface WorkbenchViewProps
   goToTask(taskId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
   hideToolbar?: boolean;
+  maxTasksOptions?:
+    | QueryTabProps['maxTasksOptions']
+    | ((engine: DruidEngine) => QueryTabProps['maxTasksOptions']);
+  hiddenOptions?:
+    | QueryTabProps['hiddenOptions']
+    | ((engine: DruidEngine) => QueryTabProps['hiddenOptions']);
 }
 
 export interface WorkbenchViewState {
@@ -716,9 +717,15 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTasksLabelFn={maxTasksLabelFn}
-          maxTasksOptions={maxTasksOptions}
+          maxTasksOptions={
+            typeof maxTasksOptions === 'function'
+              ? maxTasksOptions(effectiveEngine)
+              : maxTasksOptions
+          }
           fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
-          hiddenOptions={hiddenOptions}
+          hiddenOptions={
+            typeof hiddenOptions === 'function' ? hiddenOptions(effectiveEngine) : hiddenOptions
+          }
           runMoreMenu={
             <Menu>
               {!hiddenMoreMenuItems.includes('explain') &&

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -120,7 +120,7 @@ export interface WorkbenchViewProps
   mandatoryQueryContext?: QueryContext;
   serverQueryContext?: QueryContext;
   queryEngines: DruidEngine[];
-  hiddenMoreMenuItems?: MoreMenuItem[];
+  hiddenMoreMenuItems?: MoreMenuItem[] | ((engine: DruidEngine) => MoreMenuItem[]);
   goToTask(taskId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
   hideToolbar?: boolean;
@@ -679,7 +679,6 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       baseQueryContext,
       serverQueryContext = DEFAULT_SERVER_QUERY_CONTEXT,
       queryEngines,
-      hiddenMoreMenuItems = [],
       goToTask,
       getClusterCapacity,
       maxTasksMenuHeader,
@@ -692,6 +691,11 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
     const { columnMetadataState } = this.state;
     const currentTabEntry = this.getCurrentTabEntry();
     const effectiveEngine = currentTabEntry.query.getEffectiveEngine();
+
+    const hiddenMoreMenuItems =
+      typeof this.props.hiddenMoreMenuItems === 'function'
+        ? this.props.hiddenMoreMenuItems(effectiveEngine)
+        : this.props.hiddenMoreMenuItems || [];
 
     return (
       <div className="center-panel">

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -96,6 +96,16 @@ function externalDataTabId(tabId: string | undefined): boolean {
   return String(tabId).startsWith('connect-external-data');
 }
 
+type MoreMenuItem =
+  | 'explain'
+  | 'history'
+  | 'prettify'
+  | 'convert-ingestion-to-sql'
+  | 'attach-tab-from-task-id'
+  | 'open-query-detail-archive'
+  | 'druid-sql-documentation'
+  | 'load-demo-queries';
+
 export interface WorkbenchViewProps
   extends Pick<
     QueryTabProps,
@@ -115,7 +125,7 @@ export interface WorkbenchViewProps
   mandatoryQueryContext?: QueryContext;
   serverQueryContext?: QueryContext;
   queryEngines: DruidEngine[];
-  allowExplain: boolean;
+  hiddenMoreMenuItems?: MoreMenuItem[];
   goToTask(taskId: string): void;
   getClusterCapacity: (() => Promise<CapacityInfo | undefined>) | undefined;
   hideToolbar?: boolean;
@@ -668,7 +678,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       baseQueryContext,
       serverQueryContext = DEFAULT_SERVER_QUERY_CONTEXT,
       queryEngines,
-      allowExplain,
+      hiddenMoreMenuItems = [],
       goToTask,
       getClusterCapacity,
       maxTasksMenuHeader,
@@ -711,7 +721,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           hiddenOptions={hiddenOptions}
           runMoreMenu={
             <Menu>
-              {allowExplain &&
+              {!hiddenMoreMenuItems.includes('explain') &&
                 (effectiveEngine === 'sql-native' || effectiveEngine === 'sql-msq-task') && (
                   <MenuItem
                     icon={IconNames.CLEAN}
@@ -719,14 +729,14 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
                     onClick={this.openExplainDialog}
                   />
                 )}
-              {effectiveEngine !== 'sql-msq-task' && (
+              {effectiveEngine !== 'sql-msq-task' && !hiddenMoreMenuItems.includes('history') && (
                 <MenuItem
                   icon={IconNames.HISTORY}
                   text="Query history"
                   onClick={this.openHistoryDialog}
                 />
               )}
-              {currentTabEntry.query.canPrettify() && (
+              {currentTabEntry.query.canPrettify() && !hiddenMoreMenuItems.includes('prettify') && (
                 <MenuItem
                   icon={IconNames.ALIGN_LEFT}
                   text="Prettify query"
@@ -735,38 +745,47 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
               )}
               {queryEngines.includes('sql-msq-task') && (
                 <>
-                  <MenuItem
-                    icon={IconNames.TEXT_HIGHLIGHT}
-                    text="Convert ingestion spec to SQL"
-                    onClick={this.openSpecDialog}
-                  />
-                  <MenuItem
-                    icon={IconNames.DOCUMENT_OPEN}
-                    text="Attach tab from task ID"
-                    onClick={this.openTaskIdSubmitDialog}
-                  />
-                  <MenuItem
-                    icon={IconNames.UNARCHIVE}
-                    text="Open query detail archive"
-                    onClick={this.openExecutionSubmitDialog}
-                  />
+                  {!hiddenMoreMenuItems.includes('convert-ingestion-to-sql') && (
+                    <MenuItem
+                      icon={IconNames.TEXT_HIGHLIGHT}
+                      text="Convert ingestion spec to SQL"
+                      onClick={this.openSpecDialog}
+                    />
+                  )}
+                  {!hiddenMoreMenuItems.includes('attach-tab-from-task-id') && (
+                    <MenuItem
+                      icon={IconNames.DOCUMENT_OPEN}
+                      text="Attach tab from task ID"
+                      onClick={this.openTaskIdSubmitDialog}
+                    />
+                  )}
+                  {!hiddenMoreMenuItems.includes('open-query-detail-archive') && (
+                    <MenuItem
+                      icon={IconNames.UNARCHIVE}
+                      text="Open query detail archive"
+                      onClick={this.openExecutionSubmitDialog}
+                    />
+                  )}
                 </>
               )}
               <MenuDivider />
-              <MenuItem
-                icon={IconNames.HELP}
-                text="DruidSQL documentation"
-                href={getLink('DOCS_SQL')}
-                target="_blank"
-              />
-              {queryEngines.includes('sql-msq-task') && (
+              {!hiddenMoreMenuItems.includes('druid-sql-documentation') && (
                 <MenuItem
-                  icon={IconNames.ROCKET_SLANT}
-                  text="Load demo queries"
-                  label="(replaces current tabs)"
-                  onClick={() => this.handleQueriesChange(getDemoQueries())}
+                  icon={IconNames.HELP}
+                  text="DruidSQL documentation"
+                  href={getLink('DOCS_SQL')}
+                  target="_blank"
                 />
               )}
+              {queryEngines.includes('sql-msq-task') &&
+                !hiddenMoreMenuItems.includes('load-demo-queries') && (
+                  <MenuItem
+                    icon={IconNames.ROCKET_SLANT}
+                    text="Load demo queries"
+                    label="(replaces current tabs)"
+                    onClick={() => this.handleQueriesChange(getDemoQueries())}
+                  />
+                )}
             </Menu>
           }
         />

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -103,7 +103,7 @@ export interface WorkbenchViewProps
     | 'enginesLabelFn'
     | 'maxTasksLabelFn'
     | 'fullClusterCapacityLabelFn'
-    | 'maxNumTaskOptions'
+    | 'maxTasksOptions'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -673,7 +673,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTasksMenuHeader,
       enginesLabelFn,
       maxTasksLabelFn,
-      maxNumTaskOptions,
+      maxTasksOptions,
       fullClusterCapacityLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
@@ -704,7 +704,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTasksLabelFn={maxTasksLabelFn}
-          maxNumTaskOptions={maxNumTaskOptions}
+          maxTasksOptions={maxTasksOptions}
           fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
           runMoreMenu={
             <Menu>

--- a/web-console/src/views/workbench-view/workbench-view.tsx
+++ b/web-console/src/views/workbench-view/workbench-view.tsx
@@ -99,7 +99,11 @@ function externalDataTabId(tabId: string | undefined): boolean {
 export interface WorkbenchViewProps
   extends Pick<
     QueryTabProps,
-    'maxTasksMenuHeader' | 'enginesLabelFn' | 'maxTasksLabelFn' | 'fullClusterCapacityLabelFn'
+    | 'maxTasksMenuHeader'
+    | 'enginesLabelFn'
+    | 'maxTasksLabelFn'
+    | 'fullClusterCapacityLabelFn'
+    | 'maxNumTaskOptions'
   > {
   capabilities: Capabilities;
   tabId: string | undefined;
@@ -669,6 +673,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
       maxTasksMenuHeader,
       enginesLabelFn,
       maxTasksLabelFn,
+      maxNumTaskOptions,
       fullClusterCapacityLabelFn,
     } = this.props;
     const { columnMetadataState } = this.state;
@@ -699,6 +704,7 @@ export class WorkbenchView extends React.PureComponent<WorkbenchViewProps, Workb
           maxTasksMenuHeader={maxTasksMenuHeader}
           enginesLabelFn={enginesLabelFn}
           maxTasksLabelFn={maxTasksLabelFn}
+          maxNumTaskOptions={maxNumTaskOptions}
           fullClusterCapacityLabelFn={fullClusterCapacityLabelFn}
           runMoreMenu={
             <Menu>


### PR DESCRIPTION
This improves three things:
 - the max num tasks options distribution is configurable
 - the taskAssignment options copy is more concise
 - the options for MSQ engine are reordered

<img width="498" alt="image" src="https://github.com/user-attachments/assets/cd0d2aaa-843a-4b65-bda4-c4d581ee18f6">

<img width="625" alt="image" src="https://github.com/user-attachments/assets/7393f681-a7a2-4897-b3e5-bec3d507ca73">
