### PR TITLE
remove compiler warnings about unqualified calls to yield()

### DIFF
--- a/processing/src/test/java/org/apache/druid/common/guava/CombiningSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/common/guava/CombiningSequenceTest.java
@@ -294,7 +294,7 @@ public class CombiningSequenceTest
           {
             count++;
             if (count % yieldEvery == 0) {
-              yield();
+              this.yield();
             }
             return rhs;
           }

--- a/processing/src/test/java/org/apache/druid/common/guava/ComplexSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/common/guava/ComplexSequenceTest.java
@@ -71,7 +71,7 @@ public class ComplexSequenceTest
           @Override
           public Integer accumulate(Integer accumulated, Integer in)
           {
-            yield();
+            this.yield();
             return in;
           }
         }

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/ConcatSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/ConcatSequenceTest.java
@@ -263,7 +263,7 @@ public class ConcatSequenceTest
           @Override
           public Integer accumulate(Integer accumulated, Integer in)
           {
-            yield();
+            this.yield();
             return in;
           }
         }

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/LimitedSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/LimitedSequenceTest.java
@@ -104,7 +104,7 @@ public class LimitedSequenceTest
               public OutType accumulate(OutType accumulated, Integer in)
               {
                 final OutType retVal = super.accumulate(accumulated, in);
-                yield();
+                this.yield();
                 return retVal;
               }
             }

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/SequenceTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/SequenceTestHelper.java
@@ -65,7 +65,7 @@ public class SequenceTestHelper
           {
             if (++count >= numToTake) {
               count = 0;
-              yield();
+              this.yield();
             }
 
             Assert.assertEquals(prefix, valsIter.next(), in);

--- a/processing/src/test/java/org/apache/druid/java/util/common/guava/SkippingSequenceTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/common/guava/SkippingSequenceTest.java
@@ -110,7 +110,7 @@ public class SkippingSequenceTest
               public OutType accumulate(OutType accumulated, Integer in)
               {
                 final OutType retVal = super.accumulate(accumulated, in);
-                yield();
+                this.yield();
                 return retVal;
               }
             }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -757,7 +757,7 @@ public class AggregationTestHelper implements Closeable
                 @Override
                 public Object accumulate(Object accumulated, Object in)
                 {
-                  yield();
+                  this.yield();
                   return in;
                 }
               }


### PR DESCRIPTION
Fixes compiler warnings that appear when building with newer java versions:
```
WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/java/util/common/guava/ConcatSequenceTest.java:[266,13] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java:[760,19] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/java/util/common/guava/SequenceTestHelper.java:[68,15] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/common/guava/CombiningSequenceTest.java:[297,15] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/java/util/common/guava/SkippingSequenceTest.java:[113,17] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/java/util/common/guava/LimitedSequenceTest.java:[107,17] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)
[WARNING] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/common/guava/ComplexSequenceTest.java:[74,13] 'yield' may become a restricted identifier in a future release
  (to invoke a method called yield, qualify the yield with a receiver or type name)

```

which do become actual errors if we start targeting newer jvm versions in the compiler:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:testCompile (default-testCompile) on project druid-processing: Compilation failure: Compilation failure: 
[ERROR] /Users/clint/workspace/clintropolis/druid/processing/src/test/java/org/apache/druid/java/util/common/guava/ConcatSequenceTest.java:[266,13] invalid use of a restricted identifier 'yield'
[ERROR]   (to invoke a method called yield, qualify the yield with a receiver or type name)
```