### PR TITLE
Suppress CVE-2022-1271 since it is a false positive

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -699,4 +699,13 @@
     ]]></notes>
     <vulnerabilityName>CVE-2024-25638</vulnerabilityName>
   </suppress>
+  <suppress>
+    <!-- The CVE is also not applicable to xz-java because it does not implement xzgrep and therefore is not vulnerable
+     ~ to the filename validation problem. Druid does not use xzgrep but this CVE is popping up because the CPE matches the
+     ~ Java package too. -->
+    <notes><![CDATA[
+    file name: xz-1.9.jar
+    ]]></notes>
+    <vulnerabilityName>CVE-2022-1271</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This PR suppresses the CVE-2022-1271 since it is not applicable to the xz's Java library that Druid uses. Furthermore, Druid doesn't use the xzgrep utility for which the CVE was flagged.  The CPE is broad hence the dependency-check is flagging it as a false positive. 