### PR TITLE
Log a small subset of segments to refresh for debugging Coordinator refresh logic

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -808,6 +808,9 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
     return retVal;
   }
 
+  /**
+   * Log the segment details for a datasource to be refreshed for debugging purpose.
+   */
   void logSegmentsToRefresh(String dataSource, Set<SegmentId> ids)
   {
     // no-op

--- a/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/AbstractSegmentMetadataCache.java
@@ -761,6 +761,9 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
     final Map<String, SegmentId> segmentIdMap = Maps.uniqueIndex(segments, SegmentId::toString);
 
     final Set<SegmentId> retVal = new HashSet<>();
+
+    logSegmentsToRefresh(dataSource, segments);
+
     final Sequence<SegmentAnalysis> sequence = runSegmentMetadataQuery(
         Iterables.limit(segments, MAX_SEGMENTS_PER_QUERY)
     );
@@ -803,6 +806,11 @@ public abstract class AbstractSegmentMetadataCache<T extends DataSourceInformati
     );
 
     return retVal;
+  }
+
+  void logSegmentsToRefresh(String dataSource, Set<SegmentId> ids)
+  {
+    // no-op
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import org.apache.druid.client.CoordinatorServerView;
@@ -527,6 +528,12 @@ public class CoordinatorSegmentMetadataCache extends AbstractSegmentMetadataCach
         log.debug("[%s] signature is unchanged.", dataSource);
       }
     }
+  }
+
+  @Override
+  void logSegmentsToRefresh(String dataSource, Set<SegmentId> ids)
+  {
+    log.info("Refreshing segments [%s] for datasource [%s]", Iterables.limit(ids, 10), dataSource);
   }
 
   private void filterRealtimeSegments(Set<SegmentId> segmentIds)

--- a/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
@@ -533,7 +533,7 @@ public class CoordinatorSegmentMetadataCache extends AbstractSegmentMetadataCach
   @Override
   void logSegmentsToRefresh(String dataSource, Set<SegmentId> ids)
   {
-    log.info("Refreshing segments [%s] for datasource [%s]", Iterables.limit(ids, 10), dataSource);
+    log.info("Refreshing segments [%s] for datasource [%s]", Iterables.limit(ids, 5), dataSource);
   }
 
   private void filterRealtimeSegments(Set<SegmentId> segmentIds)

--- a/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/CoordinatorSegmentMetadataCache.java
@@ -533,7 +533,7 @@ public class CoordinatorSegmentMetadataCache extends AbstractSegmentMetadataCach
   @Override
   void logSegmentsToRefresh(String dataSource, Set<SegmentId> ids)
   {
-    log.info("Refreshing segments [%s] for datasource [%s]", Iterables.limit(ids, 5), dataSource);
+    log.info("Logging a sample of 5 segments [%s] to be refreshed for datasource [%s]", Iterables.limit(ids, 5), dataSource);
   }
 
   private void filterRealtimeSegments(Set<SegmentId> segmentIds)


### PR DESCRIPTION
With [CDS](https://github.com/apache/druid/issues/14989) enabled Coordinator shouldn't ideally be issuing metadata queries to refresh segments. 

This change logs a subset of segment ids to be refreshed to enable debugging. 