### PR TITLE
Fix Centos7 EOL issue in Hadoop Dockerfile 

### DIFF
--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -19,6 +19,11 @@ FROM centos:7
 
 USER root
 
+# CentOS is EOL, have to use vault
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo && \
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # install dev tools
 RUN yum clean all \
     && rpm --rebuilddb \


### PR DESCRIPTION
The Dockerfile for buidling hadoop image is broken due to Centos 7 EOL. 
Fixed it as per https://serverfault.com/a/1161847.