### PR TITLE
Implement segment range threshold for automatic query prioritization

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1790,12 +1790,13 @@ This prioritization strategy lowers the priority of queries that cross any of a 
 
 This strategy can be enabled by setting `druid.query.scheduler.prioritization.strategy` to `threshold`.
 
-|Property|Description|Default|
-|--------|-----------|-------|
-|`druid.query.scheduler.prioritization.periodThreshold`|ISO duration threshold for how old data can be queried before automatically adjusting query priority.|none|
-|`druid.query.scheduler.prioritization.durationThreshold`|ISO duration threshold for maximum duration a queries interval can span before the priority is automatically adjusted.|none|
-|`druid.query.scheduler.prioritization.segmentCountThreshold`|Number threshold for maximum number of segments that can take part in a query before its priority is automatically adjusted.|none|
-|`druid.query.scheduler.prioritization.adjustment`|Amount to reduce the priority of queries which cross any threshold.|none|
+|Property| Description                                                                                                                  |Default|
+|--------|------------------------------------------------------------------------------------------------------------------------------|-------|
+|`druid.query.scheduler.prioritization.periodThreshold`| ISO duration threshold for how old data can be queried before automatically adjusting query priority.                        |none|
+|`druid.query.scheduler.prioritization.durationThreshold`| ISO duration threshold for maximum duration a queries interval can span before the priority is automatically adjusted.       |none|
+|`druid.query.scheduler.prioritization.segmentCountThreshold`| Number threshold for maximum number of segments that can take part in a query before its priority is automatically adjusted. |none|
+|`druid.query.scheduler.prioritization.segmentRangeThreshold`| ISO duration threshold for maximum segment range a query can span before the priority is automatically adjusted.             |none|
+|`druid.query.scheduler.prioritization.adjustment`| Amount to reduce the priority of queries which cross any threshold.                                                          |none|
 
 ##### Laning strategies
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1790,13 +1790,13 @@ This prioritization strategy lowers the priority of queries that cross any of a 
 
 This strategy can be enabled by setting `druid.query.scheduler.prioritization.strategy` to `threshold`.
 
-|Property| Description                                                                                                                  |Default|
-|--------|------------------------------------------------------------------------------------------------------------------------------|-------|
-|`druid.query.scheduler.prioritization.periodThreshold`| ISO duration threshold for how old data can be queried before automatically adjusting query priority.                        |none|
-|`druid.query.scheduler.prioritization.durationThreshold`| ISO duration threshold for maximum duration a queries interval can span before the priority is automatically adjusted.       |none|
-|`druid.query.scheduler.prioritization.segmentCountThreshold`| Number threshold for maximum number of segments that can take part in a query before its priority is automatically adjusted. |none|
-|`druid.query.scheduler.prioritization.segmentRangeThreshold`| ISO duration threshold for maximum segment range a query can span before the priority is automatically adjusted.             |none|
-|`druid.query.scheduler.prioritization.adjustment`| Amount to reduce the priority of queries which cross any threshold.                                                          |none|
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.query.scheduler.prioritization.periodThreshold`|ISO duration threshold for how old data can be queried before automatically adjusting query priority.|none|
+|`druid.query.scheduler.prioritization.durationThreshold`|ISO duration threshold for maximum duration a queries interval can span before the priority is automatically adjusted.|none|
+|`druid.query.scheduler.prioritization.segmentCountThreshold`|Number threshold for maximum number of segments that can take part in a query before its priority is automatically adjusted.|none|
+|`druid.query.scheduler.prioritization.segmentRangeThreshold`|ISO duration threshold for maximum segment range a query can span before the priority is automatically adjusted.|none|
+|`druid.query.scheduler.prioritization.adjustment`|Amount to reduce the priority of queries which cross any threshold.|none|
 
 ##### Laning strategies
 

--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -92,7 +92,8 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
         durationThreshold.map(duration -> theQuery.getDuration().isLongerThan(duration)).orElse(false);
     boolean violatesSegmentRangeThreshold = false;
     if (segmentRangeThreshold.isPresent()) {
-      long segmentRange = segments.stream().map(segment -> segment.getSegmentDescriptor().getInterval())
+      long segmentRange = segments.stream().filter(segment -> segment.getSegmentDescriptor() != null)
+              .map(segment -> segment.getSegmentDescriptor().getInterval())
               .distinct()
               .mapToLong(AbstractInterval::toDurationMillis)
               .sum();

--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -30,6 +30,7 @@ import org.apache.druid.server.QueryPrioritizationStrategy;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
+import org.joda.time.base.AbstractInterval;
 
 import javax.annotation.Nullable;
 
@@ -49,12 +50,14 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
 
   private final Optional<Duration> periodThreshold;
   private final Optional<Duration> durationThreshold;
+  private final Optional<Duration> segmentRangeThreshold;
 
   @JsonCreator
   public ThresholdBasedQueryPrioritizationStrategy(
       @JsonProperty("periodThreshold") @Nullable String periodThresholdString,
       @JsonProperty("durationThreshold") @Nullable String durationThresholdString,
       @JsonProperty("segmentCountThreshold") @Nullable Integer segmentCountThreshold,
+      @JsonProperty("segmentRangeThreshold") @Nullable String segmentRangeThresholdString,
       @JsonProperty("adjustment") @Nullable Integer adjustment
   )
   {
@@ -66,9 +69,12 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
     this.durationThreshold = durationThresholdString == null
                              ? Optional.empty()
                              : Optional.of(new Period(durationThresholdString).toStandardDuration());
+    this.segmentRangeThreshold = segmentRangeThresholdString == null
+                                 ? Optional.empty()
+                                 : Optional.of(new Period(segmentRangeThresholdString).toStandardDuration());
     Preconditions.checkArgument(
-        segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent(),
-        "periodThreshold, durationThreshold, or segmentCountThreshold must be set"
+        segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent()  || segmentRangeThreshold.isPresent(),
+        "periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
     );
   }
 
@@ -84,9 +90,18 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
     }).orElse(false);
     final boolean violatesDurationThreshold =
         durationThreshold.map(duration -> theQuery.getDuration().isLongerThan(duration)).orElse(false);
+    boolean violatesSegmentRangeThreshold = false;
+    if (segmentRangeThreshold.isPresent()) {
+      long segmentRange = segments.stream().map(segment -> segment.getSegmentDescriptor().getInterval())
+              .distinct()
+              .mapToLong(AbstractInterval::toDurationMillis)
+              .sum();
+      violatesSegmentRangeThreshold =
+              segmentRangeThreshold.map(duration -> new Duration(segmentRange).isLongerThan(duration)).orElse(false);
+    }
     boolean violatesSegmentThreshold = segments.size() > segmentCountThreshold;
 
-    if (violatesPeriodThreshold || violatesDurationThreshold || violatesSegmentThreshold) {
+    if (violatesPeriodThreshold || violatesDurationThreshold || violatesSegmentThreshold || violatesSegmentRangeThreshold) {
       final int adjustedPriority = theQuery.context().getPriority() - adjustment;
       return Optional.of(adjustedPriority);
     }

--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -73,7 +73,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
                                  ? Optional.empty()
                                  : Optional.of(new Period(segmentRangeThresholdString).toStandardDuration());
     Preconditions.checkArgument(
-        segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent()  || segmentRangeThreshold.isPresent(),
+        segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent() || segmentRangeThreshold.isPresent(),
         "periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
     );
   }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -1190,7 +1190,7 @@ public class QueryResourceTest
     final CountDownLatch waitOneScheduled = new CountDownLatch(1);
     final QueryScheduler scheduler = new QueryScheduler(
         40,
-        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null,null),
+        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null, null),
         new HiLoQueryLaningStrategy(1),
         new ServerConfig()
     );

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -1190,7 +1190,7 @@ public class QueryResourceTest
     final CountDownLatch waitOneScheduled = new CountDownLatch(1);
     final QueryScheduler scheduler = new QueryScheduler(
         40,
-        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null),
+        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null,null),
         new HiLoQueryLaningStrategy(1),
         new ServerConfig()
     );

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -553,7 +553,7 @@ public class QuerySchedulerTest
     Assert.assertEquals(
         "Unable to provision, see the following errors:\n"
         + "\n"
-        + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.ThresholdBasedQueryPrioritizationStrategy`, periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set\n"
+        + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.ThresholdBasedQueryPrioritizationStrategy`, problem: periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set\n"
         + " at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"prioritization\"]).\n"
         + "\n"
         + "1 error",

--- a/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
+++ b/server/src/test/java/org/apache/druid/server/QuerySchedulerTest.java
@@ -553,7 +553,7 @@ public class QuerySchedulerTest
     Assert.assertEquals(
         "Unable to provision, see the following errors:\n"
         + "\n"
-        + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.ThresholdBasedQueryPrioritizationStrategy`, problem: periodThreshold, durationThreshold, or segmentCountThreshold must be set\n"
+        + "1) Problem parsing object at prefix[druid.query.scheduler]: Cannot construct instance of `org.apache.druid.server.scheduling.ThresholdBasedQueryPrioritizationStrategy`, periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set\n"
         + " at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: org.apache.druid.server.QuerySchedulerProvider[\"prioritization\"]).\n"
         + "\n"
         + "1 error",

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -213,7 +213,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
             .context(ImmutableMap.of())
             .build();
     SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
-    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0));
+    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0)).times(2);
     EasyMock.replay(segmentServerSelector);
     Assert.assertFalse(
             strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of(segmentServerSelector)).isPresent()
@@ -237,7 +237,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
             .context(ImmutableMap.of())
             .build();
     SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
-    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0));
+    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0)).times(2);
     EasyMock.replay(segmentServerSelector);
     Assert.assertEquals(
             -adjustment,

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.server.QueryPrioritizationStrategy;
@@ -59,7 +60,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
   public void testPrioritizationPeriodThresholdInsidePeriod()
   {
     QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
-        "P90D", null, null, adjustment);
+        "P90D", null, null, null, adjustment);
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
@@ -77,6 +78,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
   {
     QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
         "P90D",
+        null,
         null,
         null,
         adjustment
@@ -101,6 +103,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
         null,
         "P7D",
         null,
+        null,
         adjustment
     );
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
@@ -121,6 +124,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
         null,
         "P7D",
+        null,
         null,
         adjustment
     );
@@ -144,6 +148,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
         null,
         null,
         2,
+        null,
         adjustment
     );
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
@@ -168,6 +173,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
         null,
         null,
         2,
+        null,
         adjustment
     );
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
@@ -187,6 +193,55 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
                 EasyMock.createMock(SegmentServerSelector.class)
             )
         ).get()
+    );
+  }
+
+  @Test
+  public void testPrioritizationSegmentRangeWithinThreshold()
+  {
+    QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
+            null,
+            null,
+            null,
+            "P7D",
+            adjustment
+    );
+    DateTime startDate = DateTimes.nowUtc().minusDays(1);
+    DateTime endDate = DateTimes.nowUtc();
+    TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+            .granularity(Granularities.MINUTE)
+            .context(ImmutableMap.of())
+            .build();
+    SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
+    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0));
+    EasyMock.replay(segmentServerSelector);
+    Assert.assertFalse(
+            strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of(segmentServerSelector)).isPresent()
+    );
+  }
+
+  @Test
+  public void testPrioritizationSegmentRangeOverThreshold()
+  {
+    QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
+            null,
+            null,
+            null,
+            "P7D",
+            adjustment
+    );
+    DateTime startDate = DateTimes.nowUtc().minusDays(20);
+    DateTime endDate = DateTimes.nowUtc();
+    TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+            .granularity(Granularities.HOUR)
+            .context(ImmutableMap.of())
+            .build();
+    SegmentServerSelector segmentServerSelector = EasyMock.createMock(SegmentServerSelector.class);
+    EasyMock.expect(segmentServerSelector.getSegmentDescriptor()).andReturn(new SegmentDescriptor(new Interval(startDate, endDate), "", 0));
+    EasyMock.replay(segmentServerSelector);
+    Assert.assertEquals(
+            -adjustment,
+            (int) strategy.computePriority(QueryPlus.wrap(query), ImmutableSet.of(segmentServerSelector)).get()
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Implements threshold based automatic query prioritization using the time period of the actual segments scanned. This differs from the current implementation of durationThreshold which uses the duration in the user supplied query. There are some usability constraints with using durationThreshold from the user supplied query, especially when using SQL. For example, if a client does not explicitly specify both start and end timestamps then the duration is extremely large and will always exceed the configured durationThreshold. This is one example interval from a query that specifies no end timestamp:
"interval":["2024-08-30T08:05:41.944Z/146140482-04-24T15:36:27.903Z"]. This interval is generated from a query like SELECT * FROM table WHERE __time > CURRENT_TIMESTAMP - INTERVAL '15' HOUR. Using the time period of the actual segments scanned allows proper prioritization without explicitly having to specify start and end timestamps. This PR adds onto https://github.com/apache/druid/pull/9493 
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 
If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Automatic query prioritization based on the period of the actual segments scanned in a query.

<hr>

##### Key changed/added classes in this PR
 * `ThresholdBasedQueryPrioritizationStrategy`
 * `ThresholdBasedQueryPrioritizationStrategyTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [X] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [X] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [X] added integration tests.
- [X] been tested in a test Druid cluster.
