### PR TITLE
Set response type `application/json` in CustomExceptionMapper to return correct failure message 

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1400,6 +1400,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   @POST
   @Path("/report")
   @Consumes(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
+  @Produces(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
   public Response report(
       SubTaskReport report,
       @Context final HttpServletRequest req

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1400,7 +1400,6 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   @POST
   @Path("/report")
   @Consumes(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
-  @Produces(MediaType.APPLICATION_JSON)
   public Response report(
       SubTaskReport report,
       @Context final HttpServletRequest req

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1400,7 +1400,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   @POST
   @Path("/report")
   @Consumes(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
-  @Produces(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
+  @Produces(MediaType.APPLICATION_JSON)
   public Response report(
       SubTaskReport report,
       @Context final HttpServletRequest req

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/CustomExceptionMapper.java
@@ -23,6 +23,7 @@ package org.apache.druid.server.initialization.jetty;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.common.collect.ImmutableMap;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -38,6 +39,7 @@ public class CustomExceptionMapper implements ExceptionMapper<JsonMappingExcepti
                        "error",
                        exception.getMessage() == null ? "unknown json mapping exception" : exception.getMessage()
                    ))
+                   .type(MediaType.APPLICATION_JSON)
                    .build();
   }
 }


### PR DESCRIPTION
ParallelIndexSupervisorTask#report API in `index_parallel` task was logging below exception when invoked with backward incompatible object. 

```
com.sun.jersey.spi.container.ContainerResponse - Mapped exception to response: 500 (Internal Server Error)
javax.ws.rs.WebApplicationException: com.sun.jersey.api.MessageException: A message body writer for Java class com.google.common.collect.SingletonImmutableBiMap, and Java type class com.google.common.collect.SingletonImmutableBiMap, and MIME media type application/octet-stream was not found.
	at com.sun.jersey.spi.container.ContainerResponse.write(ContainerResponse.java:284) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1510) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1419) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1409) ~[jersey-server-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:409) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:558) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:733) ~[jersey-servlet-1.19.4.jar:1.19.4]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
...
```

After the fix correct failure message is being returned to the client. 
```
2024-09-06T07:21:08,604 ERROR [task-runner-0-priority-0] org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseSubTask - Encountered exception in parallel sub task.
java.lang.RuntimeException: org.apache.druid.rpc.HttpResponseException: Server error [400 Bad Request]; body: {"error":"Please make sure to load all the necessary extensions and jars with type 'taskContext' on 'druid/middleManager' service. Could not resolve type id 'taskContext' as a subtype of `org.apache.druid.indexing.common.TaskReport` known type ids = [ingestionStatsAndErrors, killUnusedSegments, multiStageQuery] (for POJO property 'taskReport')\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: -1, column: 860725] (through reference chain: org.apache.druid.indexing.common.task.batch.parallel.PushedSegmentsReport[\"taskReport\"]->org.apache.druid.indexing.common.TaskReport$ReportMap[\"taskContext\"])"}
	at org.apache.druid.common.guava.FutureUtils.getUnchecked(FutureUtils.java:83) ~[druid-processing-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervisorTaskClientImpl.report(ParallelIndexSupervisorTaskClientImpl.java:99) ~[druid-indexing-service-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseSubTask.runTask(SinglePhaseSubTask.java:284) [druid-indexing-service-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.common.task.AbstractTask.run(AbstractTask.java:179) [druid-indexing-service-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:478) [druid-indexing-service-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.indexing.overlord.SingleTaskBackgroundRunner$SingleTaskBackgroundRunnerCallable.call(SingleTaskBackgroundRunner.java:450) [druid-indexing-service-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:131) [guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:75) [guava-32.0.1-jre.jar:?]
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:82) [guava-32.0.1-jre.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.base/java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: org.apache.druid.rpc.HttpResponseException: Server error [400 Bad Request]; body: {"error":"Please make sure to load all the necessary extensions and jars with type 'taskContext' on 'druid/middleManager' service. Could not resolve type id 'taskContext' as a subtype of `org.apache.druid.indexing.common.TaskReport` known type ids = [ingestionStatsAndErrors, killUnusedSegments, multiStageQuery] (for POJO property 'taskReport')\n at [Source: (org.eclipse.jetty.server.HttpInputOverHTTP); line: -1, column: 860725] (through reference chain: org.apache.druid.indexing.common.task.batch.parallel.PushedSegmentsReport[\"taskReport\"]->org.apache.druid.indexing.common.TaskReport$ReportMap[\"taskContext\"])"}
	at org.apache.druid.rpc.ServiceClientImpl$1.onSuccess(ServiceClientImpl.java:201) ~[druid-server-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at org.apache.druid.rpc.ServiceClientImpl$1.onSuccess(ServiceClientImpl.java:183) ~[druid-server-2024.08.0-iap-SNAPSHOT.jar:2024.08.0-iap-SNAPSHOT]
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1133) ~[guava-32.0.1-jre.jar:?]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[?:?]
	... 3 more
```