### PR TITLE
Add Delta snapshot version to the web-console

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -1077,7 +1077,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           name: 'inputSource.snapshotVersion',
           label: 'Delta snapshot version',
           type: 'number',
-          placeholder: '2',
+          placeholder: '(latest)',
           defaultValue: {},
           info: (
             <>

--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -1060,6 +1060,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           name: 'inputSource.filter',
           label: 'Delta filter',
           type: 'json',
+          placeholder: '{"type": "=", "column": "name", "value": "foo"}',
           defaultValue: {},
           info: (
             <>
@@ -1069,6 +1070,19 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
                 filter
               </ExternalLink>
               <p>A Delta filter json object to filter Delta Lake scan files.</p>
+            </>
+          ),
+        },
+        {
+          name: 'inputSource.snapshotVersion',
+          label: 'Delta snapshot version',
+          type: 'number',
+          placeholder: '2',
+          defaultValue: {},
+          info: (
+            <>
+              The snapshot version to read from the Delta table. By default, the latest snapshot is
+              read.
             </>
           ),
         },

--- a/web-console/src/druid-models/input-source/input-source.tsx
+++ b/web-console/src/druid-models/input-source/input-source.tsx
@@ -667,7 +667,7 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
     name: 'snapshotVersion',
     label: 'Delta snapshot version',
     type: 'number',
-    placeholder: '3',
+    placeholder: '(latest)',
     defined: typeIsKnown(KNOWN_TYPES, 'delta'),
     required: false,
     info: (

--- a/web-console/src/druid-models/input-source/input-source.tsx
+++ b/web-console/src/druid-models/input-source/input-source.tsx
@@ -652,7 +652,7 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
     label: 'Delta filter',
     type: 'json',
     placeholder: '{"type": "=", "column": "name", "value": "foo"}',
-    defined: inputSource => inputSource.type === 'delta' && deepGet(inputSource, 'filter'),
+    defined: typeIsKnown(KNOWN_TYPES, 'delta'),
     required: false,
     info: (
       <>
@@ -660,6 +660,19 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
           filter
         </ExternalLink>
         <p>A Delta filter json object to filter Delta Lake scan files.</p>
+      </>
+    ),
+  },
+  {
+    name: 'snapshotVersion',
+    label: 'Delta snapshot version',
+    type: 'number',
+    placeholder: '3',
+    defined: typeIsKnown(KNOWN_TYPES, 'delta'),
+    required: false,
+    info: (
+      <>
+        The snapshot version to read from the Delta table. By default, the latest snapshot is read.
       </>
     ),
   },


### PR DESCRIPTION
Web-console change for https://github.com/apache/druid/pull/17004.

Adds `snapshot.version` to the `delta` input source in the web-console:

<img width="335" alt="CleanShot 2024-09-09 at 12 50 57@2x" src="https://github.com/user-attachments/assets/8a96d54b-e69d-406e-98ca-8d5f051ac20a">

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
