### PR TITLE
GHA steps to collect and upload heap dumps to debug UT OOM errors

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -121,7 +121,7 @@ jobs:
         if: ${{ failure() }}
         id: check_for_heap_dump
         run: |
-          if ls ${GITHUB_WORKSPACE}/*.hprof 1> /dev/null 2>&1; then
+          if ls ${GITHUB_WORKSPACE}/target/*.hprof 1> /dev/null 2>&1; then
             echo "found_hprof=true" >> "$GITHUB_ENV"
           else
             echo "found_hprof=false" >> "$GITHUB_ENV"
@@ -130,7 +130,7 @@ jobs:
       - name: Collect tarball hprof dumps if they exist on failure
         if: ${{ failure() && env.found_hprof == 'true' }}
         run: |
-          tar cvzf ${RUNNER_TEMP}/hprof-dumps.tgz ${GITHUB_WORKSPACE}/*.hprof
+          tar cvzf ${RUNNER_TEMP}/hprof-dumps.tgz ${GITHUB_WORKSPACE}/target/*.hprof
 
       - name: Upload hprof dumps to GitHub if they exist on failure
         if: ${{ failure() && env.found_hprof == 'true' }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -123,9 +123,9 @@ jobs:
         id: check_for_heap_dump
         run: |
           if ls ${GITHUB_WORKSPACE}/*.hprof 1> /dev/null 2>&1; then
-            echo "::set-output name=found_hprof::true"
+            echo "found_hprof=true" >> $GITHUB_ENV
           else
-            echo "::set-output name=found_hprof::false"
+            echo "found_hprof=false" >> $GITHUB_ENV
           fi
 
       # Tarball the heap dumps on failure and if the heap dump exists

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -122,7 +122,7 @@ jobs:
         if: ${{ failure() }}
         id: check_for_heap_dump
         run: |
-          if ls /home/runner/work/druid/druid/*.hprof 1> /dev/null 2>&1; then
+          if ls ${GITHUB_WORKSPACE}/*.hprof 1> /dev/null 2>&1; then
             echo "::set-output name=found_hprof::true"
           else
             echo "::set-output name=found_hprof::false"
@@ -132,7 +132,7 @@ jobs:
       - name: Collect tarball hprof dumps on failure
         if: ${{ failure() && steps.check_for_heap_dump.outputs.found_hprof == 'true' }}
         run: |
-          tar cvzf ./hprof-dumps.tgz /home/runner/work/druid/druid/*.hprof
+          tar cvzf ${RUNNER_TEMP}/hprof-dumps.tgz ${GITHUB_WORKSPACE}/*.hprof
 
       # Upload the heap dump tarball on failure and if the heap dump exists
       - name: Upload hprof dumps to GitHub
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: Hprof-${{ inputs.group }} hprof dumps (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }})
-          path: hprof-dumps.tgz
+          path: ${{ runner.temp }}/hprof-dumps.tgz
 
       - name: set outputs on failure
         id: set_outputs

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -117,6 +117,31 @@ jobs:
           MAVEN_PROJECTS: ${{ inputs.maven_projects }}
         run: ./.github/scripts/unit_tests_script.sh
 
+      # Check if .hprof dumps exist on failure
+      - name: Check for .hprof files
+        if: ${{ failure() }}
+        id: check_for_heap_dump
+        run: |
+          if ls /home/runner/work/druid/druid/*.hprof 1> /dev/null 2>&1; then
+            echo "::set-output name=found_hprof::true"
+          else
+            echo "::set-output name=found_hprof::false"
+          fi
+
+      # Tarball the heap dumps on failure and if the heap dump exists
+      - name: Collect tarball hprof dumps on failure
+        if: ${{ failure() && steps.check_for_heap_dump.outputs.found_hprof == 'true' }}
+        run: |
+          tar cvzf ./hprof-dumps.tgz /home/runner/work/druid/druid/*.hprof
+
+      # Upload the heap dump tarball on failure and if the heap dump exists
+      - name: Upload hprof dumps to GitHub
+        if: ${{ failure() && steps.check_for_heap_dump.outputs.found_hprof == 'true' }}
+        uses: actions/upload-artifact@master
+        with:
+          name: Hprof-${{ inputs.group }} hprof dumps (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }})
+          path: hprof-dumps.tgz
+
       - name: set outputs on failure
         id: set_outputs
         if: ${{ failure() }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -117,26 +117,23 @@ jobs:
           MAVEN_PROJECTS: ${{ inputs.maven_projects }}
         run: ./.github/scripts/unit_tests_script.sh
 
-      # Check if .hprof dumps exist on failure
-      - name: Check for .hprof files
+      - name: Check for .hprof files on failure
         if: ${{ failure() }}
         id: check_for_heap_dump
         run: |
           if ls ${GITHUB_WORKSPACE}/*.hprof 1> /dev/null 2>&1; then
-            echo "found_hprof=true" >> $GITHUB_ENV
+            echo "found_hprof=true" >> "$GITHUB_ENV"
           else
-            echo "found_hprof=false" >> $GITHUB_ENV
+            echo "found_hprof=false" >> "$GITHUB_ENV"
           fi
 
-      # Tarball the heap dumps on failure and if the heap dump exists
-      - name: Collect tarball hprof dumps on failure
-        if: ${{ failure() && steps.check_for_heap_dump.outputs.found_hprof == 'true' }}
+      - name: Collect tarball hprof dumps if they exist on failure
+        if: ${{ failure() && env.found_hprof == 'true' }}
         run: |
           tar cvzf ${RUNNER_TEMP}/hprof-dumps.tgz ${GITHUB_WORKSPACE}/*.hprof
 
-      # Upload the heap dump tarball on failure and if the heap dump exists
-      - name: Upload hprof dumps to GitHub
-        if: ${{ failure() && steps.check_for_heap_dump.outputs.found_hprof == 'true' }}
+      - name: Upload hprof dumps to GitHub if they exist on failure
+        if: ${{ failure() && env.found_hprof == 'true' }}
         uses: actions/upload-artifact@master
         with:
           name: Hprof-${{ inputs.group }} hprof dumps (Compile=jdk${{ inputs.build_jdk }}, Run=jdk${{ inputs.runtime_jdk }})

--- a/pom.xml
+++ b/pom.xml
@@ -1778,6 +1778,9 @@
                             -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                             -Ddruid.test.stupidPool.poison=true
+                            <!-- the path needs to come from a maven option or so -->
+                            -XX:OnOutOfMemoryError='chmod 644 /home/runner/work/druid/druid/*.hprof'
+                            -XX:HeapDumpPath=/home/runner/work/druid/druid/
                             <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
                             ${jfrProfilerArgLine}

--- a/pom.xml
+++ b/pom.xml
@@ -1778,9 +1778,9 @@
                             -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                             -Ddruid.test.stupidPool.poison=true
-                            <!-- the path needs to come from a maven option or so -->
-                            -XX:OnOutOfMemoryError='chmod 644 /home/runner/work/druid/druid/*.hprof'
-                            -XX:HeapDumpPath=/home/runner/work/druid/druid/
+                            <!-- Heap dump in the project's root directory -->
+                            -XX:OnOutOfMemoryError='chmod 644 ${project.parent.basedir}/*.hprof'
+                            -XX:HeapDumpPath=${project.parent.basedir}
                             <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
                             ${jfrProfilerArgLine}

--- a/pom.xml
+++ b/pom.xml
@@ -1778,9 +1778,8 @@
                             -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                             -Ddruid.test.stupidPool.poison=true
-                            <!-- Heap dump in the project's root directory -->
-                            -XX:OnOutOfMemoryError='chmod 644 ${project.parent.basedir}/*.hprof'
-                            -XX:HeapDumpPath=${project.parent.basedir}
+                            -XX:OnOutOfMemoryError='chmod 644 ${project.parent.basedir}/target/*.hprof'
+                            -XX:HeapDumpPath=${project.parent.basedir}/target
                             <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double
                             ${jfrProfilerArgLine}


### PR DESCRIPTION
Some [UTs](https://github.com/apache/druid/actions/runs/10796374752/job/29955096914?pr=17027) have recently [been](https://github.com/apache/druid/actions/runs/10781889856/job/29904194227) failing with OOMs: https://github.com/apache/druid/actions/runs/10796374752/job/29955096914?pr=17027

```
Warning:  Tests run: 15, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4.868 s -- in org.apache.druid.msq.test.CalciteUnionQueryMSQTest
[INFO] Running org.apache.druid.msq.test.CalciteSelectQueryMSQTest
java.lang.OutOfMemoryError: Java heap space
Dumping heap to java_pid21084.hprof ...
Heap dump file created [3035323731 bytes in 8.410 secs]
Terminating due to java.lang.OutOfMemoryError: Java heap space
```

So this PR adds some GHA steps to tarball and upload the heap dump if they exist.

This PR has:

- [x] been self-reviewed.
