### PR TITLE
MSQ window functions: Reject MVDs during window processing

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
@@ -67,11 +67,8 @@ import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.timeline.SegmentId;
 import org.hamcrest.CoreMatchers;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -80,19 +77,8 @@ import java.util.Map;
 
 public class MSQWindowTest extends MSQTestBase
 {
-  public static Collection<Object[]> data()
-  {
-    Object[][] data = new Object[][]{
-        {DEFAULT, DEFAULT_MSQ_CONTEXT}
-    };
-
-    return Arrays.asList(data);
-  }
-
-
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithPartitionByAndInnerGroupBy(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithPartitionByAndInnerGroupBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -111,7 +97,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.FLOAT
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -124,7 +110,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("d0", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaiveSortOperatorFactory(ImmutableList.of(ColumnWithDirection.ascending("d0"))),
@@ -154,7 +140,7 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0},
             new Object[]{6.0f, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedCountersForStageWorkerChannel(
             CounterSnapshotMatcher
                 .with().totalFiles(1),
@@ -173,9 +159,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithFirstWindowPartitionNextWindowEmpty(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithFirstWindowPartitionNextWindowEmpty()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -201,7 +186,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.DOUBLE
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -218,7 +203,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("d0", ColumnType.FLOAT)
                     .add("d1", ColumnType.DOUBLE)
@@ -261,7 +246,7 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0, 5.0, 21.0},
             new Object[]{6.0f, 6.0, 6.0, 21.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedCountersForStageWorkerChannel(
             CounterSnapshotMatcher
                 .with().totalFiles(1),
@@ -280,12 +265,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWith2WindowsBothWindowsHavingPartitionByInnerGroupBy(
-      String contextName,
-      Map<String, Object> context
-  )
+  @Test
+  public void testWindowOnFooWith2WindowsBothWindowsHavingPartitionByInnerGroupBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -311,7 +292,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.DOUBLE
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -328,7 +309,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("d0", ColumnType.FLOAT)
                     .add("d1", ColumnType.DOUBLE)
@@ -375,7 +356,7 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0, 5.0, 5.0},
             new Object[]{6.0f, 6.0, 6.0, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedCountersForStageWorkerChannel(
             CounterSnapshotMatcher
                 .with().totalFiles(1),
@@ -394,12 +375,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWith2WindowsBothPartitionByWithOrderReversed(
-      String contextName,
-      Map<String, Object> context
-  )
+  @Test
+  public void testWindowOnFooWith2WindowsBothPartitionByWithOrderReversed()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -424,7 +401,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.DOUBLE
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -441,7 +418,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("d0", ColumnType.FLOAT)
                     .add("d1", ColumnType.DOUBLE)
@@ -488,7 +465,7 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0, 5.0, 5.0},
             new Object[]{6.0f, 6.0, 6.0, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedCountersForStageWorkerChannel(
             CounterSnapshotMatcher
                 .with().totalFiles(1),
@@ -507,9 +484,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithEmptyOverWithGroupBy(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithEmptyOverWithGroupBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -528,7 +504,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.FLOAT
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -541,7 +517,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("d0", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaivePartitioningOperatorFactory(ImmutableList.of()),
@@ -570,7 +546,7 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 21.0},
             new Object[]{6.0f, 21.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedCountersForStageWorkerChannel(
             CounterSnapshotMatcher
                 .with().totalFiles(1),
@@ -589,9 +565,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithNoGroupByAndPartition(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithNoGroupByAndPartition()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -606,7 +581,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(DruidQuery.CTX_SCAN_SIGNATURE, "[{\"name\":\"m1\",\"type\":\"FLOAT\"}]")
                     .build();
 
@@ -620,7 +595,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("m1", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaiveSortOperatorFactory(ImmutableList.of(ColumnWithDirection.ascending("m1"))),
@@ -650,13 +625,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0},
             new Object[]{6.0f, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithNoGroupByAndPartitionOnTwoElements(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithNoGroupByAndPartitionOnTwoElements()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -671,7 +645,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"m1\",\"type\":\"FLOAT\"},{\"name\":\"m2\",\"type\":\"DOUBLE\"}]"
@@ -688,7 +662,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("m1", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaiveSortOperatorFactory(ImmutableList.of(
@@ -721,13 +695,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0},
             new Object[]{6.0f, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithNoGroupByAndPartitionByAnother(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithNoGroupByAndPartitionByAnother()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -742,7 +715,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"m1\",\"type\":\"FLOAT\"},{\"name\":\"m2\",\"type\":\"DOUBLE\"}]"
@@ -759,7 +732,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("m1", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaiveSortOperatorFactory(ImmutableList.of(ColumnWithDirection.ascending("m2"))),
@@ -789,13 +762,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0},
             new Object[]{6.0f, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithGroupByAndInnerLimit(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithGroupByAndInnerLimit()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("m1", ColumnType.FLOAT)
@@ -828,10 +800,10 @@ public class MSQWindowTest extends MSQTestBase
                             )
                         ))
                         .setLimit(5)
-                        .setContext(context)
+                        .setContext(DEFAULT_MSQ_CONTEXT)
                         .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("d0", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaivePartitioningOperatorFactory(ImmutableList.of()),
@@ -864,17 +836,16 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{4.0f, 15.0},
             new Object[]{5.0f, 15.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithNoGroupByAndPartitionAndVirtualColumns(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithNoGroupByAndPartitionAndVirtualColumns()
   {
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"m1\",\"type\":\"FLOAT\"},{\"name\":\"v0\",\"type\":\"LONG\"}]"
@@ -904,7 +875,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("v0", ColumnType.LONG)
                     .add("m1", ColumnType.FLOAT)
@@ -939,19 +910,18 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{3, 5.0f, 5.0},
             new Object[]{3, 6.0f, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithNoGroupByAndEmptyOver(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithNoGroupByAndEmptyOver()
   {
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(DruidQuery.CTX_SCAN_SIGNATURE, "[{\"name\":\"m1\",\"type\":\"FLOAT\"}]")
                     .build();
 
@@ -976,7 +946,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("m1", ColumnType.FLOAT).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaivePartitioningOperatorFactory(ImmutableList.of()),
@@ -1005,17 +975,16 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 21.0},
             new Object[]{6.0f, 21.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithPartitionByOrderBYWithJoin(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithPartitionByOrderBYWithJoin()
   {
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"j0.m2\",\"type\":\"DOUBLE\"},{\"name\":\"m1\",\"type\":\"FLOAT\"}]"
@@ -1024,7 +993,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature1 =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"m2\",\"type\":\"DOUBLE\"},{\"name\":\"v0\",\"type\":\"FLOAT\"}]"
@@ -1073,7 +1042,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("m1", ColumnType.FLOAT)
                     .add("w0", ColumnType.DOUBLE)
@@ -1109,17 +1078,16 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0, 5.0},
             new Object[]{6.0f, 6.0, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithEmptyOverWithJoin(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithEmptyOverWithJoin()
   {
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"j0.m2\",\"type\":\"DOUBLE\"},{\"name\":\"m1\",\"type\":\"FLOAT\"}]"
@@ -1128,7 +1096,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature1 =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"m2\",\"type\":\"DOUBLE\"},{\"name\":\"v0\",\"type\":\"FLOAT\"}]"
@@ -1177,7 +1145,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("m1", ColumnType.FLOAT)
                     .add("w0", ColumnType.DOUBLE)
@@ -1212,13 +1180,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 21.0, 5.0},
             new Object[]{6.0f, 21.0, 6.0}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithDim2(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithDim2()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("dim2", ColumnType.STRING)
@@ -1233,7 +1200,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"dim2\",\"type\":\"STRING\"},{\"name\":\"m1\",\"type\":\"FLOAT\"}]"
@@ -1250,7 +1217,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("dim2", ColumnType.STRING).add("w0", ColumnType.DOUBLE).build(),
         ImmutableList.of(
             new NaiveSortOperatorFactory(ImmutableList.of(ColumnWithDirection.ascending("dim2"))),
@@ -1290,17 +1257,16 @@ public class MSQWindowTest extends MSQTestBase
                 new Object[]{"abc", 5.0},
                 new Object[]{null, 8.0}
             ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithEmptyOverWithUnnest(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithEmptyOverWithUnnest()
   {
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"j0.unnest\",\"type\":\"STRING\"},{\"name\":\"m1\",\"type\":\"FLOAT\"}]"
@@ -1336,7 +1302,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("m1", ColumnType.FLOAT)
                     .add("w0", ColumnType.DOUBLE)
@@ -1373,17 +1339,16 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 24.0, NullHandling.sqlCompatible() ? null : ""},
             new Object[]{6.0f, 24.0, NullHandling.sqlCompatible() ? null : ""}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnFooWithPartitionByAndWithUnnest(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnFooWithPartitionByAndWithUnnest()
   {
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"j0.unnest\",\"type\":\"STRING\"},{\"name\":\"m1\",\"type\":\"FLOAT\"}]"
@@ -1419,7 +1384,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder()
                     .add("m1", ColumnType.FLOAT)
                     .add("w0", ColumnType.DOUBLE)
@@ -1457,14 +1422,13 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{5.0f, 5.0, NullHandling.sqlCompatible() ? null : ""},
             new Object[]{6.0f, 6.0, NullHandling.sqlCompatible() ? null : ""}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
   // Insert Tests
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testInsertWithWindow(String contextName, Map<String, Object> context)
+  @Test
+  public void testInsertWithWindow()
   {
     List<Object[]> expectedRows = ImmutableList.of(
         new Object[]{946684800000L, 1.0f, 1.0},
@@ -1487,7 +1451,7 @@ public class MSQWindowTest extends MSQTestBase
                          + "SUM(m1) OVER(PARTITION BY m1) as summ1\n"
                          + "from foo\n"
                          + "GROUP BY __time, m1 PARTITIONED BY ALL")
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedResultRows(expectedRows)
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
@@ -1495,9 +1459,8 @@ public class MSQWindowTest extends MSQTestBase
 
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testInsertWithWindowEmptyOver(String contextName, Map<String, Object> context)
+  @Test
+  public void testInsertWithWindowEmptyOver()
   {
     List<Object[]> expectedRows = ImmutableList.of(
         new Object[]{946684800000L, 1.0f, 21.0},
@@ -1520,7 +1483,7 @@ public class MSQWindowTest extends MSQTestBase
                          + "SUM(m1) OVER() as summ1\n"
                          + "from foo\n"
                          + "GROUP BY __time, m1 PARTITIONED BY ALL")
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedResultRows(expectedRows)
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
@@ -1528,9 +1491,8 @@ public class MSQWindowTest extends MSQTestBase
 
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testInsertWithWindowPartitionByOrderBy(String contextName, Map<String, Object> context)
+  @Test
+  public void testInsertWithWindowPartitionByOrderBy()
   {
     List<Object[]> expectedRows = ImmutableList.of(
         new Object[]{946684800000L, 1.0f, 1.0},
@@ -1553,7 +1515,7 @@ public class MSQWindowTest extends MSQTestBase
                          + "SUM(m1) OVER(PARTITION BY m1 ORDER BY m1 ASC) as summ1\n"
                          + "from foo\n"
                          + "GROUP BY __time, m1 PARTITIONED BY ALL")
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedResultRows(expectedRows)
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
@@ -1563,9 +1525,8 @@ public class MSQWindowTest extends MSQTestBase
 
 
   // Replace Tests
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testReplaceWithWindowsAndUnnest(String contextName, Map<String, Object> context)
+  @Test
+  public void testReplaceWithWindowsAndUnnest()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1579,7 +1540,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY m1")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1597,9 +1558,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSimpleWindowWithPartitionBy(String contextName, Map<String, Object> context)
+  @Test
+  public void testSimpleWindowWithPartitionBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1612,7 +1572,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY m1")
                      .setExpectedDataSource("foo")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1628,9 +1588,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSimpleWindowWithEmptyOver(String contextName, Map<String, Object> context)
+  @Test
+  public void testSimpleWindowWithEmptyOver()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1643,7 +1602,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY m1")
                      .setExpectedDataSource("foo")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1659,9 +1618,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSimpleWindowWithEmptyOverNoGroupBy(String contextName, Map<String, Object> context)
+  @Test
+  public void testSimpleWindowWithEmptyOverNoGroupBy()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1674,7 +1632,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY m1")
                      .setExpectedDataSource("foo")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1690,9 +1648,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSimpleWindowWithDuplicateSelectNode(String contextName, Map<String, Object> context)
+  @Test
+  public void testSimpleWindowWithDuplicateSelectNode()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1706,7 +1663,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY m1")
                      .setExpectedDataSource("foo")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1722,9 +1679,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSimpleWindowWithJoins(String contextName, Map<String, Object> context)
+  @Test
+  public void testSimpleWindowWithJoins()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -1738,7 +1694,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY DAY CLUSTERED BY m1")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -1764,9 +1720,8 @@ public class MSQWindowTest extends MSQTestBase
   }
 
   // Bigger dataset tests
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSelectWithWikipedia(String contextName, Map<String, Object> context)
+  @Test
+  public void testSelectWithWikipedia()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("cityName", ColumnType.STRING)
@@ -1782,7 +1737,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> contextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"added\",\"type\":\"LONG\"},{\"name\":\"cityName\",\"type\":\"STRING\"}]"
@@ -1800,7 +1755,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(contextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("cityName", ColumnType.STRING)
                     .add("added", ColumnType.LONG)
                     .add("w0", ColumnType.LONG).build(),
@@ -1833,17 +1788,16 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{"Albuquerque", 9L, 140L},
             new Object[]{"Albuquerque", 2L, 140L}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSelectWithWikipediaEmptyOverWithCustomContext(String contextName, Map<String, Object> context)
+  @Test
+  public void testSelectWithWikipediaEmptyOverWithCustomContext()
   {
     final Map<String, Object> customContext =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(MultiStageQueryContext.MAX_ROWS_MATERIALIZED_IN_WINDOW, 200)
                     .build();
 
@@ -1855,9 +1809,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testSelectWithWikipediaWithPartitionKeyNotInSelect(String contextName, Map<String, Object> context)
+  @Test
+  public void testSelectWithWikipediaWithPartitionKeyNotInSelect()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("cityName", ColumnType.STRING)
@@ -1873,7 +1826,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> innerContextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"added\",\"type\":\"LONG\"},{\"name\":\"cityName\",\"type\":\"STRING\"},{\"name\":\"countryIsoCode\",\"type\":\"STRING\"}]"
@@ -1891,7 +1844,7 @@ public class MSQWindowTest extends MSQTestBase
                 .context(innerContextWithRowSignature)
                 .build()),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("cityName", ColumnType.STRING)
                     .add("added", ColumnType.LONG)
                     .add("w0", ColumnType.LONG).build(),
@@ -1905,7 +1858,7 @@ public class MSQWindowTest extends MSQTestBase
 
     final Map<String, Object> outerContextWithRowSignature =
         ImmutableMap.<String, Object>builder()
-                    .putAll(context)
+                    .putAll(DEFAULT_MSQ_CONTEXT)
                     .put(
                         DruidQuery.CTX_SCAN_SIGNATURE,
                         "[{\"name\":\"added\",\"type\":\"LONG\"},{\"name\":\"cityName\",\"type\":\"STRING\"},{\"name\":\"w0\",\"type\":\"LONG\"}]"
@@ -1944,13 +1897,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{"Tokyo", 0L, 12615L},
             new Object[]{"Santiago", 161L, 401L}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testGroupByWithWikipedia(String contextName, Map<String, Object> context)
+  @Test
+  public void testGroupByWithWikipedia()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("cityName", ColumnType.STRING)
@@ -1975,7 +1927,7 @@ public class MSQWindowTest extends MSQTestBase
                                                    ColumnType.LONG
                                                )
                                            ))
-                                           .setContext(context)
+                                           .setContext(DEFAULT_MSQ_CONTEXT)
                                            .build();
 
 
@@ -1988,7 +1940,7 @@ public class MSQWindowTest extends MSQTestBase
     final WindowOperatorQuery query = new WindowOperatorQuery(
         new QueryDataSource(groupByQuery),
         new LegacySegmentSpec(Intervals.ETERNITY),
-        context,
+        DEFAULT_MSQ_CONTEXT,
         RowSignature.builder().add("d0", ColumnType.STRING)
                     .add("d1", ColumnType.LONG)
                     .add("w0", ColumnType.LONG).build(),
@@ -2022,13 +1974,12 @@ public class MSQWindowTest extends MSQTestBase
             new Object[]{"Albuquerque", 9L, 140L},
             new Object[]{"Albuquerque", 129L, 140L}
         ))
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testReplaceGroupByOnWikipedia(String contextName, Map<String, Object> context)
+  @Test
+  public void testReplaceGroupByOnWikipedia()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -2044,7 +1995,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY ALL CLUSTERED BY added")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -2058,11 +2009,10 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testWindowOnMixOfEmptyAndNonEmptyOverWithMultipleWorkers(String contextName, Map<String, Object> context)
+  @Test
+  public void testWindowOnMixOfEmptyAndNonEmptyOverWithMultipleWorkers()
   {
-    final Map<String, Object> multipleWorkerContext = new HashMap<>(context);
+    final Map<String, Object> multipleWorkerContext = new HashMap<>(DEFAULT_MSQ_CONTEXT);
     multipleWorkerContext.put(MultiStageQueryContext.CTX_MAX_NUM_TASKS, 5);
 
     final RowSignature rowSignature = RowSignature.builder()
@@ -2289,9 +2239,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testReplaceWithPartitionedByDayOnWikipedia(String contextName, Map<String, Object> context)
+  @Test
+  public void testReplaceWithPartitionedByDayOnWikipedia()
   {
     RowSignature rowSignature = RowSignature.builder()
                                             .add("__time", ColumnType.LONG)
@@ -2307,7 +2256,7 @@ public class MSQWindowTest extends MSQTestBase
                              + "PARTITIONED BY DAY")
                      .setExpectedDataSource("foo1")
                      .setExpectedRowSignature(rowSignature)
-                     .setQueryContext(context)
+                     .setQueryContext(DEFAULT_MSQ_CONTEXT)
                      .setExpectedDestinationIntervals(Intervals.ONLY_ETERNITY)
                      .setExpectedResultRows(
                          ImmutableList.of(
@@ -2327,9 +2276,8 @@ public class MSQWindowTest extends MSQTestBase
                      .verifyResults();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testFailurePartitionByMVD_1(String contextName, Map<String, Object> context)
+  @Test
+  public void testFailurePartitionByMVD_1()
   {
     testSelectQuery()
         .setSql("select cityName, countryName, array_to_mv(array[1,length(cityName)]), "
@@ -2337,7 +2285,7 @@ public class MSQWindowTest extends MSQTestBase
                 + "from wikipedia\n"
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
             CoreMatchers.instanceOf(ISE.class),
             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
@@ -2346,9 +2294,8 @@ public class MSQWindowTest extends MSQTestBase
         .verifyExecutionError();
   }
 
-  @MethodSource("data")
-  @ParameterizedTest(name = "{index}:with context {0}")
-  public void testFailurePartitionByMVD_2(String contextName, Map<String, Object> context)
+  @Test
+  public void testFailurePartitionByMVD_2()
   {
     testSelectQuery()
         .setSql("  select cityName, countryName, array_to_mv(array[1,length(cityName)]),"
@@ -2357,7 +2304,7 @@ public class MSQWindowTest extends MSQTestBase
                 + "from wikipedia\n"
                 + "where countryName in ('Austria', 'Republic of Korea') and cityName is not null\n"
                 + "order by 1, 2, 3")
-        .setQueryContext(context)
+        .setQueryContext(DEFAULT_MSQ_CONTEXT)
         .setExpectedExecutionErrorMatcher(CoreMatchers.allOf(
             CoreMatchers.instanceOf(ISE.class),
             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/RearrangedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/RearrangedRowsAndColumns.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.rowsandcols;
 
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessorBasedColumn;
@@ -28,6 +29,7 @@ import org.apache.druid.segment.column.ColumnType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -128,7 +130,16 @@ public class RearrangedRowsAndColumns implements RowsAndColumns
             @Override
             public Object getObject(int rowNum)
             {
-              return accessor.getObject(pointers[start + rowNum]);
+              Object value = accessor.getObject(pointers[start + rowNum]);
+              if (ColumnType.STRING.equals(getType()) && value instanceof List) {
+                // special handling to reject MVDs
+                throw new UOE(
+                    "Encountered a multi value column [%s]. Window processing does not support MVDs. "
+                    + "Consider using UNNEST or MV_TO_ARRAY.",
+                    name
+                );
+              }
+              return value;
             }
 
             @Override


### PR DESCRIPTION
### Description

This PR aims to reject MVDs when used as `partition by` columns during window function processing for MSQ engine.

Prior to this change, a MSQ query like the following was failing with ClassCastException:
```sql
select cityName, countryName, array_to_mv(array[1,length(cityName)]),
row_number() over (partition by  array_to_mv(array[1,length(cityName)]) order by countryName, cityName)
from wikipedia
where countryName in ('Austria', 'Republic of Korea') and cityName is not null
order by 1, 2, 3
```

This is a follow-up on https://github.com/apache/druid/pull/17002, where a similar thing was done for sql-native engine.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
