### PR TITLE
Add "targetPartitionsPerWorker" setting for MSQ.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
@@ -30,6 +30,8 @@ import org.apache.druid.msq.input.table.SegmentsInputSlice;
 import org.apache.druid.msq.input.table.TableInputSpec;
 import org.apache.druid.msq.kernel.QueryDefinition;
 import org.apache.druid.msq.kernel.controller.ControllerQueryKernelConfig;
+import org.apache.druid.msq.querykit.QueryKit;
+import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.server.DruidNode;
 
 /**
@@ -100,4 +102,10 @@ public interface ControllerContext
    * Client for communicating with workers.
    */
   WorkerClient newWorkerClient();
+
+  /**
+   * Default target partitions per worker for {@link QueryKit#makeQueryDefinition}. Can be overridden using
+   * {@link MultiStageQueryContext#CTX_TARGET_PARTITIONS_PER_WORKER}.
+   */
+  int defaultTargetPartitionsPerWorker();
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/MultiQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/MultiQueryKit.java
@@ -46,6 +46,7 @@ public class MultiQueryKit implements QueryKit<Query<?>>
       QueryKit<Query<?>> toolKitForSubQueries,
       ShuffleSpecFactory resultShuffleSpecFactory,
       int maxWorkerCount,
+      int targetPartitionsPerWorker,
       int minStageNumber
   )
   {
@@ -59,6 +60,7 @@ public class MultiQueryKit implements QueryKit<Query<?>>
           this,
           resultShuffleSpecFactory,
           maxWorkerCount,
+          targetPartitionsPerWorker,
           minStageNumber
       );
     } else {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/QueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/QueryKit.java
@@ -40,6 +40,7 @@ public interface QueryKit<QueryType extends Query<?>>
    * @param minStageNumber           lowest stage number to use for any generated stages. Useful if the resulting
    *                                 {@link QueryDefinition} is going to be added to an existing
    *                                 {@link org.apache.druid.msq.kernel.QueryDefinitionBuilder}.
+   * @param targetPartitionsPerWorker preferred number of partitions per worker for subqueries
    */
   QueryDefinition makeQueryDefinition(
       String queryId,
@@ -47,6 +48,7 @@ public interface QueryKit<QueryType extends Query<?>>
       QueryKit<Query<?>> toolKitForSubQueries,
       ShuffleSpecFactory resultShuffleSpecFactory,
       int maxWorkerCount,
+      int targetPartitionsPerWorker,
       int minStageNumber
   );
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
@@ -71,6 +71,7 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
       final QueryKit<Query<?>> queryKit,
       final ShuffleSpecFactory resultShuffleSpecFactory,
       final int maxWorkerCount,
+      final int targetPartitionsPerWorker,
       final int minStageNumber
   )
   {
@@ -86,6 +87,7 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
         originalQuery.getFilter(),
         null,
         maxWorkerCount,
+        targetPartitionsPerWorker,
         minStageNumber,
         false
     );
@@ -139,9 +141,10 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
       // __time in such queries is generated using either an aggregator (e.g. sum(metric) as __time) or using a
       // post-aggregator (e.g. TIMESTAMP '2000-01-01' as __time)
       // For example: INSERT INTO foo SELECT COUNT(*), TIMESTAMP '2000-01-01' AS __time FROM bar PARTITIONED BY DAY
-      shuffleSpecFactoryPreAggregation = intermediateClusterBy.isEmpty()
-                                         ? ShuffleSpecFactories.singlePartition()
-                                         : ShuffleSpecFactories.globalSortWithMaxPartitionCount(maxWorkerCount);
+      shuffleSpecFactoryPreAggregation =
+          intermediateClusterBy.isEmpty()
+          ? ShuffleSpecFactories.singlePartition()
+          : ShuffleSpecFactories.globalSortWithMaxPartitionCount(maxWorkerCount * targetPartitionsPerWorker);
 
       if (doLimitOrOffset) {
         shuffleSpecFactoryPostAggregation = ShuffleSpecFactories.singlePartitionWithLimit(postAggregationLimitHint);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
@@ -91,6 +91,7 @@ public class ScanQueryKit implements QueryKit<ScanQuery>
       final QueryKit<Query<?>> queryKit,
       final ShuffleSpecFactory resultShuffleSpecFactory,
       final int maxWorkerCount,
+      final int targetPartitionsPerWorker,
       final int minStageNumber
   )
   {
@@ -104,6 +105,7 @@ public class ScanQueryKit implements QueryKit<ScanQuery>
         originalQuery.getFilter(),
         null,
         maxWorkerCount,
+        targetPartitionsPerWorker,
         minStageNumber,
         false
     );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -190,6 +190,12 @@ public class MultiStageQueryContext
 
   public static final String CTX_SKIP_TYPE_VERIFICATION = "skipTypeVerification";
 
+  /**
+   * Number of partitions to target per worker when creating shuffle specs that involve specific numbers of
+   * partitions. This helps us utilize more parallelism when workers are multi-threaded.
+   */
+  public static final String CTX_TARGET_PARTITIONS_PER_WORKER = "targetPartitionsPerWorker";
+
   private static final Pattern LOOKS_LIKE_JSON_ARRAY = Pattern.compile("^\\s*\\[.*", Pattern.DOTALL);
 
   public static String getMSQMode(final QueryContext queryContext)
@@ -378,6 +384,14 @@ public class MultiStageQueryContext
   public static ArrayIngestMode getArrayIngestMode(final QueryContext queryContext)
   {
     return queryContext.getEnum(CTX_ARRAY_INGEST_MODE, ArrayIngestMode.class, DEFAULT_ARRAY_INGEST_MODE);
+  }
+
+  public static int getTargetPartitionsPerWorkerWithDefault(
+      final QueryContext queryContext,
+      final int defaultValue
+  )
+  {
+    return queryContext.getInt(CTX_TARGET_PARTITIONS_PER_WORKER, defaultValue);
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestControllerContext.java
@@ -342,4 +342,10 @@ public class MSQTestControllerContext implements ControllerContext
   {
     return new MSQTestWorkerClient(inMemoryWorkers);
   }
+
+  @Override
+  public int defaultTargetPartitionsPerWorker()
+  {
+    return 1;
+  }
 }


### PR DESCRIPTION
As we move towards multi-threaded MSQ workers, it helps for parallelism to generate more than one partition per worker. That way, we can fully utilize all worker threads throughout all stages.

The default value is the number of processing threads. Currently, this is hard-coded to 1 for peons, but that is expected to change in the future.