### PR TITLE
Provide `chmod` command for `-XX:OnOutOfMemoryError` from shell script

### DIFF
--- a/dev/chmod-heap-dumps.sh
+++ b/dev/chmod-heap-dumps.sh
@@ -1,3 +1,19 @@
-#!/bin/bash
+#!/bin/bash -eux
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 chmod 644 "${project.parent.basedir}/target/*.hprof"

--- a/dev/chmod-heap-dumps.sh
+++ b/dev/chmod-heap-dumps.sh
@@ -16,4 +16,4 @@
 # limitations under the License.
 
 BASE_DIR=$(git rev-parse --show-toplevel)
-chmod 644 "${BASE_DIR}/target/*.hprof"
+chmod 644 ${BASE_DIR}/target/*.hprof

--- a/dev/chmod-heap-dumps.sh
+++ b/dev/chmod-heap-dumps.sh
@@ -15,5 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-chmod 644 "${project.parent.basedir}/target/*.hprof"
+BASE_DIR=$(git rev-parse --show-toplevel)
+chmod 644 "${BASE_DIR}/target/*.hprof"

--- a/dev/chmod-heap-dumps.sh
+++ b/dev/chmod-heap-dumps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+chmod 644 "${project.parent.basedir}/target/*.hprof"

--- a/pom.xml
+++ b/pom.xml
@@ -1778,7 +1778,7 @@
                             -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
                             -Daws.region=us-east-1 <!-- required for s3-related unit tests -->
                             -Ddruid.test.stupidPool.poison=true
-                            -XX:OnOutOfMemoryError='chmod 644 ${project.parent.basedir}/target/*.hprof'
+                            -XX:OnOutOfMemoryError=${project.parent.basedir}/dev/chmod-heap-dumps.sh
                             -XX:HeapDumpPath=${project.parent.basedir}/target
                             <!--@TODO After fixing https://github.com/apache/druid/issues/4964 remove this parameter-->
                             -Ddruid.indexing.doubleStorage=double


### PR DESCRIPTION
A command line arg `-XX:OnOutOfMemoryError='chmod 644 ${project.parent.basedir}/target/*.hprof'` was added to collect heap dumps: https://github.com/apache/druid/pull/17029

This arg is causing problems when running tests from Intellij. Intellij doesn't seem to like`chmod 644`, but this command works as expected in `mvn`. So as a workaround, add the `chmod 644 ${BASE_DIR/target/*.hprof'` command in a shell script that can then be executed when `OnOutOfMemoryError` happens to make Intellij happy.

Verified that I'm able to run tests on Intellij successfully on reimporting pom.xml with this change.
