### PR TITLE
fix negative lag metircs issue + improve API design for parition lag

### DIFF
--- a/extensions-contrib/compressed-bigdecimal/pom.xml
+++ b/extensions-contrib/compressed-bigdecimal/pom.xml
@@ -97,7 +97,7 @@
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
-      <!--<classifier>tests</classifier>-->
+      <classifier>tests</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/compressed-bigdecimal/pom.xml
+++ b/extensions-contrib/compressed-bigdecimal/pom.xml
@@ -97,7 +97,7 @@
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
-      <classifier>tests</classifier>
+      <!--<classifier>tests</classifier>-->
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/rabbit-stream-indexing-service/pom.xml
+++ b/extensions-contrib/rabbit-stream-indexing-service/pom.xml
@@ -124,6 +124,11 @@
       <version>2.0.2</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
@@ -60,8 +60,6 @@ import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.joda.time.DateTime;
 
-import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/main/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisor.java
@@ -48,9 +48,11 @@ import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.indexing.seekablestream.common.StreamPartitionLagType;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorReportPayload;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -66,6 +68,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -235,7 +238,7 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
   }
 
   @Override
-  protected Map<String, Long> getPartitionRecordLag()
+  protected Pair<StreamPartitionLagType, Map<String, Long>> getPartitionLag()
   {
     Map<String, Long> highestCurrentOffsets = getHighestCurrentOffsets();
 
@@ -250,15 +253,7 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
           highestCurrentOffsets.keySet());
     }
 
-    return getRecordLagPerPartitionInLatestSequences(highestCurrentOffsets);
-  }
-
-  @Nullable
-  @Override
-  protected Map<String, Long> getPartitionTimeLag()
-  {
-    // time lag not currently support with rabbit
-    return null;
+    return Pair.of(StreamPartitionLagType.RECORD_LAG, getRecordLagPerPartitionInLatestSequences(highestCurrentOffsets));
   }
 
   // suppress use of CollectionUtils.mapValues() since the valueMapper function
@@ -289,13 +284,14 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
   // dependent on map key here
   @SuppressWarnings("SSBasedInspection")
   // Used while generating Supervisor lag reports per task
-  protected Map<String, Long> getRecordLagPerPartition(Map<String, Long> currentOffsets)
+  protected Pair<StreamPartitionLagType, Map<String, Long>> getLagPerPartition(Map<String, Long> currentOffsets)
   {
     if (latestSequenceFromStream == null || currentOffsets == null) {
-      return Collections.emptyMap();
+      return Pair.of(StreamPartitionLagType.RECORD_LAG, Collections.emptyMap());
     }
 
-    return currentOffsets
+    return Pair.of(StreamPartitionLagType.RECORD_LAG,
+        currentOffsets
         .entrySet()
         .stream()
         .filter(e -> latestSequenceFromStream.get(e.getKey()) != null)
@@ -304,13 +300,8 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
                 Entry::getKey,
                 e -> e.getValue() != null
                     ? latestSequenceFromStream.get(e.getKey()) + 1 - e.getValue()
-                    : 0));
-  }
-
-  @Override
-  protected Map<String, Long> getTimeLagPerPartition(Map<String, Long> currentOffsets)
-  {
-    return null;
+                    : 0))
+    );
   }
 
   @Override
@@ -358,12 +349,12 @@ public class RabbitStreamSupervisor extends SeekableStreamSupervisor<String, Lon
   @Override
   public LagStats computeLagStats()
   {
-    Map<String, Long> partitionRecordLag = getPartitionRecordLag();
-    if (partitionRecordLag == null) {
+    Pair<StreamPartitionLagType, Map<String, Long>> partitionRecordLag = getPartitionLag();
+    if (Objects.isNull(partitionRecordLag) || Objects.isNull(partitionRecordLag.rhs)) {
       return new LagStats(0, 0, 0);
     }
 
-    return computeLags(partitionRecordLag);
+    return computeLags(partitionRecordLag.rhs);
   }
 
   @Override

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
@@ -305,9 +305,9 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
   public void testGetters()
   {
     supervisor = getDefaultSupervisor();
-    Assert.assertNull(supervisor.getPartitionTimeLag());
+    Assert.assertNull(supervisor.getPartitionLag());
 
-    Assert.assertNull(supervisor.getTimeLagPerPartition(null));
+    Assert.assertNull(supervisor.getLagPerPartition(null));
     Assert.assertFalse(supervisor.isEndOfShard(null));
     Assert.assertFalse(supervisor.isShardExpirationMarker(null));
 

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
@@ -307,7 +307,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
     supervisor = getDefaultSupervisor();
     Assert.assertNull(supervisor.getPartitionLag());
 
-    Assert.assertNull(supervisor.getLagPerPartition(null));
+    Assert.assertTrue(supervisor.getLagPerPartition(null).rhs.isEmpty());
     Assert.assertFalse(supervisor.isEndOfShard(null));
     Assert.assertFalse(supervisor.isShardExpirationMarker(null));
 

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -128,6 +128,11 @@
       <artifactId>jakarta.validation-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisor.java
@@ -75,7 +75,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/extensions-core/kinesis-indexing-service/pom.xml
+++ b/extensions-core/kinesis-indexing-service/pom.xml
@@ -141,6 +141,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Tests -->
         <dependency>
             <groupId>org.easymock</groupId>

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -22,7 +22,6 @@ package org.apache.druid.indexing.kinesis.supervisor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
@@ -69,7 +68,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/StreamPartitionLagType.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/StreamPartitionLagType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream.common;
+
+/**
+ * @author hpan
+ */
+public enum StreamPartitionLagType {
+    RECORD_LAG,
+    TIME_LAG
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/StreamPartitionLagType.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/common/StreamPartitionLagType.java
@@ -19,10 +19,8 @@
 
 package org.apache.druid.indexing.seekablestream.common;
 
-/**
- * @author hpan
- */
-public enum StreamPartitionLagType {
+public enum StreamPartitionLagType
+{
     RECORD_LAG,
     TIME_LAG
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1338,8 +1338,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                   startTime,
                   remainingSeconds,
                   TaskReportData.TaskType.ACTIVE,
-                  includeOffsets ? (Objects.nonNull(pair) && pair.lhs == StreamPartitionLagType.RECORD_LAG ? pair.rhs : null ) : null,
-                  includeOffsets ? (Objects.nonNull(pair) && pair.lhs == StreamPartitionLagType.TIME_LAG ? pair.rhs : null ) : null
+                  includeOffsets ? (Objects.nonNull(pair) && pair.lhs == StreamPartitionLagType.RECORD_LAG ? pair.rhs : null) : null,
+                  includeOffsets ? (Objects.nonNull(pair) && pair.lhs == StreamPartitionLagType.TIME_LAG ? pair.rhs : null) : null
               )
           );
         }
@@ -4093,7 +4093,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     coalesceAndAwait(futures);
   }
 
-  private void appendHistoricalPartitionLag() {
+  private void appendHistoricalPartitionLag()
+  {
     if (Objects.nonNull(sequenceLastUpdated)) {
       Pair<StreamPartitionLagType, Map<PartitionIdType, Long>> partitionLag = getPartitionLag();
       if (Objects.nonNull(partitionLag) && MapUtils.isNotEmpty(partitionLag.rhs)) {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -41,6 +41,7 @@ import org.apache.druid.indexing.overlord.supervisor.autoscaler.LagStats;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
+import org.apache.druid.indexing.seekablestream.common.StreamPartitionLagType;
 import org.apache.druid.indexing.seekablestream.supervisor.IdleConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
@@ -53,6 +54,7 @@ import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.LagBasedAu
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.LagBasedAutoScalerConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.NoopTaskAutoScaler;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -166,14 +168,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
 
     @Nullable
     @Override
-    protected Map<String, Long> getPartitionRecordLag()
-    {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionTimeLag()
+    protected Pair<StreamPartitionLagType, Map<String, Long>> getPartitionLag()
     {
       return null;
     }
@@ -259,13 +254,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     }
 
     @Override
-    protected Map<String, Long> getRecordLagPerPartition(Map<String, String> currentOffsets)
-    {
-      return null;
-    }
-
-    @Override
-    protected Map<String, Long> getTimeLagPerPartition(Map<String, String> currentOffsets)
+    protected Pair<StreamPartitionLagType, Map<String, Long>> getLagPerPartition(Map<String, String> currentOffsets)
     {
       return null;
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -69,12 +69,14 @@ import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
+import org.apache.druid.indexing.seekablestream.common.StreamPartitionLagType;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorStateManager.SeekableStreamExceptionEvent;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorStateManager.SeekableStreamState;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -2776,14 +2778,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     @Nullable
     @Override
-    protected Map<String, Long> getPartitionRecordLag()
-    {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionTimeLag()
+    protected Pair<StreamPartitionLagType, Map<String, Long>> getPartitionLag()
     {
       return null;
     }
@@ -2882,13 +2877,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     }
 
     @Override
-    protected Map<String, Long> getRecordLagPerPartition(Map<String, String> currentOffsets)
-    {
-      return null;
-    }
-
-    @Override
-    protected Map<String, Long> getTimeLagPerPartition(Map<String, String> currentOffsets)
+    protected Pair<StreamPartitionLagType, Map<String, Long>> getLagPerPartition(Map<String, String> currentOffsets)
     {
       return null;
     }
@@ -3013,16 +3002,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     @Nullable
     @Override
-    protected Map<String, Long> getPartitionRecordLag()
+    protected Pair<StreamPartitionLagType, Map<String, Long>> getPartitionLag()
     {
-      return partitionsRecordLag;
-    }
-
-    @Nullable
-    @Override
-    protected Map<String, Long> getPartitionTimeLag()
-    {
-      return partitionsTimeLag;
+      return Pair.of(StreamPartitionLagType.RECORD_LAG, partitionsRecordLag);
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -1607,41 +1607,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   @Test
-  public void testEmitBothLag() throws Exception
-  {
-    expectEmitterSupervisor(false);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        TestEmittingTestSeekableStreamSupervisor.LAG,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
-    );
-
-
-    supervisor.start();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
-
-
-    latch.await();
-
-    final Map<String, Object> dimFilters = ImmutableMap.of(DruidMetrics.TAGS, METRIC_TAGS);
-    emitter.verifyValue("ingest/test/lag", dimFilters, 850L);
-    emitter.verifyValue("ingest/test/maxLag", dimFilters, 500L);
-    emitter.verifyValue("ingest/test/avgLag", dimFilters, 283L);
-    emitter.verifyValue("ingest/test/lag/time", dimFilters, 45000L);
-    emitter.verifyValue("ingest/test/maxLag/time", dimFilters, 20000L);
-    emitter.verifyValue("ingest/test/avgLag/time", dimFilters, 15000L);
-    verifyAll();
-  }
-
-  @Test
   public void testEmitRecordLag() throws Exception
   {
     expectEmitterSupervisor(false);
@@ -1650,8 +1615,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
         latch,
         TestEmittingTestSeekableStreamSupervisor.LAG,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        null
+        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L)
     );
 
     supervisor.start();
@@ -1669,39 +1633,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     emitter.verifyValue("ingest/test/lag", dimFilters, 850L);
     emitter.verifyValue("ingest/test/maxLag", dimFilters, 500L);
     emitter.verifyValue("ingest/test/avgLag", dimFilters, 283L);
-    verifyAll();
-  }
-
-  @Test
-  public void testEmitTimeLag() throws Exception
-  {
-    expectEmitterSupervisor(false);
-
-    CountDownLatch latch = new CountDownLatch(1);
-    TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
-        latch,
-        TestEmittingTestSeekableStreamSupervisor.LAG,
-        null,
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
-    );
-
-
-    supervisor.start();
-
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
-
-
-    latch.await();
-
-    final Map<String, Object> dimFilters = ImmutableMap.of(DruidMetrics.TAGS, METRIC_TAGS);
-    emitter.verifyValue("ingest/test/lag/time", dimFilters, 45000L);
-    emitter.verifyValue("ingest/test/maxLag/time", dimFilters, 20000L);
-    emitter.verifyValue("ingest/test/avgLag/time", dimFilters, 15000L);
-
     verifyAll();
   }
 
@@ -1714,7 +1645,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
         latch,
         TestEmittingTestSeekableStreamSupervisor.NOTICE_QUEUE,
-        null,
         null
     );
 
@@ -1747,7 +1677,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
         latch,
         TestEmittingTestSeekableStreamSupervisor.NOTICE_PROCESS,
-        null,
         null
     );
     supervisor.start();
@@ -1778,8 +1707,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestEmittingTestSeekableStreamSupervisor supervisor = new TestEmittingTestSeekableStreamSupervisor(
         latch,
         TestEmittingTestSeekableStreamSupervisor.LAG,
-        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L),
-        ImmutableMap.of("1", 10000L, "2", 15000L, "3", 20000L)
+        ImmutableMap.of("1", 100L, "2", 250L, "3", 500L)
     );
 
 
@@ -1797,9 +1725,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     emitter.verifyNotEmitted("ingest/test/lag");
     emitter.verifyNotEmitted("ingest/test/maxLag");
     emitter.verifyNotEmitted("ingest/test/avgLag");
-    emitter.verifyNotEmitted("ingest/test/lag/time");
-    emitter.verifyNotEmitted("ingest/test/maxLag/time");
-    emitter.verifyNotEmitted("ingest/test/avgLag/time");
 
     verifyAll();
   }
@@ -2449,7 +2374,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   @Test
-  public void testStaleOffsetsNegativeLagNotEmitted() throws Exception
+  public void testStaleOffsetsNegativeLagEmitted() throws Exception
   {
     expectEmitterSupervisor(false);
 
@@ -2459,8 +2384,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         latch,
         TestEmittingTestSeekableStreamSupervisor.LAG,
         // Record lag must not be emitted
-        ImmutableMap.of("0", 10L, "1", -100L),
-        null
+        ImmutableMap.of("0", 10L, "1", -100L)
     );
     supervisor.start();
     // Forcibly set the offsets to be stale
@@ -2469,7 +2393,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     latch.await();
 
     supervisor.emitLag();
-    Assert.assertEquals(0, emitter.getEvents().size());
+    Assert.assertTrue(emitter.getEvents().size() > 0);
   }
 
   private void validateSupervisorStateAfterResetOffsets(
@@ -2978,8 +2902,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private class TestEmittingTestSeekableStreamSupervisor extends BaseTestSeekableStreamSupervisor
   {
     private final CountDownLatch latch;
-    private final Map<String, Long> partitionsRecordLag;
-    private final Map<String, Long> partitionsTimeLag;
+    private final Map<String, Long> partitionsLag;
     private final byte metricFlag;
 
     private static final byte LAG = 0x01;
@@ -2990,21 +2913,19 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     TestEmittingTestSeekableStreamSupervisor(
         CountDownLatch latch,
         byte metricFlag,
-        Map<String, Long> partitionsRecordLag,
-        Map<String, Long> partitionsTimeLag
+        Map<String, Long> partitionsLag
     )
     {
       this.latch = latch;
       this.metricFlag = metricFlag;
-      this.partitionsRecordLag = partitionsRecordLag;
-      this.partitionsTimeLag = partitionsTimeLag;
+      this.partitionsLag = partitionsLag;
     }
 
     @Nullable
     @Override
     protected Pair<StreamPartitionLagType, Map<String, Long>> getPartitionLag()
     {
-      return Pair.of(StreamPartitionLagType.RECORD_LAG, partitionsRecordLag);
+      return Pair.of(StreamPartitionLagType.RECORD_LAG, partitionsLag);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #XXXX.
`
org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor
org.apache.druid.indexing.kafka.supervisor.KafkaSupervisor
org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisor.java
org.apache.druid.indexing.rabbitstream.supervisor.RabbitStreamSupervisor
`

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

**Problem 1: negtive lag issue for 2 scenarios**
S1: No issue for kafka, but there is occasional negative lag due to thread-safe issue. (we should fix this issue)
S2: If can't connect to kafka or kafka connection was broken, we can see negative lag. (negative is helpful to application, should not be skipped)


skip emitting if there was negative lag, this is bad idea. 
For S1, looks no impact on data ingestion, only emitter metrics is missing at few time points.
For S2, some companies already build monitoring based on the negative partition lag, if negative lag was not reported, their monitor will not work.
Back to the negative lag issue, I think we should fix it instead of skipping.


For S1, why there was negative lag?
In class `SeekableStreamSupervisor`:

updateCurrentAndLatestOffsets() : PT30S
--updateCurrentOffsets() -> get task reading offset : OFFSET1
--updatePartitionLagFromStream() -> get partition writing end offset : OFFSET2

in another thread:
/druid/indexer/v1/supervisor/<id>/status -> SeekableStreamSupervisor::getStatus() -> SeekableStreamSupervisor::generateReport() -> calculation lag = OFFSET2 - OFFSET1

When the negative lag issue happend? 
1) updateCurrentAndLatestOffsets() : executed
2) /druid/indexer/v1/supervisor/<id>/status : invoked
3) updatePartitionLagFromStream() : not executed


So the idea is we can make the OFFSET1 & OFFSET2  have the same version.



=================================================================================
**Problem 2: Bad design for getPartitionRecordLag() & getPartitionTimeLag()**

We want to support 2 kinds of partition lag, but like KafkaSupervisor, only need record partition lag. Like KinesisSupervisor, only need time partition lag.
For expansibility, if we want to add another type of partition lag, do we plan to add another method like: getPartition*Lag() ? 
And all the existing *Supervisor class need to implements the new method, sounds not make sense.
From the design pattern side, provide 1 method with returned type is better than provide 2 separated methods.


```
protected abstract Pair<StreamPartitionLagType, Map<PartitionIdType, Long>> getPartitionLag();
```
vs
```
protected abstract Map<PartitionIdType, Long> getPartitionRecordLag();
protected abstract Map<PartitionIdType, Long> getPartitionTimeLag();
```

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
