### PR TITLE
Fix formatting of error message from validateNoIllegalRightyJoins.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/QueryValidations.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/QueryValidations.java
@@ -75,7 +75,7 @@ public class QueryValidations
       if (shuttle.found != null) {
         throw new ValidationException(
             StringUtils.format(
-                "%s join is not supported by engine [%s] with %s: [%s]. Try %s: %s.",
+                "%s JOIN is not supported by engine[%s] with %s[%s]. Try %s[%s].",
                 shuttle.found.getJoinType(),
                 plannerContext.getEngine().name(),
                 PlannerContext.CTX_SQL_JOIN_ALGORITHM,


### PR DESCRIPTION
The prior formatting was inconsistent in terms of punctuation and capitalization.