### PR TITLE
abstract `IncrementalIndex` cursor stuff to prepare for using different "views" of the data based on the cursor build spec

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/FactsHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/FactsHolder.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.incremental;
+
+import java.util.Comparator;
+import java.util.Iterator;
+
+/**
+ * {@link IncrementalIndexRow} storage interface, a mutable data structure for building up a set or rows to eventually
+ * persist into an immutable segment
+ *
+ * @see IncrementalIndex for the data processor which constructs {@link IncrementalIndexRow} to store here
+ */
+public interface FactsHolder
+{
+  /**
+   * @return the previous rowIndex associated with the specified key, or
+   * {@link IncrementalIndexRow#EMPTY_ROW_INDEX} if there was no mapping for the key.
+   */
+  int getPriorIndex(IncrementalIndexRow key);
+
+  /**
+   * Get minimum {@link IncrementalIndexRow#getTimestamp()} present in the facts holder
+   */
+  long getMinTimeMillis();
+
+  /**
+   * Get maximum {@link IncrementalIndexRow#getTimestamp()} present in the facts holder
+   */
+  long getMaxTimeMillis();
+
+  /**
+   * Get all {@link IncrementalIndex}, depending on the implementation, these rows may or may not be ordered in the same
+   * order they will be persisted in. Use {@link #persistIterable()} if this is required.
+   */
+  Iterator<IncrementalIndexRow> iterator(boolean descending);
+
+  /**
+   * Get all {@link IncrementalIndexRow} with {@link IncrementalIndexRow#getTimestamp()} between the start and end
+   * timestamps specified
+   */
+  Iterable<IncrementalIndexRow> timeRangeIterable(boolean descending, long timeStart, long timeEnd);
+
+  /**
+   * Get all row {@link IncrementalIndexRow} 'keys', which is distinct groups if this is an aggregating facts holder or
+   * just every row present if not
+   */
+  Iterable<IncrementalIndexRow> keySet();
+
+  /**
+   * Get all {@link IncrementalIndexRow} to persist, ordered with {@link Comparator <IncrementalIndexRow>}
+   */
+  Iterable<IncrementalIndexRow> persistIterable();
+
+  /**
+   * @return the previous rowIndex associated with the specified key, or
+   * {@link IncrementalIndexRow#EMPTY_ROW_INDEX} if there was no mapping for the key.
+   */
+  int putIfAbsent(IncrementalIndexRow key, int rowIndex);
+
+  /**
+   * Clear all rows present in the facts holder
+   */
+  void clear();
+}

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -772,9 +772,9 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
   }
 
   @Override
-  public int getTimePosition()
+  public List<OrderBy> getOrdering()
   {
-    return timePosition;
+    return metadata.getOrdering();
   }
 
   public static ColumnValueSelector<?> makeMetricColumnValueSelector(

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -822,13 +822,6 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
     return isEmpty() ? null : DateTimes.utc(getMaxTimeMillis());
   }
 
-  @Nullable
-  public Integer getDimensionIndex(String dimension)
-  {
-    DimensionDesc dimSpec = getDimension(dimension);
-    return dimSpec == null ? null : dimSpec.getIndex();
-  }
-
   /**
    * Returns names of time and dimension columns, in persist sort order. Includes {@link ColumnHolder#TIME_COLUMN_NAME}.
    */

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactory.java
@@ -99,9 +99,9 @@ public class IncrementalIndexCursorFactory implements CursorFactory
     return snapshotColumnCapabilities(index, column);
   }
 
-  static ColumnCapabilities snapshotColumnCapabilities(IncrementalIndex index, String column)
+  static ColumnCapabilities snapshotColumnCapabilities(IncrementalIndexRowSelector selector, String column)
   {
-    IncrementalIndex.DimensionDesc desc = index.getDimension(column);
+    IncrementalIndex.DimensionDesc desc = selector.getDimension(column);
     // nested column indexer is a liar, and behaves like any type if it only processes unnested literals of a single
     // type, so force it to use nested column type
     if (desc != null && desc.getIndexer() instanceof NestedDataColumnIndexerV4) {
@@ -122,7 +122,7 @@ public class IncrementalIndexCursorFactory implements CursorFactory
     // multi-valuedness at cursor creation time, instead of the latest state, and getSnapshotColumnCapabilities could
     // be removed.
     return ColumnCapabilitiesImpl.snapshot(
-        index.getColumnCapabilities(column),
+        selector.getColumnCapabilities(column),
         COERCE_LOGIC
     );
   }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorHolder.java
@@ -23,36 +23,32 @@ import com.google.common.collect.Iterators;
 import org.apache.druid.query.BaseQuery;
 import org.apache.druid.query.Order;
 import org.apache.druid.query.OrderBy;
-import org.apache.druid.query.filter.Filter;
 import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.CursorBuildSpec;
 import org.apache.druid.segment.CursorHolder;
 import org.apache.druid.segment.Cursors;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.filter.ValueMatchers;
-import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 public class IncrementalIndexCursorHolder implements CursorHolder
 {
-  private final IncrementalIndex index;
+  private final IncrementalIndexRowSelector rowSelector;
   private final CursorBuildSpec spec;
   private final List<OrderBy> ordering;
 
   public IncrementalIndexCursorHolder(
-      IncrementalIndex index,
+      IncrementalIndexRowSelector rowSelector,
       CursorBuildSpec spec
   )
   {
-    this.index = index;
+    this.rowSelector = rowSelector;
     this.spec = spec;
-    if (index.timePosition == 0) {
+    if (rowSelector.getTimePosition() == 0) {
       if (Cursors.preferDescendingTimeOrdering(spec)) {
         this.ordering = Cursors.descendingTimeOrder();
       } else {
@@ -68,7 +64,7 @@ public class IncrementalIndexCursorHolder implements CursorHolder
   @Override
   public Cursor asCursor()
   {
-    if (index.isEmpty()) {
+    if (rowSelector.isEmpty()) {
       return null;
     }
 
@@ -76,13 +72,10 @@ public class IncrementalIndexCursorHolder implements CursorHolder
       spec.getQueryMetrics().vectorized(false);
     }
 
-
     return new IncrementalIndexCursor(
-        index,
-        spec.getVirtualColumns(),
-        Cursors.getTimeOrdering(ordering),
-        spec.getFilter(),
-        spec.getInterval()
+        rowSelector,
+        spec,
+        Cursors.getTimeOrdering(ordering)
     );
   }
 
@@ -94,11 +87,11 @@ public class IncrementalIndexCursorHolder implements CursorHolder
 
   static class IncrementalIndexCursor implements Cursor
   {
-    private IncrementalIndexRowHolder currEntry;
+    private final IncrementalIndexRowSelector rowSelector;
+    private final IncrementalIndexRowHolder currEntry;
     private final ColumnSelectorFactory columnSelectorFactory;
     private final ValueMatcher filterMatcher;
     private final int maxRowIndex;
-    private final IncrementalIndex.FactsHolder facts;
     private Iterator<IncrementalIndexRow> baseIter;
     private Iterable<IncrementalIndexRow> cursorIterable;
     private boolean emptyRange;
@@ -106,30 +99,31 @@ public class IncrementalIndexCursorHolder implements CursorHolder
     private boolean done;
 
     IncrementalIndexCursor(
-        IncrementalIndex index,
-        VirtualColumns virtualColumns,
-        Order timeOrder,
-        @Nullable Filter filter,
-        Interval actualInterval
+        IncrementalIndexRowSelector index,
+        CursorBuildSpec buildSpec,
+        Order timeOrder
     )
     {
       currEntry = new IncrementalIndexRowHolder();
+      // Set maxRowIndex before creating the filterMatcher. See https://github.com/apache/druid/pull/6340
+      maxRowIndex = index.getLastRowIndex();
+      numAdvanced = -1;
+
+      rowSelector = index;
+      cursorIterable = rowSelector.getFacts().timeRangeIterable(
+          timeOrder == Order.DESCENDING,
+          buildSpec.getInterval().getStartMillis(),
+          buildSpec.getInterval().getEndMillis()
+      );
       columnSelectorFactory = new IncrementalIndexColumnSelectorFactory(
-          index,
-          virtualColumns,
+          rowSelector,
+          buildSpec.getVirtualColumns(),
           timeOrder,
           currEntry
       );
-      // Set maxRowIndex before creating the filterMatcher. See https://github.com/apache/druid/pull/6340
-      maxRowIndex = index.getLastRowIndex();
-      filterMatcher = filter == null ? ValueMatchers.allTrue() : filter.makeMatcher(columnSelectorFactory);
-      numAdvanced = -1;
-      facts = index.getFacts();
-      cursorIterable = facts.timeRangeIterable(
-          timeOrder == Order.DESCENDING,
-          actualInterval.getStartMillis(),
-          actualInterval.getEndMillis()
-      );
+      filterMatcher = buildSpec.getFilter() == null
+                      ? ValueMatchers.allTrue()
+                      : buildSpec.getFilter().makeMatcher(columnSelectorFactory);
       emptyRange = !cursorIterable.iterator().hasNext();
 
       reset();
@@ -152,7 +146,7 @@ public class IncrementalIndexCursorHolder implements CursorHolder
       while (baseIter.hasNext()) {
         BaseQuery.checkInterrupted();
 
-        IncrementalIndexRow entry = baseIter.next();
+        final IncrementalIndexRow entry = baseIter.next();
         if (beyondMaxRowIndex(entry.getRowIndex())) {
           continue;
         }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexCursorHolder.java
@@ -31,7 +31,6 @@ import org.apache.druid.segment.CursorHolder;
 import org.apache.druid.segment.Cursors;
 import org.apache.druid.segment.filter.ValueMatchers;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -48,16 +47,15 @@ public class IncrementalIndexCursorHolder implements CursorHolder
   {
     this.rowSelector = rowSelector;
     this.spec = spec;
-    if (rowSelector.getTimePosition() == 0) {
+    List<OrderBy> ordering = rowSelector.getOrdering();
+    if (Cursors.getTimeOrdering(ordering) != Order.NONE) {
       if (Cursors.preferDescendingTimeOrdering(spec)) {
         this.ordering = Cursors.descendingTimeOrder();
       } else {
         this.ordering = Cursors.ascendingTimeOrder();
       }
     } else {
-      // In principle, we could report a sort order here for certain types of fact holders; for example the
-      // RollupFactsHolder would be sorted by dimensions. However, this is left for future work.
-      this.ordering = Collections.emptyList();
+      this.ordering = ordering;
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRow.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRow.java
@@ -144,6 +144,8 @@ public final class IncrementalIndexRow
           {
             if (input == null || (input.getClass().isArray() && Array.getLength(input) == 0)) {
               return Collections.singletonList("null");
+            } else if (input instanceof int[]) {
+              return Arrays.toString((int[]) input);
             }
             return Collections.singletonList(input);
           }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRowSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRowSelector.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.incremental;
+
+import org.apache.druid.segment.ColumnInspector;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface that abstracts selecting data from a {@link FactsHolder}
+ */
+public interface IncrementalIndexRowSelector extends ColumnInspector
+{
+  /**
+   * get {@link IncrementalIndex.DimensionDesc} for the specified column, if available, which provides access to things
+   * like {@link org.apache.druid.segment.DimensionIndexer} and {@link org.apache.druid.segment.DimensionHandler} as
+   * well as column capabilities and position within the row
+   */
+  @Nullable
+  IncrementalIndex.DimensionDesc getDimension(String columnName);
+
+  /**
+   * Get {@link IncrementalIndex.MetricDesc} which provides column capabilities and position in the aggregators section
+   * of the row
+   */
+  @Nullable
+  IncrementalIndex.MetricDesc getMetric(String s);
+
+  /**
+   * Position of {@link org.apache.druid.segment.column.ColumnHolder#TIME_COLUMN_NAME} in the dimensions list
+   */
+  int getTimePosition();
+
+  /**
+   * Are there any {@link IncrementalIndexRow} stored in the {@link FactsHolder}?
+   */
+  boolean isEmpty();
+
+  /**
+   * Get the {@link FactsHolder} containing all of the {@link IncrementalIndexRow} backing this selector
+   */
+  FactsHolder getFacts();
+
+  /**
+   * Highest value {@link IncrementalIndexRow#getRowIndex()} available in this selector. Note that these values do not
+   * reflect the position of the row in the {@link FactsHolder}, rather just the order in which they were processed
+   */
+  int getLastRowIndex();
+
+  /**
+   * @param rowOffset row to get float aggregator value
+   * @param aggOffset position of the aggregator in the aggregators array of the data schema
+   * @return          float value of the metric
+   */
+  float getMetricFloatValue(int rowOffset, int aggOffset);
+
+  /**
+   * @param rowOffset row to get long aggregator value
+   * @param aggOffset position of the aggregator in the aggregators array of the data schema
+   * @return          long value of the aggregator for this row
+   */
+  long getMetricLongValue(int rowOffset, int aggOffset);
+
+  /**
+   * @param rowOffset row to get double aggregator value
+   * @param aggOffset position of the aggregator in the aggregators array of the data schema
+   * @return          double value of the aggregator for this row
+   */
+  double getMetricDoubleValue(int rowOffset, int aggOffset);
+
+  /**
+   * @param rowOffset row to get long aggregator value
+   * @param aggOffset position of the aggregator in the aggregators array of the data schema
+   * @return          long value of the aggregator for this row
+   */
+  @Nullable
+  Object getMetricObjectValue(int rowOffset, int aggOffset);
+
+  /**
+   * @param rowOffset row to check for a aggregator value
+   * @param aggOffset position of the aggregator in the aggregators array of the data schema
+   * @return          is the value null for this row?
+   */
+  boolean isNull(int rowOffset, int aggOffset);
+}

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRowSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndexRowSelector.java
@@ -19,9 +19,11 @@
 
 package org.apache.druid.segment.incremental;
 
+import org.apache.druid.query.OrderBy;
 import org.apache.druid.segment.ColumnInspector;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * Interface that abstracts selecting data from a {@link FactsHolder}
@@ -44,9 +46,9 @@ public interface IncrementalIndexRowSelector extends ColumnInspector
   IncrementalIndex.MetricDesc getMetric(String s);
 
   /**
-   * Position of {@link org.apache.druid.segment.column.ColumnHolder#TIME_COLUMN_NAME} in the dimensions list
+   * Ordering for the data in the facts table
    */
-  int getTimePosition();
+  List<OrderBy> getOrdering();
 
   /**
    * Are there any {@link IncrementalIndexRow} stored in the {@link FactsHolder}?

--- a/processing/src/test/java/org/apache/druid/frame/processor/test/TestFrameProcessorUtils.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/test/TestFrameProcessorUtils.java
@@ -26,10 +26,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.testutil.FrameSequenceBuilder;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.CursorFactory;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
@@ -48,15 +45,11 @@ public final class TestFrameProcessorUtils
   {
     final IncrementalIndex index = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(
-            new IncrementalIndexSchema(
-                0,
-                new TimestampSpec("__time", "millis", null),
-                Granularities.NONE,
-                VirtualColumns.EMPTY,
-                DimensionsSpec.builder().useSchemaDiscovery(true).build(),
-                new AggregatorFactory[0],
-                false
-            )
+            IncrementalIndexSchema.builder()
+                                  .withTimestampSpec(new TimestampSpec("__time", "millis", null))
+                                  .withDimensionsSpec(DimensionsSpec.builder().useSchemaDiscovery(true).build())
+                                  .withRollup(false)
+                                  .build()
         )
         .setMaxRowCount(1000)
         .build();

--- a/processing/src/test/java/org/apache/druid/segment/AutoTypeColumnIndexerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/AutoTypeColumnIndexerTest.java
@@ -26,8 +26,6 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.guice.BuiltInTypesModule;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.column.ColumnType;
@@ -494,18 +492,17 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     long minTimestamp = System.currentTimeMillis();
     IncrementalIndex index = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(
-            new IncrementalIndexSchema(
-                minTimestamp,
-                new TimestampSpec(TIME_COL, "millis", null),
-                Granularities.NONE,
-                VirtualColumns.EMPTY,
-                DimensionsSpec.builder()
-                              .setDimensions(ImmutableList.of(new AutoTypeColumnSchema(NESTED_COL, ColumnType.STRING)))
-                              .useSchemaDiscovery(true)
-                              .build(),
-                new AggregatorFactory[0],
-                false
-            )
+            IncrementalIndexSchema.builder()
+                                  .withMinTimestamp(minTimestamp)
+                                  .withTimestampSpec(new TimestampSpec(TIME_COL, "millis", null))
+                                  .withDimensionsSpec(
+                                      DimensionsSpec.builder()
+                                                    .setDimensions(ImmutableList.of(new AutoTypeColumnSchema(NESTED_COL, ColumnType.STRING)))
+                                                    .useSchemaDiscovery(true)
+                                                    .build()
+                                  )
+                                  .withRollup(false)
+                                  .build()
         )
         .setMaxRowCount(1000)
         .build();
@@ -699,15 +696,16 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
   {
     IncrementalIndex index = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(
-            new IncrementalIndexSchema(
-                minTimestamp,
-                new TimestampSpec(TIME_COL, "millis", null),
-                Granularities.NONE,
-                VirtualColumns.EMPTY,
-                DimensionsSpec.builder().useSchemaDiscovery(true).build(),
-                new AggregatorFactory[0],
-                false
-            )
+            IncrementalIndexSchema.builder()
+                                  .withMinTimestamp(minTimestamp)
+                                  .withTimestampSpec(new TimestampSpec(TIME_COL, "millis", null))
+                                  .withDimensionsSpec(
+                                      DimensionsSpec.builder()
+                                                    .useSchemaDiscovery(true)
+                                                    .build()
+                                  )
+                                  .withRollup(false)
+                                  .build()
         )
         .setMaxRowCount(1000)
         .build();

--- a/processing/src/test/java/org/apache/druid/segment/NestedDataColumnIndexerV4Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/NestedDataColumnIndexerV4Test.java
@@ -26,8 +26,6 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.guice.BuiltInTypesModule;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.segment.column.ColumnType;
@@ -478,15 +476,16 @@ public class NestedDataColumnIndexerV4Test extends InitializedNullHandlingTest
   {
     IncrementalIndex index = new OnheapIncrementalIndex.Builder()
         .setIndexSchema(
-            new IncrementalIndexSchema(
-                minTimestamp,
-                new TimestampSpec(TIME_COL, "millis", null),
-                Granularities.NONE,
-                VirtualColumns.EMPTY,
-                DimensionsSpec.builder().useSchemaDiscovery(true).build(),
-                new AggregatorFactory[0],
-                false
-            )
+            IncrementalIndexSchema.builder()
+                                  .withMinTimestamp(minTimestamp)
+                                  .withTimestampSpec(new TimestampSpec(TIME_COL, "millis", null))
+                                  .withDimensionsSpec(
+                                      DimensionsSpec.builder()
+                                                    .useSchemaDiscovery(true)
+                                                    .build()
+                                  )
+                                  .withRollup(false)
+                                  .build()
         )
         .setMaxRowCount(1000)
         .build();

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexIngestionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexIngestionTest.java
@@ -25,9 +25,12 @@ import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.guice.BuiltInTypesModule;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.Aggregator;
+import org.apache.druid.query.aggregation.AggregatorAndSize;
 import org.apache.druid.query.aggregation.LongMaxAggregator;
 import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
 import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.ColumnSelectorFactory;
+import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
 import org.junit.Rule;
@@ -69,22 +72,39 @@ public class IncrementalIndexIngestionTest extends InitializedNullHandlingTest
   {
     // Prepare the mocks & set close() call count expectation to 1
     Aggregator mockedAggregator = EasyMock.createMock(LongMaxAggregator.class);
+    EasyMock.expect(mockedAggregator.aggregateWithSize()).andReturn(0L).anyTimes();
     mockedAggregator.close();
     EasyMock.expectLastCall().times(1);
 
-    final IncrementalIndex genericIndex = indexCreator.createIndex(
+
+    EasyMock.replay(mockedAggregator);
+
+    final IncrementalIndex incrementalIndex = indexCreator.createIndex(
         new IncrementalIndexSchema.Builder()
             .withQueryGranularity(Granularities.MINUTE)
-            .withMetrics(new LongMaxAggregatorFactory("max", "max"))
+            .withMetrics(new LongMaxAggregatorFactory("max", "max")
+            {
+              @Override
+              protected Aggregator factorize(ColumnSelectorFactory metricFactory, ColumnValueSelector selector)
+              {
+                return mockedAggregator;
+              }
+
+              @Override
+              public AggregatorAndSize factorizeWithSize(ColumnSelectorFactory metricFactory)
+              {
+                return new AggregatorAndSize(mockedAggregator, Long.BYTES);
+              }
+            })
             .build()
     );
 
     // This test is specific to the on-heap index
-    if (!(genericIndex instanceof OnheapIncrementalIndex)) {
+    if (!(incrementalIndex instanceof OnheapIncrementalIndex)) {
       return;
     }
 
-    final OnheapIncrementalIndex index = (OnheapIncrementalIndex) genericIndex;
+    final OnheapIncrementalIndex index = (OnheapIncrementalIndex) incrementalIndex;
 
     index.add(new MapBasedInputRow(
             0,
@@ -92,11 +112,7 @@ public class IncrementalIndexIngestionTest extends InitializedNullHandlingTest
             ImmutableMap.of("billy", 1, "max", 1)
     ));
 
-    // override the aggregators with the mocks
-    index.concurrentGet(0)[0] = mockedAggregator;
-
     // close the indexer and validate the expectations
-    EasyMock.replay(mockedAggregator);
     index.close();
     EasyMock.verify(mockedAggregator);
   }

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
@@ -28,10 +28,7 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.guice.BuiltInTypesModule;
-import org.apache.druid.java.util.common.granularity.Granularities;
-import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.CloserRule;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -80,15 +77,11 @@ public class IncrementalIndexMultiValueSpecTest extends InitializedNullHandlingT
             new StringDimensionSchema("string3", DimensionSchema.MultiValueHandling.SORTED_SET, true)
         )
     );
-    IncrementalIndexSchema schema = new IncrementalIndexSchema(
-        0,
-        new TimestampSpec("ds", "auto", null),
-        Granularities.ALL,
-        VirtualColumns.EMPTY,
-        dimensionsSpec,
-        new AggregatorFactory[0],
-        false
-    );
+    IncrementalIndexSchema schema = IncrementalIndexSchema.builder()
+                                                          .withTimestampSpec(new TimestampSpec("ds", "auto", null))
+                                                          .withDimensionsSpec(dimensionsSpec)
+                                                          .withRollup(false)
+                                                          .build();
     Map<String, Object> map = new HashMap<String, Object>()
     {
       @Override

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.common.guava.SettableSupplier;
 import org.apache.druid.data.input.MapBasedInputRow;
-import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -50,7 +49,6 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.TestObjectColumnSelector;
-import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
@@ -620,15 +618,10 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     // underlying dimension selector.
     // This occurred during schemaless ingestion with spare dimension values and no explicit null rows, so the
     // conditions are replicated by this test. See https://github.com/apache/druid/pull/10248 for details
-    IncrementalIndexSchema schema = new IncrementalIndexSchema(
-        0,
-        new TimestampSpec("time", "millis", DateTimes.nowUtc()),
-        Granularities.NONE,
-        VirtualColumns.EMPTY,
-        DimensionsSpec.EMPTY,
-        new AggregatorFactory[]{new CountAggregatorFactory("count")},
-        true
-    );
+    IncrementalIndexSchema schema = IncrementalIndexSchema.builder()
+                                                          .withTimestampSpec(new TimestampSpec("time", "millis", DateTimes.nowUtc()))
+                                                          .withMetrics(new AggregatorFactory[]{new CountAggregatorFactory("count")})
+                                                          .build();
 
     IncrementalIndex index = new OnheapIncrementalIndex.Builder().setMaxRowCount(100).setIndexSchema(schema).build();
     index.add(


### PR DESCRIPTION
changes:
* introduce `IncrementalIndexRowSelector` interface to capture how `IncrementalIndexCursor` and `IncrementalIndexColumnSelectorFactory` read data
* `IncrementalIndex` implements `IncrementalIndexRowSelector`
* move `FactsHolder` interface to separate file
* other minor refactorings