### PR TITLE
Handle memory leaks from Mockito inline mocks

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -381,6 +381,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
   @AfterEach
   public void tearDown2()
   {
+    Mockito.framework().clearInlineMocks();
     groupByBuffers.close();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1765,7 +1765,7 @@
                             @{jacocoArgLine}
                             ${jdk.strong.encapsulation.argLine}
                             ${jdk.security.manager.allow.argLine}
-                            -Xmx2500m
+                            -Xmx2048m
                             -XX:MaxDirectMemorySize=2500m
                             -XX:+ExitOnOutOfMemoryError
                             -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
### Description

In https://github.com/apache/druid/pull/17056, we increased the test JVM max heap from 2 GB to 2.5 GB as we were running into OOM issues in some tests. It was a temporary measure to unblock the CI/CD pipeline.

On digging into the heap dump, the issue seems similar to https://github.com/mockito/mockito/issues/2503, and the suggestion was to use `Mockito.framework().clearInlineMocks()`.

This PR adds `Mockito.framework().clearInlineMocks()` to `MSQTestBase#AfterEach` to handle the memory leaks from Mockito's inline mocks, and reduces the test JVM max heap back to 2 GB.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
