### PR TITLE
Fix Multiple GC declared error when running Druid Cluster

### DIFF
--- a/examples/conf/druid/auto/_common/common.jvm.config
+++ b/examples/conf/druid/auto/_common/common.jvm.config
@@ -1,6 +1,5 @@
 -server
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/cluster/master/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/cluster/master/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms15g
 -Xmx15g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/cluster/query/router/jvm.config
+++ b/examples/conf/druid/cluster/query/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms1g
 -Xmx1g
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/large/broker/jvm.config
+++ b/examples/conf/druid/single-server/large/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx12g
 -XX:MaxDirectMemorySize=11g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/large/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/large/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms15g
 -Xmx15g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/large/historical/jvm.config
+++ b/examples/conf/druid/single-server/large/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx16g
 -XX:MaxDirectMemorySize=25g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/large/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/large/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms256m
 -Xmx256m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/large/router/jvm.config
+++ b/examples/conf/druid/single-server/large/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms1g
 -Xmx1g
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/medium/broker/jvm.config
+++ b/examples/conf/druid/single-server/medium/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx8g
 -XX:MaxDirectMemorySize=5g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/medium/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/medium/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms9g
 -Xmx9g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/medium/historical/jvm.config
+++ b/examples/conf/druid/single-server/medium/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx8g
 -XX:MaxDirectMemorySize=13g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/medium/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/medium/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms256m
 -Xmx256m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/medium/router/jvm.config
+++ b/examples/conf/druid/single-server/medium/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms512m
 -Xmx512m
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/micro-quickstart/broker/jvm.config
+++ b/examples/conf/druid/single-server/micro-quickstart/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx512m
 -XX:MaxDirectMemorySize=768m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/micro-quickstart/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/micro-quickstart/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms256m
 -Xmx256m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/micro-quickstart/historical/jvm.config
+++ b/examples/conf/druid/single-server/micro-quickstart/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx512m
 -XX:MaxDirectMemorySize=1280m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/micro-quickstart/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/micro-quickstart/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms64m
 -Xmx64m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/micro-quickstart/router/jvm.config
+++ b/examples/conf/druid/single-server/micro-quickstart/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms128m
 -Xmx128m
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/nano-quickstart/broker/jvm.config
+++ b/examples/conf/druid/single-server/nano-quickstart/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx512m
 -XX:MaxDirectMemorySize=400m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/nano-quickstart/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/nano-quickstart/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms256m
 -Xmx256m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/nano-quickstart/historical/jvm.config
+++ b/examples/conf/druid/single-server/nano-quickstart/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx512m
 -XX:MaxDirectMemorySize=400m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/nano-quickstart/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/nano-quickstart/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms64m
 -Xmx64m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/nano-quickstart/router/jvm.config
+++ b/examples/conf/druid/single-server/nano-quickstart/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms128m
 -Xmx128m
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/small/broker/jvm.config
+++ b/examples/conf/druid/single-server/small/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx4g
 -XX:MaxDirectMemorySize=3g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/small/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/small/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms4500m
 -Xmx4500m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/small/historical/jvm.config
+++ b/examples/conf/druid/single-server/small/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx4g
 -XX:MaxDirectMemorySize=8g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/small/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/small/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms128m
 -Xmx128m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/small/router/jvm.config
+++ b/examples/conf/druid/single-server/small/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms512m
 -Xmx512m
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC

--- a/examples/conf/druid/single-server/small/router/jvm.config
+++ b/examples/conf/druid/single-server/small/router/jvm.config
@@ -4,7 +4,6 @@
 -XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/xlarge/broker/jvm.config
+++ b/examples/conf/druid/single-server/xlarge/broker/jvm.config
@@ -3,7 +3,6 @@
 -Xmx16g
 -XX:MaxDirectMemorySize=12g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/xlarge/coordinator-overlord/jvm.config
+++ b/examples/conf/druid/single-server/xlarge/coordinator-overlord/jvm.config
@@ -2,7 +2,6 @@
 -Xms18g
 -Xmx18g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/xlarge/historical/jvm.config
+++ b/examples/conf/druid/single-server/xlarge/historical/jvm.config
@@ -3,7 +3,6 @@
 -Xmx24g
 -XX:MaxDirectMemorySize=44g
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/xlarge/middleManager/jvm.config
+++ b/examples/conf/druid/single-server/xlarge/middleManager/jvm.config
@@ -2,7 +2,6 @@
 -Xms256m
 -Xmx256m
 -XX:+ExitOnOutOfMemoryError
--XX:+UseG1GC
 -Duser.timezone=UTC
 -Dfile.encoding=UTF-8
 -Djava.io.tmpdir=var/tmp

--- a/examples/conf/druid/single-server/xlarge/router/jvm.config
+++ b/examples/conf/druid/single-server/xlarge/router/jvm.config
@@ -1,7 +1,6 @@
 -server
 -Xms1g
 -Xmx1g
--XX:+UseG1GC
 -XX:MaxDirectMemorySize=128m
 -XX:+ExitOnOutOfMemoryError
 -Duser.timezone=UTC


### PR DESCRIPTION
### Description

This problem surfaced when I am attempting to get MM-less Druid running on ZGC with Kubernetes. 

After declaring `-XX:+UseZGC` under `JAVA_OPTS` for my services, I faced the following error for only the Coordinator, Overlord and Router:
"Error occurred during initialization of VM, Multiple garbage collectors selected". 

It turns out that the declaration of the G1GC in the cluster configuration causes the error to surface. I also find it weird that this G1GC configuration is only in the Coordinator/Overlord and Router configuration. By removing the G1GC configuration, I am able to run my cluster with ZGC. 

Since G1GC is the default option, there will be no change to Druid's default GC with this removal.

#### Fixed the multiple GC declared error.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Allow Druid to run non-G1 Garbage Collectors with `JAVA_OPTS`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
