### PR TITLE
Add support for compressed kinesis data

### DIFF
--- a/docs/ingestion/kinesis-ingestion.md
+++ b/docs/ingestion/kinesis-ingestion.md
@@ -55,6 +55,7 @@ The following example shows a supervisor spec for a stream with the name `Kinesi
       "inputFormat": {
         "type": "json"
       },
+      "compressionFormat": "zstd",
       "useEarliestSequenceNumber": true
     },
     "tuningConfig": {
@@ -147,6 +148,12 @@ The Kinesis indexing service supports the following values for `inputFormat`:
 * `protobuf`
 
 You can use `parser` to read [`thrift`](../development/extensions-contrib/thrift.md) formats.
+
+### Compression
+
+Unlike Kafka, Kinesis does not offer built in compression. Due to the operational costs of operating Kinesis streams at scale, you may find it advantageous to compress incoming data.
+
+Druid supports `bz2`, `gz`, `snappy`, `xz`, `zip`, and `zstd` compressed kinesis data. If your incoming data is compressed, include the compression type in the `compressionFormat` field. 
 
 ### Tuning configuration
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -145,7 +145,8 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, Ki
         tuningConfig.getRecordBufferFullWait(),
         maxBytesPerPoll,
         false,
-        useListShards
+        useListShards,
+        ioConfig.getCompressionFormat()
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskIOConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskIOConfig.java
@@ -27,6 +27,7 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskIOConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
+import org.apache.druid.utils.CompressionUtils;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -53,6 +54,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
 
   private final String awsAssumedRoleArn;
   private final String awsExternalId;
+  private final CompressionUtils.Format compressionFormat;
 
   @JsonCreator
   public KinesisIndexTaskIOConfig(
@@ -78,7 +80,8 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
       @JsonProperty("endpoint") String endpoint,
       @JsonProperty("fetchDelayMillis") Integer fetchDelayMillis,
       @JsonProperty("awsAssumedRoleArn") String awsAssumedRoleArn,
-      @JsonProperty("awsExternalId") String awsExternalId
+      @JsonProperty("awsExternalId") String awsExternalId,
+      @JsonProperty("compressionFormat") CompressionUtils.Format compressionFormat
   )
   {
     super(
@@ -103,6 +106,7 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
     this.fetchDelayMillis = fetchDelayMillis != null ? fetchDelayMillis : DEFAULT_FETCH_DELAY_MILLIS;
     this.awsAssumedRoleArn = awsAssumedRoleArn;
     this.awsExternalId = awsExternalId;
+    this.compressionFormat = compressionFormat;
   }
 
   public KinesisIndexTaskIOConfig(
@@ -117,7 +121,8 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
       String endpoint,
       Integer fetchDelayMillis,
       String awsAssumedRoleArn,
-      String awsExternalId
+      String awsExternalId,
+      CompressionUtils.Format compressionFormat
   )
   {
     this(
@@ -135,7 +140,8 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
         endpoint,
         fetchDelayMillis,
         awsAssumedRoleArn,
-        awsExternalId
+        awsExternalId,
+        compressionFormat
     );
   }
 
@@ -223,6 +229,13 @@ public class KinesisIndexTaskIOConfig extends SeekableStreamIndexTaskIOConfig<St
   public String getAwsExternalId()
   {
     return awsExternalId;
+  }
+
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public CompressionUtils.Format getCompressionFormat()
+  {
+    return compressionFormat;
   }
 
   @Override

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
@@ -80,7 +80,8 @@ public class KinesisSamplerSpec extends SeekableStreamSamplerSpec
         tuningConfig.getRecordBufferFullWait(),
         tuningConfig.getMaxBytesPerPollOrDefault(),
         ioConfig.isUseEarliestSequenceNumber(),
-        tuningConfig.isUseListShards()
+        tuningConfig.isUseListShards(),
+        ioConfig.getCompressionFormat()
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisor.java
@@ -145,7 +145,8 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
         ioConfig.getEndpoint(),
         ioConfig.getFetchDelayMillis(),
         ioConfig.getAwsAssumedRoleArn(),
-        ioConfig.getAwsExternalId()
+        ioConfig.getAwsExternalId(),
+        ioConfig.getCompressionFormat()
     );
   }
 
@@ -202,7 +203,8 @@ public class KinesisSupervisor extends SeekableStreamSupervisor<String, String, 
         taskTuningConfig.getRecordBufferFullWait(),
         taskTuningConfig.getMaxBytesPerPollOrDefault(),
         ioConfig.isUseEarliestSequenceNumber(),
-        spec.getSpec().getTuningConfig().isUseListShards()
+        spec.getSpec().getTuningConfig().isUseListShards(),
+        spec.getSpec().getIOConfig().getCompressionFormat()
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfig.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfig.java
@@ -29,6 +29,7 @@ import org.apache.druid.indexing.kinesis.KinesisRegion;
 import org.apache.druid.indexing.seekablestream.supervisor.IdleConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
+import org.apache.druid.utils.CompressionUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 
@@ -54,6 +55,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
   private final String awsAssumedRoleArn;
   private final String awsExternalId;
   private final boolean deaggregate;
+  private final CompressionUtils.Format compressionFormat;
 
   @JsonCreator
   public KinesisSupervisorIOConfig(
@@ -76,7 +78,8 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
       @JsonProperty("awsAssumedRoleArn") String awsAssumedRoleArn,
       @JsonProperty("awsExternalId") String awsExternalId,
       @Nullable @JsonProperty("autoScalerConfig") AutoScalerConfig autoScalerConfig,
-      @JsonProperty("deaggregate") @Deprecated boolean deaggregate
+      @JsonProperty("deaggregate") @Deprecated boolean deaggregate,
+      @JsonProperty("compressionFormat") CompressionUtils.Format compressionFormat
   )
   {
     super(
@@ -107,6 +110,7 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
     this.awsAssumedRoleArn = awsAssumedRoleArn;
     this.awsExternalId = awsExternalId;
     this.deaggregate = deaggregate;
+    this.compressionFormat = compressionFormat;
   }
 
   @JsonProperty
@@ -151,6 +155,13 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
     return deaggregate;
   }
 
+  @Nullable
+  @JsonProperty
+  public CompressionUtils.Format getCompressionFormat()
+  {
+    return compressionFormat;
+  }
+
   @Override
   public String toString()
   {
@@ -172,7 +183,8 @@ public class KinesisSupervisorIOConfig extends SeekableStreamSupervisorIOConfig
            ", fetchDelayMillis=" + fetchDelayMillis +
            ", awsAssumedRoleArn='" + awsAssumedRoleArn + '\'' +
            ", awsExternalId='" + awsExternalId + '\'' +
-           ", deaggregate=" + deaggregate +
+           ", deaggregate=" + deaggregate + '\'' +
+           ", compressionFormat=" + compressionFormat +
            '}';
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
@@ -267,7 +267,8 @@ public class KinesisIOConfigTest
         "endpoint",
         2000,
         "awsAssumedRoleArn",
-        "awsExternalId"
+        "awsExternalId",
+        null
     );
 
     final byte[] json = mapper.writeValueAsBytes(currentConfig);

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -94,6 +94,7 @@ public class KinesisIndexTaskSerdeTest
       "endpoint",
       null,
       null,
+      null,
       null
   );
   private static final String ACCESS_KEY = "test-access-key";

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -785,6 +785,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             "awsEndpoint",
             null,
             null,
+            null,
             null
         )
     );
@@ -845,6 +846,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             DateTimes.of("2010"),
             INPUT_FORMAT,
             "awsEndpoint",
+            null,
             null,
             null,
             null
@@ -1946,6 +1948,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             "awsEndpoint",
             null,
             null,
+            null,
             null
         ),
         context
@@ -2106,6 +2109,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             null,
             INPUT_FORMAT,
             "awsEndpoint",
+            null,
             null,
             null,
             null
@@ -2307,6 +2311,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             null,
             INPUT_FORMAT,
             "awsEndpoint",
+            null,
             null,
             null,
             null

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -149,7 +149,8 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
             null,
             null,
             null,
-            false
+            false,
+            null
         ),
         null,
         null,
@@ -228,7 +229,8 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
             null,
             null,
             null,
-            false
+            false,
+            null
         ),
         null,
         null,
@@ -281,7 +283,8 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
             null,
             null,
             null,
-            false
+            false,
+            null
         ),
         null,
         null,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -460,7 +460,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        false
+        false,
+        null
     );
     KinesisIndexTaskClientFactory clientFactory = new KinesisIndexTaskClientFactory(null, OBJECT_MAPPER);
     KinesisSupervisor supervisor = new KinesisSupervisor(
@@ -524,7 +525,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        false
+        false,
+        null
     );
 
     AutoScalerConfig autoscalerConfigNull = kinesisSupervisorIOConfigWithNullAutoScalerConfig.getAutoScalerConfig();
@@ -551,7 +553,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         OBJECT_MAPPER.convertValue(new HashMap<>(), AutoScalerConfig.class),
-        false
+        false,
+        null
     );
 
     AutoScalerConfig autoscalerConfig = kinesisSupervisorIOConfigWithEmptyAutoScalerConfig.getAutoScalerConfig();
@@ -4178,7 +4181,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
             null,
             null,
             null,
-            false
+            false,
+            null
         ),
         null,
         null,
@@ -5103,7 +5107,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        false
+        false,
+        null
     );
 
     KinesisIndexTaskClientFactory taskClientFactory = new KinesisIndexTaskClientFactory(
@@ -5245,7 +5250,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
          autoScalerConfig,
-        false
+        false,
+        null
     );
 
     KinesisIndexTaskClientFactory taskClientFactory = new KinesisIndexTaskClientFactory(
@@ -5334,7 +5340,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        false
+        false,
+        null
     );
 
     KinesisIndexTaskClientFactory taskClientFactory = new KinesisIndexTaskClientFactory(
@@ -5422,7 +5429,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null,
         null,
         null,
-        false
+        false,
+        null
     );
 
     KinesisIndexTaskClientFactory taskClientFactory = new KinesisIndexTaskClientFactory(
@@ -5565,6 +5573,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             maximumMessageTime,
             INPUT_FORMAT,
             "awsEndpoint",
+            null,
             null,
             null,
             null

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -471,6 +471,11 @@
       <artifactId>system-rules</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Implements #17062.

### Description

Allows usage of built in compression formats for Kinesis ingestion based on an optional `compressionFormat` parameter in `ioConfig`.

Unlike Kafka, Kinesis does not provide much by the means of data compression - it is a common industry pattern to compress Kinesis data across the wire with client-implemented decompression.


### Changes

#### Prerequisite additions to CompressionUtils.java.
- Added Jackson deserialization support to `Format` to enable simplified config exposure.

- Added general `compress`/`decompress` utilities with `ByteBuffer`, `InputStream`, and `OutputStream` parameters
  - User specifies desired compression/decompression format as method parameter

#### Added `compressionFormat` Enum to IOConfig

- By linking to a specified enum, the field's values are limited at load time - invalid values are automatically rejected by existing Druid spec safeguards.

- Field is safely fed through:
  - `KinesisSupervisor`
  - `KinesisSupervisorIOConfig`
  - `KinesisSamplerSpec`
  - `KinesisTask`
  - `KinesisTaskIOConfig`
  - `KinesisRecordSupplier`

#### Added handling logic to Kinesis Record Supplier

- If compression is enabled, decompress the user record and replace the existing userRecord in-place. This ensures that:
  1. We do not store both the compressed and decompressed versions of the record 
  2. Buffer sizes for calculating the aggregate size of outstanding Kinesis ingestion data act on the decompressed  / 'true' size of data

```
 if (compressionFormat != null) {
    userRecord.setData(CompressionUtils.decompress(userRecord.getData(), compressionFormat));
  }
```

Discussion remains open on competing designs - this is more or less a starting point of available functionality to provoke discussion (or implement if satisfactory as-is).

#### Release note

Added support for compressed Kinesis streams. Users may specify a `compressionFormat` in IOConfig. Accepted values are `bz2`, `gz`, `snappy`, `xz`, `zip`, and `zstd`.


##### Key changed/added classes in this PR
 * `CompressionUtils`
 * `KinesisRecordSupplier`

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster. (Active production use on streams >1GB/s aggregate throughput)
