### PR TITLE
add VirtualColumns.findEquivalent and VirtualColumn.isEquivalent

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumn.java
@@ -336,4 +336,12 @@ public interface VirtualColumn extends Cacheable
   {
     return NoIndexesColumnIndexSupplier.getInstance();
   }
+
+  /**
+   * Check if a virtual column is the same as some other virtual column, ignoring output name.
+   */
+  default boolean isEquivalent(VirtualColumn other)
+  {
+    return this.equals(other);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
+++ b/processing/src/main/java/org/apache/druid/segment/VirtualColumns.java
@@ -135,6 +135,7 @@ public class VirtualColumns implements Cacheable
   // For getVirtualColumn:
   private final Map<String, VirtualColumn> withDotSupport;
   private final Map<String, VirtualColumn> withoutDotSupport;
+  private final boolean hasNoDotColumns;
 
   private VirtualColumns(
       List<VirtualColumn> virtualColumns,
@@ -146,6 +147,7 @@ public class VirtualColumns implements Cacheable
     this.withDotSupport = withDotSupport;
     this.withoutDotSupport = withoutDotSupport;
     this.virtualColumnNames = new ArrayList<>(virtualColumns.size());
+    this.hasNoDotColumns = withDotSupport.isEmpty();
 
     for (VirtualColumn virtualColumn : virtualColumns) {
       detectCycles(virtualColumn, null);
@@ -172,8 +174,26 @@ public class VirtualColumns implements Cacheable
     if (vc != null) {
       return vc;
     }
+    if (hasNoDotColumns) {
+      return null;
+    }
     final String baseColumnName = splitColumnName(columnName).lhs;
     return withDotSupport.get(baseColumnName);
+  }
+
+  /**
+   * Check if a virtual column is already defined which is the same as some other virtual column, ignoring output name,
+   * returning that virtual column if it exists, or null if there is no equivalent virtual column.
+   */
+  @Nullable
+  public VirtualColumn findEquivalent(VirtualColumn virtualColumn)
+  {
+    for (VirtualColumn vc : virtualColumns) {
+      if (vc.isEquivalent(virtualColumn)) {
+        return vc;
+      }
+    }
+    return null;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVirtualColumn.java
@@ -349,6 +349,17 @@ public class ExpressionVirtualColumn implements VirtualColumn
   }
 
   @Override
+  public boolean isEquivalent(VirtualColumn other)
+  {
+    if (getClass() != other.getClass()) {
+      return false;
+    }
+    final ExpressionVirtualColumn that = (ExpressionVirtualColumn) other;
+    return Objects.equals(expression, that.expression) &&
+           Objects.equals(outputType, that.outputType);
+  }
+
+  @Override
   public boolean equals(final Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumn.java
@@ -252,6 +252,18 @@ public class ListFilteredVirtualColumn implements VirtualColumn
   }
 
   @Override
+  public boolean isEquivalent(VirtualColumn other)
+  {
+    if (getClass() != other.getClass()) {
+      return false;
+    }
+    ListFilteredVirtualColumn that = (ListFilteredVirtualColumn) other;
+    return allowList == that.allowList &&
+           delegate.equals(that.delegate) &&
+           values.equals(that.values);
+  }
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumn.java
@@ -1297,6 +1297,19 @@ public class NestedFieldVirtualColumn implements VirtualColumn
   }
 
   @Override
+  public boolean isEquivalent(VirtualColumn other)
+  {
+    if (getClass() != other.getClass()) {
+      return false;
+    }
+    NestedFieldVirtualColumn that = (NestedFieldVirtualColumn) other;
+    return parts.equals(that.parts) &&
+           Objects.equals(expectedType, that.expectedType) &&
+           processFromRaw == that.processFromRaw;
+  }
+
+
+  @Override
   public boolean equals(Object o)
   {
     if (this == o) {

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ListFilteredVirtualColumnTest.java
@@ -62,6 +62,31 @@ public class ListFilteredVirtualColumnTest
   }
 
   @Test
+  public void testEquivalence()
+  {
+    ListFilteredVirtualColumn virtualColumn = new ListFilteredVirtualColumn(
+        "hello",
+        new DefaultDimensionSpec("column", "output", ColumnType.STRING),
+        ImmutableSet.of("foo", "bar"),
+        false
+    );
+    ListFilteredVirtualColumn virtualColumn2 = new ListFilteredVirtualColumn(
+        "hello2",
+        new DefaultDimensionSpec("column", "output", ColumnType.STRING),
+        ImmutableSet.of("foo", "bar"),
+        false
+    );
+    ListFilteredVirtualColumn virtualColumn3 = new ListFilteredVirtualColumn(
+        "hello",
+        new DefaultDimensionSpec("column", "output", ColumnType.STRING),
+        ImmutableSet.of("foo", "bar", "baz"),
+        false
+    );
+    Assert.assertTrue(virtualColumn.isEquivalent(virtualColumn2));
+    Assert.assertFalse(virtualColumn.isEquivalent(virtualColumn3));
+  }
+
+  @Test
   public void testEqualsAndHashcode()
   {
     EqualsVerifier.forClass(ListFilteredVirtualColumn.class).usingGetClass().verify();

--- a/processing/src/test/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/NestedFieldVirtualColumnTest.java
@@ -87,6 +87,16 @@ public class NestedFieldVirtualColumnTest
   }
 
   @Test
+  public void testEquivalence()
+  {
+    NestedFieldVirtualColumn v1 = new NestedFieldVirtualColumn("nested", "$.x.y.z", "v0", ColumnType.LONG);
+    NestedFieldVirtualColumn v2 = new NestedFieldVirtualColumn("nestedDifferentName", "$.x.y.z", "v0", ColumnType.LONG);
+    NestedFieldVirtualColumn v3 = new NestedFieldVirtualColumn("nested", "$.x.y.z[0]", "v0", ColumnType.LONG);
+    Assert.assertTrue(v1.isEquivalent(v2));
+    Assert.assertFalse(v1.isEquivalent(v3));
+  }
+
+  @Test
   public void testEqualsAndHashcode()
   {
     EqualsVerifier.forClass(NestedFieldVirtualColumn.class)


### PR DESCRIPTION
Adds methods to make it easier to check for equivalent virtual columns in the 'native' engine layer, even in cases where output names differ. This method isn't really used yet, but has some use cases in follow-up PRs.

I have only implemented this method for `ExpressionVirtualColumn`, `NestedFieldVirtualColumn`, and `ListFilteredVirtualColumn` so far, and really only needed it for `ExpressionVirtualColumn`. The default implementation falls back to using equals, though I noticed a handful of implementations (`FallbackVirtualColumn`, `HashPartitionVirtualColumn`, and `SettableLongVirtualColumn`) do not implement that either. Given their use-cases, and the intended use-case of this method, I don't think it probably matters, though it should be easy enough to add them if we need it.