### PR TITLE
Update note about `sys.tasks` table

### DIFF
--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -37,7 +37,7 @@ Task APIs are available in two main places:
 review logs and reports, and more. Refer to the [Tasks API reference](../api-reference/tasks-api.md) for a
 full list.
 - Druid SQL includes a [`sys.tasks`](../querying/sql-metadata-tables.md#tasks-table) table that provides information about active
-and recently-completed tasks. This table is read-only, and has a limited (but useful!) subset of the full information available through
+and recently completed tasks. This table is read-only and has a subset of the full task report available through
 the Overlord APIs.
 
 <a name="reports"></a>

--- a/docs/ingestion/tasks.md
+++ b/docs/ingestion/tasks.md
@@ -36,8 +36,8 @@ Task APIs are available in two main places:
 - The [Overlord](../design/overlord.md) process offers HTTP APIs to submit tasks, cancel tasks, check their status,
 review logs and reports, and more. Refer to the [Tasks API reference](../api-reference/tasks-api.md) for a
 full list.
-- Druid SQL includes a [`sys.tasks`](../querying/sql-metadata-tables.md#tasks-table) table that provides information about currently
-running tasks. This table is read-only, and has a limited (but useful!) subset of the full information available through
+- Druid SQL includes a [`sys.tasks`](../querying/sql-metadata-tables.md#tasks-table) table that provides information about active
+and recently-completed tasks. This table is read-only, and has a limited (but useful!) subset of the full information available through
 the Overlord APIs.
 
 <a name="reports"></a>

--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -266,7 +266,7 @@ GROUP BY servers.server;
 
 ### TASKS table
 
-The tasks table provides information about active and recently-completed indexing tasks. For more information
+The tasks table provides information about active and recently-completed tasks. For more information
 check out the documentation for [ingestion tasks](../ingestion/tasks.md).
 
 |Column|Type|Notes|

--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -266,7 +266,7 @@ GROUP BY servers.server;
 
 ### TASKS table
 
-The tasks table provides information about active and recently-completed tasks. For more information
+The tasks table provides information about active and recently completed tasks. For more information
 check out the documentation for [ingestion tasks](../ingestion/tasks.md).
 
 |Column|Type|Notes|


### PR DESCRIPTION
Noticed a couple of doc inaccuracies related to `sys.tasks` from this slack [thread](https://apachedruidworkspace.slack.com/archives/C0303FDCZEZ/p1726485400168549:):
- `sys.tasks` also serves info about recently-completed tasks (success/failed), not just active tasks
- Removed "indexing" because the table also contains info about non-indexing tasks like MSQ select queries
