### PR TITLE
Joins can take forever to finish on historicals without ever timing out.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/Cursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/Cursor.java
@@ -69,7 +69,8 @@ public interface Cursor
 
   /**
    * Advance to the cursor to the next position. Callers should check {@link #isDone()} or
-   * {@link #isDoneOrInterrupted()} before getting the next value from a selector.
+   * {@link #isDoneOrInterrupted()} before getting the next value from a selector. However, underlying
+   * implementation may still check for thread interruption if advancing the cursor is a long-running operation.
    */
   void advanceUninterruptibly();
 

--- a/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
@@ -201,6 +201,17 @@ public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
   @Test
   public void testAdvanceWithInterruption() throws IOException, InterruptedException
   {
+    testAdvance(true);
+  }
+
+  @Test
+  public void testAdvanceWithoutInterruption() throws IOException, InterruptedException
+  {
+    testAdvance(false);
+  }
+
+  private void testAdvance(boolean withInterruption) throws IOException, InterruptedException
+  {
 
     final int rowsBeforeInterrupt = 1000;
 
@@ -214,7 +225,7 @@ public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
 
     countriesTable = JoinTestHelper.createCountriesIndexedTable();
 
-    Thread joinCursorThread = new Thread(() -> makeCursorAndAdvance());
+    Thread joinCursorThread = new Thread(() -> makeCursorAndAdvance(withInterruption));
     ExceptionHandler exceptionHandler = new ExceptionHandler();
     joinCursorThread.setUncaughtExceptionHandler(exceptionHandler);
     joinCursorThread.start();
@@ -234,7 +245,7 @@ public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
     fail();
   }
 
-  public void makeCursorAndAdvance()
+  public void makeCursorAndAdvance(boolean withInterruption)
   {
 
     List<JoinableClause> joinableClauses = ImmutableList.of(
@@ -272,7 +283,11 @@ public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
         }
       });
 
-      cursor.advance();
+      if (withInterruption) {
+        cursor.advance();
+      } else {
+        cursor.advanceUninterruptibly();
+      }
     }
   }
 }


### PR DESCRIPTION
<img width="1369" alt="Screenshot 2024-09-18 at 11 13 09 AM" src="https://github.com/user-attachments/assets/e104bfe3-37eb-4836-83e4-7685a46f0a03">

This screenshot is of a processing thread that keeps running, hogging the CPU well beyond the configured timeout because PostJoinCursor is not interruptible. This PR fixes the problem by always allowing interruptions when PostJoinCursor is in play. 