### PR TITLE
Backport #16658 to 31.0.0

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/field/StringFieldReader.java
@@ -480,9 +480,8 @@ public class StringFieldReader implements FieldReader
         public boolean isNull(int rowNum)
         {
           final long fieldPosition = coach.computeFieldPosition(rowNum);
-          byte[] nullBytes = new byte[3];
-          dataRegion.getByteArray(fieldPosition, nullBytes, 0, 3);
-          return Arrays.equals(nullBytes, EXPECTED_BYTES_FOR_NULL);
+          return dataRegion.getByte(fieldPosition) == StringFieldWriter.NULL_ROW
+                 && dataRegion.getByte(fieldPosition + 1) == StringFieldWriter.ROW_TERMINATOR;
         }
 
         @Override

--- a/processing/src/main/java/org/apache/druid/frame/read/columnar/FrameColumnReaders.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/columnar/FrameColumnReaders.java
@@ -51,7 +51,7 @@ public class FrameColumnReaders
         return new DoubleFrameColumnReader(columnNumber);
 
       case STRING:
-        return new StringFrameColumnReader(columnNumber, false);
+        return new StringFrameColumnReader(columnNumber);
 
       case COMPLEX:
         return new ComplexFrameColumnReader(columnNumber);
@@ -59,7 +59,7 @@ public class FrameColumnReaders
       case ARRAY:
         switch (columnType.getElementType().getType()) {
           case STRING:
-            return new StringFrameColumnReader(columnNumber, true);
+            return new StringArrayFrameColumnReader(columnNumber);
           case LONG:
             return new LongArrayFrameColumnReader(columnNumber);
           case FLOAT:

--- a/processing/src/main/java/org/apache/druid/frame/read/columnar/StringArrayFrameColumnReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/columnar/StringArrayFrameColumnReader.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.frame.read.columnar;
+
+import com.google.common.primitives.Ints;
+import it.unimi.dsi.fastutil.objects.ObjectArrays;
+import org.apache.datasketches.memory.Memory;
+import org.apache.druid.common.config.NullHandling;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.read.FrameReaderUtils;
+import org.apache.druid.frame.write.FrameWriterUtils;
+import org.apache.druid.frame.write.columnar.FrameColumnWriters;
+import org.apache.druid.frame.write.columnar.StringFrameColumnWriter;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
+import org.apache.druid.query.rowsandcols.column.Column;
+import org.apache.druid.query.rowsandcols.column.ColumnAccessorBasedColumn;
+import org.apache.druid.query.rowsandcols.column.accessor.ObjectColumnAccessorBase;
+import org.apache.druid.segment.ColumnValueSelector;
+import org.apache.druid.segment.ObjectColumnSelector;
+import org.apache.druid.segment.column.BaseColumn;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.data.ReadableOffset;
+import org.apache.druid.segment.vector.ReadableVectorInspector;
+import org.apache.druid.segment.vector.ReadableVectorOffset;
+import org.apache.druid.segment.vector.VectorObjectSelector;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.util.Comparator;
+
+/**
+ * Reader for {@link ColumnType#STRING_ARRAY}.
+ * This is similar to {@link StringFrameColumnReader} reading mvds in reading bytes from frame
+ */
+public class StringArrayFrameColumnReader implements FrameColumnReader
+{
+  private final int columnNumber;
+
+  /**
+   * Create a new reader.
+   *
+   * @param columnNumber column number
+   */
+  StringArrayFrameColumnReader(int columnNumber)
+  {
+    this.columnNumber = columnNumber;
+  }
+
+  @Override
+  public Column readRACColumn(Frame frame)
+  {
+    final Memory memory = frame.region(columnNumber);
+    validate(memory);
+
+    final long positionOfLengths = getStartOfStringLengthSection(frame.numRows());
+    final long positionOfPayloads = getStartOfStringDataSection(memory, frame.numRows());
+
+    StringArrayFrameColumn frameCol = new StringArrayFrameColumn(
+        frame,
+        memory,
+        positionOfLengths,
+        positionOfPayloads
+    );
+
+    return new ColumnAccessorBasedColumn(frameCol);
+  }
+
+  @Override
+  public ColumnPlus readColumn(final Frame frame)
+  {
+    final Memory memory = frame.region(columnNumber);
+    validate(memory);
+
+    final long startOfStringLengthSection = getStartOfStringLengthSection(frame.numRows());
+    final long startOfStringDataSection = getStartOfStringDataSection(memory, frame.numRows());
+
+    final BaseColumn baseColumn = new StringArrayFrameColumn(
+        frame,
+        memory,
+        startOfStringLengthSection,
+        startOfStringDataSection
+    );
+
+    return new ColumnPlus(
+        baseColumn,
+        new ColumnCapabilitiesImpl().setType(ColumnType.STRING_ARRAY)
+                                    .setHasMultipleValues(false)
+                                    .setDictionaryEncoded(false),
+        frame.numRows()
+    );
+  }
+
+  private void validate(final Memory region)
+  {
+    // Check if column is big enough for a header
+    if (region.getCapacity() < StringFrameColumnWriter.DATA_OFFSET) {
+      throw DruidException.defensive("Column[%s] is not big enough for a header", columnNumber);
+    }
+
+    final byte typeCode = region.getByte(0);
+    if (typeCode != FrameColumnWriters.TYPE_STRING_ARRAY) {
+      throw DruidException.defensive(
+          "Column[%s] does not have the correct type code; expected[%s], got[%s]",
+          columnNumber,
+          FrameColumnWriters.TYPE_STRING_ARRAY,
+          typeCode
+      );
+    }
+  }
+
+  private static long getStartOfCumulativeLengthSection()
+  {
+    return StringFrameColumnWriter.DATA_OFFSET;
+  }
+
+  private static long getStartOfStringLengthSection(final int numRows)
+  {
+    return StringFrameColumnWriter.DATA_OFFSET + (long) Integer.BYTES * numRows;
+  }
+
+  private long getStartOfStringDataSection(
+      final Memory memory,
+      final int numRows
+  )
+  {
+    if (numRows < 0) {
+      throw DruidException.defensive("Encountered -ve numRows [%s] while reading frame", numRows);
+    }
+    final int totalNumValues = FrameColumnReaderUtils.getAdjustedCumulativeRowLength(
+        memory,
+        getStartOfCumulativeLengthSection(),
+        numRows - 1
+    );
+
+    return getStartOfStringLengthSection(numRows) + (long) Integer.BYTES * totalNumValues;
+  }
+
+  private static class StringArrayFrameColumn extends ObjectColumnAccessorBase implements BaseColumn
+  {
+    private final Frame frame;
+    private final Memory memory;
+    private final long startOfStringLengthSection;
+    private final long startOfStringDataSection;
+
+    private StringArrayFrameColumn(
+        Frame frame,
+        Memory memory,
+        long startOfStringLengthSection,
+        long startOfStringDataSection
+    )
+    {
+      this.frame = frame;
+      this.memory = memory;
+      this.startOfStringLengthSection = startOfStringLengthSection;
+      this.startOfStringDataSection = startOfStringDataSection;
+    }
+
+    @Override
+    public ColumnValueSelector<?> makeColumnValueSelector(ReadableOffset offset)
+    {
+      return new ObjectColumnSelector<Object>()
+      {
+        @Override
+        public void inspectRuntimeShape(RuntimeShapeInspector inspector)
+        {
+          // Do nothing.
+        }
+
+        @Nullable
+        @Override
+        public Object getObject()
+        {
+          return getRowAsObject(frame.physicalRow(offset.getOffset()), true);
+        }
+
+        @Override
+        public Class<?> classOfObject()
+        {
+          return Object[].class;
+        }
+      };
+    }
+
+    @Override
+    public VectorObjectSelector makeVectorObjectSelector(final ReadableVectorOffset offset)
+    {
+      class StringArrayFrameVectorObjectSelector implements VectorObjectSelector
+      {
+        private final Object[] vector = new Object[offset.getMaxVectorSize()];
+        private int id = ReadableVectorInspector.NULL_ID;
+
+        @Override
+        public Object[] getObjectVector()
+        {
+          computeVectorIfNeeded();
+          return vector;
+        }
+
+        @Override
+        public int getMaxVectorSize()
+        {
+          return offset.getMaxVectorSize();
+        }
+
+        @Override
+        public int getCurrentVectorSize()
+        {
+          return offset.getCurrentVectorSize();
+        }
+
+        private void computeVectorIfNeeded()
+        {
+          if (id == offset.getId()) {
+            return;
+          }
+
+          if (offset.isContiguous()) {
+            final int start = offset.getStartOffset();
+
+            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
+              final int physicalRow = frame.physicalRow(i + start);
+              vector[i] = getRowAsObject(physicalRow, true);
+            }
+          } else {
+            final int[] offsets = offset.getOffsets();
+
+            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
+              final int physicalRow = frame.physicalRow(offsets[i]);
+              vector[i] = getRowAsObject(physicalRow, true);
+            }
+          }
+
+          id = offset.getId();
+        }
+      }
+
+      return new StringArrayFrameVectorObjectSelector();
+    }
+
+    @Override
+    public void close()
+    {
+      // Do nothing.
+    }
+
+    @Override
+    public ColumnType getType()
+    {
+      return ColumnType.STRING_ARRAY;
+    }
+
+    @Override
+    public int numRows()
+    {
+      return frame.numRows();
+    }
+
+    @Override
+    protected Object getVal(int rowNum)
+    {
+      return getRowAsObject(frame.physicalRow(rowNum), true);
+    }
+
+    @Override
+    protected Comparator<Object> getComparator()
+    {
+      return Comparator.nullsFirst(ColumnType.STRING_ARRAY.getStrategy());
+    }
+
+    /**
+     * Returns a ByteBuffer containing UTF-8 encoded string number {@code index}. The ByteBuffer is always newly
+     * created, so it is OK to change its position, limit, etc. However, it may point to shared memory, so it is
+     * not OK to write to its contents.
+     */
+    @Nullable
+    private ByteBuffer getStringUtf8(final int index)
+    {
+      if (startOfStringLengthSection > Long.MAX_VALUE - (long) Integer.BYTES * index) {
+        throw DruidException.defensive("length index would overflow trying to read the frame memory!");
+      }
+
+      final int dataEndVariableIndex = memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * index);
+      if (startOfStringDataSection > Long.MAX_VALUE - dataEndVariableIndex) {
+        throw DruidException.defensive("data end index would overflow trying to read the frame memory!");
+      }
+
+      final long dataStart;
+      final long dataEnd = startOfStringDataSection + dataEndVariableIndex;
+
+      if (index == 0) {
+        dataStart = startOfStringDataSection;
+      } else {
+        final int dataStartVariableIndex = memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * (index
+                                                                                                              - 1));
+        if (startOfStringDataSection > Long.MAX_VALUE - dataStartVariableIndex) {
+          throw DruidException.defensive("data start index would overflow trying to read the frame memory!");
+        }
+        dataStart = startOfStringDataSection + dataStartVariableIndex;
+      }
+
+      final int dataLength = Ints.checkedCast(dataEnd - dataStart);
+
+      if ((dataLength == 0 && NullHandling.replaceWithDefault()) ||
+          (dataLength == 1 && memory.getByte(dataStart) == FrameWriterUtils.NULL_STRING_MARKER)) {
+        return null;
+      }
+
+      return FrameReaderUtils.readByteBuffer(memory, dataStart, dataLength);
+    }
+
+    @Nullable
+    private String getString(final int index)
+    {
+      final ByteBuffer stringUtf8 = getStringUtf8(index);
+
+      if (stringUtf8 == null) {
+        return null;
+      } else {
+        return StringUtils.fromUtf8(stringUtf8);
+      }
+    }
+
+    /**
+     * Returns the object at the given physical row number.
+     *
+     * @param physicalRow physical row number
+     * @param decode      if true, return java.lang.String. If false, return UTF-8 ByteBuffer.
+     */
+    @Nullable
+    private Object getRowAsObject(final int physicalRow, final boolean decode)
+    {
+      final int cumulativeRowLength = FrameColumnReaderUtils.getCumulativeRowLength(
+          memory,
+          getStartOfCumulativeLengthSection(),
+          physicalRow
+      );
+      final int rowLength;
+
+      if (FrameColumnReaderUtils.isNullRow(cumulativeRowLength)) {
+        return null;
+      } else if (physicalRow == 0) {
+        rowLength = cumulativeRowLength;
+      } else {
+        rowLength = cumulativeRowLength - FrameColumnReaderUtils.getAdjustedCumulativeRowLength(
+            memory,
+            getStartOfCumulativeLengthSection(),
+            physicalRow - 1
+        );
+      }
+
+      if (rowLength == 0) {
+        return ObjectArrays.EMPTY_ARRAY;
+      } else {
+        final Object[] row = new Object[rowLength];
+
+        for (int i = 0; i < rowLength; i++) {
+          final int index = cumulativeRowLength - rowLength + i;
+          row[i] = decode ? getString(index) : getStringUtf8(index);
+        }
+
+        return row;
+      }
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/frame/read/columnar/StringFrameColumnReader.java
+++ b/processing/src/main/java/org/apache/druid/frame/read/columnar/StringFrameColumnReader.java
@@ -19,18 +19,16 @@
 
 package org.apache.druid.frame.read.columnar;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
-import it.unimi.dsi.fastutil.objects.ObjectArrays;
 import org.apache.datasketches.memory.Memory;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.read.FrameReaderUtils;
 import org.apache.druid.frame.write.FrameWriterUtils;
 import org.apache.druid.frame.write.columnar.FrameColumnWriters;
 import org.apache.druid.frame.write.columnar.StringFrameColumnWriter;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.filter.DruidPredicateFactory;
@@ -40,13 +38,11 @@ import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessorBasedColumn;
 import org.apache.druid.query.rowsandcols.column.accessor.ObjectColumnAccessorBase;
 import org.apache.druid.segment.BaseSingleValueDimensionSelector;
-import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.DimensionSelectorUtils;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.segment.column.BaseColumn;
-import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
@@ -67,23 +63,20 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * Reader for {@link StringFrameColumnWriter}, types {@link ColumnType#STRING} and {@link ColumnType#STRING_ARRAY}.
+ * Reader for {@link StringFrameColumnWriter}, type {@link ColumnType#STRING}.
  */
 public class StringFrameColumnReader implements FrameColumnReader
 {
   private final int columnNumber;
-  private final boolean asArray;
 
   /**
    * Create a new reader.
    *
    * @param columnNumber column number
-   * @param asArray      true for {@link ColumnType#STRING_ARRAY}, false for {@link ColumnType#STRING}
    */
-  StringFrameColumnReader(int columnNumber, boolean asArray)
+  StringFrameColumnReader(int columnNumber)
   {
     this.columnNumber = columnNumber;
-    this.asArray = asArray;
   }
 
   @Override
@@ -92,18 +85,20 @@ public class StringFrameColumnReader implements FrameColumnReader
     final Memory memory = frame.region(columnNumber);
     validate(memory);
 
+    if (isMultiValue(memory)) {
+      throw InvalidInput.exception("Encountered a multi value column. Window processing does not support MVDs. "
+                         + "Consider using UNNEST or MV_TO_ARRAY.");
+    }
     final long positionOfLengths = getStartOfStringLengthSection(frame.numRows(), false);
     final long positionOfPayloads = getStartOfStringDataSection(memory, frame.numRows(), false);
 
-    StringFrameColumn frameCol =
-        new StringFrameColumn(
-            frame,
-            false,
-            memory,
-            positionOfLengths,
-            positionOfPayloads,
-            asArray || isMultiValue(memory) // Read MVDs as String arrays
-        );
+    StringFrameColumn frameCol = new StringFrameColumn(
+        frame,
+        false,
+        memory,
+        positionOfLengths,
+        positionOfPayloads
+    );
 
     return new ColumnAccessorBasedColumn(frameCol);
   }
@@ -118,35 +113,19 @@ public class StringFrameColumnReader implements FrameColumnReader
     final long startOfStringLengthSection = getStartOfStringLengthSection(frame.numRows(), multiValue);
     final long startOfStringDataSection = getStartOfStringDataSection(memory, frame.numRows(), multiValue);
 
-    final BaseColumn baseColumn;
-
-    if (asArray) {
-      baseColumn = new StringArrayFrameColumn(
-          frame,
-          multiValue,
-          memory,
-          startOfStringLengthSection,
-          startOfStringDataSection
-      );
-    } else {
-      baseColumn = new StringFrameColumn(
-          frame,
-          multiValue,
-          memory,
-          startOfStringLengthSection,
-          startOfStringDataSection,
-          false
-      );
-    }
+    final BaseColumn baseColumn = new StringFrameColumn(
+        frame,
+        multiValue,
+        memory,
+        startOfStringLengthSection,
+        startOfStringDataSection
+    );
 
     return new ColumnPlus(
         baseColumn,
-        new ColumnCapabilitiesImpl().setType(asArray ? ColumnType.STRING_ARRAY : ColumnType.STRING)
-                                    .setHasMultipleValues(!asArray && multiValue)
-                                    .setDictionaryEncoded(false)
-                                    .setHasBitmapIndexes(false)
-                                    .setHasSpatialIndexes(false)
-                                    .setHasNulls(ColumnCapabilities.Capable.UNKNOWN),
+        new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                    .setHasMultipleValues(multiValue)
+                                    .setDictionaryEncoded(false),
         frame.numRows()
     );
   }
@@ -159,12 +138,11 @@ public class StringFrameColumnReader implements FrameColumnReader
     }
 
     final byte typeCode = region.getByte(0);
-    final byte expectedTypeCode = asArray ? FrameColumnWriters.TYPE_STRING_ARRAY : FrameColumnWriters.TYPE_STRING;
-    if (typeCode != expectedTypeCode) {
+    if (typeCode != FrameColumnWriters.TYPE_STRING) {
       throw DruidException.defensive(
           "Column[%s] does not have the correct type code; expected[%s], got[%s]",
           columnNumber,
-          expectedTypeCode,
+          FrameColumnWriters.TYPE_STRING,
           typeCode
       );
     }
@@ -172,7 +150,7 @@ public class StringFrameColumnReader implements FrameColumnReader
 
   private static boolean isMultiValue(final Memory memory)
   {
-    return memory.getByte(1) == 1;
+    return memory.getByte(StringFrameColumnWriter.MULTI_VALUE_POSITION) == StringFrameColumnWriter.MULTI_VALUE_BYTE;
   }
 
   private static long getStartOfCumulativeLengthSection()
@@ -213,8 +191,7 @@ public class StringFrameColumnReader implements FrameColumnReader
     return getStartOfStringLengthSection(numRows, multiValue) + (long) Integer.BYTES * totalNumValues;
   }
 
-  @VisibleForTesting
-  static class StringFrameColumn extends ObjectColumnAccessorBase implements DictionaryEncodedColumn<String>
+  private static class StringFrameColumn extends ObjectColumnAccessorBase implements DictionaryEncodedColumn<String>
   {
     private final Frame frame;
     private final Memory memory;
@@ -226,18 +203,12 @@ public class StringFrameColumnReader implements FrameColumnReader
      */
     private final boolean multiValue;
 
-    /**
-     * Whether the column is being read as {@link ColumnType#STRING_ARRAY} (true) or {@link ColumnType#STRING} (false).
-     */
-    private final boolean asArray;
-
     private StringFrameColumn(
         Frame frame,
         boolean multiValue,
         Memory memory,
         long startOfStringLengthSection,
-        long startOfStringDataSection,
-        final boolean asArray
+        long startOfStringDataSection
     )
     {
       this.frame = frame;
@@ -245,7 +216,6 @@ public class StringFrameColumnReader implements FrameColumnReader
       this.memory = memory;
       this.startOfStringLengthSection = startOfStringLengthSection;
       this.startOfStringDataSection = startOfStringDataSection;
-      this.asArray = asArray;
     }
 
     @Override
@@ -292,247 +262,6 @@ public class StringFrameColumnReader implements FrameColumnReader
 
     @Override
     public DimensionSelector makeDimensionSelector(ReadableOffset offset, @Nullable ExtractionFn extractionFn)
-    {
-      if (asArray) {
-        throw new ISE("Cannot call makeDimensionSelector on field of type [%s]", ColumnType.STRING_ARRAY);
-      }
-
-      return makeDimensionSelectorInternal(offset, extractionFn);
-    }
-
-    @Override
-    public SingleValueDimensionVectorSelector makeSingleValueDimensionVectorSelector(ReadableVectorOffset offset)
-    {
-      // Callers should use object selectors, because we have no dictionary.
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public MultiValueDimensionVectorSelector makeMultiValueDimensionVectorSelector(ReadableVectorOffset vectorOffset)
-    {
-      // Callers should use object selectors, because we have no dictionary.
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public VectorObjectSelector makeVectorObjectSelector(final ReadableVectorOffset offset)
-    {
-      class StringFrameVectorObjectSelector implements VectorObjectSelector
-      {
-        private final Object[] vector = new Object[offset.getMaxVectorSize()];
-        private int id = ReadableVectorInspector.NULL_ID;
-
-        @Override
-        public Object[] getObjectVector()
-        {
-          computeVectorIfNeeded();
-          return vector;
-        }
-
-        @Override
-        public int getMaxVectorSize()
-        {
-          return offset.getMaxVectorSize();
-        }
-
-        @Override
-        public int getCurrentVectorSize()
-        {
-          return offset.getCurrentVectorSize();
-        }
-
-        private void computeVectorIfNeeded()
-        {
-          if (id == offset.getId()) {
-            return;
-          }
-
-          if (offset.isContiguous()) {
-            final int start = offset.getStartOffset();
-
-            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
-              final int physicalRow = frame.physicalRow(i + start);
-              vector[i] = getRowAsObject(physicalRow, true);
-            }
-          } else {
-            final int[] offsets = offset.getOffsets();
-
-            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
-              final int physicalRow = frame.physicalRow(offsets[i]);
-              vector[i] = getRowAsObject(physicalRow, true);
-            }
-          }
-
-          id = offset.getId();
-        }
-      }
-
-      return new StringFrameVectorObjectSelector();
-    }
-
-    @Override
-    public int length()
-    {
-      return frame.numRows();
-    }
-
-    @Override
-    public void close()
-    {
-      // Do nothing.
-    }
-
-    @Override
-    public ColumnType getType()
-    {
-      return asArray ? ColumnType.STRING_ARRAY : ColumnType.STRING;
-    }
-
-    @Override
-    public int numRows()
-    {
-      return length();
-    }
-
-    @Override
-    protected Object getVal(int rowNum)
-    {
-      return getString(frame.physicalRow(rowNum));
-    }
-
-    @Override
-    protected Comparator<Object> getComparator()
-    {
-      return Comparator.nullsFirst(Comparator.comparing(o -> ((String) o)));
-    }
-
-    /**
-     * Returns a ByteBuffer containing UTF-8 encoded string number {@code index}. The ByteBuffer is always newly
-     * created, so it is OK to change its position, limit, etc. However, it may point to shared memory, so it is
-     * not OK to write to its contents.
-     */
-    @Nullable
-    private ByteBuffer getStringUtf8(final int index)
-    {
-      final long dataStart;
-      final long dataEnd =
-          startOfStringDataSection +
-          memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * index);
-
-      if (index == 0) {
-        dataStart = startOfStringDataSection;
-      } else {
-        dataStart =
-            startOfStringDataSection +
-            memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * (index - 1));
-      }
-
-      final int dataLength = Ints.checkedCast(dataEnd - dataStart);
-
-      if ((dataLength == 0 && NullHandling.replaceWithDefault()) ||
-          (dataLength == 1 && memory.getByte(dataStart) == FrameWriterUtils.NULL_STRING_MARKER)) {
-        return null;
-      }
-
-      return FrameReaderUtils.readByteBuffer(memory, dataStart, dataLength);
-    }
-
-    @Nullable
-    private String getString(final int index)
-    {
-      final ByteBuffer stringUtf8 = getStringUtf8(index);
-
-      if (stringUtf8 == null) {
-        return null;
-      } else {
-        return StringUtils.fromUtf8(stringUtf8);
-      }
-    }
-
-    /**
-     * Returns the object at the given physical row number.
-     *
-     * When {@link #asArray}, the return value is always of type {@code Object[]}. Otherwise, the return value
-     * is either an empty list (if the row is empty), a single String (if the row has one value), or a List
-     * of Strings (if the row has more than one value).
-     *
-     * @param physicalRow physical row number
-     * @param decode      if true, return java.lang.String. If false, return UTF-8 ByteBuffer.
-     */
-    @Nullable
-    private Object getRowAsObject(final int physicalRow, final boolean decode)
-    {
-      if (multiValue) {
-        final int cumulativeRowLength = FrameColumnReaderUtils.getCumulativeRowLength(
-            memory,
-            getStartOfCumulativeLengthSection(),
-            physicalRow
-        );
-        final int rowLength;
-
-        if (FrameColumnReaderUtils.isNullRow(cumulativeRowLength)) {
-          return null;
-        } else if (physicalRow == 0) {
-          rowLength = cumulativeRowLength;
-        } else {
-          rowLength = cumulativeRowLength - FrameColumnReaderUtils.getAdjustedCumulativeRowLength(
-              memory,
-              getStartOfCumulativeLengthSection(),
-              physicalRow - 1
-          );
-        }
-
-        if (rowLength == 0) {
-          return asArray ? ObjectArrays.EMPTY_ARRAY : Collections.emptyList();
-        } else if (rowLength == 1) {
-          final int index = cumulativeRowLength - 1;
-          final Object o = decode ? getString(index) : getStringUtf8(index);
-          return asArray ? new Object[]{o} : o;
-        } else {
-          final Object[] row = new Object[rowLength];
-
-          for (int i = 0; i < rowLength; i++) {
-            final int index = cumulativeRowLength - rowLength + i;
-            row[i] = decode ? getString(index) : getStringUtf8(index);
-          }
-
-          return asArray ? row : Arrays.asList(row);
-        }
-      } else {
-        final Object o = decode ? getString(physicalRow) : getStringUtf8(physicalRow);
-        return asArray ? new Object[]{o} : o;
-      }
-    }
-
-    /**
-     * Returns the value at the given physical row number as a list of ByteBuffers. Only valid when !asArray, i.e.,
-     * when type is {@link ColumnType#STRING}.
-     *
-     * @param physicalRow physical row number
-     */
-    private List<ByteBuffer> getRowAsListUtf8(final int physicalRow)
-    {
-      if (asArray) {
-        throw DruidException.defensive("Unexpected call for array column");
-      }
-
-      final Object object = getRowAsObject(physicalRow, false);
-
-      if (object == null) {
-        return Collections.singletonList(null);
-      } else if (object instanceof List) {
-        //noinspection unchecked
-        return (List<ByteBuffer>) object;
-      } else {
-        return Collections.singletonList((ByteBuffer) object);
-      }
-    }
-
-    /**
-     * Selector used by this column. It's versatile: it can run as string array (asArray = true) or regular string
-     * column (asArray = false).
-     */
-    private DimensionSelector makeDimensionSelectorInternal(ReadableOffset offset, @Nullable ExtractionFn extractionFn)
     {
       if (multiValue) {
         class MultiValueSelector implements DimensionSelector
@@ -671,41 +400,224 @@ public class StringFrameColumnReader implements FrameColumnReader
         return new SingleValueSelector();
       }
     }
-  }
 
-  static class StringArrayFrameColumn implements BaseColumn
-  {
-    private final StringFrameColumn delegate;
-
-    private StringArrayFrameColumn(
-        Frame frame,
-        boolean multiValue,
-        Memory memory,
-        long startOfStringLengthSection,
-        long startOfStringDataSection
-    )
+    @Override
+    public SingleValueDimensionVectorSelector makeSingleValueDimensionVectorSelector(ReadableVectorOffset offset)
     {
-      this.delegate = new StringFrameColumn(
-          frame,
-          multiValue,
-          memory,
-          startOfStringLengthSection,
-          startOfStringDataSection,
-          true
-      );
+      // Callers should use object selectors, because we have no dictionary.
+      throw new UnsupportedOperationException();
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
-    public ColumnValueSelector makeColumnValueSelector(ReadableOffset offset)
+    public MultiValueDimensionVectorSelector makeMultiValueDimensionVectorSelector(ReadableVectorOffset vectorOffset)
     {
-      return delegate.makeDimensionSelectorInternal(offset, null);
+      // Callers should use object selectors, because we have no dictionary.
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VectorObjectSelector makeVectorObjectSelector(final ReadableVectorOffset offset)
+    {
+      class StringFrameVectorObjectSelector implements VectorObjectSelector
+      {
+        private final Object[] vector = new Object[offset.getMaxVectorSize()];
+        private int id = ReadableVectorInspector.NULL_ID;
+
+        @Override
+        public Object[] getObjectVector()
+        {
+          computeVectorIfNeeded();
+          return vector;
+        }
+
+        @Override
+        public int getMaxVectorSize()
+        {
+          return offset.getMaxVectorSize();
+        }
+
+        @Override
+        public int getCurrentVectorSize()
+        {
+          return offset.getCurrentVectorSize();
+        }
+
+        private void computeVectorIfNeeded()
+        {
+          if (id == offset.getId()) {
+            return;
+          }
+
+          if (offset.isContiguous()) {
+            final int start = offset.getStartOffset();
+
+            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
+              final int physicalRow = frame.physicalRow(i + start);
+              vector[i] = getRowAsObject(physicalRow, true);
+            }
+          } else {
+            final int[] offsets = offset.getOffsets();
+
+            for (int i = 0; i < offset.getCurrentVectorSize(); i++) {
+              final int physicalRow = frame.physicalRow(offsets[i]);
+              vector[i] = getRowAsObject(physicalRow, true);
+            }
+          }
+
+          id = offset.getId();
+        }
+      }
+
+      return new StringFrameVectorObjectSelector();
+    }
+
+    @Override
+    public int length()
+    {
+      return frame.numRows();
     }
 
     @Override
     public void close()
     {
-      delegate.close();
+      // Do nothing.
+    }
+
+    @Override
+    public ColumnType getType()
+    {
+      return ColumnType.STRING;
+    }
+
+    @Override
+    public int numRows()
+    {
+      return length();
+    }
+
+    @Override
+    protected Object getVal(int rowNum)
+    {
+      return getRowAsObject(frame.physicalRow(rowNum), true);
+    }
+
+    @Override
+    protected Comparator<Object> getComparator()
+    {
+      return Comparator.nullsFirst(Comparator.comparing(o -> ((String) o)));
+    }
+
+    /**
+     * Returns a ByteBuffer containing UTF-8 encoded string number {@code index}. The ByteBuffer is always newly
+     * created, so it is OK to change its position, limit, etc. However, it may point to shared memory, so it is
+     * not OK to write to its contents.
+     */
+    @Nullable
+    private ByteBuffer getStringUtf8(final int index)
+    {
+      final long dataStart;
+      final long dataEnd =
+          startOfStringDataSection +
+          memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * index);
+
+      if (index == 0) {
+        dataStart = startOfStringDataSection;
+      } else {
+        dataStart =
+            startOfStringDataSection +
+            memory.getInt(startOfStringLengthSection + (long) Integer.BYTES * (index - 1));
+      }
+
+      final int dataLength = Ints.checkedCast(dataEnd - dataStart);
+
+      if ((dataLength == 0 && NullHandling.replaceWithDefault()) ||
+          (dataLength == 1 && memory.getByte(dataStart) == FrameWriterUtils.NULL_STRING_MARKER)) {
+        return null;
+      }
+
+      return FrameReaderUtils.readByteBuffer(memory, dataStart, dataLength);
+    }
+
+    @Nullable
+    private String getString(final int index)
+    {
+      final ByteBuffer stringUtf8 = getStringUtf8(index);
+
+      if (stringUtf8 == null) {
+        return null;
+      } else {
+        return StringUtils.fromUtf8(stringUtf8);
+      }
+    }
+
+    /**
+     * Returns the object at the given physical row number.
+     *
+     * @param physicalRow physical row number
+     * @param decode      if true, return java.lang.String. If false, return UTF-8 ByteBuffer.
+     */
+    @Nullable
+    private Object getRowAsObject(final int physicalRow, final boolean decode)
+    {
+      if (multiValue) {
+        final int cumulativeRowLength = FrameColumnReaderUtils.getCumulativeRowLength(
+            memory,
+            getStartOfCumulativeLengthSection(),
+            physicalRow
+        );
+        final int rowLength;
+
+        if (FrameColumnReaderUtils.isNullRow(cumulativeRowLength)) {
+          return null;
+        } else if (physicalRow == 0) {
+          rowLength = cumulativeRowLength;
+        } else {
+          rowLength = cumulativeRowLength - FrameColumnReaderUtils.getAdjustedCumulativeRowLength(
+              memory,
+              getStartOfCumulativeLengthSection(),
+              physicalRow - 1
+          );
+        }
+
+        if (rowLength == 0) {
+          return Collections.emptyList();
+        } else if (rowLength == 1) {
+          final int index = cumulativeRowLength - 1;
+          final Object o = decode ? getString(index) : getStringUtf8(index);
+          return o;
+        } else {
+          final Object[] row = new Object[rowLength];
+
+          for (int i = 0; i < rowLength; i++) {
+            final int index = cumulativeRowLength - rowLength + i;
+            row[i] = decode ? getString(index) : getStringUtf8(index);
+          }
+
+          return Arrays.asList(row);
+        }
+      } else {
+        final Object o = decode ? getString(physicalRow) : getStringUtf8(physicalRow);
+        return o;
+      }
+    }
+
+    /**
+     * Returns the value at the given physical row number as a list of ByteBuffers.
+     *
+     * @param physicalRow physical row number
+     */
+    private List<ByteBuffer> getRowAsListUtf8(final int physicalRow)
+    {
+      final Object object = getRowAsObject(physicalRow, false);
+
+      if (object == null) {
+        return Collections.singletonList(null);
+      } else if (object instanceof List) {
+        //noinspection unchecked
+        return (List<ByteBuffer>) object;
+      } else {
+        return Collections.singletonList((ByteBuffer) object);
+      }
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/frame/write/columnar/StringFrameColumnWriter.java
+++ b/processing/src/main/java/org/apache/druid/frame/write/columnar/StringFrameColumnWriter.java
@@ -44,6 +44,9 @@ public abstract class StringFrameColumnWriter<T extends ColumnValueSelector> imp
 
   public static final long DATA_OFFSET = 1 /* type code */ + 1 /* single or multi-value? */;
 
+  public static final byte MULTI_VALUE_BYTE = (byte) 0x01;
+  public static final long MULTI_VALUE_POSITION = 1;
+
   private final T selector;
   private final byte typeCode;
   protected final ColumnCapabilities.Capable multiValue;
@@ -228,7 +231,7 @@ public abstract class StringFrameColumnWriter<T extends ColumnValueSelector> imp
     long currentPosition = startPosition;
 
     memory.putByte(currentPosition, typeCode);
-    memory.putByte(currentPosition + 1, writeMultiValue ? (byte) 1 : (byte) 0);
+    memory.putByte(currentPosition + 1, writeMultiValue ? MULTI_VALUE_BYTE : (byte) 0);
     currentPosition += 2;
 
     if (writeMultiValue) {

--- a/processing/src/main/java/org/apache/druid/jackson/DruidDefaultSerializersModule.java
+++ b/processing/src/main/java/org/apache/druid/jackson/DruidDefaultSerializersModule.java
@@ -37,7 +37,6 @@ import org.apache.druid.query.FrameBasedInlineDataSourceSerializer;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.context.ResponseContextDeserializer;
 import org.apache.druid.query.rowsandcols.RowsAndColumns;
-import org.apache.druid.query.rowsandcols.semantic.WireTransferable;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -189,20 +188,7 @@ public class DruidDefaultSerializersModule extends SimpleModule
     );
     addDeserializer(ResponseContext.class, new ResponseContextDeserializer());
 
-    addSerializer(RowsAndColumns.class, new JsonSerializer<RowsAndColumns>()
-    {
-      @Override
-      public void serialize(
-          RowsAndColumns value,
-          JsonGenerator gen,
-          SerializerProvider serializers
-      ) throws IOException
-      {
-        // It would be really cool if jackson offered an output stream that would allow us to push bytes
-        // through, but it doesn't right now, so we have to build a byte[] instead.  Maybe something to contribute
-        // back to Jackson at some point.
-        gen.writeBinary(WireTransferable.fromRAC(value).bytesToTransfer());
-      }
-    });
+    addSerializer(RowsAndColumns.class, new RowsAndColumns.RowsAndColumnsSerializer());
+    addDeserializer(RowsAndColumns.class, new RowsAndColumns.RowsAndColumnsDeserializer());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/operator/WindowOperatorQueryQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/operator/WindowOperatorQueryQueryRunnerFactory.java
@@ -21,7 +21,6 @@ package org.apache.druid.query.operator;
 
 import com.google.common.base.Function;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.frame.Frame;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
@@ -31,10 +30,8 @@ import org.apache.druid.query.QueryRunnerFactory;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.rowsandcols.LazilyDecoratedRowsAndColumns;
 import org.apache.druid.query.rowsandcols.RowsAndColumns;
-import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumns;
-import org.apache.druid.query.rowsandcols.semantic.WireTransferable;
+import org.apache.druid.query.rowsandcols.concrete.FrameRowsAndColumns;
 import org.apache.druid.segment.Segment;
-import org.apache.druid.segment.column.RowSignature;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -100,19 +97,8 @@ public class WindowOperatorQueryQueryRunnerFactory implements QueryRunnerFactory
                       @Override
                       public RowsAndColumns apply(@Nullable RowsAndColumns input)
                       {
-                        // This is interim code to force a materialization by synthesizing the wire transfer
-                        // that will need to naturally happen as we flesh out this code more.  For now, we
-                        // materialize the bytes on-heap and then read them back in as a frame.
                         if (input instanceof LazilyDecoratedRowsAndColumns) {
-                          final WireTransferable wire = WireTransferable.fromRAC(input);
-                          final byte[] frameBytes = wire.bytesToTransfer();
-
-                          RowSignature.Builder sigBob = RowSignature.builder();
-                          for (String column : input.getColumnNames()) {
-                            sigBob.add(column, input.findColumn(column).toAccessor().getType());
-                          }
-
-                          return new ColumnBasedFrameRowsAndColumns(Frame.wrap(frameBytes), sigBob.build());
+                          return input.as(FrameRowsAndColumns.class);
                         }
                         return input;
                       }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/AppendableMapOfColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/AppendableMapOfColumns.java
@@ -79,14 +79,4 @@ public class AppendableMapOfColumns implements AppendableRowsAndColumns
     }
     return retVal;
   }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> T as(Class<T> clazz)
-  {
-    if (AppendableRowsAndColumns.class.equals(clazz)) {
-      return (T) this;
-    }
-    return null;
-  }
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/ConcatRowsAndColumns.java
@@ -141,13 +141,6 @@ public class ConcatRowsAndColumns implements RowsAndColumns
     }
   }
 
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
-  {
-    return null;
-  }
-
   private class ConcatedidColumn implements Column
   {
 

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/CursorFactoryRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/CursorFactoryRowsAndColumns.java
@@ -61,7 +61,7 @@ public class CursorFactoryRowsAndColumns implements CloseableShapeshifter, RowsA
     if (CursorFactory.class == clazz) {
       return (T) cursorFactory;
     }
-    return null;
+    return RowsAndColumns.super.as(clazz);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/EmptyRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/EmptyRowsAndColumns.java
@@ -21,7 +21,6 @@ package org.apache.druid.query.rowsandcols;
 
 import org.apache.druid.query.rowsandcols.column.Column;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -41,13 +40,6 @@ public class EmptyRowsAndColumns implements RowsAndColumns
 
   @Override
   public Column findColumn(String name)
-  {
-    return null;
-  }
-
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
   {
     return null;
   }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/LazilyDecoratedRowsAndColumns.java
@@ -39,10 +39,10 @@ import org.apache.druid.query.operator.OffsetLimit;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
 import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumns;
+import org.apache.druid.query.rowsandcols.concrete.FrameRowsAndColumns;
 import org.apache.druid.query.rowsandcols.semantic.ColumnSelectorFactoryMaker;
 import org.apache.druid.query.rowsandcols.semantic.DefaultRowsAndColumnsDecorator;
 import org.apache.druid.query.rowsandcols.semantic.RowsAndColumnsDecorator;
-import org.apache.druid.query.rowsandcols.semantic.WireTransferable;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.CursorBuildSpec;
@@ -150,16 +150,10 @@ public class LazilyDecoratedRowsAndColumns implements RowsAndColumns
 
   @SuppressWarnings("unused")
   @SemanticCreator
-  public WireTransferable toWireTransferable()
+  public FrameRowsAndColumns toFrameRowsAndColumns()
   {
-    return () -> {
-      final Pair<byte[], RowSignature> materialized = materialize();
-      if (materialized == null) {
-        return new byte[]{};
-      } else {
-        return materialized.lhs;
-      }
-    };
+    maybeMaterialize();
+    return base.as(FrameRowsAndColumns.class);
   }
 
   private void maybeMaterialize()

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/LimitedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/LimitedRowsAndColumns.java
@@ -23,7 +23,6 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.rowsandcols.column.Column;
 import org.apache.druid.query.rowsandcols.column.LimitedColumn;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 
 public class LimitedRowsAndColumns implements RowsAndColumns
@@ -66,12 +65,4 @@ public class LimitedRowsAndColumns implements RowsAndColumns
 
     return new LimitedColumn(column, start, end);
   }
-
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
-  {
-    return null;
-  }
-
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/MapOfColumnsRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/MapOfColumnsRowsAndColumns.java
@@ -164,7 +164,7 @@ public class MapOfColumnsRowsAndColumns implements RowsAndColumns
     if (AppendableRowsAndColumns.class.equals(clazz)) {
       return (T) new AppendableMapOfColumns(this);
     }
-    return null;
+    return RowsAndColumns.super.as(clazz);
   }
 
   public static class Builder

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/RearrangedRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/RearrangedRowsAndColumns.java
@@ -164,11 +164,4 @@ public class RearrangedRowsAndColumns implements RowsAndColumns
       );
     }
   }
-
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
-  {
-    return null;
-  }
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/RowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/RowsAndColumns.java
@@ -19,12 +19,30 @@
 
 package org.apache.druid.query.rowsandcols;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.FrameType;
+import org.apache.druid.frame.channel.ByteTracker;
+import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.query.rowsandcols.column.Column;
+import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumns;
+import org.apache.druid.query.rowsandcols.concrete.FrameRowsAndColumns;
+import org.apache.druid.query.rowsandcols.concrete.RowBasedFrameRowsAndColumns;
 import org.apache.druid.query.rowsandcols.semantic.AppendableRowsAndColumns;
 import org.apache.druid.query.rowsandcols.semantic.FramedOnHeapAggregatable;
+import org.apache.druid.segment.column.RowSignature;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
 import java.util.Collection;
 
 /**
@@ -110,6 +128,72 @@ public interface RowsAndColumns
    * @return A concrete implementation of the interface, or null if there is no meaningful optimization to be had
    * through a local implementation of the interface.
    */
+  @SuppressWarnings("unchecked")
   @Nullable
-  <T> T as(Class<T> clazz);
+  default <T> T as(Class<T> clazz)
+  {
+    if (clazz.isInstance(this)) {
+      return (T) this;
+    }
+    return null;
+  }
+
+  /**
+   * Serializer for {@link RowsAndColumns} by converting the instance to {@link FrameRowsAndColumns}
+   */
+  class RowsAndColumnsSerializer extends StdSerializer<RowsAndColumns>
+  {
+    public RowsAndColumnsSerializer()
+    {
+      super(RowsAndColumns.class);
+    }
+
+    @Override
+    public void serialize(
+        RowsAndColumns rac,
+        JsonGenerator jsonGenerator,
+        SerializerProvider serializerProvider
+    ) throws IOException
+    {
+      FrameRowsAndColumns frameRAC = rac.as(FrameRowsAndColumns.class);
+      if (frameRAC == null) {
+        throw DruidException.defensive("Unable to serialize RAC");
+      }
+      JacksonUtils.writeObjectUsingSerializerProvider(jsonGenerator, serializerProvider, frameRAC.getSignature());
+
+      Frame frame = frameRAC.getFrame();
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      frame.writeTo(Channels.newChannel(baos), false, null, ByteTracker.unboundedTracker());
+
+      jsonGenerator.writeBinary(baos.toByteArray());
+    }
+  }
+
+  /**
+   * Deserializer for {@link RowsAndColumns} returning as an instance of {@link FrameRowsAndColumns}
+   */
+  class RowsAndColumnsDeserializer extends StdDeserializer<RowsAndColumns>
+  {
+    public RowsAndColumnsDeserializer()
+    {
+      super(RowsAndColumns.class);
+    }
+
+    @Override
+    public FrameRowsAndColumns deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException
+    {
+      RowSignature sig = jsonParser.readValueAs(RowSignature.class);
+      jsonParser.nextValue();
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      jsonParser.readBinaryValue(baos);
+      Frame frame = Frame.wrap(baos.toByteArray());
+      if (frame.type() == FrameType.COLUMNAR) {
+        return new ColumnBasedFrameRowsAndColumns(frame, sig);
+      } else {
+        return new RowBasedFrameRowsAndColumns(frame, sig);
+      }
+    }
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/AbstractFrameRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/AbstractFrameRowsAndColumns.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.rowsandcols.concrete;
+
+import com.google.common.base.Objects;
+import org.apache.druid.frame.Frame;
+import org.apache.druid.frame.read.FrameReader;
+import org.apache.druid.query.rowsandcols.column.Column;
+import org.apache.druid.segment.CloseableShapeshifter;
+import org.apache.druid.segment.CursorFactory;
+import org.apache.druid.segment.column.RowSignature;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+
+public abstract class AbstractFrameRowsAndColumns implements FrameRowsAndColumns, AutoCloseable, CloseableShapeshifter
+{
+  final Frame frame;
+  final RowSignature signature;
+  final LinkedHashMap<String, Column> colCache = new LinkedHashMap<>();
+
+  public AbstractFrameRowsAndColumns(Frame frame, RowSignature signature)
+  {
+    this.frame = frame;
+    this.signature = signature;
+  }
+
+  @Override
+  public Frame getFrame()
+  {
+    return frame;
+  }
+
+  @Override
+  public RowSignature getSignature()
+  {
+    return signature;
+  }
+
+  @Override
+  public Collection<String> getColumnNames()
+  {
+    return signature.getColumnNames();
+  }
+
+  @Override
+  public int numRows()
+  {
+    return frame.numRows();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nullable
+  @Override
+  public <T> T as(Class<T> clazz)
+  {
+    if (CursorFactory.class.equals(clazz)) {
+      return (T) FrameReader.create(signature).makeCursorFactory(frame);
+    }
+    return FrameRowsAndColumns.super.as(clazz);
+  }
+
+  @Override
+  public void close()
+  {
+    // nothing to close
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hashCode(frame, signature);
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AbstractFrameRowsAndColumns)) {
+      return false;
+    }
+    AbstractFrameRowsAndColumns otherFrame = (AbstractFrameRowsAndColumns) o;
+
+    return frame.writableMemory().equals(otherFrame.frame.writableMemory()) && signature.equals(otherFrame.signature);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/FrameRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/FrameRowsAndColumns.java
@@ -17,21 +17,15 @@
  * under the License.
  */
 
-package org.apache.druid.query.rowsandcols.semantic;
+package org.apache.druid.query.rowsandcols.concrete;
 
-import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.frame.Frame;
 import org.apache.druid.query.rowsandcols.RowsAndColumns;
+import org.apache.druid.segment.column.RowSignature;
 
-public interface WireTransferable
+public interface FrameRowsAndColumns extends RowsAndColumns
 {
-  static WireTransferable fromRAC(RowsAndColumns rac)
-  {
-    WireTransferable retVal = rac.as(WireTransferable.class);
-    if (retVal == null) {
-      throw new ISE("Rac[%s] cannot be transferred over the wire", rac.getClass());
-    }
-    return retVal;
-  }
+  Frame getFrame();
 
-  byte[] bytesToTransfer();
+  RowSignature getSignature();
 }

--- a/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/RowBasedFrameRowsAndColumns.java
+++ b/processing/src/main/java/org/apache/druid/query/rowsandcols/concrete/RowBasedFrameRowsAndColumns.java
@@ -24,40 +24,17 @@ import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.field.FieldReader;
 import org.apache.druid.frame.field.FieldReaders;
-import org.apache.druid.frame.read.FrameReader;
-import org.apache.druid.query.rowsandcols.RowsAndColumns;
 import org.apache.druid.query.rowsandcols.column.Column;
-import org.apache.druid.segment.CloseableShapeshifter;
-import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 
 import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.LinkedHashMap;
 
-public class RowBasedFrameRowsAndColumns implements RowsAndColumns, AutoCloseable, CloseableShapeshifter
+public class RowBasedFrameRowsAndColumns extends AbstractFrameRowsAndColumns
 {
-  private final Frame frame;
-  private final RowSignature signature;
-  private final LinkedHashMap<String, Column> colCache = new LinkedHashMap<>();
-
   public RowBasedFrameRowsAndColumns(Frame frame, RowSignature signature)
   {
-    this.frame = FrameType.ROW_BASED.ensureType(frame);
-    this.signature = signature;
-  }
-
-  @Override
-  public Collection<String> getColumnNames()
-  {
-    return signature.getColumnNames();
-  }
-
-  @Override
-  public int numRows()
-  {
-    return frame.numRows();
+    super(FrameType.ROW_BASED.ensureType(frame), signature);
   }
 
   @Nullable
@@ -85,22 +62,5 @@ public class RowBasedFrameRowsAndColumns implements RowsAndColumns, AutoCloseabl
       }
     }
     return colCache.get(name);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
-  {
-    if (CursorFactory.class.equals(clazz)) {
-      return (T) FrameReader.create(signature).makeCursorFactory(frame);
-    }
-    return null;
-  }
-
-  @Override
-  public void close()
-  {
-    // nothing to close
   }
 }

--- a/processing/src/test/java/org/apache/druid/jackson/DefaultObjectMapperTest.java
+++ b/processing/src/test/java/org/apache/druid/jackson/DefaultObjectMapperTest.java
@@ -22,18 +22,26 @@ package org.apache.druid.jackson;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.rowsandcols.MapOfColumnsRowsAndColumns;
+import org.apache.druid.query.rowsandcols.RowsAndColumns;
+import org.apache.druid.query.rowsandcols.column.IntArrayColumn;
+import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumns;
+import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumnsTest;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  *
@@ -101,5 +109,23 @@ public class DefaultObjectMapperTest
       return;
     }
     Assert.fail("We expect InvalidTypeIdException to be thrown");
+  }
+
+  @Test
+  public void testColumnBasedFrameRowsAndColumns() throws Exception
+  {
+    DefaultObjectMapper om = new DefaultObjectMapper("test");
+
+    MapOfColumnsRowsAndColumns input = (MapOfColumnsRowsAndColumns.fromMap(
+        ImmutableMap.of(
+            "colA", new IntArrayColumn(new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+            "colB", new IntArrayColumn(new int[]{4, -4, 3, -3, 4, 82, -90, 4, 0, 0})
+        )));
+
+    ColumnBasedFrameRowsAndColumns frc = ColumnBasedFrameRowsAndColumnsTest.buildFrame(input);
+    byte[] bytes = om.writeValueAsBytes(frc);
+
+    ColumnBasedFrameRowsAndColumns frc2 = (ColumnBasedFrameRowsAndColumns) om.readValue(bytes, RowsAndColumns.class);
+    assertEquals(frc, frc2);
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/operator/window/RowsAndColumnsHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/operator/window/RowsAndColumnsHelper.java
@@ -29,6 +29,7 @@ import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
 import org.apache.druid.segment.column.ColumnType;
 import org.junit.Assert;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -279,6 +280,17 @@ public class RowsAndColumnsHelper
             Assert.assertEquals(msg, 0, accessor.getLong(i));
           } else {
             Assert.assertEquals(msg, ((Long) expectedVal).longValue(), accessor.getLong(i));
+          }
+        } else if (expectedVal instanceof Object[]) {
+          Object actualVal = accessor.getObject(i);
+          if (expectedNulls[i]) {
+            Assert.assertNull(msg, accessor.getObject(i));
+          } else {
+            if (actualVal instanceof ArrayList) {
+              Assert.assertArrayEquals(msg, (Object[]) expectedVals[i], ((ArrayList<?>) actualVal).toArray());
+            } else {
+              Assert.assertArrayEquals(msg, (Object[]) expectedVals[i], (Object[]) actualVal);
+            }
           }
         } else {
           if (expectedNulls[i]) {

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/NoAsRowsAndColumns.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/NoAsRowsAndColumns.java
@@ -21,7 +21,6 @@ package org.apache.druid.query.rowsandcols;
 
 import org.apache.druid.query.rowsandcols.column.Column;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 
 public class NoAsRowsAndColumns implements RowsAndColumns
@@ -49,13 +48,5 @@ public class NoAsRowsAndColumns implements RowsAndColumns
   public Column findColumn(String name)
   {
     return rac.findColumn(name);
-  }
-
-  @Nullable
-  @Override
-  public <T> T as(Class<T> clazz)
-  {
-    // Pretend like this doesn't implement any semantic interfaces
-    return null;
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/concrete/ColumnBasedFrameRowsAndColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/concrete/ColumnBasedFrameRowsAndColumnsTest.java
@@ -37,7 +37,15 @@ public class ColumnBasedFrameRowsAndColumnsTest extends RowsAndColumnsTestBase
 
   public static ColumnBasedFrameRowsAndColumns buildFrame(MapOfColumnsRowsAndColumns input)
   {
-    LazilyDecoratedRowsAndColumns rac = new LazilyDecoratedRowsAndColumns(input, null, null, null, OffsetLimit.limit(Integer.MAX_VALUE), null, null);
+    LazilyDecoratedRowsAndColumns rac = new LazilyDecoratedRowsAndColumns(
+        input,
+        null,
+        null,
+        null,
+        OffsetLimit.limit(Integer.MAX_VALUE),
+        null,
+        null
+    );
 
     rac.numRows(); // materialize
     return (ColumnBasedFrameRowsAndColumns) rac.getBase();

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/EvaluateRowsAndColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/EvaluateRowsAndColumnsTest.java
@@ -38,31 +38,43 @@ import java.util.function.Function;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeNotNull;
 
-public class TestVirtualColumnEvaluationRowsAndColumnsTest extends SemanticTestBase
+public class EvaluateRowsAndColumnsTest extends SemanticTestBase
 {
-  public TestVirtualColumnEvaluationRowsAndColumnsTest(String name, Function<MapOfColumnsRowsAndColumns, RowsAndColumns> fn)
+  public EvaluateRowsAndColumnsTest(String name, Function<MapOfColumnsRowsAndColumns, RowsAndColumns> fn)
   {
     super(name, fn);
   }
 
   @Test
-  public void testMaterializeVirtualColumns()
+  public void testMaterializeColumns()
   {
     Object[][] vals = new Object[][] {
-        {1L, "a", 123L, 0L},
-        {2L, "a", 456L, 1L},
-        {3L, "b", 789L, 2L},
-        {4L, "b", 123L, 3L},
+        {1L, "a", 123L, new Object[]{"xyz", "x"}, 0L},
+        {2L, "a", 456L, new Object[]{"abc"}, 1L},
+        {3L, "b", 789L, new Object[]{null}, 2L},
+        {4L, null, 123L, null, 3L},
     };
 
     RowSignature siggy = RowSignature.builder()
         .add("__time", ColumnType.LONG)
         .add("dim", ColumnType.STRING)
         .add("val", ColumnType.LONG)
+        .add("array", ColumnType.STRING_ARRAY)
         .add("arrayIndex", ColumnType.LONG)
         .build();
 
     final RowsAndColumns base = make(MapOfColumnsRowsAndColumns.fromRowObjects(vals, siggy));
+
+    Object[] expectedArr = new Object[][] {
+        {"xyz", "x"},
+        {"abc"},
+        {null},
+        null
+    };
+
+    new RowsAndColumnsHelper()
+        .expectColumn("array", expectedArr, ColumnType.STRING_ARRAY)
+        .validate(base);
 
     assumeNotNull("skipping: CursorFactory not supported", base.as(CursorFactory.class));
 
@@ -82,12 +94,18 @@ public class TestVirtualColumnEvaluationRowsAndColumnsTest extends SemanticTestB
     // do the materialziation
     ras.numRows();
 
-    assertEquals(Lists.newArrayList("__time", "dim", "val", "arrayIndex", "expr"), ras.getColumnNames());
+    assertEquals(Lists.newArrayList("__time", "dim", "val", "array", "arrayIndex", "expr"), ras.getColumnNames());
 
     new RowsAndColumnsHelper()
         .expectColumn("expr", new long[] {123 * 2, 456L * 2, 789 * 2, 123 * 2})
         .validate(ras);
 
-  }
+    new RowsAndColumnsHelper()
+        .expectColumn("dim", new String[] {"a", "a", "b", null}, ColumnType.STRING)
+        .validate(ras);
 
+    new RowsAndColumnsHelper()
+        .expectColumn("array", expectedArr, ColumnType.STRING_ARRAY)
+        .validate(ras);
+  }
 }

--- a/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/RowsAndColumnsDecoratorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/rowsandcols/semantic/RowsAndColumnsDecoratorTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.rowsandcols.semantic;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
@@ -32,6 +33,9 @@ import org.apache.druid.query.operator.OffsetLimit;
 import org.apache.druid.query.rowsandcols.MapOfColumnsRowsAndColumns;
 import org.apache.druid.query.rowsandcols.RowsAndColumns;
 import org.apache.druid.query.rowsandcols.column.ColumnAccessor;
+import org.apache.druid.query.rowsandcols.column.IntArrayColumn;
+import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumns;
+import org.apache.druid.query.rowsandcols.concrete.ColumnBasedFrameRowsAndColumnsTest;
 import org.apache.druid.segment.ArrayListSegment;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.Cursor;
@@ -212,6 +216,39 @@ public class RowsAndColumnsDecoratorTest extends SemanticTestBase
         }
       }
     }
+  }
+
+  @Test
+  public void testDecoratorWithColumnBasedFrameRAC()
+  {
+    RowSignature siggy = RowSignature.builder()
+                                     .add("colA", ColumnType.LONG)
+                                     .add("colB", ColumnType.LONG)
+                                     .build();
+
+    Object[][] vals = new Object[][]{
+        {1L, 4L},
+        {2L, -4L},
+        {3L, 3L},
+        {4L, -3L},
+        {5L, 4L},
+        {6L, 82L},
+        {7L, -90L},
+        {8L, 4L},
+        {9L, 0L},
+        {10L, 0L}
+        };
+
+    MapOfColumnsRowsAndColumns input = MapOfColumnsRowsAndColumns.fromMap(
+        ImmutableMap.of(
+            "colA", new IntArrayColumn(new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+            "colB", new IntArrayColumn(new int[]{4, -4, 3, -3, 4, 82, -90, 4, 0, 0})
+        )
+    );
+
+    ColumnBasedFrameRowsAndColumns frc = ColumnBasedFrameRowsAndColumnsTest.buildFrame(input);
+
+    validateDecorated(frc, siggy, vals, null, null, OffsetLimit.NONE, null);
   }
 
   private void validateDecorated(

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/NativeSqlEngine.java
@@ -109,7 +109,6 @@ public class NativeSqlEngine implements SqlEngine
       case ALLOW_TOP_LEVEL_UNION_ALL:
       case TIME_BOUNDARY_QUERY:
       case GROUPBY_IMPLICITLY_SORTS:
-      case WINDOW_LEAF_OPERATOR:
         return true;
       case CAN_INSERT:
       case CAN_REPLACE:
@@ -117,6 +116,7 @@ public class NativeSqlEngine implements SqlEngine
       case WRITE_EXTERNAL_DATA:
       case SCAN_ORDER_BY_NON_TIME:
       case SCAN_NEEDS_SIGNATURE:
+      case WINDOW_LEAF_OPERATOR:
         return false;
       default:
         throw SqlEngines.generateUnrecognizedFeatureException(NativeSqlEngine.class.getSimpleName(), feature);

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -16086,6 +16086,7 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         .run();
   }
 
+  @NotYetSupported(Modes.UNSUPPORTED_DATASOURCE)
   @Test
   public void testWindowingOverJoin()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteWindowQueryTest.java
@@ -266,7 +266,7 @@ public class CalciteWindowQueryTest extends BaseCalciteQueryTest
     );
 
     assertEquals(
-        "Encountered a multi value column [v0]. Window processing does not support MVDs. "
+        "Encountered a multi value column. Window processing does not support MVDs. "
         + "Consider using UNNEST or MV_TO_ARRAY.",
         e.getMessage()
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
@@ -89,6 +89,7 @@ public @interface NotYetSupported
     RESULT_MISMATCH(AssertionError.class, "(assertResulEquals|AssertionError: column content mismatch)"),
     LONG_CASTING(AssertionError.class, "expected: java.lang.Long"),
     UNSUPPORTED_NULL_ORDERING(DruidException.class, "(A|DE)SCENDING ordering with NULLS (LAST|FIRST)"),
+    UNSUPPORTED_DATASOURCE(DruidException.class, "WindowOperatorQuery must run on top of a query or inline data source"),
     UNION_WITH_COMPLEX_OPERAND(DruidException.class, "Only Table and Values are supported as inputs for Union"),
     UNION_MORE_STRICT_ROWTYPE_CHECK(DruidException.class, "Row signature mismatch in Union inputs"),
     JOIN_CONDITION_NOT_PUSHED_CONDITION(DruidException.class, "SQL requires a join with '.*' condition"),

--- a/sql/src/test/resources/calcite/tests/window/wikipediaFramedAggregations.sqlTest
+++ b/sql/src/test/resources/calcite/tests/window/wikipediaFramedAggregations.sqlTest
@@ -2,7 +2,7 @@ type: "operatorValidation"
 
 sql: |
     SELECT
-      countryIsoCode, 
+      countryIsoCode,
       CAST (FLOOR(__time TO HOUR) AS BIGINT) t,
       SUM(delta) delta, 
       SUM(SUM(delta)) OVER (PARTITION BY countryIsoCode ORDER BY CAST (FLOOR(__time TO HOUR) AS BIGINT) ROWS BETWEEN 3 PRECEDING AND 2 FOLLOWING) windowedDelta


### PR DESCRIPTION
Backport (#16658) 

Register a Ser-De for RowsAndColumns so that the window operator query running on leaf operators would be transferred properly on the wire. Would fix the empty response given by window queries without group by on the native engine.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
