### PR TITLE
[Backport] Handle memory leaks from Mockito inline mocks

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -381,6 +381,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
   @AfterEach
   public void tearDown2()
   {
+    Mockito.framework().clearInlineMocks();
     groupByBuffers.close();
   }
 


### PR DESCRIPTION
Backport of #17070 to 31.0.0.