### PR TITLE
Add maximumCapacity to taskRunner

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
@@ -269,9 +269,9 @@ public class KubernetesAndWorkerTaskRunner implements TaskLogStreamer, WorkerTas
   }
 
   @Override
-  public int getMaximumCapacity()
+  public int getMaximumCapacityWithAutoscale()
   {
-    return workerTaskRunner.getMaximumCapacity() + kubernetesTaskRunner.getMaximumCapacity();
+    return workerTaskRunner.getMaximumCapacityWithAutoscale() + kubernetesTaskRunner.getMaximumCapacityWithAutoscale();
   }
 
   @Override

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunner.java
@@ -269,6 +269,12 @@ public class KubernetesAndWorkerTaskRunner implements TaskLogStreamer, WorkerTas
   }
 
   @Override
+  public int getMaximumCapacity()
+  {
+    return workerTaskRunner.getMaximumCapacity() + kubernetesTaskRunner.getMaximumCapacity();
+  }
+
+  @Override
   public int getUsedCapacity()
   {
     int k8sCapacity = kubernetesTaskRunner.getUsedCapacity();

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
@@ -375,10 +375,10 @@ public class KubernetesAndWorkerTaskRunnerTest extends EasyMockSupport
   @Test
   public void test_getMaximumCapacity()
   {
-    EasyMock.expect(kubernetesTaskRunner.getMaximumCapacity()).andReturn(1);
-    EasyMock.expect(workerTaskRunner.getMaximumCapacity()).andReturn(1);
+    EasyMock.expect(kubernetesTaskRunner.getMaximumCapacityWithAutoscale()).andReturn(1);
+    EasyMock.expect(workerTaskRunner.getMaximumCapacityWithAutoscale()).andReturn(1);
     replayAll();
-    Assert.assertEquals(2, runner.getMaximumCapacity());
+    Assert.assertEquals(2, runner.getMaximumCapacityWithAutoscale());
     verifyAll();
   }
 }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerTest.java
@@ -371,4 +371,14 @@ public class KubernetesAndWorkerTaskRunnerTest extends EasyMockSupport
     runner.updateLocation(task, TaskLocation.unknown());
     verifyAll();
   }
+
+  @Test
+  public void test_getMaximumCapacity()
+  {
+    EasyMock.expect(kubernetesTaskRunner.getMaximumCapacity()).andReturn(1);
+    EasyMock.expect(workerTaskRunner.getMaximumCapacity()).andReturn(1);
+    replayAll();
+    Assert.assertEquals(2, runner.getMaximumCapacity());
+    verifyAll();
+  }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -1649,8 +1649,13 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
   }
 
+  /**
+   * Retrieves the maximum capacity of the task runner when autoscaling is enabled.*
+   * @return The maximum capacity as an integer value. Returns -1 if the maximum
+   *         capacity cannot be determined or if autoscaling is not enabled.
+   */
   @Override
-  public int getMaximumCapacity()
+  public int getMaximumCapacityWithAutoscale()
   {
     int maximumCapacity = -1;
     WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/RemoteTaskRunner.java
@@ -58,6 +58,7 @@ import org.apache.druid.indexing.overlord.autoscaling.ProvisioningService;
 import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.indexing.overlord.config.RemoteTaskRunnerConfig;
+import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerSelectStrategy;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
@@ -1646,6 +1647,30 @@ public class RemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
   public int getTotalCapacity()
   {
     return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
+  }
+
+  @Override
+  public int getMaximumCapacity()
+  {
+    int maximumCapacity = -1;
+    WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();
+    if (workerBehaviorConfig == null) {
+      // Auto scale not setup
+      log.debug("Cannot calculate maximum worker capacity as worker behavior config is not configured");
+      maximumCapacity = -1;
+    } else if (workerBehaviorConfig instanceof DefaultWorkerBehaviorConfig) {
+      DefaultWorkerBehaviorConfig defaultWorkerBehaviorConfig = (DefaultWorkerBehaviorConfig) workerBehaviorConfig;
+      if (defaultWorkerBehaviorConfig.getAutoScaler() == null) {
+        // Auto scale not setup
+        log.debug("Cannot calculate maximum worker capacity as auto scaler not configured");
+        maximumCapacity = -1;
+      } else {
+        int maxWorker = defaultWorkerBehaviorConfig.getAutoScaler().getMaxNumWorkers();
+        int expectedWorkerCapacity = provisioningStrategy.getExpectedWorkerCapacity(getWorkers());
+        maximumCapacity = expectedWorkerCapacity == -1 ? -1 : maxWorker * expectedWorkerCapacity;
+      }
+    }
+    return maximumCapacity;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
@@ -374,11 +374,11 @@ public class TaskQueryTool
     }
     TaskRunner taskRunner = taskRunnerOptional.get();
 
-    int currentCapacity = taskRunner.getTotalCapacity();
-    int usedCapacity = taskRunner.getUsedCapacity();
-    int maximumCapacity = taskRunner.getMaximumCapacity();
-
-    return new TotalWorkerCapacityResponse(currentCapacity, maximumCapacity, usedCapacity);
+    return new TotalWorkerCapacityResponse(
+        taskRunner.getTotalCapacity(),
+        taskRunner.getMaximumCapacityWithAutoscale(),
+        taskRunner.getUsedCapacity()
+    );
   }
 
   public WorkerBehaviorConfig getLatestWorkerConfig()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
@@ -156,6 +156,15 @@ public interface TaskRunner
   }
 
   /**
+   * The maximum number of tasks this TaskRunner can run concurrently with autoscaling hints.
+   * Can return -1 if this method is not implemented or capacity can't be found.
+   */
+  default int getMaximumCapacity()
+  {
+    return -1;
+  }
+
+  /**
    * The current number of tasks this TaskRunner is running.
    * Can return -1 if this method is not implemented or the # of tasks can't be found.
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskRunner.java
@@ -157,9 +157,9 @@ public interface TaskRunner
 
   /**
    * The maximum number of tasks this TaskRunner can run concurrently with autoscaling hints.
-   * Can return -1 if this method is not implemented or capacity can't be found.
+   * @return -1 if this method is not implemented or capacity can't be found.
    */
-  default int getMaximumCapacity()
+  default int getMaximumCapacityWithAutoscale()
   {
     return -1;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunner.java
@@ -1792,8 +1792,14 @@ public class HttpRemoteTaskRunner implements WorkerTaskRunner, TaskLogStreamer
     return getWorkers().stream().mapToInt(workerInfo -> workerInfo.getWorker().getCapacity()).sum();
   }
 
+
+  /**
+   * Retrieves the maximum capacity of the task runner when autoscaling is enabled.*
+   * @return The maximum capacity as an integer value. Returns -1 if the maximum
+   *         capacity cannot be determined or if autoscaling is not enabled.
+   */
   @Override
-  public int getMaximumCapacity()
+  public int getMaximumCapacityWithAutoscale()
   {
     int maximumCapacity = -1;
     WorkerBehaviorConfig workerBehaviorConfig = workerConfigRef.get();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTest.java
@@ -155,7 +155,7 @@ public class RemoteTaskRunnerTest
     Assert.assertEquals(3, remoteTaskRunner.getIdleTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(0, remoteTaskRunner.getUsedTaskSlotCount().get(WorkerConfig.DEFAULT_CATEGORY).longValue());
     Assert.assertEquals(3, remoteTaskRunner.getTotalCapacity());
-    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacityWithAutoscale());
     Assert.assertEquals(0, remoteTaskRunner.getUsedCapacity());
 
 
@@ -621,7 +621,7 @@ public class RemoteTaskRunnerTest
         httpClient,
         null
     );
-    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacityWithAutoscale());
   }
 
   @Test
@@ -634,7 +634,7 @@ public class RemoteTaskRunnerTest
         httpClient,
         new DefaultWorkerBehaviorConfig(new EqualDistributionWorkerSelectStrategy(null), null)
     );
-    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, remoteTaskRunner.getMaximumCapacityWithAutoscale());
   }
 
   @Test
@@ -648,7 +648,7 @@ public class RemoteTaskRunnerTest
         DefaultWorkerBehaviorConfig.defaultConfig()
     );
     // Default autoscaler has max workers of 0
-    Assert.assertEquals(0, remoteTaskRunner.getMaximumCapacity());
+    Assert.assertEquals(0, remoteTaskRunner.getMaximumCapacityWithAutoscale());
   }
 
   private void doSetup() throws Exception

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/RemoteTaskRunnerTestUtils.java
@@ -118,6 +118,21 @@ public class RemoteTaskRunnerTestUtils
       HttpClient httpClient
   )
   {
+    return makeRemoteTaskRunner(
+        config,
+        provisioningStrategy,
+        httpClient,
+        DefaultWorkerBehaviorConfig.defaultConfig()
+    );
+  }
+
+  public RemoteTaskRunner makeRemoteTaskRunner(
+      RemoteTaskRunnerConfig config,
+      ProvisioningStrategy<WorkerTaskRunner> provisioningStrategy,
+      HttpClient httpClient,
+      WorkerBehaviorConfig workerBehaviorConfig
+  )
+  {
     RemoteTaskRunner remoteTaskRunner = new TestableRemoteTaskRunner(
         jsonMapper,
         config,
@@ -134,7 +149,7 @@ public class RemoteTaskRunnerTestUtils
         cf,
         new PathChildrenCacheFactory.Builder(),
         httpClient,
-        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        DSuppliers.of(new AtomicReference<>(workerBehaviorConfig)),
         provisioningStrategy
     );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TestProvisioningStrategy.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TestProvisioningStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.druid.indexing.overlord;
+
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningService;
+import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
+import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+
+
+public class TestProvisioningStrategy<T extends TaskRunner> implements ProvisioningStrategy<T>
+{
+  @Override
+  public ProvisioningService makeProvisioningService(T runner)
+  {
+    return new ProvisioningService()
+    {
+      @Override
+      public void close()
+      {
+        // nothing to close
+      }
+
+      @Override
+      public ScalingStats getStats()
+      {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  public int getExpectedWorkerCapacity(@Nonnull Collection<ImmutableWorkerInfo> workers)
+  {
+    return 1;
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -149,7 +149,7 @@ public class HttpRemoteTaskRunnerTest
     Assert.assertEquals(numTasks, taskRunner.getKnownTasks().size());
     Assert.assertEquals(numTasks, taskRunner.getCompletedTasks().size());
     Assert.assertEquals(4, taskRunner.getTotalCapacity());
-    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
     Assert.assertEquals(0, taskRunner.getUsedCapacity());
   }
 
@@ -1802,7 +1802,7 @@ public class HttpRemoteTaskRunnerTest
         new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null),
         new NoopServiceEmitter()
     );
-    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
   }
 
   @Test
@@ -1826,7 +1826,7 @@ public class HttpRemoteTaskRunnerTest
         new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null),
         new NoopServiceEmitter()
     );
-    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacityWithAutoscale());
   }
 
   @Test
@@ -1851,7 +1851,7 @@ public class HttpRemoteTaskRunnerTest
         new NoopServiceEmitter()
     );
     // Default autoscaler has max workers of 0
-    Assert.assertEquals(0, taskRunner.getMaximumCapacity());
+    Assert.assertEquals(0, taskRunner.getMaximumCapacityWithAutoscale());
   }
 
   public static HttpRemoteTaskRunner createTaskRunnerForTestTaskAddedOrUpdated(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/hrtr/HttpRemoteTaskRunnerTest.java
@@ -42,11 +42,13 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunnerListener;
 import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.TaskStorage;
+import org.apache.druid.indexing.overlord.TestProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.NoopProvisioningStrategy;
 import org.apache.druid.indexing.overlord.autoscaling.ProvisioningService;
 import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
 import org.apache.druid.indexing.overlord.config.HttpRemoteTaskRunnerConfig;
 import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
+import org.apache.druid.indexing.overlord.setup.EqualDistributionWorkerSelectStrategy;
 import org.apache.druid.indexing.worker.TaskAnnouncement;
 import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -147,6 +149,7 @@ public class HttpRemoteTaskRunnerTest
     Assert.assertEquals(numTasks, taskRunner.getKnownTasks().size());
     Assert.assertEquals(numTasks, taskRunner.getCompletedTasks().size());
     Assert.assertEquals(4, taskRunner.getTotalCapacity());
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
     Assert.assertEquals(0, taskRunner.getUsedCapacity());
   }
 
@@ -1776,6 +1779,79 @@ public class HttpRemoteTaskRunnerTest
     Assert.assertEquals(3, taskRunner.getWorkerSyncerDebugInfo().size());
     taskRunner.syncMonitoring();
     Assert.assertEquals(3, taskRunner.getWorkerSyncerDebugInfo().size());
+  }
+
+  @Test
+  public void testGetMaximumCapacity_noWorkerConfig()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+        .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(null)),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        EasyMock.createNiceMock(CuratorFramework.class),
+        new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null),
+        new NoopServiceEmitter()
+    );
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
+  }
+
+  @Test
+  public void testGetMaximumCapacity_noAutoScaler()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+        .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(new DefaultWorkerBehaviorConfig(new EqualDistributionWorkerSelectStrategy(null), null))),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        EasyMock.createNiceMock(CuratorFramework.class),
+        new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null),
+        new NoopServiceEmitter()
+    );
+    Assert.assertEquals(-1, taskRunner.getMaximumCapacity());
+  }
+
+  @Test
+  public void testGetMaximumCapacity_withAutoScaler()
+  {
+    TestDruidNodeDiscovery druidNodeDiscovery = new TestDruidNodeDiscovery();
+    DruidNodeDiscoveryProvider druidNodeDiscoveryProvider = EasyMock.createMock(DruidNodeDiscoveryProvider.class);
+    EasyMock.expect(druidNodeDiscoveryProvider.getForService(WorkerNodeService.DISCOVERY_SERVICE_KEY))
+        .andReturn(druidNodeDiscovery);
+    EasyMock.replay(druidNodeDiscoveryProvider);
+
+    HttpRemoteTaskRunner taskRunner = new HttpRemoteTaskRunner(
+        TestHelper.makeJsonMapper(),
+        new HttpRemoteTaskRunnerConfig(),
+        EasyMock.createNiceMock(HttpClient.class),
+        DSuppliers.of(new AtomicReference<>(DefaultWorkerBehaviorConfig.defaultConfig())),
+        new TestProvisioningStrategy<>(),
+        druidNodeDiscoveryProvider,
+        EasyMock.createMock(TaskStorage.class),
+        EasyMock.createNiceMock(CuratorFramework.class),
+        new IndexerZkConfig(new ZkPathsConfig(), null, null, null, null),
+        new NoopServiceEmitter()
+    );
+    // Default autoscaler has max workers of 0
+    Assert.assertEquals(0, taskRunner.getMaximumCapacity());
   }
 
   public static HttpRemoteTaskRunner createTaskRunnerForTestTaskAddedOrUpdated(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -1315,7 +1315,7 @@ public class OverlordResourceTest
             .andReturn(workerBehaviorConfigAtomicReference);
     EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(-1);
     EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(-1);
-    EasyMock.expect(taskRunner.getMaximumCapacity()).andReturn(-1);
+    EasyMock.expect(taskRunner.getMaximumCapacityWithAutoscale()).andReturn(-1);
     EasyMock.expect(overlord.isLeader()).andReturn(true);
     replayAll();
 
@@ -1338,7 +1338,7 @@ public class OverlordResourceTest
         .andReturn(workerBehaviorConfigAtomicReference);
     EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(expectedWorkerCapacity);
     EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(expectedWorkerCapacity);
-    EasyMock.expect(taskRunner.getMaximumCapacity()).andReturn(expectedWorkerCapacityWithAutoscale);
+    EasyMock.expect(taskRunner.getMaximumCapacityWithAutoscale()).andReturn(expectedWorkerCapacityWithAutoscale);
     EasyMock.expect(overlord.isLeader()).andReturn(true);
     replayAll();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -43,7 +43,6 @@ import org.apache.druid.indexing.common.task.KillUnusedSegmentsTask;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.DruidOverlord;
-import org.apache.druid.indexing.overlord.ImmutableWorkerInfo;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
 import org.apache.druid.indexing.overlord.TaskLockbox;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -52,14 +51,9 @@ import org.apache.druid.indexing.overlord.TaskQueue;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
 import org.apache.druid.indexing.overlord.TaskStorage;
-import org.apache.druid.indexing.overlord.WorkerTaskRunner;
 import org.apache.druid.indexing.overlord.WorkerTaskRunnerQueryAdapter;
-import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
 import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
-import org.apache.druid.indexing.overlord.setup.DefaultWorkerBehaviorConfig;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
-import org.apache.druid.indexing.worker.Worker;
-import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.RE;
@@ -1321,6 +1315,7 @@ public class OverlordResourceTest
             .andReturn(workerBehaviorConfigAtomicReference);
     EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(-1);
     EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(-1);
+    EasyMock.expect(taskRunner.getMaximumCapacity()).andReturn(-1);
     EasyMock.expect(overlord.isLeader()).andReturn(true);
     replayAll();
 
@@ -1332,130 +1327,26 @@ public class OverlordResourceTest
   }
 
   @Test
-  public void testGetTotalWorkerCapacityWithWorkerTaskRunnerButWorkerBehaviorConfigNotConfigured()
-  {
-    AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference = new AtomicReference<>(null);
-    EasyMock.expect(configManager.watch(WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class)).andReturn(workerBehaviorConfigAtomicReference);
-    EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(-1);
-    EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(-1);
-    EasyMock.expect(overlord.isLeader()).andReturn(true);
-    replayAll();
-
-    final Response response = overlordResource.getTotalWorkerCapacity();
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatus());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getCurrentClusterCapacity());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getUsedClusterCapacity());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getMaximumCapacityWithAutoScale());
-  }
-
-  @Test
-  public void testGetTotalWorkerCapacityWithWorkerTaskRunnerButAutoScaleNotConfigured()
-  {
-    DefaultWorkerBehaviorConfig workerBehaviorConfig = new DefaultWorkerBehaviorConfig(null, null);
-    AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference = new AtomicReference<>(workerBehaviorConfig);
-    EasyMock.expect(configManager.watch(WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class)).andReturn(workerBehaviorConfigAtomicReference);
-    EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(-1);
-    EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(-1);
-    EasyMock.expect(overlord.isLeader()).andReturn(true);
-    replayAll();
-
-    final Response response = overlordResource.getTotalWorkerCapacity();
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatus());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getCurrentClusterCapacity());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getUsedClusterCapacity());
-    Assert.assertEquals(-1, ((TotalWorkerCapacityResponse) response.getEntity()).getMaximumCapacityWithAutoScale());
-  }
-
-  @Test
-  public void testGetTotalWorkerCapacityWithAutoScaleConfiguredAndProvisioningStrategySupportExpectedWorkerCapacity()
+  public void testGetTotalWorkerCapacityWithMaximumCapacity()
   {
     int expectedWorkerCapacity = 3;
-    int maxNumWorkers = 2;
-    WorkerTaskRunner workerTaskRunner = EasyMock.createMock(WorkerTaskRunner.class);
-    Collection<ImmutableWorkerInfo> workerInfos = ImmutableList.of(
-        new ImmutableWorkerInfo(
-            new Worker(
-                "http", "testWorker", "192.0.0.1", expectedWorkerCapacity, "v1", WorkerConfig.DEFAULT_CATEGORY
-            ),
-            2,
-            ImmutableSet.of("grp1", "grp2"),
-            ImmutableSet.of("task1", "task2"),
-            DateTimes.of("2015-01-01T01:01:01Z")
-        )
-    );
-    EasyMock.expect(workerTaskRunner.getWorkers()).andReturn(workerInfos);
-    EasyMock.expect(workerTaskRunner.getTotalCapacity()).andReturn(expectedWorkerCapacity);
-    EasyMock.expect(workerTaskRunner.getUsedCapacity()).andReturn(0);
-
-    EasyMock.reset(taskMaster);
-    EasyMock.expect(taskMaster.getTaskRunner()).andReturn(
-        Optional.of(workerTaskRunner)
-    ).anyTimes();
-    EasyMock.expect(provisioningStrategy.getExpectedWorkerCapacity(workerInfos)).andReturn(expectedWorkerCapacity).anyTimes();
-    AutoScaler autoScaler = EasyMock.createMock(AutoScaler.class);
-    EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
-    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxNumWorkers);
-    DefaultWorkerBehaviorConfig workerBehaviorConfig = new DefaultWorkerBehaviorConfig(null, autoScaler);
-    AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference = new AtomicReference<>(workerBehaviorConfig);
-    EasyMock.expect(configManager.watch(WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class)).andReturn(workerBehaviorConfigAtomicReference);
-    EasyMock.replay(
-        workerTaskRunner,
-        autoScaler
-    );
+    int expectedWorkerCapacityWithAutoscale = 10;
+    WorkerBehaviorConfig workerBehaviorConfig = EasyMock.createMock(WorkerBehaviorConfig.class);
+    AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference
+        = new AtomicReference<>(workerBehaviorConfig);
+    EasyMock.expect(configManager.watch(WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class))
+        .andReturn(workerBehaviorConfigAtomicReference);
+    EasyMock.expect(taskRunner.getTotalCapacity()).andReturn(expectedWorkerCapacity);
+    EasyMock.expect(taskRunner.getUsedCapacity()).andReturn(expectedWorkerCapacity);
+    EasyMock.expect(taskRunner.getMaximumCapacity()).andReturn(expectedWorkerCapacityWithAutoscale);
     EasyMock.expect(overlord.isLeader()).andReturn(true);
     replayAll();
+
     final Response response = overlordResource.getTotalWorkerCapacity();
     Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatus());
     Assert.assertEquals(expectedWorkerCapacity, ((TotalWorkerCapacityResponse) response.getEntity()).getCurrentClusterCapacity());
-    Assert.assertEquals(0, ((TotalWorkerCapacityResponse) response.getEntity()).getUsedClusterCapacity());
-    Assert.assertEquals(expectedWorkerCapacity * maxNumWorkers, ((TotalWorkerCapacityResponse) response.getEntity()).getMaximumCapacityWithAutoScale());
-  }
-
-  @Test
-  public void testGetTotalWorkerCapacityWithAutoScaleConfiguredAndProvisioningStrategyNotSupportExpectedWorkerCapacity()
-  {
-    int invalidExpectedCapacity = -1;
-    int currentTotalCapacity = 3;
-    int currentCapacityUsed = 2;
-    int maxNumWorkers = 2;
-    WorkerTaskRunner workerTaskRunner = EasyMock.createMock(WorkerTaskRunner.class);
-    Collection<ImmutableWorkerInfo> workerInfos = ImmutableList.of(
-        new ImmutableWorkerInfo(
-            new Worker(
-                "http", "testWorker", "192.0.0.1", currentTotalCapacity, "v1", WorkerConfig.DEFAULT_CATEGORY
-            ),
-            currentCapacityUsed,
-            ImmutableSet.of("grp1", "grp2"),
-            ImmutableSet.of("task1", "task2"),
-            DateTimes.of("2015-01-01T01:01:01Z")
-        )
-    );
-    EasyMock.expect(workerTaskRunner.getWorkers()).andReturn(workerInfos);
-    EasyMock.expect(workerTaskRunner.getTotalCapacity()).andReturn(currentTotalCapacity);
-    EasyMock.expect(workerTaskRunner.getUsedCapacity()).andReturn(currentCapacityUsed);
-    EasyMock.reset(taskMaster);
-    EasyMock.expect(taskMaster.getTaskRunner()).andReturn(
-        Optional.of(workerTaskRunner)
-    ).anyTimes();
-    EasyMock.expect(provisioningStrategy.getExpectedWorkerCapacity(workerInfos)).andReturn(invalidExpectedCapacity).anyTimes();
-    AutoScaler<?> autoScaler = EasyMock.createMock(AutoScaler.class);
-    EasyMock.expect(autoScaler.getMinNumWorkers()).andReturn(0);
-    EasyMock.expect(autoScaler.getMaxNumWorkers()).andReturn(maxNumWorkers);
-    DefaultWorkerBehaviorConfig workerBehaviorConfig = new DefaultWorkerBehaviorConfig(null, autoScaler);
-    AtomicReference<WorkerBehaviorConfig> workerBehaviorConfigAtomicReference = new AtomicReference<>(workerBehaviorConfig);
-    EasyMock.expect(configManager.watch(WorkerBehaviorConfig.CONFIG_KEY, WorkerBehaviorConfig.class)).andReturn(workerBehaviorConfigAtomicReference);
-    EasyMock.replay(
-        workerTaskRunner,
-        autoScaler
-    );
-    EasyMock.expect(overlord.isLeader()).andReturn(true);
-    replayAll();
-    final Response response = overlordResource.getTotalWorkerCapacity();
-    Assert.assertEquals(HttpResponseStatus.OK.getCode(), response.getStatus());
-    Assert.assertEquals(workerInfos.stream().findFirst().get().getWorker().getCapacity(), ((TotalWorkerCapacityResponse) response.getEntity()).getCurrentClusterCapacity());
-    Assert.assertEquals(invalidExpectedCapacity, ((TotalWorkerCapacityResponse) response.getEntity()).getMaximumCapacityWithAutoScale());
-    Assert.assertEquals(currentTotalCapacity, ((TotalWorkerCapacityResponse) response.getEntity()).getCurrentClusterCapacity());
-    Assert.assertEquals(currentCapacityUsed, ((TotalWorkerCapacityResponse) response.getEntity()).getUsedClusterCapacity());
+    Assert.assertEquals(expectedWorkerCapacity, ((TotalWorkerCapacityResponse) response.getEntity()).getUsedClusterCapacity());
+    Assert.assertEquals(expectedWorkerCapacityWithAutoscale, ((TotalWorkerCapacityResponse) response.getEntity()).getMaximumCapacityWithAutoScale());
   }
 
   @Test


### PR DESCRIPTION
Move logic for calculating maximumCapacity (tatal capacity based on max workers from autoscaling) to task runners
### Description
It is possible to get weird responses from the /totalWorkerCapacity endpoint if mmless ingestion is enabled and the overlord dynamic.autoscaler config is set. This is because the TaskQueryTool.getTotalWorkerCapacity gets totalCapacity from the overlord's task runner but gets maximumCapacity directly from the dynamic config.

I think it makes sense to just expose a getMaximumCapacity method on TaskRunner that defaults to -1 (the default value of maximumCapacity) and gets overwritten.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
In order to move getMaximumCapacity logic into each TaskRunner, i had to duplicate logic between HttpRemoteTaskRunner and RemoteTaskRunner since they have the same logic (check the overlord dynamic configuration), but I think this is okay in order for the task runners to be responsible for their own max capacity values.

#### Release note
- TaskRunner should expose a getMaximumCapacity field

##### Key changed/added classes in this PR
 * `TaskRunner`
 * `HttpRemoteTaskRunner/RemoteTaskRunner`
 * `KubernetesAndWorkerTaskRunner/KubernetesTaskRunner`
 * `TaskQueryTool`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
