### PR TITLE
docs: Separate section on ingesting MVDs in migration guide

### DIFF
--- a/docs/release-info/migr-mvd-array.md
+++ b/docs/release-info/migr-mvd-array.md
@@ -231,7 +231,11 @@ GROUP BY 1, 2
 ```
 
 
-## How to ingest data as arrays
+## How to ingest arrays
+
+:::tip
+As a best practice, always use the ARRAY data type in your input schema.
+:::
 
 You can ingest arrays in Druid as follows:
 
@@ -242,5 +246,12 @@ For an example, see [Ingesting arrays: Native batch and streaming ingestion](../
 * For SQL-based batch ingestion, include the [query context parameter](../multi-stage-query/reference.md#context-parameters) `"arrayIngestMode": "array"` and reference the relevant array type (`VARCHAR ARRAY`, `BIGINT ARRAY`, or `DOUBLE ARRAY`) in the [EXTEND clause](../multi-stage-query/reference.md#extern-function) that lists the column names and data types.
 For examples, see [Ingesting arrays: SQL-based ingestion](../querying/arrays.md#sql-based-ingestion).
 
-   As a best practice, always use the ARRAY data type in your input schema. If you want to ingest MVDs, explicitly wrap the string array in [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv). For an example, see [Multi-value dimensions: SQL-based ingestion](../querying/multi-value-dimensions.md#sql-based-ingestion).
+## How to ingest MVDs
 
+You can't mix arrays and MVDs in the same column.
+If you have an MVD column and want to continue ingesting MVDs, explicitly wrap the string array in [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv).
+For an example, see [Multi-value dimensions: SQL-based ingestion](../querying/multi-value-dimensions.md#sql-based-ingestion).
+
+If you have MVD columns and want to migrate to array columns, [reindex](../data-management/update.md#reindex) your data to update its schema.
+Reindexing overwrites existing data where the source of new data is the existing data itself.
+Follow the same guidance on [How to ingest arrays](#how-to-ingest-arrays).

--- a/docs/release-info/migr-mvd-array.md
+++ b/docs/release-info/migr-mvd-array.md
@@ -234,7 +234,7 @@ GROUP BY 1, 2
 ## How to ingest arrays
 
 :::tip
-As a best practice, always use the ARRAY data type in your input schema.
+As a best practice, prefer the ARRAY data type to store your data.
 :::
 
 You can ingest arrays in Druid as follows:

--- a/docs/release-info/migr-mvd-array.md
+++ b/docs/release-info/migr-mvd-array.md
@@ -249,8 +249,11 @@ For examples, see [Ingesting arrays: SQL-based ingestion](../querying/arrays.md#
 ## How to ingest MVDs
 
 You can't mix arrays and MVDs in the same column.
-If you have an MVD column and want to continue ingesting MVDs, explicitly wrap the string array in [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv).
-For an example, see [Multi-value dimensions: SQL-based ingestion](../querying/multi-value-dimensions.md#sql-based-ingestion).
+If you need to continue to use MVDs, modify your ingestion to include the [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv) function.
+This ensures that VARCHAR ARRAYS are stored as MVDs rather than arrays of strings.
+Ingest MVDs explicitly so that you can continue to use existing queries that involve MVDs without incompatible behavior from arrays.
+
+For an example using ARRAY_TO_MV, see [Multi-value dimensions: SQL-based ingestion](../querying/multi-value-dimensions.md#sql-based-ingestion).
 
 If you have MVD columns and want to migrate to array columns, [reindex](../data-management/update.md#reindex) your data to update its schema.
 Reindexing overwrites existing data where the source of new data is the existing data itself.

--- a/docs/release-info/migr-mvd-array.md
+++ b/docs/release-info/migr-mvd-array.md
@@ -249,9 +249,9 @@ For examples, see [Ingesting arrays: SQL-based ingestion](../querying/arrays.md#
 ## How to ingest MVDs
 
 You can't mix arrays and MVDs in the same column.
-If you need to continue to use MVDs, modify your ingestion to include the [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv) function.
+If you need to continue to use MVDs, use the [ARRAY_TO_MV](../querying/sql-functions.md#array_to_mv) function when you ingest data.
 This ensures that VARCHAR ARRAYS are stored as MVDs rather than arrays of strings.
-Ingest MVDs explicitly so that you can continue to use existing queries that involve MVDs without incompatible behavior from arrays.
+To continue using MVDs in your existing queries, you need to ingest MVDs explicitly since arrays and MVDs behave differently.
 
 For an example using ARRAY_TO_MV, see [Multi-value dimensions: SQL-based ingestion](../querying/multi-value-dimensions.md#sql-based-ingestion).
 

--- a/docs/release-info/migr-mvd-array.md
+++ b/docs/release-info/migr-mvd-array.md
@@ -234,7 +234,7 @@ GROUP BY 1, 2
 ## How to ingest arrays
 
 :::tip
-As a best practice, prefer the ARRAY data type to store your data.
+As a best practice, store data as arrays rather than MVDs.
 :::
 
 You can ingest arrays in Druid as follows:


### PR DESCRIPTION
Adds a separate section to make it clear that we have guidance on how to continue ingesting MVDs. We also discourage mixing of arrays and MVDs.

This PR has:

- [x] been self-reviewed.