### PR TITLE
[Backport] Add Delta snapshot version to the web-console

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -1060,6 +1060,7 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           name: 'inputSource.filter',
           label: 'Delta filter',
           type: 'json',
+          placeholder: '{"type": "=", "column": "name", "value": "foo"}',
           defaultValue: {},
           info: (
             <>
@@ -1069,6 +1070,19 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
                 filter
               </ExternalLink>
               <p>A Delta filter json object to filter Delta Lake scan files.</p>
+            </>
+          ),
+        },
+        {
+          name: 'inputSource.snapshotVersion',
+          label: 'Delta snapshot version',
+          type: 'number',
+          placeholder: '(latest)',
+          defaultValue: {},
+          info: (
+            <>
+              The snapshot version to read from the Delta table. By default, the latest snapshot is
+              read.
             </>
           ),
         },

--- a/web-console/src/druid-models/input-source/input-source.tsx
+++ b/web-console/src/druid-models/input-source/input-source.tsx
@@ -652,7 +652,7 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
     label: 'Delta filter',
     type: 'json',
     placeholder: '{"type": "=", "column": "name", "value": "foo"}',
-    defined: inputSource => inputSource.type === 'delta' && deepGet(inputSource, 'filter'),
+    defined: typeIsKnown(KNOWN_TYPES, 'delta'),
     required: false,
     info: (
       <>
@@ -660,6 +660,19 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
           filter
         </ExternalLink>
         <p>A Delta filter json object to filter Delta Lake scan files.</p>
+      </>
+    ),
+  },
+  {
+    name: 'snapshotVersion',
+    label: 'Delta snapshot version',
+    type: 'number',
+    placeholder: '(latest)',
+    defined: typeIsKnown(KNOWN_TYPES, 'delta'),
+    required: false,
+    info: (
+      <>
+        The snapshot version to read from the Delta table. By default, the latest snapshot is read.
       </>
     ),
   },


### PR DESCRIPTION
Backport of https://github.com/apache/druid/pull/17023 to `31.0.0` release.