### PR TITLE
Support Iceberg ingestion from REST based catalogs

### DIFF
--- a/docs/development/extensions-contrib/iceberg.md
+++ b/docs/development/extensions-contrib/iceberg.md
@@ -28,6 +28,7 @@ Apache Iceberg is an open table format for huge analytic datasets. [IcebergInput
 
 Iceberg manages most of its metadata in metadata files in the object storage. However, it is still dependent on a metastore to manage a certain amount of metadata.
 Iceberg refers to these metastores as catalogs. The Iceberg extension lets you connect to the following Iceberg catalog types:
+* REST-based catalog
 * Hive metastore catalog
 * Local catalog
 

--- a/docs/development/extensions-contrib/iceberg.md
+++ b/docs/development/extensions-contrib/iceberg.md
@@ -31,7 +31,7 @@ Iceberg refers to these metastores as catalogs. The Iceberg extension lets you c
 * Hive metastore catalog
 * Local catalog
 
-Druid does not support AWS Glue and REST based catalogs yet.
+Druid does not support AWS Glue catalog yet.
 
 For a given catalog, Iceberg input source reads the table name from the catalog, applies the filters, and extracts all the underlying live data files up to the latest snapshot.
 The data files can be in Parquet, ORC, or Avro formats. The data files typically reside in a warehouse location, which can be in HDFS, S3, or the local filesystem.
@@ -106,6 +106,11 @@ Since the Hadoop AWS connector uses the `s3a` filesystem client, specify the war
 
 The local catalog type can be used for catalogs configured on the local filesystem. Set the `icebergCatalog` type to `local`. You can use this catalog for demos or localized tests. It is not recommended for production use cases.
 The `warehouseSource` is set to `local` because this catalog only supports reading from a local filesystem.
+
+## REST catalog
+
+To connect to an Iceberg REST Catalog server, configure the `icebergCatalog` type as `rest`. The Iceberg REST Open API spec gives catalogs greater control over the implementation and in most cases, the `warehousePath` does not have to be provided by the client.
+Security credentials may be provided in the `catalogProperties` object.
 
 ## Downloading Iceberg extension
 

--- a/docs/ingestion/input-sources.md
+++ b/docs/ingestion/input-sources.md
@@ -1063,7 +1063,7 @@ The following is a sample spec for a S3 warehouse source:
 
 ### Catalog Object
 
-The catalog object supports `local` and `hive` catalog types.
+The catalog object supports `local`,`hive` and `rest` catalog types.
 
 The following table lists the properties of a `local` catalog:
 
@@ -1084,9 +1084,18 @@ The following table lists the properties of a `hive` catalog:
 |catalogProperties|Map of any additional properties that needs to be attached to the catalog.|None|no|
 |caseSensitive|Toggle case sensitivity for column names during Iceberg table reads.|true|no|
 
+The following table lists the properties of a `rest` catalog:
+
+|Property|Description|Default|Required|
+|--------|-----------|-------|---------|
+|type|Set this value to `rest`.|None|yes|
+|catalogUri|The URI associated with the catalog's HTTP endpoint.|None|yes|
+|catalogProperties|Map of any additional properties that needs to be attached to the catalog.|None|no|
+
 ### Iceberg filter object
 
 This input source provides the following filters: `and`, `equals`, `interval`, and `or`. You can use these filters to filter out data files from a snapshot, reducing the number of files Druid has to ingest.
+If the filter column is not an Iceberg partition column, it is highly recommended to define an additional filter defined in the [`transformSpec`](./ingestion-spec.md#transformspec). This is because for non-partition columns, Iceberg filters may return rows that do not match the expression. 
 
 `equals` Filter:
 

--- a/docs/ingestion/input-sources.md
+++ b/docs/ingestion/input-sources.md
@@ -1063,7 +1063,7 @@ The following is a sample spec for a S3 warehouse source:
 
 ### Catalog Object
 
-The catalog object supports `local`,`hive` and `rest` catalog types.
+The catalog object supports `rest`, `hive` and `local` catalog types.
 
 The following table lists the properties of a `local` catalog:
 
@@ -1095,7 +1095,7 @@ The following table lists the properties of a `rest` catalog:
 ### Iceberg filter object
 
 This input source provides the following filters: `and`, `equals`, `interval`, and `or`. You can use these filters to filter out data files from a snapshot, reducing the number of files Druid has to ingest.
-If the filter column is not an Iceberg partition column, it is highly recommended to define an additional filter defined in the [`transformSpec`](./ingestion-spec.md#transformspec). This is because for non-partition columns, Iceberg filters may return rows that do not match the expression. 
+It is strongly recommended to apply filtering only on Iceberg partition columns. When filtering on non-partition columns, Iceberg filters may return rows that do not fully match the expression. To address this, it may help to define an additional filter in the [`transformSpec`](./ingestion-spec.md#transformspec) to remove residual rows.
 
 `equals` Filter:
 

--- a/extensions-contrib/druid-iceberg-extensions/pom.xml
+++ b/extensions-contrib/druid-iceberg-extensions/pom.xml
@@ -35,7 +35,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <iceberg.core.version>1.4.1</iceberg.core.version>
+    <iceberg.core.version>1.6.1</iceberg.core.version>
     <hive.version>3.1.3</hive.version>
   </properties>
   <dependencies>
@@ -257,10 +257,6 @@
         <exclusion>
           <groupId>io.airlift</groupId>
           <artifactId>aircompressor</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents.client5</groupId>
-          <artifactId>httpclient5</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/common/IcebergDruidModule.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/common/IcebergDruidModule.java
@@ -28,6 +28,7 @@ import org.apache.druid.iceberg.guice.HiveConf;
 import org.apache.druid.iceberg.input.HiveIcebergCatalog;
 import org.apache.druid.iceberg.input.IcebergInputSource;
 import org.apache.druid.iceberg.input.LocalCatalog;
+import org.apache.druid.iceberg.input.RestIcebergCatalog;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,6 +46,7 @@ public class IcebergDruidModule implements DruidModule
             .registerSubtypes(
                 new NamedType(HiveIcebergCatalog.class, HiveIcebergCatalog.TYPE_KEY),
                 new NamedType(LocalCatalog.class, LocalCatalog.TYPE_KEY),
+                new NamedType(RestIcebergCatalog.class, RestIcebergCatalog.TYPE_KEY),
                 new NamedType(IcebergInputSource.class, IcebergInputSource.TYPE_KEY)
 
             )

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/HiveIcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/HiveIcebergCatalog.java
@@ -32,7 +32,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hive.HiveCatalog;
 
 import javax.annotation.Nullable;
@@ -45,7 +45,6 @@ import java.util.Map;
  */
 public class HiveIcebergCatalog extends IcebergCatalog
 {
-  public static final String DRUID_DYNAMIC_CONFIG_PROVIDER_KEY = "druid.dynamic.config.provider";
   public static final String TYPE_KEY = "hive";
 
   @JsonProperty
@@ -62,7 +61,7 @@ public class HiveIcebergCatalog extends IcebergCatalog
 
   private final Configuration configuration;
 
-  private BaseMetastoreCatalog hiveCatalog;
+  private Catalog hiveCatalog;
 
   private static final Logger log = new Logger(HiveIcebergCatalog.class);
 
@@ -88,7 +87,7 @@ public class HiveIcebergCatalog extends IcebergCatalog
   }
 
   @Override
-  public BaseMetastoreCatalog retrieveCatalog()
+  public Catalog retrieveCatalog()
   {
     if (hiveCatalog == null) {
       hiveCatalog = setupCatalog();

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergCatalog.java
@@ -25,7 +25,6 @@ import org.apache.druid.iceberg.filter.IcebergFilter;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.Catalog;
@@ -46,9 +45,10 @@ import java.util.List;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = InputFormat.TYPE_PROPERTY)
 public abstract class IcebergCatalog
 {
+  public static final String DRUID_DYNAMIC_CONFIG_PROVIDER_KEY = "druid.dynamic.config.provider";
   private static final Logger log = new Logger(IcebergCatalog.class);
 
-  public abstract BaseMetastoreCatalog retrieveCatalog();
+  public abstract Catalog retrieveCatalog();
 
   public boolean isCaseSensitive()
   {

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/LocalCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/LocalCatalog.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 
 import javax.annotation.Nullable;
@@ -46,7 +46,7 @@ public class LocalCatalog extends IcebergCatalog
   @JsonProperty
   private final Boolean caseSensitive;
 
-  private BaseMetastoreCatalog catalog;
+  private Catalog catalog;
 
   @JsonCreator
   public LocalCatalog(
@@ -83,7 +83,7 @@ public class LocalCatalog extends IcebergCatalog
   }
 
   @Override
-  public BaseMetastoreCatalog retrieveCatalog()
+  public Catalog retrieveCatalog()
   {
     if (catalog == null) {
       catalog = setupCatalog();

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.iceberg.input;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.iceberg.guice.HiveConf;
+import org.apache.druid.utils.DynamicConfigProviderUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTCatalog;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Catalog implementation for Iceberg REST catalogs.
+ */
+public class RestIcebergCatalog extends IcebergCatalog
+{
+  public static final String TYPE_KEY = "rest";
+
+  @JsonProperty
+  private final String catalogUri;
+
+  @JsonProperty
+  private final Map<String, String> catalogProperties;
+
+  private final Configuration configuration;
+
+  private Catalog restCatalog;
+
+  @JsonCreator
+  public RestIcebergCatalog(
+      @JsonProperty("catalogUri") String catalogUri,
+      @JsonProperty("catalogProperties") @Nullable
+          Map<String, Object> catalogProperties,
+      @JacksonInject @Json ObjectMapper mapper,
+      @JacksonInject @HiveConf Configuration configuration
+  )
+  {
+    this.catalogUri = Preconditions.checkNotNull(catalogUri, "catalogUri cannot be null");
+    this.catalogProperties = DynamicConfigProviderUtils.extraConfigAndSetStringMap(
+        catalogProperties,
+        DRUID_DYNAMIC_CONFIG_PROVIDER_KEY,
+        mapper
+    );
+    this.configuration = configuration;
+  }
+
+  @Override
+  public Catalog retrieveCatalog()
+  {
+    if (restCatalog == null) {
+      restCatalog = setupCatalog();
+    }
+    return restCatalog;
+  }
+
+  public String getCatalogUri()
+  {
+    return catalogUri;
+  }
+
+  public Map<String, String> getCatalogProperties()
+  {
+    return catalogProperties;
+  }
+
+  private RESTCatalog setupCatalog()
+  {
+    RESTCatalog restCatalog = new RESTCatalog(
+        SessionCatalog.SessionContext.createEmpty(),
+        config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build()
+    );
+    restCatalog.setConf(configuration);
+    catalogProperties.put(CatalogProperties.URI, catalogUri);
+    restCatalog.initialize("rest", catalogProperties);
+    return restCatalog;
+  }
+}

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Preconditions;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.iceberg.guice.HiveConf;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
@@ -63,7 +63,10 @@ public class RestIcebergCatalog extends IcebergCatalog
       @JacksonInject @HiveConf Configuration configuration
   )
   {
-    this.catalogUri = Preconditions.checkNotNull(catalogUri, "catalogUri cannot be null");
+    if (catalogUri == null) {
+      throw InvalidInput.exception("catalogUri cannot be null");
+    }
+    this.catalogUri = catalogUri;
     this.catalogProperties = DynamicConfigProviderUtils.extraConfigAndSetStringMap(
         catalogProperties,
         DRUID_DYNAMIC_CONFIG_PROVIDER_KEY,

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.iceberg.input;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.io.IOUtils;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+public class RestCatalogTest
+{
+  private final ObjectMapper mapper = new DefaultObjectMapper();
+
+  @Test
+  public void testCatalogCreate() throws IOException
+  {
+
+    HttpServer server = null;
+    InputStream inputStream = null;
+    InputStream inputStreamPartial = null;
+    ServerSocket serverSocket = null;
+    try {
+      serverSocket = new ServerSocket(0);
+      int port = serverSocket.getLocalPort();
+      serverSocket.close();
+      server = HttpServer.create(new InetSocketAddress("localhost", port), 0);
+      server.createContext(
+          "/v1/config", // API for catalog fetchConfig which is invoked on catalog initialization
+          (httpExchange) -> {
+            String payload = "{}";
+            byte[] outputBytes = payload.getBytes(StandardCharsets.UTF_8);
+            httpExchange.sendResponseHeaders(200, outputBytes.length);
+            OutputStream os = httpExchange.getResponseBody();
+            httpExchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, "application/octet-stream");
+            httpExchange.getResponseHeaders().set(HttpHeaders.CONTENT_LENGTH, String.valueOf(outputBytes.length));
+            httpExchange.getResponseHeaders().set(HttpHeaders.CONTENT_RANGE, "bytes 0");
+            os.write(outputBytes);
+            os.close();
+          }
+      );
+      server.start();
+
+      String catalogUri = "http://localhost:" + port;
+
+      RestIcebergCatalog testRestCatalog = new RestIcebergCatalog(
+          catalogUri,
+          new HashMap<>(),
+          mapper,
+          new Configuration()
+      );
+      RESTCatalog innerCatalog = (RESTCatalog) testRestCatalog.retrieveCatalog();
+
+      Assert.assertEquals("rest", innerCatalog.name());
+      Assert.assertNotNull(innerCatalog.properties());
+      Assert.assertNotNull(testRestCatalog.getCatalogProperties());
+      Assert.assertEquals(testRestCatalog.getCatalogUri(), innerCatalog.properties().get("uri"));
+    }
+    finally {
+      IOUtils.closeQuietly(inputStream);
+      IOUtils.closeQuietly(inputStreamPartial);
+      if (server != null) {
+        server.stop(0);
+      }
+      if (serverSocket != null) {
+        serverSocket.close();
+      }
+    }
+  }
+}

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.iceberg.input;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.net.HttpHeaders;
 import com.sun.net.httpserver.HttpServer;
-import org.apache.commons.io.IOUtils;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.rest.RESTCatalog;
@@ -30,7 +29,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -44,10 +42,7 @@ public class RestCatalogTest
   @Test
   public void testCatalogCreate() throws IOException
   {
-
     HttpServer server = null;
-    InputStream inputStream = null;
-    InputStream inputStreamPartial = null;
     ServerSocket serverSocket = null;
     try {
       serverSocket = new ServerSocket(0);
@@ -86,8 +81,6 @@ public class RestCatalogTest
       Assert.assertEquals(testRestCatalog.getCatalogUri(), innerCatalog.properties().get("uri"));
     }
     finally {
-      IOUtils.closeQuietly(inputStream);
-      IOUtils.closeQuietly(inputStreamPartial);
       if (server != null) {
         server.stop(0);
       }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- Adds support to the `iceberg` input source to read from Iceberg [REST](https://iceberg.apache.org/concepts/catalog/#decoupling-using-the-rest-catalog) catalogs.
- Upgrades iceberg core dependency to `1.6.1`

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

 Adds support to the `iceberg` input source to read from Iceberg REST Catalogs.
<hr>


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
