### PR TITLE
Web console: add CPU counters and new tooltip interface

### DIFF
--- a/web-console/src/components/braced-text/braced-text.tsx
+++ b/web-console/src/components/braced-text/braced-text.tsx
@@ -84,7 +84,7 @@ function hideThousandsSeparator(text: string) {
 }
 
 export const BracedText = React.memo(function BracedText(props: BracedTextProps) {
-  const { className, text, braces, padFractionalPart, unselectableThousandsSeparator, title } =
+  const { className, text, braces, padFractionalPart, unselectableThousandsSeparator, ...rest } =
     props;
 
   let effectiveBraces = braces.concat(text);
@@ -115,7 +115,7 @@ export const BracedText = React.memo(function BracedText(props: BracedTextProps)
   }
 
   return (
-    <span className={classNames('braced-text', className)} title={title}>
+    <span className={classNames('braced-text', className)} {...rest}>
       <span className="brace-text">{findMostNumbers(effectiveBraces)}</span>
       <span className="real-text">
         {unselectableThousandsSeparator ? hideThousandsSeparator(text) : text}

--- a/web-console/src/components/click-to-copy/__snapshots__/click-to-copy.spec.tsx.snap
+++ b/web-console/src/components/click-to-copy/__snapshots__/click-to-copy.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ClickToCopy matches snapshot 1`] = `
 <a
   class="click-to-copy"
-  title="Click to copy:
+  data-tooltip="Click to copy:
 Hello world"
 >
   Hello world

--- a/web-console/src/components/click-to-copy/click-to-copy.tsx
+++ b/web-console/src/components/click-to-copy/click-to-copy.tsx
@@ -31,7 +31,7 @@ export const ClickToCopy = React.memo(function ClickToCopy(props: ClickToCopyPro
   return (
     <a
       className="click-to-copy"
-      title={`Click to copy:\n${text}`}
+      data-tooltip={`Click to copy:\n${text}`}
       onClick={() => {
         copy(text, { format: 'text/plain' });
         AppToaster.show({

--- a/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
+++ b/web-console/src/components/header-bar/__snapshots__/header-bar.spec.tsx.snap
@@ -199,6 +199,7 @@ exports[`HeaderBar matches snapshot 1`] = `
       <Blueprint5.Button
         active={false}
         className="header-entry"
+        data-tooltip="More views"
         icon="more"
         minimal={true}
       />
@@ -212,7 +213,7 @@ exports[`HeaderBar matches snapshot 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": true,
+          "multiStageQueryTask": true,
           "overlord": true,
           "queryType": "nativeAndSql",
         }
@@ -333,6 +334,7 @@ exports[`HeaderBar matches snapshot 1`] = `
     >
       <Blueprint5.Button
         className="header-entry"
+        data-tooltip="Settings"
         icon="cog"
         minimal={true}
       />
@@ -418,6 +420,7 @@ exports[`HeaderBar matches snapshot 1`] = `
     >
       <Blueprint5.Button
         className="header-entry"
+        data-tooltip="Help"
         icon="help"
         minimal={true}
       />

--- a/web-console/src/components/header-bar/header-bar.tsx
+++ b/web-console/src/components/header-bar/header-bar.tsx
@@ -106,7 +106,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
   const [overlordDynamicConfigDialogOpen, setOverlordDynamicConfigDialogOpen] = useState(false);
   const [compactionDynamicConfigDialogOpen, setCompactionDynamicConfigDialogOpen] = useState(false);
 
-  const showSplitDataLoaderMenu = capabilities.hasMultiStageQuery();
+  const showSplitDataLoaderMenu = capabilities.hasMultiStageQueryTask();
 
   const loadDataViewsMenuActive = oneOf(
     active,
@@ -360,6 +360,7 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
             minimal
             icon={IconNames.MORE}
             active={moreViewsMenuActive}
+            data-tooltip="More views"
           />
         </Popover>
       </NavbarGroup>
@@ -407,10 +408,10 @@ export const HeaderBar = React.memo(function HeaderBar(props: HeaderBarProps) {
           </Popover>
         )}
         <Popover content={configMenu} position={Position.BOTTOM_RIGHT}>
-          <Button className="header-entry" minimal icon={IconNames.COG} />
+          <Button className="header-entry" minimal icon={IconNames.COG} data-tooltip="Settings" />
         </Popover>
         <Popover content={helpMenu} position={Position.BOTTOM_RIGHT}>
-          <Button className="header-entry" minimal icon={IconNames.HELP} />
+          <Button className="header-entry" minimal icon={IconNames.HELP} data-tooltip="Help" />
         </Popover>
       </NavbarGroup>
       {aboutDialogOpen && <AboutDialog onClose={() => setAboutDialogOpen(false)} />}

--- a/web-console/src/components/record-table-pane/record-table-pane.tsx
+++ b/web-console/src/components/record-table-pane/record-table-pane.tsx
@@ -140,7 +140,7 @@ export const RecordTablePane = React.memo(function RecordTablePane(props: Record
               Header() {
                 return (
                   <div className="clickable-cell">
-                    <div className="output-name" title={columnToSummary(column)}>
+                    <div className="output-name" data-tooltip={columnToSummary(column)}>
                       {icon && <Icon className="type-icon" icon={icon} size={12} />}
                       {h}
                       {hasFilterOnHeader(h, i) && <Icon icon={IconNames.FILTER} size={14} />}

--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -348,7 +348,6 @@ exports[`RuleEditor matches snapshot no tier in rule 1`] = `
           >
             <button
               class="bp5-button bp5-minimal"
-              title=""
               type="button"
             >
               <span
@@ -1088,7 +1087,6 @@ exports[`RuleEditor matches snapshot with existing tier and non existing tier in
           >
             <button
               class="bp5-button bp5-minimal"
-              title=""
               type="button"
             >
               <span
@@ -1480,7 +1478,6 @@ exports[`RuleEditor matches snapshot with existing tier in rule 1`] = `
           >
             <button
               class="bp5-button bp5-minimal"
-              title=""
               type="button"
             >
               <span
@@ -1877,7 +1874,6 @@ exports[`RuleEditor matches snapshot with non existing tier in rule 1`] = `
           >
             <button
               class="bp5-button bp5-minimal"
-              title=""
               type="button"
             >
               <span

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -144,7 +144,7 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
           minimal
           icon={IconNames.PLUS}
           disabled={disabled}
-          title={disabled ? 'There are no tiers left to assign' : ''}
+          data-tooltip={disabled ? 'There are no tiers left to assign' : undefined}
         >
           Add historical tier replication
         </Button>

--- a/web-console/src/components/supervisor-history-panel/supervisor-history-panel.tsx
+++ b/web-console/src/components/supervisor-history-panel/supervisor-history-panel.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Tab, Tabs } from '@blueprintjs/core';
+import { Tab, Tabs, TabsExpander } from '@blueprintjs/core';
 import * as JSONBig from 'json-bigint-native';
 import React, { useState } from 'react';
 
@@ -68,7 +68,7 @@ export const SupervisorHistoryPanel = React.memo(function SupervisorHistoryPanel
           <Tab
             id={i}
             key={i}
-            title={pastSupervisor.version}
+            data-tooltip={pastSupervisor.version}
             panelClassName="panel"
             panel={
               <ShowValue
@@ -79,7 +79,7 @@ export const SupervisorHistoryPanel = React.memo(function SupervisorHistoryPanel
             }
           />
         ))}
-        <Tabs.Expander />
+        <TabsExpander />
       </Tabs>
       {diffIndex !== -1 && (
         <DiffDialog

--- a/web-console/src/components/table-cell/__snapshots__/table-cell.spec.tsx.snap
+++ b/web-console/src/components/table-cell/__snapshots__/table-cell.spec.tsx.snap
@@ -3,16 +3,16 @@
 exports[`TableCell matches snapshot Date (invalid) 1`] = `
 <div
   class="table-cell timestamp"
-  title="NaN"
+  data-tooltip="NaN"
 >
-  Unusable date
+  Invalid date
 </div>
 `;
 
 exports[`TableCell matches snapshot Date 1`] = `
 <div
   class="table-cell timestamp"
-  title="1645664523000"
+  data-tooltip="1645664523000"
 >
   2022-02-24T01:02:03.000Z
 </div>

--- a/web-console/src/components/table-cell/table-cell.tsx
+++ b/web-console/src/components/table-cell/table-cell.tsx
@@ -97,8 +97,8 @@ export const TableCell = React.memo(function TableCell(props: TableCellProps) {
   } else if (value instanceof Date) {
     const dateValue = value.valueOf();
     return (
-      <div className="table-cell timestamp" title={String(value.valueOf())}>
-        {isNaN(dateValue) ? 'Unusable date' : value.toISOString()}
+      <div className="table-cell timestamp" data-tooltip={String(value.valueOf())}>
+        {isNaN(dateValue) ? 'Invalid date' : value.toISOString()}
       </div>
     );
   } else if (isSimpleArray(value)) {

--- a/web-console/src/components/table-clickable-cell/table-clickable-cell.tsx
+++ b/web-console/src/components/table-clickable-cell/table-clickable-cell.tsx
@@ -36,13 +36,13 @@ export interface TableClickableCellProps {
 export const TableClickableCell = React.memo(function TableClickableCell(
   props: TableClickableCellProps,
 ) {
-  const { className, onClick, hoverIcon, title, disabled, children } = props;
+  const { className, onClick, hoverIcon, disabled, children, ...rest } = props;
 
   return (
     <div
       className={classNames('table-clickable-cell', className, { disabled })}
-      title={title}
       onClick={disabled ? undefined : onClick}
+      {...rest}
     >
       {children}
       {hoverIcon && !disabled && <Icon className="hover-icon" icon={hoverIcon} />}

--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -28,7 +28,7 @@ import type { Filter } from 'react-table';
 
 import type { HeaderActiveTab } from './components';
 import { HeaderBar, Loader } from './components';
-import type { DruidEngine, QueryContext, QueryWithContext } from './druid-models';
+import type { QueryContext, QueryWithContext } from './druid-models';
 import { Capabilities, maybeGetClusterCapacity } from './helpers';
 import { stringToTableFilters, tableFiltersToString } from './react-table';
 import { AppToaster } from './singletons';
@@ -307,14 +307,6 @@ export class ConsoleApplication extends React.PureComponent<
       this.props;
     const { capabilities } = this.state;
 
-    const queryEngines: DruidEngine[] = ['native'];
-    if (capabilities.hasSql()) {
-      queryEngines.push('sql-native');
-    }
-    if (capabilities.hasMultiStageQuery()) {
-      queryEngines.push('sql-msq-task');
-    }
-
     return this.wrapInViewContainer(
       'workbench',
       <WorkbenchView
@@ -326,7 +318,7 @@ export class ConsoleApplication extends React.PureComponent<
         mandatoryQueryContext={mandatoryQueryContext}
         baseQueryContext={baseQueryContext}
         serverQueryContext={serverQueryContext}
-        queryEngines={queryEngines}
+        queryEngines={capabilities.getSupportedQueryEngines()}
         goToTask={this.goToTasksWithTaskId}
         getClusterCapacity={maybeGetClusterCapacity}
       />,
@@ -469,7 +461,7 @@ export class ConsoleApplication extends React.PureComponent<
                   component={this.wrappedClassicBatchDataLoaderView}
                 />
               )}
-              {capabilities.hasCoordinatorAccess() && capabilities.hasMultiStageQuery() && (
+              {capabilities.hasCoordinatorAccess() && capabilities.hasMultiStageQueryTask() && (
                 <Route path="/sql-data-loader" component={this.wrappedSqlDataLoaderView} />
               )}
 

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -1620,21 +1620,12 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
         onClick={[Function]}
         text="History"
       />
-      <Blueprint5.Tooltip
-        compact={false}
-        content="There is no compaction config currently set for this datasource"
-        hoverCloseDelay={0}
-        hoverOpenDelay={100}
-        interactionKind="hover-target"
-        minimal={false}
-        transitionDuration={100}
-      >
-        <Blueprint5.Button
-          disabled={true}
-          intent="danger"
-          text="Delete"
-        />
-      </Blueprint5.Tooltip>
+      <Blueprint5.Button
+        data-tooltip="There is no compaction config currently set for this datasource"
+        disabled={true}
+        intent="danger"
+        text="Delete"
+      />
       <Blueprint5.Button
         onClick={[Function]}
         text="Close"

--- a/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
+++ b/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Callout, Classes, Code, Dialog, Intent, Switch, Tooltip } from '@blueprintjs/core';
+import { Button, Callout, Classes, Code, Dialog, Intent, Switch } from '@blueprintjs/core';
 import React, { useState } from 'react';
 
 import type { FormJsonTabs } from '../../components';
@@ -163,9 +163,12 @@ export const CompactionConfigDialog = React.memo(function CompactionConfigDialog
           {compactionConfig ? (
             <Button text="Delete" intent={Intent.DANGER} onClick={onDelete} />
           ) : (
-            <Tooltip content="There is no compaction config currently set for this datasource">
-              <Button text="Delete" disabled intent={Intent.DANGER} />
-            </Tooltip>
+            <Button
+              text="Delete"
+              disabled
+              intent={Intent.DANGER}
+              data-tooltip="There is no compaction config currently set for this datasource"
+            />
           )}
           <Button text="Close" onClick={onClose} />
           <Button

--- a/web-console/src/dialogs/compaction-history-dialog/compaction-history-dialog.tsx
+++ b/web-console/src/dialogs/compaction-history-dialog/compaction-history-dialog.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Callout, Classes, Dialog, Tab, Tabs, Tag } from '@blueprintjs/core';
+import { Button, Callout, Classes, Dialog, Tab, Tabs, TabsExpander, Tag } from '@blueprintjs/core';
 import * as JSONBig from 'json-bigint-native';
 import React, { useState } from 'react';
 
@@ -113,7 +113,7 @@ export const CompactionHistoryDialog = React.memo(function CompactionHistoryDial
                   }
                 />
               ))}
-              <Tabs.Expander />
+              <TabsExpander />
             </Tabs>
           ) : (
             <div>

--- a/web-console/src/dialogs/history-dialog/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog/history-dialog.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Classes, Dialog, Tab, Tabs } from '@blueprintjs/core';
+import { Button, Classes, Dialog, Tab, Tabs, TabsExpander } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import * as JSONBig from 'json-bigint-native';
@@ -83,7 +83,7 @@ export const HistoryDialog = React.memo(function HistoryDialog(props: HistoryDia
             />
           );
         })}
-        <Tabs.Expander />
+        <TabsExpander />
       </Tabs>
     );
   }

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -516,9 +516,9 @@ exports[`RetentionDialog matches snapshot 1`] = `
                             >
                               <button
                                 class="bp5-button bp5-disabled bp5-minimal"
+                                data-tooltip="There are no tiers left to assign"
                                 disabled=""
                                 tabindex="-1"
-                                title="There are no tiers left to assign"
                                 type="button"
                               >
                                 <span

--- a/web-console/src/druid-models/execution/execution.ts
+++ b/web-console/src/druid-models/execution/execution.ts
@@ -255,12 +255,13 @@ export class Execution {
       };
     }
 
+    const { createdAt, durationMs, state } = asyncSubmitResult;
     return new Execution({
       engine: 'sql-msq-task',
       id: queryId,
-      startTime: new Date(asyncSubmitResult.createdAt),
-      duration: asyncSubmitResult.durationMs,
-      status: Execution.normalizeAsyncState(asyncSubmitResult.state),
+      startTime: new Date(createdAt),
+      duration: durationMs >= 0 ? durationMs : undefined,
+      status: Execution.normalizeAsyncState(state),
       sqlQuery,
       queryContext,
       stages: Array.isArray(stages) && counters ? new Stages(stages, counters) : undefined,
@@ -335,7 +336,7 @@ export class Execution {
       status: Execution.normalizeTaskStatus(status),
       segmentStatus: segmentLoaderStatus,
       startTime: isNaN(startTime.getTime()) ? undefined : startTime,
-      duration: typeof durationMs === 'number' ? durationMs : undefined,
+      duration: typeof durationMs === 'number' && durationMs >= 0 ? durationMs : undefined,
       usageInfo: getUsageInfoFromStatusPayload(
         deepGet(taskReport, 'multiStageQuery.payload.status'),
       ),
@@ -439,6 +440,13 @@ export class Execution {
 
       _payload: this._payload,
     };
+  }
+
+  public changeEngine(engine: DruidEngine): Execution {
+    return new Execution({
+      ...this.valueOf(),
+      engine,
+    });
   }
 
   public changeSqlQuery(sqlQuery: string, queryContext?: QueryContext): Execution {

--- a/web-console/src/druid-models/query-context/query-context.tsx
+++ b/web-console/src/druid-models/query-context/query-context.tsx
@@ -42,6 +42,7 @@ export interface QueryContext {
   waitUntilSegmentsLoad?: boolean;
   useConcurrentLocks?: boolean;
   forceSegmentSortByTime?: boolean;
+  includeAllCounters?: boolean;
 
   [key: string]: any;
 }
@@ -65,6 +66,7 @@ export const DEFAULT_SERVER_QUERY_CONTEXT: QueryContext = {
   waitUntilSegmentsLoad: false,
   useConcurrentLocks: false,
   forceSegmentSortByTime: true,
+  includeAllCounters: false,
 };
 
 export interface QueryWithContext {

--- a/web-console/src/druid-models/stages/stages.spec.ts
+++ b/web-console/src/druid-models/stages/stages.spec.ts
@@ -16,7 +16,52 @@
  * limitations under the License.
  */
 
+import { aggregateSortProgressCounters } from './stages';
 import { STAGES } from './stages.mock';
+
+describe('aggregateSortProgressCounters', () => {
+  it('works', () => {
+    expect(
+      aggregateSortProgressCounters([
+        {
+          type: 'sortProgress',
+          totalMergingLevels: 2,
+          levelToTotalBatches: { 0: 3, 1: 4, 2: 4 },
+          levelToMergedBatches: { 0: 3, 1: 4, 2: 4 },
+          totalMergersForUltimateLevel: 1,
+        },
+        {
+          type: 'sortProgress',
+          totalMergingLevels: 4,
+          levelToTotalBatches: { 0: 2, 1: 4, 2: 6, 3: 5 },
+          levelToMergedBatches: { 0: 2, 1: 4, 2: 6, 3: 5 },
+          totalMergersForUltimateLevel: 1,
+        },
+      ]),
+    ).toEqual({
+      totalMergingLevels: {
+        '2': 1,
+        '4': 1,
+      },
+      levelToBatches: {
+        '0': {
+          '2': 1,
+          '3': 1,
+        },
+        '1': {
+          '4': 2,
+        },
+        '2': {
+          '4': 1,
+          '6': 1,
+        },
+        '3': {
+          '5': 1,
+        },
+      },
+    });
+  });
+});
 
 describe('Stages', () => {
   describe('#overallProgress', () => {

--- a/web-console/src/druid-models/task/task.ts
+++ b/web-console/src/druid-models/task/task.ts
@@ -113,6 +113,12 @@ export interface MsqTaskReportResponse {
       };
       stages: StageDefinition[];
       counters: Counters;
+      results?: {
+        signature: { name: string; type: string }[];
+        sqlTypeNames: string[];
+        results: any[];
+        resultsTruncated?: boolean;
+      };
     };
   };
   error?: any;

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -153,7 +153,7 @@ export class WorkbenchQuery {
 
   static fromTaskQueryAndContext(queryString: string, context: QueryContext): WorkbenchQuery {
     const noSqlOuterLimit = typeof context['sqlOuterLimit'] === 'undefined';
-    const cleanContext = deleteKeys(context, ['sqlOuterLimit']);
+    const cleanContext = deleteKeys(context, ['sqlOuterLimit', '__resultFormat']);
 
     let retQuery = WorkbenchQuery.blank()
       .changeEngine('sql-msq-task')

--- a/web-console/src/entry.scss
+++ b/web-console/src/entry.scss
@@ -36,6 +36,7 @@ body {
   overflow: hidden;
   font-size: 13px;
   overscroll-behavior-x: none;
+  cursor: default;
 }
 
 body {

--- a/web-console/src/entry.tsx
+++ b/web-console/src/entry.tsx
@@ -32,7 +32,7 @@ import type { QueryContext } from './druid-models';
 import type { Links } from './links';
 import { setLinkOverrides } from './links';
 import { Api, UrlBaser } from './singletons';
-import { setLocalStorageNamespace } from './utils';
+import { initMouseTooltip, setLocalStorageNamespace } from './utils';
 
 import './entry.scss';
 
@@ -117,6 +117,8 @@ createRoot(container).render(
     />
   </OverlaysProvider>,
 );
+
+initMouseTooltip();
 
 // ---------------------------------
 // Taken from https://hackernoon.com/removing-that-ugly-focus-ring-and-keeping-it-too-6c8727fefcd2

--- a/web-console/src/utils/basic-action.tsx
+++ b/web-console/src/utils/basic-action.tsx
@@ -45,7 +45,7 @@ export function basicActionsToMenu(
           intent={intent}
           onClick={onAction}
           disabled={Boolean(disabledReason)}
-          title={disabledReason}
+          data-super-title={disabledReason}
         />
       ))}
     </Menu>

--- a/web-console/src/utils/date.ts
+++ b/web-console/src/utils/date.ts
@@ -28,8 +28,10 @@ export function dateToIsoDateString(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
-export function prettyFormatIsoDate(isoDate: string): string {
-  return isoDate.replace('T', ' ').replace(/\.\d\d\dZ$/, '');
+export function prettyFormatIsoDate(isoDate: string | Date): string {
+  return (typeof isoDate === 'string' ? isoDate : isoDate.toISOString())
+    .replace('T', ' ')
+    .replace(/\.\d\d\dZ$/, '');
 }
 
 export function utcToLocalDate(utcDate: Date): Date {

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -148,7 +148,7 @@ export function change<T>(xs: readonly T[], from: T, to: T): T[] {
 
 export function countBy<T>(
   array: readonly T[],
-  fn: (x: T, index: number) => string = String,
+  fn: (x: T, index: number) => string | number = String,
 ): Record<string, number> {
   const counts: Record<string, number> = {};
   for (let i = 0; i < array.length; i++) {
@@ -207,7 +207,7 @@ export function groupBy<T, Q>(
 
 export function groupByAsMap<T, Q>(
   array: readonly T[],
-  keyFn: (x: T, index: number) => string,
+  keyFn: (x: T, index: number) => string | number,
   aggregateFn: (xs: readonly T[], key: string) => Q,
 ): Record<string, Q> {
   const buckets: Record<string, T[]> = {};
@@ -317,6 +317,10 @@ export function formatDurationWithMs(ms: NumberLike): string {
   return (
     timeInHours + ':' + pad2(timeInMin) + ':' + pad2(timeInSec) + '.' + pad3(Math.floor(n) % 1000)
   );
+}
+
+export function formatDurationWithMsIfNeeded(ms: NumberLike): string {
+  return Number(ms) < 1000 ? formatDurationWithMs(ms) : formatDuration(ms);
 }
 
 export function formatDurationHybrid(ms: NumberLike): string {

--- a/web-console/src/utils/index.tsx
+++ b/web-console/src/utils/index.tsx
@@ -26,6 +26,7 @@ export * from './formatter';
 export * from './general';
 export * from './local-storage-backed-visibility';
 export * from './local-storage-keys';
+export * from './mouse-tooltip/mouse-tooltip';
 export * from './null-mode-detection';
 export * from './object-change';
 export * from './query-action';

--- a/web-console/src/utils/mouse-tooltip/mouse-tooltip.scss
+++ b/web-console/src/utils/mouse-tooltip/mouse-tooltip.scss
@@ -16,29 +16,17 @@
  * limitations under the License.
  */
 
-import type { Execution } from '../druid-models';
+@import '../../variables';
 
-export interface WorkbenchRunningPromise {
-  executionPromise: Promise<Execution>;
-  startTime: Date;
-}
-
-export class WorkbenchRunningPromises {
-  private static readonly promises = new Map<string, WorkbenchRunningPromise>();
-
-  static isWorkbenchRunningPromise(x: any): x is WorkbenchRunningPromise {
-    return Boolean(x.executionPromise);
-  }
-
-  static storePromise(id: string, promise: WorkbenchRunningPromise): void {
-    WorkbenchRunningPromises.promises.set(id, promise);
-  }
-
-  static getPromise(id: string): WorkbenchRunningPromise | undefined {
-    return WorkbenchRunningPromises.promises.get(id);
-  }
-
-  static deletePromise(id: string): void {
-    WorkbenchRunningPromises.promises.delete(id);
-  }
+.mouse-tooltip {
+  position: absolute;
+  background: $dark-gray1;
+  color: $light-gray5;
+  padding: 5px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 1000;
+  font-size: 11px;
+  max-width: 75vw;
+  white-space: pre-wrap;
 }

--- a/web-console/src/utils/mouse-tooltip/mouse-tooltip.ts
+++ b/web-console/src/utils/mouse-tooltip/mouse-tooltip.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { clamp } from '../general';
+
+import './mouse-tooltip.scss';
+
+const OFFSET_X = 0;
+const OFFSET_Y = 30;
+
+function findDataTooltip(element: HTMLElement): string | undefined {
+  let e: HTMLElement | null = element;
+  while (e) {
+    const t = e.getAttribute('data-tooltip');
+    if (t) return t;
+    e = e.parentElement;
+  }
+  return;
+}
+
+export function initMouseTooltip() {
+  let tooltipDiv: HTMLDivElement | undefined;
+
+  // Mouse move handler to follow the mouse
+  const handleMouseMove = (event: MouseEvent) => {
+    if (!tooltipDiv) return;
+
+    tooltipDiv.style.left = `${clamp(
+      event.pageX + OFFSET_X,
+      0,
+      window.innerWidth - tooltipDiv.offsetWidth,
+    )}px`;
+    tooltipDiv.style.top = `${clamp(
+      event.pageY + OFFSET_Y,
+      0,
+      window.innerHeight - tooltipDiv.offsetHeight,
+    )}px`;
+  };
+
+  // Mouse over handler to show the tooltip for elements with the appropriate attribute
+  const handleMouseOver = (event: MouseEvent) => {
+    const title = findDataTooltip(event.target as HTMLElement);
+    if (title) {
+      if (!tooltipDiv) {
+        tooltipDiv = document.createElement('div');
+        tooltipDiv.className = 'mouse-tooltip';
+        document.body.appendChild(tooltipDiv);
+        document.addEventListener('mousemove', handleMouseMove);
+      }
+      if (tooltipDiv.innerText !== title) {
+        tooltipDiv.innerText = title;
+        handleMouseMove(event); // Position the div as it might be the first positioning
+      }
+    } else if (tooltipDiv) {
+      document.removeEventListener('mousemove', handleMouseMove);
+      tooltipDiv.remove();
+      tooltipDiv = undefined;
+    }
+  };
+
+  document.addEventListener('mouseover', handleMouseOver);
+}

--- a/web-console/src/views/home-view/__snapshots__/home-view.spec.tsx.snap
+++ b/web-console/src/views/home-view/__snapshots__/home-view.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`HomeView matches snapshot (coordinator) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": false,
+        "multiStageQueryTask": false,
         "overlord": false,
         "queryType": "none",
       }
@@ -21,7 +21,7 @@ exports[`HomeView matches snapshot (coordinator) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": false,
+          "multiStageQueryTask": false,
           "overlord": false,
           "queryType": "none",
         }
@@ -32,7 +32,7 @@ exports[`HomeView matches snapshot (coordinator) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": false,
+          "multiStageQueryTask": false,
           "overlord": false,
           "queryType": "none",
         }
@@ -44,7 +44,7 @@ exports[`HomeView matches snapshot (coordinator) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": false,
+        "multiStageQueryTask": false,
         "overlord": false,
         "queryType": "none",
       }
@@ -55,7 +55,7 @@ exports[`HomeView matches snapshot (coordinator) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": false,
+        "multiStageQueryTask": false,
         "overlord": false,
         "queryType": "none",
       }
@@ -73,7 +73,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": true,
+        "multiStageQueryTask": true,
         "overlord": true,
         "queryType": "nativeAndSql",
       }
@@ -85,7 +85,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": true,
+          "multiStageQueryTask": true,
           "overlord": true,
           "queryType": "nativeAndSql",
         }
@@ -96,7 +96,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": true,
+          "multiStageQueryTask": true,
           "overlord": true,
           "queryType": "nativeAndSql",
         }
@@ -109,7 +109,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": true,
+          "multiStageQueryTask": true,
           "overlord": true,
           "queryType": "nativeAndSql",
         }
@@ -120,7 +120,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
         Capabilities {
           "coordinator": true,
           "maxTaskSlots": undefined,
-          "multiStageQuery": true,
+          "multiStageQueryTask": true,
           "overlord": true,
           "queryType": "nativeAndSql",
         }
@@ -132,7 +132,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": true,
+        "multiStageQueryTask": true,
         "overlord": true,
         "queryType": "nativeAndSql",
       }
@@ -143,7 +143,7 @@ exports[`HomeView matches snapshot (full) 1`] = `
       Capabilities {
         "coordinator": true,
         "maxTaskSlots": undefined,
-        "multiStageQuery": true,
+        "multiStageQueryTask": true,
         "overlord": true,
         "queryType": "nativeAndSql",
       }
@@ -161,7 +161,7 @@ exports[`HomeView matches snapshot (overlord) 1`] = `
       Capabilities {
         "coordinator": false,
         "maxTaskSlots": undefined,
-        "multiStageQuery": false,
+        "multiStageQueryTask": false,
         "overlord": true,
         "queryType": "none",
       }
@@ -173,7 +173,7 @@ exports[`HomeView matches snapshot (overlord) 1`] = `
         Capabilities {
           "coordinator": false,
           "maxTaskSlots": undefined,
-          "multiStageQuery": false,
+          "multiStageQueryTask": false,
           "overlord": true,
           "queryType": "none",
         }
@@ -184,7 +184,7 @@ exports[`HomeView matches snapshot (overlord) 1`] = `
         Capabilities {
           "coordinator": false,
           "maxTaskSlots": undefined,
-          "multiStageQuery": false,
+          "multiStageQueryTask": false,
           "overlord": true,
           "queryType": "none",
         }

--- a/web-console/src/views/home-view/home-view.scss
+++ b/web-console/src/views/home-view/home-view.scss
@@ -37,4 +37,8 @@
   @media (max-width: 600px) {
     grid-template-columns: 1fr;
   }
+
+  .tooltip-info {
+    text-decoration: underline dotted;
+  }
 }

--- a/web-console/src/views/home-view/status-card/status-card.tsx
+++ b/web-console/src/views/home-view/status-card/status-card.tsx
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-import { Tooltip } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import React, { useState } from 'react';
 
@@ -89,20 +88,15 @@ export const StatusCard = React.memo(function StatusCard(props: StatusCardProps)
           </>
         )}
         {nullModeDetection && (
-          <Tooltip
-            content={
-              <div>
-                <p>
-                  <strong>Null related server properties</strong>
-                </p>
-                {explainNullModeDetection(nullModeDetection).map((line, i) => (
-                  <p key={i}>{line}</p>
-                ))}
-              </div>
-            }
+          <p
+            className="tooltip-info"
+            data-tooltip={[
+              'Null related server properties',
+              ...explainNullModeDetection(nullModeDetection),
+            ].join('\n')}
           >
-            <p>{summarizeNullModeDetection(nullModeDetection)}</p>
-          </Tooltip>
+            {summarizeNullModeDetection(nullModeDetection)}
+          </p>
         )}
       </HomeViewCard>
       {showStatusDialog && (

--- a/web-console/src/views/load-data-view/filter-table/__snapshots__/filter-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/filter-table/__snapshots__/filter-table.spec.tsx.snap
@@ -233,7 +233,7 @@ exports[`FilterTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366400000"
+              data-tooltip="1460366400000"
             >
               2016-04-11T09:20:00.000Z
             </div>
@@ -321,7 +321,7 @@ exports[`FilterTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366460000"
+              data-tooltip="1460366460000"
             >
               2016-04-11T09:21:00.000Z
             </div>
@@ -409,7 +409,7 @@ exports[`FilterTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366520000"
+              data-tooltip="1460366520000"
             >
               2016-04-11T09:22:00.000Z
             </div>

--- a/web-console/src/views/load-data-view/parse-time-table/__snapshots__/parse-time-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/parse-time-table/__snapshots__/parse-time-table.spec.tsx.snap
@@ -231,7 +231,7 @@ exports[`ParseTimeTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366400000"
+              data-tooltip="1460366400000"
             >
               2016-04-11T09:20:00.000Z
             </div>
@@ -319,7 +319,7 @@ exports[`ParseTimeTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366460000"
+              data-tooltip="1460366460000"
             >
               2016-04-11T09:21:00.000Z
             </div>
@@ -407,7 +407,7 @@ exports[`ParseTimeTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366520000"
+              data-tooltip="1460366520000"
             >
               2016-04-11T09:22:00.000Z
             </div>

--- a/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/schema-table/__snapshots__/schema-table.spec.tsx.snap
@@ -240,7 +240,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366400000"
+              data-tooltip="1460366400000"
             >
               2016-04-11T09:20:00.000Z
             </div>
@@ -328,7 +328,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366460000"
+              data-tooltip="1460366460000"
             >
               2016-04-11T09:21:00.000Z
             </div>
@@ -416,7 +416,7 @@ exports[`SchemaTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366520000"
+              data-tooltip="1460366520000"
             >
               2016-04-11T09:22:00.000Z
             </div>

--- a/web-console/src/views/load-data-view/transform-table/__snapshots__/transform-table.spec.tsx.snap
+++ b/web-console/src/views/load-data-view/transform-table/__snapshots__/transform-table.spec.tsx.snap
@@ -233,7 +233,7 @@ exports[`TransformTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366400000"
+              data-tooltip="1460366400000"
             >
               2016-04-11T09:20:00.000Z
             </div>
@@ -321,7 +321,7 @@ exports[`TransformTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366460000"
+              data-tooltip="1460366460000"
             >
               2016-04-11T09:21:00.000Z
             </div>
@@ -409,7 +409,7 @@ exports[`TransformTable matches snapshot 1`] = `
           >
             <div
               class="table-cell timestamp"
-              title="1460366520000"
+              data-tooltip="1460366520000"
             >
               2016-04-11T09:22:00.000Z
             </div>

--- a/web-console/src/views/sql-data-loader-view/destination-form/destination-form.tsx
+++ b/web-console/src/views/sql-data-loader-view/destination-form/destination-form.tsx
@@ -24,7 +24,6 @@ import {
   Intent,
   Radio,
   RadioGroup,
-  Tooltip,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
@@ -88,9 +87,12 @@ export const DestinationForm = React.memo(function DestinationForm(props: Destin
             placeholder="Choose a name"
             rightElement={
               existingTables.includes(table) ? (
-                <Tooltip content="Table name already exists">
-                  <Button icon={IconNames.DELETE} intent={Intent.DANGER} minimal />
-                </Tooltip>
+                <Button
+                  icon={IconNames.DELETE}
+                  intent={Intent.DANGER}
+                  minimal
+                  data-tooltip="Table name already exists"
+                />
               ) : undefined
             }
           />

--- a/web-console/src/views/sql-data-loader-view/schema-step/preview-table/preview-table.tsx
+++ b/web-console/src/views/sql-data-loader-view/schema-step/preview-table/preview-table.tsx
@@ -138,7 +138,7 @@ export const PreviewTable = React.memo(function PreviewTable(props: PreviewTable
             Header() {
               return (
                 <div className="header-wrapper" onClick={() => onEditColumn(i)}>
-                  <div className="output-name" title={columnToSummary(column)}>
+                  <div className="output-name" data-tooltip={columnToSummary(column)}>
                     {icon && <Icon className="type-icon" icon={icon} size={12} />}
                     {h}
                     {hasFilterOnHeader(h, i) && (

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -849,19 +849,19 @@ export class SupervisorsView extends React.PureComponent<
               )?.map((t: SupervisorStatusTask) => t.id);
               const c = getTotalSupervisorStats(value, statsKey, activeTaskIds);
               const seconds = getRowStatsKeySeconds(statsKey);
-              const totalLabel = `Total over ${statsKey}: `;
+              const totalLabel = `Total (past ${statsKey}): `;
               const bytes = c.processedBytes ? ` (${formatByteRate(c.processedBytes)})` : '';
               return (
                 <div>
                   <div
-                    title={`${totalLabel}${formatInteger(c.processed * seconds)} (${formatBytes(
-                      c.processedBytes * seconds,
-                    )})`}
+                    data-tooltip={`${totalLabel}${formatInteger(
+                      c.processed * seconds,
+                    )} (${formatBytes(c.processedBytes * seconds)})`}
                   >{`Processed: ${formatRate(c.processed)}${bytes}`}</div>
                   {Boolean(c.processedWithError) && (
                     <div
                       className="warning-line"
-                      title={`${totalLabel}${formatInteger(c.processedWithError * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(c.processedWithError * seconds)}`}
                     >
                       Processed with error: {formatRate(c.processedWithError)}
                     </div>
@@ -869,7 +869,7 @@ export class SupervisorsView extends React.PureComponent<
                   {Boolean(c.thrownAway) && (
                     <div
                       className="warning-line"
-                      title={`${totalLabel}${formatInteger(c.thrownAway * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(c.thrownAway * seconds)}`}
                     >
                       Thrown away: {formatRate(c.thrownAway)}
                     </div>
@@ -877,7 +877,7 @@ export class SupervisorsView extends React.PureComponent<
                   {Boolean(c.unparseable) && (
                     <div
                       className="warning-line"
-                      title={`${totalLabel}${formatInteger(c.unparseable * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(c.unparseable * seconds)}`}
                     >
                       Unparseable: {formatRate(c.unparseable)}
                     </div>

--- a/web-console/src/views/tasks-view/tasks-view.tsx
+++ b/web-console/src/views/tasks-view/tasks-view.tsx
@@ -414,8 +414,11 @@ ORDER BY
             }),
             Cell: row => {
               if (row.aggregated) return '';
-              const { status } = row.original;
-              const errorMsg = row.original.error_msg;
+              const { status, error_msg } = row.original;
+              const errorMsg =
+                error_msg && !TASK_CANCELED_ERROR_MESSAGES.includes(error_msg)
+                  ? error_msg
+                  : undefined;
               return (
                 <TableFilterableCell
                   field="status"
@@ -423,10 +426,10 @@ ORDER BY
                   filters={filters}
                   onFiltersChange={onFiltersChange}
                 >
-                  <span title={errorMsg}>
+                  <span data-tooltip={errorMsg}>
                     <span style={{ color: statusToColor(status) }}>&#x25cf;&nbsp;</span>
                     {status}
-                    {errorMsg && !TASK_CANCELED_ERROR_MESSAGES.includes(errorMsg) && (
+                    {errorMsg && (
                       <a onClick={() => this.setState({ alertErrorMsg: errorMsg })}>&nbsp;?</a>
                     )}
                   </span>

--- a/web-console/src/views/workbench-view/column-tree/__snapshots__/column-tree.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/column-tree/__snapshots__/column-tree.spec.tsx.snap
@@ -90,6 +90,7 @@ exports[`ColumnTree matches snapshot 1`] = `
           usePortal={true}
         >
           <Blueprint5.Button
+            data-tooltip="Search settings"
             icon="settings"
           />
         </Blueprint5.Popover>
@@ -110,10 +111,10 @@ exports[`ColumnTree matches snapshot 1`] = `
                   aria-hidden={true}
                   autoLoad={true}
                   className="bp5-tree-node-icon"
+                  data-tooltip="TIMESTAMP"
                   icon="time"
                   tabIndex={-1}
                   tagName="span"
-                  title="TIMESTAMP"
                 />,
                 "id": "__time",
                 "label": <Blueprint5.Popover
@@ -151,10 +152,10 @@ exports[`ColumnTree matches snapshot 1`] = `
                   aria-hidden={true}
                   autoLoad={true}
                   className="bp5-tree-node-icon"
+                  data-tooltip="BIGINT"
                   icon="numerical"
                   tabIndex={-1}
                   tagName="span"
-                  title="BIGINT"
                 />,
                 "id": "added",
                 "label": <Blueprint5.Popover
@@ -192,10 +193,10 @@ exports[`ColumnTree matches snapshot 1`] = `
                   aria-hidden={true}
                   autoLoad={true}
                   className="bp5-tree-node-icon"
+                  data-tooltip="FLOAT"
                   icon="floating-point"
                   tabIndex={-1}
                   tagName="span"
-                  title="FLOAT"
                 />,
                 "id": "addedBy10",
                 "label": <Blueprint5.Popover

--- a/web-console/src/views/workbench-view/column-tree/column-tree.tsx
+++ b/web-console/src/views/workbench-view/column-tree/column-tree.tsx
@@ -469,7 +469,7 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                       icon={dataTypeToIcon(columnData.DATA_TYPE)}
                       aria-hidden
                       tabIndex={-1}
-                      title={columnData.DATA_TYPE}
+                      data-tooltip={columnData.DATA_TYPE}
                     />
                   ),
                   label: (
@@ -648,7 +648,7 @@ export class ColumnTree extends React.PureComponent<ColumnTreeProps, ColumnTreeS
                 </Menu>
               }
             >
-              <Button icon={IconNames.SETTINGS} />
+              <Button icon={IconNames.SETTINGS} data-tooltip="Search settings" />
             </Popover>
           </ButtonGroup>
         }

--- a/web-console/src/views/workbench-view/execution-details-pane/__snapshots__/execution-details-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-details-pane/__snapshots__/execution-details-pane.spec.tsx.snap
@@ -42,7 +42,57 @@ exports[`ExecutionDetailsPane matches snapshot no init tab 1`] = `
     className="execution-details-pane-general"
   >
     <p>
-      General info for query-26d490c6-c06d-4cd2-938f-bc5f7f982754 ingesting into "kttm-blank-lines"
+      General info for 
+      <Blueprint5.Tag
+        active={false}
+        fill={false}
+        interactive={false}
+        large={false}
+        minimal={true}
+        round={false}
+      >
+        query-26d490c6-c06d-4cd2-938f-bc5f7f982754
+      </Blueprint5.Tag>
+      <React.Fragment>
+         
+        ingesting into 
+        <Blueprint5.Tag
+          active={false}
+          fill={false}
+          interactive={false}
+          large={false}
+          minimal={true}
+          round={false}
+        >
+          "kttm-blank-lines"
+        </Blueprint5.Tag>
+      </React.Fragment>
+    </p>
+    <p>
+      Query took 
+      <Blueprint5.Tag
+        active={false}
+        fill={false}
+        interactive={false}
+        large={false}
+        minimal={true}
+        round={false}
+      >
+        0:00:04
+      </Blueprint5.Tag>
+       
+      (starting at 
+      <Blueprint5.Tag
+        active={false}
+        fill={false}
+        interactive={false}
+        large={false}
+        minimal={true}
+        round={false}
+      >
+        2024-01-23 19:56:44
+      </Blueprint5.Tag>
+      )
     </p>
     <p>
       Results written to dataSource

--- a/web-console/src/views/workbench-view/execution-details-pane/execution-details-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-details-pane/execution-details-pane.tsx
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+import { Tag } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import { T } from '@druid-toolkit/query';
 import * as JSONBig from 'json-bigint-native';
@@ -23,7 +24,13 @@ import React, { useState } from 'react';
 
 import { FancyTabPane } from '../../../components';
 import type { Execution } from '../../../druid-models';
-import { formatDuration, formatDurationWithMs, pluralIfNeeded } from '../../../utils';
+import {
+  formatDuration,
+  formatDurationWithMs,
+  formatDurationWithMsIfNeeded,
+  pluralIfNeeded,
+  prettyFormatIsoDate,
+} from '../../../utils';
 import { DestinationPagesPane } from '../destination-pages-pane/destination-pages-pane';
 import { ExecutionErrorPane } from '../execution-error-pane/execution-error-pane';
 import { ExecutionStagesPane } from '../execution-stages-pane/execution-stages-pane';
@@ -62,9 +69,21 @@ export const ExecutionDetailsPane = React.memo(function ExecutionDetailsPane(
         const ingestDatasource = execution.getIngestDatasource();
         return (
           <div className="execution-details-pane-general">
-            <p>{`General info for ${execution.id}${
-              ingestDatasource ? ` ingesting into ${T(ingestDatasource)}` : ''
-            }`}</p>
+            <p>
+              General info for <Tag minimal>{execution.id}</Tag>
+              {ingestDatasource && (
+                <>
+                  {' '}
+                  ingesting into <Tag minimal>{T(ingestDatasource).toString()}</Tag>
+                </>
+              )}
+            </p>
+            {execution.startTime && execution.duration && (
+              <p>
+                Query took <Tag minimal>{formatDurationWithMsIfNeeded(execution.duration)}</Tag>{' '}
+                (starting at <Tag minimal>{prettyFormatIsoDate(execution.startTime)}</Tag>)
+              </p>
+            )}
             {execution.destination && (
               <p>
                 {`Results written to ${execution.destination.type}`}

--- a/web-console/src/views/workbench-view/execution-stages-pane/__snapshots__/execution-stages-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-stages-pane/__snapshots__/execution-stages-pane.spec.tsx.snap
@@ -110,19 +110,35 @@ exports[`ExecutionStagesPane matches snapshot 1`] = `
         "width": 150,
       },
       {
-        "Header": "Phase",
-        "accessor": [Function],
-        "className": "padded",
-        "id": "phase",
-        "width": 130,
-      },
-      {
         "Cell": [Function],
         "Header": "Timing",
         "accessor": [Function],
-        "className": "padded",
         "id": "timing",
         "width": 170,
+      },
+      {
+        "Cell": [Function],
+        "Header": <React.Fragment>
+          CPU utilization
+          <br />
+          <i>
+            <span
+              className="cpu-label"
+            >
+              counter
+            </span>
+            <span
+              className="cpu-counter"
+            >
+              wall time
+            </span>
+          </i>
+        </React.Fragment>,
+        "accessor": [Function],
+        "className": "padded",
+        "id": "cpu",
+        "show": false,
+        "width": 220,
       },
       {
         "Header": <React.Fragment>
@@ -135,22 +151,11 @@ exports[`ExecutionStagesPane matches snapshot 1`] = `
         "width": 75,
       },
       {
-        "Header": <React.Fragment>
-          Output
-          <br />
-          partitions
-        </React.Fragment>,
+        "Cell": [Function],
+        "Header": "Output",
         "accessor": "partitionCount",
         "className": "padded",
-        "width": 75,
-      },
-      {
-        "Cell": [Function],
-        "Header": "Cluster by",
-        "accessor": [Function],
-        "className": "padded",
-        "id": "clusterBy",
-        "minWidth": 400,
+        "width": 120,
       },
     ]
   }

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
@@ -41,7 +41,7 @@
     opacity: 0.6;
   }
 
-  .sort-marker {
+  .detail-line {
     font-style: italic;
     opacity: 0.6;
   }
@@ -99,12 +99,38 @@
     }
 
     .detail-counters-for-partitions,
-    .detail-counters-for-workers {
+    .detail-counters-for-workers,
+    .detail-counters-for-sort {
       display: inline-block;
       margin-left: 10px;
       margin-top: 10px;
       vertical-align: top;
       background: $dark-gray3;
+    }
+  }
+
+  .cpu-label {
+    display: inline-block;
+    width: 120px;
+  }
+
+  .cpu-counter {
+    display: inline-block;
+    width: 80px;
+  }
+
+  .timing-value {
+    position: relative;
+    height: 100%;
+    padding: 10px 5px;
+    margin-right: 1px; // This is to allow to show a 1px wide .timing-bar bar right at "left: 99.9%"
+
+    .timing-bar {
+      position: absolute;
+      top: 10px;
+      height: 36px;
+      background: $druid-brand;
+      opacity: 0.15;
     }
   }
 }

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { Button, Icon, Intent, Tooltip } from '@blueprintjs/core';
+import { Button, Icon, Intent } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import * as JSONBig from 'json-bigint-native';
@@ -37,9 +37,14 @@ import type {
   StageDefinition,
   StageInput,
 } from '../../../druid-models';
-import { formatClusterBy, Stages, summarizeInputSource } from '../../../druid-models';
+import {
+  CPUS_COUNTER_FIELDS,
+  cpusCounterFieldTitle,
+  formatClusterBy,
+  Stages,
+  summarizeInputSource,
+} from '../../../druid-models';
 import { DEFAULT_TABLE_CLASS_NAME } from '../../../react-table';
-import type { NumberLike } from '../../../utils';
 import {
   assemble,
   capitalizeFirst,
@@ -47,12 +52,12 @@ import {
   deepGet,
   filterMap,
   formatBytesCompact,
-  formatDuration,
   formatDurationWithMs,
+  formatDurationWithMsIfNeeded,
   formatInteger,
   formatPercent,
   oneOf,
-  prettyFormatIsoDate,
+  pluralIfNeeded,
   twoLines,
 } from '../../../utils';
 
@@ -81,8 +86,6 @@ function formatBreakdown(breakdown: Record<string, number>): string {
 const formatRows = formatInteger;
 const formatRowRate = formatInteger;
 const formatFrames = formatInteger;
-const formatDurationDynamic = (n: NumberLike) =>
-  n < 1000 ? formatDurationWithMs(n) : formatDuration(n);
 
 const formatFileOfTotal = (files: number, totalFiles: number) =>
   `(${formatInteger(files)} / ${formatInteger(totalFiles)})`;
@@ -98,12 +101,15 @@ function inputLabelContent(stage: StageDefinition, inputIndex: number) {
       Input{' '}
       {stageInput.type === 'stage' && <span className="stage">{`Stage${stageInput.stage}`}</span>}
       {stageInput.type === 'table' && (
-        <span className="datasource" title={summarizeTableInput(stageInput)}>
+        <span className="datasource" data-tooltip={summarizeTableInput(stageInput)}>
           {stageInput.dataSource}
         </span>
       )}
       {stageInput.type === 'external' && (
-        <span className="external" title={summarizeInputSource(stageInput.inputSource, true)}>
+        <span
+          className="external"
+          data-tooltip={summarizeInputSource(stageInput.inputSource, true)}
+        >
           {`${stageInput.inputSource.type} external`}
         </span>
       )}
@@ -111,7 +117,7 @@ function inputLabelContent(stage: StageDefinition, inputIndex: number) {
         <Icon
           className="broadcast-tag"
           icon={IconNames.CELL_TOWER}
-          title="This input is being broadcast to all workers in this stage."
+          data-tooltip="This input is being broadcast to all workers in this stage."
         />
       )}
     </>
@@ -156,6 +162,8 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
   const { execution, onErrorClick, onWarningClick, goToTask } = props;
   const stages = execution.stages || new Stages([]);
   const error = execution.error;
+  const executionStartTime = execution.startTime;
+  const executionDuration = execution.duration;
 
   const rowRateValues = stages.stages.map(s =>
     formatRowRate(stages.getRateFromStage(s, 'rows') || 0),
@@ -183,6 +191,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
         {detailedCountersForPartitions(stage, 'in', phase === 'READING_INPUT')}
         {detailedCountersForWorkers(stage)}
         {detailedCountersForPartitions(stage, 'out', phaseIsWorking)}
+        {detailedCountersForSort(stage)}
       </div>
     );
   }
@@ -238,11 +247,47 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
               return (
                 <TableClickableCell
                   hoverIcon={IconNames.SHARE}
-                  title={`Go to task: ${taskId}`}
+                  data-tooltip={`Go to task: ${taskId}`}
                   onClick={() => {
                     goToTask(taskId);
                   }}
                 >{`Worker${value}`}</TableClickableCell>
+              );
+            },
+          } as Column<SimpleWideCounter>,
+          {
+            Header: twoLines(
+              'CPU utilization',
+              <i>
+                <span className="cpu-label">counter</span>
+                <span className="cpu-counter">wall time</span>
+              </i>,
+            ),
+            id: 'cpu',
+            accessor: d => d.cpu?.main?.cpu || 0,
+            className: 'padded',
+            width: 220,
+            Cell({ original }) {
+              const cpuTotals = original.cpu || {};
+              return (
+                <>
+                  {filterMap(CPUS_COUNTER_FIELDS, k => {
+                    const v = cpuTotals[k];
+                    if (!v) return;
+                    const fieldTitle = cpusCounterFieldTitle(k);
+                    return (
+                      <div
+                        key={k}
+                        data-tooltip={`${fieldTitle}\nCPU time: ${formatDurationWithMs(
+                          v.cpu / 1e6,
+                        )}`}
+                      >
+                        <span className="cpu-label">{cpusCounterFieldTitle(k)}</span>
+                        <span className="cpu-counter">{formatDurationWithMs(v.wall / 1e6)}</span>
+                      </div>
+                    );
+                  })}
+                </>
               );
             },
           } as Column<SimpleWideCounter>,
@@ -261,7 +306,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
               id: counterName,
               accessor: d => d[counterName]!.rows,
               className: 'padded',
-              width: 180,
+              width: 160,
               Cell({ value, original }) {
                 const c = (original as SimpleWideCounter)[counterName]!;
                 return (
@@ -269,7 +314,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
                     <BracedText
                       text={formatRows(value)}
                       braces={bracesRows[counterName]}
-                      title={
+                      data-tooltip={
                         c.bytes
                           ? `Uncompressed size: ${formatBytesCompact(c.bytes)} ${NOT_SIZE_ON_DISK}`
                           : NO_SIZE_INFO
@@ -315,6 +360,48 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
               ]
             : [],
         )}
+      />
+    );
+  }
+
+  function detailedCountersForSort(stage: StageDefinition) {
+    const aggregatedSortProgress = stages.getAggregatedSortProgressForStage(stage);
+    if (!aggregatedSortProgress) return;
+
+    const data = [
+      { name: 'levelToBatches', counts: aggregatedSortProgress.totalMergingLevels },
+      ...Object.entries(aggregatedSortProgress.levelToBatches).map(([level, counts]) => ({
+        name: `Level ${level}`,
+        counts,
+      })),
+    ];
+
+    return (
+      <ReactTable
+        className="detail-counters-for-sort"
+        data={data}
+        loading={false}
+        defaultPageSize={clamp(data.length, 1, MAX_DETAIL_ROWS)}
+        showPagination={data.length > MAX_DETAIL_ROWS}
+        columns={[
+          {
+            Header: `Sort stat`,
+            accessor: 'name',
+            className: 'padded',
+            width: 120,
+          },
+          {
+            Header: `Counts`,
+            accessor: 'counts',
+            className: 'padded',
+            width: 180,
+            Cell({ value }) {
+              return Object.entries(value)
+                .map(([n, v]) => (Number(v) > 1 ? `${n} (${v})` : n))
+                .join(', ');
+            },
+          },
+        ]}
       />
     );
   }
@@ -376,7 +463,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
                   <BracedText
                     text={formatRows(value)}
                     braces={bracesRows[counterName]}
-                    title={
+                    data-tooltip={
                       c.bytes
                         ? `Uncompressed size: ${formatBytesCompact(c.bytes)} ${NOT_SIZE_ON_DISK}`
                         : NO_SIZE_INFO
@@ -401,7 +488,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
       <div
         className="data-transfer"
         key={inputNumber}
-        title={
+        data-tooltip={
           bytes
             ? `${inputLabel} uncompressed size: ${formatBytesCompact(bytes)} ${NOT_SIZE_ON_DISK}`
             : `${inputLabel}: ${NO_SIZE_INFO}`
@@ -459,7 +546,7 @@ export const ExecutionStagesPane = React.memo(function ExecutionStagesPane(
     return (
       <div
         className="data-transfer"
-        title={`${title} frames: ${formatFrames(
+        data-tooltip={`${title} frames: ${formatFrames(
           stages.getTotalCounterForStage(stage, 'output', 'frames'),
         )}
 ${title} uncompressed size: ${formatBytesCompact(
@@ -486,7 +573,7 @@ ${title} uncompressed size: ${formatBytesCompact(
     return (
       <div
         className="data-transfer"
-        title={`${title} frames: ${formatFrames(
+        data-tooltip={`${title} frames: ${formatFrames(
           stages.getTotalCounterForStage(stage, 'shuffle', 'frames'),
         )}
 ${title} uncompressed size: ${formatBytesCompact(
@@ -507,7 +594,7 @@ ${title} uncompressed size: ${formatBytesCompact(
     if (!stages.hasCounterForStage(stage, 'segmentGenerationProgress')) return;
 
     return (
-      <div className="data-transfer" title={NO_SIZE_INFO}>
+      <div className="data-transfer" data-tooltip={NO_SIZE_INFO}>
         <BracedText
           text={formatRows(stages.getTotalSegmentGenerationProgressForStage(stage, field))}
           braces={rowsValues}
@@ -544,43 +631,33 @@ ${title} uncompressed size: ${formatBytesCompact(
                   <span className="stage">{`Stage${stage.stageNumber}`}</span>
                 </div>
                 <div>{stage.definition.processor.type}</div>
-                {stage.sort && <div className="sort-marker">(with sort)</div>}
+                {stage.sort && <div className="detail-line">(with sort)</div>}
                 {(myError || warnings > 0) && (
                   <div className="error-warning">
                     {myError && (
-                      <Tooltip
-                        content={
-                          <div>
-                            {(error.error.errorCode ? `${error.error.errorCode}: ` : '') +
-                              error.error.errorMessage}
-                          </div>
+                      <Button
+                        minimal
+                        small
+                        icon={IconNames.ERROR}
+                        intent={Intent.DANGER}
+                        onClick={onErrorClick}
+                        data-tooltip={
+                          (error.error.errorCode ? `${error.error.errorCode}: ` : '') +
+                          error.error.errorMessage
                         }
-                      >
-                        <Button
-                          minimal
-                          small
-                          icon={IconNames.ERROR}
-                          intent={Intent.DANGER}
-                          onClick={onErrorClick}
-                        />
-                      </Tooltip>
+                      />
                     )}
                     {myError && warnings > 0 && ' '}
                     {warnings > 0 && (
-                      <Tooltip
-                        content={
-                          <pre>{formatBreakdown(stages.getWarningBreakdownForStage(stage))}</pre>
-                        }
-                      >
-                        <Button
-                          minimal
-                          small
-                          icon={IconNames.WARNING_SIGN}
-                          text={warnings > 1 ? `${warnings}` : undefined}
-                          intent={Intent.WARNING}
-                          onClick={onWarningClick}
-                        />
-                      </Tooltip>
+                      <Button
+                        minimal
+                        small
+                        icon={IconNames.WARNING_SIGN}
+                        text={warnings > 1 ? `${warnings}` : undefined}
+                        intent={Intent.WARNING}
+                        onClick={onWarningClick}
+                        data-tooltip={formatBreakdown(stages.getWarningBreakdownForStage(stage))}
+                      />
                     )}
                   </div>
                 )}
@@ -670,34 +747,84 @@ ${title} uncompressed size: ${formatBytesCompact(
             const byteRate = stages.getRateFromStage(stage, 'bytes');
             return (
               <BracedText
+                className="moon"
                 text={formatRowRate(value)}
                 braces={rowRateValues}
-                title={byteRate ? `${formatBytesCompact(byteRate)}/s` : undefined}
+                data-tooltip={byteRate ? `${formatBytesCompact(byteRate)}/s` : 'Unknown byte rate'}
               />
             );
           },
         },
         {
-          Header: 'Phase',
-          id: 'phase',
-          accessor: row => (row.phase ? capitalizeFirst(row.phase.replace(/_/g, ' ')) : ''),
-          className: 'padded',
-          width: 130,
-        },
-        {
           Header: 'Timing',
           id: 'timing',
           accessor: row => row.startTime,
-          className: 'padded',
           width: 170,
           Cell({ value, original }) {
-            const duration: number | undefined = original.duration;
+            const { duration, phase } = original;
             if (!value) return null;
+
+            const sinceQueryStart =
+              new Date(value).valueOf() - (executionStartTime?.valueOf() || 0);
+
             return (
-              <div title={value + (duration ? `/${formatDurationWithMs(duration)}` : '')}>
-                <div>{prettyFormatIsoDate(value)}</div>
-                <div>{duration ? formatDurationDynamic(duration) : ''}</div>
+              <div
+                className="timing-value"
+                data-tooltip={assemble(
+                  `Start: T+${formatDurationWithMs(sinceQueryStart)} (${value})`,
+                  duration ? `Duration: ${formatDurationWithMs(duration)}` : undefined,
+                ).join('\n')}
+              >
+                {executionDuration && executionDuration > 0 && (
+                  <div
+                    className="timing-bar"
+                    style={{
+                      left: `${(sinceQueryStart / executionDuration) * 100}%`,
+                      width: `max(${(duration / executionDuration) * 100}%, 1px)`,
+                    }}
+                  />
+                )}
+                <div>{`Start: T+${formatDurationWithMsIfNeeded(sinceQueryStart)}`}</div>
+                <div>Duration: {duration ? formatDurationWithMsIfNeeded(duration) : ''}</div>
+                {phase && (
+                  <div className="detail-line">{capitalizeFirst(phase.replace(/_/g, ' '))}</div>
+                )}
               </div>
+            );
+          },
+        },
+        {
+          Header: twoLines(
+            'CPU utilization',
+            <i>
+              <span className="cpu-label">counter</span>
+              <span className="cpu-counter">wall time</span>
+            </i>,
+          ),
+          id: 'cpu',
+          accessor: () => null,
+          className: 'padded',
+          width: 220,
+          show: stages.hasCounter('cpu'),
+          Cell({ original }) {
+            const cpuTotals = stages.getCpuTotalsForStage(original);
+            return (
+              <>
+                {filterMap(CPUS_COUNTER_FIELDS, k => {
+                  const v = cpuTotals[k];
+                  if (!v) return;
+                  const fieldTitle = cpusCounterFieldTitle(k);
+                  return (
+                    <div
+                      key={k}
+                      data-tooltip={`${fieldTitle}\nCPU time: ${formatDurationWithMs(v.cpu / 1e6)}`}
+                    >
+                      <span className="cpu-label">{fieldTitle}</span>
+                      <span className="cpu-counter">{formatDurationWithMs(v.wall / 1e6)}</span>
+                    </div>
+                  );
+                })}
+              </>
             );
           },
         },
@@ -708,33 +835,25 @@ ${title} uncompressed size: ${formatBytesCompact(
           width: 75,
         },
         {
-          Header: twoLines('Output', 'partitions'),
+          Header: 'Output',
           accessor: 'partitionCount',
           className: 'padded',
-          width: 75,
-        },
-        {
-          Header: 'Cluster by',
-          id: 'clusterBy',
-          className: 'padded',
-          minWidth: 400,
-          accessor: row => formatClusterBy(deepGet(row, 'definition.shuffleSpec.clusterBy')),
+          width: 120,
           Cell({ value, original }) {
+            const { shuffle } = original;
             const clusterBy: ClusterBy | undefined = deepGet(
               original,
               'definition.shuffleSpec.clusterBy',
             );
-            if (!clusterBy) return null;
-            if (clusterBy.bucketByCount) {
-              return (
-                <>
-                  <div>{`Partition by: ${formatClusterBy(clusterBy, 'partition')}`}</div>
-                  <div>{`Cluster by: ${formatClusterBy(clusterBy, 'cluster')}`}</div>
-                </>
-              );
-            } else {
-              return <div title={value}>{value}</div>;
-            }
+            return (
+              <div data-tooltip={clusterBy ? formatClusterBy(clusterBy) : 'No clusterBy'}>
+                <div>{shuffle}</div>
+                <div className="detail-line">{original.output}</div>
+                {typeof value === 'number' ? (
+                  <div className="detail-line">{pluralIfNeeded(value, 'partition')}</div>
+                ) : undefined}
+              </div>
+            );
           },
         },
       ]}

--- a/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
+++ b/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
@@ -28,6 +28,7 @@ import {
   downloadQueryResults,
   formatDurationHybrid,
   formatInteger,
+  oneOf,
   pluralIfNeeded,
 } from '../../../utils';
 import { DestinationPagesDialog } from '../destination-pages-dialog/destination-pages-dialog';
@@ -95,7 +96,7 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
         }
         onClick={() => {
           if (!execution) return;
-          if (execution.engine === 'sql-msq-task') {
+          if (oneOf(execution.engine, 'sql-msq-task')) {
             onExecutionDetail();
           }
         }}
@@ -104,6 +105,7 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
         <Button
           key="download"
           icon={IconNames.DOWNLOAD}
+          data-tooltip="Download data"
           minimal
           onClick={() => setShowDestinationPages(true)}
         />
@@ -129,14 +131,22 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
           }
           position={Position.BOTTOM_RIGHT}
         >
-          <Button icon={IconNames.DOWNLOAD} minimal />
+          <Button icon={IconNames.DOWNLOAD} data-tooltip="Download data in view" minimal />
         </Popover>
       ),
     );
   }
 
   if (onReset) {
-    buttons.push(<Button key="reset" icon={IconNames.CROSS} minimal onClick={onReset} />);
+    buttons.push(
+      <Button
+        key="reset"
+        icon={IconNames.CROSS}
+        data-tooltip="Clear output pane"
+        minimal
+        onClick={onReset}
+      />,
+    );
   }
 
   return (

--- a/web-console/src/views/workbench-view/explain-dialog/explain-dialog.tsx
+++ b/web-console/src/views/workbench-view/explain-dialog/explain-dialog.tsx
@@ -25,6 +25,7 @@ import {
   Intent,
   Tab,
   Tabs,
+  TabsExpander,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import * as JSONBig from 'json-bigint-native';
@@ -94,13 +95,21 @@ export const ExplainDialog = React.memo(function ExplainDialog(props: ExplainDia
       };
 
       let result: any[];
-      try {
-        result =
-          engine === 'sql-msq-task'
-            ? (await Api.instance.post(`/druid/v2/sql/task`, payload)).data
-            : await queryDruidSql(payload);
-      } catch (e) {
-        throw new Error(getDruidErrorMessage(e));
+      switch (engine) {
+        case 'sql-native':
+          result = await queryDruidSql(payload);
+          break;
+
+        case 'sql-msq-task':
+          try {
+            result = (await Api.instance.post(`/druid/v2/sql/task`, payload)).data;
+          } catch (e) {
+            throw new Error(getDruidErrorMessage(e));
+          }
+          break;
+
+        default:
+          throw new Error(`Explain not supported for engine ${engine}`);
       }
 
       const plan = deepGet(result, '0.PLAN');
@@ -180,7 +189,7 @@ export const ExplainDialog = React.memo(function ExplainDialog(props: ExplainDia
               panel={renderQueryExplanation(queryExplanation)}
             />
           ))}
-          <Tabs.Expander />
+          <TabsExpander />
         </Tabs>
       );
     }

--- a/web-console/src/views/workbench-view/ingest-success-pane/ingest-success-pane.tsx
+++ b/web-console/src/views/workbench-view/ingest-success-pane/ingest-success-pane.tsx
@@ -28,7 +28,7 @@ import './ingest-success-pane.scss';
 
 export interface IngestSuccessPaneProps {
   execution: Execution;
-  onDetails(id: string, initTab?: ExecutionDetailsTab): void;
+  onDetails(execution: Execution, initTab?: ExecutionDetailsTab): void;
   onQueryTab?(newQuery: WorkbenchQuery, tabName?: string): void;
 }
 
@@ -56,7 +56,7 @@ export const IngestSuccessPane = React.memo(function IngestSuccessPane(
         {warnings > 0 && (
           <>
             {' '}
-            <span className="action" onClick={() => onDetails(execution.id, 'warnings')}>
+            <span className="action" onClick={() => onDetails(execution, 'warnings')}>
               {pluralIfNeeded(warnings, 'warning')}
             </span>{' '}
             recorded.
@@ -66,7 +66,7 @@ export const IngestSuccessPane = React.memo(function IngestSuccessPane(
       <p>
         {duration ? `Insert query took ${formatDuration(duration)}. ` : `Insert query completed. `}
         {segmentStatusDescription ? segmentStatusDescription.label + ' ' : ''}
-        <span className="action" onClick={() => onDetails(execution.id)}>
+        <span className="action" onClick={() => onDetails(execution)}>
           Show details
         </span>
       </p>

--- a/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
+++ b/web-console/src/views/workbench-view/recent-query-task-panel/recent-query-task-panel.tsx
@@ -69,17 +69,6 @@ interface RecentQueryEntry {
   errorMessage?: string;
 }
 
-function formatDetail(entry: RecentQueryEntry): string | undefined {
-  const lines: string[] = [];
-  if (entry.datasource !== Execution.INLINE_DATASOURCE_MARKER) {
-    lines.push(`Datasource: ${entry.datasource}`);
-  }
-  if (entry.errorMessage) {
-    lines.push(entry.errorMessage);
-  }
-  return lines.length ? lines.join('\n\n') : undefined;
-}
-
 export interface RecentQueryTaskPanelProps {
   onClose(): void;
   onExecutionDetails(id: string): void;
@@ -227,7 +216,10 @@ LIMIT 100`,
             const [icon, color] = statusToIconAndColor(w.taskStatus);
             return (
               <Popover className="work-entry" key={w.taskId} position="left" content={menu}>
-                <div title={formatDetail(w)} onDoubleClick={() => onExecutionDetails(w.taskId)}>
+                <div
+                  data-tooltip={w.errorMessage}
+                  onDoubleClick={() => onExecutionDetails(w.taskId)}
+                >
                   <div className="line1">
                     <Icon
                       className={'status-icon ' + w.taskStatus.toLowerCase()}

--- a/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
+++ b/web-console/src/views/workbench-view/result-table-pane/result-table-pane.tsx
@@ -610,7 +610,7 @@ export const ResultTablePane = React.memo(function ResultTablePane(props: Result
                 return (
                   <Popover content={<Deferred content={() => getHeaderMenu(column, i)} />}>
                     <div className="clickable-cell">
-                      <div className="output-name" title={columnToSummary(column)}>
+                      <div className="output-name" data-tooltip={columnToSummary(column)}>
                         {icon && <Icon className="type-icon" icon={icon} size={12} />}
                         {h}
                         {hasFilterOnHeader(h, i) && (

--- a/web-console/src/views/workbench-view/workbench-history-dialog/workbench-history-dialog.tsx
+++ b/web-console/src/views/workbench-view/workbench-history-dialog/workbench-history-dialog.tsx
@@ -16,7 +16,16 @@
  * limitations under the License.
  */
 
-import { Button, Classes, Dialog, Intent, Popover, Tab, Tabs } from '@blueprintjs/core';
+import {
+  Button,
+  Classes,
+  Dialog,
+  Intent,
+  Popover,
+  Tab,
+  Tabs,
+  TabsExpander,
+} from '@blueprintjs/core';
 import * as JSONBig from 'json-bigint-native';
 import type { JSX } from 'react';
 import React, { useState } from 'react';
@@ -111,7 +120,7 @@ export const WorkbenchHistoryDialog = React.memo(function WorkbenchHistoryDialog
             panelClassName="panel"
           />
         ))}
-        <Tabs.Expander />
+        <TabsExpander />
       </Tabs>
     );
   }

--- a/web-console/src/views/workbench-view/workbench-view.scss
+++ b/web-console/src/views/workbench-view/workbench-view.scss
@@ -34,12 +34,20 @@ $recent-query-task-panel-width: 250px;
     @include card-like;
   }
 
-  .recent-query-task-panel {
+  .recent-panel {
     position: absolute;
     top: 0;
     right: 0;
     height: 100%;
     width: $recent-query-task-panel-width;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+
+    .recent-query-task-panel,
+    .current-viper-panel {
+      flex: 1;
+    }
   }
 
   .center-panel {
@@ -94,7 +102,7 @@ $recent-query-task-panel-width: 250px;
           }
         }
 
-        .add-tab {
+        .new-tab {
           display: inline-block;
           vertical-align: top;
           padding: 6px 14px;
@@ -116,7 +124,7 @@ $recent-query-task-panel-width: 250px;
     left: 0;
   }
 
-  &.hide-work-history .center-panel {
+  &.hide-right-panel .center-panel {
     right: 0;
   }
 }


### PR DESCRIPTION
This is the web console followup to https://github.com/apache/druid/pull/16914

If CPU counters are present show them as a column in the stages detail view

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/3d226713-b23f-49e5-82ec-c3f589877d8b">

Also added a custom tooltip interface so that data hidden in the tooltips (like CPU time) is more discoverable.