### PR TITLE
Web console: switch to using arrays by default

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -296,6 +296,9 @@ export type SchemaMode = 'fixed' | 'string-only-discovery' | 'type-aware-discove
 export type ArrayMode = 'arrays' | 'multi-values';
 
 export const DEFAULT_FORCE_SEGMENT_SORT_BY_TIME = true;
+export const DEFAULT_SCHEMA_MODE: SchemaMode = 'fixed';
+export const DEFAULT_ARRAY_MODE: ArrayMode = 'arrays';
+
 export function getForceSegmentSortByTime(spec: Partial<IngestionSpec>): boolean {
   return (
     deepGet(spec, 'spec.dataSchema.dimensionsSpec.forceSegmentSortByTime') ??

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -83,7 +83,9 @@ import {
   computeFlattenPathsForData,
   CONSTANT_TIMESTAMP_SPEC,
   CONSTANT_TIMESTAMP_SPEC_FIELDS,
+  DEFAULT_ARRAY_MODE,
   DEFAULT_FORCE_SEGMENT_SORT_BY_TIME,
+  DEFAULT_SCHEMA_MODE,
   DIMENSION_SPEC_FIELDS,
   fillDataSourceNameIfNeeded,
   fillInputFormatIfNeeded,
@@ -317,8 +319,8 @@ function initializeSchemaWithSampleIfNeeded(
     spec,
     sample,
     DEFAULT_FORCE_SEGMENT_SORT_BY_TIME,
-    'fixed',
-    'multi-values',
+    DEFAULT_SCHEMA_MODE,
+    DEFAULT_ARRAY_MODE,
     getRollup(spec, false),
   );
 }

--- a/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
+++ b/web-console/src/views/workbench-view/input-format-step/input-format-step.tsx
@@ -27,6 +27,7 @@ import type { ArrayMode, InputFormat, InputSource } from '../../../druid-models'
 import {
   BATCH_INPUT_FORMAT_FIELDS,
   chooseByBestTimestamp,
+  DEFAULT_ARRAY_MODE,
   DETECTION_TIMESTAMP_SPEC,
   getPossibleSystemFieldsForInputSource,
   guessColumnTypeFromSampleResponse,
@@ -93,7 +94,7 @@ export const InputFormatStep = React.memo(function InputFormatStep(props: InputF
     InputSourceAndFormat | undefined
   >(isValidInputFormat(initInputFormat) ? inputSourceAndFormat : undefined);
   const [selectTimestamp, setSelectTimestamp] = useState(true);
-  const [arrayMode, setArrayMode] = useState<ArrayMode>('multi-values');
+  const [arrayMode, setArrayMode] = useState<ArrayMode>(DEFAULT_ARRAY_MODE);
 
   const [previewState] = useQueryManager<InputSourceAndFormat, SampleResponse>({
     query: inputSourceAndFormatToSample,


### PR DESCRIPTION
Console follow up to Druid changes in regarding the default array mode.