### PR TITLE
Web console: add stage graph

### DIFF
--- a/web-console/src/druid-models/stages/graph-info.ts
+++ b/web-console/src/druid-models/stages/graph-info.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filterMap } from '../../utils';
+
+import type { StageDefinition } from './stages';
+
+export type GraphInfoLane =
+  | { type: 'stage'; stageNumber: number; fromLanes: number[]; hasOut: boolean }
+  | { type: 'line'; stageNumber: number; fromLane: number };
+
+export type GraphInfo = GraphInfoLane[];
+
+export function computeNextInfo(
+  stage: StageDefinition,
+  prevInfo: GraphInfo,
+  isLastStage: boolean,
+): GraphInfo {
+  const inputStageNumbers = filterMap(stage.definition.input, i =>
+    i.type === 'stage' ? i.stage : undefined,
+  );
+
+  const myInfo: GraphInfo = [];
+  let addedSelf = false;
+  for (let i = 0; i < prevInfo.length; i++) {
+    const prevLane = prevInfo[i];
+    if (addedSelf) {
+      if (inputStageNumbers.includes(prevLane.stageNumber)) {
+        // Do nothing because this was already recorded in the 'stage' lane
+      } else {
+        myInfo.push({ type: 'line', stageNumber: prevLane.stageNumber, fromLane: i });
+      }
+    } else {
+      if (inputStageNumbers.includes(prevLane.stageNumber)) {
+        // Add self
+        myInfo.push({
+          type: 'stage',
+          stageNumber: stage.stageNumber,
+          fromLanes: filterMap(prevInfo, (lane, i) =>
+            inputStageNumbers.includes(lane.stageNumber) ? i : undefined,
+          ),
+          hasOut: !isLastStage,
+        });
+        addedSelf = true;
+      } else {
+        myInfo.push({ type: 'line', stageNumber: prevLane.stageNumber, fromLane: i });
+      }
+    }
+  }
+
+  // If the stage was not already added then it must be a new source, start a new lane
+  if (!addedSelf) {
+    myInfo.push({
+      type: 'stage',
+      stageNumber: stage.stageNumber,
+      fromLanes: [], // We know the stage is a source
+      hasOut: !isLastStage,
+    });
+  }
+
+  return myInfo;
+}

--- a/web-console/src/druid-models/stages/stages.spec.ts
+++ b/web-console/src/druid-models/stages/stages.spec.ts
@@ -290,4 +290,51 @@ describe('Stages', () => {
       `);
     });
   });
+
+  describe('#getGraphInfos', () => {
+    it('works for mock', () => {
+      expect(STAGES.getGraphInfos()).toMatchInlineSnapshot(`
+        [
+          [
+            {
+              "fromLanes": [],
+              "hasOut": true,
+              "stageNumber": 0,
+              "type": "stage",
+            },
+          ],
+          [
+            {
+              "fromLanes": [
+                0,
+              ],
+              "hasOut": true,
+              "stageNumber": 1,
+              "type": "stage",
+            },
+          ],
+          [
+            {
+              "fromLanes": [
+                0,
+              ],
+              "hasOut": true,
+              "stageNumber": 2,
+              "type": "stage",
+            },
+          ],
+          [
+            {
+              "fromLanes": [
+                0,
+              ],
+              "hasOut": false,
+              "stageNumber": 3,
+              "type": "stage",
+            },
+          ],
+        ]
+      `);
+    });
+  });
 });

--- a/web-console/src/druid-models/stages/stages.ts
+++ b/web-console/src/druid-models/stages/stages.ts
@@ -22,6 +22,9 @@ import { deleteKeys, filterMap, oneOf, zeroDivide } from '../../utils';
 import type { InputFormat } from '../input-format/input-format';
 import type { InputSource } from '../input-source/input-source';
 
+import type { GraphInfo } from './graph-info';
+import { computeNextInfo } from './graph-info';
+
 const SHUFFLE_WEIGHT = 0.5;
 const READING_INPUT_WITH_SHUFFLE_WEIGHT = 1 - SHUFFLE_WEIGHT;
 
@@ -577,5 +580,20 @@ export class Stages {
     }
 
     return potentiallyStuckIndex;
+  }
+
+  getGraphInfos(): GraphInfo[] {
+    const { stages } = this;
+
+    let prevInfo: GraphInfo = [];
+    const ret: GraphInfo[] = [];
+
+    for (const stage of stages) {
+      ret.push(
+        (prevInfo = computeNextInfo(stage, prevInfo, stage.stageNumber === stages.length - 1)),
+      );
+    }
+
+    return ret;
   }
 }

--- a/web-console/src/views/workbench-view/execution-stages-pane/__snapshots__/execution-stages-pane.spec.tsx.snap
+++ b/web-console/src/views/workbench-view/execution-stages-pane/__snapshots__/execution-stages-pane.spec.tsx.snap
@@ -61,6 +61,15 @@ exports[`ExecutionStagesPane matches snapshot 1`] = `
     [
       {
         "Cell": [Function],
+        "accessor": "stageNumber",
+        "className": "graph-cell",
+        "id": "graph",
+        "minWidth": 20,
+        "show": false,
+        "width": 20,
+      },
+      {
+        "Cell": [Function],
         "Header": <React.Fragment>
           Stage
           <br />

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
@@ -23,6 +23,24 @@
     cursor: default;
   }
 
+  .graph-cell {
+    position: relative;
+
+    & > svg {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+
+      line {
+        stroke: $light-gray5;
+      }
+
+      circle {
+        fill: $light-gray5;
+      }
+    }
+  }
+
   .stage {
     color: #8dd3c7;
   }

--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.tsx
@@ -63,6 +63,10 @@ const MAX_DETAIL_ROWS = 20;
 const NOT_SIZE_ON_DISK = '(does not represent size on disk)';
 const NO_SIZE_INFO = 'no size info';
 
+// For the graph
+const LANE_WIDTH = 20;
+const STAGE_OFFSET = '19px';
+
 function summarizeTableInput(tableStageInput: StageInput): string {
   if (tableStageInput.type !== 'table') return '';
   return assemble(
@@ -516,6 +520,13 @@ ${title} uncompressed size: ${formatBytesCompact(
     );
   }
 
+  const graphInfos = stages.getGraphInfos();
+  const maxLanes = Math.max(...graphInfos.map(graphInfo => graphInfo.length));
+
+  function laneX(laneNumber: number) {
+    return `${((laneNumber + 0.5) / maxLanes) * 100}%`;
+  }
+
   return (
     <ReactTable
       className={classNames('execution-stages-pane', DEFAULT_TABLE_CLASS_NAME)}
@@ -528,6 +539,61 @@ ${title} uncompressed size: ${formatBytesCompact(
       showPagination={stages.stageCount() > MAX_STAGE_ROWS}
       SubComponent={({ original }) => detailedStats(original)}
       columns={[
+        {
+          id: 'graph',
+          className: 'graph-cell',
+          accessor: 'stageNumber',
+          show: maxLanes > 1,
+          width: LANE_WIDTH * maxLanes,
+          minWidth: LANE_WIDTH,
+          Cell({ value }) {
+            const graphInfo = graphInfos[value];
+
+            return (
+              <svg xmlns="http://www.w3.org/2000/svg">
+                {graphInfo.flatMap((lane, i) => {
+                  switch (lane.type) {
+                    case 'line':
+                      return (
+                        <line
+                          key={`line${i}`}
+                          x1={laneX(lane.fromLane)}
+                          y1="0%"
+                          x2={laneX(i)}
+                          y2="100%"
+                        />
+                      );
+
+                    case 'stage':
+                      return [
+                        ...lane.fromLanes.map(fromLane => (
+                          <line
+                            key={`stage${i}_from${fromLane}`}
+                            x1={laneX(fromLane)}
+                            y1="0%"
+                            x2={laneX(i)}
+                            y2={STAGE_OFFSET}
+                          />
+                        )),
+                        ...(lane.hasOut
+                          ? [
+                              <line
+                                key={`stage${i}_out`}
+                                x1={laneX(i)}
+                                y1={STAGE_OFFSET}
+                                x2={laneX(i)}
+                                y2="100%"
+                              />,
+                            ]
+                          : []),
+                        <circle key={`stage${i}_stage`} cx={laneX(i)} cy={STAGE_OFFSET} r={5} />,
+                      ];
+                  }
+                })}
+              </svg>
+            );
+          },
+        },
         {
           Header: twoLines('Stage', <i>processorType</i>),
           id: 'stage',


### PR DESCRIPTION
This PR adds a simple graph vis to the side of the stage table to better show which stage flows into which other stage

![image](https://github.com/user-attachments/assets/093a5bda-5665-4844-bce1-d5c04993646c)
