### PR TITLE
MSQ window functions: Fix boost column not being written to the frame in window stage

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -136,6 +136,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     if (segmentGranularityVirtualColumn != null) {
       frameWriterVirtualColumns.add(segmentGranularityVirtualColumn);
     }
+    frameWriterVirtualColumns.add(this.partitionBoostVirtualColumn);
     this.frameWriterVirtualColumns = VirtualColumns.create(frameWriterVirtualColumns);
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQDrillWindowQueryTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQDrillWindowQueryTest.java
@@ -175,6 +175,105 @@ public class MSQDrillWindowQueryTest extends DrillWindowQueryTest
     windowQueryTest();
   }
 
+  @Override
+  @DrillTest("ntile_func/ntileFn_47")
+  @Test
+  public void test_ntile_func_ntileFn_47()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_49")
+  @Test
+  public void test_ntile_func_ntileFn_49()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_50")
+  @Test
+  public void test_ntile_func_ntileFn_50()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_51")
+  @Test
+  public void test_ntile_func_ntileFn_51()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_52")
+  @Test
+  public void test_ntile_func_ntileFn_52()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_53")
+  @Test
+  public void test_ntile_func_ntileFn_53()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_54")
+  @Test
+  public void test_ntile_func_ntileFn_54()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_55")
+  @Test
+  public void test_ntile_func_ntileFn_55()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_56")
+  @Test
+  public void test_ntile_func_ntileFn_56()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_57")
+  @Test
+  public void test_ntile_func_ntileFn_57()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
+  @Override
+  @DrillTest("ntile_func/ntileFn_58")
+  @Test
+  public void test_ntile_func_ntileFn_58()
+  {
+    useSingleWorker();
+    windowQueryTest();
+  }
+
   /*
   Queries having window functions can give multiple correct results because of using MixShuffleSpec in the previous stage.
   So we want to use a single worker to get the same result everytime for such test cases.

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQWindowTest.java
@@ -1272,20 +1272,20 @@ public class MSQWindowTest extends MSQTestBase
         .setExpectedResultRows(
             NullHandling.replaceWithDefault() ?
             ImmutableList.of(
-                new Object[]{"a", 5.0},
                 new Object[]{"", 11.0},
                 new Object[]{"", 11.0},
+                new Object[]{"", 11.0},
                 new Object[]{"a", 5.0},
-                new Object[]{"abc", 5.0},
-                new Object[]{"", 11.0}
+                new Object[]{"a", 5.0},
+                new Object[]{"abc", 5.0}
             ) :
             ImmutableList.of(
-                new Object[]{"a", 5.0},
+                new Object[]{null, 8.0},
                 new Object[]{null, 8.0},
                 new Object[]{"", 3.0},
                 new Object[]{"a", 5.0},
-                new Object[]{"abc", 5.0},
-                new Object[]{null, 8.0}
+                new Object[]{"a", 5.0},
+                new Object[]{"abc", 5.0}
             ))
         .setQueryContext(context)
         .verifyResults();
@@ -1935,11 +1935,11 @@ public class MSQWindowTest extends MSQTestBase
                                    .build())
         .setExpectedRowSignature(rowSignature)
         .setExpectedResultRows(ImmutableList.of(
-            new Object[]{"Auburn", 0L, 1698L},
-            new Object[]{"Mexico City", 0L, 6136L},
-            new Object[]{"Seoul", 663L, 5582L},
-            new Object[]{"Tokyo", 0L, 12615L},
-            new Object[]{"Santiago", 161L, 401L}
+            new Object[]{"Al Ain", 8L, 6334L},
+            new Object[]{"Dubai", 3L, 6334L},
+            new Object[]{"Dubai", 6323L, 6334L},
+            new Object[]{"Tirana", 26L, 26L},
+            new Object[]{"Benguela", 0L, 0L}
         ))
         .setQueryContext(context)
         .verifyResults();
@@ -2272,16 +2272,58 @@ public class MSQWindowTest extends MSQTestBase
 
         // Stage 3, Worker 0
         .setExpectedCountersForStageWorkerChannel(
-            CounterSnapshotMatcher.with().rows(13).bytes(1327).frames(1),
+            CounterSnapshotMatcher.with().rows(3).bytes(318).frames(1),
             3, 0, "input0"
         )
         .setExpectedCountersForStageWorkerChannel(
-            CounterSnapshotMatcher.with().rows(13).bytes(1379).frames(1),
+            CounterSnapshotMatcher.with().rows(3).bytes(330).frames(1),
             3, 0, "output"
         )
         .setExpectedCountersForStageWorkerChannel(
-            CounterSnapshotMatcher.with().rows(13).bytes(1327).frames(1),
+            CounterSnapshotMatcher.with().rows(3).bytes(318).frames(1),
             3, 0, "shuffle"
+        )
+
+        // Stage 3, Worker 1
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(0, 3).bytes(0, 333).frames(0, 1),
+            3, 1, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(3).bytes(345).frames(1),
+            3, 1, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(3).bytes(333).frames(1),
+            3, 1, "shuffle"
+        )
+
+        // Stage 3, Worker 2
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(0, 0, 3).bytes(0, 0, 352).frames(0, 0, 1),
+            3, 2, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(3).bytes(364).frames(1),
+            3, 2, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(3).bytes(352).frames(1),
+            3, 2, "shuffle"
+        )
+
+        // Stage 3, Worker 3
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(0, 0, 0, 4).bytes(0, 0, 0, 426).frames(0, 0, 0, 1),
+            3, 3, "input0"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(4).bytes(442).frames(1),
+            3, 3, "output"
+        )
+        .setExpectedCountersForStageWorkerChannel(
+            CounterSnapshotMatcher.with().rows(4).bytes(426).frames(1),
+            3, 3, "shuffle"
         )
         .verifyResults();
   }


### PR DESCRIPTION
### Description

In `WindowOperatorQueryFrameProcessor`, currently we were not adding the partition boost column to the `ColumnSelectorFactory` used to create the `FrameWriter`. Because of this, the boost column was not being written to the frame.

This was causing the quantile sketch to misjudge the number of output partitions to create, as it was creating a single partition boundary because we had the same value for boost column (null byte) across all rows.

For example, for the following query with `maxNumTasks=5`:
```sql
REPLACE INTO "test_1" OVERWRITE ALL
SELECT
  "__time",
  "countryName",
  "cityName",
  count(cityName) over (partition by countryName) as countCity,
  ROW_NUMBER() over (partition by countryName) as rowNumberCity
FROM "wikipedia"
group by __time, countryName, cityName
PARTITIONED BY HOUR
CLUSTERED BY countryName
```

Currently, we were getting 1 worker in the Scan stage after the Window stage:

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/9c2b079b-d9f5-4bb0-bfaf-41231d933094">

With this PR's change, we get multiple workers in the Scan stage after the Window stage:

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/b3f610e1-c8db-4cf8-b2a5-91af214befa2">

### Test changes of the PR

- I had to update some MSQ drill tests to use single worker as they were giving a different correct result. I could add some `order by` to try and make the output deterministically correct for queries of these tests, but since these were tests from the drill suite, I thought it's best to leave them untouched and just use a single worker for these.
- The changes in `testWindowOnMixOfEmptyAndNonEmptyOverWithMultipleWorkers` reflects the above situation where previously we were getting 1 worker in the stage after the Window stage, but now we're getting 4 workers (as we use `maxNumTasks=5` in this particular test).

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
