### PR TITLE
Fix RejectExecutionHandler of Blocking Single Threaded executor

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -50,6 +51,8 @@ public class Execs
   {
     return DummyExecutorService.INSTANCE;
   }
+
+  private static final EmittingLogger log = new EmittingLogger(Execs.class);
 
   public static ExecutorService singleThreaded(@NotNull String nameFormat)
   {
@@ -159,6 +162,10 @@ public class Execs
           @Override
           public void rejectedExecution(Runnable r, ThreadPoolExecutor executor)
           {
+            if (executor.isShutdown()) {
+              log.debug("Executor is shutdown, rejecting task");
+              return;
+            }
             try {
               executor.getQueue().put(r);
             }

--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
@@ -163,8 +163,7 @@ public class Execs
           public void rejectedExecution(Runnable r, ThreadPoolExecutor executor)
           {
             if (executor.isShutdown()) {
-              log.debug("Executor is shutdown, rejecting task");
-              return;
+              throw new RejectedExecutionException("Executor is shutdown, rejecting task");
             }
             try {
               executor.getQueue().put(r);

--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/Execs.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.druid.java.util.emitter.EmittingLogger;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -51,8 +50,6 @@ public class Execs
   {
     return DummyExecutorService.INSTANCE;
   }
-
-  private static final EmittingLogger log = new EmittingLogger(Execs.class);
 
   public static ExecutorService singleThreaded(@NotNull String nameFormat)
   {

--- a/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
+++ b/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
@@ -19,15 +19,19 @@
 
 package org.apache.druid.concurrent;
 
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ExecsTest
@@ -116,6 +120,38 @@ public class ExecsTest
     // cleanup
     blockingExecutor.shutdown();
     producer.shutdown();
+  }
+
+  @Test
+  public void testSynchronousQueueSingleThreadedExecutor() throws Exception
+  {
+    // The implementation of Execs.newBlockingSingleThreaded() rejectedExecutionHandler should not add tasks when it's in shutDown state
+    // When capacity is 0, a SynchronousQueue is used and if a task is put in it in ShutDown state, it will forever stuck in WAITING state
+    // as executor will not take() the task to schedule it.
+    final ListeningExecutorService intermediateTempExecutor = MoreExecutors.listeningDecorator(
+        Execs.newBlockingSingleThreaded("[TASK_ID]-appenderator-abandon", 0)
+    );
+    Callable<Void> task = () -> {
+      try {
+        Thread.sleep(1000); // Simulate long-running task
+      }
+      catch (InterruptedException e) {
+        Thread.sleep(1500);
+        Thread.currentThread().interrupt(); // Restore interrupted status
+      }
+      return null;
+    };
+
+    // Submit multiple tasks together
+    intermediateTempExecutor.submit(task);
+    intermediateTempExecutor.submit(task);
+    intermediateTempExecutor.submit(task);
+
+    intermediateTempExecutor.shutdownNow();
+    // Submit task after shutDown / shutDownNow should not be added in queue
+    intermediateTempExecutor.submit(task);
+    intermediateTempExecutor.awaitTermination(10, TimeUnit.SECONDS);
+    Assert.assertTrue(intermediateTempExecutor.isShutdown());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
+++ b/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -123,7 +124,7 @@ public class ExecsTest
   }
 
   @Test
-  public void testTaskAddedToShutDownSynchronousQueueSingleThreadedExecutor() throws Exception
+  public void testTaskAddedToShutdownExecutorThrowsException() throws Exception
   {
     // The implementation of Execs.newBlockingSingleThreaded() rejectedExecutionHandler should not add tasks when it's in shutDown state
     // When a SynchronousQueue is used in executor and a task is put in it in ShutDown state, it will forever stuck in WAITING state

--- a/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
+++ b/processing/src/test/java/org/apache/druid/concurrent/ExecsTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.concurrent;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -133,24 +134,23 @@ public class ExecsTest
     );
     Callable<Void> task = () -> {
       try {
-        Thread.sleep(1000); // Simulate long-running task
+        Thread.sleep(500); // Simulate long-running task
       }
       catch (InterruptedException e) {
-        Thread.sleep(1500);
         Thread.currentThread().interrupt(); // Restore interrupted status
       }
       return null;
     };
 
     // Submit multiple tasks together
-    intermediateTempExecutor.submit(task);
-    intermediateTempExecutor.submit(task);
-    intermediateTempExecutor.submit(task);
+    ListenableFuture<Void> unused = intermediateTempExecutor.submit(task);
+    unused = intermediateTempExecutor.submit(task);
+    unused = intermediateTempExecutor.submit(task);
 
     intermediateTempExecutor.shutdownNow();
     // Submit task after shutDown / shutDownNow should not be added in queue
-    intermediateTempExecutor.submit(task);
-    intermediateTempExecutor.awaitTermination(10, TimeUnit.SECONDS);
+    unused = intermediateTempExecutor.submit(task);
+    Assert.assertTrue(intermediateTempExecutor.awaitTermination(10, TimeUnit.SECONDS));
     Assert.assertTrue(intermediateTempExecutor.isShutdown());
   }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #16783.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

As discussed in issue https://github.com/apache/druid/issues/16783 ,  there are times when intermediateTempExecutor thread get stuck in `WAITING` state and the executor is not able to terminate. This causes the main task to get stuck in `PUBLISHING` state forever, until we kill it or pendingCompletionTimeout interrupts the thread.

The underlying cause of this issue is that this intermediateTempExecutor is implemented using newBlockingSingleThreaded, which created a thread pool executor with maxCoreSize: 1 and a [SynchronousQueue](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/SynchronousQueue.html). 
The `rejectedExecutionHandler` of this ThreadExecutor should not add tasks when it's in shutDown state because, a SynchronousQueue is used and if a task is `put()` in it in ShutDown state, it will forever stuck in WAITING state as executor will not `take()` the task to schedule it. In a `SynchronousQueue` there should always be a `take()` WAITING for every `put()` operation and vice-versa. 

In the [issue](https://github.com/apache/druid/issues/16783), I have added thread dumps too that confirm tasks being stuck during `rejectedExecution()` when task is added in queue during a shutDown state. The Unit test confirms the thread getting stuck. 
In `StreamAppenderator`, it happens when  there is a race condition [here](https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunner.java#L879-L883)
```
        Futures.allAsList(publishWaitList).cancel(true);
        Futures.allAsList(handOffWaitList).cancel(true);
        if (appenderator != null) {
          appenderator.closeNow();
        }
```
We don't wait for appenderator.drop() to be interrupted in handOffWaitList and appenderator.closeNow() shuts down the exeuctors. Thus a new task is sometimes added in intermediateTempExecutor through appenderator.drop() while executor is already shutDown.
<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
https://github.com/apache/druid/issues/16783
#### Renamed the class ...
#### Added a forbidden-apis entry ...

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
