### PR TITLE
ScanQueryFrameProcessor: Close CursorHolders as we go along.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
@@ -260,7 +260,7 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
 
       final CursorHolder nextCursorHolder =
           cursorFactory.makeCursorHolder(ScanQueryEngine.makeCursorBuildSpec(query, null));
-      final Cursor nextCursor = cursorHolder.asCursor();
+      final Cursor nextCursor = nextCursorHolder.asCursor();
 
       if (nextCursor == null) {
         // No cursors!


### PR DESCRIPTION
The change in #16533 added CursorHolders to the processor-level Closer. This is problematic when running on an input channel: it means we started keeping around all CursorHolders for all frames we process and closing them when the channel is complete, rather than closing them as we go along.

This patch restores the prior behavior, where resources are closed as we go.