### PR TITLE
Update Delta Kernel to 3.2.1

### DIFF
--- a/extensions-contrib/druid-deltalake-extensions/pom.xml
+++ b/extensions-contrib/druid-deltalake-extensions/pom.xml
@@ -35,7 +35,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <delta-kernel.version>3.2.0</delta-kernel.version>
+    <delta-kernel.version>3.2.1</delta-kernel.version>
   </properties>
 
   <dependencies>

--- a/extensions-contrib/druid-deltalake-extensions/src/main/java/org/apache/druid/delta/input/DeltaInputSource.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/main/java/org/apache/druid/delta/input/DeltaInputSource.java
@@ -340,20 +340,10 @@ public class DeltaInputSource implements SplittableInputSource<DeltaSplit>
 
   private Snapshot getSnapshotForTable(final Table table, final Engine engine)
   {
-    // Setting the LogStore class loader before calling the Delta Kernel snapshot API is required as a workaround with
-    // the 3.2.0 Delta Kernel because the Kernel library cannot instantiate the LogStore class otherwise. Please see
-    // https://github.com/delta-io/delta/issues/3299 for details. This workaround can be removed once the issue is fixed.
-    final ClassLoader currCtxCl = Thread.currentThread().getContextClassLoader();
-    try {
-      Thread.currentThread().setContextClassLoader(LogStore.class.getClassLoader());
-      if (snapshotVersion != null) {
-        return table.getSnapshotAsOfVersion(engine, snapshotVersion);
-      } else {
-        return table.getLatestSnapshot(engine);
-      }
-    }
-    finally {
-      Thread.currentThread().setContextClassLoader(currCtxCl);
+    if (snapshotVersion != null) {
+      return table.getSnapshotAsOfVersion(engine, snapshotVersion);
+    } else {
+      return table.getLatestSnapshot(engine);
     }
   }
 


### PR DESCRIPTION
Changes:
- Updated Delta Kernel to `3.2.1`, which was released yesterday: https://github.com/delta-io/delta/releases/tag/v3.2.1
- The class loader workaround for reading snapshots has been removed, as the [fix](https://github.com/delta-io/delta/pull/3304) for the LogStore class is available in version 3.2.1. I verified it locally too.
- The upstream version also contains fixes to reading long columns and the retry mechanism.


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
