### PR TITLE
read metadata in SimpleQueryableIndex if available to compute segment ordering

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -49,6 +49,7 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   private final Map<String, Supplier<ColumnHolder>> columns;
   private final SmooshedFileMapper fileMapper;
   private final Supplier<Map<String, DimensionHandler>> dimensionHandlers;
+  private final List<OrderBy> ordering;
 
   public SimpleQueryableIndex(
       Interval dataInterval,
@@ -83,6 +84,14 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
     } else {
       this.dimensionHandlers = () -> initDimensionHandlers(availableDimensions);
     }
+
+    final Metadata metadata = getMetadata();
+    if (metadata != null && metadata.getOrdering() != null) {
+      this.ordering = metadata.getOrdering();
+    } else {
+      // When sort order isn't set in metadata.drd, assume the segment is sorted by __time.
+      this.ordering = Cursors.ascendingTimeOrder();
+    }
   }
 
   @Override
@@ -112,13 +121,7 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   @Override
   public List<OrderBy> getOrdering()
   {
-    final Metadata metadata = getMetadata();
-    if (metadata != null && metadata.getOrdering() != null) {
-      return metadata.getOrdering();
-    } else {
-      // When sort order isn't set in metadata.drd, assume the segment is sorted by __time.
-      return Cursors.ascendingTimeOrder();
-    }
+    return ordering;
   }
 
   @Override


### PR DESCRIPTION
#16700 made `QueryableIndex.getMetadata` be 'lazy', which is kind of nice in some ways since we don't have to hang on to the segment metadata object unless we need it, however changes in #16533, #16849, and #16985 made it so that we read the segment "ordering" every time we make a cursor, which comes from the metadata, and seems pretty unchill with the lazy metadata reading.

This PR makes it so that we precompute the ordering in `SimpleQueryableIndex` constructor so that `getOrdering` is a cheap call.