### PR TITLE
fix string array grouping comparator

### DIFF
--- a/processing/src/test/java/org/apache/druid/query/groupby/NestedGroupByArrayQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/NestedGroupByArrayQueryTest.java
@@ -32,6 +32,9 @@ import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
+import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
+import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
+import org.apache.druid.query.ordering.StringComparators;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
@@ -132,6 +135,43 @@ public class NestedGroupByArrayQueryTest
                                           .setDimensions(DefaultDimensionSpec.of("arrayString", ColumnType.STRING_ARRAY))
                                           .setAggregatorSpecs(new CountAggregatorFactory("count"))
                                           .setContext(getContext())
+                                          .build();
+
+
+    runResults(
+        groupQuery,
+        ImmutableList.of(
+            new Object[]{null, 8L},
+            new Object[]{new Object[]{"a", "b"}, 8L},
+            new Object[]{new Object[]{"a", "b", "c"}, 4L},
+            new Object[]{new Object[]{"b", "c"}, 4L},
+            new Object[]{new Object[]{"d", "e"}, 4L}
+        )
+    );
+  }
+
+  @Test
+  public void testGroupByRootArrayStringOrderAndLimit()
+  {
+    GroupByQuery groupQuery = GroupByQuery.builder()
+                                          .setDataSource("test_datasource")
+                                          .setGranularity(Granularities.ALL)
+                                          .setInterval(Intervals.ETERNITY)
+                                          .setDimensions(DefaultDimensionSpec.of("arrayString", ColumnType.STRING_ARRAY))
+                                          .setAggregatorSpecs(new CountAggregatorFactory("count"))
+                                          .setContext(getContext())
+                                          .setLimitSpec(
+                                              new DefaultLimitSpec(
+                                                  ImmutableList.of(
+                                                      new OrderByColumnSpec(
+                                                          "arrayString",
+                                                          OrderByColumnSpec.Direction.ASCENDING,
+                                                          StringComparators.NATURAL
+                                                      )
+                                                  ),
+                                                  100
+                                              )
+                                          )
                                           .build();
 
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteArraysQueryTest.java
@@ -7477,4 +7477,49 @@ public class CalciteArraysQueryTest extends BaseCalciteQueryTest
         )
     );
   }
+
+  @Test
+  public void testArrayGroupStringArrayColumnLimit()
+  {
+    cannotVectorize();
+    testQuery(
+        "SELECT arrayStringNulls, SUM(cnt) FROM druid.arrays GROUP BY 1 ORDER BY 1 DESC LIMIT 10",
+        QUERY_CONTEXT_NO_STRINGIFY_ARRAY,
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(CalciteTests.ARRAYS_DATASOURCE)
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setDimensions(
+                            dimensions(
+                                new DefaultDimensionSpec("arrayStringNulls", "d0", ColumnType.STRING_ARRAY)
+                            )
+                        )
+                        .setAggregatorSpecs(aggregators(new LongSumAggregatorFactory("a0", "cnt")))
+                        .setLimitSpec(
+                            new DefaultLimitSpec(
+                                ImmutableList.of(
+                                    new OrderByColumnSpec(
+                                        "d0",
+                                        OrderByColumnSpec.Direction.DESCENDING,
+                                        StringComparators.NATURAL
+                                    )
+                                ),
+                                10
+                            )
+                        )
+                        .setContext(QUERY_CONTEXT_NO_STRINGIFY_ARRAY)
+                        .build()
+        ),
+        ImmutableList.of(
+            new Object[]{Arrays.asList("d", null, "b"), 2L},
+            new Object[]{Arrays.asList("b", "b"), 2L},
+            new Object[]{Arrays.asList("a", "b"), 3L},
+            new Object[]{Arrays.asList(null, "b"), 2L},
+            new Object[]{Collections.singletonList(null), 1L},
+            new Object[]{Collections.emptyList(), 1L},
+            new Object[]{null, 3L}
+        )
+    );
+  }
 }


### PR DESCRIPTION
Fixes an issue that can occur when grouping on a string array and sorting by it, where we were not checking for the 'natural' comparator.