### PR TITLE
Fix bug with while adding DistinctSketches

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollector.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/statistics/DistinctKeyCollector.java
@@ -120,8 +120,9 @@ public class DistinctKeyCollector implements KeyCollector<DistinctKeyCollector>
     if (isNewMin || isKeySelected(key)) {
       if (isNewMin && !retainedKeys.isEmpty() && !isKeySelected(retainedKeys.firstKey())) {
         // Old min should be kicked out.
-        totalWeightUnadjusted -= retainedKeys.removeLong(retainedKeys.firstKey());
-        retainedBytes -= retainedKeys.firstKey().estimatedObjectSizeBytes();
+        RowKey rowKey = retainedKeys.firstKey();
+        totalWeightUnadjusted -= retainedKeys.removeLong(rowKey);
+        retainedBytes -= rowKey.estimatedObjectSizeBytes();
       }
 
       if (retainedKeys.putIfAbsent(key, weight) == MISSING_KEY_WEIGHT) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/statistics/DistinctKeyCollectorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.msq.statistics;
 
 import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.objects.Object2LongRBTreeMap;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.frame.key.ClusterBy;
 import org.apache.druid.frame.key.ClusterByPartition;
@@ -88,6 +89,21 @@ public class DistinctKeyCollectorTest
           verifyCollector(collector, clusterBy, comparator, sortedKeyWeights);
         }
     );
+  }
+
+  @Test
+  public void test_single_key_addition()
+  {
+    DistinctKeyCollector distinctKeyCollector = new DistinctKeyCollector(
+        clusterBy.keyComparator(signature),
+        new Object2LongRBTreeMap<>(comparator),
+        2
+    );
+    List<Pair<RowKey, Integer>> pairs = KeyCollectorTestUtils.sequentialKeys(2);
+
+    distinctKeyCollector.add(pairs.get(1).lhs, pairs.get(1).rhs);
+    distinctKeyCollector.downSample();
+    distinctKeyCollector.add(pairs.get(0).lhs, pairs.get(0).rhs);
   }
 
   @Test


### PR DESCRIPTION
Fix a bug where we incorrectly call `retainedKeys.firstKey()` twice while adding another sketch. This can sometimes throw an exception if there was only one key, and/or create an inaccurate estimate of the bytes retained.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
