### PR TITLE
Add verbose column tracking metric in default query metrics

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java
@@ -88,6 +88,7 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
     subQueryId(query);
     sqlQueryId(query);
     context(query);
+    columns(query);
   }
 
   @Override
@@ -158,6 +159,12 @@ public class DefaultQueryMetrics<QueryType extends Query<?>> implements QueryMet
   public void context(QueryType query)
   {
     setDimension("context", query.getContext() == null ? ImmutableMap.of() : query.getContext());
+  }
+
+  @Override
+  public void columns(QueryType query)
+  {
+    // Emit nothing by default.
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryMetrics.java
@@ -233,6 +233,12 @@ public interface QueryMetrics<QueryType extends Query<?>>
   @PublicApi
   void context(QueryType query);
 
+  /**
+   * Sets {@link Query#getRequiredColumns()} of the given query as dimension.
+   */
+  @PublicApi
+  void columns(QueryType query);
+
   void server(String host);
 
   void remoteAddress(String remoteAddress);

--- a/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
+++ b/processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java
@@ -122,6 +122,12 @@ public class DefaultSearchQueryMetrics implements SearchQueryMetrics
   }
 
   @Override
+  public void columns(SearchQuery query)
+  {
+    // Don't emit by default
+  }
+
+  @Override
   public void server(String host)
   {
     delegateQueryMetrics.server(host);


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Adds a verbose column tracking metric to DefaultQueryMetrics. This metric would track which columns the query touched when fetching the results. By nature, this can be very verbose so by default it is disabled and it is left to the extension to override with their own implementation.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Goal: adding support for more fine-grain observability into user query pattern behavior.

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

- Added `void columns(QueryType query)` to the default `QueryMetrics.java` interface.
- Added no-op stubs in both `DefaultQueryMetrics.java` and `DefaultSearchQueryMetrics.java`

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Add an opt-in per-query accessed columns metric dimension interface to DefaultQueryMetrics.

<hr>

##### Key changed/added classes in this PR
 * `processing/src/main/java/org/apache/druid/query/DefaultQueryMetrics.java`
 * `processing/src/main/java/org/apache/druid/query/QueryMetrics.java`
 * `processing/src/main/java/org/apache/druid/query/search/DefaultSearchQueryMetrics.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
