### PR TITLE
WindowOperatorQueryFrameProcessor: Fix frame writer capacity issues + adhere to FrameProcessor's contract

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -293,20 +293,18 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
       } else if (comparePartitionKeys(outputRow, currentRow, partitionColumnNames)) {
         // Add current row to the same batch of rows for processing.
         rowsToProcess.add(currentRow);
+        if (rowsToProcess.size() > maxRowsMaterialized) {
+          // We don't want to materialize more than maxRowsMaterialized rows at any point in time, so process the pending batch.
+          processRowsUpToLastPartition();
+        }
+        ensureMaxRowsInAWindowConstraint(rowsToProcess.size());
       } else {
         lastPartitionIndex = rowsToProcess.size() - 1;
         outputRow = currentRow.copy();
-        rowsToProcess.add(currentRow);
+        return ReturnOrAwait.runAgain();
       }
 
       frameCursor.advance();
-
-      if (rowsToProcess.size() > maxRowsMaterialized) {
-        // We don't want to materialize more than maxRowsMaterialized rows at any point in time, so process the pending batch.
-        processRowsUpToLastPartition();
-        ensureMaxRowsInAWindowConstraint(rowsToProcess.size());
-        return ReturnOrAwait.runAgain();
-      }
     }
     return ReturnOrAwait.runAgain();
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -219,7 +219,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
 
     // If there are rows pending flush, flush them and run again before processing any more rows.
     if (frameHasRowsPendingFlush()) {
-      flushAllRowsAndCols(resultRowAndCols, rowId);
+      flushAllRowsAndCols();
       return ReturnOrAwait.runAgain();
     }
 
@@ -340,7 +340,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
       public void completed()
       {
         try {
-          flushAllRowsAndCols(resultRowAndCols, rowId);
+          flushAllRowsAndCols();
         }
         catch (IOException e) {
           throw new RuntimeException(e);
@@ -350,11 +350,10 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
   }
 
   /**
-   * @param resultRowAndCols Flush the list of {@link RowsAndColumns} to a frame
-   * @param rowId An AtomicInteger representing the current row ID
+   * Flushes {@link #resultRowAndCols} to the frame starting from {@link #rowId}, upto the frame writer's capacity.
    * @throws IOException
    */
-  private void flushAllRowsAndCols(ArrayList<RowsAndColumns> resultRowAndCols, AtomicInteger rowId) throws IOException
+  private void flushAllRowsAndCols() throws IOException
   {
     RowsAndColumns rac = new ConcatRowsAndColumns(resultRowAndCols);
     createFrameWriterIfNeeded(rac, rowId);

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -246,10 +246,6 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
       return ReturnOrAwait.awaitAll(inputChannels().size());
     }
 
-    // This helps us avoid OOM issues, as it ensures that we don't keep accumulating the processed rows in-memory, if
-    // the rate of processing of the rows is higher than the allowed capacity of frame writer in each iteration of runIncrementally.
-    clearRACBuffers();
-
     // Scenario 2: All window functions in the query have OVER() clause with a PARTITION BY
     if (frameCursor == null || frameCursor.isDone()) {
       if (readableInputs.isEmpty()) {
@@ -402,6 +398,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     }
 
     flushFrameWriter();
+    clearRACBuffers();
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -268,9 +268,8 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
         // This handles the rows pending flush to the output channel, if we have any.
         if (frameHasRowsPendingFlush()) {
           return flushRACsAndRunAgain();
-        }
-         else {
-           clearRACBuffers();
+        } else {
+          clearRACBuffers();
         }
         return ReturnOrAwait.returnObject(Unit.instance());
       } else {
@@ -282,8 +281,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     // the rate of processing of the rows is higher than the allowed capacity of frame writer in each iteration of runIncrementally.
     if (frameHasRowsPendingFlush()) {
       return flushRACsAndRunAgain();
-    }
-    else {
+    } else {
       clearRACBuffers();
     }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -303,7 +303,6 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
         outputRow = currentRow.copy();
         return ReturnOrAwait.runAgain();
       }
-
       frameCursor.advance();
     }
     return ReturnOrAwait.runAgain();

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -219,7 +219,8 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
 
     // If there are rows pending flush, flush them and run again before processing any more rows.
     if (frameHasRowsPendingFlush()) {
-      return flushRACsAndRunAgain();
+      flushAllRowsAndCols(resultRowAndCols, rowId);
+      return ReturnOrAwait.runAgain();
     }
 
     if (partitionColumnNames.isEmpty()) {
@@ -560,17 +561,6 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
   private boolean frameHasRowsPendingFlush()
   {
     return frameWriter != null && frameWriter.getNumRows() > 0;
-  }
-
-  /**
-   * Flushes the rows in resultRowAndCols starting with rowId. We return a signal to run again as it's possible
-   * that we weren't able to flush all the rows to the output channel due to frame writer's capacity.
-   * @return A ReturnOrAwait object signaling that the processing should run again.
-   */
-  private ReturnOrAwait<Object> flushRACsAndRunAgain() throws IOException
-  {
-    flushAllRowsAndCols(resultRowAndCols, rowId);
-    return ReturnOrAwait.runAgain();
   }
 
   private void clearRACBuffers()

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -356,15 +356,14 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
   private void flushAllRowsAndCols() throws IOException
   {
     RowsAndColumns rac = new ConcatRowsAndColumns(resultRowAndCols);
-    createFrameWriterIfNeeded(rac, rowId);
-    writeRacToFrame(rac, rowId);
+    createFrameWriterIfNeeded(rac);
+    writeRacToFrame(rac);
   }
 
   /**
    * @param rac   The frame writer to write this {@link RowsAndColumns} object
-   * @param rowId RowId to get the column selector factory from the {@link RowsAndColumns} object
    */
-  private void createFrameWriterIfNeeded(RowsAndColumns rac, AtomicInteger rowId)
+  private void createFrameWriterIfNeeded(RowsAndColumns rac)
   {
     if (frameWriter == null) {
       final ColumnSelectorFactoryMaker csfm = ColumnSelectorFactoryMaker.fromRAC(rac);
@@ -377,10 +376,9 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
 
   /**
    * @param rac   {@link RowsAndColumns} to be written to frame
-   * @param rowId Counter to keep track of how many rows are added
    * @throws IOException
    */
-  public void writeRacToFrame(RowsAndColumns rac, AtomicInteger rowId) throws IOException
+  public void writeRacToFrame(RowsAndColumns rac) throws IOException
   {
     final int numRows = rac.numRows();
     while (rowId.get() < numRows) {
@@ -389,7 +387,7 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
         rowId.incrementAndGet();
       } else if (frameWriter.getNumRows() > 0) {
         flushFrameWriter();
-        createFrameWriterIfNeeded(rac, rowId);
+        createFrameWriterIfNeeded(rac);
 
         if (frameWriter.addSelection()) {
           incrementBoostColumn();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
@@ -79,7 +79,7 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
   @Test
   public void testFrameWriterReachingCapacity() throws IOException
   {
-    // This test validates that all output outputRows are flushed to the output channel even if frame writer's
+    // This test validates that all output rows are flushed to the output channel even if frame writer's
     // capacity is reached, by subsequent iterations of runIncrementally.
     final ReadableInput factChannel = buildWindowTestInputChannel();
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorTest.java
@@ -66,7 +66,7 @@ import java.util.Map;
 
 public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBase
 {
-  private static final List<Map<String, Object>> inputRows = ImmutableList.of(
+  private static final List<Map<String, Object>> INPUT_ROWS = ImmutableList.of(
       ImmutableMap.of("added", 1L, "cityName", "city1"),
       ImmutableMap.of("added", 1L, "cityName", "city2"),
       ImmutableMap.of("added", 2L, "cityName", "city3"),
@@ -120,7 +120,7 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
             Collections.emptyList(),
             false
         ),
-        inputRows.size() / 4 // This forces frameWriter's capacity to be reached.
+        INPUT_ROWS.size() / 4 // This forces frameWriter's capacity to be reached.
     );
 
     final BlockingQueueFrameChannel outputChannel = BlockingQueueFrameChannel.minimal();
@@ -147,10 +147,10 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
     );
 
     List<List<Object>> outputRows = rowsFromProcessor.toList();
-    Assert.assertEquals(inputRows.size(), outputRows.size());
+    Assert.assertEquals(INPUT_ROWS.size(), outputRows.size());
 
-    for (int i = 0; i < inputRows.size(); i++) {
-      Map<String, Object> inputRow = inputRows.get(i);
+    for (int i = 0; i < INPUT_ROWS.size(); i++) {
+      Map<String, Object> inputRow = INPUT_ROWS.get(i);
       List<Object> outputRow = outputRows.get(i);
 
       Assert.assertEquals("cityName should match", inputRow.get("cityName"), outputRow.get(0));
@@ -288,7 +288,7 @@ public class WindowOperatorQueryFrameProcessorTest extends FrameProcessorTestBas
                                               .add("cityName", ColumnType.STRING)
                                               .add("added", ColumnType.LONG)
                                               .build();
-    return makeChannelFromRows(inputRows, inputSignature, Collections.emptyList());
+    return makeChannelFromRows(INPUT_ROWS, inputSignature, Collections.emptyList());
   }
 
   private ReadableInput makeChannelFromRows(

--- a/extensions-core/multi-stage-query/src/test/quidem/org.apache.druid.msq.quidem.MSQQuidemTest/msq2.iq
+++ b/extensions-core/multi-stage-query/src/test/quidem/org.apache.druid.msq.quidem.MSQQuidemTest/msq2.iq
@@ -1,0 +1,54 @@
+!set plannerStrategy DECOUPLED
+!use druidtest://?componentSupplier=DrillWindowQueryMSQComponentSupplier
+!set outputformat mysql
+
+# This test validates that all output rows are flushed to the output channel even if frame writer's capacity is reached.
+
+select count(*) as actualNumRows
+from (
+	select countryName, cityName, channel, added, delta, row_number() over() as rowNumber
+	from wikipedia
+	group by countryName, cityName, channel, added, delta
+);
++---------------+
+| actualNumRows |
++---------------+
+|         11631 |
++---------------+
+(1 row)
+
+!ok
+
+# Validate that all rows are outputted by window WindowOperatorQueryFrameProcessor layer for empty over() clause scenario.
+
+select count(*) as numRows, max(rowNumber) as maxRowNumber
+from (
+	select countryName, cityName, channel, added, delta, row_number() over() as rowNumber
+	from wikipedia
+	group by countryName, cityName, channel, added, delta
+);
++---------+--------------+
+| numRows | maxRowNumber |
++---------+--------------+
+|   11631 |        11631 |
++---------+--------------+
+(1 row)
+
+!ok
+
+# Validate that all rows are outputted by window WindowOperatorQueryFrameProcessor layer for non-empty over() clause scenario.
+
+select rowNumber, count(rowNumber) as numRows
+from (
+	select countryName, cityName, channel, added, delta, row_number() over(partition by countryName, cityName, channel, added, delta) as rowNumber
+	from wikipedia
+	group by countryName, cityName, channel, added, delta
+) group by rowNumber;
++-----------+---------+
+| rowNumber | numRows |
++-----------+---------+
+|         1 |   11631 |
++-----------+---------+
+(1 row)
+
+!ok


### PR DESCRIPTION
### Description

Currently, we had a bug in the `WindowOperatorQueryFrameProcessor` where the frame writer's capacity could get reached for larger queries, causing it to not output all of the result rows.

For example, the following query gives incomplete output rows when we use `maxNumTasks=2`, compared to when we use more workers.
```sql
select trip_id, row_number() over(partition by trip_id) as c1 from "trips_xaa" where __time < TIMESTAMP '2013-09-20 11:15:25' group by trip_id
-- This gives 20479 rows with maxNumTasks=2
-- This gives 30341 rows with maxNumTasks=5
-- This gives 30341 rows with maxNumTasks=11
```

This PR fixes the above issue by maintaining the state of `last rowId flushed to output channel`, and triggering another iteration of `runIncrementally()` method if frame writer has rows pending flush to the output channel.

The above is done keeping in mind `FrameProcessor`'s contract which enforces that we should write only a single frame to each output channel in any given iteration of `runIncrementally()`.

For manual testing, I've been verifying the behavior with queries like the following:
```sql
select trip_id, row_number() over(partition by trip_id) as c1 from "trips_xaa" where __time < TIMESTAMP '2016-10-20 11:15:25' group by trip_id
-- 49795247 rows inputted, 49795247 rows outputted by window stage (with maxNumTasks=2 and maxNumTasks=11)

select c1, count(c1) from (select trip_id, row_number() over(partition by trip_id) as c1 from "trips_xaa" where __time < TIMESTAMP '2016-10-20 11:15:25' group by trip_id) group by c1
-- [1, 49795247] with maxNumTasks=2 and maxNumTasks=11
```

Additionally, I have added a test `WindowOperatorQueryFrameProcessorTest#testFrameWriterReachingCapacity()` which was previously writing less number of rows to the output channel, but is writing the complete set of rows.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
