### PR TITLE
WindowOperatorQueryFrameProcessor: Avoid unnecessary re-runs of runIncrementally()

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -256,17 +256,19 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
       } else if (comparePartitionKeys(outputRow, currentRow, partitionColumnNames)) {
         // Add current row to the same batch of rows for processing.
         rowsToProcess.add(currentRow);
-        if (rowsToProcess.size() > maxRowsMaterialized) {
-          // We don't want to materialize more than maxRowsMaterialized rows at any point in time, so process the pending batch.
-          processRowsUpToLastPartition();
-        }
-        ensureMaxRowsInAWindowConstraint(rowsToProcess.size());
       } else {
         lastPartitionIndex = rowsToProcess.size() - 1;
         outputRow = currentRow.copy();
-        return ReturnOrAwait.runAgain();
+        rowsToProcess.add(currentRow);
       }
       frameCursor.advance();
+
+      if (rowsToProcess.size() > maxRowsMaterialized) {
+        // We don't want to materialize more than maxRowsMaterialized rows at any point in time, so process the pending batch.
+        processRowsUpToLastPartition();
+        ensureMaxRowsInAWindowConstraint(rowsToProcess.size());
+        return ReturnOrAwait.runAgain();
+      }
     }
     return ReturnOrAwait.runAgain();
   }


### PR DESCRIPTION
### Description

This PR optimizes the scenarios where we had all window functions with some `partition by` clause. Currently, we were triggering another run of `runIncrementally()` on every `partition by` change. But this is unnecessary overhead. This PR changes the behavior to only trigger a re-run when we write a frame to the output channel.

For example, the below query that processes almost 50M rows was run with `maxNumTasks=2` against the current master code vs this PR's code.

```sql
select c1, count(c1) from (select trip_id, row_number() over(partition by trip_id) as c1 from "trips_xaa" where __time < TIMESTAMP '2016-10-20 11:15:25' group by trip_id) group by c1
```

We can see in the following screenshots that the window stage took `5:37 minutes` in the current master code compared to `35 seconds` with this PR's code, making the overall query time to go down from 23 minutes to 18 minutes.

Current master code             |  This PR's code
:-------------------------:|:-------------------------:
![image](https://github.com/user-attachments/assets/d38bc1a3-6826-4704-be15-a85981a07bb2)  |  ![image](https://github.com/user-attachments/assets/705d72aa-b7f7-4e5b-aa5b-2173c0b26d53)

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
