### PR TITLE
Simplify release script find-missing-backports.py

### DIFF
--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -23,6 +23,7 @@ on:
       - 'examples/**/jupyter-notebooks/**'
       - 'web-console/**'
       - 'website/**'
+      - 'distribution/bin/**'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -36,6 +36,7 @@ on:
       - 'examples/**/jupyter-notebooks/**'
       - 'web-console/**'
       - 'website/**'
+      - 'distribution/bin/**'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -19,11 +19,11 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'dev/**'
+      - 'distribution/bin/**'
       - 'docs/**'
       - 'examples/**/jupyter-notebooks/**'
       - 'web-console/**'
       - 'website/**'
-      - 'distribution/bin/**'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches
@@ -32,11 +32,11 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'dev/**'
+      - 'distribution/bin/**'
       - 'docs/**'
       - 'examples/**/jupyter-notebooks/**'
       - 'web-console/**'
       - 'website/**'
-      - 'distribution/bin/**'
     branches:
       - master
       - '[0-9]+.[0-9]+.[0-9]+' # release branches

--- a/distribution/bin/find-missing-backports.py
+++ b/distribution/bin/find-missing-backports.py
@@ -64,17 +64,18 @@ def find_next_url(links):
     return None
 
 
-if len(sys.argv) != 5:
-  sys.stderr.write('usage: program <github-username> <previous-release-branch> <current-release-branch> <milestone-number>\n')
-  sys.stderr.write("  e.g., program myusername 0.17.0 0.18.0 30")
-  sys.stderr.write("  e.g., The milestone number for Druid 30 is 56, since the milestone has the url https://github.com/apache/druid/milestone/56\n")
-  sys.stderr.write("  It is also necessary to set a GIT_TOKEN environment variable containing a personal access token.")
+if len(sys.argv) != 4:
+  sys.stderr.write('Incorrect program arguments.\n')
+  sys.stderr.write('Usage: program <github-username> <previous-major-release-branch> <current-major-release-branch>\n')
+  sys.stderr.write("  e.g., program myusername 29.0.0 30.0.0\n")
+  sys.stderr.write("  Ensure that the title of the milestone is the same as the release branch.\n")
+  sys.stderr.write("  Ensure that a GIT_TOKEN environment variable containing a personal access token has been set.\n")
   sys.exit(1)
 
 github_username = sys.argv[1]
 previous_branch = sys.argv[2]
 release_branch = sys.argv[3]
-milestone_number = int(sys.argv[4])
+milestone_title = release_branch
 
 master_branch = "master"
 command = "git log {}..{} --oneline | tail -1".format(master_branch, previous_branch)
@@ -102,9 +103,6 @@ for commit_msg in all_release_commits.splitlines():
 
 print("Number of release PR subjects: {}".format(len(release_pr_subjects)))
 # Get all closed PRs and filter out with milestone
-milestone_url = "https://api.github.com/repos/apache/druid/milestones/{}".format(milestone_number)
-resp = requests.get(milestone_url, auth=(github_username, os.environ["GIT_TOKEN"])).json()
-milestone_title = resp['title']
 pr_items = []
 page = 0
 while True:


### PR DESCRIPTION
### Changes

- Remove milestone number argument required by script. The milestone number is used
only to fetch the milestone title which is always the same as the release branch name.
- Improve error messages in the script

### Usage example

#### Before
```bash
export GIT_TOKEN=abcdef...
python3 find-missing-backports.py 30.0.0 31.0.0 57
```

<details>
<summary>Output:</summary>
<p>

```bash
Previous branch: 30.0.0, first commit: c19b784477
Number of release PR subjects: 478
Total PRs for current milestone: 87
Total expected count: 87
Missing backport found for PR 17193, url: https://github.com/apache/druid/pull/17193
Missing backport found for PR 17181, url: https://github.com/apache/druid/pull/17181
Missing backport found for PR 17180, url: https://github.com/apache/druid/pull/17180
Missing backport found for PR 17173, url: https://github.com/apache/druid/pull/17173
Missing backport found for PR 17168, url: https://github.com/apache/druid/pull/17168
Missing backport found for PR 17152, url: https://github.com/apache/druid/pull/17152
Missing backport found for PR 17147, url: https://github.com/apache/druid/pull/17147
Missing backport found for PR 17140, url: https://github.com/apache/druid/pull/17140
Missing backport found for PR 17135, url: https://github.com/apache/druid/pull/17135
Missing backport found for PR 17133, url: https://github.com/apache/druid/pull/17133
Missing backport found for PR 17132, url: https://github.com/apache/druid/pull/17132
Missing backport found for PR 17021, url: https://github.com/apache/druid/pull/17021
Missing backport found for PR 16991, url: https://github.com/apache/druid/pull/16991
```
</details>

#### After
```bash
export GIT_TOKEN=abcdef...
python3 find-missing-backports.py 30.0.0 31.0.0
```

<details>
<summary>Output</summary>
<p>

```bash
Previous branch: 30.0.0, first commit: c19b784477
Number of release PR subjects: 478
Total PRs for current milestone: 87
Total expected count: 87
Missing backport found for PR 17193, url: https://github.com/apache/druid/pull/17193
Missing backport found for PR 17181, url: https://github.com/apache/druid/pull/17181
Missing backport found for PR 17180, url: https://github.com/apache/druid/pull/17180
Missing backport found for PR 17173, url: https://github.com/apache/druid/pull/17173
Missing backport found for PR 17168, url: https://github.com/apache/druid/pull/17168
Missing backport found for PR 17152, url: https://github.com/apache/druid/pull/17152
Missing backport found for PR 17147, url: https://github.com/apache/druid/pull/17147
Missing backport found for PR 17140, url: https://github.com/apache/druid/pull/17140
Missing backport found for PR 17135, url: https://github.com/apache/druid/pull/17135
Missing backport found for PR 17133, url: https://github.com/apache/druid/pull/17133
Missing backport found for PR 17132, url: https://github.com/apache/druid/pull/17132
Missing backport found for PR 17021, url: https://github.com/apache/druid/pull/17021
Missing backport found for PR 16991, url: https://github.com/apache/druid/pull/16991
```
</details>

### Error message

Command
```
python3 find-missing-backports.py kfaraz 30.0.0
```

```bash
Incorrect program arguments.
Usage: program <github-username> <previous-major-release-branch> <current-major-release-branch>
  e.g., program myusername 29.0.0 30.0.0
  Ensure that the title of the milestone is the same as the release branch.
  Ensure that a GIT_TOKEN environment variable containing a personal access token has been set.
```