### PR TITLE
DartTableInputSpecSlicer: Fix for TLS workers.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/DartTableInputSpecSlicer.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/DartTableInputSpecSlicer.java
@@ -168,7 +168,7 @@ public class DartTableInputSpecSlicer implements InputSpecSlicer
       return UNKNOWN;
     }
 
-    final String serverHostAndPort = server.getServer().getHostAndPort();
+    final String serverHostAndPort = server.getServer().getHost();
     final int workerNumber = workerIdToNumber.getInt(serverHostAndPort);
 
     // The worker number may be UNKNOWN in a race condition, such as the set of Historicals changing while

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/DartTableInputSpecSlicerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/DartTableInputSpecSlicerTest.java
@@ -76,8 +76,8 @@ public class DartTableInputSpecSlicerTest extends InitializedNullHandlingTest
    * This makes tests deterministic.
    */
   private static final List<DruidServerMetadata> SERVERS = ImmutableList.of(
-      new DruidServerMetadata("no", "localhost:1001", null, 1, ServerType.HISTORICAL, "__default", 2),
-      new DruidServerMetadata("no", "localhost:1002", null, 1, ServerType.HISTORICAL, "__default", 1),
+      new DruidServerMetadata("no", "localhost:1001", null, 1, ServerType.HISTORICAL, "__default", 2), // plaintext
+      new DruidServerMetadata("no", null, "localhost:1002", 1, ServerType.HISTORICAL, "__default", 1), // TLS
       new DruidServerMetadata("no", "localhost:1003", null, 1, ServerType.REALTIME, "__default", 0)
   );
 
@@ -86,7 +86,7 @@ public class DartTableInputSpecSlicerTest extends InitializedNullHandlingTest
    */
   private static final List<String> WORKER_IDS =
       SERVERS.stream()
-             .map(server -> new WorkerId("http", server.getHostAndPort(), QUERY_ID).toString())
+             .map(server -> new WorkerId("http", server.getHost(), QUERY_ID).toString())
              .collect(Collectors.toList());
 
   /**


### PR DESCRIPTION
We should use getHost(), which returns TLS if configured or plaintext otherwise. getHostAndPort() returns plaintext only.