### PR TITLE
Upgrade commons-io to 2.17.0

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -50,8 +50,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -147,7 +147,7 @@ public class DruidPeonClientIntegrationTest
                                  .map(Integer::parseInt)
                                  .collect(Collectors.toList()));
       }
-      catch (IOException e) {
+      catch (UncheckedIOException e) {
         throw new RuntimeException(e);
       }
     });

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -35,7 +35,7 @@
   </parent>
 
   <properties>
-    <commons-io.version>2.11.0</commons-io.version>
+    <commons-io.version>2.17.0</commons-io.version>
     <okio.version>3.6.0</okio.version>
   </properties>
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -546,13 +546,13 @@ name: Apache Commons IO
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.11.0
+version: 2.17.0
 libraries:
   - commons-io: commons-io
 notices:
   - commons-io: |
       Apache Commons IO
-      Copyright 2002-2021 The Apache Software Foundation
+      Copyright 2002-2024 The Apache Software Foundation
 
 ---
 
@@ -2518,20 +2518,6 @@ notices:
   - commons-digester: |
       Apache Jakarta Commons Digester
       Copyright 2001-2006 The Apache Software Foundation
-
----
-
-name: Apache Commons IO
-license_category: binary
-module: hadoop-client
-license_name: Apache License version 2.0
-version: 2.4
-libraries:
-  - commons-io: commons-io
-notices:
-  - commons-io: |
-      Apache Commons IO
-      Copyright 2002-2012 The Apache Software Foundation
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.17.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>


### PR DESCRIPTION
In latest version of commons-io IOException is replaced with UncheckedIOException
https://github.com/apache/commons-io/commit/166dea37e810fcfa9c72cf1f107fd38cfb432486