### PR TITLE
Docs: adds MSQ examples to front coded dict. migration

### DIFF
--- a/docs/release-info/migr-front-coded-dict.md
+++ b/docs/release-info/migr-front-coded-dict.md
@@ -64,14 +64,14 @@ In the Web Console, select *Edit context* from the context from the *Engine:* me
 
 ```json
 {
-  ...
-  "indexSpec": {
-    "stringDictionaryEncoding": {
-      "type": "frontCoded",
-      "bucketSize": 4,
-      "formatVersion": 1
-    }
+...
+"indexSpec": {
+  "stringDictionaryEncoding": {
+  "type": "frontCoded",
+  "bucketSize": 4,
+  "formatVersion": 1
   }
+}
 }
 ```
 
@@ -79,16 +79,15 @@ For API calls to the SQL-based ingestion API, include the `indexSpec` in the con
 
 ```json
 {
-  "query": ...
-  "context": {
-    "maxNumTasks": 3
-    "indexSpec": {
-    "stringDictionaryEncoding": {
-      "type": "frontCoded",
-      "bucketSize": 4,
-      "formatVersion": 1
+"query": ...
+"context": {
+  "maxNumTasks": 3
+  "indexSpec": {
+  "stringDictionaryEncoding": {
+    "type": "frontCoded",
+    "bucketSize": 4,
+    "formatVersion": 1}
     }
-  }
   }
 }
 ```

--- a/docs/release-info/migr-front-coded-dict.md
+++ b/docs/release-info/migr-front-coded-dict.md
@@ -47,7 +47,7 @@ You can specify the following optional properties:
 
 For example:
 
-```
+```json
 "tuningConfig": {
   "indexSpec": {
     "stringDictionaryEncoding": {
@@ -55,6 +55,40 @@ For example:
       "bucketSize": 4,
       "formatVersion": 0
     }
+  }
+}
+```
+
+For SQL based ingestion, you can add the `indexSpec` to your query context.
+In the Web Console, select *Edit context* from the context from the *Engine:* menu and enter the `indexSpec`. For example:
+
+```json
+{
+  ...
+  "indexSpec": {
+    "stringDictionaryEncoding": {
+      "type": "frontCoded",
+      "bucketSize": 4,
+      "formatVersion": 1
+    }
+  }
+}
+```
+
+For API calls to the SQL-based ingestion API, include the `indexSpec` in the context in the request payload. For example:
+
+```json
+{
+  "query": ...
+  "context": {
+    "maxNumTasks": 3
+    "indexSpec": {
+    "stringDictionaryEncoding": {
+      "type": "frontCoded",
+      "bucketSize": 4,
+      "formatVersion": 1
+    }
+  }
   }
 }
 ```


### PR DESCRIPTION
Adds MSQ examples to front coded dict. migration

This PR has:

- [x ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
