### PR TITLE
SuperSorter: Don't set allDone if it's already set.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/SuperSorter.java
@@ -391,6 +391,11 @@ public class SuperSorter
   @GuardedBy("runWorkersLock")
   private void setAllDoneIfPossible()
   {
+    if (isAllDone()) {
+      // Already done, no need to set allDone again.
+      return;
+    }
+
     try {
       if (totalInputFrames == 0 && outputPartitionsFuture.isDone()) {
         // No input data -- generate empty output channels.


### PR DESCRIPTION
Iif there is no output at all, `setAllDoneIfPossible` can be called twice (once when the output partitions future resolves, and once when the batcher finishes). If the calls happen in that order, it would try to create nil output channels both times, resulting in a "Channel already set" error. This patch fixes that issue by having `setAllDoneIfPossible` return without doing anything if `allDone` is already set.