### PR TITLE
Web console: don't assume that activeTasks is an array

### DIFF
--- a/web-console/src/views/explore-view/components/module-pane/module-pane.tsx
+++ b/web-console/src/views/explore-view/components/module-pane/module-pane.tsx
@@ -20,7 +20,7 @@ import { ResizeSensor } from '@blueprintjs/core';
 import type { QueryResult, SqlExpression, SqlQuery } from '@druid-toolkit/query';
 import React, { useMemo, useState } from 'react';
 
-import type { ParameterDefinition, QuerySource } from '../../models';
+import type { ParameterDefinition, ParameterValues, QuerySource } from '../../models';
 import { effectiveParameterDefault, Stage } from '../../models';
 import { ModuleRepository } from '../../module-repository/module-repository';
 import { Issue } from '../issue/issue';
@@ -28,7 +28,7 @@ import { Issue } from '../issue/issue';
 import './module-pane.scss';
 
 function fillInDefaults(
-  parameterValues: Record<string, any>,
+  parameterValues: ParameterValues,
   parameters: Record<string, ParameterDefinition>,
   querySource: QuerySource,
 ): Record<string, any> {
@@ -46,8 +46,8 @@ export interface ModulePaneProps {
   where: SqlExpression;
   setWhere(where: SqlExpression): void;
 
-  parameterValues: Record<string, any>;
-  setParameterValues(parameters: Record<string, any>): void;
+  parameterValues: ParameterValues;
+  setParameterValues(parameters: ParameterValues): void;
   runSqlQuery(query: string | SqlQuery): Promise<QueryResult>;
 }
 

--- a/web-console/src/views/explore-view/explore-state.ts
+++ b/web-console/src/views/explore-view/explore-state.ts
@@ -42,7 +42,7 @@ interface ExploreStateValue {
   showSourceQuery?: boolean;
   where: SqlExpression;
   moduleId: string;
-  parameterValues: Record<string, any>;
+  parameterValues: ParameterValues;
 }
 
 export class ExploreState {
@@ -64,7 +64,7 @@ export class ExploreState {
   public readonly showSourceQuery: boolean;
   public readonly where: SqlExpression;
   public readonly moduleId: string;
-  public readonly parameterValues: Record<string, any>;
+  public readonly parameterValues: ParameterValues;
 
   public readonly parsedSource: SqlQuery | undefined;
   public readonly parseError: string | undefined;
@@ -178,8 +178,10 @@ export class ExploreState {
       parameterValues = {};
     } else {
       moduleId = 'grouping-table';
-      parameterValues = this.moduleId === moduleId ? this.parameterValues : {};
-      parameterValues.splitColumns = [ExpressionMeta.fromColumn(column)];
+      parameterValues = {
+        ...(this.moduleId === moduleId ? this.parameterValues : {}),
+        splitColumns: [ExpressionMeta.fromColumn(column)],
+      };
     }
 
     return this.change({

--- a/web-console/src/views/explore-view/explore-view.tsx
+++ b/web-console/src/views/explore-view/explore-view.tsx
@@ -186,7 +186,7 @@ export const ExploreView = React.memo(function ExploreView() {
     }
   }, [module, parameterValues, querySourceState.data]);
 
-  function setModuleId(moduleId: string, parameterValues: Record<string, any>) {
+  function setModuleId(moduleId: string, parameterValues: ParameterValues) {
     if (exploreState.moduleId === moduleId) return;
     setExploreState(exploreState.change({ moduleId, parameterValues }));
   }
@@ -326,7 +326,7 @@ export const ExploreView = React.memo(function ExploreView() {
           <ModulePicker
             selectedModuleId={moduleId}
             onSelectedModuleIdChange={newModuleId => {
-              const newParameterValues = getStickyParameterValuesForModule(newModuleId);
+              let newParameterValues = getStickyParameterValuesForModule(newModuleId);
 
               const oldModule = ModuleRepository.getModule(moduleId);
               const newModule = ModuleRepository.getModule(newModuleId);
@@ -349,11 +349,14 @@ export const ExploreView = React.memo(function ExploreView() {
                   );
                   if (!target) continue;
 
-                  newParameterValues[target[0]] = adjustTransferValue(
-                    parameterValue,
-                    oldParameterDefinition.type,
-                    target[1].type,
-                  );
+                  newParameterValues = {
+                    ...newParameterValues,
+                    [target[0]]: adjustTransferValue(
+                      parameterValue,
+                      oldParameterDefinition.type,
+                      target[1].type,
+                    ),
+                  };
                 }
               }
 

--- a/web-console/src/views/explore-view/models/parameter.ts
+++ b/web-console/src/views/explore-view/models/parameter.ts
@@ -26,9 +26,9 @@ import type { QuerySource } from './query-source';
 
 export type OptionValue = string | number;
 
-export type ModuleFunctor<T> = T | ((options: { parameterValues: Record<string, any> }) => T);
+export type ModuleFunctor<T> = T | ((options: { parameterValues: ParameterValues }) => T);
 
-export function evaluateFunctor<T>(fn: ModuleFunctor<T>, parameterValues: Record<string, any>): T {
+export function evaluateFunctor<T>(fn: ModuleFunctor<T>, parameterValues: ParameterValues): T {
   if (typeof fn === 'function') {
     return (fn as any)({ parameterValues });
   } else {
@@ -144,7 +144,7 @@ export function getModuleOptionLabel(
   );
 }
 
-export type ParameterValues = Record<string, any>;
+export type ParameterValues = Readonly<Record<string, any>>;
 export type Parameters = Record<string, ParameterDefinition>;
 
 // -----------------------------------------------------

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -843,10 +843,14 @@ export class SupervisorsView extends React.PureComponent<
             accessor: 'stats',
             Cell: ({ value, original }) => {
               if (!value) return;
-              const activeTaskIds: string[] | undefined = deepGet(
+              const activeTasks: SupervisorStatusTask[] | undefined = deepGet(
                 original,
                 'status.payload.activeTasks',
-              )?.map((t: SupervisorStatusTask) => t.id);
+              );
+              const activeTaskIds: string[] | undefined = Array.isArray(activeTasks)
+                ? activeTasks.map((t: SupervisorStatusTask) => t.id)
+                : undefined;
+
               const c = getTotalSupervisorStats(value, statsKey, activeTaskIds);
               const seconds = getRowStatsKeySeconds(statsKey);
               const totalLabel = `Total (past ${statsKey}): `;


### PR DESCRIPTION
A small fix, activeTasks would always be `.map`ed even if it was not an Array.
Also use the correct `ParameterValues` type everywhere