### PR TITLE
docs: concurrent append and replace is gA

### DIFF
--- a/docs/ingestion/concurrent-append-replace.md
+++ b/docs/ingestion/concurrent-append-replace.md
@@ -22,10 +22,6 @@ title: Concurrent append and replace
   ~ under the License.
   -->
 
-:::info
-Concurrent append and replace is an [experimental feature](../development/experimental.md) available for JSON-based batch, streaming, and SQL-based ingestion.
-:::
-
 Concurrent append and replace safely replaces the existing data in an interval of a datasource while new data is being appended to that interval. One of the most common applications of this feature is appending new data (such as with streaming ingestion) to an interval while compaction of that interval is already in progress. Druid segments the data ingested during this time dynamically. The subsequent compaction run segments the data into the  granularity you specified.
 
 To set up concurrent append and replace, use the context flag `useConcurrentLocks`. Druid will then determine the correct lock type for you, either append or replace. Although you can set the type of lock manually, we don't recommend it. 


### PR DESCRIPTION
Removes experimental note from concurrent append and replace. It is considered GA in Druid 31.0.0

This PR has:

- [x] been self-reviewed.
